### PR TITLE
Refresh CodeMirror editor when focused, and remove duplicate listener

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -132,7 +132,12 @@ class CodeEditor extends React.Component {
 
   focus() {
     if (this.codeMirror) {
-      this.codeMirror.focus();
+      // Refresh must happen when the editor is visible,
+      // so use nextTick to give time for it to be visible.
+      process.nextTick(() => {
+        this.codeMirror.refresh();
+        this.codeMirror.focus();
+      });
     }
   }
 
@@ -268,7 +273,6 @@ class CodeEditor extends React.Component {
 
     // Set default listeners
     const debounceMillis = typeof ms === 'number' ? ms : DEBOUNCE_MILLIS;
-    this.codeMirror.on('changes', misc.debounce(this._codemirrorValueChanged, debounceMillis));
     this.codeMirror.on('changes', misc.debounce(this._codemirrorValueChanged, debounceMillis));
     this.codeMirror.on('beforeChange', this._codemirrorValueBeforeChange);
     this.codeMirror.on('keydown', this._codemirrorKeyDown);

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -132,12 +132,13 @@ class CodeEditor extends React.Component {
 
   focus() {
     if (this.codeMirror) {
-      // Refresh must happen when the editor is visible,
-      // so use nextTick to give time for it to be visible.
-      process.nextTick(() => {
-        this.codeMirror.refresh();
-        this.codeMirror.focus();
-      });
+      this.codeMirror.focus();
+    }
+  }
+
+  refresh() {
+    if (this.codeMirror) {
+      this.codeMirror.refresh();
     }
   }
 

--- a/packages/insomnia-app/app/ui/components/response-pane.js
+++ b/packages/insomnia-app/app/ui/components/response-pane.js
@@ -141,7 +141,12 @@ class ResponsePane extends React.PureComponent<Props> {
 
   _handleTabSelect(index: number, lastIndex: number) {
     if (this._responseViewer != null && index === 0 && index !== lastIndex) {
-      this._responseViewer.focus();
+      // Fix for CodeMirror editor not updating its content.
+      // Refresh must be called when the editor is visible,
+      // so use nextTick to give time for it to be visible.
+      process.nextTick(() => {
+        this._responseViewer.refresh();
+      });
     }
   }
 

--- a/packages/insomnia-app/app/ui/components/response-pane.js
+++ b/packages/insomnia-app/app/ui/components/response-pane.js
@@ -55,6 +55,12 @@ type Props = {
 
 @autobind
 class ResponsePane extends React.PureComponent<Props> {
+  _responseViewer: any;
+
+  _setResponseViewerRef(n: any) {
+    this._responseViewer = n;
+  }
+
   _handleGetResponseBody(): Buffer | null {
     if (!this.props.response) {
       return null;
@@ -131,6 +137,12 @@ class ResponsePane extends React.PureComponent<Props> {
         });
       }
     });
+  }
+
+  _handleTabSelect(index: number, lastIndex: number) {
+    if (this._responseViewer != null && index === 0 && index !== lastIndex) {
+      this._responseViewer.focus();
+    }
   }
 
   render() {
@@ -242,7 +254,10 @@ class ResponsePane extends React.PureComponent<Props> {
             />
           </header>
         )}
-        <Tabs className={paneBodyClasses + ' react-tabs'} forceRenderTabPanel>
+        <Tabs
+          className={paneBodyClasses + ' react-tabs'}
+          onSelect={this._handleTabSelect}
+          forceRenderTabPanel>
           <TabList>
             <Tab>
               <PreviewModeDropdown
@@ -274,6 +289,7 @@ class ResponsePane extends React.PureComponent<Props> {
           </TabList>
           <TabPanel className="react-tabs__tab-panel">
             <ResponseViewer
+              ref={this._setResponseViewerRef}
               // Send larger one because legacy responses have bytesContent === -1
               responseId={response._id}
               bytes={Math.max(response.bytesContent, response.bytesRead)}

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
@@ -60,6 +60,12 @@ class ResponseViewer extends React.Component<Props, State> {
     };
   }
 
+  focus() {
+    if (this._isViewFocusable()) {
+      this._selectableView.focus();
+    }
+  }
+
   _decodeIconv(bodyBuffer: Buffer, charset: string): string {
     try {
       return iconv.decode(bodyBuffer, charset);
@@ -161,12 +167,12 @@ class ResponseViewer extends React.Component<Props, State> {
     this._selectableView = n;
   }
 
+  _isViewFocusable() {
+    return this._selectableView != null && typeof this._selectableView.focus === 'function';
+  }
+
   _isViewSelectable() {
-    return (
-      this._selectableView != null &&
-      typeof this._selectableView.focus === 'function' &&
-      typeof this._selectableView.selectAll === 'function'
-    );
+    return this._isViewFocusable() && typeof this._selectableView.selectAll === 'function';
   }
 
   _handleKeyDown(e: KeyboardEvent) {

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
@@ -60,9 +60,9 @@ class ResponseViewer extends React.Component<Props, State> {
     };
   }
 
-  focus() {
-    if (this._isViewFocusable()) {
-      this._selectableView.focus();
+  refresh() {
+    if (this._selectableView != null && typeof this._selectableView.refresh === 'function') {
+      this._selectableView.refresh();
     }
   }
 
@@ -167,12 +167,12 @@ class ResponseViewer extends React.Component<Props, State> {
     this._selectableView = n;
   }
 
-  _isViewFocusable() {
-    return this._selectableView != null && typeof this._selectableView.focus === 'function';
-  }
-
   _isViewSelectable() {
-    return this._isViewFocusable() && typeof this._selectableView.selectAll === 'function';
+    return (
+      this._selectableView != null &&
+      typeof this._selectableView.focus === 'function' &&
+      typeof this._selectableView.selectAll === 'function'
+    );
   }
 
   _handleKeyDown(e: KeyboardEvent) {


### PR DESCRIPTION
Closes: #1031
I added response pane tab select listener, then trigger CodeMirror editor refresh when it is selected. For the editor to be able to be refreshed it must be visible; but since the tab selection listener is triggered right before that, I used `process.nextTick()` to do the refresh.
I also removed a seemingly duplicate line that registers the same callback to CodeMirror, which causes the callback to be called twice everytime the editor's value is changed.