### PR TITLE
Stop send interval on request change

### DIFF
--- a/app/ui/components/request-pane.js
+++ b/app/ui/components/request-pane.js
@@ -198,7 +198,7 @@ class RequestPane extends PureComponent {
       <section className="pane request-pane">
         <header className="pane__header">
           <RequestUrlBar
-            key={uniqueKey}
+            uniquenessKey={uniqueKey}
             method={request.method}
             onMethodChange={updateRequestMethod}
             onUrlChange={this._handleUpdateRequestUrl}
@@ -210,6 +210,7 @@ class RequestPane extends PureComponent {
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
             url={request.url}
+            requestId={request._id}
           />
         </header>
         <Tabs className="pane__body" forceRenderTabPanel>

--- a/app/ui/components/request-url-bar.js
+++ b/app/ui/components/request-url-bar.js
@@ -180,6 +180,11 @@ class RequestUrlBar extends PureComponent {
     }
   }
 
+  _handleResetTimeouts () {
+    this._handleStopTimeout();
+    this._handleStopInterval();
+  }
+
   _handleClickSend (e) {
     const metaPressed = isMac() ? e.metaKey : e.ctrlKey;
 
@@ -200,6 +205,12 @@ class RequestUrlBar extends PureComponent {
 
   componentWillUnmount () {
     document.body.removeEventListener('keydown', this._handleKeyDown);
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.requestId !== this.props.requestId) {
+      this._handleResetTimeouts();
+    }
   }
 
   renderSendButton () {
@@ -278,7 +289,8 @@ class RequestUrlBar extends PureComponent {
       method,
       handleRender,
       handleGetRenderContext,
-      handleAutocompleteUrls
+      handleAutocompleteUrls,
+      uniquenessKey
     } = this.props;
 
     return (
@@ -288,6 +300,7 @@ class RequestUrlBar extends PureComponent {
         </MethodDropdown>
         <form onSubmit={this._handleFormSubmit}>
           <OneLineEditor
+            key={uniquenessKey}
             ref={this._setInputRef}
             onPaste={this._handleUrlPaste}
             forceEditor
@@ -316,7 +329,9 @@ RequestUrlBar.propTypes = {
   onMethodChange: PropTypes.func.isRequired,
   handleGenerateCode: PropTypes.func.isRequired,
   url: PropTypes.string.isRequired,
-  method: PropTypes.string.isRequired
+  method: PropTypes.string.isRequired,
+  requestId: PropTypes.string.isRequired,
+  uniquenessKey: PropTypes.string.isRequired
 };
 
 export default RequestUrlBar;


### PR DESCRIPTION
Before, the interval would continue in the background but the UI to stop it would be gone. This change makes the interval stop when the request changes.