### PR TITLE
New ClientCertificate model and ability to have private certificates

### DIFF
--- a/app/models/__tests__/workspace.test.js
+++ b/app/models/__tests__/workspace.test.js
@@ -1,0 +1,56 @@
+import * as models from '../index';
+import {globalBeforeEach} from '../../__jest__/before-each';
+
+describe('migrate()', () => {
+  beforeEach(globalBeforeEach);
+  it('migrates client certificates properly', async () => {
+    const workspace = await models.workspace.create({
+      name: 'My Workspace',
+      certificates: [
+        {key: 'key', passphrase: 'mypass'},
+        {disabled: true, cert: 'cert'}
+      ]
+    });
+
+    const migratedWorkspace = await models.workspace.migrate(workspace);
+    const certs = await models.clientCertificate.findByParentId(workspace._id);
+
+    // Delete modified and created so we can assert them
+    for (const cert of certs) {
+      expect(typeof cert.modified).toBe('number');
+      expect(typeof cert.created).toBe('number');
+      delete cert.modified;
+      delete cert.created;
+    }
+
+    expect(certs.length).toBe(2);
+    expect(certs.sort((c1, c2) => c1._id > c2._id ? -1 : 1)).toEqual([{
+      _id: 'crt_a262d22b5fa8491c9bd958fba03e301e',
+      cert: null,
+      disabled: false,
+      isPrivate: false,
+      key: 'key',
+      parentId: 'wrk_cc1dd2ca4275747aa88199e8efd42403',
+      passphrase: 'mypass',
+      pfx: null,
+      type: 'ClientCertificate'
+    }, {
+      _id: 'crt_2e7c268809ee44b8900d5cbbaa7d3a19',
+      cert: 'cert',
+      disabled: false,
+      isPrivate: false,
+      key: null,
+      parentId: 'wrk_cc1dd2ca4275747aa88199e8efd42403',
+      passphrase: null,
+      pfx: null,
+      type: 'ClientCertificate'
+    }]);
+
+    expect(migratedWorkspace.certificates).toBeUndefined();
+
+    // Make sure we don't create new certs if we migrate again
+    await models.workspace.migrate(migratedWorkspace);
+    const certsAgain = await models.clientCertificate.findByParentId(workspace._id);
+    expect(certsAgain.length).toBe(2);
+  });
+});

--- a/app/models/client-certificate.js
+++ b/app/models/client-certificate.js
@@ -1,0 +1,68 @@
+// @flow
+import * as db from '../common/database';
+import type {BaseModel} from './index';
+
+export const name = 'Client Certificate';
+export const type = 'ClientCertificate';
+export const prefix = 'crt';
+export const canDuplicate = true;
+
+type BaseClientCertificate = {
+  parentId: string,
+  host: string,
+  passphrase: string | null,
+  cert: string | null,
+  key: string | null,
+  pfx: string | null,
+  disabled: boolean,
+
+  // For sync control
+  isPrivate: boolean
+};
+
+export type ClientCertificate = BaseModel & BaseClientCertificate;
+
+export function init (): BaseClientCertificate {
+  return {
+    parentId: '',
+    host: '',
+    passphrase: null,
+    disabled: false,
+    cert: null,
+    key: null,
+    pfx: null,
+    isPrivate: false
+  };
+}
+
+export async function migrate (doc: ClientCertificate) {
+  return doc;
+}
+
+export function create (patch: Object = {}): Promise<ClientCertificate> {
+  if (!patch.parentId) {
+    throw new Error('New ClientCertificate missing `parentId`: ' + JSON.stringify(patch));
+  }
+
+  return db.docCreate(type, patch);
+}
+
+export function update (cert: ClientCertificate, patch: Object = {}): Promise<ClientCertificate> {
+  return db.docUpdate(cert, patch);
+}
+
+export function getById (id: string): Promise<ClientCertificate | null> {
+  return db.get(type, id);
+}
+
+export function findByParentId (parentId: string): Promise<Array<ClientCertificate>> {
+  return db.find(type, {parentId});
+}
+
+export function remove (cert: ClientCertificate): Promise<void> {
+  return db.remove(cert);
+}
+
+export function all (): Promise<Array<ClientCertificate>> {
+  return db.all(type);
+}

--- a/app/models/environment.js
+++ b/app/models/environment.js
@@ -12,6 +12,8 @@ type BaseEnvironment = {
   name: string,
   data: Object,
   color: string | null,
+
+  // For sync control
   isPrivate: boolean
 };
 

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -12,6 +12,7 @@ import * as _requestVersion from './request-version';
 import * as _requestMeta from './request-meta';
 import * as _response from './response';
 import * as _oAuth2Token from './o-auth-2-token';
+import * as _clientCertificate from './client-certificate';
 import {generateId} from '../common/misc';
 
 export type BaseModel = {
@@ -36,6 +37,7 @@ export const requestVersion = _requestVersion;
 export const requestMeta = _requestMeta;
 export const response = _response;
 export const oAuth2Token = _oAuth2Token;
+export const clientCertificate = _clientCertificate;
 
 export function all () {
   return [
@@ -51,7 +53,8 @@ export function all () {
     requestVersion,
     requestMeta,
     response,
-    oAuth2Token
+    oAuth2Token,
+    clientCertificate
   ];
 }
 

--- a/app/models/workspace.js
+++ b/app/models/workspace.js
@@ -10,14 +10,7 @@ export const canDuplicate = true;
 
 type BaseWorkspace = {
   name: string,
-  description: string,
-  certificates: Array<{
-    host: string,
-    passphrase: string,
-    cert: string,
-    key: string,
-    pfx: string
-  }>
+  description: string
 };
 
 export type Workspace = BaseModel & BaseWorkspace;
@@ -25,10 +18,7 @@ export type Workspace = BaseModel & BaseWorkspace;
 export function init () {
   return {
     name: 'New Workspace',
-    description: '',
-    certificates: [
-      // {host, port, cert, key, pfx, passphrase}
-    ]
+    description: ''
   };
 }
 
@@ -41,6 +31,7 @@ export async function migrate (doc: Workspace): Promise<Workspace> {
   }
 
   await _ensureDependencies(doc);
+  doc = await _migrateExtractClientCertificates(doc);
 
   return doc;
 }
@@ -81,4 +72,30 @@ export function remove (workspace: Workspace): Promise<void> {
 async function _ensureDependencies (workspace: Workspace) {
   await models.cookieJar.getOrCreateForParentId(workspace._id);
   await models.environment.getOrCreateForWorkspaceId(workspace._id);
+}
+
+async function _migrateExtractClientCertificates (workspace: Workspace) {
+  if (!Array.isArray(workspace.certificates)) {
+    // Already migrated
+    return workspace;
+  }
+
+  for (const cert of workspace.certificates) {
+    await models.clientCertificate.create({
+      parentId: workspace._id,
+      host: cert.host,
+      passphrase: cert.passphrase || null,
+      cert: cert.cert || null,
+      key: cert.key || null,
+      pfx: cert.pfx || null,
+      isPrivate: false
+    });
+  }
+
+  delete workspace.certificates;
+
+  // This will remove the now-missing `certificates` property
+  await update(workspace, {});
+
+  return workspace;
 }

--- a/app/network/__tests__/network.test.js
+++ b/app/network/__tests__/network.test.js
@@ -75,7 +75,6 @@ describe('actuallySend()', () => {
         ACCEPT_ENCODING: '',
         COOKIEFILE: '',
         FOLLOWLOCATION: true,
-        MAXREDIRS: -1,
         HTTPHEADER: [
           'Content-Type: application/json',
           'Expect: ',
@@ -129,7 +128,6 @@ describe('actuallySend()', () => {
         ACCEPT_ENCODING: '',
         COOKIEFILE: '',
         FOLLOWLOCATION: true,
-        MAXREDIRS: -1,
         HTTPHEADER: [
           'Content-Type: application/x-www-form-urlencoded',
           'Expect: ',
@@ -208,7 +206,6 @@ describe('actuallySend()', () => {
         CUSTOMREQUEST: 'GET',
         ACCEPT_ENCODING: '',
         FOLLOWLOCATION: true,
-        MAXREDIRS: -1,
         HTTPHEADER: [
           'Content-Type: application/json',
           'Expect: ',
@@ -259,7 +256,6 @@ describe('actuallySend()', () => {
         CUSTOMREQUEST: 'POST',
         COOKIEFILE: '',
         FOLLOWLOCATION: true,
-        MAXREDIRS: -1,
         HTTPHEADER: [
           'Content-Type: application/octet-stream',
           'Expect: ',
@@ -316,7 +312,6 @@ describe('actuallySend()', () => {
       ACCEPT_ENCODING: '',
       COOKIEFILE: '',
       FOLLOWLOCATION: true,
-      MAXREDIRS: -1,
       CUSTOMREQUEST: 'POST',
       HTTPHEADER: [
         'Content-Type: multipart/form-data; boundary=X-INSOMNIA-BOUNDARY',
@@ -369,7 +364,6 @@ describe('actuallySend()', () => {
         ACCEPT_ENCODING: '',
         COOKIEFILE: '',
         FOLLOWLOCATION: true,
-        MAXREDIRS: -1,
         HTTPHEADER: ['content-type: '],
         NOPROGRESS: false,
         PROXY: '',
@@ -404,7 +398,6 @@ describe('actuallySend()', () => {
         ACCEPT_ENCODING: '',
         COOKIEFILE: '',
         FOLLOWLOCATION: true,
-        MAXREDIRS: -1,
         HTTPHEADER: ['content-type: '],
         NOPROGRESS: false,
         PROXY: '',
@@ -438,7 +431,6 @@ describe('actuallySend()', () => {
         ACCEPT_ENCODING: '',
         COOKIEFILE: '',
         FOLLOWLOCATION: true,
-        MAXREDIRS: -1,
         HTTPHEADER: ['content-type: '],
         NOPROGRESS: false,
         PROXY: '',
@@ -473,7 +465,6 @@ describe('actuallySend()', () => {
         ACCEPT_ENCODING: '',
         COOKIEFILE: '',
         FOLLOWLOCATION: true,
-        MAXREDIRS: -1,
         HTTPHEADER: ['content-type: '],
         NOPROGRESS: false,
         PROXY: '',

--- a/app/network/network.js
+++ b/app/network/network.js
@@ -138,6 +138,7 @@ export function _actuallySend (
       setOpt(Curl.option.ACCEPT_ENCODING, ''); // Auto decode everything
 
       // Set maximum amount of redirects allowed
+      // NOTE: Setting this to -1 breaks some versions of libcurl
       if (settings.maxRedirects > 0) {
         setOpt(Curl.option.MAXREDIRS, settings.maxRedirects);
       }

--- a/app/network/network.js
+++ b/app/network/network.js
@@ -132,11 +132,15 @@ export function _actuallySend (
 
       // Set all the basic options
       setOpt(Curl.option.FOLLOWLOCATION, settings.followRedirects);
-      setOpt(Curl.option.MAXREDIRS, settings.maxRedirects);
       setOpt(Curl.option.TIMEOUT_MS, settings.timeout); // 0 for no timeout
       setOpt(Curl.option.VERBOSE, true); // True so debug function works
       setOpt(Curl.option.NOPROGRESS, false); // False so progress function works
       setOpt(Curl.option.ACCEPT_ENCODING, ''); // Auto decode everything
+
+      // Set maximum amount of redirects allowed
+      if (settings.maxRedirects > 0) {
+        setOpt(Curl.option.MAXREDIRS, settings.maxRedirects);
+      }
 
       // Only set CURLOPT_CUSTOMREQUEST if not HEAD or GET. This is because Curl
       // See https://curl.haxx.se/libcurl/c/CURLOPT_CUSTOMREQUEST.html
@@ -327,7 +331,8 @@ export function _actuallySend (
       }
 
       // Set client certs if needed
-      for (const certificate of workspace.certificates) {
+      const clientCertificates = await models.clientCertificate.findByParentId(workspace._id);
+      for (const certificate of clientCertificates) {
         if (certificate.disabled) {
           continue;
         }

--- a/app/sync/index.js
+++ b/app/sync/index.js
@@ -17,7 +17,8 @@ const WHITE_LIST = {
   [models.request.type]: true,
   [models.requestGroup.type]: true,
   [models.environment.type]: true,
-  [models.cookieJar.type]: true
+  [models.cookieJar.type]: true,
+  [models.clientCertificate.type]: true
 };
 
 export const logger = new Logger();

--- a/app/ui/components/wrapper.js
+++ b/app/ui/components/wrapper.js
@@ -42,6 +42,7 @@ import * as importers from 'insomnia-importers';
 import type {CookieJar} from '../../models/cookie-jar';
 import type {Environment} from '../../models/environment';
 import ErrorBoundary from './error-boundary';
+import type {ClientCertificate} from '../../models/client-certificate';
 
 type Props = {
   // Helper Functions
@@ -102,6 +103,7 @@ type Props = {
   activeWorkspace: Workspace,
   activeCookieJar: CookieJar,
   activeEnvironment: Environment | null,
+  activeWorkspaceClientCertificates: Array<ClientCertificate>,
 
   // Optional
   oAuth2Token: ?OAuth2Token,
@@ -339,6 +341,7 @@ class Wrapper extends React.PureComponent<Props, State> {
       activeCookieJar,
       activeRequestResponses,
       activeResponse,
+      activeWorkspaceClientCertificates,
       environments,
       handleActivateRequest,
       handleCreateRequest,
@@ -455,6 +458,7 @@ class Wrapper extends React.PureComponent<Props, State> {
 
           <WorkspaceSettingsModal
             ref={registerModal}
+            clientCertificates={activeWorkspaceClientCertificates}
             workspace={activeWorkspace}
             editorFontSize={settings.editorFontSize}
             editorIndentSize={settings.editorIndentSize}

--- a/app/ui/containers/app.js
+++ b/app/ui/containers/app.js
@@ -21,7 +21,7 @@ import * as globalActions from '../redux/modules/global';
 import * as db from '../../common/database';
 import * as models from '../../models';
 import {trackEvent} from '../../analytics';
-import {selectActiveCookieJar, selectActiveOAuth2Token, selectActiveRequest, selectActiveRequestMeta, selectActiveRequestResponses, selectActiveResponse, selectActiveWorkspace, selectActiveWorkspaceMeta, selectEntitiesLists, selectSidebarChildren, selectUnseenWorkspaces, selectWorkspaceRequestsAndRequestGroups} from '../redux/selectors';
+import {selectActiveCookieJar, selectActiveOAuth2Token, selectActiveRequest, selectActiveRequestMeta, selectActiveRequestResponses, selectActiveResponse, selectActiveWorkspace, selectActiveWorkspaceClientCertificates, selectActiveWorkspaceMeta, selectEntitiesLists, selectSidebarChildren, selectUnseenWorkspaces, selectWorkspaceRequestsAndRequestGroups} from '../redux/selectors';
 import RequestCreateModal from '../components/modals/request-create-modal';
 import GenerateCodeModal from '../components/modals/generate-code-modal';
 import WorkspaceSettingsModal from '../components/modals/workspace-settings-modal';
@@ -818,6 +818,7 @@ function mapStateToProps (state, props) {
   // Workspace stuff
   const workspaceMeta = selectActiveWorkspaceMeta(state, props) || {};
   const activeWorkspace = selectActiveWorkspace(state, props);
+  const activeWorkspaceClientCertificates = selectActiveWorkspaceClientCertificates(state, props);
   const sidebarHidden = workspaceMeta.sidebarHidden || false;
   const sidebarFilter = workspaceMeta.sidebarFilter || '';
   const sidebarWidth = workspaceMeta.sidebarWidth || DEFAULT_SIDEBAR_WIDTH;
@@ -861,6 +862,7 @@ function mapStateToProps (state, props) {
     isLoading,
     loadStartTime,
     activeWorkspace,
+    activeWorkspaceClientCertificates,
     activeRequest,
     activeRequestResponses,
     activeResponse,

--- a/app/ui/css/constants/dimensions.less
+++ b/app/ui/css/constants/dimensions.less
@@ -38,7 +38,7 @@
 @dropdown-min-width: round(@font-size * 12);
 
 /* Modals */
-@modal-width: round(@font-size * 50);
+@modal-width: round(@font-size * 60);
 @modal-width-wide: round(@font-size * 70);
 
 /* Other */

--- a/app/ui/index.js
+++ b/app/ui/index.js
@@ -5,6 +5,7 @@ import {Provider} from 'react-redux';
 import {DragDropContext} from 'react-dnd';
 import App from './containers/app';
 import * as models from '../models';
+import * as db from '../common/database';
 import {types as modelTypes} from '../models';
 import {init as initStore} from './redux/modules';
 import {init as initDB} from '../common/database';
@@ -53,4 +54,5 @@ import {isDevelopment} from '../common/constants';
 // Export some useful things for dev
 if (isDevelopment()) {
   window.models = models;
+  window.db = db;
 }

--- a/app/ui/redux/modules/index.js
+++ b/app/ui/redux/modules/index.js
@@ -49,7 +49,8 @@ async function getAllDocs () {
     ...await models.request.all(),
     ...await models.requestMeta.all(),
     ...await models.response.all(),
-    ...await models.oAuth2Token.all()
+    ...await models.oAuth2Token.all(),
+    ...await models.clientCertificate.all()
   ];
 
   return allDocs;

--- a/app/ui/redux/selectors.js
+++ b/app/ui/redux/selectors.js
@@ -28,6 +28,14 @@ export const selectActiveWorkspace = createSelector(
   }
 );
 
+export const selectActiveWorkspaceClientCertificates = createSelector(
+  selectEntitiesLists,
+  selectActiveWorkspace,
+  (entities, activeWorkspace) => {
+    return entities.clientCertificates.filter(c => c.parentId === activeWorkspace._id);
+  }
+);
+
 export const selectActiveWorkspaceMeta = createSelector(
   selectActiveWorkspace,
   selectEntitiesLists,


### PR DESCRIPTION
Closes #552 

## To-Do

- [x] Make new `ClientCertificate` model
- [x] Write migration to extract certificates from `Workspace` model
- [x] Add `isPrivate` attribute to `ClientCertificate` to control sync and export
- [x] Add UI to create/show private status on certificates

<img width="789" alt="image" src="https://user-images.githubusercontent.com/587576/32228527-beefe76e-be4e-11e7-9368-2a6355ce9c91.png">
