### PR TITLE
Show build info in console

### DIFF
--- a/webpack/webpack.config.development.babel.js
+++ b/webpack/webpack.config.development.babel.js
@@ -17,7 +17,6 @@ module.exports = {
   devServer: {
     hot: true,
     hotOnly: true,
-    noInfo: true,
     port: PORT,
     publicPath: `http://localhost:${PORT}/`
   },


### PR DESCRIPTION
There has been some confusion around the development process. When the build server is started, it takes about 30 seconds for the initial build to complete (on decent hardware), leaving just a white screen. 

This change enables Webpack build logs to appear in the console, providing more details as to when the initial build finishes.

![image](https://cloud.githubusercontent.com/assets/587576/26083908/4a13b6b4-398d-11e7-9bf2-791a5b651ed5.png)
