### PR TITLE
Convert Less vars to CSS vars

### DIFF
--- a/packages/insomnia-app/app/ui/css/components/app.less
+++ b/packages/insomnia-app/app/ui/css/components/app.less
@@ -1,9 +1,5 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .app {
   position: relative;
   height: 100%;
   width: 100%;
 }
-

--- a/packages/insomnia-app/app/ui/css/components/changelog.less
+++ b/packages/insomnia-app/app/ui/css/components/changelog.less
@@ -1,22 +1,19 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .changelog {
   h2 {
-    font-size: @font-size-xl;
+    font-size: var(--font-size-xl);
   }
 
   h3 {
-    font-size: @font-size-xl;
+    font-size: var(--font-size-xl);
   }
 
   ul {
     list-style: disc;
-    padding-left: @padding-lg;
+    padding-left: var(--padding-lg);
     margin-bottom: 1.5em;
   }
 
   hr {
-    margin: @padding-lg 0 !important;
+    margin: var(--padding-lg) 0 !important;
   }
 }

--- a/packages/insomnia-app/app/ui/css/components/cookie-list.less
+++ b/packages/insomnia-app/app/ui/css/components/cookie-list.less
@@ -1,14 +1,11 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .cookie-list {
   height: 100%;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
 
   table {
-    input:not([type="checkbox"]) {
-      padding: @padding-xs @padding-xxs;
+    input:not([type='checkbox']) {
+      padding: var(--padding-xs) var(--padding-xxs);
       width: 100%;
       background: none;
     }
@@ -16,14 +13,14 @@
     .btn {
       cursor: pointer;
       margin: 0;
-      padding: 0 @padding-sm;
-      height: @line-height-xs;
+      padding: 0 var(--padding-sm);
+      height: var(--line-height-xs);
     }
   }
 
   .cookie-list__list {
     height: 100%;
-    padding: 0 @padding-md @padding-md @padding-md;
+    padding: 0 var(--padding-md) var(--padding-md) var(--padding-md);
     position: relative;
     overflow-y: auto;
   }

--- a/packages/insomnia-app/app/ui/css/components/cookie-modify-modal.less
+++ b/packages/insomnia-app/app/ui/css/components/cookie-modify-modal.less
@@ -1,18 +1,15 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .cookie-modify.modal__body {
   overflow: visible;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
 
   table {
-    input:not([type="checkbox"]) {
-      padding: @padding-xs @padding-xxs;
+    input:not([type='checkbox']) {
+      padding: var(--padding-xs) var(--padding-xxs);
       width: 100%;
       background: none;
     }
-    
+
     td {
       cursor: pointer;
       vertical-align: middle;
@@ -21,8 +18,8 @@
     .btn {
       cursor: pointer;
       margin: 0;
-      padding: 0 @padding-sm;
-      height: @line-height-xs;
+      padding: 0 var(--padding-sm);
+      height: var(--line-height-xs);
     }
   }
 

--- a/packages/insomnia-app/app/ui/css/components/dropdown.less
+++ b/packages/insomnia-app/app/ui/css/components/dropdown.less
@@ -1,7 +1,3 @@
-@import '../constants/colors';
-@import '../constants/dimensions';
-@import '../constants/fonts';
-
 .dropdown {
   position: relative;
   display: inline-block;
@@ -35,29 +31,29 @@
     position: fixed;
     top: 0;
     left: 0;
-    border: 1px solid @hl-sm;
+    border: 1px solid var(--hl-sm);
     box-shadow: 0 0 1rem 0 rgba(0, 0, 0, 0.1);
     box-sizing: border-box;
     background: var(--color-bg);
 
     // Separate it from it's surroundings a bit
-    margin: @padding-xxs 3px;
+    margin: var(--padding-xxs) 3px;
 
-    padding-top: @radius-md;
-    padding-bottom: @radius-md;
+    padding-top: var(--radius-md);
+    padding-bottom: var(--radius-md);
 
-    border-radius: @radius-md;
+    border-radius: var(--radius-md);
     overflow: auto;
 
     .dropdown__filter {
       border: 1px solid var(--hl-md);
-      margin: @padding-xs;
+      margin: var(--padding-xs);
       width: auto;
-      border-radius: @radius-sm;
+      border-radius: var(--radius-sm);
       display: flex;
       flex-direction: row;
       align-items: center;
-      padding-left: @padding-sm;
+      padding-left: var(--padding-sm);
 
       // Can't "display: none" this because we need to be able to type
       // in it. So, we'll just store it off screen
@@ -66,7 +62,7 @@
 
       input {
         margin: 0;
-        padding: @padding-xs @padding-sm;
+        padding: var(--padding-xs) var(--padding-sm);
         color: var(--color-font);
       }
 
@@ -101,19 +97,19 @@
 
       .dropdown__hint,
       .dropdown__right {
-        color: @hl-xl;
+        color: var(--hl-xl);
         margin-left: auto;
-        padding-left: @padding-lg;
+        padding-left: var(--padding-lg);
       }
     }
 
     li > button {
       min-width: 15rem;
-      font-size: @font-size-md;
+      font-size: var(--font-size-md);
       text-align: left;
-      padding-right: @padding-md;
-      padding-left: @padding-sm;
-      height: @line-height-xs;
+      padding-right: var(--padding-md);
+      padding-left: var(--padding-sm);
+      height: var(--line-height-xs);
       width: 100%;
       display: block;
       color: var(--color-font) !important;
@@ -129,32 +125,32 @@
 
     li > button:hover:not(:disabled),
     li.active > button:not(:disabled) {
-      background: @hl-sm;
+      background: var(--hl-sm);
     }
 
     li > button:active:not(:disabled) {
-      background: @hl-md;
+      background: var(--hl-md);
     }
 
     .dropdown__divider {
-      border-bottom: 1px solid @hl-lg;
+      border-bottom: 1px solid var(--hl-lg);
       overflow: visible !important;
       height: 0;
-      margin: @padding-md @padding-md @padding-md @padding-md;
+      margin: var(--padding-md) var(--padding-md) var(--padding-md) var(--padding-md);
 
       .dropdown__divider__label {
         position: relative;
-        left: calc(-1 * @padding-sm);
+        left: calc(-1 * var(--padding-sm));
         top: -0.7rem;
-        color: @hl;
+        color: var(--hl);
         padding-right: 1em;
         background: var(--color-bg);
-        font-size: @font-size-xs;
+        font-size: var(--font-size-xs);
         text-transform: uppercase;
       }
 
       &.dropdown__divider--no-name {
-        margin: @padding-xs 0;
+        margin: var(--padding-xs) 0;
 
         .dropdown__divider__label {
           display: none;

--- a/packages/insomnia-app/app/ui/css/components/editable.less
+++ b/packages/insomnia-app/app/ui/css/components/editable.less
@@ -1,5 +1,3 @@
-@import '../constants/colors';
-
 input.editable {
   font-style: italic !important;
   opacity: 0.9;

--- a/packages/insomnia-app/app/ui/css/components/environment-editor.less
+++ b/packages/insomnia-app/app/ui/css/components/environment-editor.less
@@ -1,5 +1,3 @@
-@import '../constants/dimensions.less';
-
 .environment-editor {
   display: grid;
   grid-template-rows: 1fr auto;

--- a/packages/insomnia-app/app/ui/css/components/environment-modal.less
+++ b/packages/insomnia-app/app/ui/css/components/environment-modal.less
@@ -1,6 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .env-modal.modal__body {
   display: grid;
   grid-template-columns: 17rem minmax(0, 1fr);
@@ -9,8 +6,8 @@
   width: 100%;
 
   .env-modal__sidebar {
-    border-right: 1px solid @hl-md;
-    padding: @padding-md 0;
+    border-right: 1px solid var(--hl-md);
+    padding: var(--padding-md) 0;
     box-sizing: border-box;
     overflow-y: auto;
     height: 100%;
@@ -19,7 +16,7 @@
       display: flex;
       flex-direction: row;
       align-items: center;
-      padding: @padding-sm @padding-sm 0;
+      padding: var(--padding-sm) var(--padding-sm) 0;
 
       & > * {
         height: 100%;
@@ -28,13 +25,13 @@
 
       & > *:first-child {
         width: 100%;
-        padding: @padding-sm 0 @padding-sm @padding-sm;
+        padding: var(--padding-sm) 0 var(--padding-sm) var(--padding-sm);
       }
 
       button {
-        color: @hl;
+        color: var(--hl);
         height: 100%;
-        padding: @padding-sm;
+        padding: var(--padding-sm);
 
         &:hover {
           color: var(--color-font);
@@ -62,13 +59,14 @@
       display: flex;
       flex-direction: row;
       align-items: center;
-      padding: @padding-sm @padding-md @padding-sm;
-      height: @line-height-sm;
+      padding: var(--padding-sm) var(--padding-md) var(--padding-sm);
+      height: var(--line-height-sm);
     }
 
-    h1, h1 > * {
+    h1,
+    h1 > * {
       padding: 0;
-      font-size: @font-size-xl;
+      font-size: var(--font-size-xl);
       width: 100%;
     }
   }
@@ -80,11 +78,11 @@
   z-index: 100000;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  grid-template-rows: @line-height-xs;
-  color: @hl;
+  grid-template-rows: var(--line-height-xs);
+  color: var(--hl);
 
   & > button {
-    padding: 0 @padding-md 0 @padding-md;
+    padding: 0 var(--padding-md) 0 var(--padding-md);
     width: 100%;
 
     &:first-child {
@@ -96,7 +94,7 @@
       position: absolute;
       left: 0;
       opacity: 0;
-      color: var(--hl-lg)
+      color: var(--hl-lg);
     }
 
     .editable {
@@ -104,21 +102,21 @@
       overflow: hidden;
       text-overflow: ellipsis;
       display: block;
-      padding-right: @padding-xs;
+      padding-right: var(--padding-xs);
       box-sizing: border-box;
       width: 100%;
-      line-height: @line-height-xs;
+      line-height: var(--line-height-xs);
     }
   }
 
   &.env-modal__sidebar-item--dragging > button,
   &.env-modal__sidebar-item--active > button {
     color: var(--color-font);
-    background-color: @hl-xs;
+    background-color: var(--hl-xs);
   }
 
   &:hover > button {
-    background-color: @hl-xs;
+    background-color: var(--hl-xs);
   }
 
   &.env-modal__sidebar-item--dragging .drag-handle,
@@ -132,6 +130,6 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    padding-left: @padding-md;
+    padding-left: var(--padding-md);
   }
 }

--- a/packages/insomnia-app/app/ui/css/components/export-requests.less
+++ b/packages/insomnia-app/app/ui/css/components/export-requests.less
@@ -1,6 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .requests-tree {
   position: relative;
 
@@ -12,8 +9,8 @@
 
   .tree__list-root {
     // Add some space above so it's not so squished
-    padding-top: @padding-xxs;
-    padding-bottom: @padding-md;
+    padding-top: var(--padding-xxs);
+    padding-bottom: var(--padding-md);
     box-shadow: inset 0 2rem 2rem -2rem rgba(0, 0, 0, 0.03);
 
     overflow-y: auto;
@@ -37,12 +34,12 @@
 
   .tree__item {
     display: flex;
-    height: @line-height-xs;
+    height: var(--line-height-xs);
 
     & > button {
       flex-grow: 1;
-      color: @hl;
-      padding-left: @padding-sm;
+      color: var(--hl);
+      padding-left: var(--padding-sm);
     }
 
     & > * {
@@ -50,12 +47,12 @@
     }
 
     &.tree__item--big {
-      height: @line-height-sm;
+      height: var(--line-height-sm);
     }
 
     &:focus,
     &:hover {
-      background-color: @hl-xs;
+      background-color: var(--hl-xs);
       transition: background-color 0ms;
     }
 
@@ -66,13 +63,13 @@
     }
 
     .total-requests {
-      color: @hl-lg;
-      padding-left: @padding-xs;
+      color: var(--hl-lg);
+      padding-left: var(--padding-xs);
     }
   }
 
   .tree__item__icon {
-    padding-right: @padding-sm;
+    padding-right: var(--padding-sm);
   }
 
   .tree__item__checkbox > * {
@@ -82,27 +79,27 @@
   // Padding for nested folders
 
   .tree__list .tree__indent {
-    padding-left: @padding-sm;
+    padding-left: var(--padding-sm);
   }
 
   .tree__list .tree__list .tree__indent {
-    padding-left: calc(@padding-sm + @padding-md * 1);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 1);
   }
 
   .tree__list .tree__list .tree__list .tree__indent {
-    padding-left: calc(@padding-sm + @padding-md * 2);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 2);
   }
 
   .tree__list .tree__list .tree__list .tree__list .tree__indent {
-    padding-left: calc(@padding-sm + @padding-md * 3);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 3);
   }
 
   .tree__list .tree__list .tree__list .tree__list .tree__list .tree__indent {
-    padding-left: calc(@padding-sm + @padding-md * 4);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 4);
   }
 
   .tree__list .tree__list .tree__list .tree__list .tree__list .tree__list .tree__indent {
-    padding-left: calc(@padding-sm + @padding-md * 5);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 5);
   }
 
   .tree__list
@@ -113,6 +110,6 @@
     .tree__list
     .tree__list
     .tree__indent {
-    padding-left: calc(@padding-sm + @padding-md * 6);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 6);
   }
 }

--- a/packages/insomnia-app/app/ui/css/components/forms.less
+++ b/packages/insomnia-app/app/ui/css/components/forms.less
@@ -1,10 +1,7 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .form-control {
   outline: none;
   border: 0;
-  margin-bottom: @padding-sm;
+  margin-bottom: var(--padding-sm);
   width: 100%;
   box-sizing: border-box;
 
@@ -23,7 +20,7 @@
       position: absolute;
       right: 0;
       top: 0;
-      padding: 0 @padding-sm;
+      padding: 0 var(--padding-sm);
       height: 100%;
       display: flex;
       align-items: center;
@@ -44,7 +41,7 @@
     width: 100%;
     height: 100%;
     display: block;
-    margin-top: @padding-xs;
+    margin-top: var(--padding-xs);
     box-sizing: border-box;
   }
 
@@ -58,8 +55,8 @@
   input[type='checkbox'] {
     height: 1rem;
     float: left;
-    margin-top: @padding-xxs;
-    margin-right: @padding-xs;
+    margin-top: var(--padding-xxs);
+    margin-right: var(--padding-xs);
   }
 
   & > button {
@@ -73,7 +70,7 @@
   label {
     font-weight: 600;
     display: block;
-    margin-top: @padding-xs;
+    margin-top: var(--padding-xs);
     padding-top: 0;
 
     * {
@@ -86,7 +83,7 @@
       font-weight: normal;
     }
 
-    margin-bottom: @padding-xxs;
+    margin-bottom: var(--padding-xxs);
   }
 
   &.form-control--padded,
@@ -97,9 +94,9 @@
     input,
     select {
       border: 1px solid var(--hl-md);
-      padding: @padding-sm;
-      border-radius: @radius-md;
-      background-color: @hl-xxs;
+      padding: var(--padding-sm);
+      border-radius: var(--radius-md);
+      background-color: var(--hl-xxs);
     }
 
     // Because <select> is weird
@@ -112,7 +109,7 @@
       .input,
       input,
       select {
-        height: @line-height-xs;
+        height: var(--line-height-xs);
       }
     }
 
@@ -150,8 +147,8 @@
       border-right: 0;
       border-left: 0;
       background: none;
-      padding-left: @padding-xxs;
-      padding-right: @padding-xxs;
+      padding-left: var(--padding-xxs);
+      padding-right: var(--padding-xxs);
     }
   }
 
@@ -162,8 +159,8 @@
     .btn,
     select {
       border-style: dashed;
-      opacity: @opacity-subtle;
-      color: @hl-xl;
+      opacity: var(--opacity-subtle);
+      color: var(--hl-xl);
     }
   }
 }
@@ -176,7 +173,7 @@
 .form-control--no-label::before {
   content: 'nothing';
   opacity: 0;
-  padding-top: @padding-xs;
+  padding-top: var(--padding-xs);
   display: block;
 }
 
@@ -189,8 +186,8 @@
 
   & > * {
     width: 100%;
-    margin-left: @padding-xxs;
-    margin-right: @padding-xxs;
+    margin-left: var(--padding-xxs);
+    margin-right: var(--padding-xxs);
   }
 
   & > p {
@@ -224,37 +221,37 @@
   background: var(--color-bg);
 
   &:not(.btn--plain) {
-    padding: 0 calc(@padding-md * 1.5);
-    height: @line-height-md;
+    padding: 0 calc(var(--padding-md) * 1.5);
+    height: var(--line-height-md);
     border: 1px solid transparent;
   }
 
   &.btn--compact {
-    padding: 0 @padding-md;
-    height: @line-height-sm;
+    padding: 0 var(--padding-md);
+    height: var(--line-height-sm);
   }
 
   &.btn--super-compact {
-    padding: 0 @padding-md;
-    height: @line-height-xs;
+    padding: 0 var(--padding-md);
+    height: var(--line-height-xs);
   }
 
   &.btn--super-duper-compact {
-    padding: @padding-xxs @padding-sm;
+    padding: var(--padding-xxs) var(--padding-sm);
     height: auto;
   }
 
   &.btn--micro {
-    font-size: @font-size-sm;
-    line-height: @font-size-xs;
-    padding: @padding-xxs @padding-sm;
+    font-size: var(--font-size-sm);
+    line-height: var(--font-size-xs);
+    padding: var(--padding-xxs) var(--padding-sm);
     height: auto;
     border-radius: 3px;
   }
 
   &.btn--outlined {
-    border: 1px solid @hl-lg;
-    border-radius: @radius-md;
+    border: 1px solid var(--hl-lg);
+    border-radius: var(--radius-md);
   }
 
   &.btn--clicky {
@@ -268,8 +265,8 @@
   }
 
   &.btn--expandable-small {
-    padding: 0 @padding-md;
-    min-height: @line-height-sm;
+    padding: 0 var(--padding-md);
+    min-height: var(--line-height-sm);
     height: unset;
   }
 }
@@ -281,11 +278,11 @@
 .btn:focus:not(:disabled),
 .btn.focus:not(:disabled),
 .btn:hover:not(:disabled) {
-  background-color: @hl-xs;
+  background-color: var(--hl-xs);
 }
 
 .btn:active:not(:disabled) {
-  background-color: @hl-md;
+  background-color: var(--hl-md);
 }
 
 .btn.btn--no-background {
@@ -320,7 +317,7 @@ select {
   font-family: var(--font-family);
 
   &::-webkit-input-placeholder {
-    color: @hl-lg;
+    color: var(--hl-lg);
   }
 }
 
@@ -350,8 +347,8 @@ textarea.no-resize {
 }
 
 input[type='color'] {
-  height: @line-height-xs !important;
-  padding: @padding-xxs !important;
+  height: var(--line-height-xs) !important;
+  padding: var(--padding-xxs) !important;
 }
 
 label {
@@ -365,11 +362,11 @@ label {
       z-index: -1;
       content: ' ';
       position: absolute;
-      top: calc(-@padding-xxs * -1);
-      bottom: calc(-@padding-xxs * -1);
-      left: calc(-@padding-xxs * -1);
-      right: calc(-@padding-xxs * -1);
-      border-radius: @radius-sm;
+      top: var(--padding-xxs);
+      bottom: var(--padding-xxs);
+      left: var(--padding-xxs);
+      right: var(--padding-xxs);
+      border-radius: var(--radius-sm);
       background-color: var(--hl-sm);
     }
   }

--- a/packages/insomnia-app/app/ui/css/components/graph-ql-editor.less
+++ b/packages/insomnia-app/app/ui/css/components/graph-ql-editor.less
@@ -1,6 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .graphql-editor {
   position: relative;
   display: grid;
@@ -12,8 +9,8 @@
 
   & > h2 {
     color: var(--hl);
-    padding: @padding-xs @padding-sm;
-    font-size: @font-size-md;
+    padding: var(--padding-xs) var(--padding-sm);
+    font-size: var(--font-size-md);
     border-top: 1px dashed var(--hl-sm);
   }
 
@@ -22,8 +19,8 @@
     top: 0;
     right: 0;
     z-index: 10;
-    margin: @padding-xs;
-    opacity: @opacity-subtle;
+    margin: var(--padding-xs);
+    opacity: var(--opacity-subtle);
 
     &:hover {
       opacity: 1;
@@ -62,7 +59,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    padding: @padding-xxs @padding-sm;
+    padding: var(--padding-xxs) var(--padding-sm);
     flex-wrap: wrap;
   }
 
@@ -77,20 +74,20 @@
   background: var(--color-bg);
   position: fixed;
   z-index: 100;
-  padding: @padding-xs @padding-sm;
-  border: 1px solid @border-color;
+  padding: var(--padding-xs) var(--padding-sm);
+  border: 1px solid var(--hl-md);
   color: var(--color-font);
   font-weight: 600;
 
   .info-description {
     font-weight: initial;
-    padding-top: @padding-xs;
+    padding-top: var(--padding-xs);
 
     // HACK: Cancel out padding on parent container
-    margin-bottom: calc(@padding-sm * -1);
+    margin-bottom: calc(var(--padding-sm) * -1);
 
     & > * {
-      margin: @padding-xs 0 @padding-sm 0;
+      margin: var(--padding-xs) 0 var(--padding-sm) 0;
     }
   }
 

--- a/packages/insomnia-app/app/ui/css/components/graph-ql-explorer.less
+++ b/packages/insomnia-app/app/ui/css/components/graph-ql-explorer.less
@@ -1,6 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .graphql-explorer {
   display: grid;
   grid-template-columns: 100%;
@@ -17,22 +14,22 @@
   color: var(--color-font);
 
   .markdown-preview__content *:first-child {
-    margin-top: @padding-sm;
+    margin-top: var(--padding-sm);
   }
 
   &__subheading {
     border-bottom: 1px solid var(--hl-md);
-    padding-bottom: @padding-sm;
-    margin-top: @padding-lg;
-    margin-bottom: @padding-md;
+    padding-bottom: var(--padding-sm);
+    margin-top: var(--padding-lg);
+    margin-bottom: var(--padding-md);
   }
 
   &__header {
     overflow: hidden;
-    border-bottom: 1px solid @hl-md;
+    border-bottom: 1px solid var(--hl-md);
     box-sizing: border-box;
-    height: @height-nav;
-    line-height: @line-height-md;
+    height: var(--height-nav);
+    line-height: var(--line-height-md);
     color: var(--color-font);
     display: flex;
     justify-content: space-between;
@@ -42,13 +39,13 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      font-size: @font-size-lg;
+      font-size: var(--font-size-lg);
       font-weight: bold;
     }
 
     & > * {
       white-space: nowrap;
-      padding-left: @padding-md;
+      padding-left: var(--padding-md);
       display: inline-block;
       margin: 0;
     }
@@ -60,7 +57,7 @@
 
   &__body {
     box-sizing: border-box;
-    padding: @padding-md @padding-md 10rem;
+    padding: var(--padding-md) var(--padding-md) 10rem;
     overflow: auto;
     height: 100%;
     max-height: 100%;
@@ -68,16 +65,16 @@
 
   &__defs {
     &__description {
-      margin-left: @padding-sm;
+      margin-left: var(--padding-sm);
       color: var(--color-font);
     }
 
     &__arg {
-      margin-left: @padding-md;
+      margin-left: var(--padding-md);
     }
 
     li {
-      margin-bottom: @padding-md;
+      margin-bottom: var(--padding-md);
     }
   }
 

--- a/packages/insomnia-app/app/ui/css/components/header-editor.less
+++ b/packages/insomnia-app/app/ui/css/components/header-editor.less
@@ -1,9 +1,6 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .header-editor {
   display: grid;
   height: 100%;
-  grid-template-rows: minmax(0, 1fr) @line-height-md;
+  grid-template-rows: minmax(0, 1fr) var(--line-height-md);
   grid-template-columns: 100%;
 }

--- a/packages/insomnia-app/app/ui/css/components/key-value-editor.less
+++ b/packages/insomnia-app/app/ui/css/components/key-value-editor.less
@@ -1,8 +1,5 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .key-value-editor {
-  padding: @padding-md 0;
+  padding: var(--padding-md) 0;
 
   // This is the actual row
   .key-value-editor__row-wrapper {
@@ -11,7 +8,7 @@
     align-items: center;
     flex-direction: row;
     width: 100%;
-    padding-bottom: @padding-sm;
+    padding-bottom: var(--padding-sm);
     box-sizing: border-box;
 
     &.key-value-editor__row-wrapper--dragging {
@@ -28,8 +25,8 @@
       right: 0;
       left: 0;
       border-bottom: 2px dotted var(--color-surprise);
-      content: " ";
-      display: block
+      content: ' ';
+      display: block;
     }
 
     // So the line appears on the next row
@@ -49,14 +46,15 @@
   }
 
   .key-value-editor__drag {
-    width: @line-height-sm;
-    min-width: @line-height-sm;
+    width: var(--line-height-sm);
+    min-width: var(--line-height-sm);
     text-align: center;
     box-sizing: border-box;
     overflow: hidden;
 
     // Remove hover effect
-    &, &:hover {
+    &,
+    &:hover {
       color: var(--hl);
     }
   }
@@ -67,12 +65,13 @@
     display: flex;
     flex-direction: row;
     align-items: stretch;
-    padding: 0 @padding-sm 0 0;
+    padding: 0 var(--padding-sm) 0 0;
     box-sizing: border-box;
 
     // Pad the first form if there's no drag handle before it
-    &:first-child, &:first-child .form-control {
-      padding-left: @padding-md;
+    &:first-child,
+    &:first-child .form-control {
+      padding-left: var(--padding-md);
     }
 
     .form-control {
@@ -83,17 +82,18 @@
       }
     }
 
-    input, .input {
+    input,
+    .input {
       margin: 0;
     }
 
     & > * {
-      padding: 0 @padding-xs;
+      padding: 0 var(--padding-xs);
     }
 
     & > button,
     .dropdown > button {
-      color: @hl;
+      color: var(--hl);
       margin: 0;
 
       &:hover,

--- a/packages/insomnia-app/app/ui/css/components/links.less
+++ b/packages/insomnia-app/app/ui/css/components/links.less
@@ -1,5 +1,3 @@
-@import '../constants/colors';
-
 a {
   font-weight: 600 !important;
   text-decoration: none;
@@ -7,7 +5,7 @@ a {
   &:not(.a--nocolor) {
     color: var(--color-surprise);
   }
-  
+
   &:hover {
     text-decoration: underline;
   }

--- a/packages/insomnia-app/app/ui/css/components/markdown-editor.less
+++ b/packages/insomnia-app/app/ui/css/components/markdown-editor.less
@@ -1,13 +1,9 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-@import '../constants/fonts';
-
 .markdown-editor {
   border: 1px solid var(--hl-md);
   box-sizing: border-box;
 
   .markdown-editor__edit {
-    padding: @padding-xs @padding-sm;
+    padding: var(--padding-xs) var(--padding-sm);
   }
 
   &.markdown-editor--dynamic-height {
@@ -33,7 +29,7 @@
 
   .markdown-editor__preview {
     max-height: 35vh;
-    padding: @padding-sm;
+    padding: var(--padding-sm);
     overflow: auto;
   }
 }

--- a/packages/insomnia-app/app/ui/css/components/markdown-preview.less
+++ b/packages/insomnia-app/app/ui/css/components/markdown-preview.less
@@ -1,7 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-@import '../constants/fonts';
-
 // .markdown-preview {
 // }
 
@@ -13,43 +9,43 @@
   }
 
   h1 {
-    font-size: @font-size-xxl;
+    font-size: var(--font-size-xxl);
     border-bottom: 1px solid var(--hl-sm);
     font-weight: bold;
   }
 
   h2 {
-    font-size: @font-size-xl;
+    font-size: var(--font-size-xl);
     border-bottom: 1px solid var(--hl-sm);
     font-weight: bold;
   }
 
   h3 {
-    font-size: @font-size-lg;
+    font-size: var(--font-size-lg);
     font-weight: bold;
   }
 
   h4 {
-    font-size: @font-size-md;
+    font-size: var(--font-size-md);
     font-weight: bold;
     opacity: 0.9;
   }
 
   h5 {
-    font-size: @font-size-sm;
+    font-size: var(--font-size-sm);
     font-weight: bold;
     opacity: 0.9;
   }
 
   h6 {
-    font-size: @font-size-sm;
+    font-size: var(--font-size-sm);
     font-weight: bold;
     opacity: 0.8;
   }
 
   & > * {
     line-height: 1.7em;
-    margin: @padding-sm 0 @padding-md 0;
+    margin: var(--padding-sm) 0 var(--padding-md) 0;
     padding: 0;
 
     &:first-child {
@@ -68,34 +64,34 @@
 
   blockquote {
     border-left: 0.4em solid var(--hl-md);
-    padding: @padding-xxs @padding-md;
+    padding: var(--padding-xxs) var(--padding-md);
 
     p {
-      margin: @padding-xs 0;
+      margin: var(--padding-xs) 0;
     }
   }
 
   *:not(pre) > code {
-    padding: @padding-xxs @padding-xs;
-    font-size: @font-size-sm;
-    line-height: @font-size-xs;
-    font-family: @font-monospace;
+    padding: var(--padding-xxs) var(--padding-xs);
+    font-size: var(--font-size-sm);
+    line-height: var(--font-size-xs);
+    font-family: var(--font-monospace);
   }
 
   code {
     background-color: var(--hl-xs);
     border: 1px solid var(--hl-sm);
-    border-radius: @radius-sm;
+    border-radius: var(--radius-sm);
   }
 
   pre > code {
-    padding: @padding-sm;
+    padding: var(--padding-sm);
     overflow-x: auto;
   }
 
   & > ul,
   & > ol {
-    padding-left: @padding-xs;
+    padding-left: var(--padding-xs);
   }
 
   & > ul {
@@ -116,18 +112,18 @@
 
   ul,
   ol {
-    margin-left: @padding-md;
+    margin-left: var(--padding-md);
   }
 
   table {
     width: 100%;
-    background: @hl-xxs;
+    background: var(--hl-xxs);
     border-spacing: 2px;
     border-collapse: collapse;
 
     td,
     th {
-      padding: @padding-xxs @padding-sm;
+      padding: var(--padding-xxs) var(--padding-sm);
     }
 
     th {
@@ -145,7 +141,7 @@
     }
 
     thead tr {
-      background: @hl-xxs;
+      background: var(--hl-xxs);
     }
   }
 

--- a/packages/insomnia-app/app/ui/css/components/method-dropdown.less
+++ b/packages/insomnia-app/app/ui/css/components/method-dropdown.less
@@ -1,15 +1,12 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .method-dropdown {
   .dropdown__inner::before {
     content: '\25cf';
-    opacity: @opacity-subtle;
+    opacity: var(--opacity-subtle);
     -webkit-text-stroke: 1px rgba(0, 0, 0, 0.1);
   }
 
   .dropdown__text {
-    padding-left: @padding-md;
+    padding-left: var(--padding-md);
     color: var(--color-font);
     display: inline;
   }

--- a/packages/insomnia-app/app/ui/css/components/modal.less
+++ b/packages/insomnia-app/app/ui/css/components/modal.less
@@ -1,6 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .modal {
   // Hidden state
   position: absolute;
@@ -8,7 +5,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  padding: @padding-lg;
+  padding: var(--padding-lg);
 
   &:focus {
     outline: 0;
@@ -24,7 +21,7 @@
   }
 
   .modal__content__wrapper {
-    width: @modal-width;
+    width: var(--modal-width);
     height: 100%;
     max-width: 100%;
     max-height: 100%;
@@ -39,14 +36,14 @@
   }
 
   &.modal--wide .modal__content__wrapper {
-    width: @modal-width-wide;
+    width: var(--modal-width)-wide;
   }
 
   .modal__content {
     display: grid;
     grid-template-columns: 100%;
     grid-template-rows: auto minmax(0, 1fr) auto;
-    border-radius: @radius-md;
+    border-radius: var(--radius-md);
     overflow: visible;
     box-sizing: border-box;
     box-shadow: 0 0 2rem 0 rgba(0, 0, 0, 0.2);
@@ -55,7 +52,7 @@
     width: 100%;
     background-color: var(--color-bg);
     color: var(--color-font);
-    border: 1px solid @hl-sm;
+    border: 1px solid var(--hl-sm);
 
     // Since we disable pointer-events on the parent, re-enable them here
     pointer-events: auto;
@@ -63,17 +60,17 @@
 
   .modal__header {
     overflow: hidden;
-    border-bottom: 1px solid @hl-md;
-    height: @line-height-md;
-    font-size: @font-size-lg;
-    line-height: @line-height-md;
+    border-bottom: 1px solid var(--hl-md);
+    height: var(--line-height-md);
+    font-size: var(--font-size-lg);
+    line-height: var(--line-height-md);
     background-color: var(--color-bg);
     color: var(--color-font);
     display: flex;
     flex-direction: row;
 
     .modal__header__children {
-      padding-left: @padding-md;
+      padding-left: var(--padding-md);
       width: 100%;
 
       & > * {
@@ -106,7 +103,7 @@
   }
 
   .modal__footer {
-    border-top: 1px solid @hl-md;
+    border-top: 1px solid var(--hl-md);
     background-color: var(--color-bg);
     color: var(--color-font);
     display: flex;
@@ -116,7 +113,7 @@
     padding: 1px;
 
     button {
-      padding: 0 @padding-md;
+      padding: 0 var(--padding-md);
     }
   }
 
@@ -127,13 +124,13 @@
   }
 
   .modal__content > *:last-child {
-    border-bottom-left-radius: @radius-md;
-    border-bottom-right-radius: @radius-md;
+    border-bottom-left-radius: var(--radius-md);
+    border-bottom-right-radius: var(--radius-md);
   }
 
   .modal__content > *:first-child {
-    border-top-left-radius: @radius-md;
-    border-top-right-radius: @radius-md;
+    border-top-left-radius: var(--radius-md);
+    border-top-right-radius: var(--radius-md);
   }
 }
 

--- a/packages/insomnia-app/app/ui/css/components/pane.less
+++ b/packages/insomnia-app/app/ui/css/components/pane.less
@@ -1,10 +1,6 @@
-@import '../constants/colors';
-@import '../constants/dimensions';
-@import '../constants/fonts';
-
 .pane {
   display: grid;
-  grid-template-rows: @height-nav minmax(0, 1fr);
+  grid-template-rows: var(--height-nav) minmax(0, 1fr);
   grid-template-columns: 100%;
 
   .pane__header {
@@ -18,19 +14,20 @@
     color: var(--color-font);
     box-sizing: border-box;
 
-    border-left: 1px solid @hl-md;
-    border-bottom: 1px solid @hl-md;
-    border-top: 1px solid @hl-md;
+    border-left: 1px solid var(--hl-md);
+    border-bottom: 1px solid var(--hl-md);
+    border-top: 1px solid var(--hl-md);
 
     .pane__header__right {
-      box-shadow: calc(@padding-md * -1) 0 @padding-md calc(@padding-sm * -1) var(--color-bg);
+      box-shadow: calc(var(--padding-md) * -1) 0 var(--padding-md) calc(var(--padding-sm) * -1)
+        var(--color-bg);
       background: var(--color-bg);
-      font-size: @font-size-sm;
+      font-size: var(--font-size-sm);
     }
   }
 
   .pane__body {
-    border-left: 1px solid @hl-md;
+    border-left: 1px solid var(--hl-md);
     box-sizing: border-box;
     height: 100%;
     background: var(--color-bg);
@@ -39,7 +36,7 @@
 
   .pane__body--placeholder {
     overflow: hidden;
-    padding: @padding-md;
+    padding: var(--padding-md);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -47,7 +44,7 @@
 
     &,
     * {
-      color: @hl;
+      color: var(--hl);
     }
 
     & > * {
@@ -56,11 +53,11 @@
 
     .pane__body--placeholder__cta {
       width: auto;
-      margin: @padding-lg auto 0;
+      margin: var(--padding-lg) auto 0;
       display: block;
 
       & > * {
-        margin: @padding-xs;
+        margin: var(--padding-xs);
       }
     }
   }
@@ -70,24 +67,24 @@
     flex-direction: row;
     align-items: center;
     border-top: 1px solid var(--hl-md);
-    height: @line-height-xs;
-    font-size: @font-size-sm;
+    height: var(--line-height-xs);
+    font-size: var(--font-size-sm);
 
     input {
-      font-family: @font-monospace;
+      font-family: var(--font-monospace);
       margin-right: 0;
       width: 100%;
-      margin-left: @padding-md;
+      margin-left: var(--padding-md);
     }
 
     button {
       color: var(--hl);
-      padding: @padding-xs @padding-md;
+      padding: var(--padding-xs) var(--padding-md);
       height: 100%;
     }
   }
 }
 
 body[data-platform='win32'] .pane .pane__header {
-  border-top: 1px solid @hl-md;
+  border-top: 1px solid var(--hl-md);
 }

--- a/packages/insomnia-app/app/ui/css/components/query-editor.less
+++ b/packages/insomnia-app/app/ui/css/components/query-editor.less
@@ -1,10 +1,7 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .query-editor {
   display: grid;
   height: 100%;
-  grid-template-rows: auto minmax(100px, 1fr) @line-height-md;
+  grid-template-rows: auto minmax(100px, 1fr) var(--line-height-md);
   grid-template-columns: 100%;
 
   .query-editor__preview {

--- a/packages/insomnia-app/app/ui/css/components/request-pane.less
+++ b/packages/insomnia-app/app/ui/css/components/request-pane.less
@@ -1,9 +1,6 @@
-@import '../constants/colors';
-@import '../constants/dimensions';
-
 .request-pane {
   .request-pane__shortcuts-table {
-    color: @hl-xl;
+    color: var(--hl-xl);
     text-align: left;
   }
 }

--- a/packages/insomnia-app/app/ui/css/components/request-switcher.less
+++ b/packages/insomnia-app/app/ui/css/components/request-switcher.less
@@ -1,17 +1,14 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .request-switcher {
   .btn {
-    padding: @padding-xs @padding-md;
+    padding: var(--padding-xs) var(--padding-md);
   }
 
   .btn:hover {
-    background: @hl-xs;
+    background: var(--hl-xs);
   }
 
   .btn.focus {
-    background: @hl-sm;
+    background: var(--hl-sm);
   }
 
   .tag {

--- a/packages/insomnia-app/app/ui/css/components/request-url-bar.less
+++ b/packages/insomnia-app/app/ui/css/components/request-url-bar.less
@@ -1,6 +1,3 @@
-@import '../constants/colors';
-@import '../constants/dimensions';
-
 .urlbar {
   width: 100%;
   display: flex;
@@ -22,13 +19,13 @@
     // Make everything the same height
     &,
     & > i.fa {
-      line-height: @height-nav;
+      line-height: var(--height-nav);
     }
   }
 
   .urlbar__send-btn {
-    padding-right: @padding-md;
-    padding-left: @padding-md;
+    padding-right: var(--padding-md);
+    padding-left: var(--padding-md);
     min-width: 5em;
     text-align: center;
   }
@@ -37,10 +34,10 @@
     width: 100%;
     display: flex;
     flex-direction: row;
-    margin-left: @padding-xxs;
+    margin-left: var(--padding-xxs);
 
     * {
-      font-size: @font-size-md;
+      font-size: var(--font-size-md);
     }
   }
 
@@ -51,11 +48,11 @@
 
   button:focus,
   button:hover {
-    background-color: @hl-xs;
+    background-color: var(--hl-xs);
   }
 
   & > .dropdown > button {
-    padding-left: @padding-md;
-    padding-right: calc(@padding-md / 2);
+    padding-left: var(--padding-md);
+    padding-right: calc(var(--padding-md) / 2);
   }
 }

--- a/packages/insomnia-app/app/ui/css/components/response-pane.less
+++ b/packages/insomnia-app/app/ui/css/components/response-pane.less
@@ -1,5 +1,3 @@
-@import '../constants/colors';
-
 .response-pane {
   position: relative;
 

--- a/packages/insomnia-app/app/ui/css/components/scrollbar.less
+++ b/packages/insomnia-app/app/ui/css/components/scrollbar.less
@@ -1,18 +1,15 @@
-@import '../constants/colors';
-@import '../constants/dimensions';
-
 ::-webkit-scrollbar {
-  width: @scrollbar-width;
-  height: @scrollbar-width;
+  width: var(--scrollbar-width);
+  height: var(--scrollbar-width);
 }
 
 ::-webkit-scrollbar-track {
-  background-color: @hl-xs;
+  background-color: var(--hl-xs);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: @hl-md;
-  border-radius: @padding-sm;
+  background: var(--hl-md);
+  border-radius: var(--padding-sm);
 }
 
 ::-webkit-scrollbar-corner {

--- a/packages/insomnia-app/app/ui/css/components/shortcuts.less
+++ b/packages/insomnia-app/app/ui/css/components/shortcuts.less
@@ -1,6 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .shortcuts {
   td.options {
     width: 0.1em;
@@ -10,7 +7,7 @@
     input.key-comb {
       text-align: center;
       color: black;
-      font-size: @font-size-lg;
+      font-size: var(--font-size-lg);
     }
 
     .hidden {

--- a/packages/insomnia-app/app/ui/css/components/sidebar.less
+++ b/packages/insomnia-app/app/ui/css/components/sidebar.less
@@ -1,10 +1,7 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .sidebar {
   position: relative;
   display: grid;
-  grid-template-rows: @height-nav auto auto fit-content(20%) auto minmax(0, 1fr) auto;
+  grid-template-rows: var(--height-nav) auto auto fit-content(20%) auto minmax(0, 1fr) auto;
   grid-template-columns: 100%;
   z-index: 10;
 
@@ -15,7 +12,7 @@
   height: 100%;
 
   & > .sidebar__list:last-child {
-    padding-bottom: @padding-md;
+    padding-bottom: var(--padding-md);
   }
 
   &.sidebar--collapsed > * > * {
@@ -37,8 +34,8 @@
   // ~~~~~~~~~~~~~~ //
 
   .sidebar__header {
-    border-top: 1px solid @hl-md;
-    border-bottom: 1px solid @hl-md;
+    border-top: 1px solid var(--hl-md);
+    border-bottom: 1px solid var(--hl-md);
     box-sizing: border-box;
     background-color: var(--color-bg);
     color: var(--color-font);
@@ -51,7 +48,7 @@
 
     h1,
     h1 * {
-      font-size: @font-size-xl;
+      font-size: var(--font-size-xl);
     }
   }
 
@@ -62,23 +59,23 @@
   .sidebar__filter {
     // Nothing yet
     display: grid;
-    font-size: @font-size-sm;
+    font-size: var(--font-size-sm);
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     box-sizing: border-box;
-    padding: 0 0 @padding-xxs @padding-sm;
+    padding: 0 0 var(--padding-xxs) var(--padding-sm);
 
     .btn {
-      padding: 0 calc(@padding-md - @padding-xs);
-      margin-right: @padding-xxs;
-      border-radius: @radius-md;
-      margin-left: @padding-xxs;
-      margin-bottom: @padding-sm;
-      height: @line-height-xxs;
+      padding: 0 calc(var(--padding-md) - var(--padding-xs));
+      margin-right: var(--padding-xxs);
+      border-radius: var(--radius-md);
+      margin-left: var(--padding-xxs);
+      margin-bottom: var(--padding-sm);
+      height: var(--line-height-xxs);
     }
 
     .form-control input {
-      padding: @padding-xs;
+      padding: var(--padding-xs);
       margin-top: 0;
       height: auto;
       background: transparent;
@@ -91,10 +88,10 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    font-size: @font-size-sm;
-    color: @hl;
-    padding-left: @padding-xs;
-    padding-right: @padding-xs;
+    font-size: var(--font-size-sm);
+    color: var(--hl);
+    padding-left: var(--padding-xs);
+    padding-right: var(--padding-xs);
 
     // Make it scroll when too skinny
     overflow: auto;
@@ -105,8 +102,8 @@
 
     & > * {
       flex: 1;
-      margin-top: @padding-xs;
-      margin-bottom: @padding-xs;
+      margin-top: var(--padding-xs);
+      margin-bottom: var(--padding-xs);
       max-width: 100%;
     }
 
@@ -115,11 +112,11 @@
     }
 
     & > *:first-child {
-      margin-right: @padding-xxs;
+      margin-right: var(--padding-xxs);
     }
 
     & > *:last-child {
-      margin-left: @padding-xxs;
+      margin-left: var(--padding-xxs);
     }
 
     .sidebar__menu__thing {
@@ -143,9 +140,9 @@
 
     .btn {
       border-radius: 900px;
-      height: @line-height-xxs;
-      padding-left: @padding-xxs;
-      padding-right: @padding-xxs;
+      height: var(--line-height-xxs);
+      padding-left: var(--padding-xxs);
+      padding-right: var(--padding-xxs);
       color: var(--color-font);
 
       &:hover,
@@ -162,10 +159,10 @@
 
   &.sidebar--skinny .sidebar__filter {
     grid-template-columns: 100%;
-    padding-right: @padding-sm;
+    padding-right: var(--padding-sm);
 
     & > *:first-child {
-      margin-right: @padding-xs;
+      margin-right: var(--padding-xs);
     }
 
     & > *:last-child {
@@ -194,7 +191,7 @@
   .sidebar__list-separator {
     height: 2px;
     background-color: var(--hl-sm);
-    margin: @padding-sm 0;
+    margin: var(--padding-sm) 0;
 
     &--invisible {
       opacity: 0;
@@ -238,10 +235,10 @@
   .sidebar__item {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto auto;
-    grid-template-rows: @line-height-xs;
+    grid-template-rows: var(--line-height-xs);
 
     & > button {
-      color: @hl;
+      color: var(--hl);
     }
 
     & > * {
@@ -249,7 +246,7 @@
     }
 
     &.sidebar__item--big {
-      grid-template-rows: @line-height-sm;
+      grid-template-rows: var(--line-height-sm);
     }
 
     &.sidebar__item--active > button {
@@ -261,13 +258,13 @@
     }
 
     & > button {
-      border-left: @padding-xxs solid transparent;
+      border-left: var(--padding-xxs) solid transparent;
     }
 
     &.sidebar__item--active.sidebar__item--request,
     &:focus,
     &:hover {
-      background-color: @hl-xs;
+      background-color: var(--hl-xs);
       transition: background-color 0ms;
     }
 
@@ -302,23 +299,23 @@
   // Padding for nested folders
 
   .sidebar__list .sidebar__clickable {
-    padding-left: @padding-sm;
+    padding-left: var(--padding-sm);
   }
 
   .sidebar__list .sidebar__list .sidebar__clickable {
-    padding-left: calc(@padding-sm + @padding-md * 1);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 1);
   }
 
   .sidebar__list .sidebar__list .sidebar__list .sidebar__clickable {
-    padding-left: calc(@padding-sm + @padding-md * 2);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 2);
   }
 
   .sidebar__list .sidebar__list .sidebar__list .sidebar__list .sidebar__clickable {
-    padding-left: calc(@padding-sm + @padding-md * 3);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 3);
   }
 
   .sidebar__list .sidebar__list .sidebar__list .sidebar__list .sidebar__list .sidebar__clickable {
-    padding-left: calc(@padding-sm + @padding-md * 4);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 4);
   }
 
   .sidebar__list
@@ -328,7 +325,7 @@
     .sidebar__list
     .sidebar__list
     .sidebar__clickable {
-    padding-left: calc(@padding-sm + @padding-md * 5);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 5);
   }
 
   .sidebar__list
@@ -339,7 +336,7 @@
     .sidebar__list
     .sidebar__list
     .sidebar__clickable {
-    padding-left: calc(@padding-sm + @padding-md * 6);
+    padding-left: calc(var(--padding-sm) + var(--padding-md) * 6);
   }
 
   // ~~~~~~~~~~~~~~~ //
@@ -368,9 +365,9 @@
     & > button,
     & > .dropdown > button {
       display: none;
-      color: @hl;
+      color: var(--hl);
       height: 100%;
-      padding: 0 @padding-sm;
+      padding: 0 var(--padding-sm);
     }
 
     & > button:hover,
@@ -388,9 +385,9 @@
   .sidebar__item__icon-pin {
     display: flex;
     align-items: center;
-    color: @hl-xl;
+    color: var(--hl-xl);
     height: 100%;
-    padding: 0 @padding-sm;
+    padding: 0 var(--padding-sm);
   }
 
   .sidebar__item:hover .sidebar__item__icon-pin {
@@ -402,18 +399,18 @@
   // ~~~~~~~~~~~~~~ //
 
   .sidebar__footer {
-    height: @line-height-xs;
-    border-top: 1px solid @hl-md;
+    height: var(--line-height-xs);
+    border-top: 1px solid var(--hl-md);
     width: 100%;
   }
 
   .sidebar__footer > button,
   .sidebar__footer .dropdown > button {
-    font-size: @font-size-sm;
-    padding: @padding-xs @padding-md;
+    font-size: var(--font-size-sm);
+    padding: var(--padding-xs) var(--padding-md);
     height: 100%;
     margin: 0;
-    color: @hl;
+    color: var(--hl);
     box-sizing: border-box;
     overflow: hidden;
   }

--- a/packages/insomnia-app/app/ui/css/components/tabs.less
+++ b/packages/insomnia-app/app/ui/css/components/tabs.less
@@ -1,9 +1,3 @@
-@import '../constants/colors';
-@import '../constants/dimensions';
-
-@border-color: var(--hl-md);
-@focus-color: var(--hl-md);
-
 .react-tabs {
   width: 100%;
   height: 100%;
@@ -44,16 +38,16 @@
 
     &::after {
       width: 100%;
-      height: @line-height-sm;
+      height: var(--line-height-sm);
       content: '';
-      border-bottom: 1px solid @border-color;
+      border-bottom: 1px solid var(--hl-md);
     }
   }
 
   .react-tabs__tab {
-    height: @line-height-sm;
+    height: var(--line-height-sm);
     border: 1px solid transparent;
-    border-bottom: 1px solid @border-color;
+    border-bottom: 1px solid var(--hl-md);
     border-top: 0 !important;
     white-space: nowrap;
     display: flex;
@@ -91,26 +85,26 @@
     }
 
     & > * {
-      color: @hl;
+      color: var(--hl);
       height: 100%;
-      padding-left: calc(@padding-md / 4);
-      padding-right: calc(@padding-md / 4);
+      padding-left: calc(var(--padding-md) / 4);
+      padding-right: calc(var(--padding-md) / 4);
 
       &:first-child {
-        padding-left: @padding-md;
+        padding-left: var(--padding-md);
       }
 
       &:last-child {
-        padding-right: @padding-md;
+        padding-right: var(--padding-md);
       }
     }
 
     &:not(.react-tabs__tab--selected) .dropdown i.fa {
-      opacity: @opacity-super-subtle;
+      opacity: var(--opacity-super-subtle);
     }
 
     &.react-tabs__tab--selected:focus {
-      background-color: @focus-color;
+      background-color: var(--hl-md);
     }
 
     &.react-tabs__tab button:focus {
@@ -118,7 +112,7 @@
     }
 
     &.react-tabs__tab--selected {
-      border: 1px solid @border-color;
+      border: 1px solid var(--hl-md);
       border-bottom-color: transparent;
 
       * {

--- a/packages/insomnia-app/app/ui/css/components/tabs.less
+++ b/packages/insomnia-app/app/ui/css/components/tabs.less
@@ -21,11 +21,9 @@
     background-color: var(--color-bg);
     overflow: auto;
 
-    @scrollbar-height: @padding-sm;
-
     &::-webkit-scrollbar {
-      height: @scrollbar-height;
-      border-radius: calc(@scrollbar-height / 2);
+      height: var(--padding-sm);
+      border-radius: calc(var(--padding-sm) / 2);
     }
 
     &::-webkit-scrollbar-track {

--- a/packages/insomnia-app/app/ui/css/components/tag.less
+++ b/packages/insomnia-app/app/ui/css/components/tag.less
@@ -1,14 +1,11 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .tag {
   display: inline-block;
-  padding: @padding-xs @padding-sm;
+  padding: var(--padding-xs) var(--padding-sm);
   margin-right: 1em;
   line-height: 1em;
   box-sizing: border-box;
   text-align: center;
-  background: @hl-sm;
+  background: var(--hl-sm);
   border: 1px solid rgba(0, 0, 0, 0.07);
   white-space: nowrap;
 
@@ -24,9 +21,9 @@
   }
 
   &.tag--small {
-    padding: @padding-xxs @padding-xs;
-    margin-right: @padding-xs;
-    font-size: @font-size-xs;
+    padding: var(--padding-xxs) var(--padding-xs);
+    margin-right: var(--padding-xs);
+    font-size: var(--font-size-xs);
   }
 
   &.tag--no-bg {

--- a/packages/insomnia-app/app/ui/css/components/themes.less
+++ b/packages/insomnia-app/app/ui/css/components/themes.less
@@ -1,13 +1,10 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .themes {
-  padding-top: @padding-lg;
+  padding-top: var(--padding-lg);
 
   .themes__row {
     display: flex;
     flex-direction: row;
-    margin-bottom: @padding-lg;
+    margin-bottom: var(--padding-lg);
   }
 
   .themes__theme {
@@ -15,8 +12,8 @@
 
     h2 {
       margin-top: 0;
-      margin-bottom: @padding-xs;
-      font-size: @font-size-md !important;
+      margin-bottom: var(--padding-xs);
+      font-size: var(--font-size-md) !important;
     }
 
     svg {
@@ -60,14 +57,14 @@
 
   button {
     position: relative;
-    margin: @padding-md @padding-md;
+    margin: var(--padding-md) var(--padding-md);
     font-size: 0;
-    border-radius: @radius-md;
+    border-radius: var(--radius-md);
     overflow: hidden;
-    box-shadow: 0 0 0 1px @hl-sm;
+    box-shadow: 0 0 0 1px var(--hl-sm);
 
     &.active {
-      box-shadow: 0 0 0 @padding-xs var(--color-surprise);
+      box-shadow: 0 0 0 var(--padding-xs) var(--color-surprise);
     }
 
     &.active,
@@ -86,9 +83,9 @@
       align-items: center;
       font-weight: bold;
       position: absolute;
-      font-size: @font-size-md;
+      font-size: var(--font-size-md);
       text-transform: uppercase;
-      color: @hl-xl;
+      color: var(--hl-xl);
       left: 0;
       right: 0;
       top: 0;

--- a/packages/insomnia-app/app/ui/css/components/toast.less
+++ b/packages/insomnia-app/app/ui/css/components/toast.less
@@ -1,7 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-@import '../constants/animations';
-
 .toast {
   opacity: 0;
   position: absolute;
@@ -15,16 +11,16 @@
   grid-template-columns: auto auto;
   grid-template-rows: auto;
   transition: opacity 200ms, right 300ms, bottom 300ms, transform 200ms ease-out;
-  padding: @padding-sm;
+  padding: var(--padding-sm);
   transform: scale(0.8);
-  border-radius: @radius-md;
+  border-radius: var(--radius-md);
   border: 1px solid var(--hl-sm);
 
   &.toast--show {
     opacity: 1;
     transform: scale(1);
-    bottom: @padding-md;
-    right: @padding-md;
+    bottom: var(--padding-md);
+    right: var(--padding-md);
   }
 
   .toast__image,
@@ -40,7 +36,7 @@
   }
 
   .toast__actions {
-    padding-top: @padding-sm;
+    padding-top: var(--padding-sm);
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -48,18 +44,18 @@
   }
 
   .toast__image {
-    padding-right: @padding-sm;
+    padding-right: var(--padding-sm);
     display: flex;
     align-items: center;
     flex-direction: row;
 
     img {
-      margin-left: @padding-sm;
-      margin-right: @padding-sm;
+      margin-left: var(--padding-sm);
+      margin-right: var(--padding-sm);
       max-width: 5rem;
       max-height: 5rem;
       border-radius: 50%;
-      box-shadow: 0 0 @padding-sm rgba(0, 0, 0, 0.2);
+      box-shadow: 0 0 var(--padding-sm) rgba(0, 0, 0, 0.2);
     }
   }
 }

--- a/packages/insomnia-app/app/ui/css/components/tooltip.less
+++ b/packages/insomnia-app/app/ui/css/components/tooltip.less
@@ -1,5 +1,3 @@
-@import '../constants/dimensions';
-
 .tooltip {
   position: relative;
   display: inline-block;
@@ -13,9 +11,9 @@
   border: 1px solid var(--hl-sm);
   box-shadow: 0 0 1em rgba(0, 0, 0, 0.1);
   color: var(--color-font);
-  padding: @padding-sm @padding-md;
-  border-radius: @radius-sm;
-  font-size: @font-size-sm;
+  padding: var(--padding-sm) var(--padding-md);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
   max-width: 20rem;
   text-align: center;
   z-index: 10;

--- a/packages/insomnia-app/app/ui/css/components/workspace-dropdown.less
+++ b/packages/insomnia-app/app/ui/css/components/workspace-dropdown.less
@@ -1,6 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .workspace-dropdown {
   h1 {
     white-space: nowrap;
@@ -14,7 +11,7 @@
   }
 
   .btn {
-    padding: 0 @padding-md;
+    padding: 0 var(--padding-md);
     height: 100%;
   }
 

--- a/packages/insomnia-app/app/ui/css/components/wrapper.less
+++ b/packages/insomnia-app/app/ui/css/components/wrapper.less
@@ -1,6 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/colors';
-
 .wrapper {
   background-color: var(--color-bg);
   color: var(--color-font);
@@ -35,10 +32,10 @@
       position: absolute;
       height: 100%;
       z-index: 9;
-      width: @drag-width;
+      width: var(--drag-width);
       top: 0;
       // More to the right so it doesn't cover scroll bars
-      left: calc((@drag-width / 8) * -1);
+      left: calc((var(--drag-width) / 8) * -1);
     }
   }
 
@@ -88,11 +85,11 @@
 
     & > * {
       cursor: ns-resize;
-      height: @drag-width;
+      height: var(--drag-width);
       width: 100%;
       left: 0;
       // More to the right so it doesn't cover scroll bars
-      top: calc(@drag-width / 2 * -1);
+      top: calc(var(--drag-width) / 2 * -1);
     }
   }
 }

--- a/packages/insomnia-app/app/ui/css/components/wrapper.less
+++ b/packages/insomnia-app/app/ui/css/components/wrapper.less
@@ -97,7 +97,7 @@
   }
 }
 
-@media (max-width: @breakpoint-md) {
+@media (max-width: var(--breakpoint-md)) {
   .wrapper {
     .wrapper--vertical();
   }

--- a/packages/insomnia-app/app/ui/css/constants/colors.less
+++ b/packages/insomnia-app/app/ui/css/constants/colors.less
@@ -34,17 +34,6 @@
   }
 }
 
-@opacity-subtle: var(--opacity-subtle);
-@opacity-super-subtle: var(--opacity-super-subtle);
-
-@hl-xxs: var(--hl-xxs);
-@hl-xs: var(--hl-xs);
-@hl-sm: var(--hl-sm);
-@hl-md: var(--hl-md);
-@hl-lg: var(--hl-lg);
-@hl-xl: var(--hl-xl);
-@hl: var(--hl);
-
 [class^='http-method-'],
 [class*=' http-method-'] {
   // Default method color

--- a/packages/insomnia-app/app/ui/css/constants/colors.less
+++ b/packages/insomnia-app/app/ui/css/constants/colors.less
@@ -25,14 +25,17 @@
   --hl-xl: rgba(130, 130, 130, 0.8);
   --hl: rgba(130, 130, 130, 1);
 
+  --opacity-subtle: 0.7;
+  --opacity-super-subtle: 0.5;
+
   .theme--transparent-overlay {
     --color-bg: rgba(5, 5, 5, 0.7);
     --color-font: #ddd;
   }
 }
 
-@opacity-subtle: 0.7;
-@opacity-super-subtle: 0.5;
+@opacity-subtle: var(--opacity-subtle);
+@opacity-super-subtle: var(--opacity-super-subtle);
 
 @hl-xxs: var(--hl-xxs);
 @hl-xs: var(--hl-xs);

--- a/packages/insomnia-app/app/ui/css/constants/dimensions.less
+++ b/packages/insomnia-app/app/ui/css/constants/dimensions.less
@@ -1,60 +1,129 @@
 /* Fonts */
 html {
-  --font-size: 13px;
+  --color-bg: #fff;
+  --color-font: #555;
+
+  /* Colors */
+  --color-success: #50a500;
+  --color-notice: #d1b800;
+  --color-warning: #d48a39;
+  --color-danger: #bf0000;
+  --color-surprise: #8570d2;
+  --color-info: #0092bf;
+
+  /* Font Colors */
+  --color-font-success: #fff;
+  --color-font-notice: #fff;
+  --color-font-warning: #fff;
+  --color-font-danger: #fff;
+  --color-font-surprise: #fff;
+  --color-font-info: #fff;
+
+  /* Highlight */
+  --hl-xxs: rgba(130, 130, 130, 0.05);
+  --hl-xs: rgba(130, 130, 130, 0.1);
+  --hl-sm: rgba(130, 130, 130, 0.25);
+  --hl-md: rgba(130, 130, 130, 0.35);
+  --hl-lg: rgba(130, 130, 130, 0.5);
+  --hl-xl: rgba(130, 130, 130, 0.8);
+  --hl: rgba(130, 130, 130, 1);
+
+  /* Font Size */
+  --font-size-xxs: 8px;
+  --font-size-xs: 10px;
+  --font-size-sm: 12px;
+  --font-size-md: 13px;
+  --font-size-lg: 15px;
+  --font-size-xl: 19px;
+  --font-size-xxl: 21px;
+  --font-size-xxxl: 24px;
+  --font-size: var(--font-size-md);
+
+  /* Padding */
+  --padding-md: calc(var(--font-size) * 1.2);
+  --padding-sm: calc(var(--font-size) * 0.6);
+  --padding-xs: calc(var(--font-size) * 0.4);
+  --padding-xxs: calc(var(--font-size) * 0.2);
+  --padding-lg: calc(var(--font-size) * 2.5);
+  --padding-xl: calc(var(--font-size) * 5);
+
+  /* Wrapper */
+  --line-height-md: calc(var(--font-size) * 3.6);
+  --line-height-sm: calc(var(--font-size) * 2.88);
+  --line-height-xs: calc(var(--font-size) * 2.448);
+  --line-height-xxs: calc(var(--font-size) * 2.08);
+
+  /* Breakpoints */
+  --breakpoint-lg: 1100px;
+  --breakpoint-md: 880px;
+  --breakpoint-sm: 660px;
+
+  /* Radius */
+  --radius-sm: ~'calc(var(--font-size) * 0.2)';
+  --radius-md: ~'calc(var(--font-size) * 0.3)';
+
+  /* Scrollbars */
+  --scrollbar-width: ~'calc(var(--font-size) * 0.6)';
+
+  --dropdown-min-width: ~'calc(var(--font-size) * 12)';
+
+  /* Modals */
+  --modal-width: ~'calc(var(--font-size) * 60)';
+  --modal-width-wide: ~'calc(var(--font-size) * 70)';
+
+  /* Other */
+  --drag-width: ~'calc(var(--font-size) * 0.5)';
 }
 
 @font-size: var(--font-size);
-@font-size-xxs: ~'calc(var(--font-size) * 0.6)';
-@font-size-xs: ~'calc(var(--font-size) * 0.8)';
-@font-size-sm: ~'calc(var(--font-size) * 0.9)';
-@font-size-md: ~'calc(var(--font-size) * 1.0)';
-@font-size-lg: ~'calc(var(--font-size) * 1.2)';
-@font-size-xl: ~'calc(var(--font-size) * 1.35)';
-@font-size-xxl: ~'calc(var(--font-size) * 1.5)';
-@font-size-xxxl: ~'calc(var(--font-size) * 1.7)';
+@font-size-xxs: var(--font-size-xxs);
+@font-size-xs: var(--font-size-xs);
+@font-size-sm: var(--font-size-sm);
+@font-size-md: var(--font-size-md);
+@font-size-lg: var(--font-size-lg);
+@font-size-xl: var(--font-size-xl);
+@font-size-xxl: var(--font-size-xxl);
+@font-size-xxxl: var(--font-size-xxxl);
 
 /* Padding */
-@padding-md: ~'calc(var(--font-size) * 1.2)';
-@padding-sm: ~'calc(var(--font-size) * 0.6)';
-@padding-xs: ~'calc(var(--font-size) * 0.4)';
-@padding-xxs: ~'calc(var(--font-size) * 0.2)';
-@padding-lg: ~'calc(var(--font-size) * 2.5)';
-@padding-xl: ~'calc(var(--font-size) * 5)';
+@padding-xxs: var(--padding-xxs);
+@padding-xs: var(--padding-xs);
+@padding-sm: var(--padding-sm);
+@padding-md: var(--padding-md);
+@padding-lg: var(--padding-lg);
+@padding-xl: var(--padding-xl);
 
 /* Wrapper */
-// line-height-md = x * 3.6
-// line-height-sm = x * 3.6 * 0.8 (2.88)
-// line-height-xs = x * 3.6 * 0.8 * 0.85 (2.448)
-// line-height-xxs= x * 3.6 * 0.8 * 0.85 * 0.85 (2.08)
-@line-height-md: ~'calc(var(--font-size) * 3.6)';
-@line-height-sm: ~'calc(var(--font-size) * 2.88)';
-@line-height-xs: ~'calc(var(--font-size) * 2.448)';
-@line-height-xxs: ~'calc(var(--font-size) * 2.08)';
+@line-height-md: var(--line-height-md);
+@line-height-sm: var(--line-height-sm);
+@line-height-xs: var(--line-height-xs);
+@line-height-xxs: var(--line-height-xxs);
+@line-height-xxxs: var(--line-height-xxxs);
 
 /* Nav */
-@height-nav: @line-height-md;
+@height-nav: var(--line-height-md);
 
 /* Scrollbars */
-@scrollbar-width: ~'calc(var(--font-size) * 0.6)';
+@scrollbar-width: var(--scrollbar-width);
 
 /* Borders */
-@radius-sm: ~'calc(var(--font-size) * 0.2)';
-@radius-md: ~'calc(var(--font-size) * 0.3)';
+@radius-sm: var(--radius-sm);
+@radius-md: var(--radius-md);
 
 /* Dropdowns */
-@dropdown-min-width: ~'calc(var(--font-size) * 12)';
+@dropdown-min-width: var(--dropdown-min-width);
 
 /* Modals */
-@modal-width: ~'calc(var(--font-size) * 60)';
-@modal-width-wide: ~'calc(var(--font-size) * 70)';
+@modal-width: var(--modal-width);
+@modal-width-wide: var(--modal-width-wide);
 
 /* Other */
-@drag-width: ~'calc(var(--font-size) * 0.5)';
+@drag-width: var(--drag-width);
 
 /* Breakpoints */
-@breakpoint-lg: 1100px;
-@breakpoint-md: 880px;
-@breakpoint-sm: 660px;
+@breakpoint-lg: var(--breakpoint-lg);
+@breakpoint-md: var(--breakpoint-md);
+@breakpoint-sm: var(--breakpoint-sm);
 
 .txt-xxs {
   font-size: @font-size-xxs !important;

--- a/packages/insomnia-app/app/ui/css/constants/dimensions.less
+++ b/packages/insomnia-app/app/ui/css/constants/dimensions.less
@@ -59,96 +59,45 @@ html {
   --breakpoint-sm: 660px;
 
   /* Radius */
-  --radius-sm: ~'calc(var(--font-size) * 0.2)';
-  --radius-md: ~'calc(var(--font-size) * 0.3)';
+  --radius-sm: calc(var(--font-size) * 0.2);
+  --radius-md: calc(var(--font-size) * 0.3);
 
   /* Scrollbars */
-  --scrollbar-width: ~'calc(var(--font-size) * 0.6)';
-
-  --dropdown-min-width: ~'calc(var(--font-size) * 12)';
+  --scrollbar-width: calc(var(--font-size) * 0.6);
 
   /* Modals */
-  --modal-width: ~'calc(var(--font-size) * 60)';
-  --modal-width-wide: ~'calc(var(--font-size) * 70)';
+  --modal-width: calc(var(--font-size) * 60);
+  --modal-width-wide: calc(var(--font-size) * 70);
 
   /* Other */
-  --drag-width: ~'calc(var(--font-size) * 0.5)';
+  --drag-width: calc(var(--font-size) * 0.5);
+  --height-nav: var(--line-height-md);
 }
 
-@font-size: var(--font-size);
-@font-size-xxs: var(--font-size-xxs);
-@font-size-xs: var(--font-size-xs);
-@font-size-sm: var(--font-size-sm);
-@font-size-md: var(--font-size-md);
-@font-size-lg: var(--font-size-lg);
-@font-size-xl: var(--font-size-xl);
-@font-size-xxl: var(--font-size-xxl);
-@font-size-xxxl: var(--font-size-xxxl);
-
-/* Padding */
-@padding-xxs: var(--padding-xxs);
-@padding-xs: var(--padding-xs);
-@padding-sm: var(--padding-sm);
-@padding-md: var(--padding-md);
-@padding-lg: var(--padding-lg);
-@padding-xl: var(--padding-xl);
-
-/* Wrapper */
-@line-height-md: var(--line-height-md);
-@line-height-sm: var(--line-height-sm);
-@line-height-xs: var(--line-height-xs);
-@line-height-xxs: var(--line-height-xxs);
-@line-height-xxxs: var(--line-height-xxxs);
-
-/* Nav */
-@height-nav: var(--line-height-md);
-
-/* Scrollbars */
-@scrollbar-width: var(--scrollbar-width);
-
-/* Borders */
-@radius-sm: var(--radius-sm);
-@radius-md: var(--radius-md);
-
-/* Dropdowns */
-@dropdown-min-width: var(--dropdown-min-width);
-
-/* Modals */
-@modal-width: var(--modal-width);
-@modal-width-wide: var(--modal-width-wide);
-
-/* Other */
-@drag-width: var(--drag-width);
-
-/* Breakpoints */
-@breakpoint-lg: var(--breakpoint-lg);
-@breakpoint-md: var(--breakpoint-md);
-@breakpoint-sm: var(--breakpoint-sm);
-
 .txt-xxs {
-  font-size: @font-size-xxs !important;
+  font-size: var(--font-size-xxs) !important;
 }
 
 .txt-xs {
-  font-size: @font-size-xs !important;
+  font-size: var(--font-size-xs) !important;
 }
 
 .txt-sm {
-  font-size: @font-size-sm !important;
+  font-size: var(--font-size-sm) !important;
 }
 
 .txt-md {
-  font-size: @font-size-md !important;
+  font-size: var(--font-size-md) !important;
 }
 
 .txt-lg {
-  font-size: @font-size-lg !important;
+  font-size: var(--font-size-lg) !important;
 }
 
 .txt-xl {
-  font-size: @font-size-xl !important;
+  font-size: var(--font-size-xl) !important;
 }
 
 .txt-xxl {
-  font-size: @font-size-xxl !important;
+  font-size: var(--font-size-xxl) !important;
 }

--- a/packages/insomnia-app/app/ui/css/constants/fonts.less
+++ b/packages/insomnia-app/app/ui/css/constants/fonts.less
@@ -5,6 +5,3 @@ html {
     'Ubuntu', 'Droid Sans', sans-serif;
   --font-ligatures: normal;
 }
-
-@font-monospace: var(--font-monospace);
-@font-default: var(--font-default);

--- a/packages/insomnia-app/app/ui/css/editor/dialog.less
+++ b/packages/insomnia-app/app/ui/css/editor/dialog.less
@@ -1,6 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/fonts';
-
 // Search dialog (and others)
 .editor {
   .CodeMirror-dialog {
@@ -10,7 +7,7 @@
     border-color: var(--hl-md);
     box-sizing: border-box;
     width: 100%;
-    padding: @padding-sm @padding-xs @padding-xs @padding-xs;
+    padding: var(--padding-sm) var(--padding-xs) var(--padding-xs) var(--padding-xs);
     box-shadow: 0 0 1em rgba(0, 0, 0, 0.1);
     display: flex;
     flex-direction: row;
@@ -18,7 +15,7 @@
     white-space: nowrap;
 
     input {
-      font-family: @font-monospace !important;
+      font-family: var(--font-monospace) !important;
       border: 0 !important;
       height: 1em !important;
       padding: 0 !important;

--- a/packages/insomnia-app/app/ui/css/editor/general.less
+++ b/packages/insomnia-app/app/ui/css/editor/general.less
@@ -1,6 +1,4 @@
 @import '../constants/animations';
-@import '../constants/dimensions';
-@import '../constants/fonts';
 
 .editor {
   box-sizing: border-box;
@@ -41,19 +39,19 @@
     flex-direction: row;
     align-items: center;
     border-top: 1px solid var(--hl-md);
-    height: @line-height-xs;
-    font-size: @font-size-sm;
+    height: var(--line-height-xs);
+    font-size: var(--font-size-sm);
 
     input {
-      font-family: @font-monospace;
+      font-family: var(--font-monospace);
       margin-right: 0;
       width: 100%;
-      margin-left: @padding-md;
+      margin-left: var(--padding-md);
     }
 
     button {
       color: var(--hl);
-      padding: @padding-xs @padding-md;
+      padding: var(--padding-xs) var(--padding-md);
       height: 100%;
     }
   }
@@ -62,7 +60,7 @@
     height: 100% !important;
     width: 100%;
     box-sizing: border-box;
-    font-family: @font-monospace;
+    font-family: var(--font-monospace);
 
     .CodeMirror-line * {
       font-variant-ligatures: var(--font-ligatures);

--- a/packages/insomnia-app/app/ui/css/editor/hints.less
+++ b/packages/insomnia-app/app/ui/css/editor/hints.less
@@ -1,8 +1,3 @@
-@import '../constants/colors';
-@import '../constants/animations';
-@import '../constants/dimensions';
-@import '../constants/fonts';
-
 // NOTE: This is NOT a child of .editor
 .CodeMirror-hints {
   border: 0;
@@ -21,9 +16,9 @@
     padding: 0 !important; // ugh
     border-radius: 0;
     display: grid;
-    grid-template-columns: @line-height-xxs auto minmax(0, 1fr);
+    grid-template-columns: var(--line-height-xxs) auto minmax(0, 1fr);
     background: var(--color-bg);
-    font-size: @font-size-xs;
+    font-size: var(--font-size-xs);
 
     &.type--variable {
       .label {
@@ -47,7 +42,7 @@
     }
 
     &:not(.fancy-hint)::before {
-      margin-left: calc(@padding-sm * -1);
+      margin-left: calc(var(--padding-sm) * -1);
       content: '\1d43a';
       background: var(--color-warning);
       color: var(--color-font-warning);
@@ -58,8 +53,8 @@
     .value,
     .label {
       min-height: 100%;
-      line-height: @line-height-xxs;
-      padding: 0 @padding-sm !important;
+      line-height: var(--line-height-xxs);
+      padding: 0 var(--padding-sm) !important;
       margin: 0;
       box-sizing: border-box;
     }
@@ -68,7 +63,7 @@
     .name,
     .value {
       background: var(--color-bg);
-      font-family: @font-monospace !important;
+      font-family: var(--font-monospace) !important;
 
       // Ellipsis when too long
       width: 100%;
@@ -80,7 +75,7 @@
 
     .value {
       text-align: right;
-      padding-left: @padding-lg;
+      padding-left: var(--padding-lg);
       font-style: italic;
       font-size: 0.9em;
     }
@@ -88,10 +83,10 @@
     &:not(.fancy-hint)::before,
     .label {
       opacity: 0.8;
-      font-size: @font-size-sm;
-      font-family: @font-default;
+      font-size: var(--font-size-sm);
+      font-family: var(--font-default);
       text-align: center;
-      width: @line-height-xxs;
+      width: var(--line-height-xxs);
     }
 
     &:hover,

--- a/packages/insomnia-app/app/ui/css/editor/nunjucks-tag.less
+++ b/packages/insomnia-app/app/ui/css/editor/nunjucks-tag.less
@@ -1,8 +1,6 @@
-@import '../constants/fonts';
-
 .editor {
   .nunjucks-tag {
-    font-family: @font-monospace !important;
+    font-family: var(--font-monospace) !important;
     padding: 0.13em 0.5em;
     box-sizing: border-box;
     margin: 0 0.1em;

--- a/packages/insomnia-app/app/ui/css/editor/one-line-editor.less
+++ b/packages/insomnia-app/app/ui/css/editor/one-line-editor.less
@@ -1,11 +1,7 @@
-@import '../constants/colors';
-@import '../constants/animations';
-@import '../constants/dimensions';
-@import '../constants/fonts';
-
 .editor.editor--single-line {
-  &, * {
-    font-family: @font-default;
+  &,
+  * {
+    font-family: var(--font-default);
   }
 
   .CodeMirror > div > textarea {

--- a/packages/insomnia-app/app/ui/css/editor/theme.less
+++ b/packages/insomnia-app/app/ui/css/editor/theme.less
@@ -1,5 +1,3 @@
-@import '../constants/colors';
-
 /* Based on Sublime Text's Monokai theme */
 .editor {
   .CodeMirror {

--- a/packages/insomnia-app/app/ui/css/editor/tooltip.less
+++ b/packages/insomnia-app/app/ui/css/editor/tooltip.less
@@ -1,6 +1,3 @@
-@import '../constants/dimensions';
-@import '../constants/fonts';
-
 // Tooltip for errors
 // NOTE: This is a global element, and does not live inside .editor
 .CodeMirror-lint-tooltip {
@@ -9,9 +6,9 @@
   color: var(--color-font);
   border-color: var(--color-danger);
   border-radius: 0;
-  font-size: @font-size-sm;
-  font-family: @font-monospace;
-  padding: @padding-xs @padding-sm;
+  font-size: var(--font-size-sm);
+  font-family: var(--font-monospace);
+  padding: var(--padding-xs) var(--padding-sm);
   z-index: 99999;
 
   .CodeMirror-lint-message-error {

--- a/packages/insomnia-app/app/ui/css/index.less
+++ b/packages/insomnia-app/app/ui/css/index.less
@@ -16,6 +16,12 @@
 /* Layout */
 @import 'components/forms';
 
+/* Variables */
+@import './constants/animations';
+@import './constants/colors';
+@import './constants/dimensions';
+@import './constants/fonts';
+
 /* Components */
 @import 'components/app';
 @import 'components/changelog';

--- a/packages/insomnia-app/app/ui/css/layout/base.less
+++ b/packages/insomnia-app/app/ui/css/layout/base.less
@@ -759,14 +759,6 @@ strong {
   text-decoration: underline;
 }
 
-.hide-above-lg {
-  display: none;
-}
-
-.hide-above-md {
-  display: none;
-}
-
 .react-hot-loader-error-overlay > div {
   position: fixed;
   left: 0;
@@ -781,29 +773,5 @@ strong {
     margin: 0.2em;
     font-size: 0.8em;
     padding: 0.2em 0.5em;
-  }
-}
-
-@media (max-width: @breakpoint-lg) {
-  .hide-below-lg {
-    display: none;
-  }
-
-  .hide-above-lg {
-    display: initial;
-  }
-}
-
-@media (max-width: @breakpoint-md) {
-  html {
-    font-size: calc(@font-size * 0.95);
-  }
-
-  .hide-below-md {
-    display: none;
-  }
-
-  .hide-above-md {
-    display: initial;
   }
 }

--- a/packages/insomnia-app/app/ui/css/layout/base.less
+++ b/packages/insomnia-app/app/ui/css/layout/base.less
@@ -1,7 +1,3 @@
-@import '../constants/colors';
-@import '../constants/dimensions';
-@import '../constants/fonts';
-
 html {
   font-size: var(--font-size);
   font-variant-ligatures: var(--font-ligatures);
@@ -23,7 +19,7 @@ h5,
 h6,
 input {
   font-weight: 400;
-  font-family: @font-default;
+  font-family: var(--font-default);
 }
 
 body {
@@ -32,35 +28,35 @@ body {
 }
 
 h1 {
-  font-size: @font-size-xxl;
+  font-size: var(--font-size-xxl);
 }
 
 h2 {
-  font-size: @font-size-xl;
+  font-size: var(--font-size-xl);
 }
 
 h3 {
-  font-size: @font-size-lg;
+  font-size: var(--font-size-lg);
 }
 
 p,
 h1,
 h2,
 h3 {
-  margin-bottom: @padding-sm;
-  margin-top: @padding-md;
+  margin-bottom: var(--padding-sm);
+  margin-top: var(--padding-md);
 }
 
 hr {
   width: 100%;
   height: 0;
   border: 0;
-  border-bottom: 1px solid @hl-md;
-  margin: @padding-md 0;
+  border-bottom: 1px solid var(--hl-md);
+  margin: var(--padding-md) 0;
 }
 
 hr.hr--spaced {
-  margin: @padding-lg 0;
+  margin: var(--padding-lg) 0;
 }
 
 em {
@@ -69,7 +65,7 @@ em {
 
 label {
   display: inline-block;
-  padding-top: @padding-xs;
+  padding-top: var(--padding-xs);
 }
 
 p {
@@ -78,7 +74,7 @@ p {
 
 ul.ul--pretty {
   list-style: disc;
-  padding-left: @padding-lg;
+  padding-left: var(--padding-lg);
   margin-bottom: 1.5em;
 }
 
@@ -89,11 +85,11 @@ small {
 .label--small,
 label > small,
 table th {
-  color: @hl;
+  color: var(--hl);
   font-weight: 600;
   text-transform: uppercase;
-  font-size: @font-size-xs;
-  padding-bottom: @padding-xxs;
+  font-size: var(--font-size-xs);
+  padding-bottom: var(--padding-xxs);
 }
 
 webview {
@@ -107,12 +103,12 @@ table.table--fancy {
 
   td,
   th {
-    padding: @padding-sm;
+    padding: var(--padding-sm);
     vertical-align: top;
   }
 
   &.table--compact td {
-    padding: @padding-xs;
+    padding: var(--padding-xs);
   }
 
   &.table--valign-middle {
@@ -127,17 +123,17 @@ table.table--fancy {
   }
 
   &.table--striped tbody tr:nth-child(odd) {
-    background: @hl-xs;
+    background: var(--hl-xs);
   }
 
   &.table--outlined {
     th {
-      background: @hl-xxs;
+      background: var(--hl-xxs);
     }
 
     &,
     td {
-      border: 1px solid @hl-sm;
+      border: 1px solid var(--hl-sm);
     }
 
     tr.table--no-outline-row td {
@@ -146,7 +142,7 @@ table.table--fancy {
     }
 
     & {
-      border-radius: @radius-md;
+      border-radius: var(--radius-md);
       border-collapse: unset;
     }
 
@@ -163,10 +159,10 @@ table.table--fancy {
 
 code {
   display: inline-block;
-  background: @hl-xs;
-  padding: @padding-xs @padding-sm;
+  background: var(--hl-xs);
+  padding: var(--padding-xs) var(--padding-sm);
   color: var(--color-font);
-  border: 1px solid @hl-sm;
+  border: 1px solid var(--hl-sm);
   font-size: 0.9em;
 
   &.code--compact {
@@ -178,12 +174,12 @@ code {
 code,
 pre,
 .monospace {
-  font-family: @font-monospace;
+  font-family: var(--font-monospace);
   tab-size: 4;
 }
 
 .font-normal {
-  font-family: @font-default;
+  font-family: var(--font-default);
 }
 
 .pre {
@@ -195,9 +191,9 @@ div.notice,
 p.notice {
   text-align: center;
   color: var(--color-font) !important;
-  padding: calc(@padding-sm * 1.5);
+  padding: calc(var(--padding-sm) * 1.5);
   border: 1px dotted var(--hl);
-  border-radius: @radius-md;
+  border-radius: var(--radius-md);
   position: relative;
   z-index: 0;
   overflow: auto;
@@ -216,7 +212,7 @@ p.notice {
   a {
     text-decoration: underline;
     color: var(--color-font);
-    opacity: @opacity-subtle;
+    opacity: var(--opacity-subtle);
   }
 
   a:hover {
@@ -299,10 +295,10 @@ p.notice {
 
 blockquote {
   border-left: 0.4em solid var(--hl-md);
-  padding: @padding-xxs @padding-md;
+  padding: var(--padding-xxs) var(--padding-md);
 
   p {
-    margin: @padding-xs 0;
+    margin: var(--padding-xs) 0;
   }
 }
 
@@ -315,19 +311,19 @@ blockquote {
 }
 
 .faint {
-  opacity: @opacity-subtle;
+  opacity: var(--opacity-subtle);
 }
 
 .super-faint {
-  opacity: @opacity-subtle * 0.8;
+  opacity: calc(var(--opacity-subtle) * 0.8);
 }
 
 .super-duper-faint {
-  opacity: @opacity-subtle * 0.5;
+  opacity: calc(var(--opacity-subtle) * 0.5);
 }
 
 .ultra-faint {
-  opacity: @opacity-subtle * 0.2;
+  opacity: calc(var(--opacity-subtle) * 0.2);
 }
 
 .faded {
@@ -347,7 +343,7 @@ blockquote {
 }
 
 .outlined {
-  border: 1px solid @hl-md;
+  border: 1px solid var(--hl-md);
 }
 
 .valign-bottom {
@@ -383,11 +379,11 @@ blockquote {
   }
 
   & > *:not(:first-child) {
-    padding-left: @padding-xs;
+    padding-left: var(--padding-xs);
   }
 
   & > *:not(:last-child) {
-    padding-right: @padding-xs;
+    padding-right: var(--padding-xs);
   }
 }
 
@@ -430,7 +426,7 @@ blockquote {
 }
 
 .height-md {
-  height: @line-height-md;
+  height: var(--line-height-md);
 }
 
 .pointer {
@@ -498,55 +494,55 @@ i.fa.fa--fixed-width {
 }
 
 .border-top {
-  border-top: 1px solid @hl-md;
+  border-top: 1px solid var(--hl-md);
 }
 
 .pad {
   box-sizing: border-box;
-  padding: @padding-md;
+  padding: var(--padding-md);
 }
 
 .pad-sm {
   box-sizing: border-box;
-  padding: @padding-sm;
+  padding: var(--padding-sm);
 }
 
 .pad-xs {
   box-sizing: border-box;
-  padding: @padding-xs;
+  padding: var(--padding-xs);
 }
 
 .pad-xxs {
   box-sizing: border-box;
-  padding: @padding-xxs;
+  padding: var(--padding-xxs);
 }
 
 .pad-left {
   box-sizing: border-box;
-  padding-left: @padding-md;
+  padding-left: var(--padding-md);
 }
 
 .pad-left-sm {
-  padding-left: calc(@padding-md / 2);
+  padding-left: calc(var(--padding-md) / 2);
 }
 
 .pad-right {
   box-sizing: border-box;
-  padding-right: @padding-md;
+  padding-right: var(--padding-md);
 }
 
 .pad-right-sm {
-  padding-right: calc(@padding-md / 2);
+  padding-right: calc(var(--padding-md) / 2);
 }
 
 .pad-top {
   box-sizing: border-box;
-  padding-top: @padding-md;
+  padding-top: var(--padding-md);
 }
 
 .pad-top-sm {
   box-sizing: border-box;
-  padding-top: calc(@padding-sm);
+  padding-top: calc(var(--padding-sm));
 }
 
 .space-left {
@@ -562,61 +558,61 @@ i.fa.fa--fixed-width {
 }
 
 .margin {
-  margin: @padding-md;
+  margin: var(--padding-md);
 }
 
 .margin-sm {
-  margin: @padding-sm;
+  margin: var(--padding-sm);
 }
 
 .margin-xs {
-  margin: @padding-xs;
+  margin: var(--padding-xs);
 }
 
 .margin-top-sm {
-  margin-top: @padding-sm;
+  margin-top: var(--padding-sm);
 }
 
 .margin-top {
-  margin-top: @padding-md;
+  margin-top: var(--padding-md);
 }
 
 .margin-left {
-  margin-left: @padding-md;
+  margin-left: var(--padding-md);
 }
 
 .margin-left-sm {
-  margin-left: @padding-sm;
+  margin-left: var(--padding-sm);
 }
 
 .margin-right-sm {
-  margin-right: @padding-sm;
+  margin-right: var(--padding-sm);
 }
 
 .margin-bottom {
-  margin-bottom: @padding-md;
+  margin-bottom: var(--padding-md);
 }
 
 .margin-bottom-sm {
-  margin-bottom: @padding-sm;
+  margin-bottom: var(--padding-sm);
 }
 
 .margin-bottom-xs {
-  margin-bottom: @padding-xs;
+  margin-bottom: var(--padding-xs);
 }
 
 .margin-top-sm {
-  margin-top: @padding-sm !important;
+  margin-top: var(--padding-sm) !important;
 }
 
 .pad-bottom {
   box-sizing: border-box;
-  padding-bottom: @padding-md;
+  padding-bottom: var(--padding-md);
 }
 
 .pad-bottom-sm {
   box-sizing: border-box;
-  padding-bottom: @padding-sm;
+  padding-bottom: var(--padding-sm);
 }
 
 .no-margin {
@@ -737,7 +733,7 @@ i.fa.fa--fixed-width {
   }
 
   .section__body {
-    border-right: 1px solid @hl-sm;
+    border-right: 1px solid var(--hl-sm);
   }
 }
 


### PR DESCRIPTION
In order to support the `styled-components` Storybook stuff, we need to use CSS vars instead of Less vars. Since the app already used a mixture of the two, it made sense to just convert everything to CSS vars. This both simplifies things and allows us to use the same config within Storybook components.