### PR TITLE
Fix Python Requests Code generation

### DIFF
--- a/packages/insomnia-httpsnippet/src/targets/python/requests.js
+++ b/packages/insomnia-httpsnippet/src/targets/python/requests.js
@@ -24,7 +24,7 @@ module.exports = function(source, options) {
   code.push('url = "%s"', source.url).blank();
 
   // Construct query string
-  if (source.queryString.length) {
+  if (Object.keys(source.queryObj).length) {
     var qs = 'querystring = ' + JSON.stringify(source.queryObj);
 
     code.push(qs).blank();


### PR DESCRIPTION
Closes #1188

Currently the code generation with Python Requests is missing out query string variables specifed in the URL string

![image](https://user-images.githubusercontent.com/892961/46567059-f5561100-c95d-11e8-9dcd-e8d93eecf4e4.png)


New code fixes this and confirm it works with both query strings specified in URL and in query section editor
![image](https://user-images.githubusercontent.com/892961/46567168-b6758a80-c960-11e8-9bbf-687255c23d02.png)


