### PR TITLE
Add back View > Toggle Sidebar item

### DIFF
--- a/packages/insomnia-app/app/common/hotkeys.js
+++ b/packages/insomnia-app/app/common/hotkeys.js
@@ -98,8 +98,6 @@ export const hotKeyRefs = {
 
   TOGGLE_MAIN_MENU: defineHotKey('toggleMainMenu', 'Toggle Main Menu'),
 
-  SIDEBAR_TOGGLE: defineHotKey('sidebar_toggle', 'Toggle Sidebar'),
-
   REQUEST_QUICK_SWITCH: defineHotKey('request_quickSwitch', 'Switch Requests'),
 
   SHOW_RECENT_REQUESTS: defineHotKey('request_showRecent', 'Show Recent Requests'),
@@ -187,11 +185,6 @@ const defaultRegistry: HotKeyRegistry = {
   [hotKeyRefs.TOGGLE_MAIN_MENU.id]: keyBinds(
     keyComb(false, true, false, true, keyboardKeys.comma.keyCode),
     keyComb(true, true, false, false, keyboardKeys.comma.keyCode),
-  ),
-
-  [hotKeyRefs.SIDEBAR_TOGGLE.id]: keyBinds(
-    keyComb(false, false, false, true, keyboardKeys.backslash.keyCode),
-    keyComb(true, false, false, false, keyboardKeys.backslash.keyCode),
   ),
 
   [hotKeyRefs.REQUEST_QUICK_SWITCH.id]: keyBinds(

--- a/packages/insomnia-app/app/main/window-utils.js
+++ b/packages/insomnia-app/app/main/window-utils.js
@@ -206,6 +206,18 @@ export function createWindow() {
         },
       },
       {
+        label: 'Toggle Sidebar',
+        accelerator: 'CmdOrCtrl+\\',
+        click: () => {
+          const w = BrowserWindow.getFocusedWindow();
+          if (!w || !w.webContents) {
+            return;
+          }
+
+          w.webContents.send('toggle-sidebar');
+        },
+      },
+      {
         label: `Toggle ${MNEMONIC_SYM}DevTools`,
         click: () => mainWindow.toggleDevTools(),
       },

--- a/packages/insomnia-app/app/ui/components/settings/shortcuts.js
+++ b/packages/insomnia-app/app/ui/components/settings/shortcuts.js
@@ -41,7 +41,6 @@ const HOT_KEY_DEFS: Array<HotKeyDefinition> = [
   hotKeyRefs.REQUEST_FOCUS_URL,
   hotKeyRefs.RESPONSE_FOCUS,
   hotKeyRefs.REQUEST_TOGGLE_HTTP_METHOD_MENU,
-  hotKeyRefs.SIDEBAR_TOGGLE,
   hotKeyRefs.SIDEBAR_FOCUS_FILTER,
   hotKeyRefs.REQUEST_TOGGLE_HISTORY,
   hotKeyRefs.SHOW_AUTOCOMPLETE,

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -246,7 +246,6 @@ class App extends PureComponent {
           await this._handleSetRequestPinned(this.props.activeRequest, !(metas && metas.pinned));
         },
       ],
-      [hotKeyRefs.SIDEBAR_TOGGLE, this._handleToggleSidebar],
       [hotKeyRefs.PLUGIN_RELOAD, this._handleReloadPlugins],
       [
         hotKeyRefs.ENVIRONMENT_UNCOVER_VARIABLES,


### PR DESCRIPTION
Closes #1547.

As per title and issue description. Also removes hotkey definition for sidebar toggle (consistent with the other menu items that have associated keyboard shortcuts).

![](https://media2.giphy.com/media/VkIet63SWUJa0/giphy.gif)
