### PR TITLE
Homebrew curl proof-of-concept & curl version string on about page

### DIFF
--- a/app/ui/components/settings/about.js
+++ b/app/ui/components/settings/about.js
@@ -1,5 +1,6 @@
 import React, {PureComponent} from 'react';
 import Link from '../base/link';
+import {Curl} from 'node-libcurl';
 
 class About extends PureComponent {
   render () {
@@ -24,6 +25,10 @@ class About extends PureComponent {
         <p>
           ~ Gregory
         </p>
+        <h3>App Details</h3>
+        <ul>
+          <li>Compiled with <strong>{Curl.getVersion()}</strong></li>
+        </ul>
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:install": "cd build && npm install",
     "build": "npm run build:clean && npm run build:renderer && npm run build:main && npm run build:copy && npm run build:install",
     "rebuild": "electron-rebuild -f -w node-libcurl",
+    "rebuild:homebrew": "export PATH=/usr/local/opt/curl/bin:$PATH; electron-rebuild -f -w node-libcurl",
     "package:mac": "rm -rf dist/mac && node node_modules/electron-builder/out/cli/build-cli.js --publish=never --x64 --mac",
     "package:win": "rm -rf dist/win* && node node_modules/electron-builder/out/cli/build-cli.js --publish=never --x64 --win",
     "package:linux": "rm -rf dist/linux && rm -f dist/*.AppImage && rm -f dist/*.deb && node node_modules/electron-builder/out/cli/build-cli.js --publish=never --x64 --linux",


### PR DESCRIPTION
## What
* Added `npm run rebuild:homebrew` to rebuild node-libcurl using homebrew's curl
* Added curl version to the Preferences' About tab

## Why
* Because of issues running standard Mac OS X curl with insecure transport
* An OpenSSL-based curl also opens up possibility of making HTTP2 calls, etc.

## Details
* I've no idea if packages will build with a static copy of curl or if curl is still dynamically loaded.
* If curl is dynamically loaded, we'll have to change that if we want to ship an OpenSSL-based version of curl.

## Notes
* By default, Homebrew installs a copy of curl that still uses SecureTransport. This threw me off track for quite a few hours. Finally, I figured out I had to `brew uninstall curl` and `brew install curl --with-openssl --build-from-source` to get everything to work. :)

**Related Issue**: #302

![screenshot-sat jun 24 2017 17 59 56 gmt-0400 edt](https://user-images.githubusercontent.com/53444/27512249-86e28526-5908-11e7-9d89-dbece6b6e219.png)
<img width="968" alt="screen shot 2017-06-24 at 5 59 13 pm" src="https://user-images.githubusercontent.com/53444/27512250-871eee26-5908-11e7-8241-6188052adad5.png">
