### PR TITLE
Add ability to change password

### DIFF
--- a/packages/insomnia-app/app/account/session.js
+++ b/packages/insomnia-app/app/account/session.js
@@ -73,7 +73,7 @@ export async function login(rawEmail, rawPassphrase) {
   c.checkM2(Buffer.from(srpM2, 'hex'));
 
   // ~~~~~~~~~~~~~~~~~~~~~~ //
-  // Initialize the Session : Object//
+  // Initialize the Session //
   // ~~~~~~~~~~~~~~~~~~~~~~ //
 
   // Compute K (used for session ID)

--- a/packages/insomnia-app/app/ui/components/base/link.js
+++ b/packages/insomnia-app/app/ui/components/base/link.js
@@ -10,6 +10,7 @@ type Props = {|
   onClick?: Function,
   className?: string,
   children?: React.Node,
+  disabled?: boolean,
 |};
 
 @autobind
@@ -31,6 +32,7 @@ class Link extends React.PureComponent<Props> {
       href,
       children,
       className,
+      disabled,
       ...other
     } = this.props;
     return button ? (
@@ -42,6 +44,7 @@ class Link extends React.PureComponent<Props> {
         href={href}
         onClick={this._handleClick}
         className={(className || '') + ' theme--link'}
+        disabled={disabled}
         {...other}>
         {children}
       </a>

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.js
@@ -82,7 +82,7 @@ class SettingsModal extends PureComponent {
   render() {
     const { settings } = this.props;
     const { currentTabIndex } = this.state;
-    const email = session.isLoggedIn() ? session.getEmail() : null;
+    const email = session.isLoggedIn() ? session.getFullName() : null;
 
     return (
       <Modal ref={this._setModalRef} tall freshState {...this.props}>

--- a/packages/insomnia-app/app/ui/components/settings/account.js
+++ b/packages/insomnia-app/app/ui/components/settings/account.js
@@ -18,6 +18,7 @@ type State = {
   showChangePassword: boolean,
   codeSent: boolean,
   error: string,
+  finishedResetting: boolean,
 };
 
 @autobind
@@ -29,11 +30,14 @@ class Account extends React.PureComponent<Props, State> {
     codeSent: false,
     showChangePassword: false,
     error: '',
+    finishedResetting: false,
   };
 
   async _handleShowChangePasswordForm(e: SyntheticEvent<HTMLInputElement>) {
-    this.setState(state => ({ showChangePassword: !state.showChangePassword }));
-    await this._sendCode();
+    this.setState(state => ({
+      showChangePassword: !state.showChangePassword,
+      finishedResetting: false,
+    }));
   }
 
   _handleChangeCode(e: SyntheticEvent<HTMLInputElement>) {
@@ -56,7 +60,7 @@ class Account extends React.PureComponent<Props, State> {
 
     let error = '';
     if (password !== password2) {
-      error = 'Passwords did  not match';
+      error = 'Passwords did not match';
     } else if (!code) {
       error = 'Code was not provided';
     }
@@ -70,7 +74,10 @@ class Account extends React.PureComponent<Props, State> {
       await session.changePasswordWithToken(password, code);
     } catch (err) {
       this.setState({ error: err.message });
+      return;
     }
+
+    this.setState({ error: '', finishedResetting: true, showChangePassword: false });
   }
 
   async _handleLogout() {
@@ -137,7 +144,16 @@ class Account extends React.PureComponent<Props, State> {
   }
 
   renderAccount() {
-    const { code, password, password2, codeSent, showChangePassword, error } = this.state;
+    const {
+      code,
+      password,
+      password2,
+      codeSent,
+      showChangePassword,
+      error,
+      finishedResetting,
+    } = this.state;
+
     return (
       <React.Fragment>
         <div>
@@ -160,8 +176,12 @@ class Account extends React.PureComponent<Props, State> {
           </button>
         </div>
 
+        {finishedResetting && (
+          <p className="notice surprise">Your password was changed successfully</p>
+        )}
+
         {showChangePassword && (
-          <form onSubmit={this._handleSubmitPasswordChange}>
+          <form onSubmit={this._handleSubmitPasswordChange} className="pad-top">
             <hr />
             {error && <p className="notice error">{error}</p>}
             <div className="form-control form-control--outlined">
@@ -196,19 +216,19 @@ class Account extends React.PureComponent<Props, State> {
                 />
               </label>
             </div>
-            <div className="row row-spaced">
-              <p className="txt-sm">
-                {codeSent ? 'A code was sent to your email' : 'Looking for your code?'}{' '}
+            <div className="row-spaced row--top">
+              <div>
+                {codeSent ? 'A code was sent to your email' : 'Looking for a code?'}{' '}
                 <Link href="#" onClick={this._handleSendCode}>
-                  Send Another Code
+                  Email Me a Code
                 </Link>
-              </p>
+              </div>
               <div className="text-right">
                 <button
                   type="submit"
                   className="btn btn--clicky"
                   disabled={!code || !password || password !== password2}>
-                  Submit
+                  Submit Change
                 </button>
               </div>
             </div>

--- a/packages/insomnia-app/app/ui/components/settings/account.js
+++ b/packages/insomnia-app/app/ui/components/settings/account.js
@@ -1,4 +1,5 @@
-import React, { PureComponent } from 'react';
+// @flow
+import * as React from 'react';
 import autobind from 'autobind-decorator';
 import * as sync from '../../../sync-legacy/index';
 import Link from '../base/link';
@@ -7,22 +8,67 @@ import { hideAllModals, showModal } from '../modals/index';
 import PromptButton from '../base/prompt-button';
 import * as session from '../../../account/session';
 
+type Props = {};
+
+type State = {
+  code: string,
+  password: string,
+  password2: string,
+  showChangePassword: boolean,
+  codeSent: boolean,
+};
+
 @autobind
-class Account extends PureComponent {
+class Account extends React.PureComponent<Props, State> {
+  state = {
+    code: '',
+    password: '',
+    password2: '',
+    codeSent: false,
+    showChangePassword: false,
+  };
+
+  _handleShowChangePasswordForm(e: SyntheticEvent<HTMLInputElement>) {
+    this.setState(state => ({ showChangePassword: !state.showChangePassword }));
+  }
+
+  _handleChangeCode(e: SyntheticEvent<HTMLInputElement>) {
+    this.setState({ code: e.currentTarget.value });
+  }
+
+  _handleChangePassword(e: SyntheticEvent<HTMLInputElement>) {
+    this.setState({ password: e.currentTarget.value });
+  }
+
+  _handleChangePassword2(e: SyntheticEvent<HTMLInputElement>) {
+    this.setState({ password2: e.currentTarget.value });
+  }
+
+  async _handleSubmitPasswordChange(e: SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    session.changePasswordAndEmail();
+  }
+
   async _handleLogout() {
     await sync.logout();
     this.forceUpdate();
   }
 
-  _handleLogin(e) {
+  static _handleLogin(e: SyntheticEvent<HTMLButtonElement>) {
     e.preventDefault();
     hideAllModals();
     showModal(LoginModal);
   }
 
-  renderUpgrade() {
+  _handleSendCode(e: SyntheticEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    this.setState({ codeSent: true });
+  }
+
+  static renderUpgrade() {
     return (
-      <div>
+      <React.Fragment>
         <div className="notice pad surprise">
           <h1 className="no-margin-top">Try Insomnia Plus!</h1>
           <p>
@@ -48,34 +94,104 @@ class Account extends PureComponent {
         </div>
         <p>
           Or{' '}
-          <a href="#" onClick={this._handleLogin} className="theme--link">
+          <a href="#" onClick={Account._handleLogin} className="theme--link">
             Login
           </a>
         </p>
-      </div>
+      </React.Fragment>
     );
   }
 
   renderAccount() {
+    const { code, password, password2, codeSent, showChangePassword } = this.state;
     return (
-      <div>
-        <h2 className="no-margin-top">Welcome {session.getFirstName()}!</h2>
-        <p>
-          You are currently logged in as <code className="code--compact">{session.getEmail()}</code>
-        </p>
-        <br />
-        <Link button href="https://insomnia.rest/app/" className="btn btn--clicky">
-          Manage Account
-        </Link>
-        <PromptButton className="margin-left-sm btn btn--clicky" onClick={this._handleLogout}>
-          Sign Out
-        </PromptButton>
-      </div>
+      <React.Fragment>
+        <div>
+          <h2 className="no-margin-top">Welcome {session.getFirstName()}!</h2>
+          <p>
+            You are currently logged in as{' '}
+            <code className="code--compact">{session.getEmail()}</code>
+          </p>
+          <br />
+          <Link button href="https://insomnia.rest/app/" className="btn btn--clicky">
+            Manage Account
+          </Link>
+          <PromptButton className="space-left btn btn--clicky" onClick={this._handleLogout}>
+            Sign Out
+          </PromptButton>
+          <button
+            className="space-left btn btn--clicky"
+            onClick={this._handleShowChangePasswordForm}>
+            Change Password
+          </button>
+        </div>
+
+        {showChangePassword && (
+          <form onSubmit={this._handleSubmitPasswordChange}>
+            <hr />
+            <div className="form-control form-control--outlined">
+              <label>
+                New Password
+                <input
+                  required
+                  type="password"
+                  placeholder="•••••••••••••••••"
+                  onChange={this._handleChangePassword}
+                />
+              </label>
+            </div>
+            <div className="form-control form-control--outlined">
+              <label>
+                Confirm Password
+                <input
+                  required
+                  type="password"
+                  placeholder="•••••••••••••••••"
+                  onChange={this._handleChangePassword2}
+                />
+              </label>
+            </div>
+            <div className="form-control form-control--outlined">
+              <label>
+                Confirmation Code
+                <input
+                  type="text"
+                  defaultValue={code}
+                  placeholder="123456"
+                  onChange={this._handleChangeCode}
+                />
+              </label>
+            </div>
+            <div className="row row-spaced">
+              <p className="txt-sm">
+                Don't have a code yet?{' '}
+                {codeSent ? (
+                  <Link href="#" onClick={this._handleSendCode} disabled>
+                    Sent!
+                  </Link>
+                ) : (
+                  <Link href="#" onClick={this._handleSendCode}>
+                    Send to {session.getEmail()}
+                  </Link>
+                )}
+              </p>
+              <div className="text-right">
+                <button
+                  type="submit"
+                  className="btn btn--clicky"
+                  disabled={!code || !password || password !== password2}>
+                  Submit
+                </button>
+              </div>
+            </div>
+          </form>
+        )}
+      </React.Fragment>
     );
   }
 
   render() {
-    return session.isLoggedIn() ? this.renderAccount() : this.renderUpgrade();
+    return session.isLoggedIn() ? this.renderAccount() : Account.renderUpgrade();
   }
 }
 

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -896,6 +896,8 @@ class App extends PureComponent {
   }
 
   async componentDidMount() {
+    showModal(SettingsModal, 4);
+
     // Bind mouse and key handlers
     document.addEventListener('mouseup', this._handleMouseUp);
     document.addEventListener('mousemove', this._handleMouseMove);

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -896,8 +896,6 @@ class App extends PureComponent {
   }
 
   async componentDidMount() {
-    showModal(SettingsModal, 4);
-
     // Bind mouse and key handlers
     document.addEventListener('mouseup', this._handleMouseUp);
     document.addEventListener('mousemove', this._handleMouseMove);

--- a/packages/insomnia-app/app/ui/css/layout/base.less
+++ b/packages/insomnia-app/app/ui/css/layout/base.less
@@ -410,6 +410,10 @@ blockquote {
   width: 100%;
 }
 
+&.row--top {
+  align-items: start;
+}
+
 .valign-middle {
   vertical-align: middle;
 }


### PR DESCRIPTION
Password resets have always been a pain because of the use of E2EE – making it impossible to reset your password without knowing your old one. The solution until now was to delete the users account and create a new one. 

However, since the app keeps a copy of your keys around locally, it's able to perform all necessary actions needed to change a password without knowing the old one. This PR adds a change password form to the account tab in settings to allow the user to change their password.

Since the old password is not needed, a confirmation code (sent by email) is used instead to ensure some level of protection.

![image](https://user-images.githubusercontent.com/587576/58586789-de846780-8229-11e9-83dd-dc11d4a52a91.png)
