### PR TITLE
Move GraphQL introspection requests to Insomnia network stack

### DIFF
--- a/app/ui/components/editors/body/body-editor.js
+++ b/app/ui/components/editors/body/body-editor.js
@@ -51,6 +51,8 @@ class BodyEditor extends PureComponent {
       indentSize,
       lineWrapping,
       request,
+      workspace,
+      settings,
       handleRender: render,
       handleGetRenderContext: getRenderContext
     } = this.props;
@@ -104,6 +106,8 @@ class BodyEditor extends PureComponent {
           keyMap={keyMap}
           lineWrapping={lineWrapping}
           render={handleRender}
+          workspace={workspace}
+          settings={settings}
           getRenderContext={handleGetRenderContext}
           onChange={this._handleGraphQLChange}
         />
@@ -145,6 +149,9 @@ BodyEditor.propTypes = {
   handleRender: PropTypes.func.isRequired,
   handleGetRenderContext: PropTypes.func.isRequired,
   request: PropTypes.object.isRequired,
+  workspace: PropTypes.object.isRequired,
+  settings: PropTypes.object.isRequired,
+  environmentId: PropTypes.string.isRequired,
 
   // Optional
   fontSize: PropTypes.number,

--- a/app/ui/components/request-pane.js
+++ b/app/ui/components/request-pane.js
@@ -23,6 +23,7 @@ import Hotkey from './hotkey';
 import {showModal} from './modals/index';
 import RequestSettingsModal from './modals/request-settings-modal';
 import MarkdownPreview from './markdown-preview';
+import type {Settings} from '../../models/settings';
 
 @autobind
 class RequestPane extends React.PureComponent {
@@ -55,6 +56,8 @@ class RequestPane extends React.PureComponent {
     editorKeyMap: string,
     editorLineWrapping: boolean,
     workspace: Workspace,
+    settings: Settings,
+    environmentId: string,
     forceRefreshCounter: number,
 
     // Optional
@@ -171,6 +174,9 @@ class RequestPane extends React.PureComponent {
       handleSendAndDownload,
       oAuth2Token,
       request,
+      workspace,
+      environmentId,
+      settings,
       showPasswords,
       updateRequestAuthentication,
       updateRequestBody,
@@ -308,6 +314,9 @@ class RequestPane extends React.PureComponent {
               handleGetRenderContext={handleGetRenderContext}
               key={uniqueKey}
               request={request}
+              workspace={workspace}
+              environmentId={environmentId}
+              settings={settings}
               onChange={updateRequestBody}
               fontSize={editorFontSize}
               indentSize={editorIndentSize}

--- a/app/ui/components/wrapper.js
+++ b/app/ui/components/wrapper.js
@@ -431,6 +431,8 @@ class Wrapper extends React.PureComponent {
           editorKeyMap={settings.editorKeyMap}
           editorLineWrapping={settings.editorLineWrapping}
           workspace={activeWorkspace}
+          settings={settings}
+          environmentId={activeEnvironment ? activeEnvironment._id : ''}
           oAuth2Token={oAuth2Token}
           forceUpdateRequest={this._handleForceUpdateRequest}
           handleCreateRequest={handleCreateRequestForWorkspace}


### PR DESCRIPTION
## What

Currently, GraphQL introspection queries (to fetch the schema) are sent with the HTML5 fetch API. This means that a lot of Insomnia features like auth, proxy settings, and cookies are not sent. This PR moves the introspection query from fetch to libcurl by using the same code path as sending reqular requests.