### PR TITLE
Switch from Curl to tough cookie to handle response cookies

### DIFF
--- a/app/network/__tests__/network.test.js
+++ b/app/network/__tests__/network.test.js
@@ -64,10 +64,9 @@ describe('actuallySend()', () => {
     const body = JSON.parse(Buffer.from(response.body, 'base64'));
     expect(body).toEqual({
       options: {
-        COOKIEFILE: '',
         COOKIELIST: [
-          'notlocalhost\tTRUE\t/\tFALSE\t4000855249\tfoo\tbarrrrr',
-          'localhost\tTRUE\t/\tFALSE\t4000855249\tfoo\tbar'
+          'notlocalhost\tFALSE\t/\tFALSE\t4000855249\tfoo\tbarrrrr',
+          'localhost\tFALSE\t/\tFALSE\t4000855249\tfoo\tbar'
         ],
         CUSTOMREQUEST: 'POST',
         ACCEPT_ENCODING: '',
@@ -149,7 +148,6 @@ describe('actuallySend()', () => {
     const body = JSON.parse(Buffer.from(response.body, 'base64'));
     expect(body).toEqual({
       options: {
-        COOKIEFILE: '',
         CUSTOMREQUEST: 'POST',
         ACCEPT_ENCODING: '',
         FOLLOWLOCATION: true,
@@ -204,7 +202,6 @@ describe('actuallySend()', () => {
 
     expect(body).toEqual({
       options: {
-        COOKIEFILE: '',
         CUSTOMREQUEST: 'POST',
         ACCEPT_ENCODING: '',
         FOLLOWLOCATION: true,
@@ -261,7 +258,6 @@ describe('actuallySend()', () => {
     const body = JSON.parse(Buffer.from(response.body, 'base64'));
     expect(body).toEqual({
       options: {
-        COOKIEFILE: '',
         CUSTOMREQUEST: 'POST',
         ACCEPT_ENCODING: '',
         FOLLOWLOCATION: true,

--- a/app/network/network.js
+++ b/app/network/network.js
@@ -8,12 +8,13 @@ import * as models from '../models';
 import * as querystring from '../common/querystring';
 import * as util from '../common/misc.js';
 import {AUTH_BASIC, AUTH_DIGEST, AUTH_NTLM, CONTENT_TYPE_FORM_DATA, CONTENT_TYPE_FORM_URLENCODED, DEBOUNCE_MILLIS, getAppVersion} from '../common/constants';
-import {describeByteSize, hasAuthHeader, hasContentTypeHeader, hasUserAgentHeader, setDefaultProtocol} from '../common/misc';
+import {describeByteSize, getSetCookieHeaders, hasAuthHeader, hasContentTypeHeader, hasUserAgentHeader, setDefaultProtocol} from '../common/misc';
 import {getRenderedRequest} from '../common/render';
 import fs from 'fs';
 import * as db from '../common/database';
 import * as CACerts from './cacert';
 import {getAuthHeader} from './authentication';
+import {cookiesFromJar, jarFromCookies} from '../common/cookies';
 
 let cancelRequestFunction = null;
 
@@ -190,9 +191,6 @@ export function _actuallySend (renderedRequest, workspace, settings) {
         setOpt(Curl.option.CAINFO, fullCAPath);
       }
 
-      // Enable cookie handling (this is required)
-      setOpt(Curl.option.COOKIEFILE, '');
-
       // Set cookies from jar
       if (renderedRequest.settingSendCookies) {
         const cookies = renderedRequest.cookieJar.cookies || [];
@@ -202,9 +200,10 @@ export function _actuallySend (renderedRequest, workspace, settings) {
             const expiresDate = new Date(cookie.expires);
             expiresTimestamp = Math.round(expiresDate.getTime() / 1000);
           }
+
           setOpt(Curl.option.COOKIELIST, [
             cookie.httpOnly ? `#HttpOnly_${cookie.domain}` : cookie.domain,
-            cookie.hostOnly ? 'TRUE' : 'FALSE',
+            cookie.hostOnly ? 'FALSE' : 'TRUE',
             cookie.path,
             cookie.secure ? 'TRUE' : 'FALSE',
             expiresTimestamp,
@@ -386,7 +385,7 @@ export function _actuallySend (renderedRequest, workspace, settings) {
       setOpt(Curl.option.HTTPHEADER, headerStrings);
 
       // Handle the response ending
-      curl.on('end', function (_1, _2, curlHeaders) {
+      curl.on('end', async function (_1, _2, curlHeaders) {
         // Headers are an array (one for each redirect)
         curlHeaders = curlHeaders[curlHeaders.length - 1];
 
@@ -412,37 +411,30 @@ export function _actuallySend (renderedRequest, workspace, settings) {
         const contentType = contentTypeHeader ? contentTypeHeader.value : '';
 
         // Update Cookie Jar
-        if (renderedRequest.settingStoreCookies) {
-          const cookieStrings = curl.getInfo(Curl.info.COOKIELIST);
-          const cookies = cookieStrings.map(str => {
-            //  0                    1                  2     3       4       5     6
-            // [#HttpOnly_.hostname, includeSubdomains, path, secure, expiry, name, value]
-            const parts = str.split('\t');
+        const setCookieHeaders = getSetCookieHeaders(headers);
+        if (renderedRequest.settingStoreCookies && setCookieHeaders.length) {
+          const jar = jarFromCookies(renderedRequest.cookieJar.cookies);
+          jar.rejectPublicSuffixes = false;
+          jar.looseMode = true;
 
-            const hostname = parts[0].replace(/^#HttpOnly_/, '');
-            const httpOnly = hostname.length !== parts[0].length;
+          for (const header of getSetCookieHeaders(headers)) {
+            jar.setCookieSync(header.value, curl.getInfo(Curl.info.EFFECTIVE_URL));
+          }
 
-            return {
-              domain: hostname,
-              httpOnly: httpOnly,
-              hostOnly: parts[1] === 'TRUE',
-              path: parts[2],
-              secure: parts[3] === 'TRUE', // This doesn't exists?
-              expires: new Date(parts[4] * 1000),
-              key: parts[5],
-              value: parts[6]
-            };
-          });
+          const cookies = await cookiesFromJar(jar);
+          for (const cookie of cookies) {
+            if (cookie.domain[0] !== '.') {
+              cookie.domain = `.${cookie.domain}`;
+            }
+          }
 
-          // Do this async. We don't need to wait
           models.cookieJar.update(renderedRequest.cookieJar, {cookies});
 
-          if (cookies.length) {
-            timeline.push({
-              name: 'TEXT',
-              value: `Updated cookie jar with ${cookies.length} cookies`
-            });
-          }
+          const n = setCookieHeaders.length;
+          timeline.push({name: 'TEXT', value: `Saved ${n} cookie${n === 1 ? '' : 's'}`});
+        } else if (setCookieHeaders.length) {
+          const n = setCookieHeaders.length;
+          timeline.push({name: 'TEXT', value: `Ignored ${n} cookie${n === 1 ? '' : 's'}`});
         }
 
         // Handle the body


### PR DESCRIPTION
## What

This PR changes handling of set-cookie header from libcurl to [`tough-cookie`](https://github.com/salesforce/tough-cookie). 

- [x] Disable Curl's automatic handling of saving cookies
- [x] Use `tough-cookie` to update the jar with each set-cookie header

## Why

Libcurl handles cookies too strictly. For example, it will ignore most cookies set on localhost.

## Notes

This also fixes improper handling of the `host-only` attribute on libcurl cookies (it was backwards before)

Fixes #209 