### PR TITLE
Prompt Template Tag and Plugin arg validation

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/render.test.js
+++ b/packages/insomnia-app/app/common/__tests__/render.test.js
@@ -382,4 +382,30 @@ describe('render()', () => {
       expect(err.message).toBe('unknown block tag: invalid');
     }
   });
+
+  it('outputs correct error path', async () => {
+    const template = {
+      foo: [{bar: '{% foo %}'}]
+    };
+
+    try {
+      await renderUtils.render(template);
+      fail('Should have failed to render');
+    } catch (err) {
+      expect(err.path).toBe('foo[0].bar');
+    }
+  });
+
+  it('outputs correct error path when private first node', async () => {
+    const template = {
+      _foo: {_bar: {baz: '{% foo %}'}}
+    };
+
+    try {
+      await renderUtils.render(template);
+      fail('Should have failed to render');
+    } catch (err) {
+      expect(err.path).toBe('_bar.baz');
+    }
+  });
 });

--- a/packages/insomnia-app/app/plugins/context/__tests__/app.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/app.test.js
@@ -1,22 +1,17 @@
 import * as plugin from '../app';
 import * as modals from '../../../ui/components/modals';
 import {globalBeforeEach} from '../../../__jest__/before-each';
-
-const PLUGIN = {
-  name: 'my-plugin',
-  version: '1.0.0',
-  directory: '/plugins/my-plugin',
-  module: {}
-};
+import {RENDER_PURPOSE_SEND} from '../../../common/render';
 
 describe('init()', () => {
   beforeEach(globalBeforeEach);
   it('initializes correctly', async () => {
-    const result = plugin.init({name: PLUGIN});
+    const result = plugin.init();
     expect(Object.keys(result)).toEqual(['app']);
     expect(Object.keys(result.app).sort()).toEqual([
       'alert',
       'getPath',
+      'prompt',
       'showSaveDialog'
     ]);
   });
@@ -24,18 +19,56 @@ describe('init()', () => {
 
 describe('app.alert()', () => {
   beforeEach(globalBeforeEach);
-  it('shows alert with message', async () => {
+  it('does not show alert when not sending', async () => {
+    modals.showAlert = jest.fn();
+    const result = plugin.init();
+
+    result.app.alert();
+
+    // Make sure it passes correct arguments
+    expect(modals.showAlert.mock.calls).toEqual([]);
+  });
+
+  it('shows alert with message when sending', async () => {
     modals.showAlert = jest.fn().mockReturnValue('dummy-return-value');
-    const result = plugin.init(PLUGIN);
+    const result = plugin.init(RENDER_PURPOSE_SEND);
 
     // Make sure it returns result of showAlert()
     expect(result.app.alert()).toBe('dummy-return-value');
-    expect(result.app.alert('My message')).toBe('dummy-return-value');
+    expect(result.app.alert({title: 'My message'})).toBe('dummy-return-value');
 
     // Make sure it passes correct arguments
     expect(modals.showAlert.mock.calls).toEqual([
-      [{message: '', title: 'Plugin my-plugin'}],
-      [{message: 'My message', title: 'Plugin my-plugin'}]
+      [{}],
+      [{title: 'My message'}]
+    ]);
+  });
+});
+
+describe('app.prompt()', () => {
+  beforeEach(globalBeforeEach);
+  it('does not show prompt when not sending', async () => {
+    modals.showPrompt = jest.fn();
+    const result = plugin.init();
+
+    result.app.prompt();
+
+    // Make sure it passes correct arguments
+    expect(modals.showPrompt.mock.calls).toEqual([]);
+  });
+
+  it('shows alert with message when sending', async () => {
+    modals.showPrompt = jest.fn();
+    const result = plugin.init(RENDER_PURPOSE_SEND);
+
+    // Make sure it returns result of showAlert()
+    result.app.prompt();
+    result.app.prompt({title: 'My message'});
+
+    // Make sure it passes correct arguments
+    expect(modals.showPrompt.mock.calls).toEqual([
+      [{cancelable: false, onComplete: expect.any(Function)}],
+      [{cancelable: false, onComplete: expect.any(Function), title: 'My message'}]
     ]);
   });
 });

--- a/packages/insomnia-app/app/plugins/context/__tests__/request.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/request.test.js
@@ -2,13 +2,6 @@ import * as plugin from '../request';
 import * as models from '../../../models';
 import {globalBeforeEach} from '../../../__jest__/before-each';
 
-const PLUGIN = {
-  name: 'my-plugin',
-  version: '1.0.0',
-  directory: '/plugins/my-plugin',
-  module: {}
-};
-
 const CONTEXT = {
   user_key: 'my_user_key',
   hello: 'world',
@@ -25,7 +18,7 @@ describe('init()', () => {
   });
 
   it('initializes correctly', async () => {
-    const result = plugin.init(PLUGIN, await models.request.getById('req_1'), CONTEXT);
+    const result = plugin.init(await models.request.getById('req_1'), CONTEXT);
     expect(Object.keys(result)).toEqual(['request']);
     expect(Object.keys(result.request).sort()).toEqual([
       'addHeader',
@@ -49,7 +42,7 @@ describe('init()', () => {
   });
 
   it('fails to initialize without request', () => {
-    expect(() => plugin.init(PLUGIN))
+    expect(() => plugin.init())
       .toThrowError('contexts.request initialized without request');
   });
 });
@@ -70,7 +63,7 @@ describe('request.*', () => {
   });
 
   it('works for basic getters', async () => {
-    const result = plugin.init(PLUGIN, await models.request.getById('req_1'), CONTEXT);
+    const result = plugin.init(await models.request.getById('req_1'), CONTEXT);
     expect(result.request.getId()).toBe('req_1');
     expect(result.request.getName()).toBe('My Request');
     expect(result.request.getUrl()).toBe('');
@@ -78,7 +71,7 @@ describe('request.*', () => {
   });
 
   it('works for headers', async () => {
-    const result = plugin.init(PLUGIN, await models.request.getById('req_1'), CONTEXT);
+    const result = plugin.init(await models.request.getById('req_1'), CONTEXT);
 
     // getHeaders()
     expect(result.request.getHeaders()).toEqual([
@@ -112,7 +105,7 @@ describe('request.*', () => {
     const request = await models.request.getById('req_1');
     request.cookies = []; // Because the plugin technically needs a RenderedRequest
 
-    const result = plugin.init(PLUGIN, request, CONTEXT);
+    const result = plugin.init(request, CONTEXT);
 
     result.request.setCookie('foo', 'bar');
     result.request.setCookie('foo', 'baz');
@@ -123,7 +116,7 @@ describe('request.*', () => {
     const request = await models.request.getById('req_1');
     request.cookies = []; // Because the plugin technically needs a RenderedRequest
 
-    const result = plugin.init(PLUGIN, request, CONTEXT);
+    const result = plugin.init(request, CONTEXT);
 
     // getEnvironment
     expect(result.request.getEnvironment()).toEqual({

--- a/packages/insomnia-app/app/plugins/context/__tests__/response.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/response.test.js
@@ -5,17 +5,10 @@ import fs from 'fs';
 import path from 'path';
 import * as models from '../../../models/index';
 
-const PLUGIN = {
-  name: 'my-plugin',
-  version: '1.0.0',
-  directory: '/plugins/my-plugin',
-  module: {}
-};
-
 describe('init()', () => {
   beforeEach(globalBeforeEach);
   it('initializes correctly', async () => {
-    const result = plugin.init(PLUGIN, {});
+    const result = plugin.init({});
     expect(Object.keys(result)).toEqual(['response']);
     expect(Object.keys(result.response)).toEqual([
       'getRequestId',
@@ -31,7 +24,7 @@ describe('init()', () => {
   });
 
   it('fails to initialize without response', () => {
-    expect(() => plugin.init(PLUGIN))
+    expect(() => plugin.init())
       .toThrowError('contexts.response initialized without response');
   });
 });
@@ -51,7 +44,7 @@ describe('response.*', () => {
       bytesRead: 123,
       elapsedTime: 321
     });
-    const result = plugin.init(PLUGIN, response);
+    const result = plugin.init(response);
     expect(result.response.getRequestId()).toBe('req_1');
     expect(result.response.getStatusCode()).toBe(200);
     expect(result.response.getBytesRead()).toBe(123);
@@ -60,7 +53,7 @@ describe('response.*', () => {
   });
 
   it('works for basic and empty response', async () => {
-    const result = plugin.init(PLUGIN, {});
+    const result = plugin.init({});
     expect(result.response.getRequestId()).toBe('');
     expect(result.response.getStatusCode()).toBe(0);
     expect(result.response.getBytesRead()).toBe(0);
@@ -76,7 +69,7 @@ describe('response.*', () => {
         {name: 'set-cookie', value: 'baz=qux'}
       ]
     };
-    const result = plugin.init(PLUGIN, response);
+    const result = plugin.init(response);
     expect(result.response.getHeader('Does-Not-Exist')).toBeNull();
     expect(result.response.getHeader('CONTENT-TYPE')).toBe('application/json');
     expect(result.response.getHeader('set-cookie')).toEqual(['foo=bar', 'baz=qux']);

--- a/packages/insomnia-app/app/plugins/context/data.js
+++ b/packages/insomnia-app/app/plugins/context/data.js
@@ -1,8 +1,7 @@
 // @flow
-import type {Plugin} from '../';
 import {exportHAR, exportJSON, importRaw, importUri} from '../../common/import';
 
-export function init (plugin: Plugin): {'import': Object, 'export': Object} {
+export function init (): {'import': Object, 'export': Object} {
   return {
     'import': {
       async uri (uri: string, options: {workspaceId?: string} = {}): Promise<void> {

--- a/packages/insomnia-app/app/plugins/context/request.js
+++ b/packages/insomnia-app/app/plugins/context/request.js
@@ -1,10 +1,8 @@
 // @flow
-import type {Plugin} from '../';
 import type {RenderedRequest} from '../../common/render';
 import * as misc from '../../common/misc';
 
 export function init (
-  plugin: Plugin,
   renderedRequest: RenderedRequest,
   renderedContext: Object
 ): {request: Object} {

--- a/packages/insomnia-app/app/plugins/context/response.js
+++ b/packages/insomnia-app/app/plugins/context/response.js
@@ -1,5 +1,4 @@
 // @flow
-import type {Plugin} from '../';
 import type {ResponseHeader} from '../../models/response';
 import * as models from '../../models/index';
 import {Readable} from 'stream';
@@ -16,7 +15,6 @@ type MaybeResponse = {
 }
 
 export function init (
-  plugin: Plugin,
   response: MaybeResponse,
   bodyBuffer: Buffer | null = null
 ): {response: Object} {

--- a/packages/insomnia-app/app/plugins/index.js
+++ b/packages/insomnia-app/app/plugins/index.js
@@ -37,6 +37,7 @@ const CORE_PLUGINS = [
   'insomnia-plugin-file',
   'insomnia-plugin-now',
   'insomnia-plugin-uuid',
+  'insomnia-plugin-prompt',
   'insomnia-plugin-request',
   'insomnia-plugin-response'
 ];

--- a/packages/insomnia-app/app/templating/base-extension.js
+++ b/packages/insomnia-app/app/templating/base-extension.js
@@ -1,5 +1,6 @@
 import * as models from '../models/index';
 import * as templating from './index';
+import * as pluginContexts from '../plugins/context';
 
 const EMPTY_ARG = '__EMPTY_NUNJUCKS_ARG__';
 
@@ -60,6 +61,9 @@ export default class BaseExtension {
     // Pull out the meta helper
     const renderMeta = renderContext.getMeta ? renderContext.getMeta() : {};
 
+    // Pull out the purpose
+    const renderPurpose = renderContext.getPurpose ? renderContext.getPurpose() : null;
+
     // Extract the rest of the args
     const args = runArgs
       .slice(0, runArgs.length - 1)
@@ -67,6 +71,7 @@ export default class BaseExtension {
 
     // Define a helper context with utils
     const helperContext = {
+      ...pluginContexts.app.init(renderPurpose),
       context: renderContext,
       meta: renderMeta,
       util: {

--- a/packages/insomnia-app/app/templating/extensions/index.js
+++ b/packages/insomnia-app/app/templating/extensions/index.js
@@ -82,5 +82,6 @@ export type PluginTemplateTag = {
   description: string,
   run: (context: PluginTemplateTagContext, ...arg: Array<any>) => Promise<any> | any,
   deprecated?: boolean,
+  validate?: (value: any) => ?string,
   priority?: number
 };

--- a/packages/insomnia-app/app/templating/index.js
+++ b/packages/insomnia-app/app/templating/index.js
@@ -54,7 +54,7 @@ export function render (text: string, config: Object = {}): Promise<string> {
           : 'error';
 
         const newError = new RenderError(sanitizedMsg);
-        newError.path = path || null;
+        newError.path = path || '';
         newError.message = sanitizedMsg;
         newError.location = {line, column};
         newError.type = 'render';

--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
@@ -20,6 +20,7 @@ class PromptModal extends PureComponent {
       upperCase: false,
       hint: null,
       inputType: 'text',
+      cancelable: true,
       hints: []
     };
   }
@@ -66,6 +67,7 @@ class PromptModal extends PureComponent {
       selectText,
       upperCase,
       hint,
+      cancelable,
       inputType,
       placeholder,
       label,
@@ -82,6 +84,7 @@ class PromptModal extends PureComponent {
       defaultValue,
       submitName,
       selectText,
+      cancelable,
       placeholder,
       upperCase,
       hint,
@@ -107,7 +110,7 @@ class PromptModal extends PureComponent {
     );
 
     return (
-      <div type="button" key={hint} className={classes}>
+      <div key={hint} className={classes}>
         <Button className="tall" onClick={this._handleSelectHint} value={hint}>
           {hint}
         </Button>
@@ -131,7 +134,8 @@ class PromptModal extends PureComponent {
       placeholder,
       label,
       upperCase,
-      hints
+      hints,
+      cancelable
     } = this.state;
 
     const input = (
@@ -152,7 +156,7 @@ class PromptModal extends PureComponent {
     }
 
     return (
-      <Modal ref={this._setModalRef}>
+      <Modal ref={this._setModalRef} noEscape={!cancelable}>
         <ModalHeader>{title}</ModalHeader>
         <ModalBody className="wide">
           <form onSubmit={this._handleSubmit} className="wide pad">

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -509,6 +509,12 @@ class TagEditor extends React.PureComponent<Props, State> {
       typeof argDefinition.displayName === 'function'
     ) ? fnOrString(argDefinition.displayName, argDatas) : '';
 
+    let validationError = '';
+    const canValidate = argDefinition.type === 'string' || argDefinition.type === 'number';
+    if (canValidate && typeof argDefinition.validate === 'function') {
+      validationError = argDefinition.validate(strValue) || '';
+    }
+
     const formControlClasses = classnames({
       'form-control': true,
       'form-control--thin': argDefinition.type === 'boolean',
@@ -522,6 +528,7 @@ class TagEditor extends React.PureComponent<Props, State> {
             {fnOrString(displayName, argDatas)}
             {isVariable && <span className="faded space-left">(Variable)</span>}
             {help && <HelpTooltip className="space-left">{help}</HelpTooltip>}
+            {validationError && <span className="font-error space-left">{validationError}</span>}
             {argInputVariable || argInput}
           </label>
         </div>

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -108,6 +108,7 @@
     "insomnia-plugin-file": "^1.0.3",
     "insomnia-plugin-hash": "^1.0.3",
     "insomnia-plugin-now": "^1.0.3",
+    "insomnia-plugin-prompt": "^1.0.0",
     "insomnia-plugin-request": "^1.0.4",
     "insomnia-plugin-response": "^1.0.5",
     "insomnia-plugin-uuid": "^1.0.3",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.0.5",
+  "version": "1.0.6",
   "name": "insomnia-app",
   "app": {
     "name": "insomnia",
@@ -108,7 +108,7 @@
     "insomnia-plugin-file": "^1.0.3",
     "insomnia-plugin-hash": "^1.0.3",
     "insomnia-plugin-now": "^1.0.3",
-    "insomnia-plugin-prompt": "^1.0.0",
+    "insomnia-plugin-prompt": "^1.0.1",
     "insomnia-plugin-request": "^1.0.4",
     "insomnia-plugin-response": "^1.0.5",
     "insomnia-plugin-uuid": "^1.0.3",

--- a/plugins/insomnia-plugin-prompt/README.md
+++ b/plugins/insomnia-plugin-prompt/README.md
@@ -1,0 +1,5 @@
+# Insomnia Prompt Template Tag
+
+[![Npm Version](https://img.shields.io/npm/v/insomnia-plugin-prompt.svg)](https://www.npmjs.com/package/insomnia-plugin-prompt)
+
+This is a core Insomnia plugin.

--- a/plugins/insomnia-plugin-prompt/index.js
+++ b/plugins/insomnia-plugin-prompt/index.js
@@ -1,0 +1,21 @@
+module.exports.templateTags = [{
+  displayName: 'Prompt',
+  name: 'prompt',
+  description: 'prompt user for input',
+  args: [{
+    displayName: 'Title',
+    type: 'string'
+  }, {
+    displayName: 'Label',
+    type: 'string'
+  }, {
+    displayName: 'Default Value',
+    type: 'string',
+    help: 'This value is used to pre-populate the prompt dialog, but is ALSO used ' +
+    'when the app renders preview values (like the one below). This is to prevent the ' +
+    'prompt from displaying too frequently during general app use.'
+  }],
+  run (context, title, label, defaultValue) {
+    return context.app.prompt({title, label, defaultValue});
+  }
+}];

--- a/plugins/insomnia-plugin-prompt/package.json
+++ b/plugins/insomnia-plugin-prompt/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "insomnia-plugin-prompt",
+  "version": "1.0.0",
+  "author": "Gregory Schier <gschier1990@gmail.com>",
+  "description": "Insomnia prompt template tag",
+  "license": "MIT",
+  "repository": "https://github.com/getinsomnia/insomnia/tree/master/plugins/insomnia-plugin-prompt",
+  "bugs": {
+    "url": "https://github.com/getinsomnia/insomnia"
+  },
+  "main": "index.js",
+  "insomnia": {
+    "name": "prompt"
+  },
+  "scripts": {
+    "test": "node --version"
+  }
+}

--- a/plugins/insomnia-plugin-prompt/package.json
+++ b/plugins/insomnia-plugin-prompt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-prompt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Gregory Schier <gschier1990@gmail.com>",
   "description": "Insomnia prompt template tag",
   "license": "MIT",


### PR DESCRIPTION
This PR introduces a new template tag that can be used to prompt the user for input before a request (useful for sensitive info).

To-Do:

- [x] Add prompt ability to `context.app` API
- [x] Only allow prompt to show when rendering for a request (would be too noisy otherwise)
- [x] Pass a `purpose` to render API so it can know if it's rendering for a request
- [x] Add option for a `validate(value: any) => ?string` function on plugin args

<img width="341" alt="image" src="https://user-images.githubusercontent.com/587576/34216082-8b208620-e5a7-11e7-9002-8f6f72a31ff0.png">
