### PR TITLE
Fixes #1257: Fix undefined id causing improper import

### DIFF
--- a/packages/insomnia-importers/src/importers/swagger2.js
+++ b/packages/insomnia-importers/src/importers/swagger2.js
@@ -122,8 +122,9 @@ function parseEndpoints(document) {
     let { tags } = endpointSchema;
     if (!tags || tags.length == 0) tags = [''];
     tags.forEach((tag, index) => {
-      let id =
-        endpointSchema.operationId + (index > 0 ? index : '') || `__REQUEST_${requestCount++}__`;
+      let id = endpointSchema.operationId
+        ? `${endpointSchema.operationId}${index > 0 ? index : ''}`
+        : `__REQUEST_${requestCount++}__`;
       let parentId = folderLookup[tag] || defaultParent;
       requests.push(importRequest(endpointSchema, globalMimeTypes, id, parentId));
     });


### PR DESCRIPTION
When `endpointSchema.operationId` is undefined it causes `endpointSchema.operationId + (index > 0 ? index : '')` to evaluate to a string of **text value** `undefined`

That caused all requests to have the same `id` and thus new endpoints overwrote an existing one when it shouldn't have

