### PR TITLE
Add request authentication getter and setter to plugin request context.

### DIFF
--- a/packages/insomnia-app/app/plugins/context/__tests__/request.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/request.test.js
@@ -27,6 +27,7 @@ describe('init()', () => {
     expect(Object.keys(result.request).sort()).toEqual([
       'addHeader',
       'addParameter',
+      'getAuthentication',
       'getBodyText',
       'getEnvironment',
       'getEnvironmentVariable',
@@ -42,6 +43,7 @@ describe('init()', () => {
       'hasParameter',
       'removeHeader',
       'removeParameter',
+      'setAuthentication',
       'setBodyText',
       'setCookie',
       'setHeader',
@@ -57,6 +59,7 @@ describe('init()', () => {
     const result = plugin.init(await models.request.getById('req_1'), CONTEXT, true);
     expect(Object.keys(result)).toEqual(['request']);
     expect(Object.keys(result.request).sort()).toEqual([
+      'getAuthentication',
       'getBodyText',
       'getEnvironment',
       'getEnvironmentVariable',
@@ -87,6 +90,7 @@ describe('request.*', () => {
       parentId: 'wrk_1',
       name: 'My Request',
       body: { text: 'body' },
+      authentication: { type: 'oauth2' },
       headers: [
         { name: 'hello', value: 'world' },
         { name: 'Content-Type', value: 'application/json' },
@@ -102,6 +106,7 @@ describe('request.*', () => {
     expect(result.request.getUrl()).toBe('');
     expect(result.request.getMethod()).toBe('GET');
     expect(result.request.getBodyText()).toBe('body');
+    expect(result.request.getAuthentication()).toEqual({ type: 'oauth2' });
   });
 
   it('works for parameters', async () => {
@@ -202,5 +207,17 @@ describe('request.*', () => {
     });
     expect(result.request.getEnvironmentVariable('null_test')).toBe(null);
     expect(result.request.getEnvironmentVariable('bad')).toBeUndefined();
+  });
+
+  it('works for authentication', async () => {
+    const request = await models.request.getById('req_1');
+    request.authentication = {}; // Because the plugin technically needs a RenderedRequest
+
+    const result = plugin.init(request, CONTEXT);
+
+    result.request.setAuthentication('foo', 'bar');
+    result.request.setAuthentication('foo', 'baz');
+    expect(result.request.getAuthentication()).toEqual({ foo: 'baz' });
+    expect(request.authentication).toEqual({ foo: 'baz' });
   });
 });

--- a/packages/insomnia-app/app/plugins/context/__tests__/request.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/request.test.js
@@ -43,7 +43,7 @@ describe('init()', () => {
       'hasParameter',
       'removeHeader',
       'removeParameter',
-      'setAuthentication',
+      'setAuthenticationParameter',
       'setBodyText',
       'setCookie',
       'setHeader',
@@ -215,8 +215,8 @@ describe('request.*', () => {
 
     const result = plugin.init(request, CONTEXT);
 
-    result.request.setAuthentication('foo', 'bar');
-    result.request.setAuthentication('foo', 'baz');
+    result.request.setAuthenticationParameter('foo', 'bar');
+    result.request.setAuthenticationParameter('foo', 'baz');
     expect(result.request.getAuthentication()).toEqual({ foo: 'baz' });
     expect(request.authentication).toEqual({ foo: 'baz' });
   });

--- a/packages/insomnia-app/app/plugins/context/request.js
+++ b/packages/insomnia-app/app/plugins/context/request.js
@@ -131,14 +131,15 @@ export function init(
       }
     },
 
-
-    setAuthentication(name : string, value: string) : void {
-      renderedRequest.authentication[name] = value;
+    setAuthentication(name: string, value: string): void {
+      Object.assign(renderedRequest.authentication, {
+        [name]: value,
+      });
     },
 
-    getAuthentication() : Object {
+    getAuthentication(): Object {
       return renderedRequest.authentication;
-    }
+    },
 
     // NOTE: For these to make sense, we'd need to account for cookies in the jar as well
     // addCookie (name: string, value: string): void {}

--- a/packages/insomnia-app/app/plugins/context/request.js
+++ b/packages/insomnia-app/app/plugins/context/request.js
@@ -131,6 +131,15 @@ export function init(
       }
     },
 
+
+    setAuthentication(name : string, value: string) : void {
+      renderedRequest.authentication[name] = value;
+    },
+
+    getAuthentication() : Object {
+      return renderedRequest.authentication;
+    }
+
     // NOTE: For these to make sense, we'd need to account for cookies in the jar as well
     // addCookie (name: string, value: string): void {}
     // getCookie (name: string): string | null {}
@@ -152,6 +161,7 @@ export function init(
     delete request.setParameter;
     delete request.addParameter;
     delete request.addParameter;
+    delete request.setAuthentication;
   }
 
   return { request };

--- a/packages/insomnia-app/app/plugins/context/request.js
+++ b/packages/insomnia-app/app/plugins/context/request.js
@@ -131,7 +131,7 @@ export function init(
       }
     },
 
-    setAuthentication(name: string, value: string): void {
+    setAuthenticationParameter(name: string, value: string): void {
       Object.assign(renderedRequest.authentication, {
         [name]: value,
       });
@@ -162,7 +162,7 @@ export function init(
     delete request.setParameter;
     delete request.addParameter;
     delete request.addParameter;
-    delete request.setAuthentication;
+    delete request.setAuthenticationParameter;
   }
 
   return { request };


### PR DESCRIPTION
This PR enables plugin developers to set and get the authentication configuration of a request. 

I built a [small plugin](https://github.com/samirnijenhuis/insomnia-plugin-env-authentication) that allows me to define my OAuth 2 settings on an environment and automate the authentication for every request I add to my workspace. This way I don't have to look / configure auth settings for every single request.

The following issues could benefit from this pr:
https://github.com/getinsomnia/insomnia/issues/1116
https://github.com/getinsomnia/insomnia/issues/790
