### PR TITLE
Client certificate glob matching on port

### DIFF
--- a/app/network/__tests__/certificate-url-parse.test.js
+++ b/app/network/__tests__/certificate-url-parse.test.js
@@ -111,4 +111,16 @@ describe('certificateUrlParse', () => {
     expected.host = `${host}:${port}`;
     expect(certificateUrlParse(url)).toEqual(expected);
   });
+
+  it('should return the correct port if wildcard in port', () => {
+    const protocol = 'https';
+    const host = 'localhost';
+    const port = '*';
+    const path = '/some/resources';
+    const query = 'query=1&other=2';
+    const fragment = 'myfragment';
+
+    const url = `${protocol}://${host}:${port}${path}?${query}#${fragment}`;
+    expect(certificateUrlParse(url).port).toEqual(port);
+  });
 });

--- a/app/network/__tests__/url-matches-cert-host.test.js
+++ b/app/network/__tests__/url-matches-cert-host.test.js
@@ -115,6 +115,18 @@ describe('urlMatchesCertHost', () => {
       const certificateHost = '*.example.org';
       expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
     });
+
+    it('should return true if certificate host has wildcard port', () => {
+      const requestUrl = 'http://localhost:3000/some/resources?query=1';
+      const certificateHost = 'localhost:*';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return true if certificate host has wildcard in middle of port', () => {
+      const requestUrl = 'http://localhost:3000/some/resources?query=1';
+      const certificateHost = 'localhost:3*';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
   });
 
   describe('when an invalid certificate host is supplied', () => {

--- a/app/network/certificate-url-parse.js
+++ b/app/network/certificate-url-parse.js
@@ -12,6 +12,7 @@ export default function certificateUrlParse (url) {
     parsed.hostname = _reinstateWildcards(parsed.hostname);
     parsed.host = _reinstateWildcards(parsed.host);
     parsed.href = _reinstateWildcards(parsed.href);
+    parsed.port = _reinstateWildcards(parsed.port);
 
     return parsed;
   }

--- a/app/network/url-matches-cert-host.js
+++ b/app/network/url-matches-cert-host.js
@@ -13,10 +13,24 @@ export function urlMatchesCertHost (certificateHost, requestUrl) {
   const assumedCPort = parseInt(cPort) || DEFAULT_PORT;
 
   const cHostnameRegex = escapeRegex(cHostname || '').replace(/\\\*/g, '.*');
+  const cPortRegex = escapeRegex(cPort || '').replace(/\\\*/g, '.*');
 
-  if (assumedCPort !== assumedPort) {
+  // Check ports
+  if ((cPort + '').includes('*')) {
+    if (!(port || '').match(`^${cPortRegex}$`)) {
+      return false;
+    }
+  } else {
+    if (assumedCPort !== assumedPort) {
+      return false;
+    }
+  }
+
+  // Check hostnames
+  if (!(hostname || '').match(`^${cHostnameRegex}$`)) {
     return false;
   }
 
-  return !!(hostname || '').match(`^${cHostnameRegex}$`);
+  // Everything matches
+  return true;
 }


### PR DESCRIPTION
Closes #564 

This PR implements glob matching on port for client certificates so it is now possible to match something that looks like this: `https://localhost:*` or even `https://localhost:3*`.