### PR TITLE
Fixes #994: Fix multipart code generation

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/generate-code-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/generate-code-modal.js
@@ -86,7 +86,7 @@ class GenerateCodeModal extends PureComponent {
     const { environmentId } = this.props;
     const har = await exportHarRequest(request._id, environmentId, addContentLength);
     const snippet = new HTTPSnippet(har);
-    const cmd = snippet.convert(target.key, client.key);
+    const cmd = await snippet.convert(target.key, client.key);
 
     this.setState({ request, cmd, client, target });
 
@@ -95,9 +95,9 @@ class GenerateCodeModal extends PureComponent {
     window.localStorage.setItem('insomnia::generateCode::target', JSON.stringify(target));
   }
 
-  show(request) {
+  async show(request) {
     const { client, target } = this.state;
-    this._generateCode(request, target, client);
+    await this._generateCode(request, target, client);
     this.modal.show();
   }
 

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -325,7 +325,7 @@ class App extends PureComponent {
     const environmentId = activeEnvironment ? activeEnvironment._id : 'n/a';
     const har = await exportHarRequest(request._id, environmentId);
     const snippet = new HTTPSnippet(har);
-    const cmd = snippet.convert('shell', 'curl');
+    const cmd = await snippet.convert('shell', 'curl');
     clipboard.writeText(cmd);
   }
 


### PR DESCRIPTION
Closes: https://github.com/getinsomnia/insomnia/issues/994

- Multipart code generation with multiple parameters did not have all parameters in the payload due to the asynchronous nature of `pipe` and the code not waiting for it to complete
- Added a promise and made the code wait for it to be resolved before continue
- Try to look for locations of `snippet.convert` and only found 1 other location so modified that as well

Scenario mentioned [in reporting issue](https://github.com/getinsomnia/insomnia/issues/994) now correctly returns both parameters in the payload

Wasn't too familiar with async and await stuff so open for feedback if I got anything wrong 😄 

![image](https://user-images.githubusercontent.com/892961/47262901-29692e80-d527-11e8-82b4-76f60207e012.png)
