### PR TITLE
Importing OpenApi3: Ignore fields marked as readOnly when generating…

### DIFF
--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-readonly-input.yml
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-readonly-input.yml
@@ -1,0 +1,118 @@
+openapi: 3.0.1
+info:
+  title: Swagger Petstore
+  license:
+    name: MIT
+  version: 1.0.0
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      tags:
+        - pets
+      summary: List all pets
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pets'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      tags:
+        - pets
+      summary: Create a pet
+      operationId: createPets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+        required: true
+      responses:
+        201:
+          description: Null response
+          content: {}
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{petId}:
+    get:
+      tags:
+        - pets
+      summary: Info for a specific pet
+      operationId: showPetById
+      parameters:
+        - name: petId
+          in: path
+          description: The id of the pet to retrieve
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pets'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pets:
+      type: array
+      items:
+        $ref: '#/components/schemas/Pet'
+    Error:
+      required:
+        - code
+        - message
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    Pet:
+      required:
+        - id
+        - name
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          readOnly: true
+        name:
+          type: string
+        tag:
+          type: string

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-readonly-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-readonly-output.json
@@ -1,0 +1,80 @@
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2018-01-09T23:33:12.799Z",
+  "__export_source": "insomnia.importers:v0.1.0",
+  "resources": [
+    {
+      "_type": "workspace",
+      "_id": "__WORKSPACE_1__",
+      "parentId": null,
+      "name": "Swagger Petstore 1.0.0",
+      "description": ""
+    },
+    {
+      "parentId": "__WORKSPACE_1__",
+      "name": "Base environment",
+      "data": {
+        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+      },
+      "_type": "environment",
+      "_id": "__ENV_1__"
+    },
+    {
+      "parentId": "__ENV_1__",
+      "name": "OpenAPI env",
+      "data": {
+        "base_path": "/v1",
+        "scheme": "http",
+        "host": "petstore.swagger.io"
+      },
+      "_type": "environment",
+      "_id": "__ENV_2__"
+    },
+    {
+      "parentId": "__WORKSPACE_1__",
+      "name": "List all pets",
+      "url": "{{ base_url }}/pets",
+      "body": {},
+      "method": "GET",
+      "parameters": [
+        {
+          "name": "limit",
+          "disabled": true,
+          "value": "0"
+        }
+      ],
+      "headers": [],
+      "authentication": {},
+      "_type": "request",
+      "_id": "listPets"
+    },
+    {
+      "parentId": "__WORKSPACE_1__",
+      "name": "Create a pet",
+      "url": "{{ base_url }}/pets",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"name\": \"string\",\n  \"tag\": \"string\"\n}"
+      },
+      "method": "POST",
+      "parameters": [],
+      "headers": [],
+      "authentication": {},
+      "_type": "request",
+      "_id": "createPets"
+    },
+    {
+      "parentId": "__WORKSPACE_1__",
+      "name": "Info for a specific pet",
+      "url": "{{ base_url }}/pets/{{ petId }}",
+      "body": {},
+      "method": "GET",
+      "parameters": [],
+      "headers": [],
+      "authentication": {},
+      "_type": "request",
+      "_id": "showPetById"
+    }
+  ]
+}

--- a/packages/insomnia-importers/src/importers/openapi3.js
+++ b/packages/insomnia-importers/src/importers/openapi3.js
@@ -319,7 +319,11 @@ function generateParameterExample(schema) {
   }
 
   if (schema instanceof Object) {
-    const { type, format, example, default: defaultValue } = schema;
+    const { type, format, example, readOnly, default: defaultValue } = schema;
+
+    if (readOnly) {
+      return undefined;
+    }
 
     if (example) {
       return example;


### PR DESCRIPTION
… request bodies

When importing OAS3.0 specifications Insomnia includes the readOnly fields in the example requests.

References:-
https://swagger.io/specification/#schemaObject
https://github.com/swagger-api/swagger-ui/issues/3445 (similar issue in swagger-ui)

This is my first PR to your project, so please be kind :) I couldn't find an open issue for this - perhaps readOnly is such a new feature, people haven't come across this before.

<!--
Please open an [Issue](https://github.com/getinsomnia/insomnia/issues/new) first to discuss new 
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

