### PR TITLE
[Bug Fix 1288] "Undefined" for nested variables

### DIFF
--- a/packages/insomnia-app/app/common/render.js
+++ b/packages/insomnia-app/app/common/render.js
@@ -243,6 +243,11 @@ export async function getRenderContext(
       if (Object.prototype.toString.call(subObject[key]) === '[object Object]') {
         // Type is an Object, keep on going, recursively building the full key path
         getKeySource(subObject[key], inKey + key + '.', inSource);
+      } else if (Object.prototype.toString.call(subObject[key]) === '[object Array]') {
+        // Type is an Array, Loop and store the full Key and Source in keySource
+        for (let i = 0, length = subObject[key].length; i < length; i++) {
+          keySource[inKey + key + '[' + i + ']'] = inSource;
+        }
       } else {
         // For all other types, store the full Key and Source in keySource
         keySource[inKey + key] = inSource;

--- a/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.js
@@ -276,11 +276,7 @@ async function _updateElementText(render, mark, text, renderContext, isVariableU
       title = await render(str);
       const context = await renderContext();
       const con = context.context.getKeysContext();
-      // Check if property is nested, if so strip to topmost Parent property
-      const propSource = cleanedStr.includes('.')
-        ? cleanedStr.substring(0, cleanedStr.indexOf('.'))
-        : cleanedStr;
-      title = '{' + con.keyContext[propSource] + '}: ' + title;
+      title = '{' + con.keyContext[cleanedStr] + '}: ' + title;
       innerHTML = isVariableUncovered ? title : cleanedStr;
     }
     dataError = 'off';

--- a/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.js
@@ -276,7 +276,11 @@ async function _updateElementText(render, mark, text, renderContext, isVariableU
       title = await render(str);
       const context = await renderContext();
       const con = context.context.getKeysContext();
-      title = '{' + con.keyContext[cleanedStr] + '}: ' + title;
+      // Check if property is nested, if so strip to topmost Parent property
+      const propSource = cleanedStr.includes('.')
+        ? cleanedStr.substring(0, cleanedStr.indexOf('.'))
+        : cleanedStr;
+      title = '{' + con.keyContext[propSource] + '}: ' + title;
       innerHTML = isVariableUncovered ? title : cleanedStr;
     }
     dataError = 'off';


### PR DESCRIPTION
(Fixes #1288) Extract parent from nunjucks tag when it is a nested property nested. The parent is then used to fetch the keyContext

<!--
Please open an [Issue](https://github.com/getinsomnia/insomnia/issues/new) first to discuss new 
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

