### PR TITLE
Allow wildcards in client certificate hosts

### DIFF
--- a/app/network/__tests__/certificate-url-parse.test.js
+++ b/app/network/__tests__/certificate-url-parse.test.js
@@ -1,0 +1,110 @@
+import certificateUrlParse from '../certificate-url-parse';
+import {parse as urlParse} from 'url';
+
+describe('certificateUrlParse', () => {
+  it('should return the result of url.parse if no wildcard paths are supplied', () => {
+    const url = 'https://www.example.org:80/some/resources?query=1&other=2#myfragment';
+    const expected = urlParse(url);
+    expect(certificateUrlParse(url)).toEqual(expected);
+  });
+
+  it('should return the correct hostname if a single wildcard is present', () => {
+    const protocol = 'https';
+    const host = 'www.exam*ple.org';
+    const port = '123';
+    const path = '/some/resources';
+    const query = 'query=1&other=2';
+    const fragment = 'myfragment';
+
+    const url = `${protocol}://${host}:${port}${path}?${query}#${fragment}`;
+    expect(certificateUrlParse(url).hostname).toEqual(host);
+  });
+
+  it('should return the correct hostname if multiple wildcards are present', () => {
+    const protocol = 'https';
+    const host = 'www.e*xamp*le.or*g';
+    const port = '123';
+    const path = '/some/resources';
+    const query = 'query=1&other=2';
+    const fragment = 'myfragment';
+
+    const url = `${protocol}://${host}:${port}${path}?${query}#${fragment}`;
+    expect(certificateUrlParse(url).hostname).toEqual(host);
+  });
+
+  it('should return the correct hostname if a wildcard prefix is present', () => {
+    const protocol = 'https';
+    const host = '*.example.org';
+    const port = '123';
+    const path = '/some/resources';
+    const query = 'query=1&other=2';
+    const fragment = 'myfragment';
+
+    const url = `${protocol}://${host}:${port}${path}?${query}#${fragment}`;
+    expect(certificateUrlParse(url).hostname).toEqual(host);
+  });
+
+  it('should return the correct hostname if a wildcard suffix is present', () => {
+    const protocol = 'https';
+    const host = 'www.example.*';
+    const port = '123';
+    const path = '/some/resources';
+    const query = 'query=1&other=2';
+    const fragment = 'myfragment';
+
+    const url = `${protocol}://${host}:${port}${path}?${query}#${fragment}`;
+    expect(certificateUrlParse(url).hostname).toEqual(host);
+  });
+
+  it('should return a host of null if no protocol is provided for a wildcard hostname', () => {
+    const host = 'www.example.*';
+    const path = '/some/resources';
+    const query = 'query=1&other=2';
+    const fragment = 'myfragment';
+
+    const url = `${host}${path}?${query}#${fragment}`;
+    expect(certificateUrlParse(url).hostname).toEqual(null);
+  });
+
+  it('should return the correct host if basic auth is included', () => {
+    const protocol = 'https';
+    const user = 'myuser';
+    const password = 'mypass';
+    const host = 'www.example.*';
+    const path = '/some/resources';
+    const query = 'query=1&other=2';
+    const fragment = 'myfragment';
+
+    const url = `${protocol}://${user}:${password}@${host}${path}?${query}#${fragment}`;
+    expect(certificateUrlParse(url).hostname).toEqual(host);
+  });
+
+  it('should return the correct host if the path contains an @ symbol', () => {
+    const protocol = 'https';
+    const host = 'www.example.*';
+    const path = '/@some/resources';
+    const query = 'query=1&other=2';
+    const fragment = 'myfragment';
+
+    const url = `${protocol}://${host}${path}?${query}#${fragment}`;
+    expect(certificateUrlParse(url).hostname).toEqual(host);
+  });
+
+  it('should return the correct non-hostname properties for wildcard paths', () => {
+    const protocol = 'https';
+    const user = 'myuser';
+    const password = 'mypass';
+    const nonWildcardHost = 'www.example.';
+    const host = 'www.example.*';
+    const port = '123';
+    const path = '/some/resources';
+    const query = 'query=1&other=2';
+    const fragment = 'myfragment';
+
+    const url = `${protocol}://${user}:${password}@${host}:${port}${path}?${query}#${fragment}`;
+    const nonWildcardUrl = `${protocol}://${user}:${password}@${nonWildcardHost}:${port}${path}?${query}#${fragment}`;
+    const expected = urlParse(nonWildcardUrl);
+    expected.hostname = host;
+    expect(certificateUrlParse(url)).toEqual(expected);
+  });
+});

--- a/app/network/__tests__/certificate-url-parse.test.js
+++ b/app/network/__tests__/certificate-url-parse.test.js
@@ -105,6 +105,8 @@ describe('certificateUrlParse', () => {
     const nonWildcardUrl = `${protocol}://${user}:${password}@${nonWildcardHost}:${port}${path}?${query}#${fragment}`;
     const expected = urlParse(nonWildcardUrl);
     expected.hostname = host;
+    expected.href = url;
+    expected.host = `${host}:${port}`;
     expect(certificateUrlParse(url)).toEqual(expected);
   });
 });

--- a/app/network/__tests__/url-matches-cert-host.test.js
+++ b/app/network/__tests__/url-matches-cert-host.test.js
@@ -1,0 +1,129 @@
+import urlMatchesCertHost from '../url-matches-cert-host';
+
+describe('urlMatchesCertHost', () => {
+  describe('when the certificate host has no wildcard', () => {
+    it('should return false if the requested host does not match the certificate host', () => {
+      const requestUrl = 'https://www.example.org';
+      const certificateHost = 'https://www.example.com';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(false);
+    });
+
+    it('should return true if the request URL and the certificate host exactly match', () => {
+      const requestUrl = 'https://www.example.org';
+      const certificateHost = 'https://www.example.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return true if the request URL has the same host as the certificate host and no ports are specified', () => {
+      const requestUrl = 'https://www.example.org/some/resources?query=1';
+      const certificateHost = 'https://www.example.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return true if the request URL has the same host and port as the certificate host', () => {
+      const requestUrl = 'https://www.example.org:1234/some/resources?query=1';
+      const certificateHost = 'https://www.example.org:1234';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return false if the request URL and certificate host have different ports', () => {
+      const requestUrl = 'https://www.example.org:1234/some/resources?query=1';
+      const certificateHost = 'https://www.example.org:123';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(false);
+    });
+
+    it('should return true if the request URL has a port of 443 and the certificate host has no port', () => {
+      const requestUrl = 'https://www.example.org:443/some/resources?query=1';
+      const certificateHost = 'https://www.example.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return true if the request URL has no port and the certificate host has a port of 443', () => {
+      const requestUrl = 'https://www.example.org/some/resources?query=1';
+      const certificateHost = 'https://www.example.org:443';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return true if the request URL is https and the certificate host has no protocol', () => {
+      const requestUrl = 'https://www.example.org/some/resources?query=1';
+      const certificateHost = 'https://www.example.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+  });
+
+  describe('when using wildcard certificate hosts', () => {
+    it('should return true if the request URL host matches a certificate host with a wildcard prefix', () => {
+      const requestUrl = 'https://my.example.org/some/resources?query=1';
+      const certificateHost = 'https://*.example.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return true if the request URL host matches a certificate host with a wildcard in a central position', () => {
+      const requestUrl = 'https://my.example.org/some/resources?query=1';
+      const certificateHost = 'https://my.*.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return true if the request URL host matches a certificate host with a wildcard suffix', () => {
+      const requestUrl = 'https://my.example.org/some/resources?query=1';
+      const certificateHost = 'https://my.example.*';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return true if the request URL host matches a certificate host with multiple wildcards', () => {
+      const requestUrl = 'https://my.example.stage.org/some/resources?query=1';
+      const certificateHost = 'https://*.example*.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return false if the request URL host does not match the certificate host', () => {
+      const requestUrl = 'https://my.example.com/some/resources?query=1';
+      const certificateHost = 'https://*.example.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(false);
+    });
+
+    it('should return false if the request URL and certificate host ports do not match', () => {
+      const requestUrl = 'https://my.example.org:123/some/resources?query=1';
+      const certificateHost = 'https://*.example.org:456';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(false);
+    });
+
+    it('should return true if the request URL has a port of 443 and the certificate host has no port', () => {
+      const requestUrl = 'https://www.example.org:443/some/resources?query=1';
+      const certificateHost = 'https://*.example.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return true if the request URL has no port and the certificate host has a port of 443', () => {
+      const requestUrl = 'https://www.example.org/some/resources?query=1';
+      const certificateHost = 'https://*.example.org:443';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return true if the request URL is https and the certificate host has no protocol', () => {
+      const requestUrl = 'https://www.example.org/some/resources?query=1';
+      const certificateHost = '*.example.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+  });
+
+  describe('when an invalid certificate host is supplied', () => {
+    it('should return false if the certificate host contains invalid characters', () => {
+      const requestUrl = 'https://www.example.org/some/resources?query=1';
+      const certificateHost = 'https://example!.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(false);
+    });
+
+    it('should return false if the certificate protocol contains invalid characters', () => {
+      const requestUrl = 'https://www.example.org/some/resources?query=1';
+      const certificateHost = 'https!://example.org';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(false);
+    });
+
+    it('should return false if the certificate host contains regular expression special characters', () => {
+      const requestUrl = 'https://www.example.org/some/resources?query=1';
+      const certificateHost = 'https://example.org?';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(false);
+    });
+  });
+});

--- a/app/network/__tests__/url-matches-cert-host.test.js
+++ b/app/network/__tests__/url-matches-cert-host.test.js
@@ -52,6 +52,12 @@ describe('urlMatchesCertHost', () => {
   });
 
   describe('when using wildcard certificate hosts', () => {
+    it('should return true if the certificate host is only a wildcard', () => {
+      const requestUrl = 'https://www.example.org/some/resources?query=1';
+      const certificateHost = '*';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
     it('should return true if the request URL host matches a certificate host with a wildcard prefix', () => {
       const requestUrl = 'https://my.example.org/some/resources?query=1';
       const certificateHost = 'https://*.example.org';

--- a/app/network/certificate-url-parse.js
+++ b/app/network/certificate-url-parse.js
@@ -1,0 +1,53 @@
+import {parse as urlParse} from 'url';
+const wildcardCharacter = '*';
+
+const certificateUrlParse = (url) => {
+  if (url.indexOf(wildcardCharacter) === -1) {
+    return urlParse(url);
+  } else {
+    const parsed = urlParse(url.replace(/\*/g, ''));
+
+    if (parsed.hostname !== null) {
+      const wildcardIndices = findIndices(url, wildcardCharacter);
+      parsed.hostname = insertAtIndices(parsed.hostname, wildcardIndices, wildcardCharacter);
+    }
+
+    return parsed;
+  }
+};
+
+const insertAtIndices = (string, indices, charToInsert) => {
+  const result = Array.from(string).reduce((acc, char, index) => {
+    if (indices.includes(acc.length)) {
+      return `${acc}${charToInsert}${char}`;
+    } else {
+      return `${acc}${char}`;
+    }
+  }, '');
+
+  if (indices.includes(result.length)) {
+    return `${result}${charToInsert}`;
+  } else {
+    return result;
+  }
+};
+
+const findIndices = (url, character) => {
+  const hostAndPath = removeProtocolAndAuth(url);
+  const indices = [];
+  for (let index = 0; index < hostAndPath.length; index++) {
+    if (hostAndPath[index] === character) {
+      indices.push(index);
+    }
+  }
+
+  return indices;
+};
+
+const removeProtocolAndAuth = (url) => {
+  const urlWithoutProtocol = url.split('://')[1] || '';
+  const {auth} = urlParse(url);
+  return urlWithoutProtocol.replace(`${auth}@`, '');
+};
+
+export default certificateUrlParse;

--- a/app/network/certificate-url-parse.js
+++ b/app/network/certificate-url-parse.js
@@ -1,15 +1,15 @@
 import {parse as urlParse} from 'url';
-const wildcardCharacter = '*';
+const WILDCARD_CHARACTER = '*';
 
 const certificateUrlParse = (url) => {
-  if (url.indexOf(wildcardCharacter) === -1) {
+  if (url.indexOf(WILDCARD_CHARACTER) === -1) {
     return urlParse(url);
   } else {
     const parsed = urlParse(url.replace(/\*/g, ''));
 
     if (parsed.hostname !== null) {
-      const wildcardIndices = findIndices(url, wildcardCharacter);
-      parsed.hostname = insertAtIndices(parsed.hostname, wildcardIndices, wildcardCharacter);
+      const wildcardIndices = findIndices(url, WILDCARD_CHARACTER);
+      parsed.hostname = insertAtIndices(parsed.hostname, wildcardIndices, WILDCARD_CHARACTER);
     }
 
     return parsed;

--- a/app/network/certificate-url-parse.js
+++ b/app/network/certificate-url-parse.js
@@ -1,7 +1,7 @@
 import {parse as urlParse} from 'url';
 const WILDCARD_CHARACTER = '*';
 
-const certificateUrlParse = (url) => {
+export default function certificateUrlParse (url) {
   if (url.indexOf(WILDCARD_CHARACTER) === -1) {
     return urlParse(url);
   } else {
@@ -14,7 +14,7 @@ const certificateUrlParse = (url) => {
 
     return parsed;
   }
-};
+}
 
 const insertAtIndices = (string, indices, charToInsert) => {
   const result = Array.from(string).reduce((acc, char, index) => {
@@ -49,5 +49,3 @@ const removeProtocolAndAuth = (url) => {
   const {auth} = urlParse(url);
   return urlWithoutProtocol.replace(`${auth}@`, '');
 };
-
-export default certificateUrlParse;

--- a/app/network/network.js
+++ b/app/network/network.js
@@ -15,7 +15,7 @@ import * as db from '../common/database';
 import * as CACerts from './cacert';
 import {getAuthHeader} from './authentication';
 import {cookiesFromJar, jarFromCookies} from '../common/cookies';
-import {urlMatchesCertHost} from './url-matches-cert-host';
+import urlMatchesCertHost from './url-matches-cert-host';
 
 let cancelRequestFunction = null;
 

--- a/app/network/network.js
+++ b/app/network/network.js
@@ -15,6 +15,7 @@ import * as db from '../common/database';
 import * as CACerts from './cacert';
 import {getAuthHeader} from './authentication';
 import {cookiesFromJar, jarFromCookies} from '../common/cookies';
+import {urlMatchesCertHost} from './url-matches-cert-host';
 
 let cancelRequestFunction = null;
 
@@ -242,14 +243,8 @@ export function _actuallySend (renderedRequest, workspace, settings) {
       // Set client certs if needed
       for (const certificate of workspace.certificates) {
         const cHostWithProtocol = setDefaultProtocol(certificate.host, 'https:');
-        const {hostname: cHostname, port: cPort} = urlParse(cHostWithProtocol);
-        const {hostname, port} = urlParse(renderedRequest.url);
 
-        const assumedPort = parseInt(port) || 443;
-        const assumedCPort = parseInt(cPort) || 443;
-
-        // Exact host match (includes port)
-        if (cHostname === hostname && assumedCPort === assumedPort) {
+        if (urlMatchesCertHost(cHostWithProtocol, renderedRequest.url)) {
           const ensureFile = blobOrFilename => {
             if (blobOrFilename.indexOf('/') === 0) {
               return blobOrFilename;

--- a/app/network/url-matches-cert-host.js
+++ b/app/network/url-matches-cert-host.js
@@ -2,15 +2,15 @@ import {parse as urlParse} from 'url';
 import certificateUrlParse from './certificate-url-parse';
 import {setDefaultProtocol} from '../common/misc';
 
-const defaultPort = 443;
+const DEFAULT_PORT = 443;
 
 const urlMatchesCertHost = (certificateHost, requestUrl) => {
   const cHostWithProtocol = setDefaultProtocol(certificateHost, 'https:');
   const {hostname, port} = urlParse(requestUrl);
   const {hostname: cHostname, port: cPort} = certificateUrlParse(cHostWithProtocol);
 
-  const assumedPort = parseInt(port) || defaultPort;
-  const assumedCPort = parseInt(cPort) || defaultPort;
+  const assumedPort = parseInt(port) || DEFAULT_PORT;
+  const assumedCPort = parseInt(cPort) || DEFAULT_PORT;
 
   const cHostnameRegex = (cHostname || '').replace(/([.+?^=!:${}()|[\]/\\])/g, '\\$1')
                                           .replace(/\*/g, '.*');

--- a/app/network/url-matches-cert-host.js
+++ b/app/network/url-matches-cert-host.js
@@ -4,7 +4,7 @@ import {setDefaultProtocol} from '../common/misc';
 
 const DEFAULT_PORT = 443;
 
-const urlMatchesCertHost = (certificateHost, requestUrl) => {
+export default function urlMatchesCertHost (certificateHost, requestUrl) {
   const cHostWithProtocol = setDefaultProtocol(certificateHost, 'https:');
   const {hostname, port} = urlParse(requestUrl);
   const {hostname: cHostname, port: cPort} = certificateUrlParse(cHostWithProtocol);
@@ -16,6 +16,4 @@ const urlMatchesCertHost = (certificateHost, requestUrl) => {
                                           .replace(/\*/g, '.*');
 
   return (assumedCPort === assumedPort && !!hostname.match(`^${cHostnameRegex}$`));
-};
-
-export default urlMatchesCertHost;
+}

--- a/app/network/url-matches-cert-host.js
+++ b/app/network/url-matches-cert-host.js
@@ -1,0 +1,21 @@
+import {parse as urlParse} from 'url';
+import certificateUrlParse from './certificate-url-parse';
+import {setDefaultProtocol} from '../common/misc';
+
+const defaultPort = 443;
+
+const urlMatchesCertHost = (certificateHost, requestUrl) => {
+  const cHostWithProtocol = setDefaultProtocol(certificateHost, 'https:');
+  const {hostname, port} = urlParse(requestUrl);
+  const {hostname: cHostname, port: cPort} = certificateUrlParse(cHostWithProtocol);
+
+  const assumedPort = parseInt(port) || defaultPort;
+  const assumedCPort = parseInt(cPort) || defaultPort;
+
+  const cHostnameRegex = (cHostname || '').replace(/([.+?^=!:${}()|[\]/\\])/g, '\\$1')
+                                          .replace(/\*/g, '.*');
+
+  return (assumedCPort === assumedPort && !!hostname.match(`^${cHostnameRegex}$`));
+};
+
+export default urlMatchesCertHost;

--- a/app/ui/components/modals/workspace-settings-modal.js
+++ b/app/ui/components/modals/workspace-settings-modal.js
@@ -6,6 +6,7 @@ import FileInputButton from '../base/file-input-button';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
+import HelpTooltip from '../help-tooltip';
 import PromptButton from '../base/prompt-button';
 import * as models from '../../../models/index';
 import {trackEvent} from '../../../analytics/index';
@@ -285,7 +286,11 @@ class WorkspaceSettingsModal extends PureComponent {
             ) : (
               <form onSubmit={this._handleSubmitCertificate}>
                 <div className="form-control form-control--outlined no-pad-top">
-                  <label>Host <span className="faint">(port optional)</span>
+                  <label>Host
+                    <HelpTooltip position="right" className="space-left">
+                      The host for which this client certificate is valid.
+                      Port number is optional and * can be used as a wildcard.
+                    </HelpTooltip>
                     <input
                       type="text"
                       required="required"


### PR DESCRIPTION
## What

* Allow users to specify wildcards using `*` in certificate hosts.
* Wildcards can be added anywhere in the host string and multiple wildcards are supported.

## Why

Many organisations, including my own, use the same client certificate to authenticate against different deployments of the same API with altered host names (e.g `myservice.test.example.org`, `myservice.stage.example.org` and `myservice.example.org`). Allowing wildcards in the certificate host definition means that just one entry can be made for the certificate instead of three.

## Details

* When the user enters a client certificate host they can include wildcards using `*`.

## Notes

I've extracted the certificate matching logic into two files. I decided to keep their tests in separate files as well since there needed to be quite a lot of scenarios to cover all of the different conditions. Feel free to move them elsewhere if that's more in keeping with the style of the project.

One pain in doing this was that Node's `url.parse` function doesn't work when you have special characters in the host name (which isn't too surprising since the URL is invalid). For example:

```javascript
const url = require('url');
url.parse('https://myservice*.example.com');
Url {
  protocol: 'https:',
  slashes: true,
  auth: null,
  host: 'myservice',
  port: null,
  hostname: 'myservice',
  hash: null,
  search: null,
  query: null,
  pathname: '/*.example.com',
  path: '/*.example.com',
  href: 'https://myservice/*.example.com' }
```

This made the implementation significantly more complex than it would otherwise have been. I've tried to make it very fault-tolerant so it doesn't throw errors if bad certificate hosts are entered.

This change should be documented as well - can someone point me to where that should be done please?

Also, I couldn't test it using `npm run-script dev` because I kept getting a `NODE_MODULES_VERSION` issue with electron:

> node_libcurl.node was compiled against a different Node.js version using NODE_MODULE_VERSION 51. This version of Node.js requires NODE_MODULE_VERSION 53.

Any tips? I've not worked with electron before so any pointers would be great.

**Related Issue**:  #243 

