### PR TITLE
Replace font-manager with improved font-scanner module 

### DIFF
--- a/packages/insomnia-app/flow-typed/font-scanner.js
+++ b/packages/insomnia-app/flow-typed/font-scanner.js
@@ -1,5 +1,5 @@
 // @flow
 
-declare module 'font-manager' {
+declare module 'font-scanner' {
   declare module.exports: *;
 }

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -4684,10 +4684,10 @@
         "debug": "^2.2.0"
       }
     },
-    "font-manager": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/font-manager/-/font-manager-0.3.0.tgz",
-      "integrity": "sha512-6N3pzO+9kxE3yD9c4VN7reg5fqgFvjcUdxZmwauRzsExaeKRu0APfEi3DOISFakokybgKlZcLFQHawwc2TMpQQ==",
+    "font-scanner": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/font-scanner/-/font-scanner-0.1.1.tgz",
+      "integrity": "sha512-vSryfXML53dHrIUT/LAxKuxit9ynrDCL4CPfgvh698cTsbGpHYmgGa7eBQTnWvNFgkDFDY1PeXtIFRpbp0ViRw==",
       "requires": {
         "nan": ">=2.10.0"
       }

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -107,7 +107,7 @@
     "deep-equal": "^1.0.1",
     "electron-context-menu": "^0.10.0",
     "electron-squirrel-startup": "^1.0.0",
-    "font-manager": "^0.3.0",
+    "font-scanner": "^0.1.1",
     "fs-extra": "^5.0.0",
     "fuzzysort": "^1.1.1",
     "graphql": "^14.2.1",


### PR DESCRIPTION
Fixes #1453

This change replaces the `font-manager` module with `font-scanner`. There seem to be some issues with `font-manager` crashing Node on certain devices. `font-scanner` is an improved fork and seems to handle these issues better. 

The _fix_ here is to simply not show the font selector when no fonts are returned.

![image](https://user-images.githubusercontent.com/587576/56786921-8a601080-67af-11e9-8fe7-4c832b5103c6.png)
