### PR TITLE
Add ability to optionally use Hawk payload validation.

### DIFF
--- a/packages/insomnia-app/app/common/har.js
+++ b/packages/insomnia-app/app/common/har.js
@@ -341,8 +341,7 @@ export async function exportHarWithRenderedRequest(
   if (!misc.hasAuthHeader(renderedRequest.headers)) {
     const header = await getAuthHeader(
       renderedRequest._id,
-      url,
-      renderedRequest.method,
+      renderedRequest,
       renderedRequest.authentication,
     );
     if (header) {

--- a/packages/insomnia-app/app/common/har.js
+++ b/packages/insomnia-app/app/common/har.js
@@ -339,11 +339,7 @@ export async function exportHarWithRenderedRequest(
 
   // Set auth header if we have it
   if (!misc.hasAuthHeader(renderedRequest.headers)) {
-    const header = await getAuthHeader(
-      renderedRequest._id,
-      renderedRequest,
-      renderedRequest.authentication,
-    );
+    const header = await getAuthHeader(renderedRequest, url);
     if (header) {
       renderedRequest.headers.push({
         name: header.name,

--- a/packages/insomnia-app/app/network/__tests__/authentication.test.js
+++ b/packages/insomnia-app/app/network/__tests__/authentication.test.js
@@ -3,7 +3,8 @@ import { AUTH_OAUTH_1 } from '../../common/constants';
 
 describe('OAuth 1.0', () => {
   it('Does OAuth 1.0', async () => {
-    const header = await getAuthHeader('req_123', 'https://insomnia.rest/', 'GET', {
+    const request = { url: 'https://insomnia.rest/', method: 'GET' };
+    const header = await getAuthHeader('req_123', request, {
       type: AUTH_OAUTH_1,
       consumerKey: 'consumerKey',
       consumerSecret: 'consumerSecret',
@@ -31,7 +32,8 @@ describe('OAuth 1.0', () => {
   });
 
   it('Does OAuth 1.0 with RSA-SHA1', async () => {
-    const header = await getAuthHeader('req_123', 'https://insomnia.rest/', 'GET', {
+    const request = { url: 'https://insomnia.rest/', method: 'GET' };
+    const header = await getAuthHeader('req_123', request, {
       type: AUTH_OAUTH_1,
       consumerKey: 'consumerKey',
       consumerSecret: 'consumerSecret',
@@ -75,7 +77,8 @@ describe('OAuth 1.0', () => {
   });
 
   it('Does OAuth 1.0 with defaults', async () => {
-    const header = await getAuthHeader('req_123', 'https://insomnia.rest/', 'GET', {
+    const request = { url: 'https://insomnia.rest/', method: 'GET' };
+    const header = await getAuthHeader('req_123', request, {
       type: AUTH_OAUTH_1,
       consumerKey: 'consumerKey',
       consumerSecret: 'consumerSecret',

--- a/packages/insomnia-app/app/network/__tests__/authentication.test.js
+++ b/packages/insomnia-app/app/network/__tests__/authentication.test.js
@@ -3,8 +3,7 @@ import { AUTH_OAUTH_1 } from '../../common/constants';
 
 describe('OAuth 1.0', () => {
   it('Does OAuth 1.0', async () => {
-    const request = { url: 'https://insomnia.rest/', method: 'GET' };
-    const header = await getAuthHeader('req_123', request, {
+    const authentication = {
       type: AUTH_OAUTH_1,
       consumerKey: 'consumerKey',
       consumerSecret: 'consumerSecret',
@@ -14,7 +13,9 @@ describe('OAuth 1.0', () => {
       signatureMethod: 'HMAC-SHA1',
       nonce: 'nonce',
       timestamp: '1234567890',
-    });
+    };
+    const request = { url: 'https://insomnia.rest/', method: 'GET', authentication };
+    const header = await getAuthHeader(request, 'https://insomnia.rest/');
 
     expect(header).toEqual({
       name: 'Authorization',
@@ -32,8 +33,7 @@ describe('OAuth 1.0', () => {
   });
 
   it('Does OAuth 1.0 with RSA-SHA1', async () => {
-    const request = { url: 'https://insomnia.rest/', method: 'GET' };
-    const header = await getAuthHeader('req_123', request, {
+    const authentication = {
       type: AUTH_OAUTH_1,
       consumerKey: 'consumerKey',
       consumerSecret: 'consumerSecret',
@@ -59,7 +59,9 @@ describe('OAuth 1.0', () => {
         '-----END RSA PRIVATE KEY-----',
       nonce: 'nonce',
       timestamp: '1234567890',
-    });
+    };
+    const request = { url: 'https://insomnia.rest/', method: 'GET', authentication };
+    const header = await getAuthHeader(request, 'https://insomnia.rest/');
 
     expect(header).toEqual({
       name: 'Authorization',
@@ -77,13 +79,14 @@ describe('OAuth 1.0', () => {
   });
 
   it('Does OAuth 1.0 with defaults', async () => {
-    const request = { url: 'https://insomnia.rest/', method: 'GET' };
-    const header = await getAuthHeader('req_123', request, {
+    const authentication = {
       type: AUTH_OAUTH_1,
       consumerKey: 'consumerKey',
       consumerSecret: 'consumerSecret',
       signatureMethod: 'HMAC-SHA1',
-    });
+    };
+    const request = { url: 'https://insomnia.rest/', method: 'GET', authentication };
+    const header = await getAuthHeader(request, 'https://insomnia.rest/');
 
     expect(header.name).toBe('Authorization');
     expect(header.value).toMatch(

--- a/packages/insomnia-app/app/network/authentication.js
+++ b/packages/insomnia-app/app/network/authentication.js
@@ -11,7 +11,6 @@ import getOAuth2Token from './o-auth-2/get-token';
 import getOAuth1Token from './o-auth-1/get-token';
 import * as Hawk from 'hawk';
 import jwtAuthentication from 'jwt-authentication';
-import type { RequestAuthentication } from '../models/request';
 import type { RenderedRequest } from '../common/render';
 import { getBasicAuthHeader } from './basic-auth/get-header';
 import { getBearerAuthHeader } from './bearer-auth/get-header';
@@ -22,11 +21,11 @@ type Header = {
 };
 
 export async function getAuthHeader(
-  requestId: string,
   renderedRequest: RenderedRequest,
-  authentication: RequestAuthentication,
+  url: string,
 ): Promise<Header | null> {
-  const { method, url } = renderedRequest;
+  const { method, authentication } = renderedRequest;
+  const requestId = renderedRequest._id;
 
   if (authentication.disabled) {
     return null;

--- a/packages/insomnia-app/app/network/network.js
+++ b/packages/insomnia-app/app/network/network.js
@@ -596,8 +596,7 @@ export async function _actuallySend(
         } else {
           const authHeader = await getAuthHeader(
             renderedRequest._id,
-            finalUrl,
-            renderedRequest.method,
+            renderedRequest,
             renderedRequest.authentication,
           );
 

--- a/packages/insomnia-app/app/network/network.js
+++ b/packages/insomnia-app/app/network/network.js
@@ -594,11 +594,7 @@ export async function _actuallySend(
         } else if (renderedRequest.authentication.type === AUTH_NETRC) {
           setOpt(Curl.option.NETRC, Curl.netrc.REQUIRED);
         } else {
-          const authHeader = await getAuthHeader(
-            renderedRequest._id,
-            renderedRequest,
-            renderedRequest.authentication,
-          );
+          const authHeader = await getAuthHeader(renderedRequest, finalUrl);
 
           if (authHeader) {
             headers.push({

--- a/packages/insomnia-app/app/ui/components/editors/auth/hawk-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/hawk-auth.js
@@ -49,6 +49,11 @@ class HawkAuth extends React.PureComponent<Props> {
     this._handleChangeProperty('ext', value);
   }
 
+  _handleChangePayloadValidation(): void {
+    const { request } = this.props;
+    this._handleChangeProperty('validatePayload', !request.authentication.validatePayload);
+  }
+
   renderHawkAuthenticationFields(): React.Node {
     const hawkAuthId = this.renderInputRow('Auth ID', 'id', this._handleChangeHawkAuthId);
 
@@ -66,7 +71,13 @@ class HawkAuth extends React.PureComponent<Props> {
 
     const ext = this.renderInputRow('Ext', 'ext', this._handleChangeExt);
 
-    return [hawkAuthId, hawkAuthKey, algorithm, ext];
+    const payloadValidation = this.renderButtonRow(
+      'Validate Payload',
+      'validatePayload',
+      this._handleChangePayloadValidation,
+    );
+
+    return [hawkAuthId, hawkAuthKey, algorithm, ext, payloadValidation];
   }
 
   renderSelectRow(
@@ -115,7 +126,7 @@ class HawkAuth extends React.PureComponent<Props> {
       isVariableUncovered,
     } = this.props;
 
-    const {authentication} = request;
+    const { authentication } = request;
 
     const id = label.replace(/ /g, '-');
     return (
@@ -140,6 +151,44 @@ class HawkAuth extends React.PureComponent<Props> {
               getRenderContext={handleGetRenderContext}
               isVariableUncovered={isVariableUncovered}
             />
+          </div>
+        </td>
+      </tr>
+    );
+  }
+
+  renderButtonRow(label: string, property: string, onChange: Function): React.Element<*> {
+    const { request } = this.props;
+    const { authentication } = request;
+    const id = label.replace(/ /g, '-');
+    return (
+      <tr key={id}>
+        <td className="pad-right no-wrap valign-middle">
+          <label htmlFor={id} className="label--small no-pad">
+            {label}
+          </label>
+        </td>
+        <td className="wide">
+          <div
+            className={classnames('form-control form-control--underlined no-margin', {
+              'form-control--inactive': authentication.disabled,
+            })}>
+            <Button
+              className="btn btn--super-duper-compact"
+              id={id}
+              onClick={this._handleChangePayloadValidation}
+              value={authentication.validatePayload}
+              title={
+                authentication.validatePayload
+                  ? 'Enable payload validation'
+                  : 'Disable payload validation'
+              }>
+              {authentication.validatePayload ? (
+                <i className="fa fa-check-square-o" />
+              ) : (
+                <i className="fa fa-square-o" />
+              )}
+            </Button>
           </div>
         </td>
       </tr>


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/getinsomnia/insomnia/issues/new) first to discuss new 
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Closes #1321 
This change let's a user select whether Hawk Auth should use Payload Validation or not ). In terms of changes to the UI, it adds an additional checkbox to the Hawk Auth tab (which is off by default). I was a little unsure about the change I made to the signature of `getAuthHeader` so if there's a better way to get at the body and the content type without passing the whole request in let me know and I can adjust this.