### PR TITLE
[OSX] Set titleBarStyle to hiddenInset. It's so pretty now! 🌟

### DIFF
--- a/packages/insomnia-app/app/main/window-utils.js
+++ b/packages/insomnia-app/app/main/window-utils.js
@@ -59,7 +59,7 @@ export function createWindow() {
     height: height || DEFAULT_HEIGHT,
     minHeight: MINIMUM_HEIGHT,
     minWidth: MINIMUM_WIDTH,
-    titleBarStyle: titleBarStyle,
+    titleBarStyle,
     acceptFirstMouse: true,
     icon: path.resolve(__dirname, 'static/icon.png'),
     webPreferences: {

--- a/packages/insomnia-app/app/main/window-utils.js
+++ b/packages/insomnia-app/app/main/window-utils.js
@@ -45,6 +45,9 @@ export function createWindow() {
   const finalX = Math.min(maxX, x);
   const finalY = Math.min(maxX, y);
 
+  // Window frame
+  const titleBarStyle = isMac() ? 'hiddenInset' : 'default';
+
   mainWindow = new BrowserWindow({
     // Make sure we don't initialize the window outside the bounds
     x: finalX,
@@ -56,6 +59,7 @@ export function createWindow() {
     height: height || DEFAULT_HEIGHT,
     minHeight: MINIMUM_HEIGHT,
     minWidth: MINIMUM_WIDTH,
+    titleBarStyle: titleBarStyle,
     acceptFirstMouse: true,
     icon: path.resolve(__dirname, 'static/icon.png'),
     webPreferences: {
@@ -75,6 +79,10 @@ export function createWindow() {
   mainWindow.on('unmaximize', e => saveBounds());
 
   mainWindow.on('move', e => saveBounds());
+
+  mainWindow.on('enter-full-screen', e => ipcFullScreen());
+
+  mainWindow.on('leave-full-screen', e => ipcFullScreen());
 
   mainWindow.on('unresponsive', e => {
     showUnresponsiveModal();
@@ -428,4 +436,12 @@ function initLocalStorage() {
 
 function initContextMenus() {
   require('electron-context-menu')({});
+}
+
+function ipcFullScreen() {
+  if (!mainWindow) {
+    return;
+  }
+
+  mainWindow.webContents.send('full-screen-changed', mainWindow.isFullScreen());
 }

--- a/packages/insomnia-app/app/ui/css/components/pane.less
+++ b/packages/insomnia-app/app/ui/css/components/pane.less
@@ -7,6 +7,10 @@
   grid-template-rows: @height-nav minmax(0, 1fr);
   grid-template-columns: 100%;
 
+  [data-platform="darwin"] & {
+    grid-template-rows: @height-nav-darwin minmax(0, 1fr);
+  }
+
   .pane__header {
     background: var(--color-bg);
     position: relative;

--- a/packages/insomnia-app/app/ui/css/components/request-url-bar.less
+++ b/packages/insomnia-app/app/ui/css/components/request-url-bar.less
@@ -23,6 +23,10 @@
     &,
     & > i.fa {
       line-height: @height-nav;
+
+      [data-platform="darwin"] & {
+        line-height: @height-nav-darwin;
+      }
     }
   }
 

--- a/packages/insomnia-app/app/ui/css/components/sidebar.less
+++ b/packages/insomnia-app/app/ui/css/components/sidebar.less
@@ -14,6 +14,10 @@
   width: 100%;
   height: 100%;
 
+  [data-platform="darwin"] & {
+    grid-template-rows: @height-nav-darwin auto auto fit-content(20%) auto minmax(0, 1fr) auto;
+  }
+
   & > .sidebar__list:last-child {
     padding-bottom: @padding-md;
   }

--- a/packages/insomnia-app/app/ui/css/components/workspace-dropdown.less
+++ b/packages/insomnia-app/app/ui/css/components/workspace-dropdown.less
@@ -2,6 +2,10 @@
 @import '../constants/colors';
 
 .workspace-dropdown {
+  body[data-platform="darwin"]:not(.fullscreen) & {
+    padding-left: 60px;
+  }
+
   h1 {
     white-space: nowrap;
     overflow: hidden;

--- a/packages/insomnia-app/app/ui/css/constants/dimensions.less
+++ b/packages/insomnia-app/app/ui/css/constants/dimensions.less
@@ -33,6 +33,7 @@ html {
 
 /* Nav */
 @height-nav: @line-height-md;
+@height-nav-darwin: ~'calc(var(--font-size) * 3)';
 
 /* Scrollbars */
 @scrollbar-width: ~'calc(var(--font-size) * 0.6)';

--- a/packages/insomnia-app/app/ui/index.js
+++ b/packages/insomnia-app/app/ui/index.js
@@ -94,3 +94,17 @@ ipcRenderer.on('update-available', () => {
   // you relaunch too soon it doesn't work the first time.
   setTimeout(showUpdateNotification, 1000 * 10);
 });
+
+// Add helper class to body to check if full-screen
+ipcRenderer.on('full-screen-changed', (e, isFullScreen) => {
+  if (!document) {
+    return;
+  }
+
+  if (isFullScreen === true) {
+    document.body.classList.add('fullscreen');
+    return;
+  }
+
+  document.body.classList.remove('fullscreen');
+});


### PR DESCRIPTION
Insomnia looks great but it has this default grey title bar that looks awful when using most themes. So, as I like things to look pretty, I took the liberty of making some minor modifications (see screenshot) to the title bar.

I hooked in to the full-screen events to add/remove a class from the document body as in full screen the "traffic lights" are hidden, hence the workspace title should shift back to the left.

Please let me know what you think! 🎉 

![Screenshot 2019-05-28 at 00 58 10](https://user-images.githubusercontent.com/1171956/58442371-002b0500-80eb-11e9-9225-2e1f83894979.png)
