### PR TITLE
Better stats handling and update notifications

### DIFF
--- a/app/common/analytics.js
+++ b/app/common/analytics.js
@@ -41,7 +41,7 @@ export function trackEvent (
   });
 }
 
-export async function trackNonInteractiveEvent (
+export function trackNonInteractiveEvent (
   category: string,
   action: string,
   label: ?string,
@@ -52,8 +52,10 @@ export async function trackNonInteractiveEvent (
   });
 }
 
-export async function trackPageView () {
-  await _trackPageView();
+export function trackPageView () {
+  process.nextTick(async () => {
+    await _trackPageView();
+  });
 }
 
 // ~~~~~~~~~~~~~~~~~ //

--- a/app/common/misc.js
+++ b/app/common/misc.js
@@ -267,16 +267,20 @@ export function preventDefault (e: Event): void {
   e.preventDefault();
 }
 
-export function clickLink (href: string): void {
+export function attributeHref (href: string): string {
   if (href.match(/^http/i)) {
     const appName = isDevelopment() ? 'Insomnia Dev' : 'Insomnia';
     const qs = `utm_source=${appName}&utm_medium=app&utm_campaign=v${getAppVersion()}`;
-    const attributedHref = querystring.joinUrl(href, qs);
-    electron.shell.openExternal(attributedHref);
+    return querystring.joinUrl(href, qs);
   } else {
     // Don't modify non-http urls
-    electron.shell.openExternal(href);
+    return href;
   }
+}
+
+export function clickLink (href: string): void {
+  const attributedHref = attributeHref(href);
+  electron.shell.openExternal(attributedHref);
 }
 
 export function fnOrString (v: string | Function, ...args: Array<any>) {

--- a/app/models/stats.js
+++ b/app/models/stats.js
@@ -1,32 +1,46 @@
+// @flow
 import * as db from '../common/database';
+import type {BaseModel} from './index';
 
 export const name = 'Stats';
 export const type = 'Stats';
 export const prefix = 'sta';
 export const canDuplicate = false;
 
-export function init () {
+type BaseStats = {
+  currentLaunch: number | null,
+  lastLaunch: number | null,
+  currentVersion: string | null,
+  lastVersion: string | null,
+  launches: number
+};
+
+export type Stats = BaseModel & BaseStats;
+
+export function init (): BaseStats {
   return {
-    lastLaunch: Date.now(),
+    currentLaunch: null,
+    lastLaunch: null,
+    currentVersion: null,
     lastVersion: null,
     launches: 0
   };
 }
 
-export function migrate (doc) {
+export function migrate (doc: Stats): Stats {
   return doc;
 }
 
-export function create (patch = {}) {
+export function create (patch: Object = {}): Promise<Stats> {
   return db.docCreate(type, patch);
 }
 
-export async function update (patch) {
+export async function update (patch: Object): Promise<Stats> {
   const stats = await get();
   return db.docUpdate(stats, patch);
 }
 
-export async function get () {
+export async function get (): Promise<Stats> {
   const results = await db.all(type);
   if (results.length === 0) {
     return create();

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "insomnia",
-  "version": "5.12.0-beta.1",
+  "version": "5.12.0-beta.2",
   "productName": "Insomnia",
   "longName": "Insomnia REST Client",
   "description": "Debug APIs like a human, not a robot",

--- a/app/sync/session.js
+++ b/app/sync/session.js
@@ -154,7 +154,7 @@ export function getPrivateKey () {
 }
 
 export function getCurrentSessionId () {
-  if (global.window) { // NOTE: Must check for window on global
+  if (window) {
     return window.localStorage.getItem('currentSessionId');
   } else {
     return false;

--- a/app/ui/components/base/link.js
+++ b/app/ui/components/base/link.js
@@ -9,6 +9,7 @@ type Props = {|
   title?: string,
   button?: boolean,
   onClick?: Function,
+  className?: string,
   children?: React.Node
 |};
 
@@ -31,11 +32,18 @@ class Link extends React.PureComponent<Props> {
       button,
       href,
       children,
+      className,
       ...other
     } = this.props;
-    return button
-      ? <button onClick={this._handleClick} {...other}>{children}</button>
-      : <a href={href} onClick={this._handleClick} {...other}>{children}</a>;
+    return button ? (
+      <button onClick={this._handleClick} className={className} {...other}>
+        {children}
+      </button>
+    ) : (
+      <a href={href} onClick={this._handleClick} className={className} {...other}>
+        {children}
+      </a>
+    );
   }
 }
 

--- a/app/ui/components/check-for-updates-button.js
+++ b/app/ui/components/check-for-updates-button.js
@@ -25,21 +25,29 @@ class CheckForUpdatesButton extends React.PureComponent<Props, State> {
     };
   }
 
-  componentDidMount () {
-    electron.ipcRenderer.on('updater.check.status', (e, status) => {
-      if (this.state.checking) {
-        this.setState({status});
-      }
-    });
+  _listenerCheckComplete (e: any, updateAvailable: true, status: string) {
+    this.setState({status, updateAvailable});
+  }
 
-    electron.ipcRenderer.on('updater.check.complete', (e, updateAvailable, status) => {
-      this.setState({checking: false, status, updateAvailable});
-    });
+  _listenerCheckStatus (e: any, status: string) {
+    if (this.state.checking) {
+      this.setState({status});
+    }
   }
 
   _handleCheckForUpdates () {
     electron.ipcRenderer.send('updater.check');
     this.setState({checking: true});
+  }
+
+  componentDidMount () {
+    electron.ipcRenderer.on('updater.check.status', this._listenerCheckStatus);
+    electron.ipcRenderer.on('updater.check.complete', this._listenerCheckComplete);
+  }
+
+  componentWillUnmount () {
+    electron.ipcRenderer.removeListener('updater.check.complete', this._listenerCheckComplete);
+    electron.ipcRenderer.removeListener('updater.check.status', this._listenerCheckStatus);
   }
 
   render () {

--- a/app/ui/components/settings/general.js
+++ b/app/ui/components/settings/general.js
@@ -106,7 +106,6 @@ class General extends React.PureComponent<Props> {
           <label className="inline-block">
             Disable Usage Tracking
             {' '}
-            <HelpTooltip>Requires restart to take effect</HelpTooltip>
             <input type="checkbox"
                    name="disableAnalyticsTracking"
                    checked={settings.disableAnalyticsTracking}

--- a/app/ui/components/toast.js
+++ b/app/ui/components/toast.js
@@ -147,17 +147,20 @@ class Toast extends React.PureComponent<Props, State> {
     }, 1000);
   }
 
+  _listenerShowNotification (e: any, notification: ToastNotification) {
+    console.log('[toast] Received notification ' + notification.key);
+    this._handleNotification(notification);
+  }
+
   componentDidMount () {
     setTimeout(this._checkForNotifications, 1000 * 10);
     this._interval = setInterval(this._checkForNotifications, 1000 * 60 * 30);
-    electron.ipcRenderer.on('show-notification', (e: any, notification: ToastNotification) => {
-      console.log('[toast] Received notification ' + notification.key);
-      this._handleNotification(notification);
-    });
+    electron.ipcRenderer.on('show-notification', this._listenerShowNotification);
   }
 
   componentWillUnmount () {
     clearInterval(this._interval);
+    electron.ipcRenderer.removeListener('show-notification', this._listenerShowNotification);
   }
 
   render () {

--- a/app/ui/components/toast.js
+++ b/app/ui/components/toast.js
@@ -1,39 +1,71 @@
-import React, {PureComponent} from 'react';
+// @flow
+import * as React from 'react';
+import * as electron from 'electron';
 import autobind from 'autobind-decorator';
 import classnames from 'classnames';
 import GravatarImg from './gravatar-img';
 import Link from './base/link';
 import * as fetch from '../../common/fetch';
-import {trackEvent} from '../../common/analytics';
+import {trackEvent, trackNonInteractiveEvent} from '../../common/analytics';
 import * as models from '../../models/index';
 import * as constants from '../../common/constants';
 import * as db from '../../common/database';
 
 const LOCALSTORAGE_KEY = 'insomnia::notifications::seen';
 
+export type ToastNotification = {
+  key: string,
+  url: string,
+  cta: string,
+  message: string,
+  email: string
+};
+
+type Props = {};
+
+type State = {
+  notification: ToastNotification | null,
+  visible: boolean
+};
+
 @autobind
-class Toast extends PureComponent {
-  constructor (props) {
+class Toast extends React.PureComponent<Props, State> {
+  _interval: any;
+
+  constructor (props: Props) {
     super(props);
-    this.state = {notification: null, visible: false};
+    this.state = {
+      notification: null,
+      visible: false
+    };
   }
 
   _handlePostCTACleanup () {
-    trackEvent('Notification', 'Click', this.state.notification.key);
+    const {notification} = this.state;
+    if (!notification) {
+      return;
+    }
+
+    trackEvent('Notification', 'Click', notification.key);
     this._dismissNotification();
   }
 
   _handleCancelClick () {
-    trackEvent('Notification', 'Dismiss', this.state.notification.key);
+    const {notification} = this.state;
+    if (!notification) {
+      return;
+    }
+
+    trackEvent('Notification', 'Dismiss', notification.key);
     this._dismissNotification();
   }
 
-  _hasSeenNotification (notification) {
+  _hasSeenNotification (notification: ToastNotification) {
     const seenNotifications = this._loadSeen();
     return seenNotifications[notification.key];
   }
 
-  async _handleCheckNotifications () {
+  async _checkForNotifications () {
     // If there is a notification open, skip check
     if (this.state.notification) {
       return;
@@ -42,12 +74,11 @@ class Toast extends PureComponent {
     const stats = await models.stats.get();
     const settings = await models.settings.getOrCreate();
 
-    let notification;
+    let notification: ToastNotification;
 
     // Try fetching user notification
     try {
       const data = {
-        lastLaunch: stats.lastLaunch,
         firstLaunch: stats.created,
         launches: stats.launches,
         platform: constants.getAppPlatform(),
@@ -66,6 +97,10 @@ class Toast extends PureComponent {
       console.warn('[toast] Failed to fetch user notifications', err);
     }
 
+    this._handleNotification(notification);
+  }
+
+  _handleNotification (notification: ?ToastNotification) {
     // No new notifications
     if (!notification || this._hasSeenNotification(notification)) {
       return;
@@ -82,6 +117,9 @@ class Toast extends PureComponent {
 
     // Fade the notification in
     setTimeout(() => this.setState({visible: true}), 1000);
+
+    // Track it
+    trackNonInteractiveEvent('Notification', 'Shown', notification.key);
   }
 
   _loadSeen () {
@@ -103,13 +141,19 @@ class Toast extends PureComponent {
 
     // Give time for toast to fade out, then remove it
     setTimeout(() => {
-      this.setState({notification: null});
+      this.setState({notification: null}, async () => {
+        await this._checkForNotifications();
+      });
     }, 1000);
   }
 
   componentDidMount () {
-    setTimeout(this._handleCheckNotifications, 1000 * 10);
-    this._interval = setInterval(this._handleCheckNotifications, 1000 * 60 * 30);
+    setTimeout(this._checkForNotifications, 1000 * 10);
+    this._interval = setInterval(this._checkForNotifications, 1000 * 60 * 30);
+    electron.ipcRenderer.on('show-notification', (e: any, notification: ToastNotification) => {
+      console.log('[toast] Received notification ' + notification.key);
+      this._handleNotification(notification);
+    });
   }
 
   componentWillUnmount () {

--- a/flow-typed/electron-squirrel-startup.js
+++ b/flow-typed/electron-squirrel-startup.js
@@ -1,0 +1,3 @@
+declare module 'electron-squirrel-startup' {
+  declare module.exports: *
+}

--- a/flow-typed/electron.js
+++ b/flow-typed/electron.js
@@ -5,6 +5,7 @@ declare module 'electron' {
       app: Object,
       BrowserWindow: Object,
       ipcMain: Object,
+      session: Object,
       net: Object,
       dialog: Object,
       screen: Object
@@ -14,6 +15,7 @@ declare module 'electron' {
     BrowserWindow: Object,
     ipcRenderer: Object,
     ipcMain: Object,
+    session: Object,
     net: Object,
     dialog: Object,
     clipboard: Object,


### PR DESCRIPTION
Closes #485 

In a previous commit, the changelog dialog was removed but I forgot to add a new mechanism to display that the app was updated. This PR adds that mechanism and also moves stats tracking and handling to the `main` process.

If the application launches to a new version, a subtle notification will be displayed instead of an intrusive modal dialog.

<img width="341" alt="image" src="https://user-images.githubusercontent.com/587576/33147768-eb41284a-cfc0-11e7-91df-ec5d58a89c46.png">