### PR TITLE
Fixed spaces in JSON prettify

### DIFF
--- a/app/common/prettify.js
+++ b/app/common/prettify.js
@@ -87,7 +87,7 @@ export function prettifyJson (json, indentChars) {
         }
         break;
       case '"':
-        if (i > 0 && previousChar !== '\\') {
+        if (previousChar !== '\\') {
           inString = !inString;
         }
         newJson += currentChar;


### PR DESCRIPTION
Fix to handle of string JSON roots. Closes #170 

Not sure why the `i > 0` check was there before... This code was mostly copied from here originally https://github.com/zaach/jsonlint/blob/master/lib/formatter.js