### PR TITLE
Implement lazy tag rendering

### DIFF
--- a/app/common/__tests__/render.test.js
+++ b/app/common/__tests__/render.test.js
@@ -269,9 +269,9 @@ describe('buildRenderContext()', () => {
   });
 });
 
-describe('recursiveRender()', () => {
+describe('render()', () => {
   it('correctly renders simple Object', async () => {
-    const newObj = await renderUtils.recursiveRender({
+    const newObj = await renderUtils.render({
       foo: '{{ foo }}',
       bar: 'bar',
       baz: '{{ bad }}'
@@ -299,7 +299,7 @@ describe('recursiveRender()', () => {
       }
     };
 
-    const newObj = await renderUtils.recursiveRender(obj, {foo: 'bar'});
+    const newObj = await renderUtils.render(obj, {foo: 'bar'});
 
     expect(newObj).toEqual({
       foo: 'bar',
@@ -322,7 +322,7 @@ describe('recursiveRender()', () => {
 
   it('fails on bad template', async () => {
     try {
-      await renderUtils.recursiveRender({
+      await renderUtils.render({
         foo: '{{ foo }',
         bar: 'bar',
         baz: '{{ bad }}'
@@ -331,5 +331,16 @@ describe('recursiveRender()', () => {
     } catch (err) {
       expect(err.message).toContain('expected variable end');
     }
+  });
+
+  it('does not render tags when not supposed to', async () => {
+    const template = '{{ foo }} {% uuid "v4" %}';
+    const context = {foo: 'bar'};
+
+    const resultOnlyVars = await renderUtils.render(template, context, null, true);
+    const resultEverything = await renderUtils.render(template, context, null, false);
+
+    expect(resultOnlyVars).toBe('bar {% uuid "v4" %}');
+    expect(resultEverything).toBe('bar e3e96e5f-dd68-4229-8b66-dee1f0940f3d');
   });
 });

--- a/app/ui/components/modals/request-render-error-modal.js
+++ b/app/ui/components/modals/request-render-error-modal.js
@@ -40,7 +40,7 @@ class RequestRenderErrorModal extends PureComponent {
 
     const result = jq.query(request, `$.${error.path}`);
     const template = (result && result.length) ? result[0] : null;
-    const locationLabel = template.includes('\n')
+    const locationLabel = template && template.includes('\n')
       ? `line ${error.location.line} of`
       : null;
 


### PR DESCRIPTION
This PR implements lazy rendering of Nunjucks tags. 

_beside the benefit discussed below, this is also required for request chaining (#210)_

## Problem

When the environment contains a tag that throws an error, the request will fail to execute even if the variable is not referenced. This is because the entire environment is rendered on its own (to support recursive variables) before it's used to render the request. Here's an example:

```javascript
// environment
{
  "broken": "{% badname %}"
}
```

The request will fail with a render error even if it does not contain `{{ broken }}`.

## Solution

During the environment rendering phase, only render tags and not variables. Then, when rendering the request, render both variables and tags.

## To-Do 

- [x] Implement a way to skip rendering of tags (by telling Nunjucks a different tag syntax)
- [x] Render environments with `variablesOnly` set to `true`
- [x] Add test for `variablesOnly` mode
- [x] Render request twice in case a variable contains a tag as a value
  - `eg. {{ foo }} => {% uuid 'v4' %} => dd265685-16a3-4d76-a59c-e8264c16835a`