### PR TITLE
[Documentation] Add insomnia-plugin-defaults to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Here is a list of plugins available for installation via NPM.
 - [Chance](https://www.npmjs.com/package/insomnia-plugin-chance) – Generates a random value using Chance.JS
 - [Custom Timestamp](https://www.npmjs.com/package/insomnia-plugin-customtimestamp) – Advanced timestamp creator
 - [Default Headers](https://www.npmjs.com/package/insomnia-plugin-default-headers) – Set default headers on requests
+- [Defaults](https://www.npmjs.com/package/insomnia-plugin-defaults) - Set request defaults through your environment
 - [Faker](https://www.npmjs.com/package/insomnia-plugin-faker) - Generate Faker data right within Insomnia!
 - [Github Apps](https://www.npmjs.com/package/insomnia-plugin-github-apps-helper) – Generates a JWT for auth with the GitHub API as your GitHub App
 - [Javascript Eval](https://www.npmjs.com/package/insomnia-plugin-js-eval) - Evaluate/run Javascript code


### PR DESCRIPTION
I created a plugin for adding default query parameters and headers (and hopefully more things in the future, hence the un-specific name for the plugin, and re-implementation of default headers). This PR adds this plugin to the README.

https://github.com/wwselleck/insomnia-plugin-defaults