### PR TITLE
Fix environment editor focus issues after variable selection

### DIFF
--- a/app/ui/components/modals/nunjucks-modal.js
+++ b/app/ui/components/modals/nunjucks-modal.js
@@ -36,6 +36,7 @@ class NunjucksModal extends PureComponent {
   _handleModalHide () {
     if (this._onDone) {
       this._onDone(this._currentTemplate);
+      this.setState({defaultTemplate: ''});
     }
   }
 


### PR DESCRIPTION
There was an issue causing cursor to lose focus _randomly_ after using the variable/tag selector from within the environment editor. This was because the variable selector `<select>` still had focus after closing. The fix was to clear the modal contents after done editing.