### PR TITLE
Download path settings per request

### DIFF
--- a/packages/insomnia-app/app/models/request-meta.js
+++ b/packages/insomnia-app/app/models/request-meta.js
@@ -18,6 +18,7 @@ type BaseRequestMeta = {
   savedRequestBody: Object,
   pinned: boolean,
   lastActive: number,
+  downloadPath: string | null,
 };
 
 export type RequestMeta = BaseModel & BaseRequestMeta;
@@ -32,6 +33,7 @@ export function init() {
     savedRequestBody: {},
     pinned: false,
     lastActive: 0,
+    downloadPath: null,
   };
 }
 

--- a/packages/insomnia-app/app/ui/components/request-pane.js
+++ b/packages/insomnia-app/app/ui/components/request-pane.js
@@ -42,6 +42,7 @@ type Props = {
   handleGenerateCode: Function,
   handleRender: Function,
   handleGetRenderContext: Function,
+  handleUpdateDownloadPath: Function,
   updateRequestUrl: (r: Request, url: string) => Promise<Request>,
   updateRequestMethod: (r: Request, method: string) => Promise<Request>,
   updateRequestBody: (r: Request, body: RequestBody) => Promise<Request>,
@@ -64,6 +65,7 @@ type Props = {
 
   // Optional
   request: ?Request,
+  downloadPath: string | null,
   oAuth2Token: ?OAuth2Token,
 };
 
@@ -153,6 +155,7 @@ class RequestPane extends React.PureComponent<Props> {
       handleRender,
       handleSend,
       handleSendAndDownload,
+      handleUpdateDownloadPath,
       oAuth2Token,
       request,
       workspace,
@@ -167,6 +170,7 @@ class RequestPane extends React.PureComponent<Props> {
       updateRequestMethod,
       updateRequestUrl,
       headerEditorKey,
+      downloadPath,
     } = this.props;
 
     const paneClasses = 'request-pane theme--pane pane';
@@ -265,6 +269,8 @@ class RequestPane extends React.PureComponent<Props> {
               handleGetRenderContext={handleGetRenderContext}
               request={request}
               hotKeyRegistry={settings.hotKeyRegistry}
+              handleUpdateDownloadPath={handleUpdateDownloadPath}
+              downloadPath={downloadPath}
             />
           </ErrorBoundary>
         </header>

--- a/packages/insomnia-app/app/ui/components/request-url-bar.js
+++ b/packages/insomnia-app/app/ui/components/request-url-bar.js
@@ -126,6 +126,8 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
   }
 
   _handleSetDownloadLocation() {
+    const { request } = this.props;
+
     const options = {
       title: 'Select Download Location',
       buttonLabel: 'Select',
@@ -137,12 +139,14 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
         return;
       }
 
-      this.props.handleUpdateDownloadPath(paths[0]);
+      this.props.handleUpdateDownloadPath(request._id, paths[0]);
     });
   }
 
   _handleClearDownloadLocation() {
-    this.props.handleUpdateDownloadPath(null);
+    const { request } = this.props;
+
+    this.props.handleUpdateDownloadPath(request._id, null);
   }
 
   async _handleKeyDown(e: KeyboardEvent) {

--- a/packages/insomnia-app/app/ui/components/request-url-bar.js
+++ b/packages/insomnia-app/app/ui/components/request-url-bar.js
@@ -35,12 +35,13 @@ type Props = {
   request: Request,
   uniquenessKey: string,
   hotKeyRegistry: HotKeyRegistry,
+  downloadPath: string | null,
+  handleSetDownloadPath: (filepath?: string) => void,
 };
 
 type State = {
   currentInterval: number | null,
   currentTimeout: number | null,
-  downloadPath: string | null,
 };
 
 @autobind
@@ -58,7 +59,6 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
     this.state = {
       currentInterval: null,
       currentTimeout: null,
-      downloadPath: null,
     };
 
     this._lastPastedText = null;
@@ -137,12 +137,12 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
         return;
       }
 
-      this.setState({ downloadPath: paths[0] });
+      this.props.handleSetDownloadPath(paths[0]);
     });
   }
 
   _handleClearDownloadLocation() {
-    this.setState({ downloadPath: null });
+    this.props.handleSetDownloadPath(null);
   }
 
   async _handleKeyDown(e: KeyboardEvent) {
@@ -170,7 +170,7 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
 
     this._handleStopTimeout();
 
-    const { downloadPath } = this.state;
+    const { downloadPath } = this.props;
     if (downloadPath) {
       this.props.handleSendAndDownload(downloadPath);
     } else {
@@ -251,8 +251,8 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
   }
 
   renderSendButton() {
-    const { hotKeyRegistry } = this.props;
-    const { currentInterval, currentTimeout, downloadPath } = this.state;
+    const { hotKeyRegistry, downloadPath } = this.props;
+    const { currentInterval, currentTimeout } = this.state;
 
     let cancelButton = null;
     if (currentInterval) {

--- a/packages/insomnia-app/app/ui/components/request-url-bar.js
+++ b/packages/insomnia-app/app/ui/components/request-url-bar.js
@@ -28,6 +28,7 @@ type Props = {
   handleRender: string => Promise<string>,
   handleSend: () => void,
   handleSendAndDownload: (filepath?: string) => Promise<void>,
+  handleUpdateDownloadPath: Function,
   isVariableUncovered: boolean,
   nunjucksPowerUserMode: boolean,
   onMethodChange: (r: Request, method: string) => Promise<Request>,
@@ -36,7 +37,6 @@ type Props = {
   uniquenessKey: string,
   hotKeyRegistry: HotKeyRegistry,
   downloadPath: string | null,
-  handleSetDownloadPath: (filepath?: string) => void,
 };
 
 type State = {
@@ -137,12 +137,12 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
         return;
       }
 
-      this.props.handleSetDownloadPath(paths[0]);
+      this.props.handleUpdateDownloadPath(paths[0]);
     });
   }
 
   _handleClearDownloadLocation() {
-    this.props.handleSetDownloadPath(null);
+    this.props.handleUpdateDownloadPath(null);
   }
 
   async _handleKeyDown(e: KeyboardEvent) {

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -105,6 +105,7 @@ type Props = {
   handleSendRequestWithEnvironment: Function,
   handleSendAndDownloadRequestWithEnvironment: Function,
   handleUpdateRequestMimeType: Function,
+  handleUpdateDownloadPath: Function,
 
   // Properties
   loadStartTime: number,
@@ -114,6 +115,7 @@ type Props = {
   responsePreviewMode: string,
   responseFilter: string,
   responseFilterHistory: Array<string>,
+  responseDownloadPath: string | null,
   sidebarWidth: number,
   sidebarHidden: boolean,
   sidebarFilter: string,
@@ -414,6 +416,7 @@ class Wrapper extends React.PureComponent<Props, State> {
       handleStartDragPaneVertical,
       handleToggleMenuBar,
       handleUpdateRequestMimeType,
+      handleUpdateDownloadPath,
       headerEditorKey,
       isLoading,
       isVariableUncovered,
@@ -425,6 +428,7 @@ class Wrapper extends React.PureComponent<Props, State> {
       responseFilter,
       responseFilterHistory,
       responsePreviewMode,
+      responseDownloadPath,
       settings,
       sidebarChildren,
       sidebarFilter,
@@ -714,6 +718,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             handleImportFile={this._handleImportFile}
             request={activeRequest}
             workspace={activeWorkspace}
+            downloadPath={responseDownloadPath}
             settings={settings}
             environmentId={activeEnvironment ? activeEnvironment._id : ''}
             oAuth2Token={oAuth2Token}
@@ -723,6 +728,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             handleImport={this._handleImport}
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
+            handleUpdateDownloadPath={handleUpdateDownloadPath}
             updateRequestBody={Wrapper._handleUpdateRequestBody}
             forceUpdateRequestHeaders={this._handleForceUpdateRequestHeaders}
             updateRequestUrl={Wrapper._handleUpdateRequestUrl}
@@ -762,6 +768,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             request={activeRequest}
             responses={activeRequestResponses}
             response={activeResponse}
+            downloadPath={responseDownloadPath}
             editorFontSize={settings.editorFontSize}
             editorIndentSize={settings.editorIndentSize}
             editorKeyMap={settings.editorKeyMap}
@@ -778,6 +785,7 @@ class Wrapper extends React.PureComponent<Props, State> {
             handleDeleteResponses={this._handleDeleteResponses}
             handleDeleteResponse={this._handleDeleteResponse}
             handleSetFilter={this._handleSetResponseFilter}
+            handleUpdateDownloadPath={handleUpdateDownloadPath}
           />
         </ErrorBoundary>
       </div>,

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -768,7 +768,6 @@ class Wrapper extends React.PureComponent<Props, State> {
             request={activeRequest}
             responses={activeRequestResponses}
             response={activeResponse}
-            downloadPath={responseDownloadPath}
             editorFontSize={settings.editorFontSize}
             editorIndentSize={settings.editorIndentSize}
             editorKeyMap={settings.editorKeyMap}
@@ -785,7 +784,6 @@ class Wrapper extends React.PureComponent<Props, State> {
             handleDeleteResponses={this._handleDeleteResponses}
             handleDeleteResponse={this._handleDeleteResponse}
             handleSetFilter={this._handleSetResponseFilter}
-            handleUpdateDownloadPath={handleUpdateDownloadPath}
           />
         </ErrorBoundary>
       </div>,

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -477,6 +477,10 @@ class App extends PureComponent {
     App._updateRequestMetaByParentId(requestId, { previewMode });
   }
 
+  _handleUpdateDownloadPath(requestId, downloadPath) {
+    App._updateRequestMetaByParentId(requestId, { downloadPath });
+  }
+
   async _handleSetResponseFilter(requestId, responseFilter) {
     await App._updateRequestMetaByParentId(requestId, { responseFilter });
 
@@ -1123,6 +1127,7 @@ class App extends PureComponent {
               handleToggleMenuBar={this._handleToggleMenuBar}
               handleUpdateRequestMimeType={this._handleUpdateRequestMimeType}
               handleShowExportRequestsModal={this._handleShowExportRequestsModal}
+              handleUpdateDownloadPath={this._handleUpdateDownloadPath}
               isVariableUncovered={isVariableUncovered}
               headerEditorKey={forceRefreshHeaderCounter + ''}
               vcs={vcs}
@@ -1188,6 +1193,7 @@ function mapStateToProps(state, props) {
   const responsePreviewMode = requestMeta.previewMode || PREVIEW_MODE_SOURCE;
   const responseFilter = requestMeta.responseFilter || '';
   const responseFilterHistory = requestMeta.responseFilterHistory || [];
+  const responseDownloadPath = requestMeta.downloadPath || null;
 
   // Cookie Jar
   const activeCookieJar = selectActiveCookieJar(state, props);
@@ -1242,6 +1248,7 @@ function mapStateToProps(state, props) {
     activeEnvironment,
     workspaceChildren,
     syncItems,
+    responseDownloadPath,
   });
 }
 


### PR DESCRIPTION
Closes #1511.

Saves request download path in `request-meta` instead of `request-url-bar` state. This allows the setting to be per request rather than global.

Ideally I would expect this `downloadPath` setting (and others in future) to exist in a 'requestSettings` object in meta and passed around as a whole rather than adding x props for each new setting. I feel that is out of scope for this PR though - thoughts?

Send + download
![image](https://user-images.githubusercontent.com/4312346/58775126-27686180-8618-11e9-8659-d7e10aeb17df.png)

Send only
![image](https://user-images.githubusercontent.com/4312346/58775145-394a0480-8618-11e9-8a86-66f0aacb77fc.png)

![](https://media1.giphy.com/media/4Zo41lhzKt6iZ8xff9/giphy.gif)