### PR TITLE
Address some obvious performance wins

### DIFF
--- a/app/ui/components/codemirror/base-imports.js
+++ b/app/ui/components/codemirror/base-imports.js
@@ -10,7 +10,6 @@ import 'codemirror/mode/markdown/markdown';
 import 'codemirror/mode/python/python';
 import 'codemirror/mode/ruby/ruby';
 import 'codemirror/mode/swift/swift';
-import 'codemirror/addon/display/autorefresh';
 import 'codemirror/addon/dialog/dialog';
 import 'codemirror/addon/dialog/dialog.css';
 import 'codemirror/addon/fold/foldcode';

--- a/app/ui/components/codemirror/code-editor.js
+++ b/app/ui/components/codemirror/code-editor.js
@@ -27,7 +27,6 @@ const BASE_CODEMIRROR_OPTIONS = {
   placeholder: 'Start Typing...',
   foldGutter: true,
   height: 'auto',
-  autoRefresh: 500,
   lineWrapping: true,
   scrollbarStyle: 'native',
   lint: true,

--- a/app/ui/components/response-timer.js
+++ b/app/ui/components/response-timer.js
@@ -7,7 +7,6 @@ class ResponseTimer extends PureComponent {
     super(props);
     this._interval = null;
     this.state = {
-      show: false,
       elapsedTime: 0
     };
   }
@@ -16,24 +15,27 @@ class ResponseTimer extends PureComponent {
     clearInterval(this._interval);
   }
 
-  componentDidMount () {
+  componentWillReceiveProps (nextProps) {
+    const {loadStartTime} = nextProps;
+
+    if (loadStartTime <= 0) {
+      clearInterval(this._interval);
+      return;
+    }
+
+    clearInterval(this._interval); // Just to be sure
     this._interval = setInterval(() => {
-      const {loadStartTime} = this.props;
-      if (loadStartTime > 0) {
-        // Show and update if needed
-        const millis = Date.now() - loadStartTime - 200;
-        const elapsedTime = Math.round(millis / 100) / 10;
-        this.setState({show: true, elapsedTime});
-      } else if (this.state.show) {
-        // Hide if needed after a small delay (so it doesn't disappear too quickly)
-        setTimeout(() => this.setState({show: false}), 200);
-      }
+      const millis = Date.now() - loadStartTime - 200;
+      const elapsedTime = Math.round(millis / 100) / 10;
+      this.setState({elapsedTime});
     }, 100);
   }
 
   render () {
-    const {handleCancel} = this.props;
-    const {show, elapsedTime} = this.state;
+    const {handleCancel, loadStartTime} = this.props;
+    const {elapsedTime} = this.state;
+
+    const show = loadStartTime > 0;
 
     return (
       <div className={classnames('overlay theme--overlay', {'overlay--hidden': !show})}>


### PR DESCRIPTION
## What

This PR addresses some of the most obvious performance issues.

- [x] Remove CodeMirror autorefresh plugin (didn't seem to be needed anyway)
- [x] Get rid of `setInterval` in sync menu
  - Added event listener to DB to watch for changes instead of polling
- [x] Flatten sync menu React state so `PureComponent` diffing works properly
- [x] Refactor response timer overlay to only run interval when request is actually sending