### PR TITLE
[Prompt] Optionally make the prompt plugin pre-fill the last entered value

### DIFF
--- a/plugins/insomnia-plugin-prompt/index.js
+++ b/plugins/insomnia-plugin-prompt/index.js
@@ -1,23 +1,5 @@
 const crypto = require('crypto');
 
-module.exports.responseHooks = [
-  async context => {
-    const items = await context.store.all();
-    const requestId = context.request.getId();
-    const toRemove = items.filter(v => {
-      if (v.key && typeof v.key === 'string') {
-        return v.key.indexOf(requestId) === 0;
-      }
-
-      return false;
-    });
-    // Delete cached values we prompt again on the next request
-    for (const { key } of toRemove) {
-      await context.store.removeItem(key);
-    }
-  },
-];
-
 module.exports.templateTags = [
   {
     displayName: 'Prompt',
@@ -57,6 +39,15 @@ module.exports.templateTags = [
         help: 'If this is enabled, the value when input will be masked like a password field.',
         defaultValue: false,
       },
+      {
+        displayName: 'Save Last Value',
+        type: 'boolean',
+        help:
+          'If this is enabled, the value will be stored in memory and the next time this prompt' +
+          'shows, the input field will be pre-filled with this value. This option is ignored ' +
+          'when the storage key is set.',
+        defaultValue: true
+      }
     ],
     async run(context, title, label, defaultValue, explicitStorageKey, maskText) {
       if (!title) {
@@ -74,9 +65,16 @@ module.exports.templateTags = [
       const storageKey = explicitStorageKey || `${context.meta.requestId}.${titleHash}`;
       const cachedValue = await context.store.getItem(storageKey);
 
-      if (cachedValue) {
+      // Directly return cached value if using explicitly defined storage key
+      if (explicitStorageKey && cachedValue) {
         console.log(`[prompt] Used cached value under ${storageKey}`);
         return cachedValue;
+      }
+
+      // Use cached value as default value
+      if (cachedValue) {
+        defaultValue = cachedValue;
+        console.log(`[prompt] Used cached value under ${storageKey}`);
       }
 
       // Only prompt when we're actually sending


### PR DESCRIPTION
I have added an option to the prompt plugin to save the last entered value and have that set as default value the next time the prompt shows. This saves you from having to enter all details for each request while still being able to change them if needed.

This should be full backwards compatible as the old behaviour is used when a storage key is set explicitly.

### Old scenario 😢 
1. User executes a request with a few prompt tags
2. User enters details for each of them
3. User sips some coffee, fixes some bugs in his code.
4. User executes the request again
5. User has to enter all details again and make sure they are exactly the same
6. Repeat from step 3

### New scenario 😄 
1. User executes a request with a few prompt tags
2. User enters details for each of them
3. User sips some coffee, fixes some bugs in his code.
4. User executes the request again
5. Bashes enter a few times as all things are pre-filled
6. Repeat from step 3

Makes my life a lot easier 😅 