### PR TITLE
Fixed OAuth 2.0 Refresh Token

### DIFF
--- a/app/network/o-auth-2/refresh-token.js
+++ b/app/network/o-auth-2/refresh-token.js
@@ -1,7 +1,7 @@
 import * as querystring from '../../common/querystring';
 import * as c from './constants';
 import {responseToObject} from './misc';
-import {getBasicAuthHeader} from '../../common/misc';
+import {getBasicAuthHeader, setDefaultProtocol} from '../../common/misc';
 
 export default async function (accessTokenUrl,
                                credentialsInBody,
@@ -36,7 +36,9 @@ export default async function (accessTokenUrl,
     headers: headers
   };
 
-  const response = await window.fetch(accessTokenUrl, config);
+  const url = setDefaultProtocol(accessTokenUrl);
+
+  const response = await window.fetch(url, config);
   const body = await response.text();
   const results = responseToObject(body, [
     c.P_ACCESS_TOKEN,


### PR DESCRIPTION
Issue:
 - In request "Auth" - "OAuth 2.0" - "Refresh Token" button throws error "Failed to Fetch" when no protocol in access_token url.

Reason:
 - window.fetch(url, ..) url parameter wasn't getting check and added if no protocol so add  setDefaultProtocol like access_token.js uses.
