### PR TITLE
Fix parameter replacement in swagger importer

### DIFF
--- a/packages/insomnia-importers/src/importers/swagger2.js
+++ b/packages/insomnia-importers/src/importers/swagger2.js
@@ -135,7 +135,7 @@ function parseEndpoints (document) {
  * @returns {string}
  */
 function pathWithParamsAsVariables (path) {
-  return path.replace(/{(.+)}/, '{{ $1 }}');
+  return path.replace(/{([^}]+)}/g, '{{ $1 }}');
 }
 
 /**


### PR DESCRIPTION
The regex was greedily matching any character which causes problems with
multiple path parameters in a route:

input: `/api/v1/{channel}/items/{id}`
output: `/api/v1/{{ channel}/items/{id }}`

Notice that it matched form the first `{` to the last `}` and replaced 
<!--
Please open an [Issue](https://github.com/getinsomnia/insomnia/issues/new) first to discuss new 
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

