### PR TITLE
Make 'value' and 'header' lower case for consistency

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/request-headers-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/request-headers-editor.js
@@ -129,8 +129,8 @@ class RequestHeadersEditor extends React.PureComponent<Props> {
         <div className="scrollable">
           <KeyValueEditor
             sortable
-            namePlaceholder="Header"
-            valuePlaceholder="Value"
+            namePlaceholder="header"
+            valuePlaceholder="value"
             pairs={request.headers}
             nunjucksPowerUserMode={nunjucksPowerUserMode}
             isVariableUncovered={isVariableUncovered}


### PR DESCRIPTION
Now that I'm at it here's a tiny consistency PR. 'name' and 'value' is written lower case in both the form and the query editor, so 'header' and 'value' in the header editor should also be lower case - or all of them upper case ;-)