### PR TITLE
Persist editor scroll positions

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/body/body-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/body-editor.js
@@ -150,6 +150,7 @@ class BodyEditor extends React.PureComponent<Props> {
       return (
         <GraphQLEditor
           key={uniqueKey}
+          uniquenessKey={uniqueKey}
           request={request}
           content={request.body.text || ''}
           render={handleRender}
@@ -164,7 +165,7 @@ class BodyEditor extends React.PureComponent<Props> {
       const contentType = getContentTypeFromHeaders(request.headers) || mimeType;
       return (
         <RawEditor
-          key={uniqueKey}
+          uniquenessKey={uniqueKey}
           fontSize={settings.editorFontSize}
           indentSize={settings.editorIndentSize}
           keyMap={settings.editorKeyMap}

--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
@@ -38,7 +38,8 @@ type Props = {
   environmentId: string,
 
   // Optional
-  className?: string
+  className?: string,
+  uniquenessKey?: string
 };
 
 type State = {
@@ -266,7 +267,8 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
       render,
       getRenderContext,
       settings,
-      className
+      className,
+      uniquenessKey
     } = this.props;
 
     const {
@@ -291,6 +293,7 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
           <CodeEditor
             dynamicHeight
             manualPrettify
+            uniquenessKey={uniquenessKey ? uniquenessKey + '::query' : undefined}
             hintOptions={{
               schema: schema || null,
               completeSingle: false
@@ -336,6 +339,7 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
         <div className="graphql-editor__variables">
           <CodeEditor
             dynamicHeight
+            uniquenessKey={uniquenessKey ? uniquenessKey + '::variables' : undefined}
             debounceMillis={DEBOUNCE_MILLIS * 4}
             manualPrettify={false}
             fontSize={settings.editorFontSize}

--- a/packages/insomnia-app/app/ui/components/editors/body/raw-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/raw-editor.js
@@ -7,22 +7,24 @@ import CodeEditor from '../../codemirror/code-editor';
 class RawEditor extends PureComponent {
   render () {
     const {
-      contentType,
+      className,
       content,
+      contentType,
       fontSize,
+      getRenderContext,
       indentSize,
       keyMap,
-      render,
-      getRenderContext,
-      nunjucksPowerUserMode,
       lineWrapping,
+      nunjucksPowerUserMode,
       onChange,
-      className
+      render,
+      uniquenessKey
     } = this.props;
 
     return (
       <CodeEditor
         manualPrettify
+        uniquenessKey={uniquenessKey}
         fontSize={fontSize}
         indentSize={indentSize}
         keyMap={keyMap}
@@ -50,6 +52,7 @@ RawEditor.propTypes = {
   keyMap: PropTypes.string.isRequired,
   lineWrapping: PropTypes.bool.isRequired,
   nunjucksPowerUserMode: PropTypes.bool.isRequired,
+  uniquenessKey: PropTypes.string.isRequired,
 
   // Optional
   className: PropTypes.string,

--- a/packages/insomnia-app/app/ui/components/response-pane.js
+++ b/packages/insomnia-app/app/ui/components/response-pane.js
@@ -277,31 +277,29 @@ class ResponsePane extends React.PureComponent<Props> {
             </Tab>
           </TabList>
           <TabPanel className="react-tabs__tab-panel">
-            <ErrorBoundary key={response._id} errorClassName="font-error pad text-center">
-              <ResponseViewer
-                // Send larger one because legacy responses have bytesContent === -1
-                responseId={response._id}
-                bytes={Math.max(response.bytesContent, response.bytesRead)}
-                contentType={response.contentType || ''}
-                previewMode={response.error ? PREVIEW_MODE_SOURCE : previewMode}
-                filter={filter}
-                filterHistory={filterHistory}
-                updateFilter={response.error ? null : handleSetFilter}
-                download={this._handleDownloadResponseBody}
-                getBody={this._handleGetResponseBody}
-                error={response.error}
-                editorLineWrapping={editorLineWrapping}
-                editorFontSize={editorFontSize}
-                editorIndentSize={editorIndentSize}
-                editorKeyMap={editorKeyMap}
-                url={response.url}
-              />
-            </ErrorBoundary>
+            <ResponseViewer
+              // Send larger one because legacy responses have bytesContent === -1
+              responseId={response._id}
+              bytes={Math.max(response.bytesContent, response.bytesRead)}
+              contentType={response.contentType || ''}
+              previewMode={response.error ? PREVIEW_MODE_SOURCE : previewMode}
+              filter={filter}
+              filterHistory={filterHistory}
+              updateFilter={response.error ? null : handleSetFilter}
+              download={this._handleDownloadResponseBody}
+              getBody={this._handleGetResponseBody}
+              error={response.error}
+              editorLineWrapping={editorLineWrapping}
+              editorFontSize={editorFontSize}
+              editorIndentSize={editorIndentSize}
+              editorKeyMap={editorKeyMap}
+              url={response.url}
+            />
           </TabPanel>
           <TabPanel className="react-tabs__tab-panel scrollable-container">
             <div className="scrollable pad">
               <ErrorBoundary key={response._id} errorClassName="font-error pad text-center">
-                <ResponseHeadersViewer headers={response.headers} />
+                <ResponseHeadersViewer headers={response.headers}/>
               </ErrorBoundary>
             </div>
           </TabPanel>

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
@@ -317,6 +317,7 @@ class ResponseViewer extends React.Component<Props, State> {
       const charset = (match && match.length >= 2) ? match[1] : 'utf-8';
       return (
         <ResponseRaw
+          key={responseId}
           value={iconv.decode(bodyBuffer, charset)}
           fontSize={editorFontSize}
         />
@@ -344,6 +345,7 @@ class ResponseViewer extends React.Component<Props, State> {
 
       return (
         <CodeEditor
+          uniquenessKey={responseId}
           onClickLink={this._handleOpenLink}
           defaultValue={body}
           updateFilter={updateFilter}


### PR DESCRIPTION
Closes #736 

This PR adds functionality to `CodeEditor` to save and restore editor state based on a `uniquenessKey` passed into the component.

What this applies to:

- Request body text modes (JSON, XML, etc)
- GraphQL editor
- Response preview

This PR also removes the editor "flash" that happened when switching requests. Now, instead of creating a new Codemirror instance every time, it reuses the old one.