### PR TITLE
Add redirectUri to url regex for OAuth2

### DIFF
--- a/app/network/o-auth-2/grant-authorization-code.js
+++ b/app/network/o-auth-2/grant-authorization-code.js
@@ -57,8 +57,9 @@ async function _authorize (url, clientId, redirectUri = '', scope = '', state = 
   // Add query params to URL
   const qs = querystring.buildFromParams(params);
   const finalUrl = querystring.joinUrl(url, qs);
+  const regex = redirectUri ? new RegExp(redirectUri + '.*(code=|error=).*') : /(code=|error=)/;
 
-  const redirectedTo = await authorizeUserInWindow(finalUrl, /(code=|error=)/);
+  const redirectedTo = await authorizeUserInWindow(finalUrl, regex);
 
   const {query} = urlParse(redirectedTo);
   return responseToObject(query, [

--- a/app/network/o-auth-2/grant-authorization-code.js
+++ b/app/network/o-auth-2/grant-authorization-code.js
@@ -57,7 +57,8 @@ async function _authorize (url, clientId, redirectUri = '', scope = '', state = 
   // Add query params to URL
   const qs = querystring.buildFromParams(params);
   const finalUrl = querystring.joinUrl(url, qs);
-  const regex = redirectUri ? new RegExp(redirectUri + '.*(code=|error=).*') : /(code=|error=)/;
+  const escapedUri = redirectUri.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
+  const regex = new RegExp(`${escapedUri}.*(code=|error=)`);
 
   const redirectedTo = await authorizeUserInWindow(finalUrl, regex);
 


### PR DESCRIPTION
## What
Made a change to how the regex used to detect the `finalUrl` during the OAuth2 flow.

## Why
Keycloak is an  an OAuth2/OpenId Connect authentication provider. As part of Keycloak's authentication flow it loads several pages in order to prompt the user for different pieces of information. One of these pages is an internal keycloak page with a `code=12341234` at the end of the url. 

This triggers the regex and Insomnia will extract this invalid code and attempt to get a token. The access token request fails because the code is internal to keycloak and isn't actually an authorization code.

This PR will add the redirect uri, if present, to the regex so that it will only trigger if the url loaded in the window begins with the redirect uri.

## Details
Not sure if RegEx is commonly available. Don't normally contribute to node/js based projects.

## Notes
Not sure how to add tests regarding this.

**Related Issue**: _(Issue number this PR references, for example #4)_

