### PR TITLE
[WIP] Tweak Request API behavior for multi-value parameters & headers

### DIFF
--- a/packages/insomnia-app/app/plugins/context/__tests__/request.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/request.test.js
@@ -97,7 +97,13 @@ describe('request.*', () => {
         { name: 'hello', value: 'world' },
         { name: 'Content-Type', value: 'application/json' },
       ],
-      parameters: [{ name: 'foo', value: 'bar' }, { name: 'message', value: 'Hello World!' }],
+      parameters: [
+        { name: 'foo', value: 'bar' },
+        { name: 'message', value: 'Hello World!' },
+        { name: 'multi', value: 'a' },
+        { name: 'multi', value: 'b' },
+        { name: 'multi', value: 'c' },
+      ],
     });
   });
 
@@ -118,6 +124,9 @@ describe('request.*', () => {
     expect(result.request.getParameters()).toEqual([
       { name: 'foo', value: 'bar' },
       { name: 'message', value: 'Hello World!' },
+      { name: 'multi', value: 'a' },
+      { name: 'multi', value: 'b' },
+      { name: 'multi', value: 'c' },
     ]);
 
     // getParameter()
@@ -125,18 +134,28 @@ describe('request.*', () => {
     expect(result.request.getParameter('FOO')).toBe(null);
     expect(result.request.getParameter('does-not-exist')).toBe(null);
     expect(result.request.hasParameter('foo')).toBe(true);
+    expect(result.request.hasParameter('does-not-exist')).toBe(false);
+    expect(result.request.getParameter('multi')).toBe('c');
 
-    // setHeader()
+    // setParameter()
     result.request.setParameter('foo', 'baz');
     expect(result.request.getParameter('foo')).toBe('baz');
+    result.request.setParameter('multi', 'd');
+    expect(result.request.getParameter('multi')).toBe('d');
 
-    // addHeader()
+    // addParameter()
     result.request.addParameter('foo', 'another');
     result.request.addParameter('something-else', 'yet another');
     expect(result.request.getParameter('foo')).toBe('baz');
     expect(result.request.getParameter('something-else')).toBe('yet another');
+    expect(result.request.getParameters()).toEqual([
+      { name: 'foo', value: 'baz' },
+      { name: 'message', value: 'Hello World!' },
+      { name: 'multi', value: 'd' },
+      { name: 'something-else', value: 'yet another' },
+    ]);
 
-    // removeHeader()
+    // removeParameter()
     result.request.removeParameter('foo');
     expect(result.request.getParameter('foo')).toBe(null);
     expect(result.request.hasParameter('foo')).toBe(false);

--- a/packages/insomnia-app/app/plugins/context/request.js
+++ b/packages/insomnia-app/app/plugins/context/request.js
@@ -123,9 +123,12 @@ export function init(
       renderedRequest.parameters = renderedRequest.parameters.filter(p => !parameters.includes(p));
     },
     setParameter(name: string, value: string): void {
-      const parameter = misc.filterParameters(renderedRequest.parameters, name)[0];
-      if (parameter) {
-        parameter.value = value;
+      const parameters = misc.filterParameters(renderedRequest.parameters, name);
+      if (parameters.length == 1) {
+        parameters[0].value = value;
+      } else if (parameters.length > 1) {
+        this.removeParameter(name);
+        this.addParameter(name, value);
       } else {
         this.addParameter(name, value);
       }

--- a/packages/insomnia-app/app/plugins/context/request.js
+++ b/packages/insomnia-app/app/plugins/context/request.js
@@ -124,7 +124,7 @@ export function init(
     },
     setParameter(name: string, value: string): void {
       const parameters = misc.filterParameters(renderedRequest.parameters, name);
-      if (parameters.length == 1) {
+      if (parameters.length === 1) {
         parameters[0].value = value;
       } else if (parameters.length > 1) {
         this.removeParameter(name);


### PR DESCRIPTION
Closes #1518, with the changes proposed by @gschier (unless discussion takes us elsewhere):

> * Change getParameter to return a string for single matches and an array for multiple
> * Change setParameter to remove all instances of key and replace with a single new one
> * Leave addParameter(name: string) as is, since it's working as expected. The method name might be a bit confusing, but the purpose of this one is to only set the parameter if one by that name does not yet exist.
