### PR TITLE
Added support for file extension filtering as well as ability to select a directory to file picker dialog

### DIFF
--- a/packages/insomnia-app/app/templating/extensions/index.js
+++ b/packages/insomnia-app/app/templating/extensions/index.js
@@ -47,14 +47,6 @@ export type PluginArgumentFile = PluginArgumentBase & {
   type: 'file'
 };
 
-export type PluginArgumentDirectory = PluginArgumentBase & {
-  type: 'directory'
-};
-
-export type PluginArgumentFileDirectory = PluginArgumentBase & {
-  type: 'fileDirectory'
-};
-
 export type PluginArgumentNumber = PluginArgumentBase & {
   type: 'number',
   placeholder?: string,
@@ -67,8 +59,6 @@ export type PluginArgument =
   | PluginArgumentString
   | PluginArgumentBoolean
   | PluginArgumentFile
-  | PluginArgumentDirectory
-  | PluginArgumentFileDirectory
   | PluginArgumentNumber;
 
 export type PluginTemplateTagContext = {

--- a/packages/insomnia-app/app/templating/extensions/index.js
+++ b/packages/insomnia-app/app/templating/extensions/index.js
@@ -47,6 +47,14 @@ export type PluginArgumentFile = PluginArgumentBase & {
   type: 'file'
 };
 
+export type PluginArgumentDirectory = PluginArgumentBase & {
+  type: 'directory'
+};
+
+export type PluginArgumentFileDirectory = PluginArgumentBase & {
+  type: 'fileDirectory'
+};
+
 export type PluginArgumentNumber = PluginArgumentBase & {
   type: 'number',
   placeholder?: string,
@@ -59,6 +67,8 @@ export type PluginArgument =
   | PluginArgumentString
   | PluginArgumentBoolean
   | PluginArgumentFile
+  | PluginArgumentDirectory
+  | PluginArgumentFileDirectory
   | PluginArgumentNumber;
 
 export type PluginTemplateTagContext = {
@@ -69,10 +79,7 @@ export type PluginTemplateTagContext = {
       },
       response: {
         getLatestForRequestId: (id: string) => Promise<Response | null>,
-        getBodyBuffer: (
-          response: Response,
-          fallback?: any
-        ) => Promise<Buffer | null>
+        getBodyBuffer: (response: Response, fallback?: any) => Promise<Buffer | null>
       }
     }
   }
@@ -83,10 +90,7 @@ export type PluginTemplateTag = {
   name: string,
   displayName: DisplayName,
   description: string,
-  run: (
-    context: PluginTemplateTagContext,
-    ...arg: Array<any>
-  ) => Promise<any> | any,
+  run: (context: PluginTemplateTagContext, ...arg: Array<any>) => Promise<any> | any,
   deprecated?: boolean,
   validate?: (value: any) => ?string,
   priority?: number

--- a/packages/insomnia-app/app/ui/components/base/file-input-button.js
+++ b/packages/insomnia-app/app/ui/components/base/file-input-button.js
@@ -10,7 +10,7 @@ type Props = {
   path: string,
 
   // Optional
-  inputtypes?: Array<string>,
+  itemtypes?: Array<string>,
   extensions?: Array<string>,
   showFileName?: boolean,
   showFileIcon?: boolean,
@@ -34,21 +34,28 @@ class FileInputButton extends React.PureComponent<Props> {
 
   _handleChooseFile() {
     // If no types are selected then default to just files and not directories
-    const types = this.props.inputtypes ? this.props.inputtypes : ['openFile'];
+    const types = this.props.itemtypes ? this.props.itemtypes : ['file'];
     let title = 'Select ';
-    if (types.includes('openFile')) {
+    if (types.includes('file')) {
       title += ' File';
       if (types.length > 2) {
         title += ' or';
       }
     }
-    if (types.includes('openDirectory')) {
+    if (types.includes('directory')) {
       title += ' Directory';
     }
     const options: OpenDialogOptions = {
       title: title,
       buttonLabel: 'Select',
-      properties: types
+      properties: types.map(type => {
+        if (type === 'file') {
+          return 'openFile';
+        }
+        if (type === 'directory') {
+          return 'openDirectory';
+        }
+      })
     };
 
     // If extensions are provided then filter for just those extensions

--- a/packages/insomnia-app/app/ui/components/base/file-input-button.js
+++ b/packages/insomnia-app/app/ui/components/base/file-input-button.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import autobind from 'autobind-decorator';
 import { basename as pathBasename } from 'path';
-import { remote } from 'electron';
+import { OpenDialogOptions, remote } from 'electron';
 
 type Props = {
   // Required
@@ -10,6 +10,8 @@ type Props = {
   path: string,
 
   // Optional
+  inputtypes?: Array<string>,
+  extensions?: Array<string>,
   showFileName?: boolean,
   showFileIcon?: boolean,
   name?: string
@@ -31,11 +33,28 @@ class FileInputButton extends React.PureComponent<Props> {
   }
 
   _handleChooseFile() {
-    const options = {
-      title: 'Import File',
-      buttonLabel: 'Import',
-      properties: ['openFile']
+    // If no types are selected then default to just files and not directories
+    const types = this.props.inputtypes ? this.props.inputtypes : ['openFile'];
+    let title = 'Select ';
+    if (types.includes('openFile')) {
+      title += ' File';
+      if (types.length > 2) {
+        title += ' or';
+      }
+    }
+    if (types.includes('openDirectory')) {
+      title += ' Directory';
+    }
+    const options: OpenDialogOptions = {
+      title: title,
+      buttonLabel: 'Select',
+      properties: types
     };
+
+    // If extensions are provided then filter for just those extensions
+    if (this.props.extensions) {
+      options.filters = [{ name: 'Files', extensions: this.props.extensions }];
+    }
 
     remote.dialog.showOpenDialog(options, async paths => {
       // Only change the file if a new file was selected
@@ -49,13 +68,7 @@ class FileInputButton extends React.PureComponent<Props> {
   }
 
   render() {
-    const {
-      showFileName,
-      showFileIcon,
-      path,
-      name,
-      ...extraProps
-    } = this.props;
+    const { showFileName, showFileIcon, path, name, ...extraProps } = this.props;
     const fileName = pathBasename(path);
     return (
       <button

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -369,7 +369,7 @@ class TagEditor extends React.PureComponent<Props, State> {
 
   renderArgFile(
     value: string,
-    inputTypes: Array<string>,
+    itemTypes: Array<string>,
     argIndex: number,
     extensions?: Array<string>
   ) {
@@ -380,7 +380,7 @@ class TagEditor extends React.PureComponent<Props, State> {
         className="btn btn--clicky btn--super-compact"
         onChange={path => this._handleChangeFile(path, argIndex)}
         path={value}
-        inputtypes={inputTypes}
+        itemtypes={itemTypes}
         extensions={extensions}
       />
     );
@@ -497,18 +497,9 @@ class TagEditor extends React.PureComponent<Props, State> {
       const { options } = argDefinition;
       argInput = this.renderArgEnum(strValue, options);
     } else if (argDefinition.type === 'file') {
-      argInput = this.renderArgFile(strValue, ['openFile'], argIndex, argDefinition.extensions);
-    } else if (argDefinition.type === 'directory') {
       argInput = this.renderArgFile(
         strValue,
-        ['openDirectory'],
-        argIndex,
-        argDefinition.extensions
-      );
-    } else if (argDefinition.type === 'fileDirectory') {
-      argInput = this.renderArgFile(
-        strValue,
-        ['openFile', 'openDirectory'],
+        argDefinition.itemTypes,
         argIndex,
         argDefinition.extensions
       );

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -4,10 +4,7 @@ import autobind from 'autobind-decorator';
 import classnames from 'classnames';
 import clone from 'clone';
 import * as templating from '../../../templating';
-import type {
-  NunjucksParsedTag,
-  NunjucksParsedTagArg
-} from '../../../templating/utils';
+import type { NunjucksParsedTag, NunjucksParsedTagArg } from '../../../templating/utils';
 import * as templateUtils from '../../../templating/utils';
 import * as db from '../../../common/database';
 import * as models from '../../../models';
@@ -16,12 +13,7 @@ import { delay, fnOrString } from '../../../common/misc';
 import type { BaseModel } from '../../../models/index';
 import type { Workspace } from '../../../models/workspace';
 import type { PluginArgumentEnumOption } from '../../../templating/extensions/index';
-import {
-  Dropdown,
-  DropdownButton,
-  DropdownDivider,
-  DropdownItem
-} from '../base/dropdown/index';
+import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown/index';
 import FileInputButton from '../base/file-input-button';
 
 type Props = {
@@ -118,10 +110,7 @@ class TagEditor extends React.PureComponent<Props, State> {
       allDocs[type] = [];
     }
 
-    for (const doc of await db.withDescendants(
-      workspace,
-      models.request.type
-    )) {
+    for (const doc of await db.withDescendants(workspace, models.request.type)) {
       allDocs[doc.type].push(doc);
     }
 
@@ -181,10 +170,7 @@ class TagEditor extends React.PureComponent<Props, State> {
     this._update(tagDefinitions, activeTagDefinition, tagData, false);
   }
 
-  async _handleChangeArgVariable(options: {
-    argIndex: number,
-    variable: boolean
-  }) {
+  async _handleChangeArgVariable(options: { argIndex: number, variable: boolean }) {
     const { variable, argIndex } = options;
     const { activeTagData, activeTagDefinition, variables } = this.state;
 
@@ -378,12 +364,15 @@ class TagEditor extends React.PureComponent<Props, State> {
   }
 
   renderArgBoolean(checked: boolean) {
-    return (
-      <input type="checkbox" checked={checked} onChange={this._handleChange} />
-    );
+    return <input type="checkbox" checked={checked} onChange={this._handleChange} />;
   }
 
-  renderArgFile(value: string, argIndex: number) {
+  renderArgFile(
+    value: string,
+    inputTypes: Array<string>,
+    argIndex: number,
+    extensions?: Array<string>
+  ) {
     return (
       <FileInputButton
         showFileIcon
@@ -391,24 +380,21 @@ class TagEditor extends React.PureComponent<Props, State> {
         className="btn btn--clicky btn--super-compact"
         onChange={path => this._handleChangeFile(path, argIndex)}
         path={value}
+        inputtypes={inputTypes}
+        extensions={extensions}
       />
     );
   }
 
   renderArgEnum(value: string, options: Array<PluginArgumentEnumOption>) {
-    const argDatas = this.state.activeTagData
-      ? this.state.activeTagData.args
-      : [];
+    const argDatas = this.state.activeTagData ? this.state.activeTagData.args : [];
     return (
       <select value={value} onChange={this._handleChange}>
         {options.map(option => {
           let label: string;
           const { description } = option;
           if (description) {
-            label = `${fnOrString(
-              option.displayName,
-              argDatas
-            )} – ${description}`;
+            label = `${fnOrString(option.displayName, argDatas)} – ${description}`;
           } else {
             label = fnOrString(option.displayName, argDatas);
           }
@@ -446,27 +432,17 @@ class TagEditor extends React.PureComponent<Props, State> {
           if (doc.type === models.request.type) {
             const requests = allDocs[models.request.type] || [];
             const request: any = requests.find(r => r._id === doc._id);
-            const method =
-              request && typeof request.method === 'string'
-                ? request.method
-                : 'GET';
+            const method = request && typeof request.method === 'string' ? request.method : 'GET';
             const parentId = request ? request.parentId : 'n/a';
             const requestGroups = allDocs[models.requestGroup.type] || [];
-            const requestGroup: any = requestGroups.find(
-              rg => rg._id === parentId
-            );
+            const requestGroup: any = requestGroups.find(rg => rg._id === parentId);
             const requestGroupName =
-              requestGroup && typeof requestGroup.name === 'string'
-                ? requestGroup.name
-                : '';
-            const requestGroupStr = requestGroupName
-              ? `[${requestGroupName}] `
-              : '';
+              requestGroup && typeof requestGroup.name === 'string' ? requestGroup.name : '';
+            const requestGroupStr = requestGroupName ? `[${requestGroupName}] ` : '';
             namePrefix = `${requestGroupStr + method} `;
           }
 
-          const docName =
-            typeof doc.name === 'string' ? doc.name : 'Unknown Request';
+          const docName = typeof doc.name === 'string' ? doc.name : 'Unknown Request';
           return (
             <option key={doc._id} value={doc._id}>
               {namePrefix}
@@ -484,10 +460,7 @@ class TagEditor extends React.PureComponent<Props, State> {
     argIndex: number
   ) {
     // Decide whether or not to show it
-    if (
-      typeof argDefinition.hide === 'function' &&
-      argDefinition.hide(argDatas)
-    ) {
+    if (typeof argDefinition.hide === 'function' && argDefinition.hide(argDatas)) {
       return null;
     }
 
@@ -495,9 +468,7 @@ class TagEditor extends React.PureComponent<Props, State> {
     if (argIndex < argDatas.length) {
       argData = argDatas[argIndex];
     } else if (this.state.activeTagDefinition) {
-      const defaultTagData = this._getDefaultTagData(
-        this.state.activeTagDefinition
-      );
+      const defaultTagData = this._getDefaultTagData(this.state.activeTagDefinition);
       argData = defaultTagData.args[argIndex];
     } else {
       return null;
@@ -514,46 +485,50 @@ class TagEditor extends React.PureComponent<Props, State> {
 
     const strValue = argData.value.toString();
     const isVariable = argData.type === 'variable';
-    const argInputVariable = isVariable
-      ? this.renderArgVariable(strValue)
-      : null;
+    const argInputVariable = isVariable ? this.renderArgVariable(strValue) : null;
 
     let argInput;
     let isVariableAllowed = true;
     if (argDefinition.type === 'string') {
       const placeholder =
-        typeof argDefinition.placeholder === 'string'
-          ? argDefinition.placeholder
-          : '';
+        typeof argDefinition.placeholder === 'string' ? argDefinition.placeholder : '';
       argInput = this.renderArgString(strValue, placeholder);
     } else if (argDefinition.type === 'enum') {
       const { options } = argDefinition;
       argInput = this.renderArgEnum(strValue, options);
     } else if (argDefinition.type === 'file') {
-      argInput = this.renderArgFile(strValue, argIndex);
+      argInput = this.renderArgFile(strValue, ['openFile'], argIndex, argDefinition.extensions);
+    } else if (argDefinition.type === 'directory') {
+      argInput = this.renderArgFile(
+        strValue,
+        ['openDirectory'],
+        argIndex,
+        argDefinition.extensions
+      );
+    } else if (argDefinition.type === 'fileDirectory') {
+      argInput = this.renderArgFile(
+        strValue,
+        ['openFile', 'openDirectory'],
+        argIndex,
+        argDefinition.extensions
+      );
     } else if (argDefinition.type === 'model') {
       isVariableAllowed = false;
-      const model =
-        typeof argDefinition.model === 'string'
-          ? argDefinition.model
-          : 'unknown';
+      const model = typeof argDefinition.model === 'string' ? argDefinition.model : 'unknown';
       const modelId = typeof strValue === 'string' ? strValue : 'unknown';
       argInput = this.renderArgModel(modelId, model);
     } else if (argDefinition.type === 'boolean') {
       argInput = this.renderArgBoolean(strValue.toLowerCase() === 'true');
     } else if (argDefinition.type === 'number') {
       const placeholder =
-        typeof argDefinition.placeholder === 'string'
-          ? argDefinition.placeholder
-          : '';
+        typeof argDefinition.placeholder === 'string' ? argDefinition.placeholder : '';
       argInput = this.renderArgNumber(strValue, placeholder || '');
     } else {
       return null;
     }
 
     const help =
-      typeof argDefinition.help === 'string' ||
-      typeof argDefinition.help === 'function'
+      typeof argDefinition.help === 'string' || typeof argDefinition.help === 'function'
         ? fnOrString(argDefinition.help, argDatas)
         : '';
 
@@ -564,8 +539,7 @@ class TagEditor extends React.PureComponent<Props, State> {
         : '';
 
     let validationError = '';
-    const canValidate =
-      argDefinition.type === 'string' || argDefinition.type === 'number';
+    const canValidate = argDefinition.type === 'string' || argDefinition.type === 'number';
     if (canValidate && typeof argDefinition.validate === 'function') {
       validationError = argDefinition.validate(strValue) || '';
     }
@@ -583,9 +557,7 @@ class TagEditor extends React.PureComponent<Props, State> {
             {fnOrString(displayName, argDatas)}
             {isVariable && <span className="faded space-left">(Variable)</span>}
             {help && <HelpTooltip className="space-left">{help}</HelpTooltip>}
-            {validationError && (
-              <span className="font-error space-left">{validationError}</span>
-            )}
+            {validationError && <span className="font-error space-left">{validationError}</span>}
             {argInputVariable || argInput}
           </label>
         </div>
@@ -599,14 +571,12 @@ class TagEditor extends React.PureComponent<Props, State> {
               <DropdownItem
                 value={{ variable: false, argIndex }}
                 onClick={this._handleChangeArgVariable}>
-                <i className={'fa ' + (isVariable ? '' : 'fa-check')} /> Static
-                Value
+                <i className={'fa ' + (isVariable ? '' : 'fa-check')} /> Static Value
               </DropdownItem>
               <DropdownItem
                 value={{ variable: true, argIndex }}
                 onClick={this._handleChangeArgVariable}>
-                <i className={'fa ' + (isVariable ? 'fa-check' : '')} />{' '}
-                Environment Variable
+                <i className={'fa ' + (isVariable ? 'fa-check' : '')} /> Environment Variable
               </DropdownItem>
             </Dropdown>
           </div>
@@ -616,13 +586,7 @@ class TagEditor extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {
-      error,
-      preview,
-      activeTagDefinition,
-      activeTagData,
-      rendering
-    } = this.state;
+    const { error, preview, activeTagDefinition, activeTagData, rendering } = this.state;
 
     if (!activeTagData) {
       return null;
@@ -630,20 +594,11 @@ class TagEditor extends React.PureComponent<Props, State> {
 
     let previewElement;
     if (error) {
-      previewElement = (
-        <textarea
-          className="danger"
-          value={error || 'Error'}
-          readOnly
-          rows={5}
-        />
-      );
+      previewElement = <textarea className="danger" value={error || 'Error'} readOnly rows={5} />;
     } else if (rendering) {
       previewElement = <textarea value="rendering..." readOnly rows={5} />;
     } else {
-      previewElement = (
-        <textarea value={preview || 'error'} readOnly rows={5} />
-      );
+      previewElement = <textarea value={preview || 'error'} readOnly rows={5} />;
     }
 
     return (
@@ -656,9 +611,7 @@ class TagEditor extends React.PureComponent<Props, State> {
               onChange={this._handleChangeTag}
               value={activeTagDefinition ? activeTagDefinition.name : ''}>
               {this.state.tagDefinitions.map((tagDefinition, i) => (
-                <option
-                  key={`${i}::${tagDefinition.name}`}
-                  value={tagDefinition.name}>
+                <option key={`${i}::${tagDefinition.name}`} value={tagDefinition.name}>
                   {tagDefinition.displayName} – {tagDefinition.description}
                 </option>
               ))}
@@ -667,9 +620,8 @@ class TagEditor extends React.PureComponent<Props, State> {
           </label>
         </div>
         {activeTagDefinition &&
-          activeTagDefinition.args.map(
-            (argDefinition: NunjucksParsedTagArg, index) =>
-              this.renderArg(argDefinition, activeTagData.args, index)
+          activeTagDefinition.args.map((argDefinition: NunjucksParsedTagArg, index) =>
+            this.renderArg(argDefinition, activeTagData.args, index)
           )}
         {!activeTagDefinition && (
           <div className="form-control form-control--outlined">


### PR DESCRIPTION
I've added support for the file input to have a file type filter applied as well as the ability to select directories if allowed. 

Reasoning for this is to provide plugins the ability to have more complex capabilities such as looping through files in a directory or only allowing certain files to be selected.

Possible improvements would be to also allow option of multiple files to be selected.