### PR TITLE
Add support for extracting id_token from oauth2 implicit flow redirect.

### DIFF
--- a/packages/insomnia-app/app/network/o-auth-2/constants.js
+++ b/packages/insomnia-app/app/network/o-auth-2/constants.js
@@ -10,6 +10,7 @@ export const RESPONSE_TYPE_TOKEN = 'token';
 export const RESPONSE_TYPE_ID_TOKEN_TOKEN = 'id_token token';
 
 export const P_ACCESS_TOKEN = 'access_token';
+export const P_ID_TOKEN = 'id_token';
 export const P_CLIENT_ID = 'client_id';
 export const P_CLIENT_SECRET = 'client_secret';
 export const P_AUDIENCE = 'audience';

--- a/packages/insomnia-app/app/network/o-auth-2/grant-implicit.js
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-implicit.js
@@ -36,12 +36,17 @@ export default async function(
   const qs = buildQueryStringFromParams(params);
   const finalUrl = joinUrlAndQueryString(authorizationUrl, qs);
 
-  const redirectedTo = await authorizeUserInWindow(finalUrl, /(access_token=)/, /(error=)/);
+  const redirectedTo = await authorizeUserInWindow(
+    finalUrl,
+    /(access_token=|id_token=)/,
+    /(error=)/,
+  );
   const fragment = redirectedTo.split('#')[1];
 
   if (fragment) {
-    return responseToObject(fragment, [
+    const results = responseToObject(fragment, [
       c.P_ACCESS_TOKEN,
+      c.P_ID_TOKEN,
       c.P_TOKEN_TYPE,
       c.P_EXPIRES_IN,
       c.P_SCOPE,
@@ -50,6 +55,9 @@ export default async function(
       c.P_ERROR_DESCRIPTION,
       c.P_ERROR_URI,
     ]);
+    results[c.P_ACCESS_TOKEN] = results[c.P_ACCESS_TOKEN] || results[c.P_ID_TOKEN];
+    delete results[c.P_ID_TOKEN];
+    return results;
   } else {
     // Bad redirect
     return {};


### PR DESCRIPTION
This adds the final missing piece for being able to use OpenID Connect auth in Insomnia (with Google, at least).

The problem is that OpenID auth returns the token in the `id_token` param, instead of `access_token`. This has been previously discussed in #839.

This PR fixes the issue by doing the following:
- Watch for `id_token=` as well as `access_token=` to detect the redirect.
- If response type is `id_token`, get the token from `id_token` instead of `access_token`.


With this change, Google OpenID Connect auth works, with the following settings:
![Screenshot from 2019-03-15 15-49-42](https://user-images.githubusercontent.com/1247578/54440074-4e5e7800-473a-11e9-9fc9-8a09c92acae3.png)
