### PR TITLE
Try importing Swagger even if validation fails

### DIFF
--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -6,7 +6,7 @@ import * as har from './har';
 import type { BaseModel } from '../models/index';
 import * as models from '../models/index';
 import { getAppVersion } from './constants';
-import { showModal } from '../ui/components/modals/index';
+import { showModal, showError } from '../ui/components/modals/index';
 import AlertModal from '../ui/components/modals/alert-modal';
 import fs from 'fs';
 import type { Workspace } from '../models/workspace';
@@ -49,7 +49,11 @@ export async function importUri(workspaceId: string | null, uri: string): Promis
   const { summary, error } = result;
 
   if (error) {
-    showModal(AlertModal, { title: 'Import Failed', message: error });
+    showError({
+      title: 'Failed to import',
+      error: error.message,
+      message: 'Import failed',
+    });
     return;
   }
 
@@ -76,17 +80,16 @@ export async function importRaw(
   generateNewIds: boolean = false,
 ): Promise<{
   source: string,
-  error: string | null,
+  error: Error | null,
   summary: { [string]: Array<BaseModel> },
 }> {
   let results;
   try {
     results = await convert(rawContent);
-  } catch (e) {
-    console.warn('Failed to import data', e);
+  } catch (err) {
     return {
       source: 'not found',
-      error: 'No importers found for file',
+      error: err,
       summary: {},
     };
   }

--- a/packages/insomnia-app/app/ui/components/modals/error-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/error-modal.js
@@ -52,7 +52,7 @@ class ErrorModal extends PureComponent {
           {message ? <div className="notice error">{message}</div> : null}
           {error && (
             <pre className="pad-top-sm force-wrap selectable">
-              <code>{error.stack}</code>
+              <code>{error.stack || error}</code>
             </pre>
           )}
         </ModalBody>

--- a/packages/insomnia-importers/src/__tests__/fixtures/swagger2/user-example-input.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/swagger2/user-example-input.json
@@ -1,0 +1,41 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "v1",
+    "title": "docs"
+  },
+  "paths": {
+    "/api/list": {
+      "get": {
+        "tags": ["Document"],
+        "summary": "Some list",
+        "operationId": "ApiId",
+        "consumes": [],
+        "produces": ["text/plain", "application/json", "text/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Dto.Document.DocumetnDto"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [null, "Role"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/insomnia-importers/src/__tests__/fixtures/swagger2/user-example-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/swagger2/user-example-output.json
@@ -1,0 +1,47 @@
+{
+  "__export_date": "2019-04-26T04:04:46.087Z",
+  "__export_format": 4,
+  "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
+  "resources": [
+    {
+      "_id": "__WORKSPACE_1__",
+      "_type": "workspace",
+      "description": "",
+      "name": "docs v1",
+      "parentId": null
+    },
+    {
+      "_id": "__ENV_1__",
+      "_type": "environment",
+      "data": {
+        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+      },
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_1__"
+    },
+    {
+      "_id": "__ENV_2__",
+      "_type": "environment",
+      "data": {
+        "base_path": "",
+        "host": "",
+        "scheme": "http"
+      },
+      "name": "Swagger env",
+      "parentId": "__ENV_1__"
+    },
+    {
+      "_id": "ApiId",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
+      "name": "Some list",
+      "parameters": [],
+      "parentId": "__WORKSPACE_1__",
+      "url": "{{ base_url }}/api/list"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #1354

This PR changes the Swagger importer to try continuing the import even if validation fails. At the validation step, we already know it's a Swagger 2.0 document, so trying to continue is better than just bailing out and giving up.