### PR TITLE
Move response bodies out of DB

### DIFF
--- a/app/__mocks__/electron.js
+++ b/app/__mocks__/electron.js
@@ -1,8 +1,10 @@
+const RANDOM_STRING = Math.random().toString().replace('.', '');
+
 module.exports = {
   remote: {
     app: {
       getPath (name) {
-        return `/tmp/insomnia-tests/${name}`;
+        return `/tmp/insomnia-tests-${RANDOM_STRING}/${name}`;
       }
     }
   },

--- a/app/common/database.js
+++ b/app/common/database.js
@@ -294,10 +294,10 @@ export function docUpdate (originalDoc, patch = {}) {
   return update(doc);
 }
 
-export function docCreate (type, patch = {}) {
+export function docCreate (type, ...patches) {
   const doc = initModel(
     type,
-    patch,
+    ...patches,
 
     // Fields that the user can't touch
     {

--- a/app/common/database.js
+++ b/app/common/database.js
@@ -3,8 +3,7 @@ import NeDB from 'nedb';
 import fs from 'fs';
 import fsPath from 'path';
 import {DB_PERSIST_INTERVAL} from './constants';
-import {generateId} from './misc';
-import {getModel, initModel} from '../models';
+import {initModel} from '../models';
 import * as models from '../models/index';
 import AlertModal from '../ui/components/modals/alert-modal';
 import {showModal} from '../ui/components/modals/index';
@@ -145,13 +144,18 @@ export async function getMostRecentlyModified (type, query = {}) {
 
 export function findMostRecentlyModified (type, query = {}, limit = null) {
   return new Promise(resolve => {
-    db[type].find(query).sort({modified: -1}).limit(limit).exec((err, docs) => {
+    db[type].find(query).sort({modified: -1}).limit(limit).exec((err, rawDocs) => {
       if (err) {
         console.warn('[db] Failed to find docs', err);
         resolve([]);
-      } else {
-        resolve(docs);
+        return;
       }
+
+      const docs = rawDocs.map(rawDoc => {
+        return initModel(type, rawDoc);
+      });
+
+      resolve(docs);
     });
   });
 }
@@ -291,12 +295,6 @@ export function docUpdate (originalDoc, patch = {}) {
 }
 
 export function docCreate (type, patch = {}) {
-  const idPrefix = getModel(type).prefix;
-
-  if (!idPrefix) {
-    throw new Error(`No ID prefix for ${type}`);
-  }
-
   const doc = initModel(
     type,
     patch,
@@ -307,12 +305,6 @@ export function docCreate (type, patch = {}) {
       modified: Date.now()
     }
   );
-
-  // NOTE: This CAN'T be inside initModel() because initModel checks
-  // for _id existence to do migrations and stuff
-  if (!doc._id) {
-    doc._id = generateId(idPrefix);
-  }
 
   return insert(doc);
 }

--- a/app/common/misc.js
+++ b/app/common/misc.js
@@ -1,5 +1,6 @@
 import uuid from 'uuid';
-import {parse as urlParse, format as urlFormat} from 'url';
+import zlib from 'zlib';
+import {format as urlFormat, parse as urlParse} from 'url';
 import {DEBOUNCE_MILLIS, getAppVersion, isDevelopment} from './constants';
 import * as querystring from './querystring';
 import {shell} from 'electron';
@@ -277,4 +278,22 @@ export function fnOrString (v, ...args) {
   } else {
     return v(...args);
   }
+}
+
+export function compressObject (obj) {
+  const compressed = compress(JSON.stringify(obj));
+  return compressed.toString('base64');
+}
+
+export function decompressObject (input) {
+  const jsonBuffer = decompress(Buffer.from(input, 'base64'));
+  return JSON.parse(jsonBuffer);
+}
+
+export function compress (inputBuffer) {
+  return zlib.gzipSync(inputBuffer);
+}
+
+export function decompress (inputBuffer) {
+  return zlib.gunzipSync(inputBuffer);
 }

--- a/app/models/__tests__/response.test.js
+++ b/app/models/__tests__/response.test.js
@@ -1,0 +1,84 @@
+import path from 'path';
+import * as electron from 'electron';
+import * as models from '../../models';
+
+describe('migrate()', () => {
+  beforeEach(() => {
+    Date.now = jest.genMockFunction().mockReturnValue(1234567890);
+    jest.useFakeTimers();
+  });
+
+  it('migrates utf8 body correctly', async () => {
+    const initialModel = {body: 'hello world!', encoding: 'utf8'};
+
+    const newModel = models.initModel(models.response.type, initialModel);
+    const expectedBodyPath = path.join(
+      electron.remote.app.getPath('userData'),
+      `responses/fc3ff98e8c6a0d3087d515c0473f8677.zip`
+    );
+    const storedBody = models.response.getBodyBuffer(expectedBodyPath);
+
+    // Should have stripped these
+    expect(newModel.body).toBeUndefined();
+    expect(newModel.encoding).toBeUndefined();
+
+    // Should have set bodyPath and stored the body
+    expect(newModel.bodyPath).toBe(expectedBodyPath);
+    expect(storedBody + '').toBe('hello world!');
+  });
+
+  it('migrates base64 body correctly', async () => {
+    const initialModel = {body: 'aGVsbG8gd29ybGQh', encoding: 'base64'};
+
+    const newModel = models.initModel(models.response.type, initialModel);
+    jest.runAllTimers();
+    const expectedBodyPath = path.join(
+      electron.remote.app.getPath('userData'),
+      `responses/fc3ff98e8c6a0d3087d515c0473f8677.zip`
+    );
+    const storedBody = models.response.getBodyBuffer(expectedBodyPath);
+
+    // Should have stripped these
+    expect(newModel.body).toBeUndefined();
+    expect(newModel.encoding).toBeUndefined();
+
+    // Should have set bodyPath and stored the body
+    expect(newModel.bodyPath).toBe(expectedBodyPath);
+    expect(storedBody + '').toBe('hello world!');
+  });
+
+  it.only('migrates empty body', async () => {
+    const initialModel = {body: ''};
+
+    const newModel = models.initModel(models.response.type, initialModel);
+    jest.runAllTimers();
+    jest.runAllTimers();
+
+    const expectedBodyPath = path.join(
+      electron.remote.app.getPath('userData'),
+      'responses/d41d8cd98f00b204e9800998ecf8427e.zip'
+    );
+    const storedBody = models.response.getBodyBuffer(expectedBodyPath);
+
+    // Should have stripped these
+    expect(newModel.body).toBeUndefined();
+    expect(newModel.encoding).toBeUndefined();
+
+    // Should have set bodyPath and stored the body
+    expect(newModel.bodyPath).toBe(expectedBodyPath);
+    expect(storedBody + '').toBe('');
+  });
+
+  it('does not migrate body again', async () => {
+    const initialModel = {bodyPath: '/foo/bar'};
+
+    const newModel = models.initModel(models.response.type, initialModel);
+
+    // Should have stripped these
+    expect(newModel.body).toBeUndefined();
+    expect(newModel.encoding).toBeUndefined();
+
+    // Should have set bodyPath and stored the body
+    expect(newModel.bodyPath).toBe('/foo/bar');
+  });
+});

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -11,6 +11,7 @@ import * as _requestVersion from './request-version';
 import * as _requestMeta from './request-meta';
 import * as _response from './response';
 import * as _oAuth2Token from './o-auth-2-token';
+import {generateId} from '../common/misc';
 
 // Reference to each model
 export const stats = _stats;
@@ -79,15 +80,18 @@ export function initModel (type, ...sources) {
 
   // Define global default fields
   const objectDefaults = Object.assign({
-    type: type,
     _id: null,
+    type: type,
     parentId: null,
     modified: Date.now(),
     created: Date.now()
   }, model.init());
 
-  // Make a new object
   const fullObject = Object.assign({}, objectDefaults, ...sources);
+
+  if (!fullObject._id) {
+    fullObject._id = generateId(getModel(type).prefix);
+  }
 
   // Migrate the model
   // NOTE: Do migration before pruning because we might need to look at those fields

--- a/app/models/request-version.js
+++ b/app/models/request-version.js
@@ -1,7 +1,7 @@
-import zlib from 'zlib';
 import deepEqual from 'deep-equal';
 import * as models from './index';
 import * as db from '../common/database';
+import {compressObject, decompressObject} from '../common/misc';
 export const name = 'Request Version';
 export const type = 'RequestVersion';
 export const prefix = 'rvr';
@@ -39,13 +39,13 @@ export async function create (request) {
   const parentId = request._id;
   const latestRequestVersion = await getLatestByParentId(parentId);
   const latestRequest = latestRequestVersion
-    ? await _decompressRequest(latestRequestVersion.compressedRequest)
+    ? decompressObject(latestRequestVersion.compressedRequest)
     : null;
 
   const hasChanged = _diffRequests(latestRequest, request);
   if (hasChanged) {
     // Create a new version if the request has been modified
-    const compressedRequest = await _compressRequest(request);
+    const compressedRequest = compressObject(request);
     return db.docCreate(type, {parentId, compressedRequest});
   } else {
     // Re-use the latest version if not modified since
@@ -65,7 +65,7 @@ export async function restore (requestVersionId) {
     return null;
   }
 
-  const request = await _decompressRequest(requestVersion.compressedRequest);
+  const request = decompressObject(requestVersion.compressedRequest);
   return models.request.update(request);
 }
 
@@ -86,32 +86,4 @@ function _diffRequests (rOld, rNew) {
   }
 
   return false;
-}
-
-function _compressRequest (request) {
-  return new Promise((resolve, reject) => {
-    const str = JSON.stringify(request);
-    zlib.gzip(str, {}, (err, buffer) => {
-      if (err) {
-        reject(err);
-      } else {
-        const encoded = buffer.toString('base64');
-        resolve(encoded);
-      }
-    });
-  });
-}
-
-function _decompressRequest (requestJson) {
-  return new Promise((resolve, reject) => {
-    const buffer = Buffer.from(requestJson, 'base64');
-    zlib.gunzip(buffer, {}, (err, jsonStr) => {
-      if (err) {
-        reject(err);
-      } else {
-        const obj = JSON.parse(jsonStr);
-        resolve(obj);
-      }
-    });
-  });
 }

--- a/app/models/response.js
+++ b/app/models/response.js
@@ -82,12 +82,8 @@ export async function create (patch = {}, bodyBuffer = null) {
   await db.removeBulkSilently(type, {parentId, _id: {$nin: recentIds}});
 
   // Actually create the new response
-  const response = await db.docCreate(type, patch);
-
-  // Store the body.
-  // NOTE: Storing body requires doc to have an ID, so do this after insert
   const bodyPath = bodyBuffer ? storeBodyBuffer(bodyBuffer) : '';
-  return db.docUpdate(response, {bodyPath});
+  return db.docCreate(type, {bodyPath}, patch);
 }
 
 export function getLatestByParentId (parentId) {

--- a/app/models/response.js
+++ b/app/models/response.js
@@ -1,6 +1,12 @@
-import * as db from '../common/database';
+import fs from 'fs';
+import crypto from 'crypto';
+import path from 'path';
+import mkdirp from 'mkdirp';
+import * as electron from 'electron';
 import {MAX_RESPONSES} from '../common/constants';
+import * as db from '../common/database';
 import * as models from './index';
+import {compress, decompress} from '../common/misc';
 
 export const name = 'Response';
 export const type = 'Response';
@@ -18,8 +24,7 @@ export function init () {
     headers: [],
     cookies: [],
     timeline: [],
-    body: '',
-    encoding: 'utf8', // Legacy format
+    bodyPath: '', // Actual bodies are stored on the filesystem
     error: '',
     requestVersionId: null,
 
@@ -30,6 +35,7 @@ export function init () {
 }
 
 export function migrate (doc) {
+  doc = migrateBody(doc);
   return doc;
 }
 
@@ -58,7 +64,7 @@ export async function getLatestForRequest (requestId) {
   return responses[0] || null;
 }
 
-export async function create (patch = {}) {
+export async function create (patch = {}, bodyBuffer = null) {
   if (!patch.parentId) {
     throw new Error('New Response missing `parentId`');
   }
@@ -76,9 +82,54 @@ export async function create (patch = {}) {
   await db.removeBulkSilently(type, {parentId, _id: {$nin: recentIds}});
 
   // Actually create the new response
-  return db.docCreate(type, patch);
+  const response = await db.docCreate(type, patch);
+
+  // Store the body.
+  // NOTE: Storing body requires doc to have an ID, so do this after insert
+  const bodyPath = bodyBuffer ? storeBodyBuffer(bodyBuffer) : '';
+  return db.docUpdate(response, {bodyPath});
 }
 
 export function getLatestByParentId (parentId) {
   return db.getMostRecentlyModified(type, {parentId});
+}
+
+export function getBodyBuffer (bodyPath) {
+  try {
+    return decompress(fs.readFileSync(bodyPath));
+  } catch (err) {
+    console.warn('Failed to read response body', err.message);
+    return null;
+  }
+}
+
+export function storeBodyBuffer (bodyBuffer) {
+  const root = electron.remote.app.getPath('userData');
+  const dir = path.join(root, 'responses');
+
+  mkdirp.sync(dir);
+
+  const hash = crypto.createHash('md5').update(bodyBuffer).digest('hex');
+
+  const fullPath = path.join(dir, `${hash}.zip`);
+
+  try {
+    fs.writeFileSync(fullPath, compress(bodyBuffer));
+  } catch (err) {
+    console.warn('Failed to write response body to file', err.message);
+  }
+
+  return fullPath;
+}
+
+function migrateBody (doc) {
+  if (doc.hasOwnProperty('body') && doc._id && !doc.bodyPath) {
+    const bodyBuffer = Buffer.from(doc.body, doc.encoding || 'utf8');
+    const bodyPath = storeBodyBuffer(bodyBuffer);
+    const newDoc = Object.assign(doc, {bodyPath});
+    db.docUpdate(newDoc);
+    return newDoc;
+  } else {
+    return doc;
+  }
 }

--- a/app/network/__tests__/network.test.js
+++ b/app/network/__tests__/network.test.js
@@ -55,13 +55,13 @@ describe('actuallySend()', () => {
     });
 
     const renderedRequest = await getRenderedRequest(request);
-    const response = await networkUtils._actuallySend(
+    const {bodyBuffer} = await networkUtils._actuallySend(
       renderedRequest,
       workspace,
       settings
     );
 
-    const body = JSON.parse(Buffer.from(response.body, 'base64'));
+    const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       options: {
         COOKIELIST: [
@@ -111,13 +111,13 @@ describe('actuallySend()', () => {
     });
 
     const renderedRequest = await getRenderedRequest(request);
-    const response = await networkUtils._actuallySend(
+    const {bodyBuffer} = await networkUtils._actuallySend(
       renderedRequest,
       workspace,
       settings
     );
 
-    const body = JSON.parse(Buffer.from(response.body, 'base64'));
+    const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       options: {
         CUSTOMREQUEST: 'POST',
@@ -190,13 +190,13 @@ describe('actuallySend()', () => {
     });
 
     const renderedRequest = await getRenderedRequest(request);
-    const response = await networkUtils._actuallySend(
+    const {bodyBuffer} = await networkUtils._actuallySend(
       renderedRequest,
       workspace,
       settings
     );
 
-    const body = JSON.parse(Buffer.from(response.body, 'base64'));
+    const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       options: {
         CUSTOMREQUEST: 'POST',
@@ -239,13 +239,13 @@ describe('actuallySend()', () => {
     });
 
     const renderedRequest = await getRenderedRequest(request);
-    const response = await networkUtils._actuallySend(
+    const {bodyBuffer} = await networkUtils._actuallySend(
       renderedRequest,
       workspace,
       settings
     );
 
-    const body = JSON.parse(Buffer.from(response.body, 'base64'));
+    const body = JSON.parse(bodyBuffer);
 
     // READDATA is an fd (random int), so fuzzy assert this one
     expect(typeof body.options.READDATA).toBe('number');
@@ -301,13 +301,12 @@ describe('actuallySend()', () => {
     });
 
     const renderedRequest = await getRenderedRequest(request);
-    const response = await networkUtils._actuallySend(
+    const {bodyBuffer} = await networkUtils._actuallySend(
       renderedRequest,
       workspace,
       settings
     );
-
-    const body = JSON.parse(Buffer.from(response.body, 'base64'));
+    const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       options: {
         CUSTOMREQUEST: 'POST',
@@ -346,10 +345,10 @@ describe('actuallySend()', () => {
     });
 
     const renderedRequest = await getRenderedRequest(request);
-    const response = await networkUtils._actuallySend(renderedRequest, workspace, settings);
+    const {bodyBuffer} = await networkUtils._actuallySend(renderedRequest, workspace, settings);
     // console.log('HELLO', response);
 
-    const body = JSON.parse(Buffer.from(response.body, 'base64'));
+    const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       options: {
         CUSTOMREQUEST: 'GET',

--- a/app/network/network.js
+++ b/app/network/network.js
@@ -49,13 +49,15 @@ export function _actuallySend (renderedRequest, workspace, settings) {
       let timeline = [];
 
       // Define helper to add base fields when responding
-      const respond = patch => {
-        resolve(Object.assign({
+      const respond = (patch, bodyBuffer = null) => {
+        const response = Object.assign({
           parentId: renderedRequest._id,
           timeline: timeline,
           settingSendCookies: renderedRequest.settingSendCookies,
           settingStoreCookies: renderedRequest.settingStoreCookies
-        }, patch));
+        }, patch);
+
+        resolve({bodyBuffer, response});
       };
 
       // Define helper to setOpt for better error handling
@@ -476,22 +478,18 @@ export function _actuallySend (renderedRequest, workspace, settings) {
         }
 
         // Handle the body
-        const encoding = 'base64';
         const bodyBuffer = Buffer.concat(dataBuffers, dataBuffersLength);
-        const body = bodyBuffer.toString(encoding);
 
         // Return the response data
         respond({
           headers,
-          encoding,
-          body,
           contentType,
           statusCode,
           statusMessage,
           elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) * 1000,
           bytesRead: curl.getInfo(Curl.info.SIZE_DOWNLOAD),
           url: curl.getInfo(Curl.info.EFFECTIVE_URL)
-        });
+        }, bodyBuffer);
 
         // Close the request
         this.close();

--- a/app/templating/base-extension.js
+++ b/app/templating/base-extension.js
@@ -75,7 +75,10 @@ export default class BaseExtension {
           request: {getById: models.request.getById},
           workspace: {getById: models.workspace.getById},
           cookieJar: {getOrCreateForWorkspace: models.cookieJar.getOrCreateForWorkspace},
-          response: {getLatestForRequestId: models.response.getLatestForRequest}
+          response: {
+            getLatestForRequestId: models.response.getLatestForRequest,
+            getBodyBuffer: models.response.getBodyBuffer
+          }
         }
       }
     };

--- a/app/templating/extensions/__tests__/response-extension.test.js
+++ b/app/templating/extensions/__tests__/response-extension.test.js
@@ -16,7 +16,7 @@ describe('ResponseExtension General', async () => {
   });
 
   it('fails on no request', async () => {
-    await models.response.create({parentId: 'req_test', body: '{"foo": "bar"}'});
+    await models.response.create({parentId: 'req_test'}, '{"foo": "bar"}');
 
     try {
       await templating.render(`{% response "body", "req_test", "$.foo" %}`);
@@ -27,7 +27,7 @@ describe('ResponseExtension General', async () => {
   });
 
   it('fails on empty filter', async () => {
-    await models.response.create({parentId: 'req_test', body: '{"foo": "bar"}'});
+    await models.response.create({parentId: 'req_test'}, '{"foo": "bar"}');
 
     try {
       await templating.render(`{% response "body", "req_test", "" %}`);
@@ -45,9 +45,8 @@ describe('ResponseExtension JSONPath', async () => {
     const request = await models.request.create({parentId: 'foo'});
     await models.response.create({
       parentId: request._id,
-      statusCode: 200,
-      body: '{"foo": "bar"}'
-    });
+      statusCode: 200
+    }, '{"foo": "bar"}');
 
     const result = await templating.render(`{% response "body", "${request._id}", "$.foo" %}`);
 
@@ -58,9 +57,8 @@ describe('ResponseExtension JSONPath', async () => {
     const request = await models.request.create({parentId: 'foo'});
     await models.response.create({
       parentId: request._id,
-      body: '{"foo": "bar"',
       statusCode: 200
-    });
+    }, '{"foo": "bar"');
 
     try {
       await templating.render(`{% response "body", "${request._id}", "$.foo" %}`);
@@ -74,9 +72,8 @@ describe('ResponseExtension JSONPath', async () => {
     const request = await models.request.create({parentId: 'foo'});
     await models.response.create({
       parentId: request._id,
-      statusCode: 200,
-      body: '{"foo": "bar"}'
-    });
+      statusCode: 200
+    }, '{"foo": "bar"}');
 
     try {
       await templating.render(`{% response "body", "${request._id}", "$$" %}`);
@@ -90,9 +87,8 @@ describe('ResponseExtension JSONPath', async () => {
     const request = await models.request.create({parentId: 'foo'});
     await models.response.create({
       parentId: request._id,
-      statusCode: 200,
-      body: '{"foo": "bar"}'
-    });
+      statusCode: 200
+    }, '{"foo": "bar"}');
 
     try {
       await templating.render(`{% response "body", "${request._id}", "$.missing" %}`);
@@ -106,9 +102,8 @@ describe('ResponseExtension JSONPath', async () => {
     const request = await models.request.create({parentId: 'foo'});
     await models.response.create({
       parentId: request._id,
-      statusCode: 200,
-      body: '{"array": [1,2,3]}'
-    });
+      statusCode: 200
+    }, '{"array": [1,2,3]}');
 
     try {
       await templating.render(`{% response "body", "${request._id}", "$.array.*" %}`);
@@ -126,9 +121,8 @@ describe('ResponseExtension XPath', async () => {
     const request = await models.request.create({parentId: 'foo'});
     await models.response.create({
       parentId: request._id,
-      statusCode: 200,
-      body: '<foo><bar>Hello World!</bar></foo>'
-    });
+      statusCode: 200
+    }, '<foo><bar>Hello World!</bar></foo>');
 
     const result = await templating.render(`{% response "body", "${request._id}", "/foo/bar" %}`);
 
@@ -139,9 +133,8 @@ describe('ResponseExtension XPath', async () => {
     const request = await models.request.create({parentId: 'foo'});
     await models.response.create({
       parentId: request._id,
-      statusCode: 200,
-      body: '<hi></hi></sstr>'
-    });
+      statusCode: 200
+    }, '<hi></hi></sstr>');
 
     try {
       await templating.render(`{% response "body", "${request._id}", "/foo" %}`);
@@ -155,9 +148,8 @@ describe('ResponseExtension XPath', async () => {
     const request = await models.request.create({parentId: 'foo'});
     await models.response.create({
       parentId: request._id,
-      statusCode: 200,
-      body: '<foo><bar>Hello World!</bar></foo>'
-    });
+      statusCode: 200
+    }, '<foo><bar>Hello World!</bar></foo>');
 
     try {
       await templating.render(`{% response "body", "${request._id}", "//" %}`);
@@ -171,9 +163,8 @@ describe('ResponseExtension XPath', async () => {
     const request = await models.request.create({parentId: 'foo'});
     await models.response.create({
       parentId: request._id,
-      statusCode: 200,
-      body: '<foo><bar>Hello World!</bar></foo>'
-    });
+      statusCode: 200
+    }, '<foo><bar>Hello World!</bar></foo>');
 
     try {
       await templating.render(`{% response "body", "${request._id}", "/missing" %}`);
@@ -187,9 +178,8 @@ describe('ResponseExtension XPath', async () => {
     const request = await models.request.create({parentId: 'foo'});
     await models.response.create({
       parentId: request._id,
-      statusCode: 200,
-      body: '<foo><bar>Hello World!</bar><bar>And again!</bar></foo>'
-    });
+      statusCode: 200
+    }, '<foo><bar>Hello World!</bar><bar>And again!</bar></foo>');
 
     try {
       await templating.render(`{% response "body", "${request._id}", "/foo/*" %}`);
@@ -253,9 +243,8 @@ describe('ResponseExtension Raw', async () => {
     const request = await models.request.create({parentId: 'foo'});
     await models.response.create({
       parentId: request._id,
-      statusCode: 200,
-      body: 'Hello World!'
-    });
+      statusCode: 200
+    }, 'Hello World!');
 
     const result = await templating.render(`{% response "raw", "${request._id}", "" %}`);
     expect(result).toBe('Hello World!');

--- a/app/templating/extensions/response-extension.js
+++ b/app/templating/extensions/response-extension.js
@@ -66,11 +66,9 @@ export default {
     if (field === 'header') {
       return matchHeader(response.headers, sanitizedFilter);
     } else if (field === 'raw') {
-      const bodyBuffer = new Buffer(response.body, response.encoding);
-      return bodyBuffer.toString();
+      return context.util.models.response.getBodyBuffer(response.bodyPath).toString();
     } else if (field === 'body') {
-      const bodyBuffer = new Buffer(response.body, response.encoding);
-      const bodyStr = bodyBuffer.toString();
+      const bodyStr = context.util.models.response.getBodyBuffer(response.bodyPath).toString();
 
       if (sanitizedFilter.indexOf('$') === 0) {
         return matchJSONPath(bodyStr, sanitizedFilter);

--- a/app/ui/components/dropdowns/environments-dropdown.js
+++ b/app/ui/components/dropdowns/environments-dropdown.js
@@ -62,7 +62,7 @@ class EnvironmentsDropdown extends PureComponent {
               </Tooltip>
             )}
             <div className="sidebar__menu__thing__text">
-              {activeEnvironment && (
+              {activeEnvironment && activeEnvironment.color && (
                 <i className="fa fa-circle space-right" style={{color: activeEnvironment.color}}/>
               )}
               {description}

--- a/app/ui/components/tooltip.js
+++ b/app/ui/components/tooltip.js
@@ -81,7 +81,7 @@ class Tooltip extends PureComponent {
       {'tooltip--visible': visible}
     );
 
-    const bubbleClasses = classnames('tooltip__bubble', 'theme--overlay');
+    const bubbleClasses = classnames('tooltip__bubble');
 
     const bubbleStyles = {
       left: left ? `${left}px` : null,

--- a/app/ui/containers/app.js
+++ b/app/ui/containers/app.js
@@ -414,20 +414,16 @@ class App extends PureComponent {
     this.props.handleStartLoading(requestId);
 
     try {
-      const responsePatch = await network.send(requestId, environmentId);
+      const {response: responsePatch, bodyBuffer} = await network.send(requestId, environmentId);
       if (responsePatch.statusCode >= 200 && responsePatch.statusCode < 300) {
         const extension = mime.extension(responsePatch.contentType) || '';
         const name = request.name.replace(/\s/g, '-').toLowerCase();
         const filename = path.join(dir, `${name}.${extension}`);
-        const partialResponse = Object.assign({}, responsePatch, {
-          contentType: 'text/plain',
-          body: `Saved to ${filename}`,
-          encoding: 'utf8'
-        });
-        await models.response.create(partialResponse);
-        fs.writeFile(filename, responsePatch.body, responsePatch.encoding);
+        const partialResponse = Object.assign({}, responsePatch);
+        await models.response.create(partialResponse, `Saved to ${filename}`);
+        fs.writeFile(filename, bodyBuffer);
       } else {
-        await models.response.create(responsePatch);
+        await models.response.create(responsePatch, bodyBuffer);
       }
     } catch (e) {
       // It's OK
@@ -457,8 +453,8 @@ class App extends PureComponent {
     this.props.handleStartLoading(requestId);
 
     try {
-      const responsePatch = await network.send(requestId, environmentId);
-      await models.response.create(responsePatch);
+      const {response: responsePatch, bodyBuffer} = await network.send(requestId, environmentId);
+      await models.response.create(responsePatch, bodyBuffer);
     } catch (err) {
       if (err.type === 'render') {
         showModal(RequestRenderErrorModal, {request, error: err});


### PR DESCRIPTION
## Why

Since Insomnia uses an in-memory database, large response bodies caused big problems.

1. Responses needed to be kept in memory always (leading to high RAM usage)
2. Had no way of loading response details from DB without retrieving the body too
3. Caused NeDB to crash when response DB totaled more than NodeJS's 256MB string size limit.

## Details

- [x] Remove `Response.body` and `Response.encoding` (old way of storage)
- [x] Add new `Response.bodyPath` field that points the the location on the FS where the body is stored
- [x] Compress/decompress response bodies before writing/reading to/from FS
- [x] Add migration to migrate old way to new way
- [x] Add test for migration