### PR TITLE
Add support for additional claims in ASAP Auth

### DIFF
--- a/packages/insomnia-app/app/models/request.js
+++ b/packages/insomnia-app/app/models/request.js
@@ -151,6 +151,7 @@ export function newAuth (type: string, oldAuth: RequestAuthentication = {}): Req
         issuer: '',
         subject: '',
         audience: '',
+        additionalClaims: '',
         keyId: '',
         privateKey: ''
       };

--- a/packages/insomnia-app/app/network/authentication.js
+++ b/packages/insomnia-app/app/network/authentication.js
@@ -65,10 +65,27 @@ export async function getAuthHeader (
   }
 
   if (authentication.type === AUTH_ASAP) {
-    const {issuer, subject, audience, keyId, privateKey} = authentication;
+    const {issuer, subject, audience, keyId, additionalClaims, privateKey} = authentication;
 
     const generator = jwtAuthentication.client.create();
-    const claims = {iss: issuer, sub: subject, aud: audience};
+    let claims = {iss: issuer, sub: subject, aud: audience};
+
+    let parsedAdditionalClaims;
+
+    try {
+      parsedAdditionalClaims = JSON.parse(additionalClaims);
+    } catch (err) {
+      throw new Error(`Unable to parse additional-claims: ${err}`);
+    }
+
+    if (parsedAdditionalClaims) {
+      if (typeof parsedAdditionalClaims !== 'object') {
+        throw new Error(`additional-claims must be an object recieved: '${typeof parsedAdditionalClaims}' instead`);
+      }
+
+      claims = Object.assign(parsedAdditionalClaims, claims);
+    }
+
     const options = {
       privateKey,
       kid: keyId

--- a/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.js
@@ -56,6 +56,7 @@ class AsapAuth extends React.PureComponent<Props> {
       'Issuer (iss)',
       'issuer',
       'client-name',
+      'text/plain',
       (value) => this._handleChangeProperty('issuer', value)
     );
 
@@ -63,6 +64,7 @@ class AsapAuth extends React.PureComponent<Props> {
       'Subject (sub)',
       'subject',
       'some-username',
+      'text/plain',
       (value) => this._handleChangeProperty('subject', value)
     );
 
@@ -70,13 +72,23 @@ class AsapAuth extends React.PureComponent<Props> {
       'Audience (aud)',
       'audience',
       'resource-server-name',
+      'text/plain',
       (value) => this._handleChangeProperty('audience', value)
+    );
+
+    const asapAdditionalClaims = this.renderTextInput(
+      'Additional Claims',
+      'additionalClaims',
+      'additional-claims (JSON Object)',
+      'application/json',
+      (value) => this._handleChangeProperty('additionalClaims', value)
     );
 
     const asapKeyId = this.renderTextInput(
       'Key ID (kid)',
       'keyId',
       'key-identifier',
+      'text/plain',
       (value) => this._handleChangeProperty('keyId', value)
     );
 
@@ -84,13 +96,14 @@ class AsapAuth extends React.PureComponent<Props> {
       'Private Key',
     );
 
-    return [asapIssuer, asapSubject, asapAudience, asapKeyId, asapPrivateKey];
+    return [asapIssuer, asapSubject, asapAudience, asapAdditionalClaims, asapKeyId, asapPrivateKey];
   }
 
   renderTextInput (
     label: string,
     property: string,
     placeholder: string,
+    mode: string,
     onChange: Function
   ): React.Element<*> {
     const {handleRender, handleGetRenderContext, authentication, nunjucksPowerUserMode} = this.props;
@@ -108,6 +121,7 @@ class AsapAuth extends React.PureComponent<Props> {
           })}>
             <OneLineEditor
               id={id}
+              mode={mode}
               placeholder={placeholder}
               onChange={onChange}
               defaultValue={authentication[property] || ''}


### PR DESCRIPTION
PR adds field in ASAP Auth to supply additional JWT claims beyond those already required/available.

![image](https://user-images.githubusercontent.com/10364359/37561203-d4abce1e-2a9c-11e8-9376-4cf10c82bd86.png)

![image](https://user-images.githubusercontent.com/10364359/37561239-fcd63a36-2a9d-11e8-93a3-855c92eeb56a.png)
