### PR TITLE
[Feature] Added display support for X-HTTP-Method-Override

### DIFF
--- a/packages/insomnia-app/app/common/misc.js
+++ b/packages/insomnia-app/app/common/misc.js
@@ -5,7 +5,7 @@ import fuzzysort from 'fuzzysort';
 import uuid from 'uuid';
 import zlib from 'zlib';
 import { join as pathJoin } from 'path';
-import { DEBOUNCE_MILLIS } from './constants';
+import { METHOD_OPTIONS, METHOD_DELETE, DEBOUNCE_MILLIS } from './constants';
 
 const ESCAPE_REGEX_MATCH = /[-[\]/{}()*+?.\\^$|]/g;
 
@@ -115,6 +115,16 @@ export function delay(milliseconds: number = DEBOUNCE_MILLIS): Promise<void> {
 
 export function removeVowels(str: string): string {
   return str.replace(/[aeiouyAEIOUY]/g, '');
+}
+
+export function formatMethodName(method: string): string {
+  let methodName = method;
+  if (method === METHOD_DELETE || method === METHOD_OPTIONS) {
+    methodName = method.slice(0, 3);
+  } else if (method.length > 4) {
+    methodName = removeVowels(method).slice(0, 4);
+  }
+  return methodName;
 }
 
 export function keyedDebounce(callback: Function, millis: number = DEBOUNCE_MILLIS): Function {

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
@@ -59,6 +59,15 @@ class SidebarRequestRow extends PureComponent {
     showModal(RequestSettingsModal, { request: this.props.request });
   }
 
+  _getMethodOverrideHeaderValue() {
+    let header = this.props.request.headers.find(
+      h => h.name.toLowerCase() === 'x-http-method-override',
+    );
+    if (!header || header.disabled) header = null;
+    else header = header.value;
+    return header;
+  }
+
   setDragDirection(dragDirection) {
     if (dragDirection !== this.state.dragDirection) {
       this.setState({ dragDirection });
@@ -116,7 +125,10 @@ class SidebarRequestRow extends PureComponent {
               onClick={this._handleRequestActivate}
               onContextMenu={this._handleShowRequestActions}>
               <div className="sidebar__clickable">
-                <MethodTag method={request.method} />
+                <MethodTag
+                  method={request.method}
+                  override={this._getMethodOverrideHeaderValue()}
+                />
                 <Editable
                   value={request.name}
                   className="inline-block"

--- a/packages/insomnia-app/app/ui/components/tags/method-tag.js
+++ b/packages/insomnia-app/app/ui/components/tags/method-tag.js
@@ -1,24 +1,31 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import * as constants from '../../../common/constants';
+import { HTTP_METHODS } from '../../../common/constants';
 import * as util from '../../../common/misc';
 
 class MethodTag extends PureComponent {
   render() {
-    const { method, fullNames } = this.props;
+    const { method, override, fullNames } = this.props;
     let methodName = method;
+    let overrideName = override;
 
+    if (!HTTP_METHODS.includes(override)) overrideName = null;
     if (!fullNames) {
-      if (method === constants.METHOD_DELETE || method === constants.METHOD_OPTIONS) {
-        methodName = method.slice(0, 3);
-      } else if (method.length > 4) {
-        methodName = util.removeVowels(method).slice(0, 4);
-      }
+      methodName = util.formatMethodName(method);
+      if (overrideName) overrideName = util.formatMethodName(override);
     }
 
     return (
-      <div className={'tag tag--no-bg tag--small http-method-' + method}>
-        <span className="tag__inner">{methodName}</span>
+      <div style={{ position: 'relative' }}>
+        {overrideName && (
+          <div className={'tag tag--no-bg tag--superscript http-method-' + method}>
+            <span>{methodName}</span>
+          </div>
+        )}
+        <div
+          className={'tag tag--no-bg tag--small http-method-' + (overrideName ? override : method)}>
+          <span className="tag__inner">{overrideName ? overrideName : methodName}</span>
+        </div>
       </div>
     );
   }
@@ -28,6 +35,7 @@ MethodTag.propTypes = {
   method: PropTypes.string.isRequired,
 
   // Optional
+  override: PropTypes.string,
   fullNames: PropTypes.bool,
 };
 

--- a/packages/insomnia-app/app/ui/css/components/tag.less
+++ b/packages/insomnia-app/app/ui/css/components/tag.less
@@ -12,6 +12,13 @@
   border: 1px solid rgba(0, 0, 0, 0.07);
   white-space: nowrap;
 
+  &.tag--superscript {
+    position: absolute;
+    font-size: 0.6em;
+    bottom: 0.9em;
+    left: -0.6em;
+  }
+
   &:last-child {
     margin-right: 0;
   }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/getinsomnia/insomnia/issues/new) first to discuss new 
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

This PR adds first class display support for the `X-HTTP-Method-Override` header in the sidebar.
Whenever the `X-HTTP-Method-Override` header is set with a valid method name on a request, the request in sidebar shows the overriding method, with the overridden method shown smaller. 
Closes #1334.

![ins](https://user-images.githubusercontent.com/18032938/67150572-df9c5b00-f2d6-11e9-9c05-5b922f5dd85d.png)


