### PR TITLE
Add setting to enable nunjucks power mode

### DIFF
--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -21,7 +21,8 @@ type BaseSettings = {
   theme: string,
   maxRedirects: number,
   disableAnalyticsTracking: boolean,
-  pluginPath: string
+  pluginPath: string,
+  nunjucksPowerUserMode: boolean
 };
 
 export type Settings = BaseModel & Settings;
@@ -51,7 +52,8 @@ export function init (): BaseSettings {
     autoHideMenuBar: false,
     theme: 'default',
     disableAnalyticsTracking: false,
-    pluginPath: ''
+    pluginPath: '',
+    nunjucksPowerUserMode: false
   };
 }
 

--- a/app/ui/components/codemirror/code-editor.js
+++ b/app/ui/components/codemirror/code-editor.js
@@ -249,7 +249,7 @@ class CodeEditor extends React.Component {
       this._codemirrorSetValue(defaultValue || '');
 
       // Setup nunjucks listeners
-      if (this.props.render) {
+      if (this.props.render && !this.props.nunjucksPowerUserMode) {
         this.codeMirror.enableNunjucksTags(this.props.render);
       }
 
@@ -760,6 +760,7 @@ CodeEditor.propTypes = {
   onClick: PropTypes.func,
   onPaste: PropTypes.func,
   render: PropTypes.func,
+  nunjucksPowerUserMode: PropTypes.bool,
   getRenderContext: PropTypes.func,
   getAutocompleteConstants: PropTypes.func,
   keyMap: PropTypes.string,

--- a/app/ui/components/codemirror/one-line-editor.js
+++ b/app/ui/components/codemirror/one-line-editor.js
@@ -292,6 +292,7 @@ class OneLineEditor extends PureComponent {
       render,
       onPaste,
       getRenderContext,
+      nunjucksPowerUserMode,
       getAutocompleteConstants,
       mode: syntaxMode,
       type: originalType
@@ -326,6 +327,7 @@ class OneLineEditor extends PureComponent {
           onChange={onChange}
           render={render}
           getRenderContext={getRenderContext}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           getAutocompleteConstants={getAutocompleteConstants}
           className={classnames('editor--single-line', className)}
           defaultValue={defaultValue}
@@ -372,6 +374,7 @@ OneLineEditor.propTypes = {
   onPaste: PropTypes.func,
   render: PropTypes.func,
   getRenderContext: PropTypes.func,
+  nunjucksPowerUserMode: PropTypes.bool,
   getAutocompleteConstants: PropTypes.func,
   placeholder: PropTypes.string,
   className: PropTypes.string,

--- a/app/ui/components/editors/auth/auth-wrapper.js
+++ b/app/ui/components/editors/auth/auth-wrapper.js
@@ -20,6 +20,7 @@ class AuthWrapper extends PureComponent {
       request,
       handleRender,
       handleGetRenderContext,
+      nunjucksPowerUserMode,
       handleUpdateSettingsShowPasswords,
       onChange,
       showPasswords
@@ -34,6 +35,7 @@ class AuthWrapper extends PureComponent {
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
           handleUpdateSettingsShowPasswords={handleUpdateSettingsShowPasswords}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={onChange}
           showPasswords={showPasswords}
         />
@@ -45,6 +47,7 @@ class AuthWrapper extends PureComponent {
           request={request}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           handleUpdateSettingsShowPasswords={handleUpdateSettingsShowPasswords}
           onChange={onChange}
           showPasswords={showPasswords}
@@ -56,6 +59,7 @@ class AuthWrapper extends PureComponent {
           request={request}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={onChange}
         />
       );
@@ -80,6 +84,7 @@ class AuthWrapper extends PureComponent {
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
           handleUpdateSettingsShowPasswords={handleUpdateSettingsShowPasswords}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={onChange}
           showPasswords={showPasswords}
         />
@@ -90,6 +95,7 @@ class AuthWrapper extends PureComponent {
           authentication={authentication}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           handleUpdateSettingsShowPasswords={handleUpdateSettingsShowPasswords}
           onChange={onChange}
           showPasswords={showPasswords}
@@ -102,6 +108,7 @@ class AuthWrapper extends PureComponent {
           request={request}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={onChange}
         />
       );
@@ -112,6 +119,7 @@ class AuthWrapper extends PureComponent {
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
           handleUpdateSettingsShowPasswords={handleUpdateSettingsShowPasswords}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={onChange}
           showPasswords={showPasswords}
         />
@@ -144,6 +152,7 @@ AuthWrapper.propTypes = {
   handleRender: PropTypes.func.isRequired,
   handleGetRenderContext: PropTypes.func.isRequired,
   handleUpdateSettingsShowPasswords: PropTypes.func.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   request: PropTypes.object.isRequired,
   showPasswords: PropTypes.bool.isRequired,

--- a/app/ui/components/editors/auth/aws-auth.js
+++ b/app/ui/components/editors/auth/aws-auth.js
@@ -36,7 +36,8 @@ class AWSAuth extends PureComponent {
       authentication,
       showPasswords,
       handleRender,
-      handleGetRenderContext
+      handleGetRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     const pairs = [{
@@ -52,6 +53,7 @@ class AWSAuth extends PureComponent {
         disableDelete
         handleRender={handleRender}
         handleGetRenderContext={handleGetRenderContext}
+        nunjucksPowerUserMode={nunjucksPowerUserMode}
         namePlaceholder="AWS_ACCESS_KEY_ID"
         valuePlaceholder="AWS_SECRET_ACCESS_KEY"
         valueInputType={showPasswords ? 'text' : 'password'}
@@ -68,6 +70,7 @@ AWSAuth.propTypes = {
   handleRender: PropTypes.func.isRequired,
   handleGetRenderContext: PropTypes.func.isRequired,
   handleUpdateSettingsShowPasswords: PropTypes.func.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   authentication: PropTypes.object.isRequired,
   showPasswords: PropTypes.bool.isRequired

--- a/app/ui/components/editors/auth/basic-auth.js
+++ b/app/ui/components/editors/auth/basic-auth.js
@@ -36,7 +36,8 @@ class BasicAuth extends PureComponent {
       authentication,
       showPasswords,
       handleRender,
-      handleGetRenderContext
+      handleGetRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     const pairs = [{
@@ -52,6 +53,7 @@ class BasicAuth extends PureComponent {
         disableDelete
         handleRender={handleRender}
         handleGetRenderContext={handleGetRenderContext}
+        nunjucksPowerUserMode={nunjucksPowerUserMode}
         namePlaceholder="Username"
         valuePlaceholder="•••••••••••"
         valueInputType={showPasswords ? 'text' : 'password'}
@@ -68,6 +70,7 @@ BasicAuth.propTypes = {
   handleRender: PropTypes.func.isRequired,
   handleGetRenderContext: PropTypes.func.isRequired,
   handleUpdateSettingsShowPasswords: PropTypes.func.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   authentication: PropTypes.object.isRequired,
   showPasswords: PropTypes.bool.isRequired

--- a/app/ui/components/editors/auth/bearer-auth.js
+++ b/app/ui/components/editors/auth/bearer-auth.js
@@ -19,7 +19,7 @@ class BearerAuth extends PureComponent {
   }
 
   render () {
-    const {request, handleRender, handleGetRenderContext} = this.props;
+    const {request, handleRender, handleGetRenderContext, nunjucksPowerUserMode} = this.props;
     const {token} = request.authentication;
 
     return (
@@ -29,6 +29,7 @@ class BearerAuth extends PureComponent {
           onChange={this._handleChange}
           defaultValue={token || ''}
           render={handleRender}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           placeholder="token"
           getRenderContext={handleGetRenderContext}
         />
@@ -40,6 +41,7 @@ class BearerAuth extends PureComponent {
 BearerAuth.propTypes = {
   handleRender: PropTypes.func.isRequired,
   handleGetRenderContext: PropTypes.func.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   request: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired
 };

--- a/app/ui/components/editors/auth/digest-auth.js
+++ b/app/ui/components/editors/auth/digest-auth.js
@@ -36,6 +36,7 @@ class DigestAuth extends PureComponent {
       authentication,
       showPasswords,
       handleRender,
+      nunjucksPowerUserMode,
       handleGetRenderContext
     } = this.props;
 
@@ -52,6 +53,7 @@ class DigestAuth extends PureComponent {
         disableDelete
         handleRender={handleRender}
         handleGetRenderContext={handleGetRenderContext}
+        nunjucksPowerUserMode={nunjucksPowerUserMode}
         namePlaceholder="Username"
         valuePlaceholder="•••••••••••"
         valueInputType={showPasswords ? 'text' : 'password'}
@@ -68,6 +70,7 @@ DigestAuth.propTypes = {
   handleRender: PropTypes.func.isRequired,
   handleGetRenderContext: PropTypes.func.isRequired,
   handleUpdateSettingsShowPasswords: PropTypes.func.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   authentication: PropTypes.object.isRequired,
   showPasswords: PropTypes.bool.isRequired

--- a/app/ui/components/editors/auth/hawk-auth.js
+++ b/app/ui/components/editors/auth/hawk-auth.js
@@ -12,6 +12,7 @@ type Props = {
   request: Request,
   handleRender: Function,
   handleGetRenderContext: Function,
+  nunjucksPowerUserMode: boolean,
   onChange: Function
 };
 
@@ -108,7 +109,7 @@ class HawkAuth extends React.PureComponent<Props> {
     property: string,
     onChange: Function
   ): React.Element<*> {
-    const {handleRender, handleGetRenderContext, request} = this.props;
+    const {handleRender, handleGetRenderContext, request, nunjucksPowerUserMode} = this.props;
     const id = label.replace(/ /g, '-');
     return (
       <tr key={id}>
@@ -124,6 +125,7 @@ class HawkAuth extends React.PureComponent<Props> {
               type="text"
               onChange={onChange}
               defaultValue={request.authentication[property] || ''}
+              nunjucksPowerUserMode={nunjucksPowerUserMode}
               render={handleRender}
               getRenderContext={handleGetRenderContext}
             />

--- a/app/ui/components/editors/auth/ntlm-auth.js
+++ b/app/ui/components/editors/auth/ntlm-auth.js
@@ -36,7 +36,8 @@ class NTLMAuth extends PureComponent {
       authentication,
       showPasswords,
       handleRender,
-      handleGetRenderContext
+      handleGetRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     const pairs = [{
@@ -52,6 +53,7 @@ class NTLMAuth extends PureComponent {
         disableDelete
         handleRender={handleRender}
         handleGetRenderContext={handleGetRenderContext}
+        nunjucksPowerUserMode={nunjucksPowerUserMode}
         namePlaceholder="Username"
         valuePlaceholder="•••••••••••"
         valueInputType={showPasswords ? 'text' : 'password'}
@@ -68,6 +70,7 @@ NTLMAuth.propTypes = {
   handleRender: PropTypes.func.isRequired,
   handleGetRenderContext: PropTypes.func.isRequired,
   handleUpdateSettingsShowPasswords: PropTypes.func.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   authentication: PropTypes.object.isRequired,
   showPasswords: PropTypes.bool.isRequired

--- a/app/ui/components/editors/auth/o-auth-2-auth.js
+++ b/app/ui/components/editors/auth/o-auth-2-auth.js
@@ -22,6 +22,7 @@ type Props = {
   handleRender: Function,
   handleGetRenderContext: Function,
   handleUpdateSettingsShowPasswords: Function,
+  nunjucksPowerUserMode: boolean,
   onChange: Function,
   request: Request,
   showPasswords: boolean,
@@ -170,7 +171,7 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
     help: string | null = null,
     handleAutocomplete: Function | null = null
   ): React.Element<*> {
-    const {handleRender, handleGetRenderContext, request} = this.props;
+    const {handleRender, handleGetRenderContext, request, nunjucksPowerUserMode} = this.props;
     const id = label.replace(/ /g, '-');
     const type = !this.props.showPasswords && property === 'password' ? 'password' : 'text';
     return (
@@ -189,6 +190,7 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
               onChange={onChange}
               defaultValue={request.authentication[property] || ''}
               render={handleRender}
+              nunjucksPowerUserMode={nunjucksPowerUserMode}
               getAutocompleteConstants={handleAutocomplete}
               getRenderContext={handleGetRenderContext}
             />

--- a/app/ui/components/editors/body/body-editor.js
+++ b/app/ui/components/editors/body/body-editor.js
@@ -55,7 +55,8 @@ class BodyEditor extends PureComponent {
       settings,
       environmentId,
       handleRender: render,
-      handleGetRenderContext: getRenderContext
+      handleGetRenderContext: getRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     const noRender = request.settingDisableRenderRequestBody;
@@ -75,6 +76,7 @@ class BodyEditor extends PureComponent {
           onChange={this._handleFormUrlEncodedChange}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           parameters={request.body.params || []}
         />
       );
@@ -85,6 +87,7 @@ class BodyEditor extends PureComponent {
           onChange={this._handleFormChange}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           parameters={request.body.params || []}
         />
       );
@@ -111,6 +114,7 @@ class BodyEditor extends PureComponent {
           settings={settings}
           environmentId={environmentId}
           getRenderContext={handleGetRenderContext}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={this._handleGraphQLChange}
         />
       );
@@ -127,6 +131,7 @@ class BodyEditor extends PureComponent {
           content={request.body.text || ''}
           render={handleRender}
           getRenderContext={handleGetRenderContext}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={this._handleRawChange}
         />
       );
@@ -154,6 +159,7 @@ BodyEditor.propTypes = {
   workspace: PropTypes.object.isRequired,
   settings: PropTypes.object.isRequired,
   environmentId: PropTypes.string.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
 
   // Optional
   fontSize: PropTypes.number,

--- a/app/ui/components/editors/body/form-editor.js
+++ b/app/ui/components/editors/body/form-editor.js
@@ -35,7 +35,8 @@ class FormEditor extends PureComponent {
       parameters,
       onChange,
       handleRender,
-      handleGetRenderContext
+      handleGetRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     return (
@@ -49,6 +50,7 @@ class FormEditor extends PureComponent {
             valuePlaceholder="value"
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
+            nunjucksPowerUserMode={nunjucksPowerUserMode}
             onToggleDisable={this._handleTrackToggle}
             onChangeType={this._handleTrackChangeType}
             onChooseFile={this._handleTrackChooseFile}
@@ -67,6 +69,7 @@ FormEditor.propTypes = {
   // Required
   onChange: PropTypes.func.isRequired,
   parameters: PropTypes.arrayOf(PropTypes.object).isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
 
   // Optional
   handleRender: PropTypes.func,

--- a/app/ui/components/editors/body/graph-ql-editor.js
+++ b/app/ui/components/editors/body/graph-ql-editor.js
@@ -35,6 +35,7 @@ type Props = {
   lineWrapping: boolean,
   render: Function,
   getRenderContext: Function,
+  nunjucksPowerUserMode: boolean,
   request: Request,
   workspace: Workspace,
   settings: Settings,
@@ -243,6 +244,7 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
       keyMap,
       render,
       getRenderContext,
+      nunjucksPowerUserMode,
       lineWrapping,
       className
     } = this.props;
@@ -323,6 +325,7 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
             className={className}
             render={render}
             getRenderContext={getRenderContext}
+            nunjucksPowerUserMode={nunjucksPowerUserMode}
             onChange={this._handleVariablesChange}
             mode="application/json"
             lineWrapping={lineWrapping}

--- a/app/ui/components/editors/body/raw-editor.js
+++ b/app/ui/components/editors/body/raw-editor.js
@@ -14,6 +14,7 @@ class RawEditor extends PureComponent {
       keyMap,
       render,
       getRenderContext,
+      nunjucksPowerUserMode,
       lineWrapping,
       onChange,
       className
@@ -29,6 +30,7 @@ class RawEditor extends PureComponent {
         className={className}
         render={render}
         getRenderContext={getRenderContext}
+        nunjucksPowerUserMode={nunjucksPowerUserMode}
         onChange={onChange}
         mode={contentType}
         lineWrapping={lineWrapping}
@@ -47,6 +49,7 @@ RawEditor.propTypes = {
   indentSize: PropTypes.number.isRequired,
   keyMap: PropTypes.string.isRequired,
   lineWrapping: PropTypes.bool.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
 
   // Optional
   className: PropTypes.string,

--- a/app/ui/components/editors/body/url-encoded-editor.js
+++ b/app/ui/components/editors/body/url-encoded-editor.js
@@ -27,7 +27,8 @@ class UrlEncodedEditor extends PureComponent {
       parameters,
       onChange,
       handleRender,
-      handleGetRenderContext
+      handleGetRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     return (
@@ -41,6 +42,7 @@ class UrlEncodedEditor extends PureComponent {
             onChange={onChange}
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
+            nunjucksPowerUserMode={nunjucksPowerUserMode}
             onToggleDisable={this._handleTrackToggle}
             onCreate={this._handleTrackCreate}
             onDelete={this._handleTrackDelete}
@@ -56,6 +58,7 @@ UrlEncodedEditor.propTypes = {
   // Required
   onChange: PropTypes.func.isRequired,
   parameters: PropTypes.arrayOf(PropTypes.object).isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
 
   // Optional
   handleRender: PropTypes.func,

--- a/app/ui/components/editors/environment-editor.js
+++ b/app/ui/components/editors/environment-editor.js
@@ -63,6 +63,7 @@ class EnvironmentEditor extends PureComponent {
       editorKeyMap,
       render,
       getRenderContext,
+      nunjucksPowerUserMode,
       lineWrapping,
       ...props
     } = this.props;
@@ -81,6 +82,7 @@ class EnvironmentEditor extends PureComponent {
           onChange={this._handleChange}
           debounceMillis={DEBOUNCE_MILLIS * 6}
           defaultValue={JSON.stringify(environment)}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           render={render}
           getRenderContext={getRenderContext}
           mode="application/json"
@@ -101,6 +103,7 @@ EnvironmentEditor.propTypes = {
   editorKeyMap: PropTypes.string.isRequired,
   render: PropTypes.func.isRequired,
   getRenderContext: PropTypes.func.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   lineWrapping: PropTypes.bool.isRequired
 };
 

--- a/app/ui/components/editors/request-headers-editor.js
+++ b/app/ui/components/editors/request-headers-editor.js
@@ -96,7 +96,8 @@ class RequestHeadersEditor extends PureComponent {
       editorLineWrapping,
       onChange,
       handleRender,
-      handleGetRenderContext
+      handleGetRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     return bulk ? (
@@ -104,6 +105,7 @@ class RequestHeadersEditor extends PureComponent {
           <CodeEditor
             getRenderContext={handleGetRenderContext}
             render={handleRender}
+            nunjucksPowerUserMode={nunjucksPowerUserMode}
             fontSize={editorFontSize}
             indentSize={editorIndentSize}
             lineWrapping={editorLineWrapping}
@@ -119,6 +121,7 @@ class RequestHeadersEditor extends PureComponent {
               namePlaceholder="My-Header"
               valuePlaceholder="Value"
               pairs={headers}
+              nunjucksPowerUserMode={nunjucksPowerUserMode}
               handleRender={handleRender}
               handleGetRenderContext={handleGetRenderContext}
               handleGetAutocompleteNameConstants={this._getCommonHeaderNames}
@@ -140,6 +143,7 @@ RequestHeadersEditor.propTypes = {
   editorFontSize: PropTypes.number.isRequired,
   editorIndentSize: PropTypes.number.isRequired,
   editorLineWrapping: PropTypes.bool.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   handleRender: PropTypes.func.isRequired,
   handleGetRenderContext: PropTypes.func.isRequired,
   headers: PropTypes.arrayOf(PropTypes.shape({

--- a/app/ui/components/key-value-editor/editor.js
+++ b/app/ui/components/key-value-editor/editor.js
@@ -323,6 +323,7 @@ class Editor extends PureComponent {
       namePlaceholder,
       handleRender,
       handleGetRenderContext,
+      nunjucksPowerUserMode,
       handleGetAutocompleteNameConstants,
       handleGetAutocompleteValueConstants,
       allowFile,
@@ -355,6 +356,7 @@ class Editor extends PureComponent {
               onBlurName={this._handleBlurName}
               onBlurValue={this._handleBlurValue}
               onMove={this._handleMove}
+              nunjucksPowerUserMode={nunjucksPowerUserMode}
               handleRender={handleRender}
               handleGetRenderContext={handleGetRenderContext}
               handleGetAutocompleteNameConstants={handleGetAutocompleteNameConstants}
@@ -399,6 +401,7 @@ Editor.propTypes = {
   // Optional
   handleRender: PropTypes.func,
   handleGetRenderContext: PropTypes.func,
+  nunjucksPowerUserMode: PropTypes.bool,
   handleGetAutocompleteNameConstants: PropTypes.func,
   handleGetAutocompleteValueConstants: PropTypes.func,
   allowFile: PropTypes.bool,

--- a/app/ui/components/key-value-editor/row.js
+++ b/app/ui/components/key-value-editor/row.js
@@ -170,7 +170,8 @@ class KeyValueEditorRow extends PureComponent {
       valueInputType,
       valuePlaceholder,
       handleRender,
-      handleGetRenderContext
+      handleGetRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     if (pair.type === 'file') {
@@ -209,6 +210,7 @@ class KeyValueEditorRow extends PureComponent {
           onFocus={this._handleFocusValue}
           render={handleRender}
           getRenderContext={handleGetRenderContext}
+          nunjucksPowerUserMode={nunjucksPowerUserMode}
           getAutocompleteConstants={this._handleAutocompleteValues}
         />
       );
@@ -269,6 +271,7 @@ class KeyValueEditorRow extends PureComponent {
       namePlaceholder,
       handleRender,
       handleGetRenderContext,
+      nunjucksPowerUserMode,
       sortable,
       noDropZone,
       hideButtons,
@@ -313,6 +316,7 @@ class KeyValueEditorRow extends PureComponent {
               defaultValue={pair.name}
               render={handleRender}
               getRenderContext={handleGetRenderContext}
+              nunjucksPowerUserMode={nunjucksPowerUserMode}
               getAutocompleteConstants={this._handleAutocompleteNames}
               forceInput={forceInput}
               readOnly={readOnly}
@@ -392,6 +396,7 @@ KeyValueEditorRow.propTypes = {
   onBlurValue: PropTypes.func,
   handleRender: PropTypes.func,
   handleGetRenderContext: PropTypes.func,
+  nunjucksPowerUserMode: PropTypes.bool,
   handleGetAutocompleteNameConstants: PropTypes.func,
   handleGetAutocompleteValueConstants: PropTypes.func,
   namePlaceholder: PropTypes.string,

--- a/app/ui/components/markdown-editor.js
+++ b/app/ui/components/markdown-editor.js
@@ -56,7 +56,8 @@ class MarkdownEditor extends PureComponent {
       className,
       tall,
       handleRender,
-      handleGetRenderContext
+      handleGetRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     const {markdown} = this.state;
@@ -102,6 +103,7 @@ class MarkdownEditor extends PureComponent {
               defaultValue={markdown}
               render={handleRender}
               getRenderContext={handleGetRenderContext}
+              nunjucksPowerUserMode={nunjucksPowerUserMode}
               onChange={this._handleChange}
             />
           </div>
@@ -130,6 +132,7 @@ MarkdownEditor.propTypes = {
   lineWrapping: PropTypes.bool.isRequired,
   handleRender: PropTypes.func.isRequired,
   handleGetRenderContext: PropTypes.func.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
 
   // Optional
   placeholder: PropTypes.string,

--- a/app/ui/components/modals/code-prompt-modal.js
+++ b/app/ui/components/modals/code-prompt-modal.js
@@ -84,6 +84,7 @@ class CodePromptModal extends PureComponent {
   render () {
     const {
       handleGetRenderContext,
+      nunjucksPowerUserMode,
       handleRender,
       editorKeyMap,
       editorIndentSize,
@@ -130,6 +131,7 @@ class CodePromptModal extends PureComponent {
                   defaultValue={defaultValue}
                   placeholder={placeholder}
                   onChange={this._handleChange}
+                  nunjucksPowerUserMode={nunjucksPowerUserMode}
                   getRenderContext={enableRender ? handleGetRenderContext : null}
                   render={enableRender ? handleRender : null}
                   mode={mode}
@@ -172,6 +174,7 @@ CodePromptModal.propTypes = {
   editorIndentSize: PropTypes.number.isRequired,
   editorKeyMap: PropTypes.string.isRequired,
   editorLineWrapping: PropTypes.bool.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
 
   // Optional
   handleGetRenderContext: PropTypes.func,

--- a/app/ui/components/modals/cookie-modify-modal.js
+++ b/app/ui/components/modals/cookie-modify-modal.js
@@ -20,6 +20,7 @@ import type {Workspace} from '../../../models/workspace';
 type Props = {
   handleRender: Function,
   handleGetRenderContext: Function,
+  nunjucksPowerUserMode: boolean,
   workspace: Workspace,
   cookieJar: CookieJar
 };
@@ -175,7 +176,7 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
 
   _renderInputField (field: string, error: string | null = null) {
     const {cookie} = this.state;
-    const {handleRender, handleGetRenderContext} = this.props;
+    const {handleRender, handleGetRenderContext, nunjucksPowerUserMode} = this.props;
 
     if (!cookie) {
       return null;
@@ -190,6 +191,7 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
           <OneLineEditor
             render={handleRender}
             getRenderContext={handleGetRenderContext}
+            nunjucksPowerUserMode={nunjucksPowerUserMode}
             defaultValue={val || ''}
             onChange={value => this._handleChange(field, value)}/>
         </label>

--- a/app/ui/components/modals/environment-edit-modal.js
+++ b/app/ui/components/modals/environment-edit-modal.js
@@ -63,6 +63,7 @@ class EnvironmentEditModal extends PureComponent {
       lineWrapping,
       render,
       getRenderContext,
+      nunjucksPowerUserMode,
       ...extraProps
     } = this.props;
 
@@ -86,6 +87,7 @@ class EnvironmentEditModal extends PureComponent {
             didChange={this._didChange}
             render={render}
             getRenderContext={getRenderContext}
+            nunjucksPowerUserMode={nunjucksPowerUserMode}
           />
         </ModalBody>
         <ModalFooter>
@@ -108,6 +110,7 @@ EnvironmentEditModal.propTypes = {
   editorKeyMap: PropTypes.string.isRequired,
   render: PropTypes.func.isRequired,
   getRenderContext: PropTypes.func.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   lineWrapping: PropTypes.bool.isRequired
 };
 

--- a/app/ui/components/modals/request-settings-modal.js
+++ b/app/ui/components/modals/request-settings-modal.js
@@ -89,7 +89,8 @@ class RequestSettingsModal extends PureComponent {
       editorIndentSize,
       editorKeyMap,
       handleRender,
-      handleGetRenderContext
+      handleGetRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     const {showDescription, defaultPreviewMode} = this.state;
@@ -123,6 +124,7 @@ class RequestSettingsModal extends PureComponent {
             lineWrapping={editorLineWrapping}
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
+            nunjucksPowerUserMode={nunjucksPowerUserMode}
             defaultValue={request.description}
             onChange={this._handleDescriptionChange}
           />
@@ -187,6 +189,7 @@ RequestSettingsModal.propTypes = {
   editorIndentSize: PropTypes.number.isRequired,
   editorKeyMap: PropTypes.string.isRequired,
   editorLineWrapping: PropTypes.bool.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   handleRender: PropTypes.func.isRequired,
   handleGetRenderContext: PropTypes.func.isRequired
 };

--- a/app/ui/components/modals/workspace-environments-edit-modal.js
+++ b/app/ui/components/modals/workspace-environments-edit-modal.js
@@ -25,7 +25,8 @@ type Props = {
   editorKeyMap: string,
   lineWrapping: boolean,
   render: Function,
-  getRenderContext: Function
+  getRenderContext: Function,
+  nunjucksPowerUserMode: boolean
 };
 
 type State = {
@@ -257,7 +258,8 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
       editorKeyMap,
       lineWrapping,
       render,
-      getRenderContext
+      getRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     const {
@@ -384,6 +386,7 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
                 didChange={this._didChange}
                 render={render}
                 getRenderContext={getRenderContext}
+                nunjucksPowerUserMode={nunjucksPowerUserMode}
               />
             </div>
           </div>

--- a/app/ui/components/modals/workspace-settings-modal.js
+++ b/app/ui/components/modals/workspace-settings-modal.js
@@ -171,7 +171,8 @@ class WorkspaceSettingsModal extends PureComponent {
       editorIndentSize,
       editorKeyMap,
       handleRender,
-      handleGetRenderContext
+      handleGetRenderContext,
+      nunjucksPowerUserMode
     } = this.props;
 
     const {
@@ -218,6 +219,7 @@ class WorkspaceSettingsModal extends PureComponent {
                   lineWrapping={editorLineWrapping}
                   handleRender={handleRender}
                   handleGetRenderContext={handleGetRenderContext}
+                  nunjucksPowerUserMode={nunjucksPowerUserMode}
                   defaultValue={workspace.description}
                   onChange={this._handleDescriptionChange}
                 />
@@ -422,6 +424,7 @@ WorkspaceSettingsModal.propTypes = {
   editorIndentSize: PropTypes.number.isRequired,
   editorKeyMap: PropTypes.string.isRequired,
   editorLineWrapping: PropTypes.bool.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   handleRender: PropTypes.func.isRequired,
   handleGetRenderContext: PropTypes.func.isRequired,
   handleRemoveWorkspace: PropTypes.func.isRequired,

--- a/app/ui/components/request-pane.js
+++ b/app/ui/components/request-pane.js
@@ -52,6 +52,7 @@ type Props = {
   showPasswords: boolean,
   editorFontSize: number,
   editorIndentSize: number,
+  nunjucksPowerUserMode: boolean,
   editorKeyMap: string,
   editorLineWrapping: boolean,
   workspace: Workspace,
@@ -171,6 +172,7 @@ class RequestPane extends React.PureComponent<Props> {
       handleGetRenderContext,
       handleImport,
       handleRender,
+      nunjucksPowerUserMode,
       handleSend,
       handleSendAndDownload,
       oAuth2Token,
@@ -258,6 +260,7 @@ class RequestPane extends React.PureComponent<Props> {
             handleSend={handleSend}
             handleSendAndDownload={handleSendAndDownload}
             handleRender={handleRender}
+            nunjucksPowerUserMode={nunjucksPowerUserMode}
             handleGetRenderContext={handleGetRenderContext}
             url={request.url}
             requestId={request._id}
@@ -313,6 +316,7 @@ class RequestPane extends React.PureComponent<Props> {
               handleUpdateRequestMimeType={updateRequestMimeType}
               handleRender={handleRender}
               handleGetRenderContext={handleGetRenderContext}
+              nunjucksPowerUserMode={nunjucksPowerUserMode}
               key={uniqueKey}
               request={request}
               workspace={workspace}
@@ -335,6 +339,7 @@ class RequestPane extends React.PureComponent<Props> {
                 handleUpdateSettingsShowPasswords={updateSettingsShowPasswords}
                 handleRender={handleRender}
                 handleGetRenderContext={handleGetRenderContext}
+                nunjucksPowerUserMode={nunjucksPowerUserMode}
                 onChange={updateRequestAuthentication}
               />
             </div>
@@ -363,6 +368,7 @@ class RequestPane extends React.PureComponent<Props> {
                   pairs={request.parameters}
                   handleRender={handleRender}
                   handleGetRenderContext={handleGetRenderContext}
+                  nunjucksPowerUserMode={nunjucksPowerUserMode}
                   onChange={updateRequestParameters}
                 />
               </div>
@@ -381,6 +387,7 @@ class RequestPane extends React.PureComponent<Props> {
               headers={request.headers}
               handleRender={handleRender}
               handleGetRenderContext={handleGetRenderContext}
+              nunjucksPowerUserMode={nunjucksPowerUserMode}
               editorFontSize={editorFontSize}
               editorIndentSize={editorIndentSize}
               editorLineWrapping={editorLineWrapping}

--- a/app/ui/components/request-url-bar.js
+++ b/app/ui/components/request-url-bar.js
@@ -301,6 +301,7 @@ class RequestUrlBar extends PureComponent {
       url,
       method,
       handleRender,
+      nunjucksPowerUserMode,
       handleGetRenderContext,
       handleAutocompleteUrls,
       uniquenessKey
@@ -322,6 +323,7 @@ class RequestUrlBar extends PureComponent {
               forceEditor
               type="text"
               render={handleRender}
+              nunjucksPowerUserMode={nunjucksPowerUserMode}
               getAutocompleteConstants={handleAutocompleteUrls}
               getRenderContext={handleGetRenderContext}
               placeholder="https://api.myproduct.com/v1/users"
@@ -346,6 +348,7 @@ RequestUrlBar.propTypes = {
   onMethodChange: PropTypes.func.isRequired,
   handleGenerateCode: PropTypes.func.isRequired,
   url: PropTypes.string.isRequired,
+  nunjucksPowerUserMode: PropTypes.bool.isRequired,
   method: PropTypes.string.isRequired,
   requestId: PropTypes.string.isRequired,
   uniquenessKey: PropTypes.string.isRequired

--- a/app/ui/components/settings/general.js
+++ b/app/ui/components/settings/general.js
@@ -102,6 +102,20 @@ class General extends PureComponent {
           </label>
         </div>
 
+        <div className="form-control form-control--thin">
+          <label className="inline-block">
+            Nunjucks Power User Mode
+            {' '}
+            <HelpTooltip>
+              Disable tag editing interface in favor of raw Nunjucks syntax (requires restart)
+            </HelpTooltip>
+            <input type="checkbox"
+                   name="nunjucksPowerUserMode"
+                   checked={settings.nunjucksPowerUserMode}
+                   onChange={this._handleUpdateSetting}/>
+          </label>
+        </div>
+
         <div className="form-row">
           <div className="form-control form-control--outlined pad-top-sm">
             <label>Text Editor Font Size (px)

--- a/app/ui/components/wrapper.js
+++ b/app/ui/components/wrapper.js
@@ -450,6 +450,7 @@ class Wrapper extends React.PureComponent<Props, State> {
           handleImport={this._handleImport}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
+          nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
           updateRequestBody={this._handleUpdateRequestBody}
           updateRequestUrl={this._handleUpdateRequestUrl}
           updateRequestMethod={this._handleUpdateRequestMethod}
@@ -516,6 +517,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             ref={registerModal}
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
+            nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             editorFontSize={settings.editorFontSize}
             editorIndentSize={settings.editorIndentSize}
             editorKeyMap={settings.editorKeyMap}
@@ -530,11 +532,13 @@ class Wrapper extends React.PureComponent<Props, State> {
             editorLineWrapping={settings.editorLineWrapping}
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
+            nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
           />
 
           <CookiesModal
             handleShowModifyCookieModal={this._handleShowModifyCookieModal}
             handleRender={handleRender}
+            nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             ref={registerModal}
             workspace={activeWorkspace}
             cookieJar={activeCookieJar}
@@ -543,6 +547,7 @@ class Wrapper extends React.PureComponent<Props, State> {
           <CookieModifyModal
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
+            nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             ref={registerModal}
             cookieJar={activeCookieJar}
             workspace={activeWorkspace}
@@ -555,6 +560,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             handleGetRenderContext={handleGetRenderContext}
             workspace={activeWorkspace}
           />
+
           <WorkspaceSettingsModal
             ref={registerModal}
             workspace={activeWorkspace}
@@ -564,6 +570,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             editorLineWrapping={settings.editorLineWrapping}
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
+            nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             handleRemoveWorkspace={this._handleRemoveActiveWorkspace}
             handleDuplicateWorkspace={handleDuplicateWorkspace}
           />
@@ -605,6 +612,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             onChange={models.requestGroup.update}
             render={handleRender}
             getRenderContext={handleGetRenderContext}
+            nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
           />
           <SetupSyncModal
             ref={registerModal}
@@ -620,6 +628,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             activeEnvironment={activeEnvironment}
             render={handleRender}
             getRenderContext={handleGetRenderContext}
+            nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
           />
         </div>
       </div>

--- a/app/ui/css/constants/colors.less
+++ b/app/ui/css/constants/colors.less
@@ -585,3 +585,7 @@ body {
   text-shadow: 0 0 0.05em var(--color-surprise);
   color: var(--color-font-surprise) !important;
 }
+
+.font-error {
+  color: var(--color-danger);
+}


### PR DESCRIPTION
Insomnia uses Nunjucks behind the scenes to power all it's dynamic values. Nunjucks is very powerful, but Insomnia currently hides some of that power by adding fancy UI to try and make it easier to use. 

This PR adds a new setting to the app to disable the Nunjucks editing UI and let the user edit the raw text instead.

_NOTE: Autocomplete and syntax highlighting are still available_

<img width="345" alt="image" src="https://user-images.githubusercontent.com/587576/31520640-d1f04dba-afa6-11e7-8710-e926dc031b04.png">

<img width="356" alt="image" src="https://user-images.githubusercontent.com/587576/31536837-5ae19440-b000-11e7-9e2d-deb9f909fbda.png">


