### PR TITLE
Add RSA-SHA1 signing to OAuth 1.0

### DIFF
--- a/packages/insomnia-app/app/models/request.js
+++ b/packages/insomnia-app/app/models/request.js
@@ -110,6 +110,7 @@ export function newAuth (type: string, oldAuth: RequestAuthentication = {}): Req
         consumerSecret: '',
         tokenKey: '',
         tokenSecret: '',
+        privateKey: '',
         version: '1.0',
         nonce: '',
         timestamp: '',

--- a/packages/insomnia-app/app/network/__tests__/authentication.test.js
+++ b/packages/insomnia-app/app/network/__tests__/authentication.test.js
@@ -36,6 +36,55 @@ describe('OAuth 1.0', () => {
     });
   });
 
+  it('Does OAuth 1.0 with RSA-SHA1', async () => {
+    const header = await getAuthHeader(
+      'req_123',
+      'https://insomnia.rest/',
+      'GET',
+      {
+        type: AUTH_OAUTH_1,
+        consumerKey: 'consumerKey',
+        consumerSecret: 'consumerSecret',
+        callback: 'https://insomnia.rest/callback/',
+        tokenKey: 'tokenKey',
+        tokenSecret: 'tokenSecret',
+        signatureMethod: 'RSA-SHA1',
+        privateKey: '-----BEGIN RSA PRIVATE KEY-----\n' +
+                    'MIICXgIBAAKBgQC6jwJjt/KywX4N4ZA3YOLcNFrS9S2+TcArdMyo89yqLZWzC9x9\n' +
+                    'MY4gA+1+iOpG+S/jlDM3WuJSCnEzQhzDo9UGtNODC+Qr8nStRcKdjSOhywRXPd4d\n' +
+                    '+u6TOae/Flukwqzl0Pw3fsMWqwp0dni6OIc7E2gm2jj4MTLsd4oq/0igCQIDAQAB\n' +
+                    'AoGBAJCdHusRwo6SsxYrjdF/xxuPcgApkmX8e0S0a5lkP9+jKnH6ddaOPW/P25/E\n' +
+                    'nmaZ72dokDMOvnV+JrXnP8jgDNatJsBqS2aLBNpSI4TsOQDfhB3rPoafc5s2bNVY\n' +
+                    '5SRp2kr3QL74BZzLzAsIJzGDpRyKQGRPzMFiPzkQcfJuO7rpAkEA3gZq2v2OUzcV\n' +
+                    'iQIoCy7bkvxaKZUlkj6xT0msExqrAt9mtVE6XW3GsHUSyB2ePOzDz6zcKeX90nTq\n' +
+                    '79PAGTAm1wJBANcbO+xt9By9Omq8K51RuKkvlESHH8j+meAWW6DoKJvHdy2/+xnA\n' +
+                    'XEcDcWb9cV9V5FNWmJ+mMF1jfu/GxTMp9B8CQQDazaQ80KiUZbK5ZQCllLYbcspA\n' +
+                    'NJXkPBhtNQN5iEyD9jm38qb8MBUhDR9HS7kH/aUzYv1N5TRxVXu6ggnMSOHdAkBI\n' +
+                    'Gojrp6+8MnHydUDpawtLKve4QNMWvME3rEbqmOeD0EjSvReeeix0YWMR8sKeAlyW\n' +
+                    '0uA2I67ynvddyHMxw05hAkEAyXuG1xpqs3VYQeHRC67dQjkKw0YbcOeeWHpo1+cn\n' +
+                    'F29dI2yG3Ti+28/WlSdfYGe9P9SfeYM7RQbNbUp1MHWrkg==\n' +
+                    '-----END RSA PRIVATE KEY-----',
+        nonce: 'nonce',
+        timestamp: '1234567890'
+      }
+    );
+
+    expect(header).toEqual({
+      name: 'Authorization',
+      value: [
+        'OAuth ' +
+        'oauth_callback="https%3A%2F%2Finsomnia.rest%2Fcallback%2F"',
+        'oauth_consumer_key="consumerKey"',
+        'oauth_nonce="nonce"',
+        'oauth_signature="cuJlDLQcyQkIdfs8sIE9Y1769hrPy%2Fkwq8D%2BSQxl5azvk1TimWSgUECf3vJoF7DkgnvcYhFYTnduldj%2FJ9ttaOh8xmfE7krGm8Yh%2FDqYfvLPKnw%2F%2BAaKjd43Y6ulZqptTaf4q5D0%2FM9MhqI8pNRcblk30fI%2FR6JYRyjHVm3YNZo%3D"',
+        'oauth_signature_method="RSA-SHA1"',
+        'oauth_timestamp="1234567890"',
+        'oauth_token="tokenKey"',
+        'oauth_version="1.0"'
+      ].join(', ')
+    });
+  });
+
   it('Does OAuth 1.0 with defaults', async () => {
     const header = await getAuthHeader(
       'req_123',

--- a/packages/insomnia-app/app/network/o-auth-1/constants.js
+++ b/packages/insomnia-app/app/network/o-auth-1/constants.js
@@ -1,4 +1,5 @@
 // @flow
-export type OAuth1SignatureMethod = 'HMAC-SHA1' | 'PLAINTEXT';
+export type OAuth1SignatureMethod = 'HMAC-SHA1' | 'RSA-SHA1' | 'PLAINTEXT';
 export const SIGNATURE_METHOD_HMAC_SHA1: OAuth1SignatureMethod = 'HMAC-SHA1';
+export const SIGNATURE_METHOD_RSA_SHA1: OAuth1SignatureMethod = 'RSA-SHA1';
 export const SIGNATURE_METHOD_PLAINTEXT: OAuth1SignatureMethod = 'PLAINTEXT';

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.js
@@ -5,8 +5,9 @@ import * as React from 'react';
 import autobind from 'autobind-decorator';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import * as misc from '../../../../common/misc';
+import CodeEditor from '../../codemirror/code-editor';
 import HelpTooltip from '../../help-tooltip';
-import {SIGNATURE_METHOD_HMAC_SHA1, SIGNATURE_METHOD_PLAINTEXT} from '../../../../network/o-auth-1/constants';
+import {SIGNATURE_METHOD_HMAC_SHA1, SIGNATURE_METHOD_RSA_SHA1, SIGNATURE_METHOD_PLAINTEXT} from '../../../../network/o-auth-1/constants';
 
 type Props = {
   handleRender: Function,
@@ -66,6 +67,10 @@ class OAuth1Auth extends React.PureComponent<Props> {
 
   _handleChangeSignatureMethod (e: SyntheticEvent<HTMLInputElement>): void {
     this._handleChangeProperty('signatureMethod', e.currentTarget.value);
+  }
+
+  _handleChangePrivateKey (value: string): void {
+    this._handleChangeProperty('privateKey', value);
   }
 
   _handleChangeVersion (value: string): void {
@@ -142,6 +147,52 @@ class OAuth1Auth extends React.PureComponent<Props> {
     );
   }
 
+  renderPrivateKeyInput (
+    label: string,
+    property: string,
+    onChange: Function
+  ): React.Element<*> {
+    const { handleRender, handleGetRenderContext, request, nunjucksPowerUserMode } = this.props;
+    const id = label.replace(/ /g, '-');
+    const placeholderPrivateKey = '-----BEGIN RSA PRIVATE KEY-----\n' +
+    'MIIEpQIBAAKCAQEA39k9udklHnmkU0GtTLpnYtKk1l5txYmUD/cGI0bFd3HHOOLG\n' +
+    'mI0av55vMFEhxL7yrFrcL8pRKp0+pnOVStMDmbwsPE/pu9pf3uxD+m9/Flv89bUk\n' +
+    'mml+R3E8PwAYzkX0cr4yQTPN9PSSqy+d2+KrZ9QZmpc3tqltTbMVV93cxKCxfBrf\n' +
+    'jbiMIAVh7silDVY5+V46SJu8zY2kXOBBtlrE7/JoMiTURCkRjNIA8/sgSmRxBTdM\n' +
+    '313lKJM7NgxaGnREbP75U7ErfBvReJsf5p6h5+XXFirG7F2ntcqjUoR3M+opngp0\n' +
+    'CgffdGcsK7MmUUgAG7r05b0mljhI35t/0Y57MwIDAQABAoIBAQCH1rLohudJmROp\n' +
+    'Gl/qAewfQiiZlfATQavCDGuDGL1YAIme8a8GgApNYf2jWnidhiqJgRHBRor+yzFr\n' +
+    'cJV+wRTs/Szp6LXAgMmTkKMJ+9XXErUIUgwbl27Y3Rv/9ox1p5VRg+A=\n' +
+    '-----END RSA PRIVATE KEY-----';
+    return (
+      <tr key={id}>
+        <td className="pad-right pad-top-sm no-wrap valign-top">
+          <label htmlFor={id} className="label--small no-pad">
+            {label}
+            <HelpTooltip>Used for RSA-SHA1 signing</HelpTooltip>
+          </label>
+        </td>
+        <td className="wide">
+          <div className="form-control form-control--underlined form-control--tall no-margin">
+            <CodeEditor
+              id={id}
+              onChange={onChange}
+              defaultValue={request.authentication[property] || ''}
+              dynamicHeight={true}
+              hideLineNumbers={true}
+              lineWrapping={true}
+              placeholder={placeholderPrivateKey}
+              style={{height: 200}}
+              nunjucksPowerUserMode={nunjucksPowerUserMode}
+              render={handleRender}
+              getRenderContext={handleGetRenderContext}
+            />
+          </div>
+        </td>
+      </tr>
+    );
+  }
+
   renderFields (): Array<React.Element<*>> {
     const consumerKey = this.renderInputRow(
       'Consumer Key',
@@ -199,9 +250,16 @@ class OAuth1Auth extends React.PureComponent<Props> {
       'signatureMethod',
       [
         {name: 'HMAC-SHA1', value: SIGNATURE_METHOD_HMAC_SHA1},
+        {name: 'RSA-SHA1', value: SIGNATURE_METHOD_RSA_SHA1},
         {name: 'PLAINTEXT', value: SIGNATURE_METHOD_PLAINTEXT}
       ],
       this._handleChangeSignatureMethod
+    );
+
+    const privateKey = this.renderPrivateKeyInput(
+      'Private Key',
+      'privateKey',
+      this._handleChangePrivateKey
     );
 
     const version = this.renderInputRow(
@@ -216,6 +274,7 @@ class OAuth1Auth extends React.PureComponent<Props> {
       tokenKey,
       tokenSecret,
       signatureMethod,
+      privateKey,
       callback,
       version,
       timestamp,

--- a/packages/insomnia-app/flow-typed/oauth-1.0a.js
+++ b/packages/insomnia-app/flow-typed/oauth-1.0a.js
@@ -1,4 +1,4 @@
-type SignatureMethod = 'HMAC-SHA1' | 'PLAINTEXT';
+type SignatureMethod = 'HMAC-SHA1' | 'RSA-SHA1' | 'PLAINTEXT';
 type Token = {key: string, secret?: string};
 type RequestData = {
   url: string,
@@ -20,6 +20,7 @@ declare class OAuth1 {
   constructor (config: OAuth1Config): OAuth1;
   authorize: (data: RequestData, token: Token | null) => RequestData;
   toHeader: (data: RequestData) => {'Authorization': string};
+  getSigningKey: (tokenSecret: string) => string;
 }
 
 declare module 'oauth-1.0a' {


### PR DESCRIPTION
Attempts to close #606 but isn't quite there.

I took stab at #606, couldn't wrap my head around rendering on events (ie. hiding the privateKey input until the correct dropdown is selected) so I tried to get the basics of just a key input box to render and now I get `Render Failure: CodeEditor is not defined` whenever I try to access the OAuth 1 menu. Obviously this should not be merged as is, because it completely breaks the OAuth 1 UI, but maybe I can get some assistance?

As far as the actual logic for RSA_SHA1 goes, I think it should work but I haven't been able to test it because I've broken the UI 👍 