### PR TITLE
Add setBody() to response plugin API

### DIFF
--- a/packages/insomnia-app/app/plugins/context/__tests__/response.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/response.test.js
@@ -10,16 +10,17 @@ describe('init()', () => {
   it('initializes correctly', async () => {
     const result = plugin.init({});
     expect(Object.keys(result)).toEqual(['response']);
-    expect(Object.keys(result.response)).toEqual([
+    expect(Object.keys(result.response).sort()).toEqual([
+      'getBody',
+      'getBodyStream',
+      'getBytesRead',
+      'getHeader',
       'getRequestId',
       'getStatusCode',
       'getStatusMessage',
-      'getBytesRead',
       'getTime',
-      'getBody',
-      'getBodyStream',
-      'getHeader',
-      'hasHeader'
+      'hasHeader',
+      'setBody'
     ]);
   });
 

--- a/packages/insomnia-app/app/plugins/context/response.js
+++ b/packages/insomnia-app/app/plugins/context/response.js
@@ -1,6 +1,7 @@
 // @flow
 import type {ResponseHeader} from '../../models/response';
 import * as models from '../../models/index';
+import fs from 'fs';
 import {Readable} from 'stream';
 
 type MaybeResponse = {
@@ -14,10 +15,7 @@ type MaybeResponse = {
   headers?: Array<ResponseHeader>
 }
 
-export function init (
-  response: MaybeResponse,
-  bodyBuffer: Buffer | null = null
-): {response: Object} {
+export function init (response: MaybeResponse): { response: Object } {
   if (!response) {
     throw new Error('contexts.response initialized without response');
   }
@@ -49,6 +47,15 @@ export function init (
       },
       getBodyStream (): Readable | null {
         return models.response.getBodyStream(response);
+      },
+      setBody (body: Buffer) {
+        // Should never happen but just in case it does...
+        if (!response.bodyPath) {
+          throw new Error('Could not set body without existing body path');
+        }
+
+        fs.writeFileSync(response.bodyPath, body);
+        response.bytesContent = body.length;
       },
       getHeader (name: string): string | Array<string> | null {
         const headers = response.headers || [];


### PR DESCRIPTION
This PR adds a `setBody()` method to the response API within plugin hooks. 

Now, it is possible for plugins to modify the response body for things like formatting, sanitizing, filtering, etc. Since there is no way to tell that the plugin modified the response, this isn't the best user experience. However, it's been requested multiple times so it's finally here!

Here's an example of what you can do with it:

```js
module.exports = [
  context => {
    // Get the response body
    const root = JSON.parse(context.response.getBody());

    // Wrap body in a base object
    const newRoot = {root: root};

    // Re-stringify
    const newBody = JSON.stringify(newRoot);

    // Replace body with wrapped one
    context.response.setBody(Buffer.from(newBody));
  }
];
```