### PR TITLE
Editor Autocomplete

### DIFF
--- a/app/ui/components/editors/body/RawEditor.js
+++ b/app/ui/components/editors/body/RawEditor.js
@@ -15,6 +15,7 @@ class RawEditor extends Component {
 
     return (
       <Editor
+        autocompleteHints={['base_url', 'api_key', 'user_id', 'foo']}
         manualPrettify={true}
         fontSize={fontSize}
         keyMap={keyMap}

--- a/app/ui/css/components/editor.less
+++ b/app/ui/css/components/editor.less
@@ -140,6 +140,7 @@
 }
 
 /* Based on Sublime Text's Monokai theme */
+.editor,
 .CodeMirror {
   color: var(--color-font);
 
@@ -250,4 +251,32 @@
     text-decoration: underline;
     color: inherit !important;
   }
+
+  ul.CodeMirror-hints {
+    background-color: var(--color-bg);
+    border-color: var(--hl-md);
+    position: fixed;
+    box-shadow: 0 0 1rem 0 rgba(0, 0, 0, 0.1);
+  }
+
+  li.CodeMirror-hint {
+    min-width: 10rem;
+    color: var(--color-font);
+    padding: @padding-xxs @padding-xs;
+  }
+
+  li.CodeMirror-hint-active {
+    background: var(--hl-md);
+    color: var(--color-font);
+  }
+}
+
+.editor__autocomplete-container {
+  z-index: -1;
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background: rgba(255, 23, 23, 0.2);
 }

--- a/app/ui/css/layout/base.less
+++ b/app/ui/css/layout/base.less
@@ -384,7 +384,7 @@ i.fa {
 }
 
 ::selection {
- background-color: var(--hl-lg);
+ background-color: var(--hl-md);
 }
 
 .hide-scrollbars {


### PR DESCRIPTION
This is a proof-of-concept autocomplete feature for CodeMirror. It's not really that useful in Insomnia, however, because it would need to be paired with a counterpart to provide autocomplete also on regular (non-codemirror) fields.

Here's what it might look like.

![c2_loapuqaamtpr](https://cloud.githubusercontent.com/assets/587576/22277723/b55f1160-e272-11e6-80e1-c4cdb093bac2.jpg)