### PR TITLE
Adds a contentType header to body parts of multipart/form-data payload

### DIFF
--- a/packages/insomnia-app/app/network/__tests__/multipart.test.js
+++ b/packages/insomnia-app/app/network/__tests__/multipart.test.js
@@ -30,6 +30,31 @@ describe('buildMultipart()', () => {
     );
   });
 
+  it('builds a multiline request with content-type', async () => {
+    const { filePath, boundary, contentLength } = await buildMultipart([
+      { name: 'foo', value: 'bar' },
+      { name: 'json', value: '{"hello": "world"}', multiline: 'application/json' },
+    ]);
+
+    expect(boundary).toBe(DEFAULT_BOUNDARY);
+    expect(contentLength).toBe(221);
+    expect(fs.readFileSync(filePath, 'utf8')).toBe(
+      [
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="foo"',
+        '',
+        'bar',
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="json"',
+        'Content-Type: application/json',
+        '',
+        '{"hello": "world"}',
+        `--${boundary}--`,
+        '',
+      ].join('\r\n'),
+    );
+  });
+
   it('builds with file', async () => {
     const fileName = path.resolve(path.join(__dirname, './testfile.txt'));
     const { filePath, boundary, contentLength } = await buildMultipart([

--- a/packages/insomnia-app/app/network/multipart.js
+++ b/packages/insomnia-app/app/network/multipart.js
@@ -72,8 +72,13 @@ export async function buildMultipart(params: Array<RequestBodyParameter>) {
       } else {
         const name = param.name || '';
         const value = param.value || '';
+        const contentType = param.multiline;
         addString(`Content-Disposition: form-data; name="${name}"`);
         addString(lineBreak);
+        if (contentType) {
+          addString(`Content-Type: ${contentType}`);
+          addString(lineBreak);
+        }
         addString(lineBreak);
         addString(value);
       }


### PR DESCRIPTION
It uses the `multiline` parameter as chosen by the user.

Closes #1810 