### PR TITLE
[fix] swagger importer: do not assume object param type has properties

### DIFF
--- a/packages/insomnia-importers/src/importers/swagger2.js
+++ b/packages/insomnia-importers/src/importers/swagger2.js
@@ -293,9 +293,11 @@ function generateParameterExample(schema) {
       const example = {};
       const { properties } = schema;
 
-      Object.keys(properties).forEach(propertyName => {
-        example[propertyName] = generateParameterExample(properties[propertyName]);
-      });
+      if (properties) {
+        Object.keys(properties).forEach(propertyName => {
+          example[propertyName] = generateParameterExample(properties[propertyName]);
+        });
+      }
 
       return example;
     },


### PR DESCRIPTION
When playing with Docker Engine API:

https://docs.docker.com/engine/api/v1.39/

I found that it failed to import Swagger spec provided by Docker:

https://docs.docker.com/engine/api/v1.39/swagger.yaml

![image](https://user-images.githubusercontent.com/171245/59964254-0fa63e00-9531-11e9-975c-d39ab28e2943.png)

After some digging it seems when generating parameter example for object types, the swagger importer always assumes the existence of `properties` key, but it's not always the case, for example, from the Docker Engine API spec:

https://gist.github.com/forresty/374c79137e3ce997daead2e73ff92758#file-docker-swagger-insomnia-yaml-L811-L821

![image](https://user-images.githubusercontent.com/171245/59964210-5fd0d080-9530-11e9-9770-8c45677bc7ff.png)

This `ExposedPorts` does not have a `properties` key, results in a "failed to import" error.

This tiny patch fixes this problem, now it handles all endpoint definitions of the Docker Engine API yaml file and has nice examples:

![image](https://user-images.githubusercontent.com/171245/59964218-868f0700-9530-11e9-974d-4afa3ed6594a.png)

Note that some small changes need to be applied when importing the Docker spec, namely need to remove `https` from `schemes` and add the `host` key:

https://gist.github.com/forresty/374c79137e3ce997daead2e73ff92758/revisions

![image](https://user-images.githubusercontent.com/171245/59964265-3d8b8280-9531-11e9-9063-66f921dc770f.png)

Thanks for this wonderful piece of software by the way ;-)