### PR TITLE
Add ability to view introspection request/response timeline upon error

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/database.test.js
+++ b/packages/insomnia-app/app/common/__tests__/database.test.js
@@ -102,7 +102,7 @@ describe('requestCreate()', () => {
     };
 
     const r = await models.request.create(patch);
-    expect(Object.keys(r).length).toBe(20);
+    expect(Object.keys(r).length).toBe(21);
 
     expect(r._id).toMatch(/^req_[a-zA-Z0-9]{32}$/);
     expect(r.created).toBeGreaterThanOrEqual(now);

--- a/packages/insomnia-app/app/common/render.js
+++ b/packages/insomnia-app/app/common/render.js
@@ -293,6 +293,7 @@ export async function getRenderedRequestAndContext (
       settingSendCookies: renderedRequest.settingSendCookies,
       settingStoreCookies: renderedRequest.settingStoreCookies,
       settingRebuildPath: renderedRequest.settingRebuildPath,
+      settingMaxTimelineDataSize: renderedRequest.settingMaxTimelineDataSize,
       type: renderedRequest.type,
       url: renderedRequest.url
     }

--- a/packages/insomnia-app/app/models/__tests__/request.test.js
+++ b/packages/insomnia-app/app/models/__tests__/request.test.js
@@ -20,7 +20,8 @@ describe('init()', () => {
       settingSendCookies: true,
       settingDisableRenderRequestBody: false,
       settingEncodeUrl: true,
-      settingRebuildPath: true
+      settingRebuildPath: true,
+      settingMaxTimelineDataSize: 1000
     });
   });
 });
@@ -55,7 +56,8 @@ describe('create()', async () => {
       settingSendCookies: true,
       settingDisableRenderRequestBody: false,
       settingEncodeUrl: true,
-      settingRebuildPath: true
+      settingRebuildPath: true,
+      settingMaxTimelineDataSize: 1000
     };
 
     expect(request).toEqual(expected);
@@ -318,7 +320,8 @@ describe('migrate()', () => {
       settingSendCookies: true,
       settingDisableRenderRequestBody: false,
       settingEncodeUrl: true,
-      settingRebuildPath: true
+      settingRebuildPath: true,
+      settingMaxTimelineDataSize: 1000
     };
 
     const migrated = await models.initModel(models.request.type, original);

--- a/packages/insomnia-app/app/models/request.js
+++ b/packages/insomnia-app/app/models/request.js
@@ -62,7 +62,8 @@ type BaseRequest = {
   settingSendCookies: boolean,
   settingDisableRenderRequestBody: boolean,
   settingEncodeUrl: boolean,
-  settingRebuildPath: boolean
+  settingRebuildPath: boolean,
+  settingMaxTimelineDataSize: number
 };
 
 export type Request = BaseModel & BaseRequest;
@@ -85,7 +86,8 @@ export function init (): BaseRequest {
     settingSendCookies: true,
     settingDisableRenderRequestBody: false,
     settingEncodeUrl: true,
-    settingRebuildPath: true
+    settingRebuildPath: true,
+    settingMaxTimelineDataSize: 1000
   };
 }
 

--- a/packages/insomnia-app/app/plugins/context/__tests__/data.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/data.test.js
@@ -81,6 +81,7 @@ describe('app.import.*', () => {
       settingSendCookies: true,
       settingStoreCookies: true,
       settingRebuildPath: true,
+      settingMaxTimelineDataSize: 1000,
       type: 'Request',
       url: 'https://insomnia.rest'
     }]);
@@ -128,6 +129,7 @@ describe('app.import.*', () => {
       settingSendCookies: true,
       settingStoreCookies: true,
       settingRebuildPath: true,
+      settingMaxTimelineDataSize: 1000,
       type: 'Request',
       url: 'https://insomnia.rest'
     }]);
@@ -199,6 +201,7 @@ describe('app.export.*', () => {
         settingSendCookies: true,
         settingStoreCookies: true,
         settingRebuildPath: true,
+        settingMaxTimelineDataSize: 1000,
         url: 'https://insomnia.rest'
       }]
     });

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -367,6 +367,7 @@ class CodeEditor extends React.Component {
         try {
           jsonString = JSON.stringify(jq.query(obj, this.state.filter));
         } catch (err) {
+          console.log('[jsonpath] Error: ', err);
           jsonString = '[]';
         }
       }

--- a/packages/insomnia-app/app/ui/components/modals/wrapper-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/wrapper-modal.js
@@ -22,7 +22,7 @@ class WrapperModal extends React.PureComponent<Props, State> {
     this.state = {
       title: '',
       body: null,
-      tall: false,
+      tall: false
     };
   }
 

--- a/packages/insomnia-app/app/ui/components/modals/wrapper-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/wrapper-modal.js
@@ -8,7 +8,8 @@ import ModalHeader from '../base/modal-header';
 type Props = {};
 type State = {
   title: string,
-  body: React.Node
+  body: React.Node,
+  tall: boolean,
 }
 
 @autobind
@@ -20,7 +21,8 @@ class WrapperModal extends React.PureComponent<Props, State> {
 
     this.state = {
       title: '',
-      body: null
+      body: null,
+      tall: false,
     };
   }
 
@@ -29,19 +31,23 @@ class WrapperModal extends React.PureComponent<Props, State> {
   }
 
   show (options: Object = {}) {
-    const {title, body} = options;
-    this.setState({title, body});
+    const {title, body, tall} = options;
+    this.setState({
+      title,
+      body,
+      tall: !!tall
+    });
 
     this.modal && this.modal.show();
   }
 
   render () {
-    const {title, body} = this.state;
+    const {title, body, tall} = this.state;
 
     return (
-      <Modal ref={this._setModalRef}>
+      <Modal ref={this._setModalRef} tall={tall}>
         <ModalHeader>{title || 'Uh Oh!'}</ModalHeader>
-        <ModalBody className="wide pad">
+        <ModalBody>
           {body}
         </ModalBody>
       </Modal>

--- a/packages/insomnia-app/app/ui/css/components/forms.less
+++ b/packages/insomnia-app/app/ui/css/components/forms.less
@@ -175,6 +175,10 @@
   text-align: center;
   color: var(--hl);
 
+  &.icon--success {
+    color: var(--color-success);
+  }
+
   &:hover {
     color: var(--color-font);
   }


### PR DESCRIPTION
Closes #965

This PR lets the user view the introspection request/response timeline when an error occurs.

![image](https://user-images.githubusercontent.com/587576/41061934-3def7ecc-69a2-11e8-8482-79640090ac1d.png)

![image](https://user-images.githubusercontent.com/587576/41063167-e816328a-69a5-11e8-93ff-4ad996dc098c.png)

