### PR TITLE
Always include equals signs in x-www-form-urlencoded bodies

### DIFF
--- a/app/network/__tests__/network.test.js
+++ b/app/network/__tests__/network.test.js
@@ -90,6 +90,55 @@ describe('actuallySend()', () => {
     });
   });
 
+  it('sends a urlencoded', async () => {
+    const workspace = await models.workspace.create();
+    const settings = await models.settings.create();
+    const request = Object.assign(models.request.init(), {
+      _id: 'req_123',
+      parentId: workspace._id,
+      headers: [{name: 'Content-Type', value: CONTENT_TYPE_FORM_URLENCODED}],
+      method: 'POST',
+      body: {
+        mimeType: CONTENT_TYPE_FORM_URLENCODED,
+        params: [
+          {name: 'foo', value: 'bar'},
+          {name: 'bar', value: ''},
+          {name: '', value: 'value'}
+        ]
+      },
+      url: 'http://localhost'
+    });
+
+    const renderedRequest = await getRenderedRequest(request);
+    const response = await networkUtils._actuallySend(
+      renderedRequest,
+      workspace,
+      settings
+    );
+
+    const body = JSON.parse(Buffer.from(response.body, 'base64'));
+    expect(body).toEqual({
+      options: {
+        CUSTOMREQUEST: 'POST',
+        ACCEPT_ENCODING: '',
+        NOBODY: 0,
+        FOLLOWLOCATION: true,
+        HTTPHEADER: [
+          'Content-Type: application/x-www-form-urlencoded',
+          'Expect: ',
+          'Transfer-Encoding: '
+        ],
+        NOPROGRESS: false,
+        POSTFIELDS: 'foo=bar&bar=&=value',
+        PROXY: '',
+        TIMEOUT_MS: 0,
+        URL: 'http://localhost/',
+        USERAGENT: `insomnia/${getAppVersion()}`,
+        VERBOSE: true
+      }
+    });
+  });
+
   it('skips sending and storing cookies with setting', async () => {
     const workspace = await models.workspace.create();
     const settings = await models.settings.create();

--- a/app/network/network.js
+++ b/app/network/network.js
@@ -297,7 +297,7 @@ export function _actuallySend (renderedRequest, workspace, settings) {
       let noBody = false;
       const expectsBody = ['POST', 'PUT', 'PATCH'].includes(renderedRequest.method.toUpperCase());
       if (renderedRequest.body.mimeType === CONTENT_TYPE_FORM_URLENCODED) {
-        const d = querystring.buildFromParams(renderedRequest.body.params || [], true);
+        const d = querystring.buildFromParams(renderedRequest.body.params || [], false);
         setOpt(Curl.option.POSTFIELDS, d); // Send raw data
       } else if (renderedRequest.body.mimeType === CONTENT_TYPE_FORM_DATA) {
         const data = renderedRequest.body.params.map(param => {


### PR DESCRIPTION
## What

Previously, equals signs in `x-www-form-urlencoded` bodies were being treated the same as in the querystring (optional if no value). This change alters this behavior and always includes equals signs in request bodies no matter what.

For example:

```javascript
{name: "foo", value: "bar"} // foo=bar
{name: "foo", value: ""} // foo=
```

Closes #264 