### PR TITLE
Always show request timer with one decimal precision

### DIFF
--- a/app/ui/components/response-timer.js
+++ b/app/ui/components/response-timer.js
@@ -21,7 +21,7 @@ class ResponseTimer extends PureComponent {
   _handleUpdateElapsedTime () {
     const {loadStartTime} = this.props;
     const millis = Date.now() - loadStartTime - 200;
-    const elapsedTime = Math.round(millis / 100) / 10;
+    const elapsedTime = millis / 1000;
     this.setState({elapsedTime});
   }
 
@@ -47,7 +47,7 @@ class ResponseTimer extends PureComponent {
     return (
       <div className={classnames('overlay theme--overlay', {'overlay--hidden': !show})}>
         {elapsedTime >= REQUEST_TIME_TO_SHOW_COUNTER
-          ? <h2>{elapsedTime} seconds...</h2>
+          ? <h2>{elapsedTime.toFixed(1)} seconds...</h2>
           : <h2>Loading...</h2>
         }
         <div className="pad">


### PR DESCRIPTION
I was slightly bothered by the request timer jumping because it was reducing its precision when it reached `.0`. I therefore propose to always call `toFixed(1)` on it for a nicer look.

## Before
![bad](https://user-images.githubusercontent.com/1096357/33129239-8e4ef7ce-cf8f-11e7-8275-cc5b1528c08c.gif)

## After
![good](https://user-images.githubusercontent.com/1096357/33129234-8c5399e8-cf8f-11e7-8536-810b2cf4fe44.gif)
