### PR TITLE
Prevent modal closing for vim mode

### DIFF
--- a/packages/insomnia-app/app/common/constants.js
+++ b/packages/insomnia-app/app/common/constants.js
@@ -69,6 +69,12 @@ export const FLEXIBLE_URL_REGEX = /^(http|https):\/\/[\wàâäèéêëîïôóœ
 export const CHECK_FOR_UPDATES_INTERVAL = 1000 * 60 * 60 * 3; // 3 hours
 export const PLUGIN_PATH = path.join(getDataDirectory(), 'plugins');
 
+// Available editor key maps
+export const EDITOR_KEY_MAP_DEFAULT = 'default';
+export const EDITOR_KEY_MAP_EMACS = 'emacs';
+export const EDITOR_KEY_MAP_SUBLIME = 'sublime';
+export const EDITOR_KEY_MAP_VIM = 'vim';
+
 // Hotkeys
 export const MNEMONIC_SYM = isMac() ? '' : '&';
 export const CTRL_SYM = isMac() ? '⌃' : 'Ctrl';

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -10,7 +10,8 @@ import { showModal } from '../modals/index';
 import FilterHelpModal from '../modals/filter-help-modal';
 import * as misc from '../../../common/misc';
 import prettify from 'insomnia-prettify';
-import { DEBOUNCE_MILLIS, isMac } from '../../../common/constants';
+import { DEBOUNCE_MILLIS, EDITOR_KEY_MAP_VIM, isMac } from '../../../common/constants';
+import keyCodes from '../../../common/keycodes';
 import './base-imports';
 import { getTagDefinitions } from '../../../templating/index';
 import Dropdown from '../base/dropdown/dropdown';
@@ -287,6 +288,7 @@ class CodeEditor extends React.Component {
     this.codeMirror.on('blur', this._codemirrorBlur);
     this.codeMirror.on('paste', this._codemirrorPaste);
     this.codeMirror.on('scroll', this._codemirrorScroll);
+    this.codeMirror.on('keyHandled', this._codemirrorKeyHandled);
 
     // Prevent these things if we're type === "password"
     this.codeMirror.on('copy', this._codemirrorPreventWhenTypePassword);
@@ -662,6 +664,18 @@ class CodeEditor extends React.Component {
 
   _codemirrorScroll() {
     this._persistState();
+  }
+
+  _codemirrorKeyHandled(codeMirror, keyName, event) {
+    const { keyMap } = this.props;
+    const { keyCode } = event;
+
+    const isVimKeyMap = keyMap === EDITOR_KEY_MAP_VIM;
+    const pressedEscape = keyCode === keyCodes.esc;
+
+    if (isVimKeyMap && pressedEscape) {
+      event.stopPropagation();
+    }
   }
 
   _codemirrorValueBeforeChange(doc, change) {

--- a/packages/insomnia-app/app/ui/components/settings/general.js
+++ b/packages/insomnia-app/app/ui/components/settings/general.js
@@ -9,6 +9,10 @@ import {
   isWindows,
   UPDATE_CHANNEL_BETA,
   UPDATE_CHANNEL_STABLE,
+  EDITOR_KEY_MAP_DEFAULT,
+  EDITOR_KEY_MAP_EMACS,
+  EDITOR_KEY_MAP_SUBLIME,
+  EDITOR_KEY_MAP_VIM,
 } from '../../../common/constants';
 import type { Settings } from '../../../models/settings';
 import CheckForUpdatesButton from '../check-for-updates-button';
@@ -331,10 +335,10 @@ class General extends React.PureComponent<Props, State> {
                 defaultValue={settings.editorKeyMap}
                 name="editorKeyMap"
                 onChange={this._handleUpdateSetting}>
-                <option value="default">Default</option>
-                <option value="vim">Vim</option>
-                <option value="emacs">Emacs</option>
-                <option value="sublime">Sublime</option>
+                <option value={EDITOR_KEY_MAP_DEFAULT}>Default</option>
+                <option value={EDITOR_KEY_MAP_VIM}>Vim</option>
+                <option value={EDITOR_KEY_MAP_EMACS}>Emacs</option>
+                <option value={EDITOR_KEY_MAP_SUBLIME}>Sublime</option>
               </select>
             </label>
           </div>


### PR DESCRIPTION
Closes #208 (Currently closed, but the bug still exists)

This fixes the issue regarding the modal closing when `Escape` key is pressed in vim mode. CodeMirror has an event `keyHandled`, which can be used to stop the `Escape` event from closing the modal.

https://codemirror.net/doc/manual.html#event_keyHandled