### PR TITLE
Custom headers parsing

### DIFF
--- a/app/__mocks__/insomnia-node-libcurl.js
+++ b/app/__mocks__/insomnia-node-libcurl.js
@@ -6,10 +6,15 @@ class Curl extends EventEmitter {
     super();
     this._options = {};
     this._meta = {};
+    this._features = {};
   }
 
   static getVersion () {
     return 'libcurl/7.54.0 LibreSSL/2.0.20 zlib/1.2.11 nghttp2/1.24.0';
+  }
+
+  enable (name) {
+    this._features[name] = true;
   }
 
   setOpt (name, value) {
@@ -70,17 +75,19 @@ class Curl extends EventEmitter {
     process.nextTick(() => {
       const data = Buffer.from(JSON.stringify({
         options: this._options,
-        meta: this._meta
+        meta: this._meta,
+        features: this._features
       }));
 
       this.emit('data', data);
 
       process.nextTick(() => {
-        this.emit('end', 'NOT_USED', 'NOT_USED', [{
-          'Content-Length': `${data.length}`,
-          'Content-Type': 'application/json',
-          result: {code: 200, reason: 'OK'}
-        }]);
+        this.emit('end', 'NOT_USED', 'NOT_USED', [
+          'HTTP/1.1 200 OK',
+          `Content-Length: ${data.length}`,
+          'Content-Type: application/json',
+          ''
+        ].join('\n'));
       });
     });
   }
@@ -111,6 +118,10 @@ Curl.netrc = {
   IGNORED: 0,
   OPTIONAL: 1,
   REQUIRED: 2
+};
+
+Curl.feature = {
+  NO_HEADER_PARSING: 'NO_HEADER_PARSING'
 };
 
 Curl.option = {

--- a/app/common/misc.js
+++ b/app/common/misc.js
@@ -71,6 +71,11 @@ export function getSetCookieHeaders<T: Header> (headers: Array<T>): Array<T> {
   return filterHeaders(headers, 'set-cookie');
 }
 
+export function getLocationHeader<T: Header> (headers: Array<T>): T | null {
+  const matches = filterHeaders(headers, 'location');
+  return matches.length ? matches[0] : null;
+}
+
 export function getContentTypeHeader<T: Header> (headers: Array<T>): T | null {
   const matches = filterHeaders(headers, 'content-type');
   return matches.length ? matches[0] : null;

--- a/app/models/environment.js
+++ b/app/models/environment.js
@@ -51,8 +51,6 @@ export function findByParentId (parentId: string): Promise<Array<Environment>> {
 export async function getOrCreateForWorkspaceId (workspaceId: string): Promise<Environment> {
   const environments = await db.find(type, {parentId: workspaceId});
 
-  console.log('ALL', await db.find(type, {parentId: workspaceId}));
-
   if (!environments.length) {
     return await create({
       parentId: workspaceId,

--- a/app/models/response.js
+++ b/app/models/response.js
@@ -29,6 +29,7 @@ export type ResponseTimelineEntry = {
 type BaseResponse = {
   statusCode: number,
   statusMessage: string,
+  httpVersion: string,
   contentType: string,
   url: string,
   bytesRead: number,
@@ -51,6 +52,7 @@ export function init (): BaseResponse {
   return {
     statusCode: 0,
     statusMessage: '',
+    httpVersion: '',
     contentType: '',
     url: '',
     bytesRead: 0,

--- a/app/network/__tests__/network.test.js
+++ b/app/network/__tests__/network.test.js
@@ -7,6 +7,7 @@ import {AUTH_AWS_IAM, AUTH_BASIC, AUTH_NETRC, CONTENT_TYPE_FILE, CONTENT_TYPE_FO
 import {filterHeaders} from '../../common/misc';
 import {globalBeforeEach} from '../../__jest__/before-each';
 import {DEFAULT_BOUNDARY} from '../multipart';
+import {_parseHeaders} from '../network';
 
 describe('actuallySend()', () => {
   beforeEach(globalBeforeEach);
@@ -67,6 +68,9 @@ describe('actuallySend()', () => {
     const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       meta: {},
+      features: {
+        NO_HEADER_PARSING: true
+      },
       options: {
         COOKIELIST: [
           'notlocalhost\tFALSE\t/\tFALSE\t4000855249\tfoo\tbarrrrr',
@@ -125,6 +129,9 @@ describe('actuallySend()', () => {
     const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       meta: {},
+      features: {
+        NO_HEADER_PARSING: true
+      },
       options: {
         POST: 1,
         ACCEPT_ENCODING: '',
@@ -206,6 +213,9 @@ describe('actuallySend()', () => {
     const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       meta: {},
+      features: {
+        NO_HEADER_PARSING: true
+      },
       options: {
         CUSTOMREQUEST: 'GET',
         ACCEPT_ENCODING: '',
@@ -256,6 +266,9 @@ describe('actuallySend()', () => {
 
     expect(body).toEqual({
       meta: {},
+      features: {
+        NO_HEADER_PARSING: true
+      },
       options: {
         POST: 1,
         ACCEPT_ENCODING: '',
@@ -369,6 +382,9 @@ describe('actuallySend()', () => {
     const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       meta: {},
+      features: {
+        NO_HEADER_PARSING: true
+      },
       options: {
         CUSTOMREQUEST: 'GET',
         ACCEPT_ENCODING: '',
@@ -407,6 +423,9 @@ describe('actuallySend()', () => {
     const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       meta: {},
+      features: {
+        NO_HEADER_PARSING: true
+      },
       options: {
         NOBODY: 1,
         ACCEPT_ENCODING: '',
@@ -444,6 +463,9 @@ describe('actuallySend()', () => {
     const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       meta: {},
+      features: {
+        NO_HEADER_PARSING: true
+      },
       options: {
         CUSTOMREQUEST: 'GET',
         ACCEPT_ENCODING: '',
@@ -482,6 +504,9 @@ describe('actuallySend()', () => {
     const body = JSON.parse(bodyBuffer);
     expect(body).toEqual({
       meta: {},
+      features: {
+        NO_HEADER_PARSING: true
+      },
       options: {
         CUSTOMREQUEST: 'GET',
         ACCEPT_ENCODING: '',
@@ -566,5 +591,96 @@ describe('_getAwsAuthHeaders', () => {
       .toMatch(/^AWS4-HMAC-SHA256 Credential=AKIA99999999/);
     expect(filterHeaders(headers, 'content-type'))
       .toHaveLength(0);
+  });
+});
+
+describe('_parseHeaders', () => {
+  const basicHeaders = [
+    'HTTP/1.1 301 Moved Permanently',
+    'X-Powered-By: Express',
+    'location: http://localhost:3000/',
+    'Content-Type: text/plain; charset=utf-8',
+    'Content-Length: 17',
+    'ETag: W/"11-WKzg6oYof0o8Mliwrz5pkw"',
+    'Duplicate: foo',
+    'Duplicate: bar',
+    'Date: Mon, 13 Nov 2017 22:06:28 GMT',
+    'Foo', // Invalid header
+    ''
+  ];
+
+  const minimalHeaders = [
+    'HTTP/1.1 301',
+    ''
+  ];
+
+  it('Parses single response headers', () => {
+    expect(_parseHeaders(new Buffer(basicHeaders.join('\n')))).toEqual([
+      {
+        code: 301,
+        version: 'HTTP/1.1',
+        reason: 'Moved Permanently',
+        headers: [
+          {name: 'X-Powered-By', value: 'Express'},
+          {name: 'location', value: 'http://localhost:3000/'},
+          {name: 'Content-Type', value: 'text/plain; charset=utf-8'},
+          {name: 'Content-Length', value: '17'},
+          {name: 'ETag', value: 'W/"11-WKzg6oYof0o8Mliwrz5pkw"'},
+          {name: 'Duplicate', value: 'foo'},
+          {name: 'Duplicate', value: 'bar'},
+          {name: 'Date', value: 'Mon, 13 Nov 2017 22:06:28 GMT'},
+          {name: 'Foo', value: ''}
+        ]
+      }
+    ]);
+  });
+
+  it('Parses Windows newlines', () => {
+    expect(_parseHeaders(new Buffer(basicHeaders.join('\r\n')))).toEqual([
+      {
+        code: 301,
+        version: 'HTTP/1.1',
+        reason: 'Moved Permanently',
+        headers: [
+          {name: 'X-Powered-By', value: 'Express'},
+          {name: 'location', value: 'http://localhost:3000/'},
+          {name: 'Content-Type', value: 'text/plain; charset=utf-8'},
+          {name: 'Content-Length', value: '17'},
+          {name: 'ETag', value: 'W/"11-WKzg6oYof0o8Mliwrz5pkw"'},
+          {name: 'Duplicate', value: 'foo'},
+          {name: 'Duplicate', value: 'bar'},
+          {name: 'Date', value: 'Mon, 13 Nov 2017 22:06:28 GMT'},
+          {name: 'Foo', value: ''}
+        ]
+      }
+    ]);
+  });
+
+  it('Parses multiple responses', () => {
+    const blobs = basicHeaders.join('\r\n') + '\n' + minimalHeaders.join('\n');
+    expect(_parseHeaders(new Buffer(blobs))).toEqual([
+      {
+        code: 301,
+        version: 'HTTP/1.1',
+        reason: 'Moved Permanently',
+        headers: [
+          {name: 'X-Powered-By', value: 'Express'},
+          {name: 'location', value: 'http://localhost:3000/'},
+          {name: 'Content-Type', value: 'text/plain; charset=utf-8'},
+          {name: 'Content-Length', value: '17'},
+          {name: 'ETag', value: 'W/"11-WKzg6oYof0o8Mliwrz5pkw"'},
+          {name: 'Duplicate', value: 'foo'},
+          {name: 'Duplicate', value: 'bar'},
+          {name: 'Date', value: 'Mon, 13 Nov 2017 22:06:28 GMT'},
+          {name: 'Foo', value: ''}
+        ]
+      },
+      {
+        code: 301,
+        headers: [],
+        reason: '',
+        version: 'HTTP/1.1'
+      }
+    ]);
   });
 });

--- a/app/ui/components/settings/general.js
+++ b/app/ui/components/settings/general.js
@@ -173,7 +173,7 @@ class General extends PureComponent {
             </HelpTooltip>
             <input type="number"
                    name="timeout"
-                   min={0}
+                   min={-1}
                    defaultValue={settings.timeout}
                    onChange={this._handleUpdateSetting}/>
           </label>

--- a/flow-typed/insomnia-node-libcurl.js
+++ b/flow-typed/insomnia-node-libcurl.js
@@ -1,5 +1,8 @@
 declare class Curl {
-  static getVersion: () => string,
+  static getVersion: () => string;
+  static feature: {
+    NO_HEADER_PARSING: number
+  };
   static option: {
     ACCEPT_ENCODING: number,
     CAINFO: number,
@@ -70,6 +73,7 @@ declare class Curl {
   };
 
   setOpt: (option: number, ...args: Array<any>) => void;
+  enable: (option: number, ...args: Array<any>) => void;
   getInfo: (option: string, ...args: Array<any>) => any;
   perform: () => void;
   close: () => void;


### PR DESCRIPTION
Closes #588 

This PR disables `node-libcurl`'s header parsing and brings it in-house. This gives Insomnia more accurate header results like providing the ability to show multiple headers with the same name.