### PR TITLE
Support for async importers

### DIFF
--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -76,7 +76,7 @@ export async function importRaw (
 ): Promise<{source: string, error: string | null, summary: {[string]: Array<BaseModel>}}> {
   let results;
   try {
-    results = convert(rawContent);
+    results = await convert(rawContent);
   } catch (e) {
     console.warn('Failed to import data', e);
     return {

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -199,7 +199,7 @@ class Wrapper extends React.PureComponent<Props, State> {
     // Allow user to paste any import file into the url. If it results in
     // only one item, it will overwrite the current request.
     try {
-      const {data} = importers.convert(text);
+      const {data} = await importers.convert(text);
       const {resources} = data;
       const r = resources[0];
 

--- a/packages/insomnia-importers/index.js
+++ b/packages/insomnia-importers/index.js
@@ -10,9 +10,9 @@ const importers = [
   require('./src/importers/curl')
 ];
 
-module.exports.convert = function (contents) {
+module.exports.convert = async function (contents) {
   for (const importer of importers) {
-    const resources = importer.convert(contents);
+    const resources = await importer.convert(contents);
 
     if (resources) {
       return {

--- a/packages/insomnia-importers/src/__tests__/fixtures.test.js
+++ b/packages/insomnia-importers/src/__tests__/fixtures.test.js
@@ -18,7 +18,7 @@ describe('Fixtures', () => {
       const prefix = input.replace(/-input\.[^.]+/, '');
       const output = `${prefix}-output.json`;
 
-      it(`Import ${name} ${input}`, () => {
+      it(`Import ${name} ${input}`, async () => {
 
         expect(typeof input).toBe('string');
         expect(typeof output).toBe('string');
@@ -29,7 +29,7 @@ describe('Fixtures', () => {
         expect(typeof inputContents).toBe('string');
         expect(typeof outputContents).toBe('string');
 
-        const results = importers.convert(inputContents);
+        const results = await importers.convert(inputContents);
         const expected = JSON.parse(outputContents);
 
         expected.__export_date = results.data.__export_date;

--- a/packages/insomnia-importers/src/__tests__/import-errors.test.js
+++ b/packages/insomnia-importers/src/__tests__/import-errors.test.js
@@ -3,8 +3,10 @@
 const importers = require('../../index');
 
 describe('Import errors', () => {
-  it('fail to find importer', () => {
-    const fn = () => importers.convert('foo');
-    expect(fn).toThrowError('No importers found for file')
+  it('fail to find importer', async () => {
+    const fn = importers.convert('foo');
+    await expect(fn).rejects.toHaveProperty('message', 'No importers found for file');
+    //Bug in jest, that doesn't allow to check the error message using #toThrow
+    //Check: https://github.com/facebook/jest/pull/4884
   })
 });

--- a/packages/insomnia-importers/src/cli.js
+++ b/packages/insomnia-importers/src/cli.js
@@ -6,7 +6,7 @@ const importers = require('../index');
 const fs = require('fs');
 const {version} = require('../package.json');
 
-module.exports.go = function () {
+module.exports.go = async function () {
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
   // Configure the arguments parsing //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
@@ -36,7 +36,7 @@ module.exports.go = function () {
   const fullInputPath = path.resolve(inputPath);
   const fileContents = fs.readFileSync(fullInputPath, 'utf8');
 
-  const result = importers.convert(fileContents);
+  const result = await importers.convert(fileContents);
   const exportContents = JSON.stringify(result.data, null, 2);
 
   // ~~~~~~~~~~~~~~~~ //


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/getinsomnia/insomnia/issues/new) first to discuss new 
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

Adds support for asynchrous (Promise-based) importers.  It's dependency for the swagger2 importer sent in another PR (https://github.com/getinsomnia/insomnia/pull/695).

  