### PR TITLE
Add getParameters to Request Hook API

### DIFF
--- a/packages/insomnia-app/app/plugins/context/__tests__/request.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/request.test.js
@@ -30,6 +30,7 @@ describe('init()', () => {
       'getId',
       'getMethod',
       'getName',
+      'getParameters',
       'getUrl',
       'hasHeader',
       'removeHeader',

--- a/packages/insomnia-app/app/plugins/context/request.js
+++ b/packages/insomnia-app/app/plugins/context/request.js
@@ -91,6 +91,9 @@ export function init (
         if (!header) {
           renderedRequest.headers.push({name, value});
         }
+      },
+      getParameters (): Array<Object> {
+        return renderedRequest.parameters;
       }
 
       // NOTE: For these to make sense, we'd need to account for cookies in the jar as well


### PR DESCRIPTION
This will add `getParameters` so that we can access the parameters sent. It's actually pretty similar to https://github.com/getinsomnia/insomnia/pull/731 but with smaller scope (and with test). I don't mind if the former PR got merged first as I really need this functionality 😆 