### PR TITLE
More control over the prompt plugin

### DIFF
--- a/plugins/insomnia-plugin-prompt/index.js
+++ b/plugins/insomnia-plugin-prompt/index.js
@@ -40,23 +40,35 @@ module.exports.templateTags = [
         defaultValue: false,
       },
       {
-        displayName: 'Default to Last Value',
-        type: 'boolean',
+        displayName: 'Prompt for a Value...',
+        type: 'enum',
         help:
-          'If this is enabled, the input field will be pre-filled with this value. This option is ' +
-          'ignored when the storage key is set.',
-        defaultValue: true,
+          'Controls when this prompt should be shown and what value should be used to '+
+          'pre-populate the prompt dialog',
+        options: [
+          { displayName: 'on each request', value: 'always-fresh' },
+          { displayName: 'on each request, using the default value as default',  value: 'always-default' },
+          { displayName: 'on each request, using the stored value as default',  value: 'always-storage' },
+          { displayName: 'at most once, storing the value for further requests',  value: 'once-storage' },
+        ]
       },
     ],
-    async run(context, title, label, defaultValue, explicitStorageKey, maskText, saveLastValue) {
+    async run(context, title, label, defaultValue, explicitStorageKey, maskText, showCondition) {
       if (!title) {
         throw new Error('Title attribute is required for prompt tag');
       }
 
-      // If we don't have a key, default to request ID.
+      // Backward compatibility with "Default to Last Value" #1597
+      if (showCondition === true) {
+          showCondition = 'always-storage'
+      } else if (showCondition === false) {
+          showCondition = 'always-fresh'
+      }
+
+      // If we don't have a key, default to request ID and title
       // We do this because we may render the prompt multiple times per request.
-      // We cache it under the requestId so it only prompts once. We then clear
-      // the cache in a response hook when the request is sent.
+      // We cache it under the requestId.title so it only prompts once. We then
+      // clear the cache in a response hook when the request is sent.
       const titleHash = crypto
         .createHash('md5')
         .update(title)
@@ -64,21 +76,20 @@ module.exports.templateTags = [
       const storageKey = explicitStorageKey || `${context.meta.requestId}.${titleHash}`;
       const cachedValue = await context.store.getItem(storageKey);
 
-      // Directly return cached value if using explicitly defined storage key
-      if (explicitStorageKey && cachedValue) {
-        console.log(`[prompt] Used cached value under ${storageKey}`);
-        return cachedValue;
+      if (showCondition === 'once-storage' && cachedValue !== null) {
+          console.log(`[prompt] Used cached value under ${storageKey}`);
+          return cachedValue;
       }
 
-      // Use cached value as default value
-      if (cachedValue && saveLastValue) {
-        defaultValue = cachedValue;
-        console.log(`[prompt] Used cached value under ${storageKey}`);
+      if (showCondition === 'always-fresh') {
+          defaultValue = '';
+      } else if (showCondition === 'always-storage') {
+          defaultValue = cachedValue;
       }
 
       // Only prompt when we're actually sending
       if (context.renderPurpose !== 'send') {
-        if (cachedValue !== null) {
+        if (showCondition === 'once-storage' && cachedValue !== null) {
           return cachedValue;
         } else {
           return defaultValue || '';
@@ -88,6 +99,7 @@ module.exports.templateTags = [
       const value = await context.app.prompt(title || 'Enter Value', {
         label,
         defaultValue,
+        selectText: true,
         inputType: maskText ? 'password' : 'text',
       });
 

--- a/plugins/insomnia-plugin-prompt/index.js
+++ b/plugins/insomnia-plugin-prompt/index.js
@@ -43,14 +43,14 @@ module.exports.templateTags = [
         displayName: 'Prompt for a Value...',
         type: 'enum',
         help:
-          'Controls when this prompt should be shown and what value should be used to '+
+          'Controls when this prompt should be shown and what value should be used to ' +
           'pre-populate the prompt dialog',
         options: [
           { displayName: 'on each request', value: 'always-fresh' },
-          { displayName: 'on each request, using the default value as default',  value: 'always-default' },
-          { displayName: 'on each request, using the stored value as default',  value: 'always-storage' },
-          { displayName: 'at most once, storing the value for further requests',  value: 'once-storage' },
-        ]
+          { displayName: 'on each request, using the default value as default', value: 'always-default' },
+          { displayName: 'on each request, using the stored value as default', value: 'always-storage' },
+          { displayName: 'at most once, storing the value for further requests', value: 'once-storage' },
+        ],
       },
     ],
     async run(context, title, label, defaultValue, explicitStorageKey, maskText, showCondition) {
@@ -60,9 +60,9 @@ module.exports.templateTags = [
 
       // Backward compatibility with "Default to Last Value" #1597
       if (showCondition === true) {
-          showCondition = 'always-storage'
+          showCondition = 'always-storage';
       } else if (showCondition === false) {
-          showCondition = 'always-fresh'
+          showCondition = 'always-fresh';
       }
 
       // If we don't have a key, default to request ID and title


### PR DESCRIPTION
This PR extends the idea introduced in #1597 which allowed the possibility of reuse the previous entered value if you marked `Default to Last Value`.

### Background

I've found myself having a separate file with text strings to C&P them into the prompt dialogs because the behavior of that dialog wasn't as flexible as I wanted, so I tried to improve the current prompt dialog plugin with my own needs, but I thought they are general enough so they could be useful for others.

### Feature

![imagen](https://user-images.githubusercontent.com/231822/73463351-67394180-437d-11ea-935c-ca8222db7f3a.png)

This PR leaves the user to choose between a couple of options about how to show the prompt:

- on each request with an empty text box, ignoring any previously entered value (original behavior)
- on each request but defaults to the prompt's default value, ignoring any previously entered value (new behavior)
- on each request but defaults to the current stored value (aka `Default to Last Value`)
- once and storing the value for futher requests (the behavior used when a `Storage Key` was set).

As a new feature now the prompt text is autoselected in order to quickly edit it if you want to change the value.

### Remarks

In order to keep the backwards compatibility I transformed the current `Default to Last Value` booleans to the equivalents enums. 

A broken behavior is that the prompt now is shown regardless a custom storage key has been set if the user choosed any of the `on each request` options, but this could be useful because until now there was no way to change the stored message unless one reload the whole application.

