### PR TITLE
Add iconUrl to electron-builder config so it populates in Control Panel and Windows Settings properly

### DIFF
--- a/packages/insomnia-app/.electronbuilder
+++ b/packages/insomnia-app/.electronbuilder
@@ -39,6 +39,9 @@
       "zip"
     ]
   },
+  "squirrelWindows":{
+    "iconUrl": "https://github.com/getinsomnia/insomnia/blob/master/packages/insomnia-app/app/icons/icon.ico?raw=true"
+  },
   "linux": {
     "executableName": "insomnia",
     "synopsis": "A simple, beautiful, and free REST API client",


### PR DESCRIPTION
Change made due to documentation [here](https://www.electron.build/configuration/squirrel-windows).

The Insomnia app currently has no icon in Control Panel for the app:
![image](https://user-images.githubusercontent.com/30214760/58095941-e6119400-7bcb-11e9-80f4-7c738123d5ec.png)
This change gives Insomnia the correct icon in Control Panel and Windows Settings:
![image](https://user-images.githubusercontent.com/30214760/58096396-e199ab00-7bcc-11e9-9186-f7fe129ea74b.png)
![image](https://user-images.githubusercontent.com/30214760/58096432-f24a2100-7bcc-11e9-8e25-36149d752557.png)
Unfortunately does **not** solve #1405, this seems to be a bug upstream and since [Squirrel.Windows](https://github.com/Squirrel/Squirrel.Windows) is deprecated, likely will not be fixed, see that issue for discussion.