### PR TITLE
Highlight focused keyboard tab (#1299)

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
@@ -245,7 +245,6 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
         })
       );
 
-      console.log('FETCH SCHEMA');
       responsePatch = await network.send(introspectionRequest._id, environmentId);
       const bodyBuffer = models.response.getBodyBuffer(responsePatch);
 

--- a/packages/insomnia-app/app/ui/components/markdown-editor.js
+++ b/packages/insomnia-app/app/ui/components/markdown-editor.js
@@ -59,10 +59,10 @@ class MarkdownEditor extends PureComponent {
     return (
       <Tabs className={classes} defaultIndex={defaultPreviewMode ? 1 : 0}>
         <TabList>
-          <Tab>
+          <Tab tabIndex="-1">
             <Button value="Write">Write</Button>
           </Tab>
-          <Tab>
+          <Tab tabIndex="-1">
             <Button value="Preview">Preview</Button>
           </Tab>
         </TabList>

--- a/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.js
@@ -69,7 +69,7 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
     this.modal && this.modal.hide();
   }
 
-  async _saveChanges(cookieJar: CookieJar) {
+  static async _saveChanges(cookieJar: CookieJar) {
     await models.cookieJar.update(cookieJar);
   }
 
@@ -131,7 +131,7 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
 
     this.setState({ cookie });
 
-    await this._saveChanges(cookieJar);
+    await CookieModifyModal._saveChanges(cookieJar);
 
     return cookie;
   }
@@ -162,7 +162,7 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
     }, DEBOUNCE_MILLIS * 2);
   }
 
-  _capitalize(str: string) {
+  static _capitalize(str: string) {
     return str.charAt(0).toUpperCase() + str.slice(1);
   }
 
@@ -199,7 +199,7 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
     return (
       <div className="form-control form-control--outlined">
         <label>
-          {this._capitalize(field)} <span className="danger">{error}</span>
+          {CookieModifyModal._capitalize(field)} <span className="danger">{error}</span>
           <OneLineEditor
             render={handleRender}
             getRenderContext={handleGetRenderContext}
@@ -226,10 +226,10 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
             cookie && (
               <Tabs>
                 <TabList>
-                  <Tab>
+                  <Tab tabIndex="-1">
                     <button>Friendly</button>
                   </Tab>
-                  <Tab>
+                  <Tab tabIndex="-1">
                     <button>Raw</button>
                   </Tab>
                 </TabList>
@@ -254,7 +254,7 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
 
                       return (
                         <label key={i}>
-                          {this._capitalize(field)}
+                          {CookieModifyModal._capitalize(field)}
                           <input
                             className="space-left"
                             type="checkbox"

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.js
@@ -95,25 +95,25 @@ class SettingsModal extends PureComponent {
         <ModalBody noScroll>
           <Tabs className="react-tabs" defaultIndex={currentTabIndex}>
             <TabList>
-              <Tab>
+              <Tab tabIndex="-1">
                 <Button value="General">General</Button>
               </Tab>
-              <Tab>
+              <Tab tabIndex="-1">
                 <Button value="Import/Export">Data</Button>
               </Tab>
-              <Tab>
+              <Tab tabIndex="-1">
                 <Button value="Themes">Themes</Button>
               </Tab>
-              <Tab>
+              <Tab tabIndex="-1">
                 <Button value="Shortcuts">Keyboard</Button>
               </Tab>
-              <Tab>
+              <Tab tabIndex="-1">
                 <Button value="Account">Account</Button>
               </Tab>
-              <Tab>
+              <Tab tabIndex="-1">
                 <Button value="Plugins">Plugins</Button>
               </Tab>
-              <Tab>
+              <Tab tabIndex="-1">
                 <Button value="About">About</Button>
               </Tab>
             </TabList>

--- a/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.js
@@ -153,11 +153,11 @@ class WorkspaceSettingsModal extends React.PureComponent<Props, State> {
     this._handleToggleCertificateForm();
   }
 
-  async _handleDeleteCertificate(certificate: ClientCertificate) {
+  static async _handleDeleteCertificate(certificate: ClientCertificate) {
     await models.clientCertificate.remove(certificate);
   }
 
-  async _handleToggleCertificate(certificate: ClientCertificate) {
+  static async _handleToggleCertificate(certificate: ClientCertificate) {
     await models.clientCertificate.update(certificate, {
       disabled: !certificate.disabled
     });
@@ -222,7 +222,7 @@ class WorkspaceSettingsModal extends React.PureComponent<Props, State> {
             <button
               className="btn btn--super-compact width-auto"
               title="Enable or disable certificate"
-              onClick={() => this._handleToggleCertificate(certificate)}>
+              onClick={() => WorkspaceSettingsModal._handleToggleCertificate(certificate)}>
               {certificate.disabled ? (
                 <i className="fa fa-square-o" />
               ) : (
@@ -233,7 +233,7 @@ class WorkspaceSettingsModal extends React.PureComponent<Props, State> {
               className="btn btn--super-compact width-auto"
               confirmMessage=" "
               addIcon
-              onClick={() => this._handleDeleteCertificate(certificate)}>
+              onClick={() => WorkspaceSettingsModal._handleDeleteCertificate(certificate)}>
               <i className="fa fa-trash-o" />
             </PromptButton>
           </div>
@@ -273,10 +273,10 @@ class WorkspaceSettingsModal extends React.PureComponent<Props, State> {
       <ModalBody key={`body::${workspace._id}`} noScroll>
         <Tabs forceRenderTabPanel className="react-tabs">
           <TabList>
-            <Tab>
+            <Tab tabIndex="-1">
               <button>Overview</button>
             </Tab>
-            <Tab>
+            <Tab tabIndex="-1">
               <button>Client Certificates</button>
             </Tab>
           </TabList>

--- a/packages/insomnia-app/app/ui/components/request-pane.js
+++ b/packages/insomnia-app/app/ui/components/request-pane.js
@@ -254,7 +254,7 @@ class RequestPane extends React.PureComponent<Props> {
         </header>
         <Tabs className={paneBodyClasses + ' react-tabs'} forceRenderTabPanel>
           <TabList>
-            <Tab>
+            <Tab tabIndex="-1">
               <ContentTypeDropdown
                 onChange={updateRequestMimeType}
                 contentType={request.body.mimeType}
@@ -267,7 +267,7 @@ class RequestPane extends React.PureComponent<Props> {
                 <i className="fa fa-caret-down space-left" />
               </ContentTypeDropdown>
             </Tab>
-            <Tab>
+            <Tab tabIndex="-1">
               <AuthDropdown
                 onChange={updateRequestAuthentication}
                 authentication={request.authentication}
@@ -276,19 +276,19 @@ class RequestPane extends React.PureComponent<Props> {
                 <i className="fa fa-caret-down space-left" />
               </AuthDropdown>
             </Tab>
-            <Tab>
+            <Tab tabIndex="-1">
               <button>
                 Query
                 {numParameters > 0 && <span className="bubble space-left">{numParameters}</span>}
               </button>
             </Tab>
-            <Tab>
+            <Tab tabIndex="-1">
               <button>
                 Header
                 {numHeaders > 0 && <span className="bubble space-left">{numHeaders}</span>}
               </button>
             </Tab>
-            <Tab>
+            <Tab tabIndex="-1">
               <button>
                 Docs
                 {request.description && (

--- a/packages/insomnia-app/app/ui/components/response-pane.js
+++ b/packages/insomnia-app/app/ui/components/response-pane.js
@@ -244,7 +244,7 @@ class ResponsePane extends React.PureComponent<Props> {
         )}
         <Tabs className={paneBodyClasses + ' react-tabs'} forceRenderTabPanel>
           <TabList>
-            <Tab>
+            <Tab tabIndex="-1">
               <PreviewModeDropdown
                 download={this._handleDownloadResponseBody}
                 fullDownload={this._handleDownloadFullResponseBody}
@@ -252,7 +252,7 @@ class ResponsePane extends React.PureComponent<Props> {
                 updatePreviewMode={handleSetPreviewMode}
               />
             </Tab>
-            <Tab>
+            <Tab tabIndex="-1">
               <Button>
                 Header{' '}
                 {response.headers.length > 0 && (
@@ -260,7 +260,7 @@ class ResponsePane extends React.PureComponent<Props> {
                 )}
               </Button>
             </Tab>
-            <Tab>
+            <Tab tabIndex="-1">
               <Button>
                 Cookie{' '}
                 {cookieHeaders.length ? (
@@ -268,7 +268,7 @@ class ResponsePane extends React.PureComponent<Props> {
                 ) : null}
               </Button>
             </Tab>
-            <Tab>
+            <Tab tabIndex="-1">
               <Button>Timeline</Button>
             </Tab>
           </TabList>

--- a/packages/insomnia-app/app/ui/css/components/tabs.less
+++ b/packages/insomnia-app/app/ui/css/components/tabs.less
@@ -2,6 +2,7 @@
 @import '../constants/dimensions';
 
 @border-color: var(--hl-md);
+@focus-color: var(--hl-md);
 
 .react-tabs {
   width: 100%;
@@ -108,6 +109,10 @@
 
     &:not(.react-tabs__tab--selected) .dropdown i.fa {
       opacity: @opacity-super-subtle;
+    }
+
+    &.react-tabs__tab--selected:focus {
+      background-color: @focus-color;
     }
 
     &.react-tabs__tab--selected {

--- a/packages/insomnia-app/app/ui/css/components/tabs.less
+++ b/packages/insomnia-app/app/ui/css/components/tabs.less
@@ -115,6 +115,10 @@
       background-color: @focus-color;
     }
 
+    &.react-tabs__tab button:focus {
+      text-decoration: underline;
+    }
+
     &.react-tabs__tab--selected {
       border: 1px solid @border-color;
       border-bottom-color: transparent;


### PR DESCRIPTION
Closes #1299 .

Before change (focused on Overview tab via keyboard):

![image](https://user-images.githubusercontent.com/2874305/49838624-25140180-fd71-11e8-9938-20cbfd885c11.png)

After change:

![image](https://user-images.githubusercontent.com/2874305/49838637-33621d80-fd71-11e8-921f-a84034f0f2ef.png)

The tab is only highlighted when focused via the keyboard, else it appears as it does with current implementation.