### PR TITLE
Height of the query preview box is not constrained for longer query strings

### DIFF
--- a/packages/insomnia-app/app/ui/css/components/query-editor.less
+++ b/packages/insomnia-app/app/ui/css/components/query-editor.less
@@ -9,7 +9,6 @@
 
   .query-editor__preview code {
     overflow: auto;
-    max-height: 3em;
   }
 
   .key-value-editor {


### PR DESCRIPTION
Closes #869.

This is the most simple solution that does not have a negative impact on user experience in my test. With this simple CSS change the height of the query preview box appears as normal if empty and will automatically expand to fit the length of the query which is ideal for longer queries.

A more robust solution would allow the user to expand and shrink the box at will. However I don't feel that would be ideal for the user experience because it adds an extra moving part when the box can resize on it's own very easily and the container itself is scrollable.

