### PR TITLE
Add name and folder options to Request tag

### DIFF
--- a/packages/insomnia-app/app/templating/base-extension.js
+++ b/packages/insomnia-app/app/templating/base-extension.js
@@ -78,6 +78,7 @@ export default class BaseExtension {
         render: str => templating.render(str, {context: renderContext}),
         models: {
           request: {getById: models.request.getById},
+          requestGroup: {getById: models.requestGroup.getById},
           workspace: {getById: models.workspace.getById},
           oAuth2Token: {getByRequestId: models.oAuth2Token.getByParentId},
           cookieJar: {

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -192,7 +192,7 @@ class TagEditor extends React.PureComponent<Props, State> {
       const initialType = argDef ? argDef.type : 'string';
       const variable = variables.find(v => v.name === existingValue);
       const value = variable ? variable.value : '';
-      return this._updateArg(value, argIndex, initialType, {quotedBy: "'"});
+      return this._updateArg(value, argIndex, initialType, {quotedBy: '\''});
     }
   }
 
@@ -200,7 +200,7 @@ class TagEditor extends React.PureComponent<Props, State> {
     return this._updateArg(path, argIndex);
   }
 
-  _handleChange (e: SyntheticEvent<HTMLInputElement>, forceVariable: boolean = false) {
+  _handleChange (e: SyntheticEvent<HTMLInputElement>) {
     const parent = e.currentTarget.parentNode;
     let argIndex = -1;
     if (parent instanceof HTMLElement) {

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.0.16",
+  "version": "1.0.17",
   "name": "insomnia-app",
   "app": {
     "name": "insomnia",
@@ -113,7 +113,7 @@
     "insomnia-plugin-jsonpath": "^1.0.1",
     "insomnia-plugin-now": "^1.0.4",
     "insomnia-plugin-prompt": "^1.1.1",
-    "insomnia-plugin-request": "^1.0.6",
+    "insomnia-plugin-request": "^1.0.7",
     "insomnia-plugin-response": "^1.0.7",
     "insomnia-plugin-uuid": "^1.0.3",
     "insomnia-prettify": "^0.1.2",

--- a/plugins/insomnia-plugin-request/index.js
+++ b/plugins/insomnia-plugin-request/index.js
@@ -10,6 +10,8 @@ module.exports.templateTags = [{
       displayName: 'Attribute',
       type: 'enum',
       options: [
+        {displayName: 'Name', value: 'name', description: 'name of request'},
+        {displayName: 'Folder', value: 'folder', description: 'name of immediate parent folder (or workspace)'},
         {displayName: 'URL', value: 'url', description: 'fully qualified URL'},
         {displayName: 'Cookie', value: 'cookie', description: 'cookie value by name'},
         {displayName: 'Header', value: 'header', description: 'header value by name'},
@@ -18,7 +20,7 @@ module.exports.templateTags = [{
     },
     {
       type: 'string',
-      hide: args => ['url', 'oauth2'].includes(args[0].value),
+      hide: args => ['url', 'oauth2', 'name', 'folder'].includes(args[0].value),
       displayName: args => {
         switch (args[0].value) {
           case 'cookie':
@@ -54,7 +56,6 @@ module.exports.templateTags = [{
       case 'url':
         return getRequestUrl(context, request);
       case 'cookie':
-
         if (!name) {
           throw new Error('No cookie specified');
         }
@@ -89,6 +90,11 @@ module.exports.templateTags = [{
           throw new Error('No OAuth 2.0 tokens found for request');
         }
         return token.accessToken;
+      case 'name':
+        return request.name;
+      case 'folder':
+        const requestGroup = await context.util.models.requestGroup.getById(request.parentId);
+        return requestGroup ? requestGroup.name : workspace.name;
     }
 
     return null;

--- a/plugins/insomnia-plugin-request/package.json
+++ b/plugins/insomnia-plugin-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-request",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Gregory Schier <gschier1990@gmail.com>",
   "description": "Insomnia request template tag",
   "license": "MIT",


### PR DESCRIPTION
Closes #971 

This PR extends the _Request_ template tag to add `name` and `folder` options.

![image](https://user-images.githubusercontent.com/587576/41072063-809244ea-69c9-11e8-8a0d-f62a9312ba03.png)
