### PR TITLE
Add ability to specify OAuth 2 Authorization header prefix

### DIFF
--- a/app/network/authentication.js
+++ b/app/network/authentication.js
@@ -21,7 +21,7 @@ export async function getAuthHeader (requestId, authentication) {
     const oAuth2Token = await getOAuth2Token(requestId, authentication);
     if (oAuth2Token) {
       const token = oAuth2Token.accessToken;
-      return _buildBearerHeader(token);
+      return _buildBearerHeader(token, authentication.tokenPrefix);
     } else {
       return null;
     }
@@ -30,13 +30,13 @@ export async function getAuthHeader (requestId, authentication) {
   return null;
 }
 
-function _buildBearerHeader (accessToken) {
+function _buildBearerHeader (accessToken, prefix) {
   if (!accessToken) {
     return null;
   }
 
   const name = 'Authorization';
-  const value = `Bearer ${accessToken}`;
+  const value = `${prefix || 'Bearer'} ${accessToken}`;
 
   return {name, value};
 }

--- a/app/ui/css/layout/base.less
+++ b/app/ui/css/layout/base.less
@@ -194,6 +194,14 @@ p.notice {
   }
 }
 
+.notice.subtle {
+  border-color: var(--hl-lg);
+  &::before {
+    opacity: 1;
+    background-color: var(--hl-xxs);
+  }
+}
+
 .notice.surprise {
   border-color: var(--color-surprise);
   &::before {


### PR DESCRIPTION
## What

Closes #419 

Before, Insomnia added `Authorization: Bearer <MY_OAUTH_TOKEN>` with requests. However, some servers expect a different name for this, so this PR adds the ability to override the default `Bearer` prefix with something else.

This PR also moves some of the advanced OAuth2 options into a collapsed-by-default section.

![image](https://user-images.githubusercontent.com/587576/29186740-3f47bc5c-7dc2-11e7-8684-093040f4df6f.png)
![image](https://user-images.githubusercontent.com/587576/29186775-43fa51a6-7dc2-11e7-9ff6-549e93d12098.png)
