### PR TITLE
Implement custom window titlebar to match theme

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -20,7 +20,7 @@ function addUrlToOpen (e, url) {
   args.push(url);
 }
 
-const {app, ipcMain} = electron;
+const {app, ipcMain, BrowserWindow, systemPreferences} = electron;
 
 const args = process.argv.slice(1);
 
@@ -77,4 +77,27 @@ app.on('ready', () => {
       window.focus();
     }, 100);
   });
+});
+
+ipcMain.on('double-click-titlebar', e => {
+  const window = BrowserWindow.getFocusedWindow();
+
+  if (!window) {
+    return;
+  }
+
+  const action = systemPreferences.getUserDefault(
+    'AppleActionOnDoubleClick',
+    'string'
+  );
+
+  if (action === 'Maximize') {
+    if (window.isMaximized()) {
+      window.unmaximize();
+    } else {
+      window.maximize();
+    }
+  } else if (action === 'Minimize') {
+    window.minimize();
+  }
 });

--- a/app/main/window-utils.js
+++ b/app/main/window-utils.js
@@ -37,7 +37,8 @@ export function createWindow () {
     fullscreen: fullscreen,
     fullscreenable: true,
     title: getAppName(),
-    titleBarStyle: 'hidden',
+    titleBarStyle: isMac() ? 'hidden' : null,
+    frame: isMac(),
     width: width || 1200,
     height: height || 600,
     minHeight: 500,
@@ -152,7 +153,9 @@ export function createWindow () {
           }
 
           const zoomFactor = 1;
-          window.webContents.setZoomFactor(zoomFactor);
+          for (const window of BrowserWindow.getAllWindows()) {
+            window.send('set-zoom', zoomFactor);
+          }
           saveZoomFactor(zoomFactor);
           trackEvent('App Menu', 'Zoom Reset');
         }
@@ -167,7 +170,9 @@ export function createWindow () {
           }
 
           const zoomFactor = Math.min(1.8, getZoomFactor() + 0.05);
-          window.webContents.setZoomFactor(zoomFactor);
+          for (const window of BrowserWindow.getAllWindows()) {
+            window.send('set-zoom', zoomFactor);
+          }
 
           saveZoomFactor(zoomFactor);
           trackEvent('App Menu', 'Zoom In');
@@ -183,7 +188,9 @@ export function createWindow () {
           }
 
           const zoomFactor = Math.max(0.5, getZoomFactor() - 0.05);
-          window.webContents.setZoomFactor(zoomFactor);
+          for (const window of BrowserWindow.getAllWindows()) {
+            window.send('set-zoom', zoomFactor);
+          }
           saveZoomFactor(zoomFactor);
           trackEvent('App Menu', 'Zoom Out');
         }

--- a/app/main/window-utils.js
+++ b/app/main/window-utils.js
@@ -37,6 +37,7 @@ export function createWindow () {
     fullscreen: fullscreen,
     fullscreenable: true,
     title: getAppName(),
+    titleBarStyle: 'hidden',
     width: width || 1200,
     height: height || 600,
     minHeight: 500,

--- a/app/renderer.html
+++ b/app/renderer.html
@@ -5,6 +5,7 @@
   <title>Insomnia</title>
 </head>
 <body>
+<div id="titlebar" class="theme--titlebar"></div>
 <div id="root"></div>
 <script>
   // HOT RELOADING IN DEV
@@ -23,6 +24,30 @@
       document.querySelector('#root').innerHTML = `<p>${msg}</p>`;
     }
   }());
+</script>
+<script>
+  (function () {
+    const titleElement = document.querySelector('title');
+    const titleBarElement = document.querySelector('#titlebar');
+
+    document.documentElement.addEventListener('DOMSubtreeModified', e => {
+      if (e.target !== titleElement) {
+        return;
+      }
+
+      const title = e.target.innerHTML;
+      if (title === titleBarElement.innerHTML) {
+        return;
+      }
+
+      titleBarElement.innerHTML = e.target.innerHTML;
+    });
+
+    titleBarElement.addEventListener('dblclick', e => {
+      const {ipcRenderer} = require('electron');
+      ipcRenderer.send('double-click-titlebar');
+    });
+  })();
 </script>
 <script>
   // UPDATE HANDLERS

--- a/app/renderer.html
+++ b/app/renderer.html
@@ -75,6 +75,12 @@
   })();
 </script>
 <script>
+  const {ipcRenderer} = require('electron');
+  ipcRenderer.on('set-zoom', (_, zoom) => {
+    document.querySelector('#root').style.zoom = zoom;
+  });
+</script>
+<script>
   (function () {
     const {productName, version} = require('./package.json');
     if (process.env.INSOMNIA_ENV === 'development') {

--- a/app/renderer.html
+++ b/app/renderer.html
@@ -5,7 +5,9 @@
   <title>Insomnia</title>
 </head>
 <body>
-<div id="titlebar" class="theme--titlebar"></div>
+<div class="titlebar theme--titlebar">
+  <span class="titlebar__inner"></span>
+</div>
 <div id="root"></div>
 <script>
   // HOT RELOADING IN DEV
@@ -28,7 +30,8 @@
 <script>
   (function () {
     const titleElement = document.querySelector('title');
-    const titleBarElement = document.querySelector('#titlebar');
+    const titleBarElement = document.querySelector('.titlebar');
+    const titleBarInnerElement = document.querySelector('.titlebar__inner');
 
     document.documentElement.addEventListener('DOMSubtreeModified', e => {
       if (e.target !== titleElement) {
@@ -36,11 +39,11 @@
       }
 
       const title = e.target.innerHTML;
-      if (title === titleBarElement.innerHTML) {
+      if (title === titleBarInnerElement.innerHTML) {
         return;
       }
 
-      titleBarElement.innerHTML = e.target.innerHTML;
+      titleBarInnerElement.innerHTML = e.target.innerHTML;
     });
 
     titleBarElement.addEventListener('dblclick', e => {

--- a/app/ui/components/sidebar/sidebar.js
+++ b/app/ui/components/sidebar/sidebar.js
@@ -53,13 +53,13 @@ class Sidebar extends PureComponent {
     } = this.props;
 
     return (
-      <aside className={classnames('sidebar', {
+      <aside className={classnames('sidebar', 'theme--sidebar', {
         'sidebar--hidden': hidden,
         'sidebar--skinny': width < SIDEBAR_SKINNY_REMS,
         'sidebar--collapsed': width < COLLAPSE_SIDEBAR_REMS
       })}>
         <WorkspaceDropdown
-          className="sidebar__header"
+          className="sidebar__header theme--sidebar__header"
           activeWorkspace={workspace}
           workspaces={workspaces}
           handleExportFile={handleExportFile}

--- a/app/ui/css/components/dropdown.less
+++ b/app/ui/css/components/dropdown.less
@@ -18,7 +18,7 @@
     display: none;
     left: 0;
     right: 0;
-    top: 0;
+    top: 22px;
     bottom: 0;
     content: ' ';
   }

--- a/app/ui/css/components/modal.less
+++ b/app/ui/css/components/modal.less
@@ -24,7 +24,7 @@
 
   .modal__backdrop {
     position: fixed;
-    top: 0;
+    top: 22px;
     left: 0;
     right: 0;
     bottom: 0;

--- a/app/ui/css/components/pane.less
+++ b/app/ui/css/components/pane.less
@@ -19,7 +19,6 @@
 
     border-left: 1px solid @hl-md;
     border-bottom: 1px solid @hl-md;
-    border-top: 1px solid @hl-md;
 
     .pane__header__right {
       box-shadow: -@padding-md 0 @padding-md -@padding-sm var(--color-bg);
@@ -62,8 +61,4 @@
       }
     }
   }
-}
-
-body[data-platform="win32"] .pane .pane__header {
-  border-top: 1px solid @hl-md;
 }

--- a/app/ui/css/components/sidebar.less
+++ b/app/ui/css/components/sidebar.less
@@ -33,7 +33,6 @@
   // ~~~~~~~~~~~~~~ //
 
   .sidebar__header {
-    border-top: 1px solid @hl-md;
     border-bottom: 1px solid @hl-md;
     box-sizing: border-box;
     background-color: var(--color-bg);

--- a/app/ui/css/components/wrapper.less
+++ b/app/ui/css/components/wrapper.less
@@ -72,7 +72,7 @@
     grid-column-end: span 3;
     grid-row-start: 3;
     grid-row-end: span 1;
-    //z-index: 2; // So it covers the URL Bar and stuff
+    border-top: 1px solid @hl-md;
   }
 
   .drag--pane-horizontal {

--- a/app/ui/css/constants/colors.less
+++ b/app/ui/css/constants/colors.less
@@ -27,10 +27,18 @@ body {
   // Default Colors
   --color-bg: #fff;
   --color-font: #555;
+  --color-border: var(--hl-md);
+  --border-width: 1px;
 
   .overlay {
     --color-bg: rgba(30, 30, 30, 0.8);
     --color-font: #ddd;
+  }
+
+  .theme--titlebar {
+    --color-bg: #e4e4e4;
+    --color-font: #444;
+    --border-width: 0;
   }
 }
 
@@ -50,7 +58,7 @@ body {
   --color-surprise: #7461bd;
   --color-info: #1c90b4;
 
-  .sidebar,
+  .theme--sidebar,
   .pane__body {
     --color-success: #8ccf3b;
     --color-notice: #ead950;
@@ -71,7 +79,7 @@ body {
     --color-info: #22c1ee;
   }
 
-  .sidebar__header {
+  .theme--sidebar__header {
     --color-bg: #695eb8;
     --color-font: #fff;
   }
@@ -88,7 +96,7 @@ body {
     --color-font: #444;
   }
 
-  .sidebar {
+  .theme--sidebar {
     --color-bg: #2e2f2b;
     --color-font: #e0e0e0;
     --hl: #999;
@@ -131,7 +139,7 @@ body {
     border-left: 0;
   }
 
-  .sidebar {
+  .theme--sidebar {
     --color-success: #a9ea6e;
     --color-notice: #ffdb02;
     --color-warning: #ffac49;
@@ -156,7 +164,7 @@ body {
     --hl-sm: rgba(240, 235, 255, 0.3);
   }
 
-  .sidebar__header {
+  .theme--sidebar__header {
     --color-font: #eee;
   }
 
@@ -183,8 +191,13 @@ body {
   --color-surprise: #9886ff;
   --color-info: #22c1ee;
 
-  --color-bg: #232421;
-  --color-font: #ddd;
+  &,
+  .theme--titlebar {
+    --color-bg: #232421;
+    --color-font: #ddd;
+    --color-border: var(--hl-md);
+    --border-width: 1px;
+  }
 
   --hl-xxs: rgba(120, 120, 120, 0.05);
   --hl-xs: rgba(120, 120, 120, 0.1);
@@ -213,7 +226,7 @@ body {
     --color-bg: #282925;
   }
 
-  .sidebar__header {
+  .theme--sidebar__header {
     --color-font: #ccc;
   }
 
@@ -268,6 +281,12 @@ body {
   --hl-xl: rgba(142, 149, 146, 0.8);
   --hl: rgb(142, 149, 146);
 
+  .theme--titlebar {
+    --color-bg: #fdf6e3;
+    --color-font: #657b83;
+    --border-width: 1px;
+  }
+
   .overlay {
     --color-bg: rgba(238, 231, 213, 0.8);
     --color-font: #657b83;
@@ -297,6 +316,12 @@ body {
   --hl-lg: rgba(91, 118, 133, 0.6);
   --hl-xl: rgba(91, 118, 133, 0.8);
   --hl: rgb(91, 118, 133);
+
+  .theme--titlebar {
+    --color-bg: #002b36;
+    --color-font: #8ea0a2;
+    --border-width: 1px;
+  }
 
   .overlay {
     --color-bg: rgba(0, 31, 41, 0.8);
@@ -350,7 +375,7 @@ body {
   .ReactTabs > *,
   .pane > *,
   .modal,
-  .sidebar {
+  .theme--sidebar {
     --hl-xxs: rgba(114, 145, 143, 0.0);
     --hl-xs: rgba(114, 145, 143, 0.0);
     --hl-sm: rgba(114, 145, 143, 0.0);
@@ -360,21 +385,25 @@ body {
     --hl: rgb(125, 153, 151);
   }
 
-  .sidebar {
+  .theme--titlebar,
+  .theme--sidebar {
     --color-bg: #1f2b31;
+    --color-border: var(--hl-sm);
+    --color-font: #dde1e1;
+    --border-width: 1px;
   }
 
   input,
   textarea,
   table,
-  .sidebar__item,
+  .theme--sidebar__item,
   .btn,
   .tag,
   .dropdown__menu,
   .CodeMirror,
   .pane__body,
   .modal__header,
-  .sidebar__header,
+  .theme--sidebar__header,
   .form-control {
     --hl-xxs: rgba(114, 145, 143, 0.05);
     --hl-xs: rgba(114, 145, 143, 0.08);
@@ -434,11 +463,12 @@ body {
     --color-bg: #faf4e0;
   }
 
-  .sidebar__header {
+  .theme--sidebar__header {
     --color-bg: #073440;
   }
 
-  .sidebar {
+  .theme--titlebar,
+  .theme--sidebar {
     --color-bg: #073642;
     --color-font: #8ea0a2;
 
@@ -451,6 +481,9 @@ body {
     --hl: rgb(98, 127, 143);
   }
 
+  .theme--titlebar {
+    --border-width: 1px;
+  }
 }
 
 *[theme="railscasts"] {
@@ -471,6 +504,12 @@ body {
   --hl-lg: rgba(120, 120, 120, 0.4);
   --hl-xl: rgba(120, 120, 120, 0.7);
   --hl: rgba(130, 130, 130, 1);
+
+  .theme--titlebar {
+    --color-bg: #2b2b2b;
+    --color-font: #e1deda;
+    --border-width: 1px;
+  }
 
   .overlay {
     --color-bg: rgba(30, 30, 30, 0.8);

--- a/app/ui/css/constants/colors.less
+++ b/app/ui/css/constants/colors.less
@@ -385,12 +385,16 @@ body {
     --hl: rgb(125, 153, 151);
   }
 
-  .theme--titlebar,
+  .theme--titlebar {
+    --color-bg: #263238;
+    --color-font: #dde1e1;
+    --color-border: var(--hl-sm);
+    --border-width: 1px;
+  }
+
   .theme--sidebar {
     --color-bg: #1f2b31;
-    --color-border: var(--hl-sm);
     --color-font: #dde1e1;
-    --border-width: 1px;
   }
 
   input,
@@ -467,7 +471,6 @@ body {
     --color-bg: #073440;
   }
 
-  .theme--titlebar,
   .theme--sidebar {
     --color-bg: #073642;
     --color-font: #8ea0a2;
@@ -479,10 +482,6 @@ body {
     --hl-lg: rgba(91, 127, 143, 0.6);
     --hl-xl: rgba(91, 127, 143, 0.8);
     --hl: rgb(98, 127, 143);
-  }
-
-  .theme--titlebar {
-    --border-width: 1px;
   }
 }
 

--- a/app/ui/css/layout/base.less
+++ b/app/ui/css/layout/base.less
@@ -19,6 +19,28 @@ html, h1, h2, h3, h4, h5, h6, input {
 body {
   margin: 0;
   padding: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100%;
+}
+
+#titlebar {
+  font-family: Helvetica, sans-serif !important;
+  font-size: 13.5px;
+  -webkit-user-select: none;
+  -webkit-app-region: drag;
+  cursor: default;
+  height: 22px;
+  width: 100%;
+  background: var(--color-bg);
+  color: var(--color-font);
+  box-shadow: inset 0 -10px 25px -5px rgba(0, 0, 0, 0.2);
+  border-bottom: var(--border-width) solid var(--color-border);
+  margin: 0;
+  display: grid;
+  text-align: center;
+  align-content: center;
+  position: relative;
 }
 
 h1 {

--- a/app/ui/css/layout/base.less
+++ b/app/ui/css/layout/base.less
@@ -24,7 +24,7 @@ body {
   height: 100%;
 }
 
-#titlebar {
+.titlebar {
   font-family: Helvetica, sans-serif !important;
   font-size: 13.5px;
   -webkit-user-select: none;
@@ -41,6 +41,10 @@ body {
   text-align: center;
   align-content: center;
   position: relative;
+
+  .titlebar__inner {
+    opacity: 0.9;
+  }
 }
 
 h1 {

--- a/app/ui/css/layout/base.less
+++ b/app/ui/css/layout/base.less
@@ -34,7 +34,6 @@ body {
   width: 100%;
   background: var(--color-bg);
   color: var(--color-font);
-  box-shadow: inset 0 -10px 25px -5px rgba(0, 0, 0, 0.2);
   border-bottom: var(--border-width) solid var(--color-border);
   margin: 0;
   display: grid;
@@ -45,6 +44,10 @@ body {
   .titlebar__inner {
     opacity: 0.9;
   }
+}
+
+body[data-platform="darwin"] .titlebar {
+  box-shadow: inset 0 -10px 25px -5px rgba(0, 0, 0, 0.2);
 }
 
 h1 {


### PR DESCRIPTION
Closes #314

## What

This PR adds custom titlebar to app windows. This is so Insomnia can change its titlebar color to match the current theme.

- [x] Disable default titlebar 
- [x] [Mac] Add drag and double-click behaviour handling
- [x] Make titlebar text not selectable
- [x] Change zoom implementation to use CSS instead of global zoom (prevents titlebar from being affected)
- [ ] [Windows] Add window control buttons with logic
- [ ] [Windows] Do something about the application menu under the title bar
- [ ] Test custom titlebar on all platforms
  - [ ] Mac
  - [ ] Windows
  - [ ] Linux

### Color Choice

By default, the color of the titlebar will match the theme's sidebar colors.

![image](https://user-images.githubusercontent.com/587576/27159393-8210a59e-5121-11e7-8f8b-edc980f8459c.png)

Some themes don't look good with themed titlebar color, so give those a "default" feel.

![image](https://user-images.githubusercontent.com/587576/27159395-8710c538-5121-11e7-8fa8-0a4ae7d9f40b.png)
