### PR TITLE
[Feature] Certificate Authority Settings

### DIFF
--- a/packages/insomnia-app/app/models/settings.js
+++ b/packages/insomnia-app/app/models/settings.js
@@ -70,6 +70,8 @@ export function init(): BaseSettings {
     proxyEnabled: false,
     timeout: 0,
     validateSSL: true,
+    caBundle: '',
+    caBundlePath: '',
     forceVerticalLayout: false,
     autoHideMenuBar: false,
     theme: packageJson.app.theme,

--- a/packages/insomnia-app/app/models/settings.js
+++ b/packages/insomnia-app/app/models/settings.js
@@ -20,6 +20,8 @@ type BaseSettings = {
   proxyEnabled: boolean,
   timeout: number,
   validateSSL: boolean,
+  caBundle: string,
+  caBundlePath: String,
   forceVerticalLayout: boolean,
   autoHideMenuBar: boolean,
   theme: string,

--- a/packages/insomnia-app/app/models/settings.js
+++ b/packages/insomnia-app/app/models/settings.js
@@ -21,7 +21,7 @@ type BaseSettings = {
   timeout: number,
   validateSSL: boolean,
   caBundle: string,
-  caBundlePath: String,
+  caBundlePath: string,
   forceVerticalLayout: boolean,
   autoHideMenuBar: boolean,
   theme: string,

--- a/packages/insomnia-app/app/ui/components/settings/general.js
+++ b/packages/insomnia-app/app/ui/components/settings/general.js
@@ -20,6 +20,7 @@ import CheckForUpdatesButton from '../check-for-updates-button';
 import { setFont } from '../../../plugins/misc';
 import * as session from '../../../account/session';
 import Tooltip from '../tooltip';
+import FileInputButton from '../base/file-input-button';
 
 type Props = {
   settings: Settings,
@@ -63,6 +64,10 @@ class General extends React.PureComponent<Props, State> {
     }
 
     return this.props.updateSetting(el.name, value);
+  }
+
+  async _handleCaBundlePathChange(path: string) {
+    return this.props.updateSetting('caBundlePath', path);
   }
 
   async _handleToggleMenuBar(e: SyntheticEvent<HTMLInputElement>) {
@@ -293,6 +298,39 @@ class General extends React.PureComponent<Props, State> {
         <h2>Network</h2>
 
         {this.renderBooleanSetting('Validate certificates', 'validateSSL', '')}
+
+        <div className="form-control form-control--outlined">
+          <label>
+            Certificate Authority Bundle
+            <select name="caBundle" value={settings.caBundle} onChange={this._handleUpdateSetting}>
+              {isMac() ? (
+                <option value="default">Mac Keychain (Default)</option>
+              ) : (
+                <React.Fragment>
+                  <option>Insomnia CA Bundle (Default)</option>,
+                  <option value="windowsCertStore">Windows Certificate Store</option>,
+                  <option value="userProvided">User Provided Bundle</option>
+                </React.Fragment>
+              )}
+            </select>
+          </label>
+        </div>
+
+        {settings.caBundle === 'userProvided' && (
+          <div className="form-control form-control--outlined">
+            <label>
+              Certificate Authority Bundle File
+              <FileInputButton
+                className="btn btn--clicky"
+                name="CA Bundle"
+                onChange={this._handleCaBundlePathChange}
+                path={settings.caBundlePath}
+                showFileName
+              />
+            </label>
+          </div>
+        )}
+
         {this.renderBooleanSetting('Follow redirects', 'followRedirects', '')}
 
         <div className="form-row pad-top-sm">

--- a/packages/insomnia-app/flow-typed/win-ca.js
+++ b/packages/insomnia-app/flow-typed/win-ca.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare module 'win-ca' {
+  declare module.exports: *;
+}

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -4423,7 +4423,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4441,11 +4442,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4458,15 +4461,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4569,7 +4575,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4579,6 +4586,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4591,17 +4599,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4618,6 +4629,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4690,7 +4702,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4700,6 +4713,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4775,7 +4789,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4805,6 +4820,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4822,6 +4838,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4860,11 +4877,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -6304,6 +6323,11 @@
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
+    "is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+    },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
@@ -7193,7 +7217,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-      "dev": true,
       "requires": {
         "pify": "^3.0.0"
       }
@@ -8472,8 +8495,7 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "1.0.0",
@@ -12370,6 +12392,27 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "win-ca": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/win-ca/-/win-ca-3.1.1.tgz",
+      "integrity": "sha512-uZj8zifF459u1apoVjXKVBBnh4NyILbC0W5asVtILwseNenc+krP44C0FWn6RXGjOHvxLKfYoIm0xl/R8wlw+g==",
+      "requires": {
+        "is-electron": "^2.2.0",
+        "make-dir": "^1.3.0",
+        "node-forge": "^0.8.2",
+        "split": "^1.0.1"
+      },
+      "dependencies": {
+        "split": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+          "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+          "requires": {
+            "through": "2"
           }
         }
       }

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -182,6 +182,7 @@
     "uuid": "^3.0.0",
     "vkbeautify": "^0.99.1",
     "whatwg-fetch": "^2.0.1",
+    "win-ca": "^3.1.1",
     "yaml": "^1.5.0",
     "zprint-clj": "0.2.0"
   },


### PR DESCRIPTION
Related Issues: #675 and #1432
Status: In Progress

## Tasks
### [Completed] Allow Windows users to pull certificate authorities from the Windows Cert Store
With the help of the library [`win-ca`](https://github.com/ukoloff/win-ca) we are able to pull windows trusted certificates under the users profile. This package can be installed for all operating systems but will only do something on windows.

### Allow Windows/Linux/(Mac?) to provide custom ca bundle
Completed for windows/linux.

Upon research on [CURLOPT_CAINFO](https://curl.haxx.se/libcurl/c/CURLOPT_CAINFO.html) we should be able to allow mac users to also provide a CA file. 

> If the option is not set, then curl will use the certificates in the system and user Keychain to verify the peer.

### Unit Tests
The whole thing needs unit tests still.

### Polish Code
Maybe move the logic outside of network.js into its own file. Maybe a function to return the file that should be used with curl?

## Ideas
* Combine CA bundles?
* Workspace CA files? Would only work with a user provided cert?
* When on Windows use Cert Store, when on Mac use Keychain, else use provided ca info. To overwrite you would add to workspace?

@gschier would love your feedback :)