### PR TITLE
Fix Invalid_flowconfig error

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,3 @@
-
 [ignore]
 .*/node_modules/.*
 .*/__fixtures__/.*


### PR DESCRIPTION
The .flowconfig file had an empty line at the start which causes the following issue when running the "npm test:flow" command:
{"code":8,"reason":"Invalid_flowconfig","msg":".flowconfig:1 Unexpected config line not in any section"}

Removing the first line fixed the error on my system:
Microsoft Windows 10 Pro Build 15063
Node v8.6.0
Flow 0.55.0