### PR TITLE
Move request to collapsed folder by opening on hover

### DIFF
--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
@@ -89,7 +89,7 @@ class SidebarRequestGroupRow extends PureComponent {
             <div
               ref={this._setExpandTagRef}
               className={classnames('sidebar__expand', {
-                'sidebar__expand-hint': isDraggingOver,
+                'sidebar__expand-hint': isDraggingOver && isCollapsed,
               })}>
               <div className="tag tag--no-bg tag--small">
                 <span className="tag__inner">OPEN</span>

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
@@ -203,10 +203,10 @@ function isOnExpandTag(monitor, component) {
   const pointer = monitor.getClientOffset();
 
   return (
-    rect.top <= pointer.y &&
-    pointer.y <= rect.bottom &&
     rect.left <= pointer.x &&
-    pointer.x <= rect.right
+    pointer.x <= rect.right &&
+    rect.top <= pointer.y &&
+    pointer.y <= rect.bottom
   );
 }
 

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
@@ -22,6 +22,14 @@ class SidebarRequestGroupRow extends PureComponent {
     this._requestGroupActionsDropdown = n;
   }
 
+  _setExpandTagRef(n) {
+    this._expandTag = n;
+  }
+
+  getExpandTag() {
+    return this._expandTag;
+  }
+
   _handleCollapse() {
     const { requestGroup, handleSetRequestGroupCollapsed, isCollapsed } = this.props;
     handleSetRequestGroupCollapsed(requestGroup._id, !isCollapsed);
@@ -78,6 +86,15 @@ class SidebarRequestGroupRow extends PureComponent {
           <div className="sidebar__clickable">
             <i className={'sidebar__item__icon fa ' + folderIconClass} />
             <Highlight search={filter} text={requestGroup.name} />
+            <div
+              ref={this._setExpandTagRef}
+              className={classnames('sidebar__expand', {
+                'sidebar__expand-hint': isDraggingOver,
+              })}>
+              <div className="tag tag--no-bg tag--small">
+                <span className="tag__inner">OPEN</span>
+              </div>
+            </div>
           </div>
         </button>,
       ),
@@ -181,6 +198,18 @@ function isAbove(monitor, component) {
   return hoveredTop > draggedTop;
 }
 
+function isOnExpandTag(monitor, component) {
+  const rect = component.getExpandTag().getBoundingClientRect();
+  const pointer = monitor.getClientOffset();
+
+  return (
+    rect.top <= pointer.y &&
+    pointer.y <= rect.bottom &&
+    rect.left <= pointer.x &&
+    pointer.x <= rect.right
+  );
+}
+
 const dragTarget = {
   drop(props, monitor, component) {
     const movingDoc = monitor.getItem().requestGroup || monitor.getItem().request;
@@ -194,7 +223,10 @@ const dragTarget = {
     }
   },
   hover(props, monitor, component) {
-    if (isAbove(monitor, component)) {
+    if (isOnExpandTag(monitor, component)) {
+      component.props.handleSetRequestGroupCollapsed(props.requestGroup._id, false);
+      component.setDragDirection(0);
+    } else if (isAbove(monitor, component)) {
       component.setDragDirection(1);
     } else {
       component.setDragDirection(-1);

--- a/packages/insomnia-app/app/ui/css/components/sidebar.less
+++ b/packages/insomnia-app/app/ui/css/components/sidebar.less
@@ -279,7 +279,7 @@
 
   .sidebar__clickable {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
     height: 100%;
 
@@ -331,6 +331,19 @@
     .sidebar__list
     .sidebar__clickable {
     padding-left: calc(@padding-sm + @padding-md * 6);
+  }
+
+  // ~~~~~~~~~~~~~~~ //
+  // Sidebar Expand  //
+  // ~~~~~~~~~~~~~~~ //
+
+  .sidebar__expand {
+    display: none;
+
+    &.sidebar__expand-hint {
+      display: flex;
+      align-items: center;
+    }
   }
 
   // ~~~~~~~~~~~~~~~ //

--- a/packages/insomnia-app/app/ui/css/components/sidebar.less
+++ b/packages/insomnia-app/app/ui/css/components/sidebar.less
@@ -339,6 +339,7 @@
 
   .sidebar__expand {
     display: none;
+    height: 100%;
 
     &.sidebar__expand-hint {
       display: flex;


### PR DESCRIPTION
Closes #1329.

## Goals
- Use existing behavior for moving `Request` or `RequestGroup` into an expanded folder.
- Should support moving `Request` to collapsed `RequestGroup`
- Should support moving `RequestGroup` to collapsed `RequestGroup`
- Should support moving any nested combination of `Request` and `RequestGroup`

## Investigations
Initial attempt was to expand the collapsed group on drag-hover. Works, but far from ideal because in the case of multiple `RequestGroup` rows, **all** would open when dragging something from the top of the list to the bottom.

I investigated a hover delay but there is no built-in functionality to `react-dnd` to achieve this. Modifying the package feels too clunky and would be another thing to maintain.

I investigated dropping a `Request` onto the collapsed `RequestGroup` and have it added to the top of the group by default. A user would then need to click to open the group, and order to the desired location. An unnecessary additional click.

## Solution
I settled on showing an unobtrusive `open` tag when drag-hovering over a request group. While dragging, hovering over a collapsed `RequestGroup` will show the `open` tag, and hovering over the tag will expand the group. This tag is only shown on a collapsed `RequestGroup`.

Collapsed:
![image](https://user-images.githubusercontent.com/4312346/56457032-0382f080-63c9-11e9-929c-c345ff392a74.png)

Expanded:
![image](https://user-images.githubusercontent.com/4312346/56457037-1269a300-63c9-11e9-99b1-d6ce0cea1ada.png)

## Improvements
Would love some guidance on whether using `ref` to identify the expand tag in this use case is appropriate or if another solution should be used.
