### PR TITLE
Track and display response filter history

### DIFF
--- a/app/models/request-meta.js
+++ b/app/models/request-meta.js
@@ -11,6 +11,7 @@ export function init () {
     parentId: null,
     previewMode: PREVIEW_MODE_FRIENDLY,
     responseFilter: '',
+    responseFilterHistory: [],
     activeResponseId: null
   };
 }

--- a/app/ui/components/response-pane.js
+++ b/app/ui/components/response-pane.js
@@ -148,6 +148,7 @@ class ResponsePane extends PureComponent {
       editorIndentSize,
       editorKeyMap,
       filter,
+      filterHistory,
       activeResponseId,
       showCookiesModal
     } = this.props;
@@ -276,6 +277,7 @@ class ResponsePane extends PureComponent {
               previewMode={response.error ? PREVIEW_MODE_SOURCE : previewMode}
               statusCode={response.statusCode}
               filter={filter}
+              filterHistory={filterHistory}
               updateFilter={response.error ? null : handleSetFilter}
               body={response.error ? response.error : response.body}
               encoding={response.encoding}
@@ -341,6 +343,7 @@ ResponsePane.propTypes = {
   // Required
   previewMode: PropTypes.string.isRequired,
   filter: PropTypes.string.isRequired,
+  filterHistory: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   editorFontSize: PropTypes.number.isRequired,
   editorIndentSize: PropTypes.number.isRequired,
   editorKeyMap: PropTypes.string.isRequired,

--- a/app/ui/components/viewers/response-viewer.js
+++ b/app/ui/components/viewers/response-viewer.js
@@ -73,6 +73,7 @@ class ResponseViewer extends PureComponent {
     const {
       previewMode,
       filter,
+      filterHistory,
       contentType,
       editorLineWrapping,
       editorFontSize,
@@ -181,6 +182,7 @@ class ResponseViewer extends PureComponent {
           defaultValue={body}
           updateFilter={updateFilter}
           filter={filter}
+          filterHistory={filterHistory}
           autoPrettify
           noMatchBrackets
           readOnly
@@ -201,6 +203,7 @@ ResponseViewer.propTypes = {
   encoding: PropTypes.string.isRequired,
   previewMode: PropTypes.string.isRequired,
   filter: PropTypes.string.isRequired,
+  filterHistory: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   editorFontSize: PropTypes.number.isRequired,
   editorIndentSize: PropTypes.number.isRequired,
   editorKeyMap: PropTypes.string.isRequired,

--- a/app/ui/components/wrapper.js
+++ b/app/ui/components/wrapper.js
@@ -256,6 +256,7 @@ class Wrapper extends PureComponent {
       paneWidth,
       paneHeight,
       responseFilter,
+      responseFilterHistory,
       responsePreviewMode,
       oAuth2Token,
       settings,
@@ -368,6 +369,7 @@ class Wrapper extends PureComponent {
           previewMode={responsePreviewMode}
           activeResponseId={activeResponseId}
           filter={responseFilter}
+          filterHistory={responseFilterHistory}
           loadStartTime={loadStartTime}
           showCookiesModal={this._handleShowCookiesModal}
           handleShowRequestSettings={this._handleShowRequestSettingsModal}
@@ -524,6 +526,7 @@ Wrapper.propTypes = {
   paneHeight: PropTypes.number.isRequired,
   responsePreviewMode: PropTypes.string.isRequired,
   responseFilter: PropTypes.string.isRequired,
+  responseFilterHistory: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   activeResponseId: PropTypes.string.isRequired,
   sidebarWidth: PropTypes.number.isRequired,
   sidebarHidden: PropTypes.bool.isRequired,


### PR DESCRIPTION
Closes #273 

## What

This PR adds a persistent response filter history and allows the user to select a previous item.

- [x] Add `responseFilterHistory` field to `RequestMeta` model
- [x] Show history items as dropdown beside filter input
- [x] Persist last `10` history items
- [x] Debounce persistence by `2 seconds` so we don't store too often

![image](https://user-images.githubusercontent.com/587576/26907851-6d08e880-4bab-11e7-94ba-01691b5cdc57.png)
