### PR TITLE
New data models for hotkeys and store the key bindings in settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1785,7 +1785,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -1916,7 +1916,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1929,7 +1929,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2036,7 +2036,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -2329,7 +2329,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
@@ -3291,7 +3291,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -6129,7 +6129,7 @@
     },
     "jsesc": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
@@ -6159,7 +6159,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -8315,7 +8315,7 @@
     },
     "resolve": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
@@ -9736,7 +9736,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/packages/insomnia-app/app/common/constants.js
+++ b/packages/insomnia-app/app/common/constants.js
@@ -71,10 +71,11 @@ export const PLUGIN_PATH = path.join(getDataDirectory(), 'plugins');
 
 // Hotkeys
 export const MNEMONIC_SYM = isMac() ? '' : '&';
-export const MOD_SYM = isMac() ? '⌘' : 'Ctrl';
-export const ALT_SYM = isMac() ? '⌃' : 'Alt';
-export const SHIFT_SYM = isMac() ? '⇧' : 'Shift';
 export const CTRL_SYM = isMac() ? '⌃' : 'Ctrl';
+export const ALT_SYM = isMac() ? '⌥' : 'Alt';
+export const SHIFT_SYM = isMac() ? '⇧' : 'Shift';
+export const META_SYM = isMac() ? '⌘' : 'Super';
+
 export function joinHotKeys(keys) {
   return keys.join(isMac() ? '' : '+');
 }

--- a/packages/insomnia-app/app/common/hotkeys-listener.js
+++ b/packages/insomnia-app/app/common/hotkeys-listener.js
@@ -1,0 +1,59 @@
+// @flow
+import type { HotKeyDefinition, KeyBindings } from './hotkeys';
+import { getPlatformKeyCombinations } from './hotkeys';
+import * as models from '../models';
+
+function _pressedHotKey(e: KeyboardEvent, bindings: KeyBindings): boolean {
+  const isCtrlPressed = e.ctrlKey;
+  const isAltPressed = e.altKey;
+  const isShiftPressed = e.shiftKey;
+  const isMetaPressed = e.metaKey;
+  const keyCombList = getPlatformKeyCombinations(bindings);
+
+  for (const keyComb of keyCombList) {
+    const { ctrl, alt, shift, meta, keyCode } = keyComb;
+
+    if ((ctrl && !isCtrlPressed) || (!ctrl && isCtrlPressed)) {
+      continue;
+    }
+
+    if ((alt && !isAltPressed) || (!alt && isAltPressed)) {
+      continue;
+    }
+
+    if ((shift && !isShiftPressed) || (!shift && isShiftPressed)) {
+      continue;
+    }
+
+    if ((meta && !isMetaPressed) || (!meta && isMetaPressed)) {
+      continue;
+    }
+
+    if (keyCode !== e.keyCode) {
+      continue;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+export async function pressedHotKey(
+  e: KeyboardEvent,
+  definition: HotKeyDefinition,
+): Promise<boolean> {
+  const settings = await models.settings.getOrCreate();
+  return _pressedHotKey(e, settings.hotKeyRegistry[definition.id]);
+}
+
+export async function executeHotKey(
+  e: KeyboardEvent,
+  definition: HotKeyDefinition,
+  callback: Function,
+): Promise<void> {
+  const settings = await models.settings.getOrCreate();
+  if (_pressedHotKey(e, settings.hotKeyRegistry[definition.id])) {
+    callback();
+  }
+}

--- a/packages/insomnia-app/app/common/hotkeys-listener.js
+++ b/packages/insomnia-app/app/common/hotkeys-listener.js
@@ -39,6 +39,12 @@ function _pressedHotKey(e: KeyboardEvent, bindings: KeyBindings): boolean {
   return false;
 }
 
+/**
+ * Check whether a hotkey has been pressed.
+ * @param e the activated keyboard event.
+ * @param definition the hotkey definition being checked.
+ * @returns {Promise<boolean>}
+ */
 export async function pressedHotKey(
   e: KeyboardEvent,
   definition: HotKeyDefinition,
@@ -47,6 +53,13 @@ export async function pressedHotKey(
   return _pressedHotKey(e, settings.hotKeyRegistry[definition.id]);
 }
 
+/**
+ * Call callback if the hotkey has been pressed.
+ * @param e the activated keyboard event.
+ * @param definition the hotkey definition being checked.
+ * @param callback to be called if the hotkey has been activated.
+ * @returns {Promise<void>}
+ */
 export async function executeHotKey(
   e: KeyboardEvent,
   definition: HotKeyDefinition,

--- a/packages/insomnia-app/app/common/hotkeys.js
+++ b/packages/insomnia-app/app/common/hotkeys.js
@@ -1,305 +1,378 @@
 // @flow
 import keycodes from './keycodes';
-import { isMac } from './constants';
+import { isMac, isWindows } from './constants';
 
-export type Hotkey = {
+export type HotKeyDefinition = {
+  id: string,
   description: string,
-  meta: boolean,
+};
+
+export type KeyCombination = {
+  ctrl: boolean,
   alt: boolean,
   shift: boolean,
-  keycode: number | Array<number>,
-  metaIsCtrl?: boolean,
+  meta: boolean,
+  keyCode: number,
 };
 
-export const SHOW_WORKSPACE_SETTINGS: Hotkey = {
-  description: 'Show Workspace Settings',
-  meta: true,
-  alt: false,
-  shift: true,
-  keycode: keycodes.comma,
+type GenericKeyCombination = {
+  ctrlOrCmd: boolean,
+  alt: boolean,
+  shift: boolean,
+  winOrCtrl: boolean,
+  keyCode: number,
 };
 
-export const SHOW_REQUEST_SETTINGS: Hotkey = {
-  description: 'Show Request Settings',
-  meta: true,
-  alt: true,
-  shift: true,
-  keycode: keycodes.comma,
+export type KeyBindings = {
+  macKeys: Array<KeyCombination>,
+  winKeys: Array<KeyCombination>,
+  linuxKeys: Array<KeyCombination>,
 };
 
-export const SHOW_KEYBOARD_SHORTCUTS: Hotkey = {
-  description: 'Show Keyboard Shortcuts',
-  meta: true,
-  alt: false,
-  shift: true,
-  keycode: keycodes.forwardslash,
+export type HotKeyRegistry = {
+  [refId: string]: KeyBindings,
 };
 
-export const SHOW_SETTINGS: Hotkey = {
-  description: 'Show App Preferences',
-  meta: true,
-  alt: false,
-  shift: false,
-  keycode: keycodes.comma,
-};
-
-export const TOGGLE_MAIN_MENU: Hotkey = {
-  description: 'Toggle Main Menu',
-  meta: true,
-  alt: true,
-  shift: false,
-  keycode: keycodes.comma,
-};
-
-export const TOGGLE_SIDEBAR: Hotkey = {
-  description: 'Toggle Sidebar',
-  meta: true,
-  alt: false,
-  shift: false,
-  keycode: keycodes.backslash,
-};
-
-export const SHOW_QUICK_SWITCHER: Hotkey = {
-  description: 'Switch Requests',
-  meta: true,
-  alt: false,
-  shift: false,
-  keycode: keycodes.p,
-};
-
-export const RELOAD_PLUGINS: Hotkey = {
-  description: 'Reload Plugins',
-  meta: true,
-  alt: false,
-  shift: true,
-  keycode: keycodes.r,
-};
-
-export const SHOW_AUTOCOMPLETE: Hotkey = {
-  description: 'Show Autocomplete',
-  meta: true,
-  metaIsCtrl: true,
-  alt: false,
-  shift: false,
-  keycode: keycodes.space,
-};
-
-export const SEND_REQUEST: Hotkey = {
-  description: 'Send Request',
-  meta: true,
-  alt: false,
-  shift: false,
-  keycode: [keycodes.enter, keycodes.r],
-};
-
-export const SEND_REQUEST_F5: Hotkey = {
-  description: 'Send Request',
-  meta: false,
-  alt: false,
-  shift: false,
-  keycode: keycodes.f5,
-};
-
-export const SHOW_SEND_OPTIONS: Hotkey = {
-  description: 'Send Request (Options)',
-  meta: true,
-  alt: false,
-  shift: true,
-  keycode: keycodes.enter,
-};
-
-export const SHOW_ENVIRONMENTS: Hotkey = {
-  description: 'Show Environment Editor',
-  meta: true,
-  alt: false,
-  shift: false,
-  keycode: keycodes.e,
-};
-
-export const TOGGLE_ENVIRONMENTS_MENU: Hotkey = {
-  description: 'Switch Environments',
-  meta: true,
-  alt: false,
-  shift: true,
-  keycode: keycodes.e,
-};
-
-export const TOGGLE_METHOD_DROPDOWN: Hotkey = {
-  description: 'Change HTTP Method',
-  meta: true,
-  alt: false,
-  shift: true,
-  keycode: keycodes.l,
-};
-
-export const TOGGLE_HISTORY_DROPDOWN: Hotkey = {
-  description: 'Show Request History',
-  meta: true,
-  alt: false,
-  shift: true,
-  keycode: keycodes.h,
-};
-
-export const FOCUS_URL: Hotkey = {
-  description: 'Focus URL',
-  meta: true,
-  alt: false,
-  shift: false,
-  keycode: keycodes.l,
-};
-
-export const GENERATE_CODE: Hotkey = {
-  description: 'Generate Code',
-  meta: true,
-  alt: false,
-  shift: true,
-  keycode: keycodes.g,
-};
-
-export const FOCUS_FILTER: Hotkey = {
-  description: 'Filter Sidebar',
-  meta: true,
-  alt: false,
-  shift: true,
-  keycode: keycodes.f,
-};
-
-export const FOCUS_RESPONSE: Hotkey = {
-  description: 'Focus Response',
-  meta: true,
-  alt: false,
-  shift: false,
-  keycode: keycodes.singlequote,
-};
-
-export const SHOW_COOKIES: Hotkey = {
-  description: 'Edit Cookies',
-  meta: true,
-  alt: false,
-  shift: false,
-  keycode: keycodes.k,
-};
-
-export const CREATE_REQUEST: Hotkey = {
-  description: 'Create Request',
-  meta: true,
-  alt: false,
-  shift: false,
-  keycode: keycodes.n,
-};
-
-export const DELETE_REQUEST: Hotkey = {
-  description: 'Delete Request',
-  meta: true,
-  alt: false,
-  shift: true,
-  keycode: keycodes.delete,
-};
-
-export const CREATE_FOLDER: Hotkey = {
-  description: 'Create Folder',
-  meta: true,
-  alt: false,
-  shift: true,
-  keycode: keycodes.n,
-};
-
-export const DUPLICATE_REQUEST: Hotkey = {
-  description: 'Duplicate Request',
-  meta: true,
-  alt: false,
-  shift: false,
-  keycode: keycodes.d,
-};
-
-export const CLOSE_DROPDOWN: Hotkey = {
-  description: 'Close Dropdown',
-  meta: false,
-  alt: false,
-  shift: false,
-  keycode: keycodes.esc,
-};
-
-export const CLOSE_MODAL: Hotkey = {
-  description: 'Close Modal',
-  meta: false,
-  alt: false,
-  shift: false,
-  keycode: keycodes.esc,
-};
-
-export const UNCOVER_VARIABLES: Hotkey = {
-  description: 'Uncover Variables',
-  meta: false,
-  alt: true,
-  shift: true,
-  keycode: keycodes.u,
-};
-
-export function pressedHotKey(e: KeyboardEvent, definition: Hotkey): boolean {
-  const isMetaPressed = isMac() ? e.metaKey : e.ctrlKey;
-  const isAltPressed = isMac() ? e.ctrlKey : e.altKey;
-  const isShiftPressed = e.shiftKey;
-
-  const { meta, alt, shift, keycode } = definition;
-  const codes = Array.isArray(keycode) ? keycode : [keycode];
-
-  for (const code of codes) {
-    if ((alt && !isAltPressed) || (!alt && isAltPressed)) {
-      continue;
-    }
-
-    if ((meta && !isMetaPressed) || (!meta && isMetaPressed)) {
-      continue;
-    }
-
-    if ((shift && !isShiftPressed) || (!shift && isShiftPressed)) {
-      continue;
-    }
-
-    if (code !== e.keyCode) {
-      continue;
-    }
-
-    return true;
-  }
-
-  return false;
+function defineHotKey(id: string, description: string): HotKeyDefinition {
+  return {
+    id: id,
+    description: description,
+  };
 }
 
-export function executeHotKey(e: KeyboardEvent, definition: Hotkey, callback: Function): void {
-  if (pressedHotKey(e, definition)) {
-    callback();
-  }
+function keyComb(
+  ctrl: boolean,
+  alt: boolean,
+  shift: boolean,
+  meta: boolean,
+  keyCode: number,
+): KeyCombination {
+  return {
+    ctrl: ctrl,
+    alt: alt,
+    shift: shift,
+    meta: meta,
+    keyCode: keyCode,
+  };
 }
 
-export function getChar(hotkey: Hotkey) {
-  const codes = Array.isArray(hotkey.keycode) ? hotkey.keycode : [hotkey.keycode];
-  const chars = [];
+function genericKeyComb(
+  ctrlOrCmd: boolean,
+  alt: boolean,
+  shift: boolean,
+  winOrCtrl: boolean,
+  keyCode: number,
+): GenericKeyCombination {
+  return {
+    ctrlOrCmd: ctrlOrCmd,
+    alt: alt,
+    shift: shift,
+    winOrCtrl: winOrCtrl,
+    keyCode: keyCode,
+  };
+}
 
-  for (const keycode of codes) {
-    const v = Object.keys(keycodes).find(k => keycodes[k] === keycode);
+function toSpecificKeyCombs(
+  isMac: boolean,
+  generic: Array<GenericKeyCombination>,
+): Array<KeyCombination> {
+  let keyCombs: Array<KeyCombination> = [];
 
-    if (!v) {
-      console.error('Invalid hotkey', hotkey);
-    } else if (v.toUpperCase() === 'ENTER') {
-      chars.push('Enter');
-    } else if (v.toUpperCase() === 'DELETE') {
-      chars.push('Delete');
-    } else if (v.toUpperCase() === 'COMMA') {
-      chars.push(',');
-    } else if (v.toUpperCase() === 'BACKSLASH') {
-      chars.push('\\');
-    } else if (v.toUpperCase() === 'FORWARDSLASH') {
-      chars.push('/');
-    } else if (v.toUpperCase() === 'SINGLEQUOTE') {
-      chars.push("'");
-    } else if (v.toUpperCase() === 'SPACE') {
-      chars.push('Space');
+  generic.forEach(genKeyComb => {
+    let keyComb: KeyCombination;
+    if (isMac) {
+      keyComb = {
+        ctrl: genKeyComb.winOrCtrl,
+        alt: genKeyComb.alt,
+        shift: genKeyComb.shift,
+        meta: genKeyComb.ctrlOrCmd,
+        keyCode: genKeyComb.keyCode,
+      };
     } else {
-      chars.push(v.toUpperCase());
+      keyComb = {
+        ctrl: genKeyComb.ctrlOrCmd,
+        alt: genKeyComb.alt,
+        shift: genKeyComb.shift,
+        meta: genKeyComb.winOrCtrl,
+        keyCode: genKeyComb.keyCode,
+      };
+    }
+    keyCombs.push(keyComb);
+  });
+
+  return keyCombs;
+}
+
+function keyBinds(
+  generic: GenericKeyCombination | Array<GenericKeyCombination>,
+  mac?: KeyCombination | Array<KeyCombination>,
+  win?: KeyCombination | Array<KeyCombination>,
+  linux?: KeyCombination | Array<KeyCombination>,
+): KeyBindings {
+  if (!Array.isArray(generic)) {
+    generic = [generic];
+  }
+
+  if (mac == null) {
+    mac = toSpecificKeyCombs(true, generic);
+  } else if (!Array.isArray(mac)) {
+    mac = [mac];
+  }
+
+  if (win == null) {
+    win = toSpecificKeyCombs(false, generic);
+  } else if (!Array.isArray(win)) {
+    win = [win];
+  }
+
+  if (linux == null) {
+    linux = toSpecificKeyCombs(false, generic);
+  } else if (!Array.isArray(linux)) {
+    linux = [linux];
+  }
+
+  return {
+    macKeys: mac,
+    winKeys: win,
+    linuxKeys: linux,
+  };
+}
+
+// Not using dot, because NeDB prohibits field names to contain dots.
+export const hotKeyRefs = {
+  WORKSPACE_SHOW_SETTINGS: defineHotKey('workspace_showSettings', 'Show Workspace Settings'),
+
+  REQUEST_SHOW_SETTINGS: defineHotKey('request_showSettings', 'Show Request Settings'),
+
+  PREFERENCES_SHOW_KEYBOARD_SHORTCUTS: defineHotKey(
+    'preferences_showKeyboardShortcuts',
+    'Show Keyboard Shortcuts',
+  ),
+
+  PREFERENCES_SHOW_GENERAL: defineHotKey('preferences_showGeneral', 'Show App Preferences'),
+
+  TOGGLE_MAIN_MENU: defineHotKey('toggleMainMenu', 'Toggle Main Menu'),
+
+  SIDEBAR_TOGGLE: defineHotKey('sidebar_toggle', 'Toggle Sidebar'),
+
+  REQUEST_QUICK_SWITCH: defineHotKey('request_quickSwitch', 'Switch Requests'),
+
+  PLUGIN_RELOAD: defineHotKey('plugin_reload', 'Reload Plugins'),
+
+  SHOW_AUTOCOMPLETE: defineHotKey('showAutocomplete', 'Show Autocomplete'),
+
+  REQUEST_SEND: defineHotKey('request_send', 'Send Request'),
+
+  REQUEST_SHOW_OPTIONS: defineHotKey('request_showOptions', 'Send Request (Options)'),
+
+  ENVIRONMENT_SHOW_EDITOR: defineHotKey('environment_showEditor', 'Show Environment Editor'),
+
+  ENVIRONMENT_SHOW_SWITCH_MENU: defineHotKey('environment_showSwitchMenu', 'Switch Environments'),
+
+  REQUEST_TOGGLE_HTTP_METHOD_MENU: defineHotKey(
+    'request_toggleHttpMethodMenu',
+    'Change HTTP Method',
+  ),
+
+  REQUEST_TOGGLE_HISTORY: defineHotKey('request_toggleHistory', 'Show Request History'),
+
+  REQUEST_FOCUS_URL: defineHotKey('request_focusUrl', 'Focus URL'),
+
+  REQUEST_SHOW_GENERATE_CODE_EDITOR: defineHotKey(
+    'request_showGenerateCodeEditor',
+    'Generate Code',
+  ),
+
+  SIDEBAR_FOCUS_FILTER: defineHotKey('sidebar_focusFilter', 'Filter Sidebar'),
+
+  RESPONSE_FOCUS: defineHotKey('response_focus', 'Focus Response'),
+
+  SHOW_COOKIES_EDITOR: defineHotKey('showCookiesEditor', 'Edit Cookies'),
+
+  REQUEST_SHOW_CREATE: defineHotKey('request_showCreate', 'Create Request'),
+
+  REQUEST_SHOW_DELETE: defineHotKey('request_showDelete', 'Delete Request'),
+
+  REQUEST_SHOW_CREATE_FOLDER: defineHotKey('request_showCreateFolder', 'Create Folder'),
+
+  REQUEST_SHOW_DUPLICATE: defineHotKey('request_showDuplicate', 'Duplicate Request'),
+
+  CLOSE_DROPDOWN: defineHotKey('closeDropdown', 'Close Dropdown'),
+
+  CLOSE_MODAL: defineHotKey('closeModal', 'Close Modal'),
+
+  ENVIRONMENT_UNCOVER_VARIABLES: defineHotKey('environment_uncoverVariables', 'Uncover Variables'),
+};
+
+const defaultRegistry: HotKeyRegistry = {
+  [hotKeyRefs.WORKSPACE_SHOW_SETTINGS.id]: keyBinds(
+    genericKeyComb(true, false, true, false, keycodes.comma),
+  ),
+
+  [hotKeyRefs.REQUEST_SHOW_SETTINGS.id]: keyBinds(
+    genericKeyComb(true, true, true, false, keycodes.comma),
+  ),
+
+  [hotKeyRefs.PREFERENCES_SHOW_KEYBOARD_SHORTCUTS.id]: keyBinds(
+    genericKeyComb(true, false, true, false, keycodes.forwardslash),
+  ),
+
+  [hotKeyRefs.PREFERENCES_SHOW_GENERAL.id]: keyBinds(
+    genericKeyComb(true, false, false, false, keycodes.comma),
+  ),
+
+  [hotKeyRefs.TOGGLE_MAIN_MENU.id]: keyBinds(
+    genericKeyComb(true, true, false, false, keycodes.comma),
+  ),
+
+  [hotKeyRefs.SIDEBAR_TOGGLE.id]: keyBinds(
+    genericKeyComb(true, false, false, false, keycodes.backslash),
+  ),
+
+  [hotKeyRefs.REQUEST_QUICK_SWITCH.id]: keyBinds(
+    genericKeyComb(true, false, false, false, keycodes.p),
+  ),
+
+  [hotKeyRefs.PLUGIN_RELOAD.id]: keyBinds(genericKeyComb(true, false, true, false, keycodes.r)),
+
+  [hotKeyRefs.SHOW_AUTOCOMPLETE.id]: keyBinds(
+    genericKeyComb(true, false, false, false, keycodes.space),
+    keyComb(true, false, false, false, keycodes.space),
+  ),
+
+  [hotKeyRefs.REQUEST_SEND.id]: keyBinds([
+    genericKeyComb(true, false, false, false, keycodes.enter),
+    genericKeyComb(true, false, false, false, keycodes.r),
+    genericKeyComb(false, false, false, false, keycodes.f5),
+  ]),
+
+  [hotKeyRefs.REQUEST_SHOW_OPTIONS.id]: keyBinds(
+    genericKeyComb(true, false, true, false, keycodes.enter),
+  ),
+
+  [hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]: keyBinds(
+    genericKeyComb(true, false, false, false, keycodes.e),
+  ),
+
+  [hotKeyRefs.ENVIRONMENT_SHOW_SWITCH_MENU.id]: keyBinds(
+    genericKeyComb(true, false, true, false, keycodes.e),
+  ),
+
+  [hotKeyRefs.REQUEST_TOGGLE_HTTP_METHOD_MENU.id]: keyBinds(
+    genericKeyComb(true, false, true, false, keycodes.l),
+  ),
+
+  [hotKeyRefs.REQUEST_TOGGLE_HISTORY.id]: keyBinds(
+    genericKeyComb(true, false, true, false, keycodes.h),
+  ),
+
+  [hotKeyRefs.REQUEST_FOCUS_URL.id]: keyBinds(
+    genericKeyComb(true, false, false, false, keycodes.l),
+  ),
+
+  [hotKeyRefs.REQUEST_SHOW_GENERATE_CODE_EDITOR.id]: keyBinds(
+    genericKeyComb(true, false, true, false, keycodes.g),
+  ),
+
+  [hotKeyRefs.SIDEBAR_FOCUS_FILTER.id]: keyBinds(
+    genericKeyComb(true, false, true, false, keycodes.f),
+  ),
+
+  [hotKeyRefs.RESPONSE_FOCUS.id]: keyBinds(
+    genericKeyComb(true, false, false, false, keycodes.singlequote),
+  ),
+
+  [hotKeyRefs.SHOW_COOKIES_EDITOR.id]: keyBinds(
+    genericKeyComb(true, false, false, false, keycodes.k),
+  ),
+
+  [hotKeyRefs.REQUEST_SHOW_CREATE.id]: keyBinds(
+    genericKeyComb(true, false, false, false, keycodes.n),
+  ),
+
+  [hotKeyRefs.REQUEST_SHOW_DELETE.id]: keyBinds(
+    genericKeyComb(true, false, true, false, keycodes.delete),
+  ),
+
+  [hotKeyRefs.REQUEST_SHOW_CREATE_FOLDER.id]: keyBinds(
+    genericKeyComb(true, false, true, false, keycodes.n),
+  ),
+
+  [hotKeyRefs.REQUEST_SHOW_DUPLICATE.id]: keyBinds(
+    genericKeyComb(true, false, false, false, keycodes.d),
+  ),
+
+  [hotKeyRefs.CLOSE_DROPDOWN.id]: keyBinds(
+    genericKeyComb(false, false, false, false, keycodes.esc),
+  ),
+
+  [hotKeyRefs.CLOSE_MODAL.id]: keyBinds(genericKeyComb(false, false, false, false, keycodes.esc)),
+
+  [hotKeyRefs.ENVIRONMENT_UNCOVER_VARIABLES.id]: keyBinds(
+    genericKeyComb(false, true, true, false, keycodes.u),
+  ),
+};
+
+function copyKeyCombs(sources: Array<KeyCombination>): Array<KeyCombination> {
+  let targets: Array<KeyCombination> = [];
+  sources.forEach(keyComb => {
+    targets.push(Object.assign({}, keyComb));
+  });
+  return targets;
+}
+
+export function newDefaultRegistry() {
+  let newDefaults: HotKeyRegistry = {};
+  for (const refId in defaultRegistry) {
+    if (!defaultRegistry.hasOwnProperty(refId)) {
+      continue;
+    }
+    const keyBindings: KeyBindings = defaultRegistry[refId];
+    newDefaults[refId] = {
+      macKeys: copyKeyCombs(keyBindings.macKeys),
+      winKeys: copyKeyCombs(keyBindings.winKeys),
+      linuxKeys: copyKeyCombs(keyBindings.linuxKeys),
+    };
+  }
+  return newDefaults;
+}
+
+export function getPlatformKeyCombinations(bindings: KeyBindings): Array<KeyCombination> {
+  if (isMac()) {
+    return bindings.macKeys;
+  }
+  if (isWindows()) {
+    return bindings.winKeys;
+  }
+  return bindings.linuxKeys;
+}
+
+export function getChar(keyCode: number) {
+  let char;
+  const keyCodeStr = Object.keys(keycodes).find(k => keycodes[k] === keyCode);
+
+  if (!keyCodeStr) {
+    console.error('Invalid key code', keyCode);
+  } else {
+    const cap = keyCodeStr.toUpperCase();
+    if (cap === 'ENTER') {
+      char = 'Enter';
+    } else if (cap === 'DELETE') {
+      char = 'Delete';
+    } else if (cap === 'COMMA') {
+      char = ',';
+    } else if (cap === 'BACKSLASH') {
+      char = '\\';
+    } else if (cap === 'FORWARDSLASH') {
+      char = '/';
+    } else if (cap === 'SINGLEQUOTE') {
+      char = "'";
+    } else if (cap === 'SPACE') {
+      char = 'Space';
+    } else {
+      char = cap;
     }
   }
 
-  return chars[0] || 'unknown';
+  return char || 'unknown';
 }

--- a/packages/insomnia-app/app/models/settings.js
+++ b/packages/insomnia-app/app/models/settings.js
@@ -2,6 +2,7 @@
 import type { BaseModel } from './index';
 import * as db from '../common/database';
 import { UPDATE_CHANNEL_STABLE } from '../common/constants';
+import * as hotkeys from '../common/hotkeys';
 
 type BaseSettings = {
   showPasswords: boolean,
@@ -34,6 +35,7 @@ type BaseSettings = {
   fontInterface: string | null,
   fontSize: number,
   fontVariantLigatures: boolean,
+  hotKeyRegistry: hotkeys.HotKeyRegistry,
 };
 
 export type Settings = BaseModel & BaseSettings;
@@ -75,6 +77,7 @@ export function init(): BaseSettings {
     fontInterface: null,
     fontSize: 13,
     fontVariantLigatures: false,
+    hotKeyRegistry: hotkeys.newDefaultRegistry(),
   };
 }
 

--- a/packages/insomnia-app/app/ui/components/base/dropdown/dropdown-hint.js
+++ b/packages/insomnia-app/app/ui/components/base/dropdown/dropdown-hint.js
@@ -1,16 +1,16 @@
 // @flow
 import * as React from 'react';
-import type { Hotkey as HotkeyType } from '../../../../common/hotkeys';
 import Hotkey from '../../hotkey';
+import type { KeyBindings } from '../../../../common/hotkeys';
 
 type Props = {
-  hotkey: HotkeyType,
+  keyBindings: KeyBindings,
 };
 
 class DropdownHint extends React.PureComponent<Props> {
   render() {
-    const { hotkey } = this.props;
-    return <Hotkey className="dropdown__hint" hotkey={hotkey} />;
+    const { keyBindings } = this.props;
+    return <Hotkey className="dropdown__hint" keyBindings={keyBindings} />;
   }
 }
 

--- a/packages/insomnia-app/app/ui/components/base/dropdown/dropdown.js
+++ b/packages/insomnia-app/app/ui/components/base/dropdown/dropdown.js
@@ -8,7 +8,8 @@ import DropdownItem from './dropdown-item';
 import DropdownDivider from './dropdown-divider';
 import { fuzzyMatch } from '../../../../common/misc';
 import KeydownBinder from '../../keydown-binder';
-import * as hotkeys from '../../../../common/hotkeys';
+import { executeHotKey } from '../../../../common/hotkeys-listener';
+import { hotKeyRefs } from '../../../../common/hotkeys';
 
 const dropdownsContainer = document.querySelector('#dropdowns-container');
 
@@ -115,7 +116,7 @@ class Dropdown extends PureComponent {
 
     this._handleDropdownNavigation(e);
 
-    hotkeys.executeHotKey(e, hotkeys.CLOSE_DROPDOWN, () => {
+    executeHotKey(e, hotKeyRefs.CLOSE_DROPDOWN, () => {
       this.hide();
     });
   }

--- a/packages/insomnia-app/app/ui/components/base/modal.js
+++ b/packages/insomnia-app/app/ui/components/base/modal.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import autobind from 'autobind-decorator';
 import classnames from 'classnames';
 import KeydownBinder from '../keydown-binder';
-import * as hotkeys from '../../../common/hotkeys';
+import { hotKeyRefs } from '../../../common/hotkeys';
+import { pressedHotKey } from '../../../common/hotkeys-listener';
 
 // Keep global z-index reference so that every modal will
 // appear over top of an existing one.
@@ -21,7 +22,7 @@ class Modal extends PureComponent {
     };
   }
 
-  _handleKeyDown(e) {
+  async _handleKeyDown(e) {
     if (!this.state.open) {
       return;
     }
@@ -32,7 +33,7 @@ class Modal extends PureComponent {
     }
 
     const closeOnKeyCodes = this.props.closeOnKeyCodes || [];
-    const pressedEscape = hotkeys.pressedHotKey(e, hotkeys.CLOSE_MODAL);
+    const pressedEscape = await pressedHotKey(e, hotKeyRefs.CLOSE_MODAL);
     const pressedCloseButton = closeOnKeyCodes.find(c => c === e.keyCode);
 
     // Pressed escape

--- a/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
@@ -11,17 +11,19 @@ import {
 } from '../base/dropdown';
 import { showModal } from '../modals/index';
 import Tooltip from '../tooltip';
-import * as hotkeys from '../../../common/hotkeys';
 import KeydownBinder from '../keydown-binder';
 import type { Workspace } from '../../../models/workspace';
 import type { Environment } from '../../../models/environment';
+import type { HotKeyRegistry } from '../../../common/hotkeys';
+import { hotKeyRefs } from '../../../common/hotkeys';
+import { executeHotKey } from '../../../common/hotkeys-listener';
 
 type Props = {
-  workspace: Workspace,
   handleChangeEnvironment: Function,
   workspace: Workspace,
   environments: Array<Environment>,
   environmentHighlightColorStyle: String,
+  hotKeyRegistry: HotKeyRegistry,
 
   // Optional
   className?: string,
@@ -57,7 +59,7 @@ class EnvironmentsDropdown extends React.PureComponent<Props> {
   }
 
   _handleKeydown(e: KeyboardEvent) {
-    hotkeys.executeHotKey(e, hotkeys.TOGGLE_ENVIRONMENTS_MENU, () => {
+    executeHotKey(e, hotKeyRefs.ENVIRONMENT_SHOW_SWITCH_MENU, () => {
       this._dropdown && this._dropdown.toggle(true);
     });
   }
@@ -69,6 +71,7 @@ class EnvironmentsDropdown extends React.PureComponent<Props> {
       environments,
       activeEnvironment,
       environmentHighlightColorStyle,
+      hotKeyRegistry,
       ...other
     } = this.props;
 
@@ -125,7 +128,7 @@ class EnvironmentsDropdown extends React.PureComponent<Props> {
 
           <DropdownItem onClick={this._handleShowEnvironmentModal}>
             <i className="fa fa-wrench" /> Manage Environments
-            <DropdownHint hotkey={hotkeys.SHOW_ENVIRONMENTS} />
+            <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]} />
           </DropdownItem>
         </Dropdown>
       </KeydownBinder>

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
@@ -10,7 +10,7 @@ import {
   DropdownItem,
 } from '../base/dropdown/index';
 import * as models from '../../../models';
-import * as hotkeys from '../../../common/hotkeys';
+import { hotKeyRefs } from '../../../common/hotkeys';
 
 @autobind
 class RequestActionsDropdown extends PureComponent {
@@ -44,6 +44,7 @@ class RequestActionsDropdown extends PureComponent {
     const {
       request, // eslint-disable-line no-unused-vars
       handleShowSettings,
+      hotKeyRegistry,
       ...other
     } = this.props;
 
@@ -54,11 +55,13 @@ class RequestActionsDropdown extends PureComponent {
         </DropdownButton>
         <DropdownItem onClick={this._handleDuplicate}>
           <i className="fa fa-copy" /> Duplicate
-          <DropdownHint hotkey={hotkeys.DUPLICATE_REQUEST} />
+          <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_DUPLICATE.id]} />
         </DropdownItem>
         <DropdownItem onClick={this._handleGenerateCode}>
           <i className="fa fa-code" /> Generate Code
-          <DropdownHint hotkey={hotkeys.GENERATE_CODE} />
+          <DropdownHint
+            keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_GENERATE_CODE_EDITOR.id]}
+          />
         </DropdownItem>
         <DropdownItem onClick={this._handleCopyAsCurl}>
           <i className="fa fa-copy" /> Copy as Curl
@@ -71,7 +74,7 @@ class RequestActionsDropdown extends PureComponent {
 
         <DropdownItem onClick={handleShowSettings}>
           <i className="fa fa-wrench" /> Settings
-          <DropdownHint hotkey={hotkeys.SHOW_REQUEST_SETTINGS} />
+          <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_SETTINGS.id]} />
         </DropdownItem>
       </Dropdown>
     );
@@ -84,6 +87,7 @@ RequestActionsDropdown.propTypes = {
   handleCopyAsCurl: PropTypes.func.isRequired,
   handleShowSettings: PropTypes.func.isRequired,
   request: PropTypes.object.isRequired,
+  hotKeyRegistry: PropTypes.object.isRequired,
 };
 
 export default RequestActionsDropdown;

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.js
@@ -12,7 +12,7 @@ import {
 import EnvironmentEditModal from '../modals/environment-edit-modal';
 import * as models from '../../../models';
 import { showPrompt, showModal } from '../modals/index';
-import * as hotkeys from '../../../common/hotkeys';
+import { hotKeyRefs } from '../../../common/hotkeys';
 
 @autobind
 class RequestGroupActionsDropdown extends PureComponent {
@@ -63,6 +63,7 @@ class RequestGroupActionsDropdown extends PureComponent {
   render() {
     const {
       requestGroup, // eslint-disable-line no-unused-vars
+      hotKeyRegistry,
       ...other
     } = this.props;
 
@@ -73,11 +74,11 @@ class RequestGroupActionsDropdown extends PureComponent {
         </DropdownButton>
         <DropdownItem onClick={this._handleRequestCreate}>
           <i className="fa fa-plus-circle" /> New Request
-          <DropdownHint hotkey={hotkeys.CREATE_REQUEST} />
+          <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_CREATE.id]} />
         </DropdownItem>
         <DropdownItem onClick={this._handleRequestGroupCreate}>
           <i className="fa fa-folder" /> New Folder
-          <DropdownHint hotkey={hotkeys.CREATE_FOLDER} />
+          <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_CREATE_FOLDER.id]} />
         </DropdownItem>
         <DropdownDivider />
         <DropdownItem onClick={this._handleRequestGroupDuplicate}>
@@ -102,6 +103,7 @@ class RequestGroupActionsDropdown extends PureComponent {
 
 RequestGroupActionsDropdown.propTypes = {
   workspace: PropTypes.object.isRequired,
+  hotKeyRegistry: PropTypes.object.isRequired,
   handleCreateRequest: PropTypes.func.isRequired,
   handleCreateRequestGroup: PropTypes.func.isRequired,
   handleDuplicateRequestGroup: PropTypes.func.isRequired,

--- a/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.js
@@ -6,9 +6,10 @@ import StatusTag from '../tags/status-tag';
 import URLTag from '../tags/url-tag';
 import PromptButton from '../base/prompt-button';
 import KeydownBinder from '../keydown-binder';
-import * as hotkeys from '../../../common/hotkeys';
 import TimeTag from '../tags/time-tag';
 import SizeTag from '../tags/size-tag';
+import { executeHotKey } from '../../../common/hotkeys-listener';
+import { hotKeyRefs } from '../../../common/hotkeys';
 
 @autobind
 class ResponseHistoryDropdown extends PureComponent {
@@ -29,7 +30,7 @@ class ResponseHistoryDropdown extends PureComponent {
   }
 
   _handleKeydown(e) {
-    hotkeys.executeHotKey(e, hotkeys.TOGGLE_HISTORY_DROPDOWN, () => {
+    executeHotKey(e, hotKeyRefs.REQUEST_TOGGLE_HISTORY, () => {
       this._dropdown && this._dropdown.toggle(true);
     });
   }

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
@@ -17,8 +17,9 @@ import WorkspaceShareSettingsModal from '../modals/workspace-share-settings-moda
 import * as session from '../../../sync/session';
 import LoginModal from '../modals/login-modal';
 import Tooltip from '../tooltip';
-import * as hotkeys from '../../../common/hotkeys';
 import KeydownBinder from '../keydown-binder';
+import { hotKeyRefs } from '../../../common/hotkeys';
+import { executeHotKey } from '../../../common/hotkeys-listener';
 
 @autobind
 class WorkspaceDropdown extends PureComponent {
@@ -91,7 +92,7 @@ class WorkspaceDropdown extends PureComponent {
   }
 
   _handleKeydown(e) {
-    hotkeys.executeHotKey(e, hotkeys.TOGGLE_MAIN_MENU, () => {
+    executeHotKey(e, hotKeyRefs.TOGGLE_MAIN_MENU, () => {
       this._dropdown && this._dropdown.toggle(true);
     });
   }
@@ -103,6 +104,7 @@ class WorkspaceDropdown extends PureComponent {
       activeWorkspace,
       unseenWorkspaces,
       isLoading,
+      hotKeyRegistry,
       ...other
     } = this.props;
 
@@ -145,7 +147,7 @@ class WorkspaceDropdown extends PureComponent {
           <DropdownDivider>{activeWorkspace.name}</DropdownDivider>
           <DropdownItem onClick={this._handleShowWorkspaceSettings}>
             <i className="fa fa-wrench" /> Workspace Settings
-            <DropdownHint hotkey={hotkeys.SHOW_WORKSPACE_SETTINGS} />
+            <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.WORKSPACE_SHOW_SETTINGS.id]} />
           </DropdownItem>
 
           <DropdownItem onClick={this._handleShowShareSettings}>
@@ -176,7 +178,7 @@ class WorkspaceDropdown extends PureComponent {
 
           <DropdownItem onClick={this._handleShowSettings}>
             <i className="fa fa-cog" /> Preferences
-            <DropdownHint hotkey={hotkeys.SHOW_SETTINGS} />
+            <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.PREFERENCES_SHOW_GENERAL.id]} />
           </DropdownItem>
           <DropdownItem onClick={this._handleShowExport}>
             <i className="fa fa-share" /> Import/Export
@@ -215,6 +217,7 @@ WorkspaceDropdown.propTypes = {
   workspaces: PropTypes.arrayOf(PropTypes.object).isRequired,
   unseenWorkspaces: PropTypes.arrayOf(PropTypes.object).isRequired,
   activeWorkspace: PropTypes.object.isRequired,
+  hotKeyRegistry: PropTypes.object.isRequired,
 
   // Optional
   className: PropTypes.string,

--- a/packages/insomnia-app/app/ui/components/hotkey.js
+++ b/packages/insomnia-app/app/ui/components/hotkey.js
@@ -1,12 +1,12 @@
 // @flow
 import * as React from 'react';
 import classnames from 'classnames';
-import type { Hotkey as HotkeyType } from '../../common/hotkeys';
+import { ALT_SYM, CTRL_SYM, isMac, joinHotKeys, META_SYM, SHIFT_SYM } from '../../common/constants';
+import type { KeyBindings } from '../../common/hotkeys';
 import * as hotkeys from '../../common/hotkeys';
-import { ALT_SYM, CTRL_SYM, isMac, joinHotKeys, MOD_SYM, SHIFT_SYM } from '../../common/constants';
 
 type Props = {
-  hotkey: HotkeyType,
+  keyBindings: KeyBindings,
 
   // Optional
   className?: string,
@@ -14,22 +14,18 @@ type Props = {
 
 class Hotkey extends React.PureComponent<Props> {
   render() {
-    const { hotkey, className } = this.props;
-    const { alt, shift, meta, metaIsCtrl } = hotkey;
+    const { keyBindings, className } = this.props;
+
+    const keyComb = hotkeys.getPlatformKeyCombinations(keyBindings)[0];
+    const { ctrl, alt, shift, meta, keyCode } = keyComb;
     const chars = [];
 
     alt && chars.push(ALT_SYM);
     shift && chars.push(SHIFT_SYM);
+    ctrl && chars.push(CTRL_SYM);
+    meta && chars.push(META_SYM);
 
-    if (meta) {
-      if (metaIsCtrl) {
-        chars.push(CTRL_SYM);
-      } else {
-        chars.push(isMac() ? MOD_SYM : CTRL_SYM);
-      }
-    }
-
-    chars.push(hotkeys.getChar(hotkey));
+    chars.push(hotkeys.getChar(keyCode));
 
     return (
       <span className={classnames(className, { 'font-normal': isMac() })}>

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.js
@@ -137,7 +137,7 @@ class SettingsModal extends PureComponent {
               <Theme handleChangeTheme={this._handleChangeTheme} activeTheme={settings.theme} />
             </TabPanel>
             <TabPanel className="react-tabs__tab-panel pad scrollable">
-              <SettingsShortcuts />
+              <SettingsShortcuts hotKeyRegistry={settings.hotKeyRegistry} />
             </TabPanel>
             <TabPanel className="react-tabs__tab-panel pad scrollable">
               <Account />

--- a/packages/insomnia-app/app/ui/components/request-pane.js
+++ b/packages/insomnia-app/app/ui/components/request-pane.js
@@ -29,8 +29,8 @@ import { showModal } from './modals/index';
 import RequestSettingsModal from './modals/request-settings-modal';
 import MarkdownPreview from './markdown-preview';
 import type { Settings } from '../../models/settings';
-import * as hotkeys from '../../common/hotkeys';
 import ErrorBoundary from './error-boundary';
+import { hotKeyRefs } from '../../common/hotkeys';
 
 type Props = {
   // Functions
@@ -171,38 +171,42 @@ class RequestPane extends React.PureComponent<Props> {
     const paneHeaderClasses = 'pane__header theme--pane__header';
     const paneBodyClasses = 'pane__body theme--pane__body';
 
+    const hotKeyRegistry = settings.hotKeyRegistry;
+
     if (!request) {
       return (
         <section className={paneClasses}>
-          <header className={paneHeaderClasses}/>
+          <header className={paneHeaderClasses} />
           <div className={paneBodyClasses + ' pane__body--placeholder'}>
             <div>
               <table className="table--fancy">
                 <tbody>
-                <tr>
-                  <td>New Request</td>
-                  <td className="text-right">
-                    <code>
-                      <Hotkey hotkey={hotkeys.CREATE_REQUEST}/>
-                    </code>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Switch Requests</td>
-                  <td className="text-right">
-                    <code>
-                      <Hotkey hotkey={hotkeys.SHOW_QUICK_SWITCHER}/>
-                    </code>
-                  </td>
-                </tr>
-                <tr>
-                  <td>Edit Environments</td>
-                  <td className="text-right">
-                    <code>
-                      <Hotkey hotkey={hotkeys.SHOW_ENVIRONMENTS}/>
-                    </code>
-                  </td>
-                </tr>
+                  <tr>
+                    <td>New Request</td>
+                    <td className="text-right">
+                      <code>
+                        <Hotkey keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_CREATE.id]} />
+                      </code>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Switch Requests</td>
+                    <td className="text-right">
+                      <code>
+                        <Hotkey keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_QUICK_SWITCH.id]} />
+                      </code>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Edit Environments</td>
+                    <td className="text-right">
+                      <code>
+                        <Hotkey
+                          keyBindings={hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]}
+                        />
+                      </code>
+                    </td>
+                  </tr>
                 </tbody>
               </table>
 
@@ -251,6 +255,7 @@ class RequestPane extends React.PureComponent<Props> {
               isVariableUncovered={isVariableUncovered}
               handleGetRenderContext={handleGetRenderContext}
               request={request}
+              hotKeyRegistry={settings.hotKeyRegistry}
             />
           </ErrorBoundary>
         </header>
@@ -266,7 +271,7 @@ class RequestPane extends React.PureComponent<Props> {
                   ? getContentTypeName(request.body.mimeType)
                   : 'Body'}
                 {numBodyParams ? <span className="bubble space-left">{numBodyParams}</span> : null}
-                <i className="fa fa-caret-down space-left"/>
+                <i className="fa fa-caret-down space-left" />
               </ContentTypeDropdown>
             </Tab>
             <Tab tabIndex="-1">
@@ -275,7 +280,7 @@ class RequestPane extends React.PureComponent<Props> {
                 request={request}
                 className="tall">
                 {getAuthTypeName(request.authentication.type) || 'Auth'}
-                <i className="fa fa-caret-down space-left"/>
+                <i className="fa fa-caret-down space-left" />
               </AuthDropdown>
             </Tab>
             <Tab tabIndex="-1">
@@ -295,7 +300,7 @@ class RequestPane extends React.PureComponent<Props> {
                 Docs
                 {request.description && (
                   <span className="bubble space-left">
-                    <i className="fa fa--skinny fa-check txt-xxs"/>
+                    <i className="fa fa--skinny fa-check txt-xxs" />
                   </span>
                 )}
               </button>
@@ -341,7 +346,7 @@ class RequestPane extends React.PureComponent<Props> {
                 <ErrorBoundary
                   key={uniqueKey}
                   errorClassName="tall wide vertically-align font-error pad text-center">
-                  <RenderedQueryString handleRender={handleRender} request={request}/>
+                  <RenderedQueryString handleRender={handleRender} request={request} />
                 </ErrorBoundary>
               </code>
             </div>
@@ -419,10 +424,10 @@ class RequestPane extends React.PureComponent<Props> {
               <div className="overflow-hidden editor vertically-center text-center">
                 <p className="pad text-sm text-center">
                   <span className="super-faint">
-                    <i className="fa fa-file-text-o" style={{ fontSize: '8rem', opacity: 0.3 }}/>
+                    <i className="fa fa-file-text-o" style={{ fontSize: '8rem', opacity: 0.3 }} />
                   </span>
-                  <br/>
-                  <br/>
+                  <br />
+                  <br />
                   <button
                     className="btn btn--clicky faint"
                     onClick={this._handleEditDescriptionAdd}>

--- a/packages/insomnia-app/app/ui/components/request-url-bar.js
+++ b/packages/insomnia-app/app/ui/components/request-url-bar.js
@@ -14,9 +14,11 @@ import { showPrompt } from './modals/index';
 import MethodDropdown from './dropdowns/method-dropdown';
 import PromptButton from './base/prompt-button';
 import OneLineEditor from './codemirror/one-line-editor';
-import * as hotkeys from '../../common/hotkeys';
 import KeydownBinder from './keydown-binder';
 import type { Request } from '../../models/request';
+import type { HotKeyRegistry } from '../../common/hotkeys';
+import { hotKeyRefs } from '../../common/hotkeys';
+import { executeHotKey } from '../../common/hotkeys-listener';
 
 type Props = {
   handleAutocompleteUrls: Function,
@@ -32,6 +34,7 @@ type Props = {
   onUrlChange: (r: Request, url: string) => Promise<Request>,
   request: Request,
   uniquenessKey: string,
+  hotKeyRegistry: HotKeyRegistry,
 };
 
 type State = {
@@ -142,21 +145,21 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
     this.setState({ downloadPath: null });
   }
 
-  _handleKeyDown(e: KeyboardEvent) {
+  async _handleKeyDown(e: KeyboardEvent) {
     if (!this._input) {
       return;
     }
 
-    hotkeys.executeHotKey(e, hotkeys.FOCUS_URL, () => {
+    executeHotKey(e, hotKeyRefs.REQUEST_FOCUS_URL, () => {
       this._input && this._input.focus();
       this._input && this._input.selectAll();
     });
 
-    hotkeys.executeHotKey(e, hotkeys.TOGGLE_METHOD_DROPDOWN, () => {
+    executeHotKey(e, hotKeyRefs.REQUEST_TOGGLE_HTTP_METHOD_MENU, () => {
       this._methodDropdown && this._methodDropdown.toggle();
     });
 
-    hotkeys.executeHotKey(e, hotkeys.SHOW_SEND_OPTIONS, () => {
+    executeHotKey(e, hotKeyRefs.REQUEST_SHOW_OPTIONS, () => {
       this._dropdown && this._dropdown.toggle(true);
     });
   }
@@ -248,6 +251,7 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
   }
 
   renderSendButton() {
+    const { hotKeyRegistry } = this.props;
     const { currentInterval, currentTimeout, downloadPath } = this.state;
 
     let cancelButton = null;
@@ -287,7 +291,7 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
           <DropdownDivider>Basic</DropdownDivider>
           <DropdownItem onClick={this._handleClickSend}>
             <i className="fa fa-arrow-circle-o-right" /> Send Now
-            <DropdownHint hotkey={hotkeys.SEND_REQUEST} />
+            <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SEND.id]} />
           </DropdownItem>
           <DropdownItem onClick={this._handleGenerateCode}>
             <i className="fa fa-code" /> Generate Client Code

--- a/packages/insomnia-app/app/ui/components/response-pane.js
+++ b/packages/insomnia-app/app/ui/components/response-pane.js
@@ -24,8 +24,9 @@ import { PREVIEW_MODE_SOURCE } from '../../common/constants';
 import { getSetCookieHeaders, nullFn } from '../../common/misc';
 import { cancelCurrentRequest } from '../../network/network';
 import Hotkey from './hotkey';
-import * as hotkeys from '../../common/hotkeys';
 import ErrorBoundary from './error-boundary';
+import type { HotKeyRegistry } from '../../common/hotkeys';
+import { hotKeyRefs } from '../../common/hotkeys';
 
 type Props = {
   // Functions
@@ -47,6 +48,7 @@ type Props = {
   editorLineWrapping: boolean,
   loadStartTime: number,
   responses: Array<Response>,
+  hotKeyRegistry: HotKeyRegistry,
 
   // Other
   request: ?Request,
@@ -170,6 +172,7 @@ class ResponsePane extends React.PureComponent<Props> {
       filter,
       filterHistory,
       showCookiesModal,
+      hotKeyRegistry,
     } = this.props;
 
     const paneClasses = 'response-pane theme--pane pane';
@@ -197,7 +200,7 @@ class ResponsePane extends React.PureComponent<Props> {
                     <td>Send Request</td>
                     <td className="text-right">
                       <code>
-                        <Hotkey hotkey={hotkeys.SEND_REQUEST} />
+                        <Hotkey keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SEND.id]} />
                       </code>
                     </td>
                   </tr>
@@ -205,7 +208,7 @@ class ResponsePane extends React.PureComponent<Props> {
                     <td>Focus Url Bar</td>
                     <td className="text-right">
                       <code>
-                        <Hotkey hotkey={hotkeys.FOCUS_URL} />
+                        <Hotkey keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_FOCUS_URL.id]} />
                       </code>
                     </td>
                   </tr>
@@ -213,7 +216,7 @@ class ResponsePane extends React.PureComponent<Props> {
                     <td>Manage Cookies</td>
                     <td className="text-right">
                       <code>
-                        <Hotkey hotkey={hotkeys.SHOW_COOKIES} />
+                        <Hotkey keyBindings={hotKeyRegistry[hotKeyRefs.SHOW_COOKIES_EDITOR.id]} />
                       </code>
                     </td>
                   </tr>
@@ -221,7 +224,9 @@ class ResponsePane extends React.PureComponent<Props> {
                     <td>Edit Environments</td>
                     <td className="text-right">
                       <code>
-                        <Hotkey hotkey={hotkeys.SHOW_ENVIRONMENTS} />
+                        <Hotkey
+                          keyBindings={hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]}
+                        />
                       </code>
                     </td>
                   </tr>

--- a/packages/insomnia-app/app/ui/components/settings/shortcuts.js
+++ b/packages/insomnia-app/app/ui/components/settings/shortcuts.js
@@ -1,17 +1,23 @@
+// @flow
 import React, { PureComponent } from 'react';
 import autobind from 'autobind-decorator';
 import Hotkey from '../hotkey';
-import * as hotkeys from '../../../common/hotkeys';
+import type { HotKeyDefinition, HotKeyRegistry } from '../../../common/hotkeys';
+import { hotKeyRefs } from '../../../common/hotkeys';
+
+type Props = {
+  hotKeyRegistry: HotKeyRegistry,
+};
 
 @autobind
-class Shortcuts extends PureComponent {
-  renderHotkey(hotkey, i) {
+class Shortcuts extends PureComponent<Props> {
+  renderHotKey(def: HotKeyDefinition, i: number) {
     return (
       <tr key={i}>
-        <td>{hotkey.description}</td>
+        <td>{def.description}</td>
         <td className="text-right">
           <code>
-            <Hotkey hotkey={hotkey} />
+            <Hotkey keyBindings={this.props.hotKeyRegistry[def.id]} />
           </code>
         </td>
       </tr>
@@ -19,33 +25,38 @@ class Shortcuts extends PureComponent {
   }
 
   render() {
+    const hotKeyDefs: Array<HotKeyDefinition> = [
+      hotKeyRefs.PREFERENCES_SHOW_KEYBOARD_SHORTCUTS,
+      hotKeyRefs.REQUEST_QUICK_SWITCH,
+      hotKeyRefs.REQUEST_SEND,
+      hotKeyRefs.REQUEST_SHOW_OPTIONS,
+      hotKeyRefs.REQUEST_SHOW_CREATE,
+      hotKeyRefs.REQUEST_SHOW_DELETE,
+      hotKeyRefs.REQUEST_SHOW_CREATE_FOLDER,
+      hotKeyRefs.REQUEST_SHOW_DUPLICATE,
+      hotKeyRefs.SHOW_COOKIES_EDITOR,
+      hotKeyRefs.ENVIRONMENT_SHOW_EDITOR,
+      hotKeyRefs.ENVIRONMENT_SHOW_SWITCH_MENU,
+      hotKeyRefs.REQUEST_FOCUS_URL,
+      hotKeyRefs.RESPONSE_FOCUS,
+      hotKeyRefs.REQUEST_TOGGLE_HTTP_METHOD_MENU,
+      hotKeyRefs.SIDEBAR_TOGGLE,
+      hotKeyRefs.REQUEST_TOGGLE_HISTORY,
+      hotKeyRefs.SHOW_AUTOCOMPLETE,
+      hotKeyRefs.PREFERENCES_SHOW_GENERAL,
+      hotKeyRefs.WORKSPACE_SHOW_SETTINGS,
+      hotKeyRefs.REQUEST_SHOW_SETTINGS,
+      hotKeyRefs.TOGGLE_MAIN_MENU,
+      hotKeyRefs.PLUGIN_RELOAD,
+      hotKeyRefs.ENVIRONMENT_UNCOVER_VARIABLES,
+    ];
     return (
       <div>
         <table className="table--fancy">
           <tbody>
-            {this.renderHotkey(hotkeys.SHOW_KEYBOARD_SHORTCUTS)}
-            {this.renderHotkey(hotkeys.SHOW_QUICK_SWITCHER)}
-            {this.renderHotkey(hotkeys.SEND_REQUEST)}
-            {this.renderHotkey(hotkeys.SHOW_SEND_OPTIONS)}
-            {this.renderHotkey(hotkeys.CREATE_REQUEST)}
-            {this.renderHotkey(hotkeys.DELETE_REQUEST)}
-            {this.renderHotkey(hotkeys.CREATE_FOLDER)}
-            {this.renderHotkey(hotkeys.DUPLICATE_REQUEST)}
-            {this.renderHotkey(hotkeys.SHOW_COOKIES)}
-            {this.renderHotkey(hotkeys.SHOW_ENVIRONMENTS)}
-            {this.renderHotkey(hotkeys.TOGGLE_ENVIRONMENTS_MENU)}
-            {this.renderHotkey(hotkeys.FOCUS_URL)}
-            {this.renderHotkey(hotkeys.FOCUS_RESPONSE)}
-            {this.renderHotkey(hotkeys.TOGGLE_METHOD_DROPDOWN)}
-            {this.renderHotkey(hotkeys.TOGGLE_SIDEBAR)}
-            {this.renderHotkey(hotkeys.TOGGLE_HISTORY_DROPDOWN)}
-            {this.renderHotkey(hotkeys.SHOW_AUTOCOMPLETE)}
-            {this.renderHotkey(hotkeys.SHOW_SETTINGS)}
-            {this.renderHotkey(hotkeys.SHOW_WORKSPACE_SETTINGS)}
-            {this.renderHotkey(hotkeys.SHOW_REQUEST_SETTINGS)}
-            {this.renderHotkey(hotkeys.TOGGLE_MAIN_MENU)}
-            {this.renderHotkey(hotkeys.RELOAD_PLUGINS)}
-            {this.renderHotkey(hotkeys.UNCOVER_VARIABLES)}
+            {hotKeyDefs.map((def: HotKeyDefinition, idx: number) => {
+              return this.renderHotKey(def, idx);
+            })}
           </tbody>
         </table>
       </div>

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.js
@@ -6,6 +6,7 @@ import * as models from '../../../models/index';
 import type { RequestGroup } from '../../../models/request-group';
 import type { Workspace } from '../../../models/workspace';
 import type { Request } from '../../../models/request';
+import type { HotKeyRegistry } from '../../../common/hotkeys';
 
 type Child = {
   doc: Request | RequestGroup,
@@ -29,6 +30,7 @@ type Props = {
   childObjects: Array<Child>,
   workspace: Workspace,
   filter: string,
+  hotKeyRegistry: HotKeyRegistry,
 
   // Optional
   activeRequest?: Request,
@@ -50,6 +52,7 @@ class SidebarChildren extends React.PureComponent<Props> {
       handleActivateRequest,
       activeRequest,
       workspace,
+      hotKeyRegistry,
     } = this.props;
 
     const activeRequestId = activeRequest ? activeRequest._id : 'n/a';
@@ -73,6 +76,7 @@ class SidebarChildren extends React.PureComponent<Props> {
             isActive={child.doc._id === activeRequestId}
             request={child.doc}
             workspace={workspace}
+            hotKeyRegistry={hotKeyRegistry}
           />
         );
       }
@@ -113,6 +117,7 @@ class SidebarChildren extends React.PureComponent<Props> {
           numChildren={child.children.length}
           workspace={workspace}
           requestGroup={requestGroup}
+          hotKeyRegistry={hotKeyRegistry}
           children={children}
         />
       );

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-filter.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-filter.js
@@ -4,13 +4,16 @@ import autobind from 'autobind-decorator';
 import { Dropdown, DropdownHint, DropdownButton, DropdownItem } from '../base/dropdown';
 import { DEBOUNCE_MILLIS } from '../../../common/constants';
 import KeydownBinder from '../keydown-binder';
-import * as hotkeys from '../../../common/hotkeys';
+import type { HotKeyRegistry } from '../../../common/hotkeys';
+import { hotKeyRefs } from '../../../common/hotkeys';
+import { executeHotKey } from '../../../common/hotkeys-listener';
 
 type Props = {
   onChange: string => void,
   requestCreate: () => void,
   requestGroupCreate: () => void,
   filter: string,
+  hotKeyRegistry: HotKeyRegistry,
 };
 
 @autobind
@@ -48,13 +51,13 @@ class SidebarFilter extends React.PureComponent<Props> {
   }
 
   _handleKeydown(e: KeyboardEvent) {
-    hotkeys.executeHotKey(e, hotkeys.FOCUS_FILTER, () => {
+    executeHotKey(e, hotKeyRefs.SIDEBAR_FOCUS_FILTER, () => {
       this._input && this._input.focus();
     });
   }
 
   render() {
-    const { filter } = this.props;
+    const { filter, hotKeyRegistry } = this.props;
     return (
       <KeydownBinder onKeydown={this._handleKeydown}>
         <div className="sidebar__filter">
@@ -79,11 +82,13 @@ class SidebarFilter extends React.PureComponent<Props> {
             </DropdownButton>
             <DropdownItem onClick={this._handleRequestCreate}>
               <i className="fa fa-plus-circle" /> New Request
-              <DropdownHint hotkey={hotkeys.CREATE_REQUEST} />
+              <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_CREATE.id]} />
             </DropdownItem>
             <DropdownItem onClick={this._handleRequestGroupCreate}>
               <i className="fa fa-folder" /> New Folder
-              <DropdownHint hotkey={hotkeys.CREATE_FOLDER} />
+              <DropdownHint
+                keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_CREATE_FOLDER.id]}
+              />
             </DropdownItem>
           </Dropdown>
         </div>

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
@@ -55,6 +55,7 @@ class SidebarRequestGroupRow extends PureComponent {
       isDragging,
       isDraggingOver,
       workspace,
+      hotKeyRegistry,
     } = this.props;
 
     const { dragDirection } = this.state;
@@ -98,6 +99,7 @@ class SidebarRequestGroupRow extends PureComponent {
               handleMoveRequestGroup={handleMoveRequestGroup}
               workspace={workspace}
               requestGroup={requestGroup}
+              hotKeyRegistry={hotKeyRegistry}
               right
             />
           </div>
@@ -122,6 +124,7 @@ class SidebarRequestGroupRow extends PureComponent {
               workspace={workspace}
               requestCreate={handleCreateRequest}
               filter={filter}
+              hotKeyRegistry={hotKeyRegistry}
             />
           )}
         </ul>
@@ -146,6 +149,7 @@ SidebarRequestGroupRow.propTypes = {
   isCollapsed: PropTypes.bool.isRequired,
   workspace: PropTypes.object.isRequired,
   requestGroup: PropTypes.object.isRequired,
+  hotKeyRegistry: PropTypes.object.isRequired,
 
   // React DnD
   isDragging: PropTypes.bool,

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
@@ -78,6 +78,7 @@ class SidebarRequestRow extends PureComponent {
       request,
       requestGroup,
       isActive,
+      hotKeyRegistry,
     } = this.props;
 
     const { dragDirection } = this.state;
@@ -134,6 +135,7 @@ class SidebarRequestRow extends PureComponent {
                 handleShowSettings={this._handleShowRequestSettings}
                 request={request}
                 requestGroup={requestGroup}
+                hotKeyRegistry={hotKeyRegistry}
               />
             </div>
           </div>
@@ -161,6 +163,7 @@ SidebarRequestRow.propTypes = {
   // Other
   filter: PropTypes.string.isRequired,
   isActive: PropTypes.bool.isRequired,
+  hotKeyRegistry: PropTypes.object.isRequired,
 
   // React DnD
   isDragging: PropTypes.bool,

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar.js
@@ -55,6 +55,7 @@ class Sidebar extends PureComponent {
       handleActivateRequest,
       activeRequest,
       environmentHighlightColorStyle,
+      hotKeyRegistry,
     } = this.props;
 
     return (
@@ -77,6 +78,7 @@ class Sidebar extends PureComponent {
           activeWorkspace={workspace}
           workspaces={workspaces}
           unseenWorkspaces={unseenWorkspaces}
+          hotKeyRegistry={hotKeyRegistry}
           handleExportFile={handleExportFile}
           handleImportFile={handleImportFile}
           handleSetActiveWorkspace={handleSetActiveWorkspace}
@@ -90,6 +92,7 @@ class Sidebar extends PureComponent {
             environments={environments}
             workspace={workspace}
             environmentHighlightColorStyle={environmentHighlightColorStyle}
+            hotKeyRegistry={hotKeyRegistry}
           />
           <button className="btn btn--super-compact" onClick={showCookiesModal}>
             <div className="sidebar__menu__thing">
@@ -104,6 +107,7 @@ class Sidebar extends PureComponent {
           requestCreate={this._handleCreateRequestInWorkspace}
           requestGroupCreate={this._handleCreateRequestGroupInWorkspace}
           filter={filter || ''}
+          hotKeyRegistry={hotKeyRegistry}
         />
 
         <SidebarChildren
@@ -121,6 +125,7 @@ class Sidebar extends PureComponent {
           workspace={workspace}
           activeRequest={activeRequest}
           filter={filter || ''}
+          hotKeyRegistry={hotKeyRegistry}
         />
 
         <SyncButton className="sidebar__footer" key={workspace._id} workspace={workspace} />
@@ -159,6 +164,7 @@ Sidebar.propTypes = {
   unseenWorkspaces: PropTypes.arrayOf(PropTypes.object).isRequired,
   environments: PropTypes.arrayOf(PropTypes.object).isRequired,
   environmentHighlightColorStyle: PropTypes.string.isRequired,
+  hotKeyRegistry: PropTypes.object.isRequired,
 
   // Optional
   filter: PropTypes.string,

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
@@ -16,8 +16,9 @@ import {
   PREVIEW_MODE_FRIENDLY,
   PREVIEW_MODE_RAW,
 } from '../../../common/constants';
-import * as hotkeys from '../../../common/hotkeys';
 import KeydownBinder from '../keydown-binder';
+import { executeHotKey } from '../../../common/hotkeys-listener';
+import { hotKeyRefs } from '../../../common/hotkeys';
 
 let alwaysShowLargeResponses = false;
 
@@ -180,7 +181,7 @@ class ResponseViewer extends React.Component<Props, State> {
       return;
     }
 
-    hotkeys.executeHotKey(e, hotkeys.FOCUS_RESPONSE, () => {
+    executeHotKey(e, hotKeyRefs.RESPONSE_FOCUS, () => {
       if (!this._isViewSelectable()) {
         return;
       }

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -633,6 +633,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             workspaces={workspaces}
             environments={environments}
             environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
+            hotKeyRegistry={settings.hotKeyRegistry}
           />
         </ErrorBoundary>
 
@@ -697,6 +698,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             editorIndentSize={settings.editorIndentSize}
             editorKeyMap={settings.editorKeyMap}
             editorLineWrapping={settings.editorLineWrapping}
+            hotKeyRegistry={settings.hotKeyRegistry}
             previewMode={responsePreviewMode}
             filter={responseFilter}
             filterHistory={responseFilterHistory}

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -58,7 +58,8 @@ import * as render from '../../common/render';
 import { getKeys } from '../../templating/utils';
 import { showAlert, showModal, showPrompt } from '../components/modals/index';
 import { exportHarRequest } from '../../common/har';
-import * as hotkeys from '../../common/hotkeys';
+import { hotKeyRefs } from '../../common/hotkeys';
+import { executeHotKey } from '../../common/hotkeys-listener';
 import KeydownBinder from '../components/keydown-binder';
 import ErrorBoundary from '../components/error-boundary';
 import * as plugins from '../../plugins';
@@ -100,20 +101,20 @@ class App extends PureComponent {
   _setGlobalKeyMap() {
     this._globalKeyMap = [
       [
-        hotkeys.SHOW_KEYBOARD_SHORTCUTS,
+        hotKeyRefs.PREFERENCES_SHOW_KEYBOARD_SHORTCUTS,
         () => {
           showModal(SettingsModal, TAB_INDEX_SHORTCUTS);
         },
       ],
       [
-        hotkeys.SHOW_WORKSPACE_SETTINGS,
+        hotKeyRefs.WORKSPACE_SHOW_SETTINGS,
         () => {
           const { activeWorkspace } = this.props;
           showModal(WorkspaceSettingsModal, activeWorkspace);
         },
       ],
       [
-        hotkeys.SHOW_REQUEST_SETTINGS,
+        hotKeyRefs.REQUEST_SHOW_SETTINGS,
         () => {
           if (this.props.activeRequest) {
             showModal(RequestSettingsModal, {
@@ -123,29 +124,28 @@ class App extends PureComponent {
         },
       ],
       [
-        hotkeys.SHOW_QUICK_SWITCHER,
+        hotKeyRefs.REQUEST_QUICK_SWITCH,
         () => {
           showModal(RequestSwitcherModal);
         },
       ],
-      [hotkeys.SEND_REQUEST, this._handleSendShortcut],
-      [hotkeys.SEND_REQUEST_F5, this._handleSendShortcut],
+      [hotKeyRefs.REQUEST_SEND, this._handleSendShortcut],
       [
-        hotkeys.SHOW_ENVIRONMENTS,
+        hotKeyRefs.ENVIRONMENT_SHOW_EDITOR,
         () => {
           const { activeWorkspace } = this.props;
           showModal(WorkspaceEnvironmentsEditModal, activeWorkspace);
         },
       ],
       [
-        hotkeys.SHOW_COOKIES,
+        hotKeyRefs.SHOW_COOKIES_EDITOR,
         () => {
           const { activeWorkspace } = this.props;
           showModal(CookiesModal, activeWorkspace);
         },
       ],
       [
-        hotkeys.CREATE_REQUEST,
+        hotKeyRefs.REQUEST_SHOW_CREATE,
         () => {
           const { activeRequest, activeWorkspace } = this.props;
           const parentId = activeRequest ? activeRequest.parentId : activeWorkspace._id;
@@ -153,7 +153,7 @@ class App extends PureComponent {
         },
       ],
       [
-        hotkeys.DELETE_REQUEST,
+        hotKeyRefs.REQUEST_SHOW_DELETE,
         () => {
           const { activeRequest } = this.props;
 
@@ -174,7 +174,7 @@ class App extends PureComponent {
         },
       ],
       [
-        hotkeys.CREATE_FOLDER,
+        hotKeyRefs.REQUEST_SHOW_CREATE_FOLDER,
         () => {
           const { activeRequest, activeWorkspace } = this.props;
           const parentId = activeRequest ? activeRequest.parentId : activeWorkspace._id;
@@ -182,19 +182,19 @@ class App extends PureComponent {
         },
       ],
       [
-        hotkeys.GENERATE_CODE,
+        hotKeyRefs.REQUEST_SHOW_GENERATE_CODE_EDITOR,
         async () => {
           showModal(GenerateCodeModal, this.props.activeRequest);
         },
       ],
       [
-        hotkeys.DUPLICATE_REQUEST,
+        hotKeyRefs.REQUEST_SHOW_DUPLICATE,
         async () => {
           await this._requestDuplicate(this.props.activeRequest);
         },
       ],
       [
-        hotkeys.UNCOVER_VARIABLES,
+        hotKeyRefs.ENVIRONMENT_UNCOVER_VARIABLES,
         async () => {
           await this._updateIsVariableUncovered();
         },
@@ -743,7 +743,7 @@ class App extends PureComponent {
 
   _handleKeyDown(e) {
     for (const [definition, callback] of this._globalKeyMap) {
-      hotkeys.executeHotKey(e, definition, callback);
+      executeHotKey(e, definition, callback);
     }
   }
 

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-app",
-  "version": "1.0.48",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Partially closes: #1162 
This PR is the first one to enable customizable key bindings feature. I plan to submit 1-2 more PRs, so that it will be easier to review, as there could be many additions and changes.

In this PR:
- New data models for hotkeys, with the separation of key combinations by OSes (mac, win, and linux). The models and namings are loosely inspired by those of VS Code's.
- Save key bindings in DB, in `settings` model.
- Give each hotkeys an `id`, the style is similar to that of VS Code's; except that this one uses `_` instead of `.`, e.g., `request_showSettings` instead of `request.showSettings`. The reason is that NeDB prohibits naming fields with `.`.
- Use `⌥` symbol for Mac's option key, previously was `^` (is this intended?).
- Some codes' styles are changing, like [this](https://github.com/getinsomnia/insomnia/compare/develop...rickychandra:feature/custom-keybindings?expand=1#diff-3ce6983a68cc85e7b663f4847a5bb00dR479). I didn't intend to do this, maybe it's the git hook's prettifier work.

Actually I have only tested on Linux, because I couldn't get my hands on MacOS. :grimacing: 