### PR TITLE
Allow YAML extensions in file selection import dialog too

### DIFF
--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -134,10 +134,9 @@ export function importFile (workspaceId) {
       buttonLabel: 'Import',
       properties: ['openFile'],
       filters: [{
-        // Allow empty extension and JSON
         name: 'Insomnia Import',
         extensions: [
-          '', 'sh', 'txt', 'json', 'har', 'curl', 'bash', 'shell'
+          '', 'sh', 'txt', 'json', 'har', 'curl', 'bash', 'shell', 'yaml', 'yml'
         ]
       }]
     };


### PR DESCRIPTION
The Swagger importer also supports parsing a spec in YAML format.

<!--
Please open an [Issue](https://github.com/getinsomnia/insomnia/issues/new) first to discuss new 
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

