### PR TITLE
Start a fresh OAuth2 session every launch

### DIFF
--- a/app/network/o-auth-2/misc.js
+++ b/app/network/o-auth-2/misc.js
@@ -1,5 +1,8 @@
 import electron from 'electron';
+import uuid from 'uuid';
 import querystring from 'querystring';
+
+const AUTH_WINDOW_SESSION_ID = uuid.v4();
 
 export function responseToObject (body, keys) {
   let data = null;
@@ -32,7 +35,7 @@ export function authorizeUserInWindow (url, urlRegex = /.*/) {
     const child = new electron.remote.BrowserWindow({
       webPreferences: {
         nodeIntegration: false,
-        partition: `persist:oauth2`
+        partition: `oauth2_${AUTH_WINDOW_SESSION_ID}`
       },
       show: false
     });


### PR DESCRIPTION
This change makes the OAuth 2.0 window start a separate session every time the app is launched. Ideally, there should be a button somewhere to clear the session explicitly, but this should be good enough for now.

Closes #168 