### PR TITLE
add audience param to implicit Oauth grant

### DIFF
--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-implicit.test.js
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-implicit.test.js
@@ -6,6 +6,7 @@ import { globalBeforeEach } from '../../../__jest__/before-each';
 const AUTHORIZE_URL = 'https://foo.com/authorizeAuthCode';
 const CLIENT_ID = 'client_123';
 const REDIRECT_URI = 'https://foo.com/redirect';
+const AUDIENCE = 'https://foo.com/userinfo';
 const SCOPE = 'scope_123';
 const STATE = 'state_123';
 
@@ -21,7 +22,8 @@ describe('implicit', () => {
       CLIENT_ID,
       REDIRECT_URI,
       SCOPE,
-      STATE
+      STATE,
+      AUDIENCE
     );
 
     expect(result).toEqual({

--- a/packages/insomnia-app/app/network/o-auth-2/get-token.js
+++ b/packages/insomnia-app/app/network/o-auth-2/get-token.js
@@ -128,7 +128,8 @@ async function _getOAuth2ImplicitHeader(
     authentication.responseType,
     authentication.redirectUrl,
     authentication.scope,
-    authentication.state
+    authentication.state,
+    authentication.audience
   );
 
   return _updateOAuth2Token(requestId, results);

--- a/packages/insomnia-app/app/network/o-auth-2/grant-implicit.js
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-implicit.js
@@ -13,7 +13,8 @@ export default async function(
   responseType: string = c.RESPONSE_TYPE_TOKEN,
   redirectUri: string = '',
   scope: string = '',
-  state: string = ''
+  state: string = '',
+  audience: string = ''
 ): Promise<Object> {
   const params = [
     { name: c.P_RESPONSE_TYPE, value: responseType },
@@ -32,6 +33,7 @@ export default async function(
   redirectUri && params.push({ name: c.P_REDIRECT_URI, value: redirectUri });
   scope && params.push({ name: c.P_SCOPE, value: scope });
   state && params.push({ name: c.P_STATE, value: state });
+  audience && params.push({ name: c.P_AUDIENCE, value: audience });
 
   // Add query params to URL
   const qs = buildQueryStringFromParams(params);

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
@@ -458,7 +458,7 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
     } else if (grantType === GRANT_TYPE_IMPLICIT) {
       basicFields = [authorizationUrl, clientId, redirectUri, enabled];
 
-      advancedFields = [responseType, scope, state, tokenPrefix];
+      advancedFields = [responseType, scope, state, tokenPrefix, audience];
     }
 
     return { basic: basicFields, advanced: advancedFields };


### PR DESCRIPTION
Since most of the work was done when `audience` was added to the `client-credentials` grant type I just had to add the field to `implicit`.

This should take care of #1008 

