### PR TITLE
Allow fuzzy searching in Quick Switch modal

### DIFF
--- a/app/ui/components/modals/request-switcher-modal.js
+++ b/app/ui/components/modals/request-switcher-modal.js
@@ -109,13 +109,22 @@ class RequestSwitcherModal extends PureComponent {
     // OPTIMIZATION: This only filters if we have a filter
     let matchedRequests = workspaceChildren.filter(d => d.type === models.request.type);
     if (searchString) {
+      const specialCharacters = ['.', '^', '$', '*', '+', '-', '?', '(', ')', '[', ']', '{', '}', '\\', '|'];
+
+      const regexSearchString = searchString
+        .toLowerCase()
+        .split('')
+        .map((c) => specialCharacters.includes(c) ? `\\${c}` : c)
+        .join('.*');
+
+      const toMatch = new RegExp(regexSearchString);
+
       matchedRequests = matchedRequests.filter(r => {
         const name = r.name.toLowerCase();
         const id = r._id.toLowerCase();
-        const toMatch = searchString.toLowerCase();
 
-        // Match substring of name
-        const matchesName = name.indexOf(toMatch) >= 0;
+        // Fuzzy match searchString to name
+        const matchesName = toMatch.test(name);
 
         // Match exact Id
         const matchesId = id === toMatch;


### PR DESCRIPTION
## What
- [x] Allow fuzzy search in request Quick Switch modal

## Why
- Makes `searchString` a little more forgiving
- Allows matching of multiple ordered substrings in request names without having to type everything between substrings.
  - For example, if you have a request called `(Payments) Refund charges for specific account` you may search for `p refund account` to find such request.

### Before
<img width="664" alt="screen shot 2017-05-13 at 10 56 09 am" src="https://cloud.githubusercontent.com/assets/3803621/26027006/00b570d8-37cc-11e7-8332-69b97923d07e.png">

### After
<img width="665" alt="screen shot 2017-05-13 at 10 55 42 am" src="https://cloud.githubusercontent.com/assets/3803621/26027005/fa07583c-37cb-11e7-84ab-0fb82b7fadb3.png">


## Details
N/A

## Notes
I originally tried a more algorithmic approach of traversing both string to figure out if the `searchString` characters exist in order in the `matchedRequests` strings but this was significantly slower than constructing and using a regular expression (18ms vs. 1ms per `matchedRequest`)

**Related Issue**: N/A

