### PR TITLE
Add ability to assign color to environments

### DIFF
--- a/app/models/environment.js
+++ b/app/models/environment.js
@@ -8,6 +8,7 @@ export function init () {
   return {
     name: 'New Environment',
     data: {},
+    color: null,
     isPrivate: false
   };
 }

--- a/app/ui/components/base/dropdown/dropdown-item.js
+++ b/app/ui/components/base/dropdown/dropdown-item.js
@@ -27,14 +27,17 @@ class DropdownItem extends PureComponent {
       buttonClass,
       children,
       className,
+      color,
       onClick, // eslint-disable-line no-unused-vars
       stayOpenAfterClick, // eslint-disable-line no-unused-vars
       ...props
     } = this.props;
 
+    const styles = color ? {color} : {};
+
     const inner = (
       <div className={classnames('dropdown__inner', className)}>
-        <div className="dropdown__text">{children}</div>
+        <div className="dropdown__text" style={styles}>{children}</div>
       </div>
     );
 
@@ -58,7 +61,8 @@ DropdownItem.propTypes = {
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  color: PropTypes.string
 };
 
 export default DropdownItem;

--- a/app/ui/components/base/editable.js
+++ b/app/ui/components/base/editable.js
@@ -63,7 +63,7 @@ class Editable extends PureComponent {
   render () {
     const {
       value,
-      singleClick, // eslint-disable-line no-unused-vars
+      singleClick,
       onEditStart, // eslint-disable-line no-unused-vars
       className,
       ...extra
@@ -85,6 +85,7 @@ class Editable extends PureComponent {
       return (
         <div {...extra}
              className={`editable ${className}`}
+             title={singleClick ? 'Click to edit' : 'Double click to edit'}
              onClick={this._handleSingleClickEditStart}
              onDoubleClick={this._handleEditStart}>
           {value}

--- a/app/ui/components/codemirror/extensions/autocomplete.js
+++ b/app/ui/components/codemirror/extensions/autocomplete.js
@@ -19,7 +19,6 @@ const TYPE_CONSTANT = 'constant';
 const MAX_CONSTANTS = -1;
 const MAX_VARIABLES = -1;
 const MAX_TAGS = -1;
-const MIN_CHAR_MATCH = 1;
 
 const ICONS = {
   [TYPE_CONSTANT]: {char: '&#x1d484;', title: 'Constant'},
@@ -306,11 +305,6 @@ function matchSegments (listOfThings, segment, type, limit = -1) {
 
     // Throw away things that don't match
     if (!matchName.includes(matchSegment)) {
-      continue;
-    }
-
-    // Throw away short matches
-    if (matchSegment.length < MIN_CHAR_MATCH) {
       continue;
     }
 

--- a/app/ui/components/dropdowns/environments-dropdown.js
+++ b/app/ui/components/dropdowns/environments-dropdown.js
@@ -22,7 +22,8 @@ class EnvironmentsDropdown extends PureComponent {
       <DropdownItem key={environment._id}
                     value={environment._id}
                     onClick={this._handleActivateEnvironment}>
-        <i className="fa fa-random"/> Use <strong>{environment.name}</strong>
+        <i className="fa fa-random" style={{color: environment.color}}/>
+        Use <strong>{environment.name}</strong>
       </DropdownItem>
     );
   }
@@ -61,6 +62,9 @@ class EnvironmentsDropdown extends PureComponent {
               </Tooltip>
             )}
             <div className="sidebar__menu__thing__text">
+              {activeEnvironment && (
+                <i className="fa fa-circle space-right" style={{color: activeEnvironment.color}}/>
+              )}
               {description}
             </div>
             <i className="space-left fa fa-caret-down"/>

--- a/app/ui/css/components/sidebar.less
+++ b/app/ui/css/components/sidebar.less
@@ -4,7 +4,7 @@
 .sidebar {
   position: relative;
   display: grid;
-  grid-template-rows: @height-nav @line-height-sm auto minmax(0, 1fr) auto;
+  grid-template-rows: @height-nav auto auto minmax(0, 1fr) auto;
   grid-template-columns: 100%;
   z-index: 10;
 
@@ -82,16 +82,28 @@
   .sidebar__menu {
     box-sizing: border-box;
     width: 100%;
-    display: grid;
-    grid-template-columns: 55% 45%;
-    justify-items: center;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
     font-size: @font-size-sm;
     color: @hl;
-    padding: 0 @padding-sm;
+    padding-left: @padding-xs;
+    padding-right: @padding-xs;
+
+    // Make it scroll when too skinny
+    overflow: auto;
+    &::-webkit-scrollbar {
+      display: none;
+    }
 
     & > * {
-      width: 100%;
+      flex: 1;
       margin-top: @padding-xs;
+      margin-bottom: @padding-xs;
+    }
+
+    & > .dropdown > * {
+      width: 100%;
     }
 
     & > *:first-child {
@@ -122,7 +134,6 @@
     }
 
     .btn {
-      width: 100%;
       border-radius: 900px;
       height: @line-height-xxs;
       padding-left: @padding-xxs;
@@ -146,19 +157,6 @@
 
     & > *:last-child {
       display: none;
-    }
-  }
-
-  &.sidebar--skinny .sidebar__menu {
-    grid-template-columns: 100%;
-
-    & > *:last-child {
-      display: none;
-    }
-
-    .btn {
-      padding-left: @padding-xs;
-      padding-right: @padding-xs;
     }
   }
 

--- a/app/ui/css/layout/base.less
+++ b/app/ui/css/layout/base.less
@@ -264,6 +264,12 @@ p.notice {
   height: 100%;
 }
 
+.row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
 .row-fill {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
This adds the ability to color-code environments, which is useful for knowing which one is active. 

![image](https://user-images.githubusercontent.com/587576/27606765-5cac5928-5b36-11e7-9bf1-2f0c86c72bba.png)
![image](https://user-images.githubusercontent.com/587576/27606768-607c2c54-5b36-11e7-8ab8-0b0af9632f0a.png)

It also modified the sidebar styles to be more useful at small sizes. Before, the buttons used to be 50/50. Now, the flex to fit the space depending on how much text is in the buttons, and wrap to two lines if there isn't enough space (cookies button used to disappear at small sizes).

![image](https://user-images.githubusercontent.com/587576/27606852-a7595264-5b36-11e7-9c0d-49dbec637dec.png)
