### PR TITLE
Escape yarn paths

### DIFF
--- a/packages/insomnia-app/app/plugins/install.js
+++ b/packages/insomnia-app/app/plugins/install.js
@@ -63,7 +63,7 @@ async function _isInsomniaPlugin(lookupName: string): Promise<Object> {
       escape(process.execPath),
       [
         '--no-deprecation', // Because Yarn still uses `new Buffer()`
-        _getYarnPath(),
+        escape(_getYarnPath()),
         'info',
         lookupName,
         '--json',
@@ -129,7 +129,7 @@ async function _installPluginToTmpDir(lookupName: string): Promise<{ tmpDir: str
       escape(process.execPath),
       [
         '--no-deprecation', // Because Yarn still uses `new Buffer()`
-        _getYarnPath(),
+        escape(_getYarnPath()),
         'add',
         lookupName,
         '--modules-folder',


### PR DESCRIPTION
Additional fix to PR #1688

I have downloaded 7.0.0 update today and unfortunately It didn't fully fix the issue on windows. The `_getYarnPath()` also should be escaped, but I have missed that since yarn-standalone was installed in the path without space on my local env :(

I have added spaces locally to plugin and yarn folders and now it works
![electron_2019-10-03_16-08-07](https://user-images.githubusercontent.com/852846/66129776-3b899300-e5f9-11e9-8e1a-89503d8f4bad.png)
