### PR TITLE
Set cookies on 30X redirects now

### DIFF
--- a/app/network/__tests__/network.test.js
+++ b/app/network/__tests__/network.test.js
@@ -70,6 +70,7 @@ describe('actuallySend()', () => {
         ],
         CUSTOMREQUEST: 'POST',
         ACCEPT_ENCODING: '',
+        COOKIEFILE: '',
         NOBODY: 0,
         FOLLOWLOCATION: true,
         HTTPHEADER: [
@@ -121,6 +122,7 @@ describe('actuallySend()', () => {
       options: {
         CUSTOMREQUEST: 'POST',
         ACCEPT_ENCODING: '',
+        COOKIEFILE: '',
         NOBODY: 0,
         FOLLOWLOCATION: true,
         HTTPHEADER: [
@@ -253,6 +255,7 @@ describe('actuallySend()', () => {
       options: {
         CUSTOMREQUEST: 'POST',
         ACCEPT_ENCODING: '',
+        COOKIEFILE: '',
         FOLLOWLOCATION: true,
         HTTPHEADER: [
           'Content-Type: application/octet-stream',
@@ -309,6 +312,7 @@ describe('actuallySend()', () => {
       options: {
         CUSTOMREQUEST: 'POST',
         ACCEPT_ENCODING: '',
+        COOKIEFILE: '',
         FOLLOWLOCATION: true,
         HTTPHEADER: [
           'Content-Type: multipart/form-data',

--- a/app/network/network.js
+++ b/app/network/network.js
@@ -197,6 +197,10 @@ export function _actuallySend (renderedRequest, workspace, settings) {
 
       // Set cookies from jar
       if (renderedRequest.settingSendCookies) {
+        // Tell Curl to store cookies that it receives. This is only important if we receive
+        // a cookie on a redirect that needs to be sent on the next request in the chain.
+        curl.setOpt(Curl.option.COOKIEFILE, '');
+
         const cookies = renderedRequest.cookieJar.cookies || [];
         for (const cookie of cookies) {
           let expiresTimestamp = 0;
@@ -441,13 +445,14 @@ export function _actuallySend (renderedRequest, workspace, settings) {
             }
           }
 
-          const cookies = await cookiesFromJar(jar);
-          models.cookieJar.update(renderedRequest.cookieJar, {cookies});
+          // Update cookie jar if we found any cookies
+          if (cookiesFound > 0) {
+            const cookies = await cookiesFromJar(jar);
+            models.cookieJar.update(renderedRequest.cookieJar, {cookies});
+          }
 
-          timeline.push({
-            name: 'TEXT',
-            value: `Saved ${cookiesFound} cookie${cookiesFound === 1 ? '' : 's'}`
-          });
+          const n = cookiesFound;
+          timeline.push({name: 'TEXT', value: `Saved ${n} cookie${n === 1 ? '' : 's'}`});
         } else {
           timeline.push({name: 'TEXT', value: 'Ignored cookies'});
         }


### PR DESCRIPTION
Closes #311 

## What

This PR now handles `set-cookie` headers on every step of the redirect chain. Before, it would only handle the last step.