### PR TITLE
Add bar color indicator for environments

### DIFF
--- a/packages/insomnia-app/app/models/settings.js
+++ b/packages/insomnia-app/app/models/settings.js
@@ -26,7 +26,7 @@ type BaseSettings = {
   deviceId: string | null,
   updateChannel: string,
   updateAutomatically: boolean,
-  colorIndicatorType: string
+  environmentHighlightColorStyle: string
 };
 
 export type Settings = BaseModel & BaseSettings;
@@ -60,7 +60,7 @@ export function init(): BaseSettings {
     deviceId: null,
     updateChannel: UPDATE_CHANNEL_STABLE,
     updateAutomatically: true,
-    colorIndicatorType: 'dot'
+    environmentHighlightColorStyle: 'dot'
   };
 }
 

--- a/packages/insomnia-app/app/models/settings.js
+++ b/packages/insomnia-app/app/models/settings.js
@@ -25,7 +25,8 @@ type BaseSettings = {
   nunjucksPowerUserMode: boolean,
   deviceId: string | null,
   updateChannel: string,
-  updateAutomatically: boolean
+  updateAutomatically: boolean,
+  colorIndicatorType: string
 };
 
 export type Settings = BaseModel & BaseSettings;
@@ -58,7 +59,8 @@ export function init(): BaseSettings {
     nunjucksPowerUserMode: false,
     deviceId: null,
     updateChannel: UPDATE_CHANNEL_STABLE,
-    updateAutomatically: true
+    updateAutomatically: true,
+    colorIndicatorType: 'dot'
   };
 }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
@@ -21,7 +21,7 @@ type Props = {
   handleChangeEnvironment: Function,
   workspace: Workspace,
   environments: Array<Environment>,
-  colorIndicatorType: String,
+  environmentHighlightColorStyle: String,
 
   // Optional
   className?: string,
@@ -68,7 +68,7 @@ class EnvironmentsDropdown extends React.PureComponent<Props> {
       workspace,
       environments,
       activeEnvironment,
-      colorIndicatorType,
+      environmentHighlightColorStyle,
       ...other
     } = this.props;
 
@@ -104,7 +104,7 @@ class EnvironmentsDropdown extends React.PureComponent<Props> {
               <div className="sidebar__menu__thing__text">
                 {activeEnvironment &&
                 activeEnvironment.color &&
-                colorIndicatorType === 'dot' ? (
+                environmentHighlightColorStyle === 'dot' ? (
                   <i
                     className="fa fa-circle space-right"
                     style={{ color: activeEnvironment.color }}

--- a/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
@@ -21,6 +21,7 @@ type Props = {
   handleChangeEnvironment: Function,
   workspace: Workspace,
   environments: Array<Environment>,
+  colorIndicatorType: String,
 
   // Optional
   className?: string,
@@ -67,6 +68,7 @@ class EnvironmentsDropdown extends React.PureComponent<Props> {
       workspace,
       environments,
       activeEnvironment,
+      colorIndicatorType,
       ...other
     } = this.props;
 
@@ -100,7 +102,9 @@ class EnvironmentsDropdown extends React.PureComponent<Props> {
                   </Tooltip>
                 )}
               <div className="sidebar__menu__thing__text">
-                {activeEnvironment && activeEnvironment.color ? (
+                {activeEnvironment &&
+                activeEnvironment.color &&
+                colorIndicatorType === 'dot' ? (
                   <i
                     className="fa fa-circle space-right"
                     style={{ color: activeEnvironment.color }}

--- a/packages/insomnia-app/app/ui/components/settings/general.js
+++ b/packages/insomnia-app/app/ui/components/settings/general.js
@@ -146,10 +146,13 @@ class General extends React.PureComponent<Props> {
 
         <div className="form-control form-control--outlined pad-top-sm">
           <label>
-            Color Indicator Type
+            Environment Highlight Color Style{' '}
+            <HelpTooltip>
+              Configures the appearance of environment's color indicator
+            </HelpTooltip>
             <select
-              defaultValue={settings.colorIndicatorType}
-              name="colorIndicatorType"
+              defaultValue={settings.environmentHighlightColorStyle}
+              name="environmentHighlightColorStyle"
               onChange={this._handleUpdateSetting}>
               <option value="dot">Dot</option>
               <option value="bar">Bar</option>

--- a/packages/insomnia-app/app/ui/components/settings/general.js
+++ b/packages/insomnia-app/app/ui/components/settings/general.js
@@ -144,6 +144,19 @@ class General extends React.PureComponent<Props> {
           </label>
         </div>
 
+        <div className="form-control form-control--outlined pad-top-sm">
+          <label>
+            Color Indicator Type
+            <select
+              defaultValue={settings.colorIndicatorType}
+              name="colorIndicatorType"
+              onChange={this._handleUpdateSetting}>
+              <option value="dot">Dot</option>
+              <option value="bar">Bar</option>
+            </select>
+          </label>
+        </div>
+
         <div className="form-row">
           <div className="form-control form-control--outlined pad-top-sm">
             <label>

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar.js
@@ -56,7 +56,8 @@ class Sidebar extends PureComponent {
       handleSetRequestGroupCollapsed,
       moveDoc,
       handleActivateRequest,
-      activeRequest
+      activeRequest,
+      colorIndicatorType
     } = this.props;
 
     return (
@@ -83,6 +84,7 @@ class Sidebar extends PureComponent {
             activeEnvironment={activeEnvironment}
             environments={environments}
             workspace={workspace}
+            colorIndicatorType={colorIndicatorType}
           />
           <button className="btn btn--super-compact" onClick={showCookiesModal}>
             <div className="sidebar__menu__thing">
@@ -155,6 +157,7 @@ Sidebar.propTypes = {
   workspaces: PropTypes.arrayOf(PropTypes.object).isRequired,
   unseenWorkspaces: PropTypes.arrayOf(PropTypes.object).isRequired,
   environments: PropTypes.arrayOf(PropTypes.object).isRequired,
+  colorIndicatorType: PropTypes.string.isRequired,
 
   // Optional
   filter: PropTypes.string,

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar.js
@@ -57,7 +57,7 @@ class Sidebar extends PureComponent {
       moveDoc,
       handleActivateRequest,
       activeRequest,
-      colorIndicatorType
+      environmentHighlightColorStyle
     } = this.props;
 
     return (
@@ -84,7 +84,7 @@ class Sidebar extends PureComponent {
             activeEnvironment={activeEnvironment}
             environments={environments}
             workspace={workspace}
-            colorIndicatorType={colorIndicatorType}
+            environmentHighlightColorStyle={environmentHighlightColorStyle}
           />
           <button className="btn btn--super-compact" onClick={showCookiesModal}>
             <div className="sidebar__menu__thing">
@@ -157,7 +157,7 @@ Sidebar.propTypes = {
   workspaces: PropTypes.arrayOf(PropTypes.object).isRequired,
   unseenWorkspaces: PropTypes.arrayOf(PropTypes.object).isRequired,
   environments: PropTypes.arrayOf(PropTypes.object).isRequired,
-  colorIndicatorType: PropTypes.string.isRequired,
+  environmentHighlightColorStyle: PropTypes.string.isRequired,
 
   // Optional
   filter: PropTypes.string,

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -423,13 +423,6 @@ class Wrapper extends React.PureComponent<Props, State> {
     const rows = `minmax(0, ${paneHeight}fr) 0 minmax(0, ${1 - paneHeight}fr)`;
 
     return [
-      activeEnvironment &&
-      activeEnvironment.color &&
-      settings.colorIndicatorType === 'bar' ? (
-        <div
-          style={{ height: '5px', 'background-color': activeEnvironment.color }}
-        />
-      ) : null,
       <div key="modals" className="modals">
         <ErrorBoundary showAlert>
           <AlertModal ref={registerModal} />
@@ -584,7 +577,16 @@ class Wrapper extends React.PureComponent<Props, State> {
         className={classnames('wrapper', {
           'wrapper--vertical': settings.forceVerticalLayout
         })}
-        style={{ gridTemplateColumns: columns, gridTemplateRows: rows }}>
+        style={{
+          gridTemplateColumns: columns,
+          gridTemplateRows: rows,
+          borderTop:
+            activeEnvironment &&
+            activeEnvironment.color &&
+            settings.environmentHighlightColorStyle === 'bar'
+              ? '5px solid ' + activeEnvironment.color
+              : null
+        }}>
         <ErrorBoundary showAlert>
           <Sidebar
             ref={handleSetSidebarRef}
@@ -616,7 +618,9 @@ class Wrapper extends React.PureComponent<Props, State> {
             isLoading={isLoading}
             workspaces={workspaces}
             environments={environments}
-            colorIndicatorType={settings.colorIndicatorType}
+            environmentHighlightColorStyle={
+              settings.environmentHighlightColorStyle
+            }
           />
         </ErrorBoundary>
 

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -423,6 +423,13 @@ class Wrapper extends React.PureComponent<Props, State> {
     const rows = `minmax(0, ${paneHeight}fr) 0 minmax(0, ${1 - paneHeight}fr)`;
 
     return [
+      activeEnvironment &&
+      activeEnvironment.color &&
+      settings.colorIndicatorType === 'bar' ? (
+        <div
+          style={{ height: '5px', 'background-color': activeEnvironment.color }}
+        />
+      ) : null,
       <div key="modals" className="modals">
         <ErrorBoundary showAlert>
           <AlertModal ref={registerModal} />
@@ -609,6 +616,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             isLoading={isLoading}
             workspaces={workspaces}
             environments={environments}
+            colorIndicatorType={settings.colorIndicatorType}
           />
         </ErrorBoundary>
 


### PR DESCRIPTION
Add a bar color indicator along with new a setting to choose whether to use the original dot or the new bar.

Closes #995 