### PR TITLE
Make OpenAPI importer generate deterministic IDs

### DIFF
--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -163,9 +163,14 @@ export async function importRaw(
     // Replace ID placeholders (eg. __WORKSPACE_ID__) with generated values
     for (const key of Object.keys(generatedIds)) {
       const { parentId, _id } = resource;
-      const id = await fnOrString(generatedIds[key]);
-      resource.parentId = parentId ? parentId.replace(key, id) : parentId;
-      resource._id = _id ? _id.replace(key, id) : _id;
+
+      if (parentId && parentId.includes(key)) {
+        resource.parentId = parentId.replace(key, await fnOrString(generatedIds[key]));
+      }
+
+      if (_id && _id.includes(key)) {
+        resource._id = _id.replace(key, await fnOrString(generatedIds[key]));
+      }
     }
 
     const model: Object = MODELS[resource._type];

--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -24,7 +24,7 @@ const EXPORT_TYPE_COOKIE_JAR = 'cookie_jar';
 const EXPORT_TYPE_ENVIRONMENT = 'environment';
 
 // If we come across an ID of this form, we will replace it with a new one
-const REPLACE_ID_REGEX = /^__\w+_\d+__$/;
+const REPLACE_ID_REGEX = /__\w+_\d+__/g;
 
 const MODELS = {
   [EXPORT_TYPE_REQUEST]: models.request,
@@ -87,7 +87,6 @@ export async function importUri(
 export async function importRaw(
   getWorkspaceId: () => Promise<string | null>,
   rawContent: string,
-  generateNewIds: boolean = false,
 ): Promise<{
   source: string,
   error: Error | null,
@@ -109,8 +108,8 @@ export async function importRaw(
   // Generate all the ids we may need
   const generatedIds: { [string]: string | Function } = {};
   for (const r of data.resources) {
-    if (generateNewIds || r._id.match(REPLACE_ID_REGEX)) {
-      generatedIds[r._id] = generateId(MODELS[r._type].prefix);
+    for (const key of r._id.match(REPLACE_ID_REGEX) || []) {
+      generatedIds[key] = generateId(MODELS[r._type].prefix);
     }
   }
 
@@ -161,14 +160,12 @@ export async function importRaw(
       resource.parentId = WORKSPACE_ID_KEY;
     }
 
-    // Replace _id if we need to
-    if (generatedIds[resource._id]) {
-      resource._id = await fnOrString(generatedIds[resource._id]);
-    }
-
-    // Replace newly generated IDs if they exist
-    if (generatedIds[resource.parentId]) {
-      resource.parentId = await fnOrString(generatedIds[resource.parentId]);
+    // Replace ID placeholders (eg. __WORKSPACE_ID__) with generated values
+    for (const key of Object.keys(generatedIds)) {
+      const { parentId, _id } = resource;
+      const id = await fnOrString(generatedIds[key]);
+      resource.parentId = parentId ? parentId.replace(key, id) : parentId;
+      resource._id = _id ? _id.replace(key, id) : _id;
     }
 
     const model: Object = MODELS[resource._type];

--- a/packages/insomnia-cookies/package-lock.json
+++ b/packages/insomnia-cookies/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-cookies",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/insomnia-importers/package-lock.json
+++ b/packages/insomnia-importers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-importers",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/insomnia-importers/src/__tests__/fixtures.test.js
+++ b/packages/insomnia-importers/src/__tests__/fixtures.test.js
@@ -32,6 +32,16 @@ describe('Fixtures', () => {
         expected.__export_date = results.data.__export_date;
 
         expect(results.data).toEqual(expected);
+
+        const ids = new Set();
+        for (const r of results.data.resources) {
+          if (ids.has(r._id)) {
+            throw new Error(
+              'Export contained multiple duplicate IDs: ' + JSON.stringify(r, null, '\t'),
+            );
+          }
+          ids.add(r._id);
+        }
       });
     }
   }

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/dereferenced-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/dereferenced-output.json
@@ -1,314 +1,314 @@
 {
-  "_type": "export",
+  "__export_date": "2019-08-15T19:31:41.712Z",
   "__export_format": 4,
-  "__export_date": "2018-01-09T23:32:46.908Z",
   "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
   "resources": [
     {
-      "_type": "workspace",
       "_id": "__WORKSPACE_ID__",
-      "parentId": null,
+      "_type": "workspace",
+      "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
       "name": "Swagger Petstore 1.0.0",
-      "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters."
+      "parentId": null
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Base environment",
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
       "data": {
         "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
       },
-      "_type": "environment",
-      "_id": "__ENV_1__"
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_ID__"
     },
     {
-      "parentId": "__ENV_1__",
-      "name": "OpenAPI env",
+      "_id": "env___BASE_ENVIRONMENT_ID___sub",
+      "_type": "environment",
       "data": {
         "base_path": "/v2",
-        "scheme": "http",
-        "host": "petstore.swagger.io"
+        "host": "petstore.swagger.io",
+        "scheme": "http"
       },
-      "_type": "environment",
-      "_id": "__ENV_2__"
+      "name": "OpenAPI env",
+      "parentId": "__BASE_ENVIRONMENT_ID__"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Add a new pet to the store",
-      "url": "{{ base_url }}/pet",
+      "_id": "req___WORKSPACE_ID__23acbe44",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
+      "headers": [],
       "method": "POST",
+      "name": "Add a new pet to the store",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "addPet"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Update an existing pet",
-      "url": "{{ base_url }}/pet",
+      "_id": "req___WORKSPACE_ID__74a7a059",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "method": "PUT",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updatePet"
+      "method": "PUT",
+      "name": "Update an existing pet",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Finds Pets by status",
-      "url": "{{ base_url }}/pet/findByStatus",
+      "_id": "req___WORKSPACE_ID__80ab0d08",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Finds Pets by status",
       "parameters": [
         {
-          "name": "status",
           "disabled": false,
+          "name": "status",
           "value": "available"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "findPetsByStatus"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/findByStatus"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Finds Pets by tags",
-      "url": "{{ base_url }}/pet/findByTags",
+      "_id": "req___WORKSPACE_ID__42a17980",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Finds Pets by tags",
       "parameters": [
         {
-          "name": "tags",
           "disabled": false,
+          "name": "tags",
           "value": "string"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "findPetsByTags"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/findByTags"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Find pet by ID",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__3d1a51d3",
+      "_type": "request",
+      "authentication": {},
       "body": {},
-      "method": "GET",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getPetById"
+      "method": "GET",
+      "name": "Find pet by ID",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Updates a pet in the store with form data",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__a4608701",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
-      "method": "POST",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updatePetWithForm"
+      "method": "POST",
+      "name": "Updates a pet in the store with form data",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Deletes a pet",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__e804bd05",
+      "_type": "request",
+      "authentication": {},
       "body": {},
-      "method": "DELETE",
-      "parameters": [],
       "headers": [
         {
-          "name": "api_key",
           "disabled": true,
+          "name": "api_key",
           "value": "string"
         }
       ],
-      "authentication": {},
-      "_type": "request",
-      "_id": "deletePet"
+      "method": "DELETE",
+      "name": "Deletes a pet",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "uploads an image",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage",
+      "_id": "req___WORKSPACE_ID__8081fb6f",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "multipart/form-data"
       },
-      "method": "POST",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "uploadFile"
+      "method": "POST",
+      "name": "uploads an image",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__443ac9e7",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Returns pet inventories by status",
-      "url": "{{ base_url }}/store/inventory",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getInventory"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/store/inventory"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__e24a4f9e",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Place an order for a pet",
-      "url": "{{ base_url }}/store/order",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "placeOrder"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/store/order"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__f021bcd3",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Find purchase order by ID",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getOrderById"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/store/order/{{ orderId }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Delete purchase order by ID",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
+      "_id": "req___WORKSPACE_ID__15e47538",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "DELETE",
+      "name": "Delete purchase order by ID",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "deleteOrder"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/store/order/{{ orderId }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__fe3d55d0",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Create user",
-      "url": "{{ base_url }}/user",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUser"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__4cb83333",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Creates list of users with given input array",
-      "url": "{{ base_url }}/user/createWithArray",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUsersWithArrayInput"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/createWithArray"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__e94a615f",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Creates list of users with given input array",
-      "url": "{{ base_url }}/user/createWithList",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUsersWithListInput"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/createWithList"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Logs user into the system",
-      "url": "{{ base_url }}/user/login",
+      "_id": "req___WORKSPACE_ID__00ac9da2",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Logs user into the system",
       "parameters": [
         {
-          "name": "username",
           "disabled": false,
+          "name": "username",
           "value": "string"
         },
         {
-          "name": "password",
           "disabled": false,
+          "name": "password",
           "value": "string"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "loginUser"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/login"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__740025cb",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Logs out current logged in user session",
-      "url": "{{ base_url }}/user/logout",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "logoutUser"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/logout"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__74f1d1d1",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Get user by user name",
-      "url": "{{ base_url }}/user/{{ username }}",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getUserByName"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/{{ username }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Updated user",
-      "url": "{{ base_url }}/user/{{ username }}",
+      "_id": "req___WORKSPACE_ID__6d74493f",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "PUT",
+      "name": "Updated user",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updateUser"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/{{ username }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Delete user",
-      "url": "{{ base_url }}/user/{{ username }}",
-      "body": {},
-      "method": "DELETE",
-      "parameters": [],
-      "headers": [],
-      "authentication": {},
+      "_id": "req___WORKSPACE_ID__38e8e88f",
       "_type": "request",
-      "_id": "deleteUser"
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "DELETE",
+      "name": "Delete user",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/{{ username }}"
     }
   ]
 }

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/dereferenced-with-tags-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/dereferenced-with-tags-output.json
@@ -1,38 +1,38 @@
 {
-  "_type": "export",
+  "__export_date": "2019-08-15T19:31:41.767Z",
   "__export_format": 4,
-  "__export_date": "2018-01-09T23:32:46.908Z",
   "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
   "resources": [
     {
-      "_type": "workspace",
       "_id": "__WORKSPACE_ID__",
-      "parentId": null,
+      "_type": "workspace",
+      "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
       "name": "Swagger Petstore 1.0.0",
-      "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters."
+      "parentId": null
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Base environment",
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
       "data": {
         "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
       },
-      "_type": "environment",
-      "_id": "__ENV_1__"
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_ID__"
     },
     {
-      "parentId": "__ENV_1__",
-      "name": "OpenAPI env",
+      "_id": "env___BASE_ENVIRONMENT_ID___sub",
+      "_type": "environment",
       "data": {
         "base_path": "/v2",
-        "scheme": "http",
-        "host": "petstore.swagger.io"
+        "host": "petstore.swagger.io",
+        "scheme": "http"
       },
-      "_type": "environment",
-      "_id": "__ENV_2__"
+      "name": "OpenAPI env",
+      "parentId": "__BASE_ENVIRONMENT_ID__"
     },
     {
-      "_id": "__GRP_1__",
+      "_id": "fld___WORKSPACE_ID__1b034c38",
       "_type": "request_group",
       "description": "Everything about your Pets",
       "environment": {},
@@ -40,7 +40,7 @@
       "parentId": "__WORKSPACE_ID__"
     },
     {
-      "_id": "__GRP_2__",
+      "_id": "fld___WORKSPACE_ID__3a21295d",
       "_type": "request_group",
       "description": "Access to Petstore orders",
       "environment": {},
@@ -48,7 +48,7 @@
       "parentId": "__WORKSPACE_ID__"
     },
     {
-      "_id": "__GRP_3__",
+      "_id": "fld___WORKSPACE_ID__12dea96f",
       "_type": "request_group",
       "description": "Operations about user",
       "environment": {},
@@ -56,283 +56,283 @@
       "parentId": "__WORKSPACE_ID__"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Add a new pet to the store",
-      "url": "{{ base_url }}/pet",
+      "_id": "req___WORKSPACE_ID__23acbe44",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
+      "headers": [],
       "method": "POST",
+      "name": "Add a new pet to the store",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "addPet"
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Update an existing pet",
-      "url": "{{ base_url }}/pet",
+      "_id": "req___WORKSPACE_ID__74a7a059",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "method": "PUT",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updatePet"
+      "method": "PUT",
+      "name": "Update an existing pet",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Finds Pets by status",
-      "url": "{{ base_url }}/pet/findByStatus",
+      "_id": "req___WORKSPACE_ID__80ab0d08",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Finds Pets by status",
       "parameters": [
         {
-          "name": "status",
           "disabled": false,
+          "name": "status",
           "value": "available"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "findPetsByStatus"
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/findByStatus"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Finds Pets by tags",
-      "url": "{{ base_url }}/pet/findByTags",
+      "_id": "req___WORKSPACE_ID__42a17980",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Finds Pets by tags",
       "parameters": [
         {
-          "name": "tags",
           "disabled": false,
+          "name": "tags",
           "value": "string"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "findPetsByTags"
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/findByTags"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Find pet by ID",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__3d1a51d3",
+      "_type": "request",
+      "authentication": {},
       "body": {},
-      "method": "GET",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getPetById"
+      "method": "GET",
+      "name": "Find pet by ID",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Updates a pet in the store with form data",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__a4608701",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
-      "method": "POST",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updatePetWithForm"
+      "method": "POST",
+      "name": "Updates a pet in the store with form data",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Deletes a pet",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__e804bd05",
+      "_type": "request",
+      "authentication": {},
       "body": {},
-      "method": "DELETE",
-      "parameters": [],
       "headers": [
         {
-          "name": "api_key",
           "disabled": true,
+          "name": "api_key",
           "value": "string"
         }
       ],
-      "authentication": {},
-      "_type": "request",
-      "_id": "deletePet"
+      "method": "DELETE",
+      "name": "Deletes a pet",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "uploads an image",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage",
+      "_id": "req___WORKSPACE_ID__8081fb6f",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "multipart/form-data"
       },
-      "method": "POST",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "uploadFile"
+      "method": "POST",
+      "name": "uploads an image",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage"
     },
     {
-      "parentId": "__GRP_2__",
+      "_id": "req___WORKSPACE_ID__443ac9e7",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Returns pet inventories by status",
-      "url": "{{ base_url }}/store/inventory",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getInventory"
+      "parentId": "fld___WORKSPACE_ID__3a21295d",
+      "url": "{{ base_url }}/store/inventory"
     },
     {
-      "parentId": "__GRP_2__",
+      "_id": "req___WORKSPACE_ID__e24a4f9e",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Place an order for a pet",
-      "url": "{{ base_url }}/store/order",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "placeOrder"
+      "parentId": "fld___WORKSPACE_ID__3a21295d",
+      "url": "{{ base_url }}/store/order"
     },
     {
-      "parentId": "__GRP_2__",
+      "_id": "req___WORKSPACE_ID__f021bcd3",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Find purchase order by ID",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getOrderById"
+      "parentId": "fld___WORKSPACE_ID__3a21295d",
+      "url": "{{ base_url }}/store/order/{{ orderId }}"
     },
     {
-      "parentId": "__GRP_2__",
-      "name": "Delete purchase order by ID",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
+      "_id": "req___WORKSPACE_ID__15e47538",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "DELETE",
+      "name": "Delete purchase order by ID",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "deleteOrder"
+      "parentId": "fld___WORKSPACE_ID__3a21295d",
+      "url": "{{ base_url }}/store/order/{{ orderId }}"
     },
     {
-      "parentId": "__GRP_3__",
+      "_id": "req___WORKSPACE_ID__fe3d55d0",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Create user",
-      "url": "{{ base_url }}/user",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUser"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user"
     },
     {
-      "parentId": "__GRP_3__",
+      "_id": "req___WORKSPACE_ID__4cb83333",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Creates list of users with given input array",
-      "url": "{{ base_url }}/user/createWithArray",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUsersWithArrayInput"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/createWithArray"
     },
     {
-      "parentId": "__GRP_3__",
+      "_id": "req___WORKSPACE_ID__e94a615f",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Creates list of users with given input array",
-      "url": "{{ base_url }}/user/createWithList",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUsersWithListInput"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/createWithList"
     },
     {
-      "parentId": "__GRP_3__",
-      "name": "Logs user into the system",
-      "url": "{{ base_url }}/user/login",
+      "_id": "req___WORKSPACE_ID__00ac9da2",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Logs user into the system",
       "parameters": [
         {
-          "name": "username",
           "disabled": false,
+          "name": "username",
           "value": "string"
         },
         {
-          "name": "password",
           "disabled": false,
+          "name": "password",
           "value": "string"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "loginUser"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/login"
     },
     {
-      "parentId": "__GRP_3__",
+      "_id": "req___WORKSPACE_ID__740025cb",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Logs out current logged in user session",
-      "url": "{{ base_url }}/user/logout",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "logoutUser"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/logout"
     },
     {
-      "parentId": "__GRP_3__",
+      "_id": "req___WORKSPACE_ID__74f1d1d1",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Get user by user name",
-      "url": "{{ base_url }}/user/{{ username }}",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getUserByName"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/{{ username }}"
     },
     {
-      "parentId": "__GRP_3__",
-      "name": "Updated user",
-      "url": "{{ base_url }}/user/{{ username }}",
+      "_id": "req___WORKSPACE_ID__6d74493f",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "PUT",
+      "name": "Updated user",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updateUser"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/{{ username }}"
     },
     {
-      "parentId": "__GRP_3__",
-      "name": "Delete user",
-      "url": "{{ base_url }}/user/{{ username }}",
-      "body": {},
-      "method": "DELETE",
-      "parameters": [],
-      "headers": [],
-      "authentication": {},
+      "_id": "req___WORKSPACE_ID__38e8e88f",
       "_type": "request",
-      "_id": "deleteUser"
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "DELETE",
+      "name": "Delete user",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/{{ username }}"
     }
   ]
 }

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-output.json
@@ -1,314 +1,314 @@
 {
-  "_type": "export",
+  "__export_date": "2019-08-15T19:32:12.775Z",
   "__export_format": 4,
-  "__export_date": "2018-01-09T23:32:54.091Z",
   "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
   "resources": [
     {
-      "_type": "workspace",
       "_id": "__WORKSPACE_ID__",
-      "parentId": null,
+      "_type": "workspace",
+      "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
       "name": "Swagger Petstore 1.0.0",
-      "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters."
+      "parentId": null
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Base environment",
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
       "data": {
         "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
       },
-      "_type": "environment",
-      "_id": "__ENV_1__"
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_ID__"
     },
     {
-      "parentId": "__ENV_1__",
-      "name": "OpenAPI env",
+      "_id": "env___BASE_ENVIRONMENT_ID___sub",
+      "_type": "environment",
       "data": {
         "base_path": "/v2",
-        "scheme": "http",
-        "host": "petstore.swagger.io"
+        "host": "petstore.swagger.io",
+        "scheme": "http"
       },
-      "_type": "environment",
-      "_id": "__ENV_2__"
+      "name": "OpenAPI env",
+      "parentId": "__BASE_ENVIRONMENT_ID__"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Add a new pet to the store",
-      "url": "{{ base_url }}/pet",
+      "_id": "req___WORKSPACE_ID__23acbe44",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
+      "headers": [],
       "method": "POST",
+      "name": "Add a new pet to the store",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "addPet"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Update an existing pet",
-      "url": "{{ base_url }}/pet",
+      "_id": "req___WORKSPACE_ID__74a7a059",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "method": "PUT",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updatePet"
+      "method": "PUT",
+      "name": "Update an existing pet",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Finds Pets by status",
-      "url": "{{ base_url }}/pet/findByStatus",
+      "_id": "req___WORKSPACE_ID__80ab0d08",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Finds Pets by status",
       "parameters": [
         {
-          "name": "status",
           "disabled": false,
+          "name": "status",
           "value": "available"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "findPetsByStatus"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/findByStatus"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Finds Pets by tags",
-      "url": "{{ base_url }}/pet/findByTags",
+      "_id": "req___WORKSPACE_ID__42a17980",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Finds Pets by tags",
       "parameters": [
         {
-          "name": "tags",
           "disabled": false,
+          "name": "tags",
           "value": "string"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "findPetsByTags"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/findByTags"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Find pet by ID",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__3d1a51d3",
+      "_type": "request",
+      "authentication": {},
       "body": {},
-      "method": "GET",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getPetById"
+      "method": "GET",
+      "name": "Find pet by ID",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Updates a pet in the store with form data",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__a4608701",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
-      "method": "POST",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updatePetWithForm"
+      "method": "POST",
+      "name": "Updates a pet in the store with form data",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Deletes a pet",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__e804bd05",
+      "_type": "request",
+      "authentication": {},
       "body": {},
-      "method": "DELETE",
-      "parameters": [],
       "headers": [
         {
-          "name": "api_key",
           "disabled": true,
+          "name": "api_key",
           "value": "string"
         }
       ],
-      "authentication": {},
-      "_type": "request",
-      "_id": "deletePet"
+      "method": "DELETE",
+      "name": "Deletes a pet",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "uploads an image",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage",
+      "_id": "req___WORKSPACE_ID__8081fb6f",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "multipart/form-data"
       },
-      "method": "POST",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "uploadFile"
+      "method": "POST",
+      "name": "uploads an image",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__443ac9e7",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Returns pet inventories by status",
-      "url": "{{ base_url }}/store/inventory",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getInventory"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/store/inventory"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__e24a4f9e",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Place an order for a pet",
-      "url": "{{ base_url }}/store/order",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "placeOrder"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/store/order"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__f021bcd3",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Find purchase order by ID",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getOrderById"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/store/order/{{ orderId }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Delete purchase order by ID",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
+      "_id": "req___WORKSPACE_ID__15e47538",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "DELETE",
+      "name": "Delete purchase order by ID",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "deleteOrder"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/store/order/{{ orderId }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__fe3d55d0",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Create user",
-      "url": "{{ base_url }}/user",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUser"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__4cb83333",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Creates list of users with given input array",
-      "url": "{{ base_url }}/user/createWithArray",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUsersWithArrayInput"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/createWithArray"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__e94a615f",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Creates list of users with given input array",
-      "url": "{{ base_url }}/user/createWithList",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUsersWithListInput"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/createWithList"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Logs user into the system",
-      "url": "{{ base_url }}/user/login",
+      "_id": "req___WORKSPACE_ID__00ac9da2",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Logs user into the system",
       "parameters": [
         {
-          "name": "username",
           "disabled": false,
+          "name": "username",
           "value": "string"
         },
         {
-          "name": "password",
           "disabled": false,
+          "name": "password",
           "value": "string"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "loginUser"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/login"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__740025cb",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Logs out current logged in user session",
-      "url": "{{ base_url }}/user/logout",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "logoutUser"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/logout"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
+      "_id": "req___WORKSPACE_ID__74f1d1d1",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Get user by user name",
-      "url": "{{ base_url }}/user/{{ username }}",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getUserByName"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/{{ username }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Updated user",
-      "url": "{{ base_url }}/user/{{ username }}",
+      "_id": "req___WORKSPACE_ID__6d74493f",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "PUT",
+      "name": "Updated user",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updateUser"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/{{ username }}"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Delete user",
-      "url": "{{ base_url }}/user/{{ username }}",
-      "body": {},
-      "method": "DELETE",
-      "parameters": [],
-      "headers": [],
-      "authentication": {},
+      "_id": "req___WORKSPACE_ID__38e8e88f",
       "_type": "request",
-      "_id": "deleteUser"
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "DELETE",
+      "name": "Delete user",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/user/{{ username }}"
     }
   ]
 }

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-readonly-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-readonly-output.json
@@ -1,80 +1,80 @@
 {
-  "_type": "export",
+  "__export_date": "2019-08-15T19:32:12.806Z",
   "__export_format": 4,
-  "__export_date": "2018-01-09T23:33:12.799Z",
   "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
   "resources": [
     {
-      "_type": "workspace",
       "_id": "__WORKSPACE_ID__",
-      "parentId": null,
+      "_type": "workspace",
+      "description": "",
       "name": "Swagger Petstore 1.0.0",
-      "description": ""
+      "parentId": null
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Base environment",
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
       "data": {
         "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
       },
-      "_type": "environment",
-      "_id": "__ENV_1__"
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_ID__"
     },
     {
-      "parentId": "__ENV_1__",
-      "name": "OpenAPI env",
+      "_id": "env___BASE_ENVIRONMENT_ID___sub",
+      "_type": "environment",
       "data": {
         "base_path": "/v1",
-        "scheme": "http",
-        "host": "petstore.swagger.io"
+        "host": "petstore.swagger.io",
+        "scheme": "http"
       },
-      "_type": "environment",
-      "_id": "__ENV_2__"
+      "name": "OpenAPI env",
+      "parentId": "__BASE_ENVIRONMENT_ID__"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "List all pets",
-      "url": "{{ base_url }}/pets",
+      "_id": "req___WORKSPACE_ID__26e3ae98",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "List all pets",
       "parameters": [
         {
-          "name": "limit",
           "disabled": true,
+          "name": "limit",
           "value": "0"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "listPets"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pets"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Create a pet",
-      "url": "{{ base_url }}/pets",
+      "_id": "req___WORKSPACE_ID__09e1157b",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"name\": \"string\",\n  \"tag\": \"string\"\n}"
       },
-      "method": "POST",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createPets"
+      "method": "POST",
+      "name": "Create a pet",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pets"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Info for a specific pet",
-      "url": "{{ base_url }}/pets/{{ petId }}",
-      "body": {},
-      "method": "GET",
-      "parameters": [],
-      "headers": [],
-      "authentication": {},
+      "_id": "req___WORKSPACE_ID__3b13e39c",
       "_type": "request",
-      "_id": "showPetById"
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
+      "name": "Info for a specific pet",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pets/{{ petId }}"
     }
   ]
 }

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-with-tags-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-with-tags-output.json
@@ -1,38 +1,38 @@
 {
-  "_type": "export",
+  "__export_date": "2019-08-15T19:32:12.839Z",
   "__export_format": 4,
-  "__export_date": "2018-01-09T23:32:54.091Z",
   "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
   "resources": [
     {
-      "_type": "workspace",
       "_id": "__WORKSPACE_ID__",
-      "parentId": null,
+      "_type": "workspace",
+      "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
       "name": "Swagger Petstore 1.0.0",
-      "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters."
+      "parentId": null
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Base environment",
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
       "data": {
         "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
       },
-      "_type": "environment",
-      "_id": "__ENV_1__"
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_ID__"
     },
     {
-      "parentId": "__ENV_1__",
-      "name": "OpenAPI env",
+      "_id": "env___BASE_ENVIRONMENT_ID___sub",
+      "_type": "environment",
       "data": {
         "base_path": "/v2",
-        "scheme": "http",
-        "host": "petstore.swagger.io"
+        "host": "petstore.swagger.io",
+        "scheme": "http"
       },
-      "_type": "environment",
-      "_id": "__ENV_2__"
+      "name": "OpenAPI env",
+      "parentId": "__BASE_ENVIRONMENT_ID__"
     },
     {
-      "_id": "__GRP_1__",
+      "_id": "fld___WORKSPACE_ID__1b034c38",
       "_type": "request_group",
       "description": "Everything about your Pets",
       "environment": {},
@@ -40,7 +40,7 @@
       "parentId": "__WORKSPACE_ID__"
     },
     {
-      "_id": "__GRP_2__",
+      "_id": "fld___WORKSPACE_ID__3a21295d",
       "_type": "request_group",
       "description": "Access to Petstore orders",
       "environment": {},
@@ -48,7 +48,7 @@
       "parentId": "__WORKSPACE_ID__"
     },
     {
-      "_id": "__GRP_3__",
+      "_id": "fld___WORKSPACE_ID__12dea96f",
       "_type": "request_group",
       "description": "Operations about user",
       "environment": {},
@@ -56,283 +56,283 @@
       "parentId": "__WORKSPACE_ID__"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Add a new pet to the store",
-      "url": "{{ base_url }}/pet",
+      "_id": "req___WORKSPACE_ID__23acbe44",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
+      "headers": [],
       "method": "POST",
+      "name": "Add a new pet to the store",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "addPet"
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Update an existing pet",
-      "url": "{{ base_url }}/pet",
+      "_id": "req___WORKSPACE_ID__74a7a059",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "method": "PUT",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updatePet"
+      "method": "PUT",
+      "name": "Update an existing pet",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Finds Pets by status",
-      "url": "{{ base_url }}/pet/findByStatus",
+      "_id": "req___WORKSPACE_ID__80ab0d08",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Finds Pets by status",
       "parameters": [
         {
-          "name": "status",
           "disabled": false,
+          "name": "status",
           "value": "available"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "findPetsByStatus"
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/findByStatus"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Finds Pets by tags",
-      "url": "{{ base_url }}/pet/findByTags",
+      "_id": "req___WORKSPACE_ID__42a17980",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Finds Pets by tags",
       "parameters": [
         {
-          "name": "tags",
           "disabled": false,
+          "name": "tags",
           "value": "string"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "findPetsByTags"
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/findByTags"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Find pet by ID",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__3d1a51d3",
+      "_type": "request",
+      "authentication": {},
       "body": {},
-      "method": "GET",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getPetById"
+      "method": "GET",
+      "name": "Find pet by ID",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Updates a pet in the store with form data",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__a4608701",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
-      "method": "POST",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updatePetWithForm"
+      "method": "POST",
+      "name": "Updates a pet in the store with form data",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Deletes a pet",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "_id": "req___WORKSPACE_ID__e804bd05",
+      "_type": "request",
+      "authentication": {},
       "body": {},
-      "method": "DELETE",
-      "parameters": [],
       "headers": [
         {
-          "name": "api_key",
           "disabled": true,
+          "name": "api_key",
           "value": "string"
         }
       ],
-      "authentication": {},
-      "_type": "request",
-      "_id": "deletePet"
+      "method": "DELETE",
+      "name": "Deletes a pet",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/{{ petId }}"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "uploads an image",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage",
+      "_id": "req___WORKSPACE_ID__8081fb6f",
+      "_type": "request",
+      "authentication": {},
       "body": {
         "mimeType": "multipart/form-data"
       },
-      "method": "POST",
-      "parameters": [],
       "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "uploadFile"
+      "method": "POST",
+      "name": "uploads an image",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage"
     },
     {
-      "parentId": "__GRP_2__",
+      "_id": "req___WORKSPACE_ID__443ac9e7",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Returns pet inventories by status",
-      "url": "{{ base_url }}/store/inventory",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getInventory"
+      "parentId": "fld___WORKSPACE_ID__3a21295d",
+      "url": "{{ base_url }}/store/inventory"
     },
     {
-      "parentId": "__GRP_2__",
+      "_id": "req___WORKSPACE_ID__e24a4f9e",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Place an order for a pet",
-      "url": "{{ base_url }}/store/order",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "placeOrder"
+      "parentId": "fld___WORKSPACE_ID__3a21295d",
+      "url": "{{ base_url }}/store/order"
     },
     {
-      "parentId": "__GRP_2__",
+      "_id": "req___WORKSPACE_ID__f021bcd3",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Find purchase order by ID",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getOrderById"
+      "parentId": "fld___WORKSPACE_ID__3a21295d",
+      "url": "{{ base_url }}/store/order/{{ orderId }}"
     },
     {
-      "parentId": "__GRP_2__",
-      "name": "Delete purchase order by ID",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
+      "_id": "req___WORKSPACE_ID__15e47538",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "DELETE",
+      "name": "Delete purchase order by ID",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "deleteOrder"
+      "parentId": "fld___WORKSPACE_ID__3a21295d",
+      "url": "{{ base_url }}/store/order/{{ orderId }}"
     },
     {
-      "parentId": "__GRP_3__",
+      "_id": "req___WORKSPACE_ID__fe3d55d0",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Create user",
-      "url": "{{ base_url }}/user",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUser"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user"
     },
     {
-      "parentId": "__GRP_3__",
+      "_id": "req___WORKSPACE_ID__4cb83333",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Creates list of users with given input array",
-      "url": "{{ base_url }}/user/createWithArray",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUsersWithArrayInput"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/createWithArray"
     },
     {
-      "parentId": "__GRP_3__",
+      "_id": "req___WORKSPACE_ID__e94a615f",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
       "name": "Creates list of users with given input array",
-      "url": "{{ base_url }}/user/createWithList",
-      "body": {},
-      "method": "POST",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createUsersWithListInput"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/createWithList"
     },
     {
-      "parentId": "__GRP_3__",
-      "name": "Logs user into the system",
-      "url": "{{ base_url }}/user/login",
+      "_id": "req___WORKSPACE_ID__00ac9da2",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "Logs user into the system",
       "parameters": [
         {
-          "name": "username",
           "disabled": false,
+          "name": "username",
           "value": "string"
         },
         {
-          "name": "password",
           "disabled": false,
+          "name": "password",
           "value": "string"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "loginUser"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/login"
     },
     {
-      "parentId": "__GRP_3__",
+      "_id": "req___WORKSPACE_ID__740025cb",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Logs out current logged in user session",
-      "url": "{{ base_url }}/user/logout",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "logoutUser"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/logout"
     },
     {
-      "parentId": "__GRP_3__",
+      "_id": "req___WORKSPACE_ID__74f1d1d1",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
       "name": "Get user by user name",
-      "url": "{{ base_url }}/user/{{ username }}",
-      "body": {},
-      "method": "GET",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "getUserByName"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/{{ username }}"
     },
     {
-      "parentId": "__GRP_3__",
-      "name": "Updated user",
-      "url": "{{ base_url }}/user/{{ username }}",
+      "_id": "req___WORKSPACE_ID__6d74493f",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "PUT",
+      "name": "Updated user",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "updateUser"
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/{{ username }}"
     },
     {
-      "parentId": "__GRP_3__",
-      "name": "Delete user",
-      "url": "{{ base_url }}/user/{{ username }}",
-      "body": {},
-      "method": "DELETE",
-      "parameters": [],
-      "headers": [],
-      "authentication": {},
+      "_id": "req___WORKSPACE_ID__38e8e88f",
       "_type": "request",
-      "_id": "deleteUser"
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "DELETE",
+      "name": "Delete user",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__12dea96f",
+      "url": "{{ base_url }}/user/{{ username }}"
     }
   ]
 }

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-yml-input.yml
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-yml-input.yml
@@ -12,7 +12,6 @@ paths:
       tags:
         - pets
       summary: List all pets
-      operationId: listPets
       parameters:
         - name: limit
           in: query

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-yml-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-yml-output.json
@@ -1,77 +1,77 @@
 {
-  "_type": "export",
+  "__export_date": "2019-08-15T19:45:14.616Z",
   "__export_format": 4,
-  "__export_date": "2018-01-09T23:33:12.799Z",
   "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
   "resources": [
     {
-      "_type": "workspace",
       "_id": "__WORKSPACE_ID__",
-      "parentId": null,
+      "_type": "workspace",
+      "description": "",
       "name": "Swagger Petstore 1.0.0",
-      "description": ""
+      "parentId": null
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Base environment",
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
       "data": {
         "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
       },
-      "_type": "environment",
-      "_id": "__ENV_1__"
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_ID__"
     },
     {
-      "parentId": "__ENV_1__",
-      "name": "OpenAPI env",
+      "_id": "env___BASE_ENVIRONMENT_ID___sub",
+      "_type": "environment",
       "data": {
         "base_path": "/v1",
-        "scheme": "http",
-        "host": "petstore.swagger.io"
+        "host": "petstore.swagger.io",
+        "scheme": "http"
       },
-      "_type": "environment",
-      "_id": "__ENV_2__"
+      "name": "OpenAPI env",
+      "parentId": "__BASE_ENVIRONMENT_ID__"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "List all pets",
-      "url": "{{ base_url }}/pets",
+      "_id": "req___WORKSPACE_ID__2aab4183",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "List all pets",
       "parameters": [
         {
-          "name": "limit",
           "disabled": true,
+          "name": "limit",
           "value": "0"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "listPets"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pets"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Create a pet",
-      "url": "{{ base_url }}/pets",
+      "_id": "req___WORKSPACE_ID__09e1157b",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "POST",
+      "name": "Create a pet",
       "parameters": [],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "createPets"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pets"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Info for a specific pet",
-      "url": "{{ base_url }}/pets/{{ petId }}",
-      "body": {},
-      "method": "GET",
-      "parameters": [],
-      "headers": [],
-      "authentication": {},
+      "_id": "req___WORKSPACE_ID__3b13e39c",
       "_type": "request",
-      "_id": "showPetById"
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
+      "name": "Info for a specific pet",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pets/{{ petId }}"
     }
   ]
 }

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-yml-with-tags-input.yml
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-yml-with-tags-input.yml
@@ -17,6 +17,7 @@ paths:
     get:
       tags:
         - pets
+        - another
       summary: List all pets
       operationId: listPets
       parameters:

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-yml-with-tags-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/petstore-yml-with-tags-output.json
@@ -1,38 +1,38 @@
 {
-  "_type": "export",
+  "__export_date": "2019-08-15T19:50:19.680Z",
   "__export_format": 4,
-  "__export_date": "2018-01-09T23:33:12.799Z",
   "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
   "resources": [
     {
-      "_type": "workspace",
       "_id": "__WORKSPACE_ID__",
-      "parentId": null,
+      "_type": "workspace",
+      "description": "",
       "name": "Swagger Petstore 1.0.0",
-      "description": ""
+      "parentId": null
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Base environment",
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
       "data": {
         "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
       },
-      "_type": "environment",
-      "_id": "__ENV_1__"
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_ID__"
     },
     {
-      "parentId": "__ENV_1__",
-      "name": "OpenAPI env",
+      "_id": "env___BASE_ENVIRONMENT_ID___sub",
+      "_type": "environment",
       "data": {
         "base_path": "/v1",
-        "scheme": "http",
-        "host": "petstore.swagger.io"
+        "host": "petstore.swagger.io",
+        "scheme": "http"
       },
-      "_type": "environment",
-      "_id": "__ENV_2__"
+      "name": "OpenAPI env",
+      "parentId": "__BASE_ENVIRONMENT_ID__"
     },
     {
-      "_id": "__GRP_1__",
+      "_id": "fld___WORKSPACE_ID__a8acce24",
       "_type": "request_group",
       "description": "Everything about your Pets",
       "environment": {},
@@ -40,46 +40,64 @@
       "parentId": "__WORKSPACE_ID__"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "List all pets",
-      "url": "{{ base_url }}/pets",
+      "_id": "req___WORKSPACE_ID__26e3ae98",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "List all pets",
       "parameters": [
         {
-          "name": "limit",
           "disabled": true,
+          "name": "limit",
           "value": "0"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "listPets"
+      "parentId": "fld___WORKSPACE_ID__a8acce24",
+      "url": "{{ base_url }}/pets"
     },
     {
-      "parentId": "__GRP_1__",
-      "name": "Create a pet",
-      "url": "{{ base_url }}/pets",
-      "body": {},
-      "method": "POST",
-      "parameters": [],
-      "headers": [],
-      "authentication": {},
+      "_id": "req___WORKSPACE_ID__26e3ae981",
       "_type": "request",
-      "_id": "createPets"
-    },
-    {
-      "parentId": "__GRP_1__",
-      "name": "Info for a specific pet",
-      "url": "{{ base_url }}/pets/{{ petId }}",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
-      "parameters": [],
-      "headers": [],
-      "authentication": {},
+      "name": "List all pets",
+      "parameters": [
+        {
+          "disabled": true,
+          "name": "limit",
+          "value": "0"
+        }
+      ],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/pets"
+    },
+    {
+      "_id": "req___WORKSPACE_ID__09e1157b",
       "_type": "request",
-      "_id": "showPetById"
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "POST",
+      "name": "Create a pet",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__a8acce24",
+      "url": "{{ base_url }}/pets"
+    },
+    {
+      "_id": "req___WORKSPACE_ID__3b13e39c",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
+      "name": "Info for a specific pet",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__a8acce24",
+      "url": "{{ base_url }}/pets/{{ petId }}"
     }
   ]
 }

--- a/packages/insomnia-libcurl/package-lock.json
+++ b/packages/insomnia-libcurl/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-libcurl",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/insomnia-xpath/package-lock.json
+++ b/packages/insomnia-xpath/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-xpath",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/plugins/insomnia-plugin-cookie-jar/package-lock.json
+++ b/plugins/insomnia-plugin-cookie-jar/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-cookie-jar",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/plugins/insomnia-plugin-jsonpath/package-lock.json
+++ b/plugins/insomnia-plugin-jsonpath/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-jsonpath",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/plugins/insomnia-plugin-now/package-lock.json
+++ b/plugins/insomnia-plugin-now/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-now",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/plugins/insomnia-plugin-os/package-lock.json
+++ b/plugins/insomnia-plugin-os/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-os",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/plugins/insomnia-plugin-uuid/package-lock.json
+++ b/plugins/insomnia-plugin-uuid/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-uuid",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR makes the OpenAPI importer generate deterministic IDs. This is necessary if you want to be able to import the same spec a second time and have it update already existing requests/folders/environments instead of creating new ones.

