### PR TITLE
Environment Rendering Improvements

### DIFF
--- a/app/common/__tests__/render.test.js
+++ b/app/common/__tests__/render.test.js
@@ -1,6 +1,5 @@
 import * as renderUtils from '../render';
 import * as models from '../../models';
-import {RENDER_VARS} from '../../templating/index';
 
 jest.mock('electron');
 
@@ -334,14 +333,23 @@ describe('render()', () => {
     }
   });
 
-  it('does not render tags when not supposed to', async () => {
-    const template = '{{ foo }} {% uuid "v4" %}';
+  it('keep on error setting', async () => {
+    const template = '{{ foo }} {% invalid "hi" %}';
     const context = {foo: 'bar'};
 
-    const resultOnlyVars = await renderUtils.render(template, context, null, RENDER_VARS);
-    const resultEverything = await renderUtils.render(template, context, null);
+    const resultOnlyVars = await renderUtils.render(
+      template,
+      context,
+      null,
+      renderUtils.KEEP_ON_ERROR
+    );
 
-    expect(resultOnlyVars).toBe('bar {% uuid "v4" %}');
-    expect(resultEverything).toBe('bar e3e96e5f-dd68-4229-8b66-dee1f0940f3d');
+    expect(resultOnlyVars).toBe('{{ foo }} {% invalid "hi" %}');
+    try {
+      await renderUtils.render(template, context, null);
+      fail('Render should not have succeeded');
+    } catch (err) {
+      expect(err.message).toBe('unknown block tag: invalid');
+    }
   });
 });

--- a/app/common/__tests__/render.test.js
+++ b/app/common/__tests__/render.test.js
@@ -1,5 +1,6 @@
 import * as renderUtils from '../render';
 import * as models from '../../models';
+import {RENDER_VARS} from '../../templating/index';
 
 jest.mock('electron');
 
@@ -337,8 +338,8 @@ describe('render()', () => {
     const template = '{{ foo }} {% uuid "v4" %}';
     const context = {foo: 'bar'};
 
-    const resultOnlyVars = await renderUtils.render(template, context, null, true);
-    const resultEverything = await renderUtils.render(template, context, null, false);
+    const resultOnlyVars = await renderUtils.render(template, context, null, RENDER_VARS);
+    const resultEverything = await renderUtils.render(template, context, null);
 
     expect(resultOnlyVars).toBe('bar {% uuid "v4" %}');
     expect(resultEverything).toBe('bar e3e96e5f-dd68-4229-8b66-dee1f0940f3d');

--- a/app/common/render.js
+++ b/app/common/render.js
@@ -3,8 +3,9 @@ import * as models from '../models';
 import {setDefaultProtocol} from './misc';
 import * as db from './database';
 import * as templating from '../templating';
+import {RENDER_ALL, RENDER_VARS} from '../templating/index';
 
-export async function buildRenderContext (ancestors, rootEnvironment, subEnvironment, variablesOnly = true) {
+export async function buildRenderContext (ancestors, rootEnvironment, subEnvironment, baseContext = {}) {
   if (!Array.isArray(ancestors)) {
     ancestors = [];
   }
@@ -30,7 +31,7 @@ export async function buildRenderContext (ancestors, rootEnvironment, subEnviron
   // from top-most parent to bottom-most child
   // Do an Object.assign, but render each property as it overwrites. This
   // way we can keep same-name variables from the parent context.
-  const renderContext = {};
+  const renderContext = baseContext;
   for (const environment of environments) {
     // Sort the keys that may have Nunjucks last, so that other keys get
     // defined first. Very important if env variables defined in same obj
@@ -52,7 +53,13 @@ export async function buildRenderContext (ancestors, rootEnvironment, subEnviron
        * original base_url of google.com would be lost.
        */
       if (typeof renderContext[key] === 'string') {
-        renderContext[key] = await render(environment[key], renderContext, null, variablesOnly);
+        renderContext[key] = await render(
+          environment[key],
+          renderContext,
+          null,
+          RENDER_VARS,
+          'Environment'
+        );
       } else {
         renderContext[key] = environment[key];
       }
@@ -62,9 +69,15 @@ export async function buildRenderContext (ancestors, rootEnvironment, subEnviron
   // Render the context with itself to fill in the rest.
   let finalRenderContext = renderContext;
 
-  // Render up to 5 levels of recursive references.
+  // Render recursive references.
   for (let i = 0; i < 3; i++) {
-    finalRenderContext = await render(finalRenderContext, finalRenderContext, null, variablesOnly);
+    finalRenderContext = await render(
+      finalRenderContext,
+      finalRenderContext,
+      null,
+      RENDER_VARS,
+      'Environment'
+    );
   }
 
   return finalRenderContext;
@@ -75,14 +88,15 @@ export async function buildRenderContext (ancestors, rootEnvironment, subEnviron
  * @param {*} obj - object to render
  * @param {object} context - context to render against
  * @param blacklistPathRegex - don't render these paths
- * @param variablesOnly - only render variables
+ * @param renderMode - how to render
+ * @param name - name to include in error message
  * @return {Promise.<*>}
  */
-export async function render (obj, context = {}, blacklistPathRegex = null, variablesOnly = false) {
+export async function render (obj, context = {}, blacklistPathRegex = null, renderMode = RENDER_ALL, name = '') {
   // Make a deep copy so no one gets mad :)
   const newObj = clone(obj);
 
-  async function next (x, path = '') {
+  async function next (x, path = name) {
     if (blacklistPathRegex && path.match(blacklistPathRegex)) {
       return x;
     }
@@ -102,13 +116,13 @@ export async function render (obj, context = {}, blacklistPathRegex = null, vari
       // Do nothing to these types
     } else if (asStr === '[object String]') {
       try {
-        x = await templating.render(x, {context, path, variablesOnly});
+        x = await templating.render(x, {context, path, renderMode});
 
         // If the variable outputs a tag, render it again. This is a common use
         // case for environment variables:
         //   {{ foo }} => {% uuid 'v4' %} => dd265685-16a3-4d76-a59c-e8264c16835a
         if (x.includes('{%')) {
-          x = await templating.render(x, {context, path, variablesOnly});
+          x = await templating.render(x, {context, path, renderMode});
         }
       } catch (err) {
         throw err;
@@ -137,7 +151,7 @@ export async function render (obj, context = {}, blacklistPathRegex = null, vari
   return next(newObj);
 }
 
-export async function getRenderContext (request, environmentId, ancestors = null, variablesOnly = true) {
+export async function getRenderContext (request, environmentId, ancestors = null) {
   if (!request) {
     return {};
   }
@@ -153,14 +167,20 @@ export async function getRenderContext (request, environmentId, ancestors = null
   const rootEnvironment = await models.environment.getOrCreateForWorkspace(workspace);
   const subEnvironment = await models.environment.getById(environmentId);
 
-  // Generate the context we need to render
-  const context = await buildRenderContext(ancestors, rootEnvironment, subEnvironment, variablesOnly);
-
-  // Add meta data
-  context.getMeta = () => ({
+  // Add meta data helper function
+  const baseContext = {};
+  baseContext.getMeta = () => ({
     requestId: request._id,
     workspaceId: workspace._id
   });
+
+  // Generate the context we need to render
+  const context = await buildRenderContext(
+    ancestors,
+    rootEnvironment,
+    subEnvironment,
+    baseContext
+  );
 
   return context;
 }

--- a/app/templating/base-extension.js
+++ b/app/templating/base-extension.js
@@ -56,9 +56,8 @@ export default class BaseExtension {
     // Pull the callback off the end
     const callback = runArgs[runArgs.length - 1];
 
-    // Pull out the meta
+    // Pull out the meta helper
     const renderMeta = renderContext.getMeta ? renderContext.getMeta() : {};
-    delete renderContext.getMeta;
 
     // Extract the rest of the args
     const args = runArgs

--- a/app/templating/extensions/request-extension.js
+++ b/app/templating/extensions/request-extension.js
@@ -99,7 +99,8 @@ function getCookieValue (cookieJar, url, name) {
 
       const cookie = cookies.find(cookie => cookie.key === name);
       if (!cookie) {
-        reject(new Error(`No cookie found with name "${name}"`));
+        const names = cookies.map(c => `"${c.key}"`).join(', ');
+        reject(new Error(`No cookie for "${name}". Choices are ${names}`));
       } else {
         resolve(cookie ? cookie.value : null);
       }

--- a/app/ui/components/settings/plugins.js
+++ b/app/ui/components/settings/plugins.js
@@ -6,6 +6,7 @@ import Button from '../base/button';
 import CopyButton from '../base/copy-button';
 import {showPrompt} from '../modals/index';
 import {trackEvent} from '../../../analytics/index';
+import {reload} from '../../../templating/index';
 
 @autobind
 class Plugins extends PureComponent {
@@ -37,7 +38,11 @@ class Plugins extends PureComponent {
   }
 
   _handleRefreshPlugins () {
-    this.setState({plugins: getPlugins(true)});
+    // Get and reload plugins
+    const plugins = getPlugins(true);
+    reload();
+
+    this.setState({plugins});
     trackEvent('Plugins', 'Refresh');
   }
 

--- a/app/ui/components/templating/tag-editor.js
+++ b/app/ui/components/templating/tag-editor.js
@@ -135,7 +135,7 @@ class TagEditor extends PureComponent {
       template = typeof activeTagData.rawValue === 'string'
         ? activeTagData.rawValue
         : templateUtils.unTokenizeTag(activeTagData);
-      preview = await handleRender(template, true);
+      preview = await handleRender(template);
     } catch (err) {
       error = err.message;
     }

--- a/app/ui/components/templating/variable-editor.js
+++ b/app/ui/components/templating/variable-editor.js
@@ -45,7 +45,7 @@ class VariableEditor extends PureComponent {
     let error = '';
 
     try {
-      preview = await handleRender(value, true);
+      preview = await handleRender(value);
     } catch (err) {
       error = err.message;
     }

--- a/app/ui/containers/app.js
+++ b/app/ui/containers/app.js
@@ -260,7 +260,7 @@ class App extends PureComponent {
   async _fetchRenderContext () {
     const {activeEnvironment, activeRequest} = this.props;
     const environmentId = activeEnvironment ? activeEnvironment._id : null;
-    return render.getRenderContext(activeRequest, environmentId, null, false);
+    return render.getRenderContext(activeRequest, environmentId, null);
   }
 
   async _handleGetRenderContext () {


### PR DESCRIPTION
## What

This PR makes a few changes and fixes to the render pipeline to address some bugs and improve usability.

- [x] Now pass metadata in when rendering environment
  - Render consists of two phases (build and render environment, render request)
  - Metadata like active request/workspace didn't used to be passed to first stage
- [x] Handle render failures for unused environment variables better
  - used to do it by only rendering variables when rendering environment initially
  - now do it by trying to render environment variables and leaving them as-is if exception thrown
    - these exceptions will re-emerge at the second stage if the variable is actually used
    - this also addresses the case where a variable was set to a tag, then used in a filter (Fixes #350) 
- [x] Modify the cookie tag to show valid cookie names if specified one doesn't exist
   ![image](https://user-images.githubusercontent.com/587576/28041849-c2171066-657f-11e7-80d9-e816380b9177.png)
- [x] Now show `"Environment"` in rendered error path if failure occurs there
   ![image](https://user-images.githubusercontent.com/587576/28041825-b1bce254-657f-11e7-9edd-29e7e05549f9.png)


