### PR TITLE
Markdown header styles and sanitize HTML

### DIFF
--- a/app/ui/components/markdown-editor.js
+++ b/app/ui/components/markdown-editor.js
@@ -79,6 +79,7 @@ class MarkdownEditor extends PureComponent {
       tables: true,
       breaks: false,
       pedantic: false,
+      sanitize: true,
       smartLists: true,
       smartypants: false
     });

--- a/app/ui/css/components/markdown-editor.less
+++ b/app/ui/css/components/markdown-editor.less
@@ -30,6 +30,37 @@
 
       h1 {
         font-size: @font-size-xxl;
+        border-bottom: 1px solid var(--hl-sm);
+        font-weight: bold;
+      }
+
+      h2 {
+        font-size: @font-size-xl;
+        border-bottom: 1px solid var(--hl-sm);
+        font-weight: bold;
+      }
+
+      h3 {
+        font-size: @font-size-lg;
+        font-weight: bold;
+      }
+
+      h4 {
+        font-size: @font-size-md;
+        font-weight: bold;
+        opacity: 0.9;
+      }
+
+      h5 {
+        font-size: @font-size-sm;
+        font-weight: bold;
+        opacity: 0.9;
+      }
+
+      h6 {
+        font-size: @font-size-sm;
+        font-weight: bold;
+        opacity: 0.8;
       }
 
       & > * {


### PR DESCRIPTION
This is a fix for the "bug" mentioned in https://github.com/getinsomnia/insomnia/pull/279#issuecomment-306885151

This change adds more styles for h[1-6] tags, and also disables HTML inside Markdown. 

![image](https://user-images.githubusercontent.com/587576/26895387-48591030-4b76-11e7-856b-5dd3304dfd6a.png)

![image](https://user-images.githubusercontent.com/587576/26895392-4e7f4132-4b76-11e7-813d-e5181a6c43eb.png)