### PR TITLE
Add audience and resource field for OAuth2 Authorization Code grant

### DIFF
--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-authorization-code.test.js
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-authorization-code.test.js
@@ -70,6 +70,8 @@ describe('authorization_code', () => {
               { name: 'code', value: 'code_123' },
               { name: 'redirect_uri', value: REDIRECT_URI },
               { name: 'state', value: STATE },
+              { name: 'audience', value: AUDIENCE },
+              { name: 'resource', value: RESOURCE },
             ],
           },
           headers: [
@@ -157,6 +159,8 @@ describe('authorization_code', () => {
               { name: 'code', value: 'code_123' },
               { name: 'redirect_uri', value: REDIRECT_URI },
               { name: 'state', value: STATE },
+              { name: 'audience', value: AUDIENCE },
+              { name: 'resource', value: RESOURCE },
               { name: 'client_id', value: CLIENT_ID },
               { name: 'client_secret', value: CLIENT_SECRET },
             ],

--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-authorization-code.test.js
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-authorization-code.test.js
@@ -14,6 +14,7 @@ const CLIENT_SECRET = 'secret_12345456677756343';
 const REDIRECT_URI = 'https://foo.com/redirect';
 const SCOPE = 'scope_123';
 const STATE = 'state_123';
+const AUDIENCE = 'https://foo.com/resource';
 
 describe('authorization_code', () => {
   beforeEach(globalBeforeEach);
@@ -27,6 +28,7 @@ describe('authorization_code', () => {
         access_token: 'token_123',
         token_type: 'token_type',
         scope: SCOPE,
+        audience: AUDIENCE,
       }),
     );
 
@@ -48,6 +50,7 @@ describe('authorization_code', () => {
       REDIRECT_URI,
       SCOPE,
       STATE,
+      AUDIENCE,
     );
 
     // Check the request to fetch the token
@@ -91,6 +94,7 @@ describe('authorization_code', () => {
       expires_in: null,
       token_type: 'token_type',
       scope: SCOPE,
+      audience: AUDIENCE,
       error: null,
       error_uri: null,
       error_description: null,
@@ -108,6 +112,7 @@ describe('authorization_code', () => {
         access_token: 'token_123',
         token_type: 'token_type',
         scope: SCOPE,
+        audience: AUDIENCE,
       }),
     );
 
@@ -129,6 +134,7 @@ describe('authorization_code', () => {
       REDIRECT_URI,
       SCOPE,
       STATE,
+      AUDIENCE,
     );
 
     // Check the request to fetch the token
@@ -170,6 +176,7 @@ describe('authorization_code', () => {
       expires_in: null,
       token_type: 'token_type',
       scope: SCOPE,
+      audience: AUDIENCE,
       error: null,
       error_uri: null,
       error_description: null,

--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-authorization-code.test.js
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-authorization-code.test.js
@@ -15,6 +15,7 @@ const REDIRECT_URI = 'https://foo.com/redirect';
 const SCOPE = 'scope_123';
 const STATE = 'state_123';
 const AUDIENCE = 'https://foo.com/resource';
+const RESOURCE = 'foo.com';
 
 describe('authorization_code', () => {
   beforeEach(globalBeforeEach);
@@ -29,6 +30,7 @@ describe('authorization_code', () => {
         token_type: 'token_type',
         scope: SCOPE,
         audience: AUDIENCE,
+        resource: RESOURCE,
       }),
     );
 
@@ -51,6 +53,7 @@ describe('authorization_code', () => {
       SCOPE,
       STATE,
       AUDIENCE,
+      RESOURCE,
     );
 
     // Check the request to fetch the token
@@ -95,6 +98,7 @@ describe('authorization_code', () => {
       token_type: 'token_type',
       scope: SCOPE,
       audience: AUDIENCE,
+      resource: RESOURCE,
       error: null,
       error_uri: null,
       error_description: null,
@@ -113,6 +117,7 @@ describe('authorization_code', () => {
         token_type: 'token_type',
         scope: SCOPE,
         audience: AUDIENCE,
+        resource: RESOURCE,
       }),
     );
 
@@ -135,6 +140,7 @@ describe('authorization_code', () => {
       SCOPE,
       STATE,
       AUDIENCE,
+      RESOURCE,
     );
 
     // Check the request to fetch the token
@@ -177,6 +183,7 @@ describe('authorization_code', () => {
       token_type: 'token_type',
       scope: SCOPE,
       audience: AUDIENCE,
+      resource: RESOURCE,
       error: null,
       error_uri: null,
       error_description: null,

--- a/packages/insomnia-app/app/network/o-auth-2/get-token.js
+++ b/packages/insomnia-app/app/network/o-auth-2/get-token.js
@@ -64,6 +64,7 @@ async function _getOAuth2AuthorizationCodeHeader(
     authentication.scope,
     authentication.state,
     authentication.audience,
+    authentication.resource,
   );
 
   return _updateOAuth2Token(requestId, results);

--- a/packages/insomnia-app/app/network/o-auth-2/get-token.js
+++ b/packages/insomnia-app/app/network/o-auth-2/get-token.js
@@ -63,6 +63,7 @@ async function _getOAuth2AuthorizationCodeHeader(
     authentication.redirectUrl,
     authentication.scope,
     authentication.state,
+    authentication.audience,
   );
 
   return _updateOAuth2Token(requestId, results);

--- a/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.js
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.js
@@ -18,6 +18,7 @@ export default async function(
   redirectUri: string = '',
   scope: string = '',
   state: string = '',
+  audience: string = '',
 ): Promise<Object> {
   if (!authorizeUrl) {
     throw new Error('Invalid authorization URL');
@@ -27,7 +28,14 @@ export default async function(
     throw new Error('Invalid access token URL');
   }
 
-  const authorizeResults = await _authorize(authorizeUrl, clientId, redirectUri, scope, state);
+  const authorizeResults = await _authorize(
+    authorizeUrl,
+    clientId,
+    redirectUri,
+    scope,
+    state,
+    audience,
+  );
 
   // Handle the error
   if (authorizeResults[c.P_ERROR]) {
@@ -49,7 +57,7 @@ export default async function(
   );
 }
 
-async function _authorize(url, clientId, redirectUri = '', scope = '', state = '') {
+async function _authorize(url, clientId, redirectUri = '', scope = '', state = '', audience = '') {
   const params = [
     { name: c.P_RESPONSE_TYPE, value: c.RESPONSE_TYPE_CODE },
     { name: c.P_CLIENT_ID, value: clientId },
@@ -59,6 +67,7 @@ async function _authorize(url, clientId, redirectUri = '', scope = '', state = '
   redirectUri && params.push({ name: c.P_REDIRECT_URI, value: redirectUri });
   scope && params.push({ name: c.P_SCOPE, value: scope });
   state && params.push({ name: c.P_STATE, value: state });
+  audience && params.push({ name: c.P_AUDIENCE, value: audience });
 
   // Add query params to URL
   const qs = buildQueryStringFromParams(params);

--- a/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.js
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.js
@@ -19,6 +19,7 @@ export default async function(
   scope: string = '',
   state: string = '',
   audience: string = '',
+  resource: string = '',
 ): Promise<Object> {
   if (!authorizeUrl) {
     throw new Error('Invalid authorization URL');
@@ -35,6 +36,7 @@ export default async function(
     scope,
     state,
     audience,
+    resource,
   );
 
   // Handle the error
@@ -57,7 +59,15 @@ export default async function(
   );
 }
 
-async function _authorize(url, clientId, redirectUri = '', scope = '', state = '', audience = '') {
+async function _authorize(
+  url,
+  clientId,
+  redirectUri = '',
+  scope = '',
+  state = '',
+  audience = '',
+  resource = '',
+) {
   const params = [
     { name: c.P_RESPONSE_TYPE, value: c.RESPONSE_TYPE_CODE },
     { name: c.P_CLIENT_ID, value: clientId },
@@ -68,6 +78,7 @@ async function _authorize(url, clientId, redirectUri = '', scope = '', state = '
   scope && params.push({ name: c.P_SCOPE, value: scope });
   state && params.push({ name: c.P_STATE, value: state });
   audience && params.push({ name: c.P_AUDIENCE, value: audience });
+  resource && params.push({ name: c.P_RESOURCE, value: resource });
 
   // Add query params to URL
   const qs = buildQueryStringFromParams(params);

--- a/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.js
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.js
@@ -56,6 +56,8 @@ export default async function(
     authorizeResults[c.P_CODE],
     redirectUri,
     state,
+    audience,
+    resource,
   );
 }
 
@@ -109,6 +111,8 @@ async function _getToken(
   code: string,
   redirectUri: string = '',
   state: string = '',
+  audience: string = '',
+  resource: string = '',
 ): Promise<Object> {
   const params = [
     { name: c.P_GRANT_TYPE, value: c.GRANT_TYPE_AUTHORIZATION_CODE },
@@ -118,6 +122,8 @@ async function _getToken(
   // Add optional params
   redirectUri && params.push({ name: c.P_REDIRECT_URI, value: redirectUri });
   state && params.push({ name: c.P_STATE, value: state });
+  audience && params.push({ name: c.P_AUDIENCE, value: audience });
+  resource && params.push({ name: c.P_RESOURCE, value: resource });
 
   const headers = [
     { name: 'Content-Type', value: 'application/x-www-form-urlencoded' },
@@ -165,6 +171,8 @@ async function _getToken(
     c.P_EXPIRES_IN,
     c.P_TOKEN_TYPE,
     c.P_SCOPE,
+    c.P_AUDIENCE,
+    c.P_RESOURCE,
     c.P_ERROR,
     c.P_ERROR_URI,
     c.P_ERROR_DESCRIPTION,

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
@@ -425,7 +425,7 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
         enabled,
       ];
 
-      advancedFields = [scope, state, credentialsInBody, tokenPrefix, audience];
+      advancedFields = [scope, state, credentialsInBody, tokenPrefix, audience, resource];
     } else if (grantType === GRANT_TYPE_CLIENT_CREDENTIALS) {
       basicFields = [accessTokenUrl, clientId, clientSecret, enabled];
 

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
@@ -425,7 +425,7 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
         enabled,
       ];
 
-      advancedFields = [scope, state, credentialsInBody, tokenPrefix];
+      advancedFields = [scope, state, credentialsInBody, tokenPrefix, audience];
     } else if (grantType === GRANT_TYPE_CLIENT_CREDENTIALS) {
       basicFields = [accessTokenUrl, clientId, clientSecret, enabled];
 


### PR DESCRIPTION
This adds the optional field `audience` and `resource` used in OAuth 2 client credentials authorization flow against [SciTokens](https://scitokens.org/) servers.

Closes #1767 

<img width="1793" alt="Screen Shot 2019-11-06 at 3 49 38 PM" src="https://user-images.githubusercontent.com/11262902/68337411-6f4f5100-00ae-11ea-9e45-07d814508c5c.png">

<img width="1546" alt="Screen Shot 2019-11-06 at 3 49 10 PM" src="https://user-images.githubusercontent.com/11262902/68337417-72e2d800-00ae-11ea-9d61-8ac76749db08.png">
