### PR TITLE
Add environment to plugin

### DIFF
--- a/app/plugins/context/__tests__/request.test.js
+++ b/app/plugins/context/__tests__/request.test.js
@@ -9,6 +9,14 @@ const PLUGIN = {
   module: {}
 };
 
+const CONTEXT = {
+  user_key: 'my_user_key',
+  hello: 'world',
+  array_test: ['a', 'b'],
+  object_test: {a: 'A', b: 'B'},
+  null_test: null
+};
+
 describe('init()', () => {
   beforeEach(async () => {
     await globalBeforeEach();
@@ -17,7 +25,7 @@ describe('init()', () => {
   });
 
   it('initializes correctly', async () => {
-    const result = plugin.init(PLUGIN, await models.request.getById('req_1'));
+    const result = plugin.init(PLUGIN, await models.request.getById('req_1'), CONTEXT);
     expect(Object.keys(result)).toEqual(['request']);
     expect(Object.keys(result.request)).toEqual([
       'getId',
@@ -29,7 +37,9 @@ describe('init()', () => {
       'removeHeader',
       'setHeader',
       'addHeader',
-      'setCookie'
+      'setCookie',
+      'getEnvironmentVariable',
+      'getEnvironment'
     ]);
   });
 
@@ -55,7 +65,7 @@ describe('request.*', () => {
   });
 
   it('works for basic getters', async () => {
-    const result = plugin.init(PLUGIN, await models.request.getById('req_1'));
+    const result = plugin.init(PLUGIN, await models.request.getById('req_1'), CONTEXT);
     expect(result.request.getId()).toBe('req_1');
     expect(result.request.getName()).toBe('My Request');
     expect(result.request.getUrl()).toBe('');
@@ -91,10 +101,33 @@ describe('request.*', () => {
     const request = await models.request.getById('req_1');
     request.cookies = []; // Because the plugin technically needs a RenderedRequest
 
-    const result = plugin.init(PLUGIN, request);
+    const result = plugin.init(PLUGIN, request, CONTEXT);
 
     result.request.setCookie('foo', 'bar');
     result.request.setCookie('foo', 'baz');
     expect(request.cookies).toEqual([{name: 'foo', value: 'baz'}]);
+  });
+
+  it('works for environment', async () => {
+    const request = await models.request.getById('req_1');
+    request.cookies = []; // Because the plugin technically needs a RenderedRequest
+
+    const result = plugin.init(PLUGIN, request, CONTEXT);
+
+    // getEnvironment
+    expect(result.request.getEnvironment()).toEqual({
+      user_key: 'my_user_key',
+      hello: 'world',
+      array_test: ['a', 'b'],
+      object_test: {a: 'A', b: 'B'},
+      null_test: null
+    });
+
+    // getEnvironmentVariable
+    expect(result.request.getEnvironmentVariable('user_key')).toBe('my_user_key');
+    expect(result.request.getEnvironmentVariable('hello')).toBe('world');
+    expect(result.request.getEnvironmentVariable('array_test')).toEqual(['a', 'b']);
+    expect(result.request.getEnvironmentVariable('object_test')).toEqual({a: 'A', b: 'B'});
+    expect(result.request.getEnvironmentVariable('null_test')).toBe(null);
   });
 });

--- a/app/plugins/context/__tests__/request.test.js
+++ b/app/plugins/context/__tests__/request.test.js
@@ -33,6 +33,7 @@ describe('init()', () => {
       'getUrl',
       'getMethod',
       'getHeader',
+      'getHeaders',
       'hasHeader',
       'removeHeader',
       'setHeader',
@@ -73,7 +74,13 @@ describe('request.*', () => {
   });
 
   it('works for headers', async () => {
-    const result = plugin.init(PLUGIN, await models.request.getById('req_1'));
+    const result = plugin.init(PLUGIN, await models.request.getById('req_1'), CONTEXT);
+
+    // getHeaders()
+    expect(result.request.getHeaders()).toEqual([
+      {name: 'hello', value: 'world'},
+      {name: 'Content-Type', value: 'application/json'}
+    ]);
 
     // getHeader()
     expect(result.request.getHeader('content-type')).toBe('application/json');

--- a/app/plugins/context/request.js
+++ b/app/plugins/context/request.js
@@ -3,7 +3,11 @@ import type {Plugin} from '../';
 import type {RenderedRequest} from '../../common/render';
 import * as misc from '../../common/misc';
 
-export function init (plugin: Plugin, renderedRequest: RenderedRequest): {request: Object} {
+export function init (
+  plugin: Plugin,
+  renderedRequest: RenderedRequest,
+  renderedContext: Object
+): {request: Object} {
   if (!renderedRequest) {
     throw new Error('contexts.request initialized without request');
   }
@@ -63,6 +67,12 @@ export function init (plugin: Plugin, renderedRequest: RenderedRequest): {reques
         } else {
           renderedRequest.cookies.push({name, value});
         }
+      },
+      getEnvironmentVariable (name: string): string | number | boolean | Object | Array<any> | null {
+        return renderedContext[name];
+      },
+      getEnvironment (): string | number | boolean | Object | Array<any> | null {
+        return renderedContext;
       }
 
       // NOTE: For these to make sense, we'd need to account for cookies in the jar as well

--- a/app/plugins/context/request.js
+++ b/app/plugins/context/request.js
@@ -37,6 +37,9 @@ export function init (
           return null;
         }
       },
+      getHeaders (): Array<{name: string, value: string}> {
+        return renderedRequest.headers.map(h => ({ name: h.name, value: h.value }));
+      },
       hasHeader (name: string): boolean {
         return this.getHeader(name) !== null;
       },

--- a/app/plugins/install.js
+++ b/app/plugins/install.js
@@ -71,21 +71,13 @@ export default async function (moduleName: string): Promise<void> {
 async function _isInsomniaPlugin (moduleName: string): Promise<Object> {
   return new Promise((resolve, reject) => {
     childProcess.exec(
-      `npm show ${moduleName} insomnia version name dist.shasum dist.tarball`,
-      (err, stdout, stderr) => {
+      `npm show ${moduleName} --json`, (err, stdout, stderr) => {
         if (err && stderr.includes('E404')) {
           reject(new Error(`${moduleName} not found on npm`));
           return;
         }
 
-        const lines = stdout.split('\n').filter(l => !!l);
-        const info = {};
-        for (const line of lines) {
-          const match = line.match(/(.*) = '(.*)'/);
-
-          // Strip quotes off of the value
-          info[match[1]] = match[2];
-        }
+        const info = JSON.parse(stdout);
 
         if (!info.hasOwnProperty('insomnia')) {
           reject(new Error(`"${moduleName}" not a plugin! Package missing "insomnia" attribute`));
@@ -97,8 +89,8 @@ async function _isInsomniaPlugin (moduleName: string): Promise<Object> {
           name: info.name,
           version: info.version,
           dist: {
-            shasum: info['dist.shasum'],
-            tarball: info['dist.tarball']
+            shasum: info.dist.shasum,
+            tarball: info.dist.tarball
           }
         });
       }


### PR DESCRIPTION
As discussed in slack: <https://getinsomnia.slack.com/archives/C4Z8M9E86/p1502912037000177>, this pr intended to add these features:

- Allow plugin to access current context, so plugin's can get environment data now.
- Add getAllHeaders API for context request

With these improves:

- Use JSON to parse `npm show`'s output, it's indeed a JSON content, we don't need to parse it with split in `\n`.
