### PR TITLE
Support basic operationName for GraphQL

### DIFF
--- a/app/common/prettify.js
+++ b/app/common/prettify.js
@@ -26,6 +26,10 @@ const NUNJUCKS_CLOSE_STATES = {
  * @returns {string}
  */
 export function prettifyJson (json, indentChars = '\t') {
+  if (!json) {
+    return '';
+  }
+
   // Convert the unicode. To correctly mimic JSON.stringify(JSON.parse(json), null, indentChars)
   // we need to convert all escaped unicode characters to proper unicode characters.
   try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5465,11 +5465,11 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "graphql": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
-      "integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.11.7.tgz",
+      "integrity": "sha512-x7uDjyz8Jx+QPbpCFCMQ8lltnQa4p4vSYHx6ADe8rVYRTdsyhCJbvSty5DAsLVmU6cGakl+r8HQYolKHxk/tiw==",
       "requires": {
-        "iterall": "1.1.1"
+        "iterall": "1.1.3"
       }
     },
     "graphql-language-service-config": {
@@ -5490,6 +5490,16 @@
         "graphql-language-service-parser": "0.0.15",
         "graphql-language-service-types": "0.0.21",
         "graphql-language-service-utils": "0.0.17"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
+          "integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
+          "requires": {
+            "iterall": "1.1.3"
+          }
+        }
       }
     },
     "graphql-language-service-parser": {
@@ -5506,6 +5516,16 @@
       "integrity": "sha512-/fSs1JmGEee8IPd7a7FJRmzK1o0W35nJZO0aJSGk2mq7QCvyKqNC8rgKG5YozAEj4ZY2psKUIxIpm6ssCTuUbw==",
       "requires": {
         "graphql": "0.10.5"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
+          "integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
+          "requires": {
+            "iterall": "1.1.3"
+          }
+        }
       }
     },
     "graphql-language-service-utils": {
@@ -5515,6 +5535,16 @@
       "requires": {
         "graphql": "0.10.5",
         "graphql-language-service-types": "0.0.21"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz",
+          "integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
+          "requires": {
+            "iterall": "1.1.3"
+          }
+        }
       }
     },
     "growly": {
@@ -7226,9 +7256,9 @@
       }
     },
     "iterall": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.1.tgz",
-      "integrity": "sha1-9/CvEemgTsZCYmD1AZ2fzKTVAhQ="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
+      "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
     },
     "jest": {
       "version": "19.0.2",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "electron-context-menu": "^0.9.0",
     "electron-devtools-installer": "^2.2.0",
     "electron-squirrel-startup": "^1.0.0",
-    "graphql": "^0.10.5",
+    "graphql": "^0.11.7",
     "hawk": "^6.0.2",
     "highlight.js": "^9.12.0",
     "hkdf": "^0.0.2",


### PR DESCRIPTION
Closes #549

Before, Insomnia did not pass `operationName` with queries. Now, it will pass the first named query if there is one. 

Note: There is still no way for the user to specify an `operationName` explicitly if there are more than one.

P.S. This change also leaves out the `variables` param if it is not set.

<img width="640" alt="image" src="https://user-images.githubusercontent.com/587576/32172060-9b5a442c-bd7a-11e7-9757-e8a537101e1b.png">
