### PR TITLE
Fix adding context menu multiple times

### DIFF
--- a/app/ui/components/viewers/response-webview.js
+++ b/app/ui/components/viewers/response-webview.js
@@ -6,7 +6,9 @@ import contextMenu from 'electron-context-menu';
 class ResponseWebview extends PureComponent {
   _handleSetWebviewRef (n) {
     this._webview = n;
-    contextMenu({window: this._webview});
+    if (n) {
+      contextMenu({window: this._webview});
+    }
   }
 
   _handleDOMReady () {


### PR DESCRIPTION
This was a tricky one. When React calls the `ref` function during unmounting, `null` is passed to the function. This was a problem because, when `electron-context-menu` receives a falsy value, it applies itself globally (to all windows). A simple check to see if there was _actually_ a window fixed the issue.

Fixes #218 