### PR TITLE
Add GraphQL lint to editor component mount (Fixes #1507)

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
@@ -86,10 +86,15 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
     this._disabledOperationMarkers = [];
-    this._documentAST = null;
     this._queryEditor = null;
     this._isMounted = false;
+
     const body = GraphQLEditor._stringToGraphQL(props.content);
+    try {
+      this._documentAST = parse(body.query);
+    } catch (e) {
+      this._documentAST = null;
+    }
 
     let automaticFetch;
     try {
@@ -484,6 +489,15 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
     this._isMounted = true;
     (async () => {
       await this._fetchAndSetSchema(this.props.request);
+
+      // When the schema request returns the editor should
+      // exist as the first render should have completed.
+      // We put this guard in place just incase.
+      if (this._queryEditor) {
+        // $ExpectError
+        await this._queryEditor.performLint();
+        this.forceUpdate();
+      }
     })();
   }
 


### PR DESCRIPTION
## The Problem

The problem appears to be the fact that the GraphQL editor is only updated at initialization time, and when the text in it changes.

The [`render()` function](https://github.com/getinsomnia/insomnia/blob/d2670912666228f5a8b0b78fad0b7804d9b8f85e/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js#L527) gathers some state that is used to construct a [`variableTypes` object](https://github.com/getinsomnia/insomnia/blob/d2670912666228f5a8b0b78fad0b7804d9b8f85e/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js#L553), which is then used in the component HTML to specify the [linter options](https://github.com/getinsomnia/insomnia/blob/d2670912666228f5a8b0b78fad0b7804d9b8f85e/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js#L670). This option is used by the [GraphQL extension](https://github.com/graphql/graphiql/tree/master/packages/codemirror-graphql#readme) of CodeMirror to produce the warnings that are shown in the images within #1507.

This function is only called on component initialization, however the request that fetches the schema from the server does not return until later, so the editor cannot be properly rendered at construction. Though the request returns with the schema, the editor is not re-rendered until the user edits the query, hence the warnings as shown in #1507.

## Solution Requirements

In order for the `render()` function to build the `variableTypes` object which is required for the linting to take place, there are a few requirements:

1. The GraphQL schema must exist, and be stored in `this.state.schema`. It is passed to [this function](https://github.com/getinsomnia/insomnia/blob/d2670912666228f5a8b0b78fad0b7804d9b8f85e/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js#L315) which produces the final object needed for linting.

When the GraphQL editor component is created, the schema is automatically pulled from the server and stored in the `this.state.schema` variable for use. The `_fetchAndSetSchema` function is asynchronously called [here](https://github.com/getinsomnia/insomnia/blob/d2670912666228f5a8b0b78fad0b7804d9b8f85e/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js#L486), however the initial render of the component occurs before the schema request returns. 

2. `this._documentAST` must contain a representation of the user's query. It is needed [here](https://github.com/getinsomnia/insomnia/blob/d2670912666228f5a8b0b78fad0b7804d9b8f85e/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js#L320).

`this._documentAST` is defined as `null` in the component constructor, and is not set properly until the query body is changed by the user.

## Proposed Solution

The proposed solution is to ensure that the 2 requirements mentioned above are fulfilled, and then to trigger a manual re-render of the component.

We fulfill the second requirement at construction time by defining `this._documentAST` to the parsed value rather than `null`.

Since the first requirement (a valid schema in `this.state.schema`) must necessarily contact the server, we execute the re-render once the request has returned.

Once the 2 requirements are fulfilled, we call `performLint()` on the editor to update the warnings, and then call `forceUpdate()` to re-render the component.

```js
constructor(props: Props) {
    ...
    this._documentAST = parse(body.query);
    ...
}

componentDidMount() {
    (async () => {
      await this._fetchAndSetSchema(this.props.request);
      await this._queryEditor.performLint();
      this.forceUpdate();
    })();
}
```

## Shortcomings

Here is a list of things that are potentially non-ideal about this solution, and might need to be improved if deemed important:

#### Unclear on previous initial value for `this._documentAST`

I am still unclear on why `this._documentAST` was defined as `null` originally, since the query body is available for parsing at construction time. Though I tested this and everything seems to work, there may be a reason that I'm missing that invalidates this solution. If the initial value must truly be `null`, then it would always be possible to parse the body after the schema request returns.

#### `this._documentAST` surrounded by `try/catch`

The only other places setting `this._documentAST` was [here](https://github.com/getinsomnia/insomnia/blob/d2670912666228f5a8b0b78fad0b7804d9b8f85e/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js#L403), although I couldn't call this function directly because it had a built in guard against calling the function when nothing had changed. This code had a `try/catch` like this one:

```js
try {
  this._documentAST = parse(query);
} catch (e) {
  this._documentAST = null;
}
```

although I am uneasy about this since there is no comment explaining why an exception might occur and what the ramifications are. I used the same code to define the variable in the constructor, but there is probably room for improvement if anyone knows what we are attempting to `catch` here.

#### Warning is visible until schema request returns

Before the request for the schema returns, the warning is still visible as the linter cannot validate the variables in the editor. We could potentially hide the warning on initialization, although the rules around this could get confusing if there is no URL present or if the request never returns or something like that.

#### Comments

This is clearly a non-obvious problem, and I haven't added any comments to describe why things are being done like this. It might be valuable to add comments in select places, although I'm not sure what would be most helpful and where.