### PR TITLE
Add support for Base64url encoding (#1348)

### DIFF
--- a/plugins/insomnia-plugin-base64/__tests__/index.test.js
+++ b/plugins/insomnia-plugin-base64/__tests__/index.test.js
@@ -19,12 +19,19 @@ function assertTemplateFails(args, expected) {
 }
 
 describe('Base64EncodeExtension', () => {
-  it('encodes nothing', assertTemplate(['encode'], ''));
-  it('encodes something', assertTemplate(['encode', 'my string'], 'bXkgc3RyaW5n'));
-  it('decodes nothing', assertTemplate(['decode'], ''));
-  it('decodes something', assertTemplate(['decode', 'bXkgc3RyaW5n'], 'my string'));
+  it('encodes nothing', assertTemplate(['encode', 'normal', ''], ''));
+  it('encodes something', assertTemplate(['encode', 'normal', 'my string'], 'bXkgc3RyaW5n'));
+  it('urlencodes nothing', assertTemplate(['encode', 'url', ''], ''));
+  it('urlencodes something', assertTemplate(['encode', 'url', 'hello world'], 'aGVsbG8gd29ybGQ'));
+  it('decodes nothing', assertTemplate(['decode', 'normal', ''], ''));
+  it('decodes something', assertTemplate(['decode', 'normal', 'bXkgc3RyaW5n'], 'my string'));
+  it('urldecodes nothing', assertTemplate(['decode', 'url', ''], ''));
+  it('urldecodes something', assertTemplate(['decode', 'url', 'aGVsbG8gd29ybGQ'], 'hello world'));
   it(
-    'fails on invalid op',
-    assertTemplateFails(['foo'], 'Unsupported operation "foo". Must be encode or decode.'),
+    'fails on invalid action',
+    assertTemplateFails(
+      ['foo', 'normal', ''],
+      'Unsupported operation "foo". Must be encode or decode.',
+    ),
   );
 });

--- a/plugins/insomnia-plugin-base64/index.js
+++ b/plugins/insomnia-plugin-base64/index.js
@@ -13,20 +13,33 @@ module.exports.templateTags = [
         ],
       },
       {
+        displayName: 'Kind',
+        type: 'enum',
+        options: [{ displayName: 'Normal', value: 'normal' }, { displayName: 'URL', value: 'url' }],
+      },
+      {
         displayName: 'Value',
         type: 'string',
         placeholder: 'My text',
       },
     ],
-    run(context, op, text) {
+    run(context, action, kind, text) {
       text = text || '';
 
-      if (op === 'encode') {
-        return Buffer.from(text, 'utf8').toString('base64');
-      } else if (op === 'decode') {
+      if (action === 'encode') {
+        if (kind === 'normal') {
+          return Buffer.from(text, 'utf8').toString('base64');
+        } else if (kind === 'url') {
+          return Buffer.from(text, 'utf8')
+            .toString('base64')
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=/g, '');
+        }
+      } else if (action === 'decode') {
         return Buffer.from(text, 'base64').toString('utf8');
       } else {
-        throw new Error('Unsupported operation "' + op + '". Must be encode or decode.');
+        throw new Error('Unsupported operation "' + action + '". Must be encode or decode.');
       }
     },
   },

--- a/plugins/insomnia-plugin-base64/package.json
+++ b/plugins/insomnia-plugin-base64/package.json
@@ -14,6 +14,6 @@
     "description": "Encode/Decode base64 strings"
   },
   "scripts": {
-    "test": "node --version"
+    "test": "jest --silent"
   }
 }


### PR DESCRIPTION
This small and dirty change adds support for Base64url encoding & decoding.

I had only one concern though, when I intentionally broke the test, npm test was still returning successfully, so not really sure what's going on with that...