### PR TITLE
[Documentation] Change issues link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ from the website.
 
 Have a bug or a feature request? First, read the 
 [issue guidelines](CONTRIBUTING.md#using-the-issue-tracker) and search for existing and 
-closed issues. If your problem or idea is not addressed yet, [please open a new issue](/issues).
+closed issues. If your problem or idea is not addressed yet, [please open a new issue](../../issues).
 
 For more generic product questions and feedback, join the [Slack Team](https://chat.insomnia.rest) or email 
 [support@insomnia.rest](mailto:support@insomnia.rest)


### PR DESCRIPTION
hi.
i think it should refer to `issues` page or it might be `](../../issues/new` in order to _open a new issue_


