### PR TITLE
Fetch new access and refresh tokens when refresh fails

### DIFF
--- a/packages/insomnia-app/app/network/o-auth-2/get-token.js
+++ b/packages/insomnia-app/app/network/o-auth-2/get-token.js
@@ -190,6 +190,12 @@ async function _getAccessToken(
     authentication.scope,
   );
 
+  // If we didn't receive an access token it means the refresh token didn't succed,
+  // so we tell caller to fetch brand new access and refresh tokens.
+  if (!refreshResults.access_token) {
+    return null;
+  }
+
   // ~~~~~~~~~~~~~ //
   // Update the DB //
   // ~~~~~~~~~~~~~ //

--- a/packages/insomnia-app/app/network/o-auth-2/get-token.js
+++ b/packages/insomnia-app/app/network/o-auth-2/get-token.js
@@ -190,7 +190,7 @@ async function _getAccessToken(
     authentication.scope,
   );
 
-  // If we didn't receive an access token it means the refresh token didn't succed,
+  // If we didn't receive an access token it means the refresh token didn't succeed,
   // so we tell caller to fetch brand new access and refresh tokens.
   if (!refreshResults.access_token) {
     return null;

--- a/packages/insomnia-app/app/network/o-auth-2/refresh-token.js
+++ b/packages/insomnia-app/app/network/o-auth-2/refresh-token.js
@@ -48,7 +48,14 @@ export default async function(
   });
 
   const statusCode = response.statusCode || 0;
-  if (statusCode < 200 || statusCode >= 300) {
+
+  if (statusCode === 401) {
+    // If the refresh token was rejected due an unauthorized request, we will
+    // return a null access_token to trigger an authentication request to fetch
+    // brand new refresh and access tokens.
+
+    return responseToObject(null, [c.P_ACCESS_TOKEN]);
+  } else if (statusCode < 200 || statusCode >= 300) {
     throw new Error(`[oauth2] Failed to refresh token url=${url} status=${statusCode}`);
   }
 


### PR DESCRIPTION
This PR will allow Insomnia to re-authenticate again to get brand new access and refresh tokens when the refresh token request fails due an unauthorized request. This happens when the backend rejects the refresh token for some reason, like refresh token expiration.

This is an opinionated implementation, which means that this behavior is not configurable. @gschier let me know if an option to configure this behavior is necessary.

- Closes #849