### PR TITLE
Ability to resend Response Tag's dependent request

### DIFF
--- a/packages/insomnia-app/app/common/render.js
+++ b/packages/insomnia-app/app/common/render.js
@@ -193,7 +193,7 @@ export async function getRenderContext(
   request: Request,
   environmentId: string,
   ancestors: Array<BaseModel> | null = null,
-  purpose: string | null = null,
+  purpose: RenderPurpose | null = null,
 ): Promise<Object> {
   if (!ancestors) {
     ancestors = await db.withAncestors(request, [
@@ -218,7 +218,7 @@ export async function getRenderContext(
     keySource[key] = 'root';
   }
   if (subEnvironment) {
-    for (let key in subEnvironment.data || {}) {
+    for (const key of Object.keys(subEnvironment.data || {})) {
       if (subEnvironment.name) {
         keySource[key] = subEnvironment.name;
       }
@@ -232,7 +232,7 @@ export async function getRenderContext(
         ancestor.hasOwnProperty('environment') &&
         ancestor.hasOwnProperty('name')
       ) {
-        for (let key in ancestor.environment || {}) {
+        for (const key of Object.keys(ancestor.environment || {})) {
           keySource[key] = ancestor.name || '';
         }
       }
@@ -252,6 +252,8 @@ export async function getRenderContext(
 
   baseContext.getPurpose = () => purpose;
 
+  baseContext.getEnvironmentId = () => environmentId;
+
   // Generate the context we need to render
   return buildRenderContext(ancestors, rootEnvironment, subEnvironment, baseContext);
 }
@@ -259,7 +261,7 @@ export async function getRenderContext(
 export async function getRenderedRequestAndContext(
   request: Request,
   environmentId: string,
-  purpose?: string,
+  purpose?: RenderPurpose,
 ): Promise<{ request: RenderedRequest, context: Object }> {
   const ancestors = await db.withAncestors(request, [
     models.request.type,
@@ -315,7 +317,6 @@ export async function getRenderedRequestAndContext(
     context: renderContext,
     request: {
       // Add the yummy cookies
-      // TODO: Eventually get rid of RenderedRequest type and put these elsewhere
       cookieJar: renderedCookieJar,
       cookies: [],
       isPrivate: false,
@@ -349,7 +350,7 @@ export async function getRenderedRequestAndContext(
 export async function getRenderedRequest(
   request: Request,
   environmentId: string,
-  purpose?: string,
+  purpose?: RenderPurpose,
 ): Promise<RenderedRequest> {
   const result = await getRenderedRequestAndContext(request, environmentId, purpose);
   return result.request;

--- a/packages/insomnia-app/app/plugins/context/index.js
+++ b/packages/insomnia-app/app/plugins/context/index.js
@@ -3,8 +3,10 @@ import * as _app from './app';
 import * as _store from './store';
 import * as _request from './request';
 import * as _response from './response';
+import * as _network from './network';
 
 export const app = _app;
 export const store = _store;
 export const request = _request;
 export const response = _response;
+export const network = _network;

--- a/packages/insomnia-app/app/plugins/context/network.js
+++ b/packages/insomnia-app/app/plugins/context/network.js
@@ -1,0 +1,17 @@
+// @flow
+
+import { send } from '../../network/network';
+import type { Request } from '../../models/request';
+import * as models from '../../models';
+
+export function init(activeEnvironmentId: string): { network: Object } {
+  const network = {
+    async sendRequest(request: Request): Promise<Response> {
+      const responsePatch = await send(request._id, activeEnvironmentId);
+      const settings = await models.settings.getOrCreate();
+      return models.response.create(responsePatch, settings.maxHistoryResponses);
+    },
+  };
+
+  return { network };
+}

--- a/packages/insomnia-app/app/templating/base-extension.js
+++ b/packages/insomnia-app/app/templating/base-extension.js
@@ -70,6 +70,9 @@ export default class BaseExtension {
     // Pull out the purpose
     const renderPurpose = renderContext.getPurpose ? renderContext.getPurpose() : null;
 
+    // Pull out the environment ID
+    const environmentId = renderContext.getEnvironmentId ? renderContext.getEnvironmentId() : 'n/a';
+
     // Extract the rest of the args
     const args = runArgs.slice(0, runArgs.length - 1).filter(a => a !== EMPTY_ARG);
 
@@ -77,8 +80,10 @@ export default class BaseExtension {
     const helperContext = {
       ...pluginContexts.app.init(renderPurpose),
       ...pluginContexts.store.init(this._plugin),
+      ...pluginContexts.network.init(environmentId),
       context: renderContext,
       meta: renderMeta,
+      renderPurpose,
       util: {
         render: str => templating.render(str, { context: renderContext }),
         models: {


### PR DESCRIPTION
Closes #286 (Wow that's an old one)

This PR improves the Response Template Tag to add the ability to resend the request it's dependent on automatically.

- Add a new _behavior_ argument
  - never send
  - always send
  - only if no responses exist
- Add new `network` plugin context with `sendRequest` method
- Actually save the response so it shows in the UI
- Only send the dependent request when rendering for a send (vs visual preview), unless no responses exist yet.

![image](https://user-images.githubusercontent.com/587576/56844670-e5a20980-6868-11e9-9810-5d9db04b25e0.png)
