### PR TITLE
Fixed running unit tests under Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text eol=lf
+
+*.gif   binary
+*.icns  binary
+*.ico   binary
+*.png   binary
+*.woff2 binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .idea
+.vscode
 dist/*
 build/*
 .DS_Store


### PR DESCRIPTION
Upon cloning this repository with my windows git client the line endings of text files were converted from LF to CRLF. This causes the unit tests in prettify.test.js and a test in network.test.js to fail, since they expect LF line endings. This commit prevents git clients form converting the line endings in some test fixture files.

I guess the git client in the appveyor windows image doesn't automatically convert line endings and thus doesn't have this issue.
