### PR TITLE
Expanding Response Time tag to 3 decimals

### DIFF
--- a/app/ui/components/tags/time-tag.js
+++ b/app/ui/components/tags/time-tag.js
@@ -29,7 +29,7 @@ class TimeTag extends PureComponent {
       number = Math.round(number * 100) / 100;
     }
 
-    let description = `${milliseconds.toFixed(1)} milliseconds`;
+    let description = `${milliseconds.toFixed(3)} milliseconds`;
     return (
       <div className={classnames('tag', {'tag--small': small}, className)} title={description}>
         <strong>TIME</strong> {number} {unit}


### PR DESCRIPTION
## What
Expanding to third decimal in Response Time Tag. Fixes #212

## Why
Provides more insight to the response time in milliseconds rather than rounding the first decimal.

#### Before 
![time](https://cloud.githubusercontent.com/assets/236529/26080763/01439fe0-3996-11e7-812d-429d692ead4b.png)

#### After
![time2](https://cloud.githubusercontent.com/assets/236529/26080912/94c3a1fc-3996-11e7-8faa-d6b56ddd596b.png)


