### PR TITLE
Add JSON API mimetype to content types

### DIFF
--- a/app/datasets/content-types.js
+++ b/app/datasets/content-types.js
@@ -63,6 +63,7 @@ export default [
   'application/shf+xml',
   'application/timestamped-data',
   'application/vnd.android.package-archive',
+  'application/vnd.api+json',
   'application/vnd.apple.installer+xml',
   'application/vnd.apple.mpegurl',
   'application/vnd.apple.pkpass',


### PR DESCRIPTION
## What
Adds the JSON API mimetype to the list of content types.

## Why
~~It should allow syntax highlighting in the request body to work properly when this mimetype is used as the Content-Type.~~ (I just realized that this was a separate issue caused by something else.)

Allows it to appear as a suggestion in the autosuggest list for Content-Type.
