### PR TITLE
Move Response objects into Redux

### DIFF
--- a/app/models/response.js
+++ b/app/models/response.js
@@ -48,7 +48,7 @@ export function all () {
 }
 
 export async function removeForRequest (parentId) {
-  db.removeBulkSilently(type, {parentId});
+  await db.removeWhere(type, {parentId});
 }
 
 export function remove (request) {
@@ -79,7 +79,7 @@ export async function create (patch = {}, bodyBuffer = null) {
   // Delete all other responses before creating the new one
   const allResponses = await db.findMostRecentlyModified(type, {parentId}, MAX_RESPONSES);
   const recentIds = allResponses.map(r => r._id);
-  await db.removeBulkSilently(type, {parentId, _id: {$nin: recentIds}});
+  await db.removeWhere(type, {parentId, _id: {$nin: recentIds}});
 
   // Actually create the new response
   const bodyPath = bodyBuffer ? storeBodyBuffer(bodyBuffer) : '';

--- a/app/ui/components/markdown-preview.js
+++ b/app/ui/components/markdown-preview.js
@@ -63,6 +63,10 @@ class MarkdownPreview extends PureComponent {
     }
   }
 
+  componentWillUnmount () {
+    clearTimeout(this._compileTimeout);
+  }
+
   componentWillMount () {
     this._compileMarkdown(this.props.markdown);
   }

--- a/app/ui/components/response-pane.js
+++ b/app/ui/components/response-pane.js
@@ -24,19 +24,12 @@ import Hotkey from './hotkey';
 
 @autobind
 class ResponsePane extends PureComponent {
-  constructor (props) {
-    super(props);
-    this.state = {
-      response: null
-    };
-  }
-
   _trackTab (name) {
     trackEvent('Response Pane', 'View', name);
   }
 
   _handleGetResponseBody () {
-    return models.response.getBodyBuffer(this.state.response);
+    return models.response.getBodyBuffer(this.props.response);
   }
 
   async _getResponse (requestId, responseId) {
@@ -50,7 +43,7 @@ class ResponsePane extends PureComponent {
   }
 
   async _handleDownloadResponseBody () {
-    if (!this.state.response) {
+    if (!this.props.response) {
       // Should never happen
       console.warn('No response to download');
       return;
@@ -130,21 +123,11 @@ class ResponsePane extends PureComponent {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
-    const activeRequestId = nextProps.request ? nextProps.request._id : null;
-    const activeResponseId = nextProps.activeResponseId;
-    this._getResponse(activeRequestId, activeResponseId);
-  }
-
-  componentDidMount () {
-    const activeRequestId = this.props.request ? this.props.request._id : null;
-    const activeResponseId = this.props.activeResponseId;
-    this._getResponse(activeRequestId, activeResponseId);
-  }
-
   render () {
     const {
       request,
+      responses,
+      response,
       previewMode,
       handleShowRequestSettings,
       handleSetPreviewMode,
@@ -159,11 +142,8 @@ class ResponsePane extends PureComponent {
       editorKeyMap,
       filter,
       filterHistory,
-      activeResponseId,
       showCookiesModal
     } = this.props;
-
-    const {response} = this.state;
 
     if (!request) {
       return (
@@ -234,9 +214,9 @@ class ResponsePane extends PureComponent {
               <SizeTag bytes={response.bytesRead}/>
             </div>
             <ResponseHistoryDropdown
+              activeResponse={response}
+              responses={responses}
               requestId={request._id}
-              isLatestResponseActive={!activeResponseId}
-              activeResponseId={response._id}
               handleSetActiveResponse={handleSetActiveResponse}
               handleDeleteResponses={handleDeleteResponses}
               handleDeleteResponse={handleDeleteResponse}
@@ -357,10 +337,11 @@ ResponsePane.propTypes = {
   editorKeyMap: PropTypes.string.isRequired,
   editorLineWrapping: PropTypes.bool.isRequired,
   loadStartTime: PropTypes.number.isRequired,
-  activeResponseId: PropTypes.string.isRequired,
+  responses: PropTypes.arrayOf(PropTypes.object),
 
   // Other
-  request: PropTypes.object
+  request: PropTypes.object,
+  response: PropTypes.object
 };
 
 export default ResponsePane;

--- a/app/ui/components/wrapper.js
+++ b/app/ui/components/wrapper.js
@@ -163,22 +163,13 @@ class Wrapper extends PureComponent {
     this._handleSetActiveResponse(null);
   }
 
-  async _handleDeleteResponse (responseId) {
-    let response;
-    if (responseId) {
-      response = await models.response.getById(responseId);
-    } else {
-      const {activeRequest} = this.props;
-      const requestId = activeRequest ? activeRequest._id : 'n/a';
-      response = await models.response.getLatestForRequestId(requestId);
-    }
-
+  async _handleDeleteResponse (response) {
     if (response) {
       await models.response.remove(response);
     }
 
     // Also unset active response it's the one we're deleting
-    if (this.props.activeResponseId === response._id) {
+    if (this.props.activeResponse && this.props.activeResponse._id === response._id) {
       this._handleSetActiveResponse(null);
     }
   }
@@ -243,8 +234,9 @@ class Wrapper extends PureComponent {
     const {
       activeEnvironment,
       activeRequest,
-      activeResponseId,
       activeWorkspace,
+      activeRequestResponses,
+      activeResponse,
       environments,
       handleActivateRequest,
       handleCreateRequest,
@@ -384,12 +376,13 @@ class Wrapper extends PureComponent {
         <ResponsePane
           ref={handleSetResponsePaneRef}
           request={activeRequest}
+          responses={activeRequestResponses}
+          response={activeResponse}
           editorFontSize={settings.editorFontSize}
           editorIndentSize={settings.editorIndentSize}
           editorKeyMap={settings.editorKeyMap}
           editorLineWrapping={settings.editorLineWrapping}
           previewMode={responsePreviewMode}
-          activeResponseId={activeResponseId}
           filter={responseFilter}
           filterHistory={responseFilterHistory}
           loadStartTime={loadStartTime}
@@ -561,7 +554,6 @@ Wrapper.propTypes = {
   responsePreviewMode: PropTypes.string.isRequired,
   responseFilter: PropTypes.string.isRequired,
   responseFilterHistory: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
-  activeResponseId: PropTypes.string.isRequired,
   sidebarWidth: PropTypes.number.isRequired,
   sidebarHidden: PropTypes.bool.isRequired,
   sidebarFilter: PropTypes.string.isRequired,
@@ -570,6 +562,7 @@ Wrapper.propTypes = {
   workspaces: PropTypes.arrayOf(PropTypes.object).isRequired,
   workspaceChildren: PropTypes.arrayOf(PropTypes.object).isRequired,
   environments: PropTypes.arrayOf(PropTypes.object).isRequired,
+  activeRequestResponses: PropTypes.arrayOf(PropTypes.object).isRequired,
   activeWorkspace: PropTypes.shape({
     _id: PropTypes.string.isRequired
   }).isRequired,
@@ -577,6 +570,7 @@ Wrapper.propTypes = {
   // Optional
   oAuth2Token: PropTypes.object,
   activeRequest: PropTypes.object,
+  activeResponse: PropTypes.object,
   activeEnvironment: PropTypes.object
 };
 

--- a/app/ui/containers/app.js
+++ b/app/ui/containers/app.js
@@ -20,7 +20,7 @@ import * as globalActions from '../redux/modules/global';
 import * as db from '../../common/database';
 import * as models from '../../models';
 import {trackEvent} from '../../analytics';
-import {selectActiveOAuth2Token, selectActiveRequest, selectActiveRequestMeta, selectActiveWorkspace, selectActiveWorkspaceMeta, selectEntitiesLists, selectSidebarChildren, selectWorkspaceRequestsAndRequestGroups} from '../redux/selectors';
+import {selectActiveOAuth2Token, selectActiveRequest, selectActiveRequestMeta, selectActiveRequestResponses, selectActiveResponse, selectActiveWorkspace, selectActiveWorkspaceMeta, selectEntitiesLists, selectSidebarChildren, selectWorkspaceRequestsAndRequestGroups} from '../redux/selectors';
 import RequestCreateModal from '../components/modals/request-create-modal';
 import GenerateCodeModal from '../components/modals/generate-code-modal';
 import WorkspaceSettingsModal from '../components/modals/workspace-settings-modal';
@@ -483,7 +483,8 @@ class App extends PureComponent {
     this.props.handleStopLoading(requestId);
   }
 
-  async _handleSetActiveResponse (requestId, activeResponseId = null) {
+  async _handleSetActiveResponse (requestId, activeResponse = null) {
+    const activeResponseId = activeResponse ? activeResponse._id : null;
     await this._updateRequestMetaByParentId(requestId, {activeResponseId});
 
     let response;
@@ -888,7 +889,10 @@ function mapStateToProps (state, props) {
   const responsePreviewMode = requestMeta.previewMode || PREVIEW_MODE_SOURCE;
   const responseFilter = requestMeta.responseFilter || '';
   const responseFilterHistory = requestMeta.responseFilterHistory || [];
-  const activeResponseId = requestMeta.activeResponseId || '';
+
+  // Response stuff
+  const activeRequestResponses = selectActiveRequestResponses(state, props) || [];
+  const activeResponse = selectActiveResponse(state, props) || null;
 
   // Environment stuff
   const activeEnvironmentId = workspaceMeta.activeEnvironmentId;
@@ -912,7 +916,8 @@ function mapStateToProps (state, props) {
     loadStartTime,
     activeWorkspace,
     activeRequest,
-    activeResponseId,
+    activeRequestResponses,
+    activeResponse,
     sidebarHidden,
     sidebarFilter,
     sidebarWidth,

--- a/app/ui/redux/modules/index.js
+++ b/app/ui/redux/modules/index.js
@@ -48,6 +48,7 @@ async function getAllDocs () {
     models.requestGroupMeta.all(),
     models.request.all(),
     models.requestMeta.all(),
+    models.response.all(),
     models.oAuth2Token.all()
   ]);
 

--- a/app/ui/redux/selectors.js
+++ b/app/ui/redux/selectors.js
@@ -179,3 +179,29 @@ export const selectActiveRequestMeta = createSelector(
     return entities.requestMetas.find(m => m.parentId === id);
   }
 );
+
+export const selectActiveRequestResponses = createSelector(
+  selectActiveRequest,
+  selectEntitiesLists,
+  (activeRequest, entities) => {
+    const requestId = activeRequest ? activeRequest._id : 'n/a';
+    return entities.responses
+      .filter(response => requestId === response.parentId)
+      .sort((a, b) => a.created > b.created ? -1 : 1);
+  }
+);
+
+export const selectActiveResponse = createSelector(
+  selectActiveRequestMeta,
+  selectActiveRequestResponses,
+  (activeRequestMeta, responses) => {
+    const activeResponseId = activeRequestMeta ? activeRequestMeta.activeResponseId : 'n/a';
+    const activeResponse = responses.find(response => response._id === activeResponseId);
+
+    if (activeResponse) {
+      return activeResponse;
+    }
+
+    return responses[0] || null;
+  }
+);


### PR DESCRIPTION
Now that we have response bodies out of the local DB (#338) we can now keep response objects in Redux without worrying about taking up memory. Before, response bodies were looked up on demand, which was really clunky and bad.