### PR TITLE
[Improvement] Add Method to Tag Editor Request Select Field

### DIFF
--- a/app/ui/components/templating/tag-editor.js
+++ b/app/ui/components/templating/tag-editor.js
@@ -241,8 +241,7 @@ class TagEditor extends PureComponent {
 
             const requestGroupStr = requestGroup ? `[${requestGroup.name}] ` : ''
             const requestMethodStr = request.method ? `${request.method} ` : ''
-            // <MethodTag method={request.method}/>
-            console.log(request)
+            
             namePrefix = requestGroupStr + requestMethodStr
           }
 

--- a/app/ui/components/templating/tag-editor.js
+++ b/app/ui/components/templating/tag-editor.js
@@ -237,7 +237,13 @@ class TagEditor extends PureComponent {
             const parentId = request ? request.parentId : 'n/a';
             const requestGroups = allDocs[models.requestGroup.type] || [];
             const requestGroup = requestGroups.find(rg => rg._id === parentId);
-            namePrefix = requestGroup ? `[${requestGroup.name}] ` : null;
+            const requestMethod = request.method;
+
+            const requestGroupStr = requestGroup ? `[${requestGroup.name}] ` : ''
+            const requestMethodStr = request.method ? `${request.method} ` : ''
+            // <MethodTag method={request.method}/>
+            console.log(request)
+            namePrefix = requestGroupStr + requestMethodStr
           }
 
           return (


### PR DESCRIPTION
This PR adds the Request Method to the Request Select Field in the Tag Editor to see the difference between calls with different methods but same urls.
