### PR TITLE
Add clean deleted responses task on startup, and add tests

### DIFF
--- a/packages/insomnia-app/app/models/__tests__/response.test.js
+++ b/packages/insomnia-app/app/models/__tests__/response.test.js
@@ -12,6 +12,11 @@ describe('migrate()', () => {
     jest.useFakeTimers();
   });
 
+  afterEach(async () => {
+    // Reset to real timers so that other test suites don't fail.
+    jest.useRealTimers();
+  });
+
   it('migrates utf8 body correctly', async () => {
     const initialModel = { body: 'hello world!', encoding: 'utf8' };
 
@@ -134,3 +139,80 @@ describe('migrate()', () => {
     ).toBe('zip');
   });
 });
+
+describe('cleanDeletedResponses()', function() {
+  beforeEach(globalBeforeEach);
+
+  it('deletes nothing if there is no files in directory', async function() {
+    fs.readdirSync = jest.fn().mockReturnValueOnce([]);
+    fs.unlinkSync = jest.fn();
+    await models.response.cleanDeletedResponses();
+    expect(fs.unlinkSync.mock.calls.length).toBe(0);
+  });
+
+  it('only deletes response files that are not in db', async () => {
+    const responsesDir = path.join(getDataDirectory(), 'responses');
+    let dbResponseIds = await createModels(responsesDir, 1);
+    let notDbResponseIds = [];
+    for (let index = 100; index < 101; index++) {
+      notDbResponseIds.push('res_' + index);
+    }
+
+    fs.readdirSync = jest.fn().mockReturnValueOnce([...dbResponseIds, ...notDbResponseIds]);
+    fs.unlinkSync = jest.fn();
+
+    await models.response.cleanDeletedResponses();
+
+    expect(fs.unlinkSync.mock.calls.length).toBe(notDbResponseIds.length);
+    Object.keys(notDbResponseIds).map(index => {
+      const resId = notDbResponseIds[index];
+      const bodyPath = path.join(responsesDir, resId);
+      expect(fs.unlinkSync.mock.calls[index][0]).toBe(bodyPath);
+    });
+  });
+});
+
+/**
+ * Create mock workspaces, requests, and responses as many as {@code count}.
+ * @param responsesDir
+ * @param count
+ * @returns {Promise<string[]>} the created response ids
+ */
+async function createModels(responsesDir, count) {
+  if (count < 1) {
+    return [];
+  }
+
+  let responseIds = [];
+
+  for (let index = 0; index < count; index++) {
+    const workspaceId = 'wrk_' + index;
+    const requestId = 'req_' + index;
+    const responseId = 'res_' + index;
+
+    await models.workspace.create({
+      _id: workspaceId,
+      created: 111,
+      modified: 222
+    });
+    await models.request.create({
+      _id: requestId,
+      parentId: workspaceId,
+      created: 111,
+      modified: 222,
+      metaSortKey: 0,
+      url: 'https://insomnia.rest'
+    });
+
+    await models.response.create({
+      _id: responseId,
+      parentId: requestId,
+      statusCode: 200,
+      body: 'foo',
+      bodyPath: path.join(responsesDir, responseId)
+    });
+    responseIds.push(responseId);
+  }
+
+  return responseIds;
+}

--- a/packages/insomnia-app/app/sync/index.js
+++ b/packages/insomnia-app/app/sync/index.js
@@ -106,6 +106,8 @@ export async function init() {
 
   _writeChangesInterval = setInterval(writePendingChanges, WRITE_PERIOD);
 
+  await models.response.cleanDeletedResponses();
+
   logger.debug('Initialized');
 }
 


### PR DESCRIPTION
Closes #1201
I add a function in `models.response` that will get all response files from responses directory. Then check whether each of them exists in the db. If no, then delete the file.
I batch each checks to the db by `MAX_RESPONSES` (currently 20) responses, on the assumption that there could be many files in the responses directory to be checked.
I also add tests for this function, but reasons I don't know yet, the `jest.useFakeTimers()` used in the `migrate()` test suite in the same file causes the subsequent suites' tests to timeout when they are calling async/await functions. Adding `jest.useRealTimers()` seems to solve it :smile:.