### PR TITLE
Will not clear selected file if dialog is dismissed

### DIFF
--- a/app/ui/components/base/file-input-button.js
+++ b/app/ui/components/base/file-input-button.js
@@ -25,9 +25,9 @@ class FileInputButton extends PureComponent {
     };
 
     remote.dialog.showOpenDialog(options, async paths => {
+      // Only change the file if a new file was selected
       if (!paths || paths.length === 0) {
-        // Cancelling will clear the value
-        this.props.onChange('');
+        return;
       }
 
       const path = paths[0];


### PR DESCRIPTION
## What
- [x] Persists selected file when file input `dialog.showOpenDialog` window is cancelled

## Why
- We do not want to clear the selected file if the file selection dialog is dismissed. 

## Details
N/A

## Notes
This PR solves Issue #201 

**Related Issue**: #201 