### PR TITLE
Fix Response Tag infinite recursion

### DIFF
--- a/packages/insomnia-app/app/common/render.js
+++ b/packages/insomnia-app/app/common/render.js
@@ -20,6 +20,9 @@ export const RENDER_PURPOSE_SEND: RenderPurpose = 'send';
 export const RENDER_PURPOSE_GENERAL: RenderPurpose = 'general';
 export const RENDER_PURPOSE_NO_RENDER: RenderPurpose = 'no-render';
 
+/** Key/value pairs to be provided to the render context */
+export type ExtraRenderInfo = Array<{ name: string, value: any }>;
+
 export type RenderedRequest = Request & {
   cookies: Array<{ name: string, value: string, disabled?: boolean }>,
   cookieJar: CookieJar,
@@ -93,17 +96,35 @@ export async function buildRenderContext(
   // Render the context with itself to fill in the rest.
   let finalRenderContext = renderContext;
 
-  // Render recursive references.
+  // Render recursive references and tags.
   const keys = _getOrderedEnvironmentKeys(finalRenderContext);
+
+  const skipNextTime = {};
   for (let i = 0; i < 3; i++) {
     for (const key of keys) {
-      finalRenderContext[key] = await render(
+      // Skip rendering keys that stayed the same multiple times. This is here because
+      // a render failure will leave the tag as-is and thus the next iteration of the
+      // loop will try to re-render it again. We don't want to keep erroring on these
+      // because renders are expensive and potentially not idempotent.
+      if (skipNextTime[key]) {
+        continue;
+      }
+
+      const renderResult = await render(
         finalRenderContext[key],
         finalRenderContext,
         null,
         KEEP_ON_ERROR,
         'Environment',
       );
+
+      // Result didn't change, so skip
+      if (renderResult === finalRenderContext[key]) {
+        skipNextTime[key] = true;
+        continue;
+      }
+
+      finalRenderContext[key] = renderResult;
     }
   }
 
@@ -195,6 +216,7 @@ export async function getRenderContext(
   environmentId: string | null,
   ancestors: Array<BaseModel> | null = null,
   purpose: RenderPurpose | null = null,
+  extraInfo: ExtraRenderInfo | null = null,
 ): Promise<Object> {
   if (!ancestors) {
     ancestors = await db.withAncestors(request, [
@@ -218,6 +240,7 @@ export async function getRenderContext(
   for (let key in (rootEnvironment || {}).data) {
     keySource[key] = 'root';
   }
+
   if (subEnvironment) {
     for (const key of Object.keys(subEnvironment.data || {})) {
       if (subEnvironment.name) {
@@ -225,6 +248,7 @@ export async function getRenderContext(
       }
     }
   }
+
   if (ancestors) {
     for (let idx = 0; idx < ancestors.length; idx++) {
       let ancestor: any = ancestors[idx] || {};
@@ -252,6 +276,14 @@ export async function getRenderContext(
   });
 
   baseContext.getPurpose = () => purpose;
+  baseContext.getExtraInfo = (key: string) => {
+    if (!Array.isArray(extraInfo)) {
+      return null;
+    }
+
+    const p = extraInfo.find(v => v.name === key);
+    return p ? p.value : null;
+  };
 
   baseContext.getEnvironmentId = () => environmentId;
 
@@ -263,6 +295,7 @@ export async function getRenderedRequestAndContext(
   request: Request,
   environmentId: string | null,
   purpose?: RenderPurpose,
+  extraInfo?: ExtraRenderInfo,
 ): Promise<{ request: RenderedRequest, context: Object }> {
   const ancestors = await db.withAncestors(request, [
     models.request.type,
@@ -273,7 +306,13 @@ export async function getRenderedRequestAndContext(
   const parentId = workspace ? workspace._id : 'n/a';
   const cookieJar = await models.cookieJar.getOrCreateForParentId(parentId);
 
-  const renderContext = await getRenderContext(request, environmentId, ancestors, purpose);
+  const renderContext = await getRenderContext(
+    request,
+    environmentId,
+    ancestors,
+    purpose,
+    extraInfo || null,
+  );
 
   // HACK: Switch '#}' to '# }' to prevent Nunjucks from barfing
   // https://github.com/getinsomnia/insomnia/issues/895

--- a/packages/insomnia-app/app/common/render.js
+++ b/packages/insomnia-app/app/common/render.js
@@ -96,9 +96,9 @@ export async function buildRenderContext(
   // Render the context with itself to fill in the rest.
   let finalRenderContext = renderContext;
 
-  // Render recursive references and tags.
   const keys = _getOrderedEnvironmentKeys(finalRenderContext);
 
+  // Render recursive references and tags.
   const skipNextTime = {};
   for (let i = 0; i < 3; i++) {
     for (const key of keys) {

--- a/packages/insomnia-app/app/network/network.js
+++ b/packages/insomnia-app/app/network/network.js
@@ -3,7 +3,7 @@ import type { ResponseHeader, ResponseTimelineEntry } from '../models/response';
 import type { Request, RequestHeader } from '../models/request';
 import type { Workspace } from '../models/workspace';
 import type { Settings } from '../models/settings';
-import type { RenderedRequest } from '../common/render';
+import type { ExtraRenderInfo, RenderedRequest } from '../common/render';
 import {
   getRenderedRequestAndContext,
   RENDER_PURPOSE_NO_RENDER,
@@ -33,6 +33,7 @@ import {
   delay,
   describeByteSize,
   getContentTypeHeader,
+  getDataDirectory,
   getHostHeader,
   getLocationHeader,
   getSetCookieHeaders,
@@ -42,7 +43,6 @@ import {
   hasContentTypeHeader,
   hasUserAgentHeader,
   waitForStreamToFinish,
-  getDataDirectory,
 } from '../common/misc';
 import {
   buildQueryStringFromParams,
@@ -809,7 +809,10 @@ export async function sendWithSettings(
 export async function send(
   requestId: string,
   environmentId: string | null,
+  extraInfo?: ExtraRenderInfo,
 ): Promise<ResponsePatch> {
+  console.log(`[network] Sending req=${requestId}`);
+
   // HACK: wait for all debounces to finish
   /*
    * TODO: Do this in a more robust way
@@ -841,6 +844,7 @@ export async function send(
     request,
     environmentId,
     RENDER_PURPOSE_SEND,
+    extraInfo,
   );
 
   const renderedRequestBeforePlugins = renderResult.request;
@@ -870,7 +874,20 @@ export async function send(
     };
   }
 
-  return _actuallySend(renderedRequest, renderedContextBeforePlugins, workspace, settings);
+  const response = await _actuallySend(
+    renderedRequest,
+    renderedContextBeforePlugins,
+    workspace,
+    settings,
+  );
+
+  console.log(
+    response.error
+      ? `[network] Response failed req=${requestId} err=${response.error || 'n/a'}`
+      : `[network] Response succeeded req=${requestId} status=${response.statusCode || '?'}`,
+  );
+
+  return response;
 }
 
 async function _applyRequestPluginHooks(

--- a/packages/insomnia-app/app/plugins/context/network.js
+++ b/packages/insomnia-app/app/plugins/context/network.js
@@ -3,11 +3,12 @@
 import { send } from '../../network/network';
 import type { Request } from '../../models/request';
 import * as models from '../../models';
+import type { ExtraRenderInfo } from '../../common/render';
 
 export function init(activeEnvironmentId: string | null): { network: Object } {
   const network = {
-    async sendRequest(request: Request): Promise<Response> {
-      const responsePatch = await send(request._id, activeEnvironmentId);
+    async sendRequest(request: Request, extraInfo?: ExtraRenderInfo): Promise<Response> {
+      const responsePatch = await send(request._id, activeEnvironmentId, extraInfo);
       const settings = await models.settings.getOrCreate();
       return models.response.create(responsePatch, settings.maxHistoryResponses);
     },

--- a/plugins/insomnia-plugin-response/__tests__/index.test.js
+++ b/plugins/insomnia-plugin-response/__tests__/index.test.js
@@ -420,7 +420,7 @@ describe('Response tag', () => {
   });
 });
 
-function _genTestContext(requests, responses) {
+function _genTestContext(requests, responses, extraInfo) {
   requests = requests || [];
   responses = responses || [];
   const bodies = {};
@@ -430,6 +430,15 @@ function _genTestContext(requests, responses) {
   }
   const store = {};
   return {
+    context: {
+      getExtraInfo(key) {
+        if (extraInfo) {
+          return extraInfo[key] || null;
+        } else {
+          return null;
+        }
+      },
+    },
     store: {
       hasItem: key => store.hasOwnProperty(key),
       getItem: key => store[key],

--- a/plugins/insomnia-plugin-response/__tests__/index.test.js
+++ b/plugins/insomnia-plugin-response/__tests__/index.test.js
@@ -418,9 +418,110 @@ describe('Response tag', () => {
       expect(await tag.run(context, 'raw', 'req_1')).toBe('Hello World!');
     });
   });
+
+  describe('Dependency sending', () => {
+    it('sends when behavior=always and no responses', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+      const responses = [];
+      const context = _genTestContext(requests, responses);
+
+      expect(await tag.run(context, 'raw', 'req_1', '', 'always')).toBe('Response res_1');
+    });
+
+    it('sends when behavior=always and some responses', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+      const responses = [
+        {
+          _id: 'res_1',
+          parentId: 'req_1',
+          statusCode: 200,
+          contentType: 'text/plain',
+          _body: 'Hello World!',
+        },
+      ];
+      const context = _genTestContext(requests, responses);
+
+      expect(await tag.run(context, 'raw', 'req_1', '', 'always')).toBe('Response res_2');
+    });
+
+    it('sends when behavior=no-history and no responses', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+      const responses = [];
+      const context = _genTestContext(requests, responses);
+
+      expect(await tag.run(context, 'raw', 'req_1', '', 'no-history')).toBe('Response res_1');
+    });
+
+    it('does not send when behavior=no-history and some responses', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+      const responses = [
+        {
+          _id: 'res_existing',
+          parentId: 'req_1',
+          statusCode: 200,
+          contentType: 'text/plain',
+          _body: 'Response res_existing',
+        },
+      ];
+      const context = _genTestContext(requests, responses);
+
+      expect(await tag.run(context, 'raw', 'req_1', '', 'no-history')).toBe(
+        'Response res_existing',
+      );
+    });
+
+    it('does not send when behavior=never and no responses', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+      const responses = [];
+      const context = _genTestContext(requests, responses);
+
+      try {
+        expect(await tag.run(context, 'raw', 'req_1', '', 'never')).toBe('Response res_1');
+      } catch (err) {
+        expect(err.message).toBe('No responses for request');
+        return;
+      }
+
+      throw new Error('Running tag should have thrown exception');
+    });
+
+    it('does not send when behavior=never and some responses', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+      const responses = [
+        {
+          _id: 'res_existing',
+          parentId: 'req_1',
+          statusCode: 200,
+          contentType: 'text/plain',
+          _body: 'Response res_existing',
+        },
+      ];
+      const context = _genTestContext(requests, responses);
+
+      expect(await tag.run(context, 'raw', 'req_1', '', 'never')).toBe('Response res_existing');
+    });
+
+    it('does not resend recursive', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+
+      const responses = [];
+
+      const context = _genTestContext(requests, responses, { fromResponseTag: true });
+
+      try {
+        await tag.run(context, 'raw', 'req_1', '', 'always');
+      } catch (err) {
+        expect(err.message).toBe('No responses for request');
+        return;
+      }
+
+      throw new Error('Running tag should have thrown exception');
+    });
+  });
 });
 
-function _genTestContext(requests, responses, extraInfo) {
+function _genTestContext(requests, responses, extraInfoRoot) {
+  let _extraInfo = extraInfoRoot || {};
   requests = requests || [];
   responses = responses || [];
   const bodies = {};
@@ -430,13 +531,30 @@ function _genTestContext(requests, responses, extraInfo) {
   }
   const store = {};
   return {
+    renderPurpose: 'send',
     context: {
       getExtraInfo(key) {
-        if (extraInfo) {
-          return extraInfo[key] || null;
+        if (_extraInfo) {
+          return _extraInfo[key] || null;
         } else {
           return null;
         }
+      },
+    },
+    network: {
+      sendRequest(request, extraInfo) {
+        _extraInfo = { ..._extraInfo, ...extraInfo };
+        const id = `res_${responses.length + 1}`;
+        const res = {
+          _id: id,
+          parentId: request._id,
+          statusCode: 200,
+          contentType: 'text/plain',
+        };
+
+        bodies[res._id] = `Response ${id}`;
+        responses.push(res);
+        return res;
       },
     },
     store: {


### PR DESCRIPTION
Fixes #1500 

This PR fixes the Response Tag rendering recursively forever.

- Add `extraInfo` key/value parameter to render
- Add ability to pass `extraInfo` in `network.send()`
- Set `extraInfo` `fromResponseTag = true` within Response Tag
- Check `fromResponseTag` within  Response Tag to see if it triggered recursively
- If recursive, don't trigger a send no matter what