### PR TITLE
Add audience field for oauth2 client credentials

### DIFF
--- a/packages/insomnia-app/app/network/o-auth-2/constants.js
+++ b/packages/insomnia-app/app/network/o-auth-2/constants.js
@@ -10,6 +10,7 @@ export const RESPONSE_TYPE_TOKEN = 'token';
 export const P_ACCESS_TOKEN = 'access_token';
 export const P_CLIENT_ID = 'client_id';
 export const P_CLIENT_SECRET = 'client_secret';
+export const P_AUDIENCE = 'audience';
 export const P_CODE = 'code';
 export const P_ERROR = 'error';
 export const P_ERROR_DESCRIPTION = 'error_description';

--- a/packages/insomnia-app/app/network/o-auth-2/get-token.js
+++ b/packages/insomnia-app/app/network/o-auth-2/get-token.js
@@ -72,7 +72,8 @@ async function _getOAuth2ClientCredentialsHeader (
     authentication.credentialsInBody,
     authentication.clientId,
     authentication.clientSecret,
-    authentication.scope
+    authentication.scope,
+    authentication.audience
   );
 
   return _updateOAuth2Token(requestId, results);

--- a/packages/insomnia-app/app/network/o-auth-2/grant-client-credentials.js
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-client-credentials.js
@@ -12,7 +12,8 @@ export default async function (
   credentialsInBody: boolean,
   clientId: string,
   clientSecret: string,
-  scope: string = ''
+  scope: string = '',
+  audience: string = ''
 ): Promise<Object> {
   const params = [
     {name: c.P_GRANT_TYPE, value: c.GRANT_TYPE_CLIENT_CREDENTIALS}
@@ -20,6 +21,7 @@ export default async function (
 
   // Add optional params
   scope && params.push({name: c.P_SCOPE, value: scope});
+  audience && params.push({name: c.P_AUDIENCE, value: audience});
 
   const headers = [
     {name: 'Content-Type', value: 'application/x-www-form-urlencoded'},

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
@@ -159,6 +159,10 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
     this._handleChangeProperty('tokenPrefix', value);
   }
 
+  _handleChangeAudience (value: string): void {
+    this._handleChangeProperty('audience', value);
+  }
+
   _handleChangeGrantType (e: SyntheticEvent<HTMLInputElement>): void {
     trackEvent('OAuth 2', 'Change Grant Type', e.currentTarget.value);
     this._handleChangeProperty('grantType', e.currentTarget.value);
@@ -306,6 +310,13 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
       'Change Authorization header prefix from Bearer to something else'
     );
 
+    const audience = this.renderInputRow(
+      'Audience',
+      'audience',
+      this._handleChangeAudience,
+      'Indicate what resource server to access'
+    );
+
     const credentialsInBody = this.renderSelectRow(
       'Credentials',
       'credentialsInBody',
@@ -342,7 +353,8 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
       advancedFields = [
         scope,
         credentialsInBody,
-        tokenPrefix
+        tokenPrefix,
+        audience
       ];
     } else if (grantType === GRANT_TYPE_PASSWORD) {
       basicFields = [


### PR DESCRIPTION
This PR adds an optional field "audience", used in OAuth 2 client credentials authorization flow. [Auth0](https://auth0.com/docs/api/authentication#client-credentials) (and others I'm sure) uses this field to specify which target API you want to access. The tooltip message is taken from [the RFC](https://tools.ietf.org/html/draft-tschofenig-oauth-audience-00) abstract section.

Closes #678
<img width="913" alt="screen shot 2017-12-23 at 18 30 33" src="https://user-images.githubusercontent.com/1045380/34321434-67a948f2-e80f-11e7-8f79-5738f272e5a8.png">
