### PR TITLE
[Feature Request] Allow response viewer plugins to interact with insomnia engine

### DIFF
--- a/packages/insomnia-app/app/models/request.js
+++ b/packages/insomnia-app/app/models/request.js
@@ -333,7 +333,7 @@ export function updateMimeType (
   }
 }
 
-export async function duplicate (request: Request): Promise<Request> {
+export async function duplicate (request: Request, patch: Object = {}): Promise<Request> {
   const name = `${request.name} (Copy)`;
 
   // Get sort key of next request
@@ -345,7 +345,7 @@ export async function duplicate (request: Request): Promise<Request> {
   const sortKeyIncrement = (nextSortKey - request.metaSortKey) / 2;
   const metaSortKey = request.metaSortKey + sortKeyIncrement;
 
-  return db.duplicate(request, {name, metaSortKey});
+  return db.duplicate(request, Object.assign({name, metaSortKey}, patch));
 }
 
 export function remove (request: Request): Promise<void> {

--- a/packages/insomnia-app/app/ui/components/response-pane.js
+++ b/packages/insomnia-app/app/ui/components/response-pane.js
@@ -36,6 +36,9 @@ type Props = {
   handleSetActiveResponse: Function,
   handleDeleteResponses: Function,
   handleDeleteResponse: Function,
+  handleUpdateRequest: Function,
+  handleSendRequest: Function,
+  handleSendOnNewRequest: Function,
   handleShowRequestSettings: Function,
 
   // Required
@@ -150,6 +153,9 @@ class ResponsePane extends React.PureComponent<Props> {
       responses,
       response,
       previewMode,
+      handleUpdateRequest,
+      handleSendRequest,
+      handleSendOnNewRequest,
       handleShowRequestSettings,
       handleSetPreviewMode,
       handleSetActiveResponse,
@@ -295,6 +301,10 @@ class ResponsePane extends React.PureComponent<Props> {
               editorIndentSize={editorIndentSize}
               editorKeyMap={editorKeyMap}
               url={response.url}
+              currentRequest={request}
+              handleUpdateRequest={handleUpdateRequest}
+              handleSendRequest={handleSendRequest}
+              handleSendOnNewRequest={handleSendOnNewRequest}
             />
           </TabPanel>
           <TabPanel className="react-tabs__tab-panel scrollable-container">

--- a/packages/insomnia-app/app/ui/components/viewers/response-multipart.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-multipart.js
@@ -285,6 +285,10 @@ class ResponseMultipart extends React.PureComponent<Props, State> {
               responseId={`${responseId}[${activePart}]`}
               updateFilter={null}
               url={url}
+              currentRequest={null}
+              handleUpdateRequest={null}
+              handleSendRequest={null}
+              handleSendOnNewRequest={null}
             />
           </div>
         ) : null}

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
@@ -1,4 +1,5 @@
 // @flow
+import type {Request} from '../../../models/request';
 import * as React from 'react';
 import iconv from 'iconv-lite';
 import autobind from 'autobind-decorator';
@@ -34,7 +35,11 @@ type Props = {
 
   // Optional
   updateFilter: Function | null,
-  error: string | null
+  error: string | null,
+  currentRequest: Request | null,
+  handleUpdateRequest: Function | null,
+  handleSendRequest: Function | null,
+  handleSendOnNewRequest: Function | null
 };
 
 type State = {
@@ -99,7 +104,11 @@ class ResponseViewer extends React.Component<Props, State> {
     for (const rv of this._responseViewers) {
       if (rv.previewMode === this.props.previewMode && matchRegexs(contentType, rv.contentType)) {
         return React.createElement(rv.component, {
-          bodyBuffer: this.state.bodyBuffer
+          bodyBuffer: this.state.bodyBuffer,
+          currentRequest: this.props.currentRequest,
+          handleUpdateRequest: this.props.handleUpdateRequest,
+          handleSendRequest: this.props.handleSendRequest,
+          handleSendOnNewRequest: this.props.handleSendOnNewRequest
         });
       }
     }

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -135,6 +135,12 @@ class Wrapper extends React.PureComponent<Props, State> {
     };
   }
 
+  async _handleSendOnNewRequest (newRequestPatch: Request): Promise<void> {
+    const newRequest = await this.props.handleDuplicateRequest(this.props.activeRequest, newRequestPatch);
+    const activeEnvironmentId = this.props.activeEnvironment ? this.props.activeEnvironment._id : 'n/a';
+    this.props.handleSendRequestWithEnvironment(newRequest._id, activeEnvironmentId);
+  }
+
   // Request updaters
   async _handleForceUpdateRequest (patch: Object): Promise<Request> {
     const newRequest = await rUpdate(this.props.activeRequest, patch);
@@ -629,6 +635,9 @@ class Wrapper extends React.PureComponent<Props, State> {
             handleDeleteResponses={this._handleDeleteResponses}
             handleDeleteResponse={this._handleDeleteResponse}
             handleSetFilter={this._handleSetResponseFilter}
+            handleUpdateRequest={this._handleForceUpdateRequest}
+            handleSendRequest={this._handleSendRequestWithActiveEnvironment}
+            handleSendOnNewRequest={this._handleSendOnNewRequest}
           />
         </ErrorBoundary>
       </div>

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -183,13 +183,14 @@ class App extends PureComponent {
     models.requestGroup.duplicate(requestGroup);
   }
 
-  async _requestDuplicate (request) {
+  async _requestDuplicate (request, patch = {}) {
     if (!request) {
       return;
     }
 
-    const newRequest = await models.request.duplicate(request);
+    const newRequest = await models.request.duplicate(request, patch);
     await this._handleSetActiveRequest(newRequest._id);
+    return newRequest;
   }
 
   async _workspaceDuplicate (callback) {


### PR DESCRIPTION
I also updated the test plugin (https://github.com/osvaldopina/ResponseViewerTestPlugin, https://www.npmjs.com/package/response-viewer-test-plugin) to use the newly created capabilities.

closes #942


