### PR TITLE
Update insomnia-importers README

### DIFF
--- a/packages/insomnia-importers/README.md
+++ b/packages/insomnia-importers/README.md
@@ -3,10 +3,10 @@
 [![Npm Version](https://img.shields.io/npm/v/insomnia-importers.svg)](https://www.npmjs.com/package/insomnia-importers)
 
 This repository contains converters to translate popular HTTP data formats to
-Insomnia v2 format.
+Insomnia v3 format.
 
-- Insomnia v1
-- Postman v2
+- Insomnia v1 and v2
+- Postman v2.0
 - cURL
 - HTTP Archive Format 1.2 (HAR)
 


### PR DESCRIPTION
Reasons for the changes:
* The output format of the importer is Insomnia v3 now and it also imports from Insomnia v2.
* Be more precise on the Postman version, because only v2.0 and not v2.1 is supported.

Thank you for the standalone and open source importer project. It helps me to convert the cURL output of Spring REST Docs to Insomnia (and Postman), see https://github.com/fbenz/restdocs-to-postman.

