### PR TITLE
[network] Use system CA on Linux

### DIFF
--- a/packages/insomnia-app/app/network/network.js
+++ b/packages/insomnia-app/app/network/network.js
@@ -12,6 +12,7 @@ import {
 import mkdirp from 'mkdirp';
 import crypto from 'crypto';
 import clone from 'clone';
+import certFinder from 'find-root-ca-cert';
 import { parse as urlParse, resolve as urlResolve } from 'url';
 import { Curl } from 'insomnia-libcurl';
 import { join as pathJoin } from 'path';
@@ -353,7 +354,11 @@ export async function _actuallySend(
 
       // Setup CA Root Certificates if not on Mac. Thanks to libcurl, Mac will use
       // certificates form the OS.
-      if (process.platform !== 'darwin') {
+      if (process.platform === 'linux') {
+        const fullCAPath = certFinder.findCABundle();
+        setOpt(Curl.option.CAINFO, fullCAPath);
+        console.info('[net] Set CA to', fullCAPath);
+      } else if (process.platform !== 'darwin') {
         const baseCAPath = getTempDir();
         const fullCAPath = pathJoin(baseCAPath, CACerts.filename);
 

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -4629,6 +4629,11 @@
         }
       }
     },
+    "find-root-ca-cert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-root-ca-cert/-/find-root-ca-cert-1.0.0.tgz",
+      "integrity": "sha512-KkWNspI9aOtWU+fan/mAlL0lgv3Cng5OJeINEiXfDQc5eVjsVU0FSgwQ1dpx0jDpkYmN3hcJ6DJ1VBcKlD5FTw=="
+    },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -107,6 +107,7 @@
     "codemirror-graphql": "^0.8.3",
     "deep-equal": "^1.0.1",
     "electron-context-menu": "^0.10.0",
+    "find-root-ca-cert": "^1.0.0",
     "font-scanner": "^0.1.1",
     "fs-extra": "^5.0.0",
     "fuzzysort": "^1.1.1",


### PR DESCRIPTION
- Closes #1432 
- Uses https://www.npmjs.com/package/find-root-ca-cert, which is based on [the list that golang uses](https://golang.org/src/crypto/x509/root_linux.go)