### PR TITLE
Better errors inside environment editors

### DIFF
--- a/app/network/o-auth-2/grant-password.js
+++ b/app/network/o-auth-2/grant-password.js
@@ -1,5 +1,5 @@
 import * as querystring from '../../common/querystring';
-import {getBasicAuthHeader} from '../../common/misc';
+import {getBasicAuthHeader, setDefaultProtocol} from '../../common/misc';
 import * as c from './constants';
 import {responseToObject} from './misc';
 
@@ -38,7 +38,15 @@ export default async function (accessTokenUrl,
     headers: headers
   };
 
-  const response = await window.fetch(accessTokenUrl, config);
+  const url = setDefaultProtocol(accessTokenUrl);
+
+  let response;
+  try {
+    response = await window.fetch(url, config);
+  } catch (err) {
+    throw new Error(`Failed to fetch access token at URL "${url}"`);
+  }
+
   const body = await response.text();
   const results = responseToObject(body, [
     c.P_ACCESS_TOKEN,

--- a/app/ui/components/modals/workspace-environments-edit-modal.js
+++ b/app/ui/components/modals/workspace-environments-edit-modal.js
@@ -133,7 +133,7 @@ class WorkspaceEnvironmentsEditModal extends PureComponent {
   _didChange () {
     const isValid = this._envEditor.isValid();
 
-    if (this.state.isValid === isValid) {
+    if (this.state.isValid !== isValid) {
       this.setState({isValid});
     }
 

--- a/app/ui/components/request-pane.js
+++ b/app/ui/components/request-pane.js
@@ -241,12 +241,12 @@ class RequestPane extends PureComponent {
             </Tab>
             <Tab onClick={this._trackTabQuery}>
               <button>
-                Query {numParameters ? <span className="bubble">{numParameters}</span> : null}
+                Query {numParameters > 0 && <span className="bubble">{numParameters}</span>}
               </button>
             </Tab>
             <Tab onClick={this._trackTabHeaders}>
               <button>
-                Header {numHeaders ? <span className="bubble">{numHeaders}</span> : null}
+                Header {numHeaders > 0 && <span className="bubble">{numHeaders}</span>}
               </button>
             </Tab>
           </TabList>

--- a/app/ui/components/response-pane.js
+++ b/app/ui/components/response-pane.js
@@ -90,9 +90,9 @@ class ResponsePane extends PureComponent {
 
     const {body, timeline, encoding} = this.state.response;
     const headers = timeline
-                      .filter(v => v.name === 'HEADER_IN')
-                      .map(v => v.value)
-                      .join('');
+      .filter(v => v.name === 'HEADER_IN')
+      .map(v => v.value)
+      .join('');
     const bodyBuffer = new Buffer(body, encoding);
     const fullResponse = `${headers}${bodyBuffer}`;
 
@@ -249,8 +249,11 @@ class ResponsePane extends PureComponent {
             </Tab>
             <Tab>
               <Button onClick={this._trackTab} value="Headers">
-                Header {response.headers.length ? (
-                <span className="bubble">{response.headers.length}</span>) : null}
+                Header
+                {' '}
+                {response.headers.length > 0 && (
+                  <span className="bubble">{response.headers.length}</span>
+                )}
               </Button>
             </Tab>
             <Tab>
@@ -259,7 +262,7 @@ class ResponsePane extends PureComponent {
                 <span className="bubble">{cookieHeaders.length}</span>) : null}
               </Button>
             </Tab>
-            {response.timeline && response.timeline.length && (
+            {(response.timeline && response.timeline.length > 0) && (
               <Tab>
                 <Button onClick={this._trackTab} value="Timeline">Timeline</Button>
               </Tab>
@@ -305,15 +308,15 @@ class ResponsePane extends PureComponent {
               />
             </div>
           </TabPanel>
-          {(response.timeline && response.timeline.length) && (
+          {(response.timeline && response.timeline.length > 0) && (
             <TabPanel>
-                <ResponseTimelineViewer
-                  key={response._id}
-                  timeline={response.timeline || []}
-                  editorLineWrapping={editorLineWrapping}
-                  editorFontSize={editorFontSize}
-                  editorIndentSize={editorIndentSize}
-                />
+              <ResponseTimelineViewer
+                key={response._id}
+                timeline={response.timeline || []}
+                editorLineWrapping={editorLineWrapping}
+                editorFontSize={editorFontSize}
+                editorIndentSize={editorIndentSize}
+              />
             </TabPanel>
           )}
         </Tabs>

--- a/app/ui/css/components/environment-editor.less
+++ b/app/ui/css/components/environment-editor.less
@@ -1,0 +1,5 @@
+.environment-editor {
+  display: grid;
+  grid-template-rows: 1fr auto;
+  height: 100%;
+}

--- a/app/ui/css/index.less
+++ b/app/ui/css/index.less
@@ -24,6 +24,7 @@
 @import 'components/dropdown';
 @import 'components/editable';
 @import 'components/environment-modal';
+@import 'components/environment-editor';
 @import 'components/header-editor';
 @import 'components/key-value-editor';
 @import 'components/method-dropdown';


### PR DESCRIPTION
## What

This change adds more visible errors to the environment editor. For example, if the JSON is invalid or variable names contain invalid characters like dashes or spaces.

Closes #144 

## Screenshots

Errors now show up at the bottom of the editor.

![image](https://cloud.githubusercontent.com/assets/587576/26464617/436ce170-413d-11e7-82ab-931235810edf.png)

Warnings still allow the environment to be saved, but it will inform the user of potential issues.

![image](https://cloud.githubusercontent.com/assets/587576/26464706/9456fabc-413d-11e7-9251-5ae40fcf0568.png)
