### PR TITLE
Use Insomnia network stack for OAuth 2.0 requests

### DIFF
--- a/app/common/render.js
+++ b/app/common/render.js
@@ -187,12 +187,17 @@ export async function getRenderContext (
 
   if (!ancestors) {
     ancestors = await db.withAncestors(request, [
+      models.request.type,
       models.requestGroup.type,
       models.workspace.type
     ]);
   }
 
   const workspace = ancestors.find(doc => doc.type === models.workspace.type);
+  if (!workspace) {
+    throw new Error('Failed to render. Could not find workspace');
+  }
+
   const rootEnvironment = await models.environment.getOrCreateForWorkspaceId(workspace ? workspace._id : 'n/a');
   const subEnvironment = await models.environment.getById(environmentId);
 
@@ -219,6 +224,7 @@ export async function getRenderedRequest (
   environmentId: string
 ): Promise<RenderedRequest> {
   const ancestors = await db.withAncestors(request, [
+    models.request.type,
     models.requestGroup.type,
     models.workspace.type
   ]);

--- a/app/models/cookie-jar.js
+++ b/app/models/cookie-jar.js
@@ -1,6 +1,7 @@
 // @flow
 import * as db from '../common/database';
 import type {BaseModel} from './index';
+
 export const name = 'Cookie Jar';
 export const type = 'CookieJar';
 export const prefix = 'jar';
@@ -44,6 +45,10 @@ export function migrate (doc: CookieJar): CookieJar {
 }
 
 export function create (patch: Object = {}) {
+  if (!patch.parentId) {
+    throw new Error(`New CookieJar missing \`parentId\`: ${JSON.stringify(patch)}`);
+  }
+
   return db.docCreate(type, patch);
 }
 

--- a/app/network/o-auth-2/__tests__/grant-authorization-code.test.js
+++ b/app/network/o-auth-2/__tests__/grant-authorization-code.test.js
@@ -1,6 +1,7 @@
 import getToken from '../grant-authorization-code';
 import {createBWRedirectMock} from './helpers';
 import {globalBeforeEach} from '../../../__jest__/before-each';
+import * as network from '../../network';
 
 // Mock some test things
 const AUTHORIZE_URL = 'https://foo.com/authorizeAuthCode';
@@ -15,12 +16,19 @@ describe('authorization_code', () => {
   beforeEach(globalBeforeEach);
   it('gets token with JSON and basic auth', async () => {
     createBWRedirectMock(`${REDIRECT_URI}?code=code_123&state=${STATE}`);
-    window.fetch = jest.fn(() => new window.Response(
-      JSON.stringify({access_token: 'token_123', token_type: 'token_type', scope: SCOPE}),
-      {headers: {'Content-Type': 'application/json'}}
-    ));
+    network.sendWithSettings = jest.fn(() => ({
+      bodyBuffer: Buffer.from(JSON.stringify({
+        access_token: 'token_123',
+        token_type: 'token_type',
+        scope: SCOPE
+      })),
+      response: {
+        headers: [{name: 'Content-Type', value: 'application/json'}]
+      }
+    }));
 
     const result = await getToken(
+      'req_1',
       AUTHORIZE_URL,
       ACCESS_TOKEN_URL,
       false,
@@ -32,19 +40,23 @@ describe('authorization_code', () => {
     );
 
     // Check the request to fetch the token
-    expect(window.fetch.mock.calls).toEqual([[ACCESS_TOKEN_URL, {
-      body: [
-        'grant_type=authorization_code',
-        'code=code_123',
-        `redirect_uri=${encodeURIComponent(REDIRECT_URI)}`,
-        `state=${STATE}`
-      ].join('&'),
+    expect(network.sendWithSettings.mock.calls).toEqual([['req_1', {
+      url: ACCESS_TOKEN_URL,
       method: 'POST',
-      headers: {
-        'Accept': 'application/x-www-form-urlencoded, application/json',
-        'Authorization': 'Basic Y2xpZW50XzEyMzpzZWNyZXRfMTIzNDU0NTY2Nzc3NTYzNDM=',
-        'Content-Type': 'application/x-www-form-urlencoded'
-      }
+      body: {
+        mimeType: 'application/x-www-form-urlencoded',
+        params: [
+          {name: 'grant_type', value: 'authorization_code', disabled: false},
+          {name: 'code', value: 'code_123', disabled: false},
+          {name: 'redirect_uri', value: REDIRECT_URI, disabled: false},
+          {name: 'state', value: STATE, disabled: false}
+        ]
+      },
+      headers: [
+        {name: 'Content-Type', value: 'application/x-www-form-urlencoded'},
+        {name: 'Accept', value: 'application/x-www-form-urlencoded, application/json'},
+        {name: 'Authorization', value: 'Basic Y2xpZW50XzEyMzpzZWNyZXRfMTIzNDU0NTY2Nzc3NTYzNDM='}
+      ]
     }]]);
 
     // Check the expected value
@@ -62,12 +74,19 @@ describe('authorization_code', () => {
 
   it('gets token with urlencoded and body auth', async () => {
     createBWRedirectMock(`${REDIRECT_URI}?code=code_123&state=${STATE}`);
-    window.fetch = jest.fn(() => new window.Response(
-      `access_token=token_123&token_type=token_type&scope=${SCOPE}`,
-      {headers: {'Content-Type': 'application/x-www-form-urlencoded'}}
-    ));
+    network.sendWithSettings = jest.fn(() => ({
+      bodyBuffer: Buffer.from(JSON.stringify({
+        access_token: 'token_123',
+        token_type: 'token_type',
+        scope: SCOPE
+      })),
+      response: {
+        headers: [{name: 'Content-Type', value: 'application/x-www-form-urlencoded'}]
+      }
+    }));
 
     const result = await getToken(
+      'req_1',
       AUTHORIZE_URL,
       ACCESS_TOKEN_URL,
       true,
@@ -79,20 +98,24 @@ describe('authorization_code', () => {
     );
 
     // Check the request to fetch the token
-    expect(window.fetch.mock.calls).toEqual([[ACCESS_TOKEN_URL, {
-      body: [
-        'grant_type=authorization_code',
-        'code=code_123',
-        `redirect_uri=${encodeURIComponent(REDIRECT_URI)}`,
-        `state=${STATE}`,
-        `client_id=${CLIENT_ID}`,
-        `client_secret=${CLIENT_SECRET}`
-      ].join('&'),
+    expect(network.sendWithSettings.mock.calls).toEqual([['req_1', {
+      url: ACCESS_TOKEN_URL,
       method: 'POST',
-      headers: {
-        'Accept': 'application/x-www-form-urlencoded, application/json',
-        'Content-Type': 'application/x-www-form-urlencoded'
-      }
+      body: {
+        mimeType: 'application/x-www-form-urlencoded',
+        params: [
+          {name: 'grant_type', value: 'authorization_code', disabled: false},
+          {name: 'code', value: 'code_123', disabled: false},
+          {name: 'redirect_uri', value: REDIRECT_URI, disabled: false},
+          {name: 'state', value: STATE, disabled: false},
+          {name: 'client_id', value: CLIENT_ID, disabled: false},
+          {name: 'client_secret', value: CLIENT_SECRET, disabled: false}
+        ]
+      },
+      headers: [
+        {name: 'Content-Type', value: 'application/x-www-form-urlencoded'},
+        {name: 'Accept', value: 'application/x-www-form-urlencoded, application/json'}
+      ]
     }]]);
 
     // Check the expected value

--- a/app/network/o-auth-2/__tests__/grant-client-credentials.test.js
+++ b/app/network/o-auth-2/__tests__/grant-client-credentials.test.js
@@ -1,5 +1,6 @@
 import getToken from '../grant-client-credentials';
 import {globalBeforeEach} from '../../../__jest__/before-each';
+import * as network from '../../network';
 
 // Mock some test things
 const ACCESS_TOKEN_URL = 'https://foo.com/access_token';
@@ -10,12 +11,20 @@ const SCOPE = 'scope_123';
 describe('client_credentials', () => {
   beforeEach(globalBeforeEach);
   it('gets token with JSON and basic auth', async () => {
-    window.fetch = jest.fn(() => new window.Response(
-      JSON.stringify({access_token: 'token_123', token_type: 'token_type', scope: SCOPE}),
-      {headers: {'Content-Type': 'application/json'}}
-    ));
+    network.sendWithSettings = jest.fn(() => ({
+      bodyBuffer: Buffer.from(JSON.stringify({
+        access_token: 'token_123',
+        token_type: 'token_type',
+        scope: SCOPE
+      })),
+      response: {
+        headers: [{name: 'Content-Type', value: 'application/json'}]
+      }
+    }));
 
+    // console.log('GET TOKEN', getToken);
     const result = await getToken(
+      'req_1',
       ACCESS_TOKEN_URL,
       false,
       CLIENT_ID,
@@ -24,17 +33,21 @@ describe('client_credentials', () => {
     );
 
     // Check the request to fetch the token
-    expect(window.fetch.mock.calls).toEqual([[ACCESS_TOKEN_URL, {
-      body: [
-        'grant_type=client_credentials',
-        `scope=${SCOPE}`
-      ].join('&'),
+    expect(network.sendWithSettings.mock.calls).toEqual([['req_1', {
+      url: ACCESS_TOKEN_URL,
       method: 'POST',
-      headers: {
-        'Accept': 'application/x-www-form-urlencoded, application/json',
-        'Authorization': 'Basic Y2xpZW50XzEyMzpzZWNyZXRfMTIzNDU0NTY2Nzc3NTYzNDM=',
-        'Content-Type': 'application/x-www-form-urlencoded'
-      }
+      body: {
+        mimeType: 'application/x-www-form-urlencoded',
+        params: [
+          {name: 'grant_type', value: 'client_credentials', disabled: false},
+          {name: 'scope', value: SCOPE, disabled: false}
+        ]
+      },
+      headers: [
+        {name: 'Content-Type', value: 'application/x-www-form-urlencoded'},
+        {name: 'Accept', value: 'application/x-www-form-urlencoded, application/json'},
+        {name: 'Authorization', value: 'Basic Y2xpZW50XzEyMzpzZWNyZXRfMTIzNDU0NTY2Nzc3NTYzNDM='}
+      ]
     }]]);
 
     // Check the expected value
@@ -50,12 +63,19 @@ describe('client_credentials', () => {
   });
 
   it('gets token with urlencoded and body auth', async () => {
-    window.fetch = jest.fn(() => new window.Response(
-      `access_token=token_123&token_type=token_type&scope=${SCOPE}`,
-      {headers: {'Content-Type': 'application/x-www-form-urlencoded'}}
-    ));
+    network.sendWithSettings = jest.fn(() => ({
+      bodyBuffer: Buffer.from(JSON.stringify({
+        access_token: 'token_123',
+        token_type: 'token_type',
+        scope: SCOPE
+      })),
+      response: {
+        headers: [{name: 'Content-Type', value: 'application/x-www-form-urlencoded'}]
+      }
+    }));
 
     const result = await getToken(
+      'req_1',
       ACCESS_TOKEN_URL,
       true,
       CLIENT_ID,
@@ -64,18 +84,22 @@ describe('client_credentials', () => {
     );
 
     // Check the request to fetch the token
-    expect(window.fetch.mock.calls).toEqual([[ACCESS_TOKEN_URL, {
-      body: [
-        'grant_type=client_credentials',
-        `scope=${SCOPE}`,
-        `client_id=${CLIENT_ID}`,
-        `client_secret=${CLIENT_SECRET}`
-      ].join('&'),
+    expect(network.sendWithSettings.mock.calls).toEqual([['req_1', {
+      url: ACCESS_TOKEN_URL,
       method: 'POST',
-      headers: {
-        'Accept': 'application/x-www-form-urlencoded, application/json',
-        'Content-Type': 'application/x-www-form-urlencoded'
-      }
+      body: {
+        mimeType: 'application/x-www-form-urlencoded',
+        params: [
+          {name: 'grant_type', value: 'client_credentials', disabled: false},
+          {name: 'scope', value: SCOPE, disabled: false},
+          {name: 'client_id', value: CLIENT_ID, disabled: false},
+          {name: 'client_secret', value: CLIENT_SECRET, disabled: false}
+        ]
+      },
+      headers: [
+        {name: 'Content-Type', value: 'application/x-www-form-urlencoded'},
+        {name: 'Accept', value: 'application/x-www-form-urlencoded, application/json'}
+      ]
     }]]);
 
     // Check the expected value

--- a/app/network/o-auth-2/__tests__/grant-password.test.js
+++ b/app/network/o-auth-2/__tests__/grant-password.test.js
@@ -1,5 +1,6 @@
 import getToken from '../grant-password';
 import {globalBeforeEach} from '../../../__jest__/before-each';
+import * as network from '../../network';
 
 // Mock some test things
 const ACCESS_TOKEN_URL = 'https://foo.com/access_token';
@@ -12,12 +13,19 @@ const SCOPE = 'scope_123';
 describe('password', () => {
   beforeEach(globalBeforeEach);
   it('gets token with JSON and basic auth', async () => {
-    window.fetch = jest.fn(() => new window.Response(
-      JSON.stringify({access_token: 'token_123', token_type: 'token_type', scope: SCOPE}),
-      {headers: {'Content-Type': 'application/json'}}
-    ));
+    network.sendWithSettings = jest.fn(() => ({
+      bodyBuffer: Buffer.from(JSON.stringify({
+        access_token: 'token_123',
+        token_type: 'token_type',
+        scope: SCOPE
+      })),
+      response: {
+        headers: [{name: 'Content-Type', value: 'application/json'}]
+      }
+    }));
 
     const result = await getToken(
+      'req_1',
       ACCESS_TOKEN_URL,
       false,
       CLIENT_ID,
@@ -28,19 +36,23 @@ describe('password', () => {
     );
 
     // Check the request to fetch the token
-    expect(window.fetch.mock.calls).toEqual([[ACCESS_TOKEN_URL, {
-      body: [
-        'grant_type=password',
-        `username=${USERNAME}`,
-        `password=${PASSWORD}`,
-        `scope=${SCOPE}`
-      ].join('&'),
+    expect(network.sendWithSettings.mock.calls).toEqual([['req_1', {
+      url: ACCESS_TOKEN_URL,
       method: 'POST',
-      headers: {
-        'Accept': 'application/x-www-form-urlencoded, application/json',
-        'Authorization': 'Basic Y2xpZW50XzEyMzpzZWNyZXRfMTIzNDU0NTY2Nzc3NTYzNDM=',
-        'Content-Type': 'application/x-www-form-urlencoded'
-      }
+      body: {
+        mimeType: 'application/x-www-form-urlencoded',
+        params: [
+          {name: 'grant_type', value: 'password', disabled: false},
+          {name: 'username', value: USERNAME, disabled: false},
+          {name: 'password', value: PASSWORD, disabled: false},
+          {name: 'scope', value: SCOPE, disabled: false}
+        ]
+      },
+      headers: [
+        {name: 'Content-Type', value: 'application/x-www-form-urlencoded'},
+        {name: 'Accept', value: 'application/x-www-form-urlencoded, application/json'},
+        {name: 'Authorization', value: 'Basic Y2xpZW50XzEyMzpzZWNyZXRfMTIzNDU0NTY2Nzc3NTYzNDM='}
+      ]
     }]]);
 
     // Check the expected value
@@ -57,12 +69,19 @@ describe('password', () => {
   });
 
   it('gets token with urlencoded and body auth', async () => {
-    window.fetch = jest.fn(() => new window.Response(
-      `access_token=token_123&token_type=token_type&scope=${SCOPE}`,
-      {headers: {'Content-Type': 'application/x-www-form-urlencoded'}}
-    ));
+    network.sendWithSettings = jest.fn(() => ({
+      bodyBuffer: Buffer.from(JSON.stringify({
+        access_token: 'token_123',
+        token_type: 'token_type',
+        scope: SCOPE
+      })),
+      response: {
+        headers: [{name: 'Content-Type', value: 'application/x-www-form-urlencoded'}]
+      }
+    }));
 
     const result = await getToken(
+      'req_1',
       ACCESS_TOKEN_URL,
       true,
       CLIENT_ID,
@@ -73,20 +92,24 @@ describe('password', () => {
     );
 
     // Check the request to fetch the token
-    expect(window.fetch.mock.calls).toEqual([[ACCESS_TOKEN_URL, {
-      body: [
-        'grant_type=password',
-        `username=${USERNAME}`,
-        `password=${PASSWORD}`,
-        `scope=${SCOPE}`,
-        `client_id=${CLIENT_ID}`,
-        `client_secret=${CLIENT_SECRET}`
-      ].join('&'),
+    expect(network.sendWithSettings.mock.calls).toEqual([['req_1', {
+      url: ACCESS_TOKEN_URL,
       method: 'POST',
-      headers: {
-        'Accept': 'application/x-www-form-urlencoded, application/json',
-        'Content-Type': 'application/x-www-form-urlencoded'
-      }
+      body: {
+        mimeType: 'application/x-www-form-urlencoded',
+        params: [
+          {name: 'grant_type', value: 'password', disabled: false},
+          {name: 'username', value: USERNAME, disabled: false},
+          {name: 'password', value: PASSWORD, disabled: false},
+          {name: 'scope', value: SCOPE, disabled: false},
+          {name: 'client_id', value: CLIENT_ID, disabled: false},
+          {name: 'client_secret', value: CLIENT_SECRET, disabled: false}
+        ]
+      },
+      headers: [
+        {name: 'Content-Type', value: 'application/x-www-form-urlencoded'},
+        {name: 'Accept', value: 'application/x-www-form-urlencoded, application/json'}
+      ]
     }]]);
 
     // Check the expected value

--- a/app/network/o-auth-2/get-token.js
+++ b/app/network/o-auth-2/get-token.js
@@ -1,7 +1,4 @@
-/**
- * Get an OAuth2Token object and also handle storing/saving/refreshing
- * @returns {Promise.<void>}
- */
+// @flow
 import getAccessTokenAuthorizationCode from './grant-authorization-code';
 import getAccessTokenClientCredentials from './grant-client-credentials';
 import getAccessTokenPassword from './grant-password';
@@ -9,8 +6,15 @@ import getAccessTokenImplicit from './grant-implicit';
 import refreshAccessToken from './refresh-token';
 import {GRANT_TYPE_AUTHORIZATION_CODE, GRANT_TYPE_CLIENT_CREDENTIALS, GRANT_TYPE_IMPLICIT, GRANT_TYPE_PASSWORD, P_ACCESS_TOKEN, P_ERROR, P_ERROR_DESCRIPTION, P_ERROR_URI, P_EXPIRES_IN, P_REFRESH_TOKEN} from './constants';
 import * as models from '../../models';
+import type {RequestAuthentication} from '../../models/request';
+import type {OAuth2Token} from '../../models/o-auth-2-token';
 
-export default async function (requestId, authentication, forceRefresh = false) {
+/** Get an OAuth2Token object and also handle storing/saving/refreshing */
+export default async function (
+  requestId: string,
+  authentication: RequestAuthentication,
+  forceRefresh: boolean = false
+): Promise<OAuth2Token | null> {
   switch (authentication.grantType) {
     case GRANT_TYPE_AUTHORIZATION_CODE:
       return _getOAuth2AuthorizationCodeHeader(requestId, authentication, forceRefresh);
@@ -25,7 +29,11 @@ export default async function (requestId, authentication, forceRefresh = false) 
   return null;
 }
 
-async function _getOAuth2AuthorizationCodeHeader (requestId, authentication, forceRefresh) {
+async function _getOAuth2AuthorizationCodeHeader (
+  requestId: string,
+  authentication: RequestAuthentication,
+  forceRefresh: boolean
+): Promise<OAuth2Token | null> {
   const oAuth2Token = await _getAccessToken(requestId, authentication, forceRefresh);
 
   if (oAuth2Token) {
@@ -33,6 +41,7 @@ async function _getOAuth2AuthorizationCodeHeader (requestId, authentication, for
   }
 
   const results = await getAccessTokenAuthorizationCode(
+    requestId,
     authentication.authorizationUrl,
     authentication.accessTokenUrl,
     authentication.credentialsInBody,
@@ -46,7 +55,11 @@ async function _getOAuth2AuthorizationCodeHeader (requestId, authentication, for
   return _updateOAuth2Token(requestId, results);
 }
 
-async function _getOAuth2ClientCredentialsHeader (requestId, authentication, forceRefresh) {
+async function _getOAuth2ClientCredentialsHeader (
+  requestId: string,
+  authentication: RequestAuthentication,
+  forceRefresh: boolean
+): Promise<OAuth2Token | null> {
   const oAuth2Token = await _getAccessToken(requestId, authentication, forceRefresh);
 
   if (oAuth2Token) {
@@ -54,6 +67,7 @@ async function _getOAuth2ClientCredentialsHeader (requestId, authentication, for
   }
 
   const results = await getAccessTokenClientCredentials(
+    requestId,
     authentication.accessTokenUrl,
     authentication.credentialsInBody,
     authentication.clientId,
@@ -64,7 +78,11 @@ async function _getOAuth2ClientCredentialsHeader (requestId, authentication, for
   return _updateOAuth2Token(requestId, results);
 }
 
-async function _getOAuth2ImplicitHeader (requestId, authentication, forceRefresh) {
+async function _getOAuth2ImplicitHeader (
+  requestId: string,
+  authentication: RequestAuthentication,
+  forceRefresh: boolean
+): Promise<OAuth2Token | null> {
   const oAuth2Token = await _getAccessToken(requestId, authentication, forceRefresh);
 
   if (oAuth2Token) {
@@ -72,6 +90,7 @@ async function _getOAuth2ImplicitHeader (requestId, authentication, forceRefresh
   }
 
   const results = await getAccessTokenImplicit(
+    requestId,
     authentication.authorizationUrl,
     authentication.clientId,
     authentication.redirectUrl,
@@ -82,7 +101,11 @@ async function _getOAuth2ImplicitHeader (requestId, authentication, forceRefresh
   return _updateOAuth2Token(requestId, results);
 }
 
-async function _getOAuth2PasswordHeader (requestId, authentication, forceRefresh) {
+async function _getOAuth2PasswordHeader (
+  requestId: string,
+  authentication: RequestAuthentication,
+  forceRefresh: boolean
+): Promise<OAuth2Token | null> {
   const oAuth2Token = await _getAccessToken(requestId, authentication, forceRefresh);
 
   if (oAuth2Token) {
@@ -90,6 +113,7 @@ async function _getOAuth2PasswordHeader (requestId, authentication, forceRefresh
   }
 
   const results = await getAccessTokenPassword(
+    requestId,
     authentication.accessTokenUrl,
     authentication.credentialsInBody,
     authentication.clientId,
@@ -102,12 +126,16 @@ async function _getOAuth2PasswordHeader (requestId, authentication, forceRefresh
   return _updateOAuth2Token(requestId, results);
 }
 
-async function _getAccessToken (requestId, authentication, forceRefresh) {
+async function _getAccessToken (
+  requestId: string,
+  authentication: RequestAuthentication,
+  forceRefresh: boolean
+): Promise<OAuth2Token | null> {
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
   // See if we have a token already //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
 
-  let token = await models.oAuth2Token.getByParentId(requestId);
+  let token: OAuth2Token | null = await models.oAuth2Token.getByParentId(requestId);
 
   if (!token) {
     return null;
@@ -118,7 +146,8 @@ async function _getAccessToken (requestId, authentication, forceRefresh) {
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
 
   // Refresh tokens are part of Auth Code, Password
-  const isExpired = token.expiresAt ? Date.now() > token.expiresAt : false;
+  const expiresAt = token.expiresAt || Infinity;
+  const isExpired = Date.now() > expiresAt;
 
   if (!isExpired && !forceRefresh) {
     return token;
@@ -135,6 +164,7 @@ async function _getAccessToken (requestId, authentication, forceRefresh) {
   }
 
   const refreshResults = await refreshAccessToken(
+    requestId,
     authentication.accessTokenUrl,
     authentication.credentialsInBody,
     authentication.clientId,
@@ -150,7 +180,7 @@ async function _getAccessToken (requestId, authentication, forceRefresh) {
   return _updateOAuth2Token(requestId, refreshResults);
 }
 
-async function _updateOAuth2Token (requestId, authResults) {
+async function _updateOAuth2Token (requestId: string, authResults: Object): Promise<OAuth2Token> {
   const oAuth2Token = await models.oAuth2Token.getOrCreateByParentId(requestId);
 
   // Calculate expiry date

--- a/app/network/o-auth-2/grant-client-credentials.js
+++ b/app/network/o-auth-2/grant-client-credentials.js
@@ -1,9 +1,18 @@
-import * as querystring from '../../common/querystring';
-import {getBasicAuthHeader} from '../../common/misc';
+// @flow
+import {getBasicAuthHeader, setDefaultProtocol} from '../../common/misc';
 import * as c from './constants';
 import {responseToObject} from './misc';
+import * as network from '../network';
+import * as models from '../../models/index';
 
-export default async function (accessTokenUrl, credentialsInBody, clientId, clientSecret, scope = '') {
+export default async function (
+  requestId: string,
+  accessTokenUrl: string,
+  credentialsInBody: boolean,
+  clientId: string,
+  clientSecret: string,
+  scope: string = ''
+): Promise<Object> {
   const params = [
     {name: c.P_GRANT_TYPE, value: c.GRANT_TYPE_CLIENT_CREDENTIALS}
   ];
@@ -11,28 +20,32 @@ export default async function (accessTokenUrl, credentialsInBody, clientId, clie
   // Add optional params
   scope && params.push({name: c.P_SCOPE, value: scope});
 
-  const headers = {
-    'Content-Type': 'application/x-www-form-urlencoded',
-    'Accept': 'application/x-www-form-urlencoded, application/json'
-  };
+  const headers = [
+    {name: 'Content-Type', value: 'application/x-www-form-urlencoded'},
+    {name: 'Accept', value: 'application/x-www-form-urlencoded, application/json'}
+  ];
 
   if (credentialsInBody) {
     params.push({name: c.P_CLIENT_ID, value: clientId});
     params.push({name: c.P_CLIENT_SECRET, value: clientSecret});
   } else {
-    const {name, value} = getBasicAuthHeader(clientId, clientSecret);
-    headers[name] = value;
+    headers.push(getBasicAuthHeader(clientId, clientSecret));
   }
 
-  const config = {
-    method: 'POST',
-    body: querystring.buildFromParams(params),
-    headers: headers
-  };
+  const url = setDefaultProtocol(accessTokenUrl);
 
-  const response = await window.fetch(accessTokenUrl, config);
-  const body = await response.text();
-  const results = responseToObject(body, [
+  const {response, bodyBuffer} = await network.sendWithSettings(requestId, {
+    headers,
+    url,
+    method: 'POST',
+    body: models.request.newBodyFormUrlEncoded(params)
+  });
+
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw new Error(`[oauth2] Failed to fetch token url=${url} status=${response.statusCode}`);
+  }
+
+  const results = responseToObject(bodyBuffer.toString('utf8'), [
     c.P_ACCESS_TOKEN,
     c.P_TOKEN_TYPE,
     c.P_EXPIRES_IN,

--- a/app/network/o-auth-2/grant-implicit.js
+++ b/app/network/o-auth-2/grant-implicit.js
@@ -1,8 +1,16 @@
+// @flow
 import * as querystring from '../../common/querystring';
 import * as c from './constants';
 import {responseToObject, authorizeUserInWindow} from './misc';
 
-export default async function (authorizationUrl, clientId, redirectUri = '', scope = '', state = '') {
+export default async function (
+  requestId: string,
+  authorizationUrl: string,
+  clientId: string,
+  redirectUri: string = '',
+  scope: string = '',
+  state: string = ''
+): Promise<Object> {
   const params = [
     {name: c.P_RESPONSE_TYPE, value: c.RESPONSE_TYPE_TOKEN},
     {name: c.P_CLIENT_ID, value: clientId}

--- a/app/ui/components/editors/body/graph-ql-editor.js
+++ b/app/ui/components/editors/body/graph-ql-editor.js
@@ -99,7 +99,6 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
 
     if (request) {
       try {
-        // TODO: Use Insomnia's network stack to handle things like authentication
         const bodyJson = JSON.stringify({query: introspectionQuery});
         const introspectionRequest = Object.assign({}, request, {
           body: newBodyRaw(bodyJson, CONTENT_TYPE_JSON),


### PR DESCRIPTION
Closes #580 

This PR changes the OAuth 2.0 handlers to use the Insomnia network stack instead of `window.fetch`. This means that the current requests parameters and settings (eg. proxy, ssl validation, etc) will be used to fetch OAuth tokens.