### PR TITLE
Add snap package. https://snapcraft.io

### DIFF
--- a/packages/insomnia-app/.electronbuilder
+++ b/packages/insomnia-app/.electronbuilder
@@ -47,16 +47,7 @@
     ]
   },
   "snap": {
-    "plugs": ["default", "desktop"],
-    "stagePackages": ["libasound2",
-                      "libcurl3",
-                      "libgconf-2-4",
-                      "libnotify4",
-                      "libnspr4",
-                      "libnss3",
-                      "libpulse0",
-                      "libxss1",
-                      "libxtst6"]
+    "stagePackages": ["default", "libcurl3"]
   },
   "deb": {
     "depends": [

--- a/packages/insomnia-app/.electronbuilder
+++ b/packages/insomnia-app/.electronbuilder
@@ -42,8 +42,21 @@
     "target": [
       "AppImage",
       "deb",
-      "tar.gz"
+      "tar.gz",
+      "snap"
     ]
+  },
+  "snap": {
+    "plugs": ["default", "desktop"],
+    "stagePackages": ["libasound2",
+                      "libcurl3",
+                      "libgconf-2-4",
+                      "libnotify4",
+                      "libnspr4",
+                      "libnss3",
+                      "libpulse0",
+                      "libxss1",
+                      "libxtst6"]
   },
   "deb": {
     "depends": [

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -163,7 +163,7 @@
     "cross-env": "^2.0.0",
     "css-loader": "^0.28.7",
     "electron": "^1.7.9",
-    "electron-builder": "^19.47.1",
+    "electron-builder": "^19.53.0",
     "electron-builder-lib": "^19.47.1",
     "electron-builder-squirrel-windows": "^19.47.0",
     "electron-download-tf": "^4.3.4",


### PR DESCRIPTION
Closes #354 
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 18.04 (daily), 17.10 and 16.04, but it should work just as well on Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run package` from `packages/insomnia-app/` it will create `dist/insomnia_5.12.4_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous insomnia_5.12.4_amd64.snap`

Run with `insomnia` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "insomnia" name](https://dashboard.snapcraft.io/register-snap/?name=insomnia).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push Ling out with:
`snapcraft push insomnia_5.12.4_amd64.snap --release stable`

(You can also push to the Snap Store [programatically from Travis](https://docs.snapcraft.io/build-snaps/ci-integration#using-travis).)