### PR TITLE
Add ability to debug OAuth 2.0 token fetch responses

### DIFF
--- a/packages/insomnia-app/app/models/o-auth-2-token.js
+++ b/packages/insomnia-app/app/models/o-auth-2-token.js
@@ -8,6 +8,10 @@ type BaseOAuth2Token = {
   accessToken: string,
   expiresAt: number | null, // Should be Date.now() if valid
 
+  // Debug
+  xResponseId: string | null,
+  xError: string | null,
+
   // Error handling
   error: string,
   errorDescription: string,
@@ -26,6 +30,10 @@ export function init(): BaseOAuth2Token {
     refreshToken: '',
     accessToken: '',
     expiresAt: null, // Should be Date.now() if valid
+
+    // Debug
+    xResponseId: null,
+    xError: null,
 
     // Error handling
     error: '',

--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-authorization-code.test.js
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-authorization-code.test.js
@@ -32,6 +32,8 @@ describe('authorization_code', () => {
 
     network.sendWithSettings = jest.fn(() => ({
       bodyPath,
+      bodyCompression: '',
+      parentId: 'req_1',
       statusCode: 200,
       headers: [{ name: 'Content-Type', value: 'application/json' }]
     }));
@@ -91,7 +93,8 @@ describe('authorization_code', () => {
       scope: SCOPE,
       error: null,
       error_uri: null,
-      error_description: null
+      error_description: null,
+      xResponseId: 'res_dd2ccc1a2745477a881a9e8ef9d42403'
     });
   });
 
@@ -110,6 +113,8 @@ describe('authorization_code', () => {
 
     network.sendWithSettings = jest.fn(() => ({
       bodyPath,
+      bodyCompression: '',
+      parentId: 'req_1',
       statusCode: 200,
       headers: [
         { name: 'Content-Type', value: 'application/x-www-form-urlencoded' }
@@ -169,7 +174,8 @@ describe('authorization_code', () => {
       scope: SCOPE,
       error: null,
       error_uri: null,
-      error_description: null
+      error_description: null,
+      xResponseId: 'res_e3e96e5fdd6842298b66dee1f0940f3d'
     });
   });
 });

--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-client-credentials.test.js
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-client-credentials.test.js
@@ -27,6 +27,8 @@ describe('client_credentials', () => {
 
     network.sendWithSettings = jest.fn(() => ({
       bodyPath,
+      bodyCompression: '',
+      parentId: 'req_1',
       statusCode: 200,
       headers: [{ name: 'Content-Type', value: 'application/json' }]
     }));
@@ -80,12 +82,13 @@ describe('client_credentials', () => {
       scope: SCOPE,
       error: null,
       error_uri: null,
-      error_description: null
+      error_description: null,
+      xResponseId: 'res_dd2ccc1a2745477a881a9e8ef9d42403'
     });
   });
 
   it('gets token with urlencoded and body auth', async () => {
-    const bodyPath = path.join(getTempDir(), 'foo.response');
+    const bodyPath = path.join(getTempDir(), 'req_1.response');
 
     fs.writeFileSync(
       bodyPath,
@@ -98,6 +101,8 @@ describe('client_credentials', () => {
 
     network.sendWithSettings = jest.fn(() => ({
       bodyPath,
+      bodyCompression: '',
+      parentId: 'req_1',
       statusCode: 200,
       headers: [
         { name: 'Content-Type', value: 'application/x-www-form-urlencoded' }
@@ -151,7 +156,8 @@ describe('client_credentials', () => {
       scope: SCOPE,
       error: null,
       error_uri: null,
-      error_description: null
+      error_description: null,
+      xResponseId: 'res_e3e96e5fdd6842298b66dee1f0940f3d'
     });
   });
 });

--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-password.test.js
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-password.test.js
@@ -29,6 +29,8 @@ describe('password', () => {
 
     network.sendWithSettings = jest.fn(() => ({
       bodyPath,
+      bodyCompression: '',
+      parentId: 'req_1',
       statusCode: 200,
       headers: [{ name: 'Content-Type', value: 'application/json' }]
     }));
@@ -87,7 +89,8 @@ describe('password', () => {
       scope: SCOPE,
       error: null,
       error_uri: null,
-      error_description: null
+      error_description: null,
+      xResponseId: 'res_dd2ccc1a2745477a881a9e8ef9d42403'
     });
   });
 
@@ -105,6 +108,8 @@ describe('password', () => {
 
     network.sendWithSettings = jest.fn(() => ({
       bodyPath,
+      bodyCompression: '',
+      parentId: 'req_1',
       statusCode: 200,
       headers: [
         { name: 'Content-Type', value: 'application/x-www-form-urlencoded' }
@@ -163,7 +168,8 @@ describe('password', () => {
       scope: SCOPE,
       error: null,
       error_uri: null,
-      error_description: null
+      error_description: null,
+      xResponseId: 'res_e3e96e5fdd6842298b66dee1f0940f3d'
     });
   });
 });

--- a/packages/insomnia-app/app/network/o-auth-2/constants.js
+++ b/packages/insomnia-app/app/network/o-auth-2/constants.js
@@ -28,3 +28,6 @@ export const P_SCOPE = 'scope';
 export const P_STATE = 'state';
 export const P_TOKEN_TYPE = 'token_type';
 export const P_USERNAME = 'username';
+
+export const X_RESPONSE_ID = 'xResponseId';
+export const X_ERROR = 'xError';

--- a/packages/insomnia-app/app/network/o-auth-2/get-token.js
+++ b/packages/insomnia-app/app/network/o-auth-2/get-token.js
@@ -10,11 +10,13 @@ import {
   GRANT_TYPE_IMPLICIT,
   GRANT_TYPE_PASSWORD,
   P_ACCESS_TOKEN,
-  P_ERROR,
   P_ERROR_DESCRIPTION,
   P_ERROR_URI,
+  P_ERROR,
   P_EXPIRES_IN,
-  P_REFRESH_TOKEN
+  P_REFRESH_TOKEN,
+  X_RESPONSE_ID,
+  X_ERROR
 } from './constants';
 import * as models from '../../models';
 import type { RequestAuthentication } from '../../models/request';
@@ -236,6 +238,10 @@ async function _updateOAuth2Token(
     accessToken: authResults[P_ACCESS_TOKEN] || null,
     error: authResults[P_ERROR] || null,
     errorDescription: authResults[P_ERROR_DESCRIPTION] || null,
-    errorUri: authResults[P_ERROR_URI] || null
+    errorUri: authResults[P_ERROR_URI] || null,
+
+    // Special Cases
+    xResponseId: authResults[X_RESPONSE_ID] || null,
+    xError: authResults[X_ERROR] || null
   });
 }

--- a/packages/insomnia-app/app/network/o-auth-2/grant-client-credentials.js
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-client-credentials.js
@@ -40,23 +40,29 @@ export default async function(
 
   const url = setDefaultProtocol(accessTokenUrl);
 
-  const response = await sendWithSettings(requestId, {
+  const responsePatch = await sendWithSettings(requestId, {
     headers,
     url,
     method: 'POST',
     body: models.request.newBodyFormUrlEncoded(params)
   });
 
+  const response = await models.response.create(responsePatch);
+
   const bodyBuffer = models.response.getBodyBuffer(response);
   if (!bodyBuffer) {
-    throw new Error(`[oauth2] No body returned from ${url}`);
+    return {
+      [c.X_ERROR]: `No body returned from ${url}`,
+      [c.X_RESPONSE_ID]: response._id
+    };
   }
 
   const statusCode = response.statusCode || 0;
   if (statusCode < 200 || statusCode >= 300) {
-    throw new Error(
-      `[oauth2] Failed to fetch token url=${url} status=${statusCode}`
-    );
+    return {
+      [c.X_ERROR]: `Failed to fetch token url=${url} status=${statusCode}`,
+      [c.X_RESPONSE_ID]: response._id
+    };
   }
 
   const results = responseToObject(bodyBuffer.toString('utf8'), [

--- a/packages/insomnia-app/app/network/o-auth-2/grant-client-credentials.js
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-client-credentials.js
@@ -75,5 +75,7 @@ export default async function(
     c.P_ERROR_DESCRIPTION
   ]);
 
+  results[c.X_RESPONSE_ID] = response._id;
+
   return results;
 }

--- a/packages/insomnia-app/app/network/o-auth-2/grant-password.js
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-password.js
@@ -42,23 +42,29 @@ export default async function(
 
   const url = setDefaultProtocol(accessTokenUrl);
 
-  const response = await network.sendWithSettings(requestId, {
+  const responsePatch = await network.sendWithSettings(requestId, {
     url,
     headers,
     method: 'POST',
     body: models.request.newBodyFormUrlEncoded(params)
   });
 
+  const response = await models.response.create(responsePatch);
+
   const bodyBuffer = models.response.getBodyBuffer(response);
   if (!bodyBuffer) {
-    throw new Error(`[oauth2] No body returned from ${url}`);
+    return {
+      [c.X_ERROR]: `No body returned from ${url}`,
+      [c.X_RESPONSE_ID]: response._id
+    };
   }
 
   const statusCode = response.statusCode || 0;
   if (statusCode < 200 || statusCode >= 300) {
-    throw new Error(
-      `[oauth2] Failed to fetch access token url=${url} status=${statusCode}`
-    );
+    return {
+      [c.X_ERROR]: `Failed to fetch token url=${url} status=${statusCode}`,
+      [c.X_RESPONSE_ID]: response._id
+    };
   }
 
   const results = responseToObject(bodyBuffer.toString(), [
@@ -71,6 +77,8 @@ export default async function(
     c.P_ERROR_URI,
     c.P_ERROR_DESCRIPTION
   ]);
+
+  results[c.X_RESPONSE_ID] = response._id;
 
   return results;
 }

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
@@ -501,7 +501,7 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
       oAuth2Token && oAuth2Token.xResponseId ? (
         <button
           onClick={this._handleDebugResponseClick}
-          className="icon space-left"
+          className="icon icon--success space-left"
           title="View response timeline">
           <i className="fa fa-bug" />
         </button>

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
@@ -24,6 +24,8 @@ import HelpTooltip from '../../help-tooltip';
 import PromptButton from '../../base/prompt-button';
 import TimeFromNow from '../../time-from-now';
 import Button from '../../base/button';
+import { showModal } from '../../modals';
+import ResponseDebugModal from '../../modals/response-debug-modal';
 
 type Props = {
   handleRender: Function,
@@ -108,6 +110,16 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
     if (oAuth2Token) {
       await models.oAuth2Token.remove(oAuth2Token);
     }
+  }
+
+  _handleDebugResponseClick(responseId: string) {
+    const { oAuth2Token } = this.props;
+
+    if (!oAuth2Token || !oAuth2Token.xResponseId) {
+      return;
+    }
+
+    showModal(ResponseDebugModal, { responseId: oAuth2Token.xResponseId });
   }
 
   async _handleRefreshToken(): Promise<void> {
@@ -482,6 +494,46 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
     );
   }
 
+  renderError() {
+    const { oAuth2Token } = this.props;
+
+    const debugButton =
+      oAuth2Token && oAuth2Token.xResponseId ? (
+        <button
+          onClick={this._handleDebugResponseClick}
+          className="icon space-left"
+          title="View response timeline">
+          <i className="fa fa-bug" />
+        </button>
+      ) : null;
+
+    const errorUriButton =
+      oAuth2Token && oAuth2Token.errorUri ? (
+        <Link
+          href={oAuth2Token.errorUri}
+          title={oAuth2Token.errorUri}
+          className="space-left icon">
+          <i className="fa fa-question-circle" />
+        </Link>
+      ) : null;
+
+    const error = oAuth2Token ? oAuth2Token.error || oAuth2Token.xError : null;
+
+    if (oAuth2Token && error) {
+      const { errorDescription } = oAuth2Token;
+      return (
+        <div className="notice error margin-bottom">
+          <h2 className="no-margin-top txt-lg force-wrap">{error}</h2>
+          <p>
+            {errorDescription || 'no description provided'}
+            {errorUriButton}
+            {debugButton}
+          </p>
+        </div>
+      );
+    }
+  }
+
   render() {
     const { request, oAuth2Token: tok } = this.props;
     const { loading, error, showAdvanced } = this.state;
@@ -532,28 +584,10 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
           </tbody>
         </table>
         <div className="notice subtle margin-top text-left">
-          {/* Handle major errors */}
           {error && (
             <p className="selectable notice warning margin-bottom">{error}</p>
           )}
-
-          {/* Handle minor errors */}
-          {tok && tok.error ? (
-            <div className="notice error margin-bottom">
-              <h2 className="no-margin-top txt-lg force-wrap">{tok.error}</h2>
-              <p>
-                {tok.errorDescription || 'no description provided'}
-                {tok.errorUri && (
-                  <span>
-                    &nbsp;
-                    <Link href={tok.errorUri} title={tok.errorUri}>
-                      <i className="fa fa-question-circle" />
-                    </Link>
-                  </span>
-                )}
-              </p>
-            </div>
-          ) : null}
+          {this.renderError()}
           <div className="form-control form-control--outlined">
             <label>
               <small>Refresh Token</small>

--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
@@ -29,8 +29,7 @@ import TimeFromNow from '../../time-from-now';
 import * as models from '../../../../models/index';
 import * as db from '../../../../common/database';
 import { showModal } from '../../modals';
-import WrapperModal from '../../modals/wrapper-modal';
-import ResponseTimelineViewer from '../../viewers/response-timeline-viewer';
+import ResponseDebugModal from '../../modals/response-debug-modal';
 import Tooltip from '../../tooltip';
 
 type GraphQLBody = {
@@ -175,7 +174,6 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
   }
 
   _handleViewResponse() {
-    const { settings } = this.props;
     const { schemaFetchError } = this.state;
 
     if (!schemaFetchError || !schemaFetchError.response) {
@@ -184,19 +182,9 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
 
     const { response } = schemaFetchError;
 
-    showModal(WrapperModal, {
+    showModal(ResponseDebugModal, {
       title: 'Introspection Request',
-      tall: true,
-      body: (
-        <div style={{ display: 'grid' }} className="tall pad-top">
-          <ResponseTimelineViewer
-            editorFontSize={settings.editorFontSize}
-            editorIndentSize={settings.editorIndentSize}
-            editorLineWrapping={settings.editorLineWrapping}
-            timeline={response.timeline}
-          />
-        </div>
-      )
+      response: response
     });
   }
 

--- a/packages/insomnia-app/app/ui/components/modals/response-debug-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/response-debug-modal.js
@@ -1,0 +1,71 @@
+// @flow
+import * as React from 'react';
+import autobind from 'autobind-decorator';
+import ResponseTimelineViewer from '../../components/viewers/response-timeline-viewer';
+import Modal from '../base/modal';
+import ModalBody from '../base/modal-body';
+import ModalHeader from '../base/modal-header';
+import * as models from '../../../models/index';
+import type { Response } from '../../../models/response';
+import type { Settings } from '../../../models/settings';
+
+type Props = { settings: Settings };
+
+type State = {
+  response: Response | null
+};
+
+@autobind
+class ResponseDebugModal extends React.PureComponent<Props, State> {
+  modal: ?Modal;
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      response: null
+    };
+  }
+
+  _setModalRef(n: ?Modal) {
+    this.modal = n;
+  }
+
+  hide() {
+    this.modal && this.modal.hide();
+  }
+
+  async show(options: { responseId: string }) {
+    const response = await models.response.getById(options.responseId);
+
+    this.setState({ response });
+    this.modal && this.modal.show();
+  }
+
+  render() {
+    const { settings } = this.props;
+    const { response } = this.state;
+
+    return (
+      <Modal ref={this._setModalRef} tall>
+        <ModalHeader>OAuth 2 Response</ModalHeader>
+        <ModalBody>
+          <div style={{ display: 'grid' }} className="tall pad-top">
+            {response ? (
+              <ResponseTimelineViewer
+                editorFontSize={settings.editorFontSize}
+                editorIndentSize={settings.editorIndentSize}
+                editorLineWrapping={settings.editorLineWrapping}
+                timeline={response.timeline}
+              />
+            ) : (
+              <div>Poop</div>
+            )}
+          </div>
+        </ModalBody>
+      </Modal>
+    );
+  }
+}
+
+export default ResponseDebugModal;

--- a/packages/insomnia-app/app/ui/components/modals/response-debug-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/response-debug-modal.js
@@ -35,8 +35,10 @@ class ResponseDebugModal extends React.PureComponent<Props, State> {
     this.modal && this.modal.hide();
   }
 
-  async show(options: { responseId: string }) {
-    const response = await models.response.getById(options.responseId);
+  async show(options: { responseId?: string, response?: Response }) {
+    const response = options.response
+      ? options.response
+      : await models.response.getById(options.responseId || 'n/a');
 
     this.setState({ response });
     this.modal && this.modal.show();
@@ -59,7 +61,7 @@ class ResponseDebugModal extends React.PureComponent<Props, State> {
                 timeline={response.timeline}
               />
             ) : (
-              <div>Poop</div>
+              <div>No response found</div>
             )}
           </div>
         </ModalBody>

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -23,6 +23,7 @@ import CookieModifyModal from '../components/modals/cookie-modify-modal';
 import EnvironmentEditModal from './modals/environment-edit-modal';
 import GenerateCodeModal from './modals/generate-code-modal';
 import LoginModal from './modals/login-modal';
+import ResponseDebugModal from './modals/response-debug-modal';
 import PaymentNotificationModal from './modals/payment-notification-modal';
 import NunjucksModal from './modals/nunjucks-modal';
 import PromptModal from './modals/prompt-modal';
@@ -525,6 +526,8 @@ class Wrapper extends React.PureComponent<Props, State> {
             handleToggleMenuBar={handleToggleMenuBar}
             settings={settings}
           />
+
+          <ResponseDebugModal ref={registerModal} settings={settings} />
 
           <RequestSwitcherModal
             ref={registerModal}


### PR DESCRIPTION
Closes #893 

This PR adds the ability to view the response timeline of failed token fetch requests.

![image](https://user-images.githubusercontent.com/587576/42137822-3cace9c0-7d41-11e8-8c5d-d78d39176060.png)

![image](https://user-images.githubusercontent.com/587576/42137825-45fdbbe4-7d41-11e8-8114-9dd3db328e7a.png)
