### PR TITLE
Add setting to disable analytics tracking

### DIFF
--- a/app/analytics/index.js
+++ b/app/analytics/index.js
@@ -1,9 +1,17 @@
 import * as google from './google';
+import * as models from '../models';
 import {ipcRenderer} from 'electron';
 import {getAppVersion, getAppPlatform} from '../common/constants';
 
 let initialized = false;
 export async function init (accountId) {
+  const settings = await models.settings.getOrCreate();
+
+  if (settings.disableAnalyticsTracking) {
+    console.log(`[ga] Not initializing due to user settings`);
+    return;
+  }
+
   if (initialized) {
     return;
   }

--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -13,6 +13,7 @@ export function init () {
     editorFontSize: 11,
     editorIndentSize: 2,
     editorLineWrapping: true,
+    disableAnalyticsTracking: false,
     editorKeyMap: 'default',
     httpProxy: '',
     httpsProxy: '',

--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -13,7 +13,6 @@ export function init () {
     editorFontSize: 11,
     editorIndentSize: 2,
     editorLineWrapping: true,
-    disableAnalyticsTracking: false,
     editorKeyMap: 'default',
     httpProxy: '',
     httpsProxy: '',
@@ -22,7 +21,8 @@ export function init () {
     validateSSL: true,
     forceVerticalLayout: false,
     autoHideMenuBar: false,
-    theme: 'default'
+    theme: 'default',
+    disableAnalyticsTracking: false
   };
 }
 

--- a/app/ui/components/settings/general.js
+++ b/app/ui/components/settings/general.js
@@ -89,6 +89,15 @@ class General extends PureComponent {
           </label>
         </div>
 
+        <div className="form-control form-control--thin">
+          <label className="inline-block">Disable Analytics Tracking (requires restart)
+            <input type="checkbox"
+                   name="disableAnalyticsTracking"
+                   checked={settings.disableAnalyticsTracking}
+                   onChange={this._handleUpdateSetting}/>
+          </label>
+        </div>
+
         <div className="form-row">
           <div className="form-control form-control--outlined pad-top-sm">
             <label>Text Editor Font Size (px)


### PR DESCRIPTION
Closes #146

## What
Added functionality to disable Google Analytics tracking.

## Why
Respect the privacy of users that do not want analytical information of their usage collected.

## Details
- Added a setting to the preference/settings modal 
- Added a disableAnalyticsTracking to the settings model
- If disableAnalyticsTracking is true, it will not complete the analytics initialization function

## Notes
- An application restart would be required when disableAnalyticsTracking is changed. I don't see any added value of initializing or destroying the analytics tracking with the application running, and, follows most applications do (eg. Google Chrome). 

- trackEvent will still produce a console log when called, however, no request to Google Analytics is made

**Related Issue**: #146 