### PR TITLE
Adding react and redux dev tools

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -4,6 +4,7 @@ import {isDevelopment, isMac} from './common/constants';
 import * as errorHandling from './main/error-handling';
 import * as updates from './main/updates';
 import * as windowUtils from './main/window-utils';
+import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer';
 
 // Handle potential auto-update
 if (needsRestart) {
@@ -55,6 +56,13 @@ app.on('activate', (e, hasVisibleWindows) => {
 
 // When the app is first launched
 app.on('ready', () => {
+  installExtension(REACT_DEVELOPER_TOOLS)
+    .then((name) => console.log(`Added Extension:  ${name}`))
+    .catch((err) => console.log('An error occurred: ', err));
+  installExtension(REDUX_DEVTOOLS)
+    .then((name) => console.log(`Added Extension:  ${name}`))
+    .catch((err) => console.log('An error occurred: ', err));
+
   app.removeListener('open-url', addUrlToOpen);
   const window = windowUtils.createWindow();
 

--- a/app/ui/redux/create.js
+++ b/app/ui/redux/create.js
@@ -5,8 +5,8 @@ import {reducer} from './modules';
 export default function () {
   const composeEnhancers =
     typeof window === 'object' &&
-    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
-      window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+      ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
         // Specify extension’s options like name, actionsBlacklist, actionsCreators, serialize...
       }) : compose;
   const middleware = [thunkMiddleware];

--- a/app/ui/redux/create.js
+++ b/app/ui/redux/create.js
@@ -1,10 +1,20 @@
-import {createStore, applyMiddleware} from 'redux';
+import {createStore, applyMiddleware, compose} from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import {reducer} from './modules';
 
 export default function () {
+  const composeEnhancers =
+    typeof window === 'object' &&
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
+      window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+        // Specify extension’s options like name, actionsBlacklist, actionsCreators, serialize...
+      }) : compose;
   const middleware = [thunkMiddleware];
-  const store = createStore(reducer, applyMiddleware(...middleware));
+  const enhancer = composeEnhancers(
+    applyMiddleware(...middleware),
+    // other store enhancers if any
+  );
+  const store = createStore(reducer, enhancer);
   if (__DEV__ && module.hot) {
     module.hot.accept('./modules/index', () => {
       store.replaceReducer(reducer);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,12 @@
       "integrity": "sha512-7+0Ai8r8Xt6NNVM0Eo+XSqiZsBUYXg2yrCwyBhQzSfFHTGQWzFv/pk9106vPR8HWjKmGK+zzUj244POs4xfO2g==",
       "dev": true
     },
+    "7zip": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/7zip/-/7zip-0.0.6.tgz",
+      "integrity": "sha1-nK+xca+CMpSQNTtIFvAzR6oVCjA=",
+      "dev": true
+    },
     "7zip-bin": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.0.4.tgz",
@@ -1633,6 +1639,12 @@
       "integrity": "sha1-vWf5bAfvtjA7f+lMHpefiEeOCjk=",
       "dev": true
     },
+    "cross-unzip": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cross-unzip/-/cross-unzip-0.0.2.tgz",
+      "integrity": "sha1-UYO8R6CVWb78+YzEZXlkmZNZNy8=",
+      "dev": true
+    },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -2052,6 +2064,12 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-0.9.0.tgz",
       "integrity": "sha1-ima+9QLwUkJVoTUKK0cE26rP1QM="
+    },
+    "electron-devtools-installer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-2.2.0.tgz",
+      "integrity": "sha1-mBPmgRr81p3co8rlQW23Lqfs+2o=",
+      "dev": true
     },
     "electron-dl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "css-loader": "^0.26.2",
     "electron": "^1.6.11",
     "electron-builder": "^10.17.3",
+    "electron-devtools-installer": "^2.2.0",
     "electron-rebuild": "^1.5.7",
     "eslint": "^3.16.1",
     "eslint-config-semistandard": "^7.0.0",


### PR DESCRIPTION
## What
* Automatically tries to install and load react and redux extensions when running in dev mode.

## Why
* Makes things more inviting to new developers.

## Details
Added a dev dependency of `electron-devtools-installer` and modified `app/ui/redux/create` to add standard boilerplate Redux DevTools support if `window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__` is present.

## Notes
Redux DevTools are awesome! 👍 

![screen shot 2017-06-24 at 2 19 42 am](https://user-images.githubusercontent.com/53444/27506311-b06bba50-5883-11e7-99f6-cf7a5018efb6.png)
![screen shot 2017-06-24 at 2 13 19 am](https://user-images.githubusercontent.com/53444/27506314-b4211de8-5883-11e7-8bec-c2391c133fa2.png)
