### PR TITLE
Correct typo on import dialog

### DIFF
--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -455,7 +455,7 @@ function askToImportIntoWorkspace(workspaceId) {
     return new Promise(resolve => {
       showModal(AskModal, {
         title: 'Import',
-        message: 'Do you wand to import into the current workspace or a new one?',
+        message: 'Do you want to import into the current workspace or a new one?',
         yesText: 'Current',
         noText: 'New Workspace',
         onDone: yes => {


### PR DESCRIPTION
Noticed a typo that showed up when importing certain file types, thought I'd open a quick PR to fix it:

![image](https://user-images.githubusercontent.com/10888943/66099231-b3a97780-e56b-11e9-8c06-eb83de8b17e7.png)
