### PR TITLE
change header placeholder from My-Header to Header so it says New Header

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/request-headers-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/request-headers-editor.js
@@ -118,7 +118,7 @@ class RequestHeadersEditor extends PureComponent {
           <div className="scrollable">
             <KeyValueEditor
               sortable
-              namePlaceholder="My-Header"
+              namePlaceholder="Header"
               valuePlaceholder="Value"
               pairs={headers}
               nunjucksPowerUserMode={nunjucksPowerUserMode}


### PR DESCRIPTION
When I create a header, it has "New My-Header" for the placeholder:

<img width="511" alt="screen shot 2018-03-17 at 1 09 49 am" src="https://user-images.githubusercontent.com/4126/37551911-b1ba24e0-2980-11e8-93e2-2777d35405a9.png">

This is a bit redundant. I think "My-Header" or "New Header" would both be good, but since the value is "New Value", I think it makes sense to change it to "New Header". Here's what it looks like after the change in this PR:

<img width="518" alt="screen shot 2018-03-17 at 1 10 04 am" src="https://user-images.githubusercontent.com/4126/37551914-b57719ee-2980-11e8-95dc-3b37fcd140ae.png">
