### PR TITLE
Add keyboard shortcut to focus on response viewer

### DIFF
--- a/packages/insomnia-app/app/common/hotkeys.js
+++ b/packages/insomnia-app/app/common/hotkeys.js
@@ -156,6 +156,14 @@ export const FOCUS_FILTER: Hotkey = {
   keycode: keycodes.f
 };
 
+export const FOCUS_RESPONSE: Hotkey = {
+  description: 'Focus Response',
+  meta: true,
+  alt: false,
+  shift: false,
+  keycode: keycodes.singlequote
+};
+
 export const SHOW_COOKIES: Hotkey = {
   description: 'Edit Cookies',
   meta: true,

--- a/packages/insomnia-app/app/ui/components/settings/shortcuts.js
+++ b/packages/insomnia-app/app/ui/components/settings/shortcuts.js
@@ -34,6 +34,7 @@ class Shortcuts extends PureComponent {
             {this.renderHotkey(hotkeys.SHOW_ENVIRONMENTS)}
             {this.renderHotkey(hotkeys.TOGGLE_ENVIRONMENTS_MENU)}
             {this.renderHotkey(hotkeys.FOCUS_URL)}
+            {this.renderHotkey(hotkeys.FOCUS_RESPONSE)}
             {this.renderHotkey(hotkeys.TOGGLE_METHOD_DROPDOWN)}
             {this.renderHotkey(hotkeys.TOGGLE_SIDEBAR)}
             {this.renderHotkey(hotkeys.TOGGLE_HISTORY_DROPDOWN)}

--- a/packages/insomnia-app/app/ui/components/viewers/response-raw.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-raw.js
@@ -42,6 +42,18 @@ class ResponseRaw extends PureComponent {
     return false;
   }
 
+  focus() {
+    if (this._textarea) {
+      this._textarea.focus();
+    }
+  }
+
+  selectAll() {
+    if (this._textarea) {
+      this._textarea.select();
+    }
+  }
+
   render() {
     const { fontSize } = this.props;
     return (

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
@@ -49,6 +49,8 @@ type State = {
 
 @autobind
 class ResponseViewer extends React.Component<Props, State> {
+  _selectableView: any;
+
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -155,7 +157,7 @@ class ResponseViewer extends React.Component<Props, State> {
     return false;
   }
 
-  _setSelectableViewRef(n) {
+  _setSelectableViewRef(n: any) {
     this._selectableView = n;
   }
 
@@ -167,7 +169,7 @@ class ResponseViewer extends React.Component<Props, State> {
     );
   }
 
-  _handleKeyDown(e) {
+  _handleKeyDown(e: KeyboardEvent) {
     if (!this._isViewSelectable()) {
       return;
     }

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
@@ -16,6 +16,8 @@ import {
   PREVIEW_MODE_FRIENDLY,
   PREVIEW_MODE_RAW
 } from '../../../common/constants';
+import * as hotkeys from '../../../common/hotkeys';
+import KeydownBinder from '../keydown-binder';
 
 let alwaysShowLargeResponses = false;
 
@@ -153,7 +155,34 @@ class ResponseViewer extends React.Component<Props, State> {
     return false;
   }
 
-  render() {
+  _setSelectableViewRef(n) {
+    this._selectableView = n;
+  }
+
+  _isViewSelectable() {
+    return (
+      this._selectableView != null &&
+      typeof this._selectableView.focus === 'function' &&
+      typeof this._selectableView.selectAll === 'function'
+    );
+  }
+
+  _handleKeyDown(e) {
+    if (!this._isViewSelectable()) {
+      return;
+    }
+
+    hotkeys.executeHotKey(e, hotkeys.FOCUS_RESPONSE, () => {
+      if (!this._isViewSelectable()) {
+        return;
+      }
+
+      this._selectableView.focus();
+      this._selectableView.selectAll();
+    });
+  }
+
+  _renderView() {
     const {
       bytes,
       download,
@@ -328,6 +357,7 @@ class ResponseViewer extends React.Component<Props, State> {
       return (
         <ResponseRaw
           key={responseId}
+          ref={this._setSelectableViewRef}
           value={this._decodeIconv(bodyBuffer, charset)}
           fontSize={editorFontSize}
         />
@@ -351,6 +381,7 @@ class ResponseViewer extends React.Component<Props, State> {
       return (
         <CodeEditor
           uniquenessKey={responseId}
+          ref={this._setSelectableViewRef}
           onClickLink={this._handleOpenLink}
           defaultValue={body}
           updateFilter={updateFilter}
@@ -368,6 +399,10 @@ class ResponseViewer extends React.Component<Props, State> {
         />
       );
     }
+  }
+
+  render() {
+    return <KeydownBinder onKeydown={this._handleKeyDown}>{this._renderView()}</KeydownBinder>;
   }
 }
 


### PR DESCRIPTION
Closes: #737
I added a keyboard shortcut `Ctrl+'` that will set focus on `ResponseViewer` in `ResponsePane` and select all the text in it. Currently the supported view modes are `Visual Preview` for responses that are rendered as source (unlike CSV and image), `Source Code`, and `Raw Data`.
This is useful to quickly copy and paste responses of types JSON, XML, and raw formats without user clicking the response pane.
I think using `Ctrl+'` would suit well with `Ctrl+;` to focus on `BodyViewer` in `RequestPane` which may be added in the future :smile:.

![select_response](https://user-images.githubusercontent.com/13415249/48662367-c0d48980-eab3-11e8-8e96-41f3a69ae7a3.gif)

![tp-1](https://user-images.githubusercontent.com/13415249/48662233-d2b52d00-eab1-11e8-806f-726c5d2a3047.png)
