### PR TITLE
Added a request "quick create" hotkey

### DIFF
--- a/packages/insomnia-app/app/common/hotkeys.js
+++ b/packages/insomnia-app/app/common/hotkeys.js
@@ -136,6 +136,8 @@ export const hotKeyRefs = {
 
   REQUEST_SHOW_CREATE: defineHotKey('request_showCreate', 'Create Request'),
 
+  REQUEST_QUICK_CREATE: defineHotKey('request_quickCreate', 'Create Request (Quick)'),
+
   REQUEST_SHOW_DELETE: defineHotKey('request_showDelete', 'Delete Request'),
 
   REQUEST_SHOW_CREATE_FOLDER: defineHotKey('request_showCreateFolder', 'Create Folder'),
@@ -264,6 +266,11 @@ const defaultRegistry: HotKeyRegistry = {
   [hotKeyRefs.REQUEST_SHOW_CREATE.id]: keyBinds(
     keyComb(false, false, false, true, keyboardKeys.n.keyCode),
     keyComb(true, false, false, false, keyboardKeys.n.keyCode),
+  ),
+
+  [hotKeyRefs.REQUEST_QUICK_CREATE.id]: keyBinds(
+    keyComb(false, true, false, true, keyboardKeys.n.keyCode),
+    keyComb(true, true, false, false, keyboardKeys.n.keyCode),
   ),
 
   [hotKeyRefs.REQUEST_SHOW_DELETE.id]: keyBinds(

--- a/packages/insomnia-app/app/models/settings.js
+++ b/packages/insomnia-app/app/models/settings.js
@@ -89,6 +89,7 @@ export function init(): BaseSettings {
 }
 
 export function migrate(doc: Settings): Settings {
+  doc = migrateEnsureHotKeys(doc);
   return doc;
 }
 
@@ -116,4 +117,15 @@ export async function getOrCreate(patch: Object = {}): Promise<Settings> {
   } else {
     return results[0];
   }
+}
+
+/**
+ * Ensure map is updated when new hotkeys are added
+ */
+function migrateEnsureHotKeys(settings: Settings): Settings {
+  settings.hotKeyRegistry = {
+    ...hotkeys.newDefaultRegistry(),
+    ...settings.hotKeyRegistry,
+  };
+  return settings;
 }

--- a/packages/insomnia-app/app/ui/components/settings/shortcuts.js
+++ b/packages/insomnia-app/app/ui/components/settings/shortcuts.js
@@ -22,6 +22,34 @@ type Props = {
   handleUpdateKeyBindings: Function,
 };
 
+const HOT_KEY_DEFS: Array<HotKeyDefinition> = [
+  hotKeyRefs.PREFERENCES_SHOW_KEYBOARD_SHORTCUTS,
+  hotKeyRefs.REQUEST_QUICK_SWITCH,
+  hotKeyRefs.REQUEST_SEND,
+  hotKeyRefs.REQUEST_SHOW_OPTIONS,
+  hotKeyRefs.REQUEST_SHOW_CREATE,
+  hotKeyRefs.REQUEST_SHOW_DELETE,
+  hotKeyRefs.REQUEST_SHOW_CREATE_FOLDER,
+  hotKeyRefs.REQUEST_SHOW_DUPLICATE,
+  hotKeyRefs.REQUEST_SHOW_GENERATE_CODE_EDITOR,
+  hotKeyRefs.SHOW_COOKIES_EDITOR,
+  hotKeyRefs.ENVIRONMENT_SHOW_EDITOR,
+  hotKeyRefs.ENVIRONMENT_SHOW_SWITCH_MENU,
+  hotKeyRefs.REQUEST_FOCUS_URL,
+  hotKeyRefs.RESPONSE_FOCUS,
+  hotKeyRefs.REQUEST_TOGGLE_HTTP_METHOD_MENU,
+  hotKeyRefs.SIDEBAR_TOGGLE,
+  hotKeyRefs.SIDEBAR_FOCUS_FILTER,
+  hotKeyRefs.REQUEST_TOGGLE_HISTORY,
+  hotKeyRefs.SHOW_AUTOCOMPLETE,
+  hotKeyRefs.PREFERENCES_SHOW_GENERAL,
+  hotKeyRefs.WORKSPACE_SHOW_SETTINGS,
+  hotKeyRefs.REQUEST_SHOW_SETTINGS,
+  hotKeyRefs.TOGGLE_MAIN_MENU,
+  hotKeyRefs.PLUGIN_RELOAD,
+  hotKeyRefs.ENVIRONMENT_UNCOVER_VARIABLES,
+];
+
 @autobind
 class Shortcuts extends PureComponent<Props> {
   /**
@@ -152,33 +180,6 @@ class Shortcuts extends PureComponent<Props> {
   }
 
   render() {
-    const hotKeyDefs: Array<HotKeyDefinition> = [
-      hotKeyRefs.PREFERENCES_SHOW_KEYBOARD_SHORTCUTS,
-      hotKeyRefs.REQUEST_QUICK_SWITCH,
-      hotKeyRefs.REQUEST_SEND,
-      hotKeyRefs.REQUEST_SHOW_OPTIONS,
-      hotKeyRefs.REQUEST_SHOW_CREATE,
-      hotKeyRefs.REQUEST_SHOW_DELETE,
-      hotKeyRefs.REQUEST_SHOW_CREATE_FOLDER,
-      hotKeyRefs.REQUEST_SHOW_DUPLICATE,
-      hotKeyRefs.REQUEST_SHOW_GENERATE_CODE_EDITOR,
-      hotKeyRefs.SHOW_COOKIES_EDITOR,
-      hotKeyRefs.ENVIRONMENT_SHOW_EDITOR,
-      hotKeyRefs.ENVIRONMENT_SHOW_SWITCH_MENU,
-      hotKeyRefs.REQUEST_FOCUS_URL,
-      hotKeyRefs.RESPONSE_FOCUS,
-      hotKeyRefs.REQUEST_TOGGLE_HTTP_METHOD_MENU,
-      hotKeyRefs.SIDEBAR_TOGGLE,
-      hotKeyRefs.SIDEBAR_FOCUS_FILTER,
-      hotKeyRefs.REQUEST_TOGGLE_HISTORY,
-      hotKeyRefs.SHOW_AUTOCOMPLETE,
-      hotKeyRefs.PREFERENCES_SHOW_GENERAL,
-      hotKeyRefs.WORKSPACE_SHOW_SETTINGS,
-      hotKeyRefs.REQUEST_SHOW_SETTINGS,
-      hotKeyRefs.TOGGLE_MAIN_MENU,
-      hotKeyRefs.PLUGIN_RELOAD,
-      hotKeyRefs.ENVIRONMENT_UNCOVER_VARIABLES,
-    ];
     return (
       <div className="shortcuts">
         <div className="row-spaced margin-bottom-xs">
@@ -190,7 +191,7 @@ class Shortcuts extends PureComponent<Props> {
         </div>
         <table className="table--fancy">
           <tbody>
-            {hotKeyDefs.map((def: HotKeyDefinition, idx: number) => {
+            {HOT_KEY_DEFS.map((def: HotKeyDefinition, idx: number) => {
               return this.renderHotKey(def, idx);
             })}
           </tbody>

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -158,6 +158,15 @@ class App extends PureComponent {
         },
       ],
       [
+        hotKeyRefs.REQUEST_QUICK_CREATE,
+        async () => {
+          const { activeRequest, activeWorkspace } = this.props;
+          const parentId = activeRequest ? activeRequest.parentId : activeWorkspace._id;
+          const request = await models.request.create({ parentId, name: 'New Request' });
+          await this._handleSetActiveRequest(request._id);
+        },
+      ],
+      [
         hotKeyRefs.REQUEST_SHOW_CREATE,
         () => {
           const { activeRequest, activeWorkspace } = this.props;


### PR DESCRIPTION
Closes #1464

This PR adds a new request "quick create" hotkey which will create a request without showing the dialog box that prompts for request name/method/body