### PR TITLE
Export folders and requests

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/import.test.js
+++ b/packages/insomnia-app/app/common/__tests__/import.test.js
@@ -52,10 +52,11 @@ describe('exportWorkspacesHAR()', () => {
     });
 
     const includePrivateDocs = true;
-    const json = await importUtil.exportWorkspacesHAR(wrk1, includePrivateDocs);
-    const data = JSON.parse(json);
 
-    expect(data).toMatchObject({
+    // Test export whole workspace.
+    const exportWorkspacesJson = await importUtil.exportWorkspacesHAR(wrk1, includePrivateDocs);
+    const exportWorkspacesData = JSON.parse(exportWorkspacesJson);
+    expect(exportWorkspacesData).toMatchObject({
       log: {
         entries: [
           {
@@ -70,7 +71,24 @@ describe('exportWorkspacesHAR()', () => {
         ],
       },
     });
-    expect(data.log.entries.length).toBe(2);
+    expect(exportWorkspacesData.log.entries.length).toBe(2);
+
+    // Test export some requests only.
+    const exportRequestsJson = await importUtil.exportRequestsHAR([req1], includePrivateDocs);
+    const exportRequestsData = JSON.parse(exportRequestsJson);
+    expect(exportRequestsData).toMatchObject({
+      log: {
+        entries: [
+          {
+            request: {
+              headers: [{ name: 'X-Environment', value: 'private1' }],
+            },
+            comment: req1.name,
+          },
+        ],
+      },
+    });
+    expect(exportRequestsData.log.entries.length).toBe(1);
   });
   it('exports all workspaces as an HTTP Archive', async () => {
     const wrk1 = await models.workspace.create({
@@ -162,8 +180,16 @@ describe('exportWorkspacesJSON()', () => {
     const w = await models.workspace.create({ name: 'Workspace' });
     const jar = await models.cookieJar.getOrCreateForParentId(w._id);
     const r1 = await models.request.create({
-      name: 'Request',
+      name: 'Request 1',
       parentId: w._id,
+    });
+    const f2 = await models.requestGroup.create({
+      name: 'Folder 2',
+      parentId: w._id,
+    });
+    const r2 = await models.request.create({
+      name: 'Request 2',
+      parentId: f2._id,
     });
     const eBase = await models.environment.getOrCreateForWorkspace(w);
     const ePub = await models.environment.create({
@@ -176,18 +202,42 @@ describe('exportWorkspacesJSON()', () => {
       parentId: eBase._id,
     });
 
-    const json = await importUtil.exportWorkspacesJSON();
-    const data = JSON.parse(json);
+    // Test export whole workspace.
+    const exportedWorkspacesJson = await importUtil.exportWorkspacesJSON();
+    const exportWorkspacesData = JSON.parse(exportedWorkspacesJson);
+    expect(exportWorkspacesData).toMatchObject({
+      _type: 'export',
+      __export_format: 3,
+      __export_date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/),
+      __export_source: `insomnia.desktop.app:v${getAppVersion()}`,
+      resources: expect.arrayContaining([
+        expect.objectContaining({ _id: w._id }),
+        expect.objectContaining({ _id: eBase._id }),
+        expect.objectContaining({ _id: jar._id }),
+        expect.objectContaining({ _id: r1._id }),
+        expect.objectContaining({ _id: f2._id }),
+        expect.objectContaining({ _id: r2._id }),
+        expect.objectContaining({ _id: ePub._id }),
+      ]),
+    });
+    expect(exportWorkspacesData.resources.length).toBe(7);
 
-    expect(data._type).toBe('export');
-    expect(data.__export_format).toBe(3);
-    expect(data.__export_date).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
-    expect(data.__export_source).toBe(`insomnia.desktop.app:v${getAppVersion()}`);
-    expect(data.resources[0]._id).toBe(w._id);
-    expect(data.resources[1]._id).toBe(eBase._id);
-    expect(data.resources[2]._id).toBe(jar._id);
-    expect(data.resources[3]._id).toBe(r1._id);
-    expect(data.resources[4]._id).toBe(ePub._id);
-    expect(data.resources.length).toBe(5);
+    // Test export some requests only.
+    const exportRequestsJson = await importUtil.exportRequestsJSON([r1]);
+    const exportRequestsData = JSON.parse(exportRequestsJson);
+    expect(exportRequestsData).toMatchObject({
+      _type: 'export',
+      __export_format: 3,
+      __export_date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/),
+      __export_source: `insomnia.desktop.app:v${getAppVersion()}`,
+      resources: expect.arrayContaining([
+        expect.objectContaining({ _id: w._id }),
+        expect.objectContaining({ _id: eBase._id }),
+        expect.objectContaining({ _id: jar._id }),
+        expect.objectContaining({ _id: r1._id }),
+        expect.objectContaining({ _id: ePub._id }),
+      ]),
+    });
+    expect(exportRequestsData.resources.length).toBe(5);
   });
 });

--- a/packages/insomnia-app/app/common/__tests__/import.test.js
+++ b/packages/insomnia-app/app/common/__tests__/import.test.js
@@ -3,7 +3,7 @@ import * as importUtil from '../import';
 import { getAppVersion } from '../constants';
 import { globalBeforeEach } from '../../__jest__/before-each';
 
-describe('exportHAR()', () => {
+describe('exportWorkspacesHAR()', () => {
   beforeEach(globalBeforeEach);
   it('exports a single workspace as an HTTP Archive', async () => {
     const wrk1 = await models.workspace.create({
@@ -52,7 +52,7 @@ describe('exportHAR()', () => {
     });
 
     const includePrivateDocs = true;
-    const json = await importUtil.exportHAR(wrk1, includePrivateDocs);
+    const json = await importUtil.exportWorkspacesHAR(wrk1, includePrivateDocs);
     const data = JSON.parse(json);
 
     expect(data).toMatchObject({
@@ -132,7 +132,7 @@ describe('exportHAR()', () => {
     });
 
     const includePrivateDocs = false;
-    const json = await importUtil.exportHAR(null, includePrivateDocs);
+    const json = await importUtil.exportWorkspacesHAR(null, includePrivateDocs);
     const data = JSON.parse(json);
 
     expect(data).toMatchObject({
@@ -156,7 +156,7 @@ describe('exportHAR()', () => {
   });
 });
 
-describe('exportJSON()', () => {
+describe('exportWorkspacesJSON()', () => {
   beforeEach(globalBeforeEach);
   it('exports all workspaces', async () => {
     const w = await models.workspace.create({ name: 'Workspace' });
@@ -176,7 +176,7 @@ describe('exportJSON()', () => {
       parentId: eBase._id,
     });
 
-    const json = await importUtil.exportJSON();
+    const json = await importUtil.exportWorkspacesJSON();
     const data = JSON.parse(json);
 
     expect(data._type).toBe('export');

--- a/packages/insomnia-app/app/common/__tests__/import.test.js
+++ b/packages/insomnia-app/app/common/__tests__/import.test.js
@@ -3,9 +3,9 @@ import * as importUtil from '../import';
 import { getAppVersion } from '../constants';
 import { globalBeforeEach } from '../../__jest__/before-each';
 
-describe('exportWorkspacesHAR()', () => {
+describe('exportWorkspacesHAR() and exportRequestsHAR()', () => {
   beforeEach(globalBeforeEach);
-  it('exports a single workspace as an HTTP Archive', async () => {
+  it('exports a single workspace and some requests only as an HTTP Archive', async () => {
     const wrk1 = await models.workspace.create({
       _id: 'wrk_1',
       name: 'Workspace 1',
@@ -155,28 +155,28 @@ describe('exportWorkspacesHAR()', () => {
 
     expect(data).toMatchObject({
       log: {
-        entries: [
-          {
-            request: {
+        entries: expect.arrayContaining([
+          expect.objectContaining({
+            request: expect.objectContaining({
               headers: [{ name: 'X-Environment', value: 'public1' }],
-            },
+            }),
             comment: 'Request 1',
-          },
-          {
-            request: {
+          }),
+          expect.objectContaining({
+            request: expect.objectContaining({
               headers: [{ name: 'X-Environment', value: 'base2' }],
-            },
+            }),
             comment: 'Request 2',
-          },
-        ],
+          }),
+        ]),
       },
     });
   });
 });
 
-describe('exportWorkspacesJSON()', () => {
+describe('exportWorkspacesJSON() and exportRequestsJSON()', () => {
   beforeEach(globalBeforeEach);
-  it('exports all workspaces', async () => {
+  it('exports all workspaces and some requests only', async () => {
     const w = await models.workspace.create({ name: 'Workspace' });
     const jar = await models.cookieJar.getOrCreateForParentId(w._id);
     const r1 = await models.request.create({

--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -188,7 +188,7 @@ export async function importRaw(
   };
 }
 
-export async function exportHAR(
+export async function exportWorkspacesHAR(
   parentDoc: BaseModel | null = null,
   includePrivateDocs: boolean = false,
 ): Promise<string> {
@@ -231,7 +231,59 @@ export async function exportHAR(
   return JSON.stringify(data, null, '\t');
 }
 
-export async function exportJSON(
+export async function exportRequestsHAR(
+  requests: Array<BaseModel>,
+  includePrivateDocs: boolean = false,
+): Promise<string> {
+  const workspaces: Array<BaseModel> = [];
+  const mapRequestIdToWorkspace: Object = {};
+  const workspaceLookup: Object = {};
+  for (const request of requests) {
+    const ancestors: Array<BaseModel> = await db.withAncestors(request, [
+      models.workspace.type,
+      models.requestGroup.type,
+    ]);
+    const workspace = ancestors.find(ancestor => ancestor.type === models.workspace.type);
+    mapRequestIdToWorkspace[request._id] = workspace;
+    if (workspace == null || workspaceLookup.hasOwnProperty(workspace._id)) {
+      continue;
+    }
+    workspaceLookup[workspace._id] = true;
+    workspaces.push(workspace);
+  }
+
+  const mapWorkspaceIdToEnvironmentId: Object = {};
+  for (const workspace of workspaces) {
+    const workspaceMeta = await models.workspaceMeta.getByParentId(workspace._id);
+    let environmentId = workspaceMeta ? workspaceMeta.activeEnvironmentId : null;
+    const environment = await models.environment.getById(environmentId || 'n/a');
+    if (!environment || (environment.isPrivate && !includePrivateDocs)) {
+      environmentId = 'n/a';
+    }
+    mapWorkspaceIdToEnvironmentId[workspace._id] = environmentId;
+  }
+
+  requests = requests.sort((a: Object, b: Object) => (a.metaSortKey < b.metaSortKey ? -1 : 1));
+  const harRequests: Array<Object> = [];
+  for (const request of requests) {
+    const workspace = mapRequestIdToWorkspace[request._id];
+    if (workspace == null) {
+      // Workspace not found for request, so don't export it.
+      continue;
+    }
+    const environmentId = mapWorkspaceIdToEnvironmentId[workspace._id];
+    harRequests.push({
+      requestId: request._id,
+      environmentId: environmentId,
+    });
+  }
+
+  const data = await har.exportHar(harRequests);
+
+  return JSON.stringify(data, null, '\t');
+}
+
+export async function exportWorkspacesJSON(
   parentDoc: BaseModel | null = null,
   includePrivateDocs: boolean = false,
 ): Promise<string> {
@@ -255,6 +307,82 @@ export async function exportJSON(
         d.type === models.cookieJar.type ||
         d.type === models.environment.type,
     )
+    .map((d: Object) => {
+      if (d.type === models.workspace.type) {
+        d._type = EXPORT_TYPE_WORKSPACE;
+      } else if (d.type === models.cookieJar.type) {
+        d._type = EXPORT_TYPE_COOKIE_JAR;
+      } else if (d.type === models.environment.type) {
+        d._type = EXPORT_TYPE_ENVIRONMENT;
+      } else if (d.type === models.requestGroup.type) {
+        d._type = EXPORT_TYPE_REQUEST_GROUP;
+      } else if (d.type === models.request.type) {
+        d._type = EXPORT_TYPE_REQUEST;
+      }
+
+      // Delete the things we don't want to export
+      delete d.type;
+      return d;
+    });
+
+  return JSON.stringify(data, null, '\t');
+}
+
+export async function exportRequestsJSON(
+  requests: Array<BaseModel>,
+  includePrivateDocs: boolean = false,
+): Promise<string> {
+  const data = {
+    _type: 'export',
+    __export_format: EXPORT_FORMAT,
+    __export_date: new Date(),
+    __export_source: `insomnia.desktop.app:v${getAppVersion()}`,
+    resources: [],
+  };
+
+  const docs: Array<BaseModel> = [];
+  const workspaces: Array<BaseModel> = [];
+  const mapTypeAndIdToDoc: Object = {};
+  for (const req of requests) {
+    const ancestors: Array<BaseModel> = await db.withAncestors(req);
+    for (const ancestor of ancestors) {
+      const key = ancestor.type + '___' + ancestor._id;
+      if (mapTypeAndIdToDoc.hasOwnProperty(key)) {
+        continue;
+      }
+      mapTypeAndIdToDoc[key] = ancestor;
+      docs.push(ancestor);
+      if (ancestor.type === models.workspace.type) {
+        workspaces.push(ancestor);
+      }
+    }
+  }
+
+  for (const workspace of workspaces) {
+    const descendants: Array<BaseModel> = (await db.withDescendants(workspace)).filter(d => {
+      // Only interested in these additional model types.
+      return d.type === models.cookieJar.type || d.type === models.environment.type;
+    });
+    docs.push(...descendants);
+  }
+
+  data.resources = docs
+    .filter(d => {
+      // Only export these model types.
+      if (
+        !(
+          d.type === models.request.type ||
+          d.type === models.requestGroup.type ||
+          d.type === models.workspace.type ||
+          d.type === models.cookieJar.type ||
+          d.type === models.environment.type
+        )
+      ) {
+        return false;
+      }
+      // BaseModel doesn't have isPrivate, so cast it first.
+      return !(d: Object).isPrivate || includePrivateDocs;
+    })
     .map((d: Object) => {
       if (d.type === models.workspace.type) {
         d._type = EXPORT_TYPE_WORKSPACE;

--- a/packages/insomnia-app/app/plugins/context/__tests__/data.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/data.test.js
@@ -171,7 +171,7 @@ describe('app.export.*', () => {
       __export_format: 3,
       __export_source: `insomnia.desktop.app:v${getAppVersion()}`,
       _type: 'export',
-      resources: [
+      resources: expect.arrayContaining([
         {
           _id: 'wrk_1',
           _type: 'workspace',
@@ -204,7 +204,7 @@ describe('app.export.*', () => {
           settingMaxTimelineDataSize: 1000,
           url: 'https://insomnia.rest',
         },
-      ],
+      ]),
     });
   });
 

--- a/packages/insomnia-app/app/plugins/context/data.js
+++ b/packages/insomnia-app/app/plugins/context/data.js
@@ -1,5 +1,10 @@
 // @flow
-import { exportHAR, exportJSON, importRaw, importUri } from '../../common/import';
+import {
+  exportWorkspacesHAR,
+  exportWorkspacesJSON,
+  importRaw,
+  importUri,
+} from '../../common/import';
 
 export function init(): { import: Object, export: Object } {
   return {
@@ -14,10 +19,10 @@ export function init(): { import: Object, export: Object } {
     export: {
       async insomnia(options: { includePrivate?: boolean } = {}): Promise<string> {
         options = options || {};
-        return exportJSON(null, options.includePrivate);
+        return exportWorkspacesJSON(null, options.includePrivate);
       },
       async har(options: { includePrivate?: boolean } = {}): Promise<string> {
-        return exportHAR(null, options.includePrivate);
+        return exportWorkspacesHAR(null, options.includePrivate);
       },
     },
   };

--- a/packages/insomnia-app/app/ui/components/export-requests/request-group-row.js
+++ b/packages/insomnia-app/app/ui/components/export-requests/request-group-row.js
@@ -1,0 +1,84 @@
+// @flow
+import * as React from 'react';
+import autobind from 'autobind-decorator';
+import classnames from 'classnames';
+import type { RequestGroup } from '../../../models/request-group';
+
+type Props = {
+  // Required.
+  handleSetRequestGroupCollapsed: Function,
+  handleSetItemSelected: Function,
+  isCollapsed: boolean,
+  totalRequests: number,
+  selectedRequests: number,
+  requestGroup: RequestGroup,
+
+  // Optional.
+  children?: React.Node,
+};
+
+@autobind
+class RequestGroupRow extends React.PureComponent<Props> {
+  checkbox: HTMLInputElement;
+
+  setCheckboxRef(checkbox: ?HTMLInputElement) {
+    if (checkbox != null) {
+      this.checkbox = checkbox;
+    }
+  }
+
+  handleCollapse() {
+    const { requestGroup, handleSetRequestGroupCollapsed, isCollapsed } = this.props;
+    handleSetRequestGroupCollapsed(requestGroup._id, !isCollapsed);
+  }
+
+  handleSelect(e: SyntheticEvent<HTMLInputElement>) {
+    const el = e.currentTarget;
+    let value = el.checked;
+    const { handleSetItemSelected, requestGroup } = this.props;
+    return handleSetItemSelected(requestGroup._id, value);
+  }
+
+  render() {
+    const { children, requestGroup, isCollapsed, totalRequests, selectedRequests } = this.props;
+
+    let folderIconClass = 'fa-folder';
+
+    folderIconClass += isCollapsed ? '' : '-open';
+
+    const isSelected = selectedRequests === totalRequests;
+    if (this.checkbox != null) {
+      // Partial or indeterminate checkbox.
+      this.checkbox.indeterminate = selectedRequests > 0 && selectedRequests < totalRequests;
+    }
+
+    return (
+      <li key={requestGroup._id} className="tree__row">
+        <div className="tree__item tree__item--big">
+          <div className="tree__item__checkbox tree__indent">
+            <input
+              ref={this.setCheckboxRef}
+              type="checkbox"
+              checked={isSelected}
+              onChange={this.handleSelect}
+            />
+          </div>
+          <button onClick={this.handleCollapse}>
+            <i className={'tree__item__icon fa ' + folderIconClass} />
+            {requestGroup.name}
+            <span className="total-requests">{totalRequests} requests</span>
+          </button>
+        </div>
+
+        <ul
+          className={classnames('tree__list', {
+            'tree__list--collapsed': isCollapsed,
+          })}>
+          {!isCollapsed ? children : null}
+        </ul>
+      </li>
+    );
+  }
+}
+
+export default RequestGroupRow;

--- a/packages/insomnia-app/app/ui/components/export-requests/request-row.js
+++ b/packages/insomnia-app/app/ui/components/export-requests/request-row.js
@@ -1,0 +1,40 @@
+// @flow
+import React, { PureComponent } from 'react';
+import autobind from 'autobind-decorator';
+import MethodTag from '../tags/method-tag';
+import type { Request } from '../../../models/request';
+
+type Props = {
+  handleSetItemSelected: Function,
+  isSelected: boolean,
+  request: Request,
+};
+
+@autobind
+class RequestRow extends PureComponent<Props> {
+  handleSelect(e: SyntheticEvent<HTMLInputElement>) {
+    const el = e.currentTarget;
+    let value = el.checked;
+    const { handleSetItemSelected, request } = this.props;
+    return handleSetItemSelected(request._id, value);
+  }
+
+  render() {
+    const { request, isSelected } = this.props;
+    return (
+      <li className="tree__row">
+        <div className="tree__item tree__item--request">
+          <div className="tree__item__checkbox tree__indent">
+            <input type="checkbox" checked={isSelected} onChange={this.handleSelect} />
+          </div>
+          <button className="wide">
+            <MethodTag method={request.method} />
+            <span className="inline-block">{request.name}</span>
+          </button>
+        </div>
+      </li>
+    );
+  }
+}
+
+export default RequestRow;

--- a/packages/insomnia-app/app/ui/components/export-requests/tree.js
+++ b/packages/insomnia-app/app/ui/components/export-requests/tree.js
@@ -1,0 +1,66 @@
+// @flow
+import * as React from 'react';
+import RequestRow from './request-row';
+import RequestGroupRow from './request-group-row';
+import * as models from '../../../models/index';
+import type { Node } from '../modals/export-requests-modal';
+import type { Request } from '../../../models/request';
+import type { RequestGroup } from '../../../models/request-group';
+
+type Props = {
+  root: ?Node,
+  handleSetRequestGroupCollapsed: Function,
+  handleSetItemSelected: Function,
+};
+
+class Tree extends React.PureComponent<Props> {
+  renderChildren(node: ?Node) {
+    if (node == null) {
+      return null;
+    }
+
+    if (node.doc.type === models.request.type) {
+      // Directly cast to Request will result in error, so cast it to any first.
+      const request: Request = ((node.doc: any): Request);
+      return (
+        <RequestRow
+          key={node.doc._id}
+          handleSetItemSelected={this.props.handleSetItemSelected}
+          isSelected={node.selectedRequests === node.totalRequests}
+          request={request}
+        />
+      );
+    }
+
+    if (node.totalRequests === 0) {
+      // Don't show empty folders.
+      return null;
+    }
+
+    const children = node.children.map(child => this.renderChildren(child));
+
+    // Directly cast to RequestGroup will result in error, so cast it to any first.
+    const requestGroup: RequestGroup = ((node.doc: any): RequestGroup);
+    return (
+      <RequestGroupRow
+        key={node.doc._id}
+        handleSetRequestGroupCollapsed={this.props.handleSetRequestGroupCollapsed}
+        handleSetItemSelected={this.props.handleSetItemSelected}
+        isCollapsed={node.collapsed}
+        totalRequests={node.totalRequests}
+        selectedRequests={node.selectedRequests}
+        requestGroup={requestGroup}
+        children={children}
+      />
+    );
+  }
+
+  render() {
+    const { root } = this.props;
+    return (
+      <ul className="tree__list tree__list-root theme--tree__list">{this.renderChildren(root)}</ul>
+    );
+  }
+}
+
+export default Tree;

--- a/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
@@ -5,22 +5,47 @@ import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
+import Tree from '../export-requests/tree';
+import type { Request } from '../../../models/request';
+import type { RequestGroup } from '../../../models/request-group';
+import * as models from '../../../models';
 
-type Props = {};
+export type Node = {
+  doc: Request | RequestGroup,
+  children: Array<Node>,
+  collapsed: boolean,
+  totalRequests: number,
+  selectedRequests: number,
+};
+
+type Props = {
+  childObjects: Array<Object>,
+};
+
+type State = {
+  treeRoot: ?Node,
+};
 
 @autobind
-class ExportRequestsModal extends PureComponent<Props> {
+class ExportRequestsModal extends PureComponent<Props, State> {
+  modal: Modal;
+
   constructor(props: Props) {
     super(props);
-    this.state = {};
+    this.state = {
+      treeRoot: null,
+    };
   }
 
-  _setModalRef(n: React.Component<*> | null) {
-    this.modal = n;
+  setModalRef(modal: ?Modal) {
+    if (modal != null) {
+      this.modal = modal;
+    }
   }
 
   show() {
     this.modal.show();
+    this.createNewTree();
   }
 
   hide() {
@@ -29,17 +54,136 @@ class ExportRequestsModal extends PureComponent<Props> {
 
   handleExport() {}
 
+  createNewTree() {
+    const { childObjects } = this.props;
+    const children: Array<Node> = childObjects.map(child => this.createTree(child));
+    const totalRequests = children
+      .map(child => child.totalRequests)
+      .reduce((acc, totalRequests) => acc + totalRequests, 0);
+    const rootFolder: RequestGroup = Object.assign({}, models.requestGroup.init(), {
+      _id: 'all',
+      type: models.requestGroup.type,
+      name: 'All requests',
+      parentId: '',
+      modified: 0,
+      created: 0,
+    });
+    this.setState({
+      treeRoot: {
+        doc: rootFolder,
+        collapsed: false,
+        children: children,
+        totalRequests: totalRequests,
+        selectedRequests: 0,
+      },
+    });
+  }
+
+  createTree(item: Object): Node {
+    const children: Array<Node> = item.children.map(child => this.createTree(child));
+    let totalRequests = children
+      .map(child => child.totalRequests)
+      .reduce((acc, totalRequests) => acc + totalRequests, 0);
+    if (item.doc.type === models.request.type) {
+      totalRequests++;
+    }
+    return {
+      doc: item.doc,
+      collapsed: false,
+      children: children,
+      totalRequests: totalRequests,
+      selectedRequests: 0,
+    };
+  }
+
+  handleSetRequestGroupCollapsed(requestGroupId: string, isCollapsed: boolean) {
+    const { treeRoot } = this.state;
+    if (treeRoot == null) {
+      return;
+    }
+    const found = this.setRequestGroupCollapsed(treeRoot, isCollapsed, requestGroupId);
+    if (!found) {
+      return;
+    }
+    this.setState({
+      treeRoot: { ...treeRoot },
+    });
+  }
+
+  handleSetItemSelected(itemId: string, isSelected: boolean) {
+    const { treeRoot } = this.state;
+    if (treeRoot == null) {
+      return;
+    }
+    const found = this.setItemSelected(treeRoot, isSelected, itemId);
+    if (!found) {
+      return;
+    }
+    this.setState({
+      treeRoot: { ...treeRoot },
+    });
+  }
+
+  setRequestGroupCollapsed(node: Node, isCollapsed: boolean, requestGroupId: string): boolean {
+    if (node.doc.type !== models.requestGroup.type) {
+      return false;
+    }
+    if (node.doc._id === requestGroupId) {
+      node.collapsed = isCollapsed;
+      return true;
+    }
+    for (const child of node.children) {
+      const found = this.setRequestGroupCollapsed(child, isCollapsed, requestGroupId);
+      if (found) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  setItemSelected(node: Node, isSelected: boolean, id?: string): boolean {
+    if (id == null || node.doc._id === id) {
+      // Switch the flags of all children in this subtree.
+      for (const child of node.children) {
+        this.setItemSelected(child, isSelected);
+      }
+      node.selectedRequests = isSelected ? node.totalRequests : 0;
+      return true;
+    }
+
+    for (const child of node.children) {
+      const found = this.setItemSelected(child, isSelected, id);
+      if (found) {
+        node.selectedRequests = node.children
+          .map(ch => ch.selectedRequests)
+          .reduce((acc, selected) => acc + selected, 0);
+        return true;
+      }
+    }
+    return false;
+  }
+
   render() {
+    const { treeRoot } = this.state;
+    const isExportDisabled = treeRoot != null ? treeRoot.selectedRequests === 0 : false;
     return (
-      <Modal ref={this._setModalRef} tall freshState {...this.props}>
+      <Modal ref={this.setModalRef} tall freshState {...this.props}>
         <ModalHeader>Export Requests</ModalHeader>
-        <ModalBody />
+        <ModalBody>
+          <div className="requests-tree">
+            <Tree
+              root={treeRoot}
+              handleSetRequestGroupCollapsed={this.handleSetRequestGroupCollapsed}
+              handleSetItemSelected={this.handleSetItemSelected}
+            />
+          </div>
+        </ModalBody>
         <ModalFooter>
           <div>
             <button className="btn" onClick={this.hide}>
               Cancel
             </button>
-            <button className="btn" onClick={this.handleExport}>
+            <button className="btn" onClick={this.handleExport} disabled={isExportDisabled}>
               Export
             </button>
           </div>

--- a/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
@@ -1,0 +1,52 @@
+// @flow
+import React, { PureComponent } from 'react';
+import autobind from 'autobind-decorator';
+import Modal from '../base/modal';
+import ModalBody from '../base/modal-body';
+import ModalHeader from '../base/modal-header';
+import ModalFooter from '../base/modal-footer';
+
+type Props = {};
+
+@autobind
+class ExportRequestsModal extends PureComponent<Props> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {};
+  }
+
+  _setModalRef(n: React.Component<*> | null) {
+    this.modal = n;
+  }
+
+  show() {
+    this.modal.show();
+  }
+
+  hide() {
+    this.modal.hide();
+  }
+
+  handleExport() {}
+
+  render() {
+    return (
+      <Modal ref={this._setModalRef} tall freshState {...this.props}>
+        <ModalHeader>Export Requests</ModalHeader>
+        <ModalBody />
+        <ModalFooter>
+          <div>
+            <button className="btn" onClick={this.hide}>
+              Cancel
+            </button>
+            <button className="btn" onClick={this.handleExport}>
+              Export
+            </button>
+          </div>
+        </ModalFooter>
+      </Modal>
+    );
+  }
+}
+
+export default ExportRequestsModal;

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.js
@@ -43,8 +43,8 @@ class SettingsModal extends PureComponent {
     this.modal.hide();
   }
 
-  _handleExportRequests() {
-    this.props.handleExportRequestsToFile();
+  _handleShowExportRequestsModal() {
+    this.props.handleShowExportRequestsModal();
     this.modal.hide();
   }
 
@@ -133,7 +133,7 @@ class SettingsModal extends PureComponent {
             <TabPanel className="react-tabs__tab-panel pad scrollable">
               <ImportExport
                 handleExportAll={this._handleExportAllToFile}
-                handleExportRequests={this._handleExportRequests}
+                handleShowExportRequestsModal={this._handleShowExportRequestsModal}
                 handleExportWorkspace={this._handleExportWorkspace}
                 handleImportFile={this._handleImportFile}
                 handleImportUri={this._handleImportUri}
@@ -164,7 +164,7 @@ class SettingsModal extends PureComponent {
 SettingsModal.propTypes = {
   // Functions
   handleExportWorkspaceToFile: PropTypes.func.isRequired,
-  handleExportRequestsToFile: PropTypes.func.isRequired,
+  handleShowExportRequestsModal: PropTypes.func.isRequired,
   handleExportAllToFile: PropTypes.func.isRequired,
   handleImportFile: PropTypes.func.isRequired,
   handleImportUri: PropTypes.func.isRequired,

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.js
@@ -43,6 +43,11 @@ class SettingsModal extends PureComponent {
     this.modal.hide();
   }
 
+  _handleExportRequests() {
+    this.props.handleExportRequestsToFile();
+    this.modal.hide();
+  }
+
   _handleExportWorkspace() {
     this.props.handleExportWorkspaceToFile();
     this.modal.hide();
@@ -128,6 +133,7 @@ class SettingsModal extends PureComponent {
             <TabPanel className="react-tabs__tab-panel pad scrollable">
               <ImportExport
                 handleExportAll={this._handleExportAllToFile}
+                handleExportRequests={this._handleExportRequests}
                 handleExportWorkspace={this._handleExportWorkspace}
                 handleImportFile={this._handleImportFile}
                 handleImportUri={this._handleImportUri}
@@ -158,6 +164,7 @@ class SettingsModal extends PureComponent {
 SettingsModal.propTypes = {
   // Functions
   handleExportWorkspaceToFile: PropTypes.func.isRequired,
+  handleExportRequestsToFile: PropTypes.func.isRequired,
   handleExportAllToFile: PropTypes.func.isRequired,
   handleImportFile: PropTypes.func.isRequired,
   handleImportUri: PropTypes.func.isRequired,

--- a/packages/insomnia-app/app/ui/components/settings/import-export.js
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.js
@@ -23,7 +23,7 @@ class ImportExport extends PureComponent {
     const {
       handleImportFile,
       handleExportAll,
-      handleExportRequests,
+      handleShowExportRequestsModal,
       handleExportWorkspace,
     } = this.props;
 
@@ -50,7 +50,7 @@ class ImportExport extends PureComponent {
               <i className="fa fa-home" />
               Current Workspace
             </DropdownItem>
-            <DropdownItem onClick={handleExportRequests}>
+            <DropdownItem onClick={handleShowExportRequestsModal}>
               <i className="fa fa-home" />
               Current Workspace's Requests
             </DropdownItem>
@@ -85,7 +85,7 @@ ImportExport.propTypes = {
   handleImportFile: PropTypes.func.isRequired,
   handleImportUri: PropTypes.func.isRequired,
   handleExportAll: PropTypes.func.isRequired,
-  handleExportRequests: PropTypes.func.isRequired,
+  handleShowExportRequestsModal: PropTypes.func.isRequired,
   handleExportWorkspace: PropTypes.func.isRequired,
 };
 

--- a/packages/insomnia-app/app/ui/components/settings/import-export.js
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.js
@@ -20,7 +20,12 @@ class ImportExport extends PureComponent {
   }
 
   render() {
-    const { handleImportFile, handleExportAll, handleExportWorkspace } = this.props;
+    const {
+      handleImportFile,
+      handleExportAll,
+      handleExportRequests,
+      handleExportWorkspace,
+    } = this.props;
 
     return (
       <div>
@@ -44,6 +49,10 @@ class ImportExport extends PureComponent {
             <DropdownItem onClick={handleExportWorkspace}>
               <i className="fa fa-home" />
               Current Workspace
+            </DropdownItem>
+            <DropdownItem onClick={handleExportRequests}>
+              <i className="fa fa-home" />
+              Current Workspace's Requests
             </DropdownItem>
             <DropdownItem onClick={handleExportAll}>
               <i className="fa fa-empty" />
@@ -76,6 +85,7 @@ ImportExport.propTypes = {
   handleImportFile: PropTypes.func.isRequired,
   handleImportUri: PropTypes.func.isRequired,
   handleExportAll: PropTypes.func.isRequired,
+  handleExportRequests: PropTypes.func.isRequired,
   handleExportWorkspace: PropTypes.func.isRequired,
 };
 

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -51,6 +51,7 @@ import type { Environment } from '../../models/environment';
 import ErrorBoundary from './error-boundary';
 import type { ClientCertificate } from '../../models/client-certificate';
 import MoveRequestGroupModal from './modals/move-request-group-modal';
+import ExportRequestsModal from './modals/export-requests-modal';
 
 type Props = {
   // Helper Functions
@@ -60,6 +61,7 @@ type Props = {
   handleImportFileToWorkspace: Function,
   handleImportUriToWorkspace: Function,
   handleExportFile: Function,
+  handleExportRequestsToFile: Function,
   handleSetActiveWorkspace: Function,
   handleSetActiveEnvironment: Function,
   handleMoveDoc: Function,
@@ -517,6 +519,7 @@ class Wrapper extends React.PureComponent<Props, State> {
           <SettingsModal
             ref={registerModal}
             handleExportWorkspaceToFile={this._handleExportWorkspaceToFile}
+            handleExportRequestsToFile={this.props.handleExportRequestsToFile}
             handleExportAllToFile={handleExportFile}
             handleImportFile={this._handleImportFile}
             handleImportUri={this._handleImportUri}
@@ -564,6 +567,8 @@ class Wrapper extends React.PureComponent<Props, State> {
             nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             isVariableUncovered={isVariableUncovered}
           />
+
+          <ExportRequestsModal ref={registerModal} />
         </ErrorBoundary>
       </div>,
       <div

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -568,7 +568,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             isVariableUncovered={isVariableUncovered}
           />
 
-          <ExportRequestsModal ref={registerModal} />
+          <ExportRequestsModal ref={registerModal} childObjects={sidebarChildren} />
         </ErrorBoundary>
       </div>,
       <div

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -61,6 +61,7 @@ type Props = {
   handleImportFileToWorkspace: Function,
   handleImportUriToWorkspace: Function,
   handleExportFile: Function,
+  handleShowExportRequestsModal: Function,
   handleExportRequestsToFile: Function,
   handleSetActiveWorkspace: Function,
   handleSetActiveEnvironment: Function,
@@ -372,6 +373,8 @@ class Wrapper extends React.PureComponent<Props, State> {
       handleDuplicateRequestGroup,
       handleMoveRequestGroup,
       handleExportFile,
+      handleShowExportRequestsModal,
+      handleExportRequestsToFile,
       handleMoveDoc,
       handleResetDragPaneHorizontal,
       handleResetDragPaneVertical,
@@ -519,7 +522,7 @@ class Wrapper extends React.PureComponent<Props, State> {
           <SettingsModal
             ref={registerModal}
             handleExportWorkspaceToFile={this._handleExportWorkspaceToFile}
-            handleExportRequestsToFile={this.props.handleExportRequestsToFile}
+            handleShowExportRequestsModal={handleShowExportRequestsModal}
             handleExportAllToFile={handleExportFile}
             handleImportFile={this._handleImportFile}
             handleImportUri={this._handleImportUri}
@@ -568,7 +571,11 @@ class Wrapper extends React.PureComponent<Props, State> {
             isVariableUncovered={isVariableUncovered}
           />
 
-          <ExportRequestsModal ref={registerModal} childObjects={sidebarChildren} />
+          <ExportRequestsModal
+            ref={registerModal}
+            childObjects={sidebarChildren}
+            handleExportRequestsToFile={handleExportRequestsToFile}
+          />
         </ErrorBoundary>
       </div>,
       <div

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -762,7 +762,7 @@ class App extends PureComponent {
     await this._handleSetSidebarHidden(sidebarHidden);
   }
 
-  _handleExportRequestsToFile() {
+  _handleShowExportRequestsModal() {
     showModal(ExportRequestsModal);
   }
 
@@ -1019,7 +1019,7 @@ class App extends PureComponent {
               handleSetSidebarFilter={this._handleSetSidebarFilter}
               handleToggleMenuBar={this._handleToggleMenuBar}
               handleUpdateRequestMimeType={this._handleUpdateRequestMimeType}
-              handleExportRequestsToFile={this._handleExportRequestsToFile}
+              handleShowExportRequestsModal={this._handleShowExportRequestsModal}
               isVariableUncovered={this.state.isVariableUncovered}
             />
           </ErrorBoundary>
@@ -1144,7 +1144,8 @@ function mapDispatchToProps(dispatch) {
     handleImportFileToWorkspace: global.importFile,
     handleImportUriToWorkspace: global.importUri,
     handleCommand: global.newCommand,
-    handleExportFile: global.exportFile,
+    handleExportFile: global.exportWorkspacesToFile,
+    handleExportRequestsToFile: global.exportRequestsToFile,
     handleMoveDoc: _moveDoc,
   };
 }

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -67,6 +67,7 @@ import AskModal from '../components/modals/ask-modal';
 import { updateMimeType } from '../../models/request';
 import MoveRequestGroupModal from '../components/modals/move-request-group-modal';
 import * as themes from '../../plugins/misc';
+import ExportRequestsModal from '../components/modals/export-requests-modal';
 
 @autobind
 class App extends PureComponent {
@@ -761,6 +762,10 @@ class App extends PureComponent {
     await this._handleSetSidebarHidden(sidebarHidden);
   }
 
+  _handleExportRequestsToFile() {
+    showModal(ExportRequestsModal);
+  }
+
   _setWrapperRef(n) {
     this._wrapper = n;
   }
@@ -1014,6 +1019,7 @@ class App extends PureComponent {
               handleSetSidebarFilter={this._handleSetSidebarFilter}
               handleToggleMenuBar={this._handleToggleMenuBar}
               handleUpdateRequestMimeType={this._handleUpdateRequestMimeType}
+              handleExportRequestsToFile={this._handleExportRequestsToFile}
               isVariableUncovered={this.state.isVariableUncovered}
             />
           </ErrorBoundary>

--- a/packages/insomnia-app/app/ui/css/components/export-requests.less
+++ b/packages/insomnia-app/app/ui/css/components/export-requests.less
@@ -1,0 +1,118 @@
+@import '../constants/dimensions';
+@import '../constants/colors';
+
+.requests-tree {
+  position: relative;
+
+  background-color: var(--color-bg);
+  color: var(--color-font);
+
+  width: 100%;
+  height: 100%;
+
+  .tree__list-root {
+    // Add some space above so it's not so squished
+    padding-top: @padding-xxs;
+    padding-bottom: @padding-md;
+    box-shadow: inset 0 2rem 2rem -2rem rgba(0, 0, 0, 0.03);
+
+    overflow-y: auto;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    &:hover::-webkit-scrollbar {
+      display: block;
+    }
+  }
+
+  .tree__row {
+    position: relative;
+  }
+
+  // ~~~~~~~~~ //
+  // Tree Item //
+  // ~~~~~~~~~ //
+
+  .tree__item {
+    display: flex;
+    height: @line-height-xs;
+
+    & > button {
+      flex-grow: 1;
+      color: @hl;
+      padding-left: @padding-sm;
+    }
+
+    & > * {
+      height: 100%;
+    }
+
+    &.tree__item--big {
+      height: @line-height-sm;
+    }
+
+    &:focus,
+    &:hover {
+      background-color: @hl-xs;
+      transition: background-color 0ms;
+    }
+
+    .tag {
+      padding-left: 0;
+      text-align: left;
+      width: 3em;
+    }
+
+    .total-requests {
+      color: @hl-lg;
+      padding-left: @padding-xs;
+    }
+  }
+
+  .tree__item__icon {
+    padding-right: @padding-sm;
+  }
+
+  .tree__item__checkbox > * {
+    height: 100%;
+  }
+
+  // Padding for nested folders
+
+  .tree__list .tree__indent {
+    padding-left: @padding-sm;
+  }
+
+  .tree__list .tree__list .tree__indent {
+    padding-left: calc(@padding-sm + @padding-md * 1);
+  }
+
+  .tree__list .tree__list .tree__list .tree__indent {
+    padding-left: calc(@padding-sm + @padding-md * 2);
+  }
+
+  .tree__list .tree__list .tree__list .tree__list .tree__indent {
+    padding-left: calc(@padding-sm + @padding-md * 3);
+  }
+
+  .tree__list .tree__list .tree__list .tree__list .tree__list .tree__indent {
+    padding-left: calc(@padding-sm + @padding-md * 4);
+  }
+
+  .tree__list .tree__list .tree__list .tree__list .tree__list .tree__list .tree__indent {
+    padding-left: calc(@padding-sm + @padding-md * 5);
+  }
+
+  .tree__list
+    .tree__list
+    .tree__list
+    .tree__list
+    .tree__list
+    .tree__list
+    .tree__list
+    .tree__indent {
+    padding-left: calc(@padding-sm + @padding-md * 6);
+  }
+}

--- a/packages/insomnia-app/app/ui/css/index.less
+++ b/packages/insomnia-app/app/ui/css/index.less
@@ -36,6 +36,7 @@
 @import 'components/query-editor';
 @import 'components/request-pane';
 @import 'components/request-switcher';
+@import 'components/export-requests';
 @import 'components/response-pane';
 @import 'components/scrollbar';
 @import 'components/sidebar';


### PR DESCRIPTION
Closes: #1273
I implemented the feature to export only certain folders and/or requests in a single workspace.
There is an alternative to this solution which is adding checkboxes in the sidebar, but IMO this makes the exporting not focusable (it's sidebar), and it's more complex in that other components in the sidebar may be disabled, etc.

**UI**
I added a new option "Current Workspace's Requests" under "Export Data" dropdown button.
![screenshot from 2019-03-05 18-30-11](https://user-images.githubusercontent.com/13415249/53805499-de533380-3f7c-11e9-9d9a-af79619c8b29.png)

If the option is chosen, then it will open a new dialog displaying the requests tree of the current workspace.
![screenshot from 2019-03-05 18-30-36](https://user-images.githubusercontent.com/13415249/53805518-ea3ef580-3f7c-11e9-9aa2-6c104dab017b.png)

The initial state is that all folders are expanded and none of the checkboxes is selected. If no folders or requests are selected, then the "Export" button will be disabled.

When the "Export" button is pressed, the flow will be the same as the existing "Export Workspace".

Since the focus here are requests, empty folders (without requests) will not appear in the tree.

There is also a top folder "All requests" which is a dummy folder to make exporting all top requests and folders easier with a single click, but will not be exported itself.

**What are exported**
The selected requests and their parent folders, the containing workspace, all environments (private ones are asked first), and cookie jar. This behavior is pretty much the same as the existing "Export Workspace".

**Implementation**
The tree structure and styling (HTML and CSS) are copied from those of sidebar's with many modifications. I am not sure whether it is better to abstract the tree structure as a separate reusable component or not, because there are many parts (DnD wrappers, dropdown buttons, checkbox, etc.) specific to each use cases.

The requests tree is constructed from the globally cached `selectSidebarChildren` and then stored as React state in the modal component.

Every time a folder is collapsed or checkbox selected, all of its children will be traversed which in worst case will result in O(N) time complexity. However, I think that this is still quite performant for most users.