### PR TITLE
No longer override `extraKeys` in CodeMirror on initialization

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -294,6 +294,7 @@ class CodeEditor extends React.Component {
     this.codeMirror.setCursor({ line: -1, ch: -1 });
 
     this.codeMirror.setOption('extraKeys', {
+      ...BASE_CODEMIRROR_OPTIONS.extraKeys,
       Tab: cm => {
         const spaces = this._indentChars();
         cm.replaceSelection(spaces);


### PR DESCRIPTION
Fixes https://github.com/getinsomnia/insomnia/issues/1694

Problem here was that `extraKeys` got overridden on initialization. Made sure to include the base options in the override. Comment toggling and other custom hotkeys should now work again in the editor.