### PR TITLE
Fix issue #1202. Lenient error handling for Yarn output. Check if out…

### DIFF
--- a/packages/insomnia-app/app/plugins/install.js
+++ b/packages/insomnia-app/app/plugins/install.js
@@ -78,11 +78,6 @@ async function _isInsomniaPlugin(lookupName: string): Promise<Object> {
         },
       },
       (err, stdout, stderr) => {
-        if (err) {
-          reject(new Error(`${lookupName} npm error: ${err.message}`));
-          return;
-        }
-
         if (stderr) {
           reject(new Error(`Yarn error ${stderr.toString('utf8')}`));
           return;
@@ -91,8 +86,12 @@ async function _isInsomniaPlugin(lookupName: string): Promise<Object> {
         let yarnOutput;
         try {
           yarnOutput = JSON.parse(stdout.toString('utf8'));
-        } catch (err) {
-          reject(new Error(`Yarn response not JSON: ${err.message}`));
+        } catch (ex) {
+          if (err) {
+            reject(new Error(`${lookupName} npm error: ${err.message}`));
+          } else {
+            reject(new Error(`Yarn response not JSON: ${ex.message}`));
+          }
           return;
         }
 
@@ -149,7 +148,7 @@ async function _installPluginToTmpDir(lookupName: string): Promise<{ tmpDir: str
         },
       },
       (err, stdout, stderr) => {
-        if (err) {
+        if (err && !stdout.toString('utf8').includes('success')) {
           reject(new Error(`${lookupName} install error: ${err.message}`));
           return;
         }

--- a/packages/insomnia-app/app/plugins/install.js
+++ b/packages/insomnia-app/app/plugins/install.js
@@ -87,6 +87,9 @@ async function _isInsomniaPlugin(lookupName: string): Promise<Object> {
         try {
           yarnOutput = JSON.parse(stdout.toString('utf8'));
         } catch (ex) {
+          // Output is not JSON. Check if yarn/electron terminated with non-zero exit code.
+          // In certain environments electron can exit with error even if output is OK.
+          // Parsing is attemted before checking exit code as workaround for false errors.
           if (err) {
             reject(new Error(`${lookupName} npm error: ${err.message}`));
           } else {
@@ -148,6 +151,9 @@ async function _installPluginToTmpDir(lookupName: string): Promise<{ tmpDir: str
         },
       },
       (err, stdout, stderr) => {
+        // Check yarn/electron process exit code.
+        // In certain environments electron can exit with error even if the command was perfomed sucesfully.
+        // Checking for sucess message in output is a workaround for false errors.
         if (err && !stdout.toString('utf8').includes('success')) {
           reject(new Error(`${lookupName} install error: ${err.message}`));
           return;


### PR DESCRIPTION
As written in #1202 the problem with exit error codes on Windows seems to be in yarn or electron. The root cause is not likely to be solved, it seems to be a reoccurring issue randomly affecting projects. It's probably deep in memory management.

The fix primarily consists of first testing if Yarn standard output is OK (either json or success prompt depending on command) and checking the exit error code only if the standard output test fails.