### PR TITLE
Display all request groups names in tag editor drop down

### DIFF
--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -409,6 +409,24 @@ class TagEditor extends React.PureComponent<Props, State> {
     );
   }
 
+  resolveRequestGroupPrefix(requestGroupId: string, allRequestGroups: Array<any>): string {
+    let prefix = '';
+    let reqGroup: any;
+
+    do {
+      // Get prefix from inner most request group.
+      reqGroup = allRequestGroups.find(rg => rg._id === requestGroupId);
+      if (reqGroup == null) {
+        break;
+      }
+      let name = typeof reqGroup.name === 'string' ? reqGroup.name : '';
+      prefix = `[${name}] ` + prefix;
+      requestGroupId = reqGroup.parentId;
+    } while (true);
+
+    return prefix;
+  }
+
   renderArgModel(value: string, modelType: string) {
     const { allDocs, loadingDocs } = this.state;
     const docs = allDocs[modelType] || [];
@@ -434,12 +452,9 @@ class TagEditor extends React.PureComponent<Props, State> {
             const request: any = requests.find(r => r._id === doc._id);
             const method = request && typeof request.method === 'string' ? request.method : 'GET';
             const parentId = request ? request.parentId : 'n/a';
-            const requestGroups = allDocs[models.requestGroup.type] || [];
-            const requestGroup: any = requestGroups.find(rg => rg._id === parentId);
-            const requestGroupName =
-              requestGroup && typeof requestGroup.name === 'string' ? requestGroup.name : '';
-            const requestGroupStr = requestGroupName ? `[${requestGroupName}] ` : '';
-            namePrefix = `${requestGroupStr + method} `;
+            const allRequestGroups = allDocs[models.requestGroup.type] || [];
+            const requestGroupPrefix = this.resolveRequestGroupPrefix(parentId, allRequestGroups);
+            namePrefix = `${requestGroupPrefix + method} `;
           }
 
           const docName = typeof doc.name === 'string' ? doc.name : 'Unknown Request';


### PR DESCRIPTION
Closes: #1286 
Added all the folders (request groups) names as prefix in tag editor dialog drop down.

![requests](https://user-images.githubusercontent.com/13415249/49593622-92f1af00-f9a6-11e8-90e8-9c2b898cfa58.png)
Request list

![dropdown](https://user-images.githubusercontent.com/13415249/49593773-eb28b100-f9a6-11e8-8b05-d43892b5c365.png)
Dropdown