### PR TITLE
Throttle sync when slow

### DIFF
--- a/app/common/fetch.js
+++ b/app/common/fetch.js
@@ -42,7 +42,7 @@ async function _fetch (method, path, json, sessionId = null) {
   config.headers.set('X-Insomnia-Client', getClientString());
 
   if (json) {
-    config.body = JSON.stringify(json, null, 2);
+    config.body = JSON.stringify(json);
     config.headers.set('Content-Type', 'application/json');
   }
 


### PR DESCRIPTION
## What

_This is a better attempt at #380_

Currently, the sync operation is ran every `15` seconds even if it longer than that. 

- [x] Enforce that the next sync operation does not start until `15` seconds after the last one finishes
- [x] Also add a backoff delay if the server is slow
  - `nextSyncTime = 15 + TIME_IT_TOOK_TO_SYNC_LAST_TIME * 2`