### PR TITLE
Make the OpenAPI 3.0 support HTTP Bearer security scheme

### DIFF
--- a/packages/insomnia-importers/README.md
+++ b/packages/insomnia-importers/README.md
@@ -10,6 +10,7 @@ Insomnia v3 format.
 - cURL
 - HTTP Archive Format 1.2 (HAR)
 - Swagger 2.0
+- OpenAPI 3.0
 
 ## Installation
 
@@ -20,7 +21,7 @@ npm install -g insomnia-importers
 ```
 
 For programmatic usage, install in project
- 
+
 ```bash
 npm install --save insomnia-importers
 ```
@@ -34,10 +35,10 @@ insomnia-import /path/to/har-export.json > insomnia-export.json
 ## Programmatic Usage
 
 ```javascript
-const importers = require('insomnia-importers')
+const importers = require('insomnia-importers');
 
 // Convert a Curl command
-const output = importers.convert('curl -X POST https://insomnia.rest --data "Cool!"')
+const output = importers.convert('curl -X POST https://insomnia.rest --data "Cool!"');
 
 // Pretty print the result
 console.log(JSON.stringify(output.data, null, 2));

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-input.yaml
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-input.yaml
@@ -10,6 +10,9 @@ components:
     Basic:
       type: http
       scheme: basic
+    Bearer:
+      type: http
+      scheme: bearer
     Key-Header:
       type: apiKey
       name: x-api_key
@@ -28,6 +31,13 @@ paths:
     get:
       security:
         - Basic: []
+      responses:
+        '200':
+          description: OK
+  /bearer:
+    get:
+      security:
+        - Bearer: []
       responses:
         '200':
           description: OK

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-output.json
@@ -1,141 +1,158 @@
 {
-  "__export_date": "2019-10-12T17:07:14.568Z",
-  "__export_format": 4,
-  "__export_source": "insomnia.importers:v0.1.0",
   "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2020-02-19T03:47:33.193Z",
+  "__export_source": "insomnia.importers:v0.1.0",
   "resources": [
     {
-      "_id": "__WORKSPACE_ID__",
       "_type": "workspace",
-      "description": "",
+      "_id": "__WORKSPACE_ID__",
+      "parentId": null,
       "name": "Endpoint Security 1.2",
-      "parentId": null
+      "description": ""
     },
     {
-      "_id": "__BASE_ENVIRONMENT_ID__",
-      "_type": "environment",
+      "parentId": "__WORKSPACE_ID__",
+      "name": "Base environment",
       "data": {
         "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
       },
-      "name": "Base environment",
-      "parentId": "__WORKSPACE_ID__"
+      "_type": "environment",
+      "_id": "__BASE_ENVIRONMENT_ID__"
     },
     {
-      "_id": "env___BASE_ENVIRONMENT_ID___sub",
-      "_type": "environment",
+      "parentId": "__BASE_ENVIRONMENT_ID__",
+      "name": "OpenAPI env",
       "data": {
-        "apiKey": "apiKey",
+        "scheme": "https",
         "base_path": "/v1",
         "host": "api.server.test",
-        "httpPassword": "password",
+        "apiKey": "apiKey",
         "httpUsername": "username",
-        "scheme": "https"
+        "httpPassword": "password",
+        "bearerToken": "bearerToken"
       },
-      "name": "OpenAPI env",
-      "parentId": "__BASE_ENVIRONMENT_ID__"
+      "_type": "environment",
+      "_id": "env___BASE_ENVIRONMENT_ID___sub"
     },
     {
-      "_id": "req___WORKSPACE_ID__4a563129",
-      "_type": "request",
-      "authentication": {
-        "password": "{{ httpPassword }}",
-        "type": "basic",
-        "username": "{{ httpUsername }}"
-      },
-      "body": {},
-      "headers": [],
-      "method": "GET",
-      "name": "/basic",
-      "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/basic"
+      "name": "/basic",
+      "url": "{{ base_url }}/basic",
+      "body": {},
+      "method": "GET",
+      "parameters": [],
+      "headers": [],
+      "authentication": {
+        "type": "basic",
+        "username": "{{ httpUsername }}",
+        "password": "{{ httpPassword }}"
+      },
+      "_type": "request",
+      "_id": "req___WORKSPACE_ID__4a563129"
     },
     {
-      "_id": "req___WORKSPACE_ID__48bba8a5",
-      "_type": "request",
-      "authentication": {},
+      "parentId": "__WORKSPACE_ID__",
+      "name": "/bearer",
+      "url": "{{ base_url }}/bearer",
       "body": {},
+      "method": "GET",
+      "parameters": [],
+      "headers": [],
+      "authentication": {
+        "type": "bearer",
+        "token": "{{bearerToken}}",
+        "prefix": ""
+      },
+      "_type": "request",
+      "_id": "req___WORKSPACE_ID__6ecf1fc2"
+    },
+    {
+      "parentId": "__WORKSPACE_ID__",
+      "name": "/key/header",
+      "url": "{{ base_url }}/key/header",
+      "body": {},
+      "method": "GET",
+      "parameters": [],
       "headers": [
         {
-          "disabled": false,
           "name": "x-api_key",
+          "disabled": false,
           "value": "{{ apiKey }}"
         }
       ],
-      "method": "GET",
-      "name": "/key/header",
-      "parameters": [],
-      "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/key/header"
+      "authentication": {},
+      "_type": "request",
+      "_id": "req___WORKSPACE_ID__48bba8a5"
     },
     {
-      "_id": "req___WORKSPACE_ID__2ea006cf",
-      "_type": "request",
-      "authentication": {},
+      "parentId": "__WORKSPACE_ID__",
+      "name": "/key/cookie",
+      "url": "{{ base_url }}/key/cookie",
       "body": {},
+      "method": "GET",
+      "parameters": [],
       "headers": [
         {
-          "disabled": false,
           "name": "Cookie",
+          "disabled": false,
           "value": "CookieName={{ apiKey }}"
         }
       ],
-      "method": "GET",
-      "name": "/key/cookie",
-      "parameters": [],
-      "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/key/cookie"
+      "authentication": {},
+      "_type": "request",
+      "_id": "req___WORKSPACE_ID__2ea006cf"
     },
     {
-      "_id": "req___WORKSPACE_ID__0a8d5285",
-      "_type": "request",
-      "authentication": {},
-      "body": {},
-      "headers": [],
-      "method": "GET",
+      "parentId": "__WORKSPACE_ID__",
       "name": "/key/query",
+      "url": "{{ base_url }}/key/query",
+      "body": {},
+      "method": "GET",
       "parameters": [
         {
-          "disabled": false,
           "name": "key",
+          "disabled": false,
           "value": "{{ apiKey }}"
         }
       ],
-      "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/key/query"
+      "headers": [],
+      "authentication": {},
+      "_type": "request",
+      "_id": "req___WORKSPACE_ID__0a8d5285"
     },
     {
-      "_id": "req___WORKSPACE_ID__e285189c",
-      "_type": "request",
-      "authentication": {
-        "password": "{{ httpPassword }}",
-        "type": "basic",
-        "username": "{{ httpUsername }}"
-      },
+      "parentId": "__WORKSPACE_ID__",
+      "name": "/all",
+      "url": "{{ base_url }}/all",
       "body": {},
+      "method": "GET",
+      "parameters": [
+        {
+          "name": "key",
+          "disabled": false,
+          "value": "{{ apiKey }}"
+        }
+      ],
       "headers": [
         {
-          "disabled": false,
           "name": "x-api_key",
+          "disabled": false,
           "value": "{{ apiKey }}"
         },
         {
-          "disabled": false,
           "name": "Cookie",
+          "disabled": false,
           "value": "CookieName={{ apiKey }}"
         }
       ],
-      "method": "GET",
-      "name": "/all",
-      "parameters": [
-        {
-          "disabled": false,
-          "name": "key",
-          "value": "{{ apiKey }}"
-        }
-      ],
-      "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/all"
+      "authentication": {
+        "type": "basic",
+        "username": "{{ httpUsername }}",
+        "password": "{{ httpPassword }}"
+      },
+      "_type": "request",
+      "_id": "req___WORKSPACE_ID__e285189c"
     }
   ]
 }

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/global-security-input.yaml
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/global-security-input.yaml
@@ -10,6 +10,9 @@ components:
     Basic:
       type: http
       scheme: basic
+    Bearer:
+      type: http
+      scheme: bearer
     Key-Header:
       type: apiKey
       name: x-api_key

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/global-security-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/global-security-output.json
@@ -1,78 +1,79 @@
 {
-  "__export_date": "2019-10-12T17:23:25.171Z",
-  "__export_format": 4,
-  "__export_source": "insomnia.importers:v0.1.0",
   "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2020-02-19T03:46:03.524Z",
+  "__export_source": "insomnia.importers:v0.1.0",
   "resources": [
     {
-      "_id": "__WORKSPACE_ID__",
       "_type": "workspace",
-      "description": "",
+      "_id": "__WORKSPACE_ID__",
+      "parentId": null,
       "name": "Global Security 1.2",
-      "parentId": null
+      "description": ""
     },
     {
-      "_id": "__BASE_ENVIRONMENT_ID__",
-      "_type": "environment",
+      "parentId": "__WORKSPACE_ID__",
+      "name": "Base environment",
       "data": {
         "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
       },
-      "name": "Base environment",
-      "parentId": "__WORKSPACE_ID__"
+      "_type": "environment",
+      "_id": "__BASE_ENVIRONMENT_ID__"
     },
     {
-      "_id": "env___BASE_ENVIRONMENT_ID___sub",
-      "_type": "environment",
+      "parentId": "__BASE_ENVIRONMENT_ID__",
+      "name": "OpenAPI env",
       "data": {
-        "apiKey": "apiKey",
+        "scheme": "https",
         "base_path": "/v1",
         "host": "api.server.test",
-        "httpPassword": "password",
+        "apiKey": "apiKey",
         "httpUsername": "username",
-        "scheme": "https"
+        "httpPassword": "password",
+        "bearerToken": "bearerToken"
       },
-      "name": "OpenAPI env",
-      "parentId": "__BASE_ENVIRONMENT_ID__"
+      "_type": "environment",
+      "_id": "env___BASE_ENVIRONMENT_ID___sub"
     },
     {
-      "_id": "req___WORKSPACE_ID__21946b60",
-      "_type": "request",
-      "authentication": {
-        "password": "{{ httpPassword }}",
-        "type": "basic",
-        "username": "{{ httpUsername }}"
-      },
+      "parentId": "__WORKSPACE_ID__",
+      "name": "/global",
+      "url": "{{ base_url }}/global",
       "body": {},
+      "method": "GET",
+      "parameters": [],
       "headers": [
         {
-          "disabled": false,
           "name": "x-api_key",
+          "disabled": false,
           "value": "{{ apiKey }}"
         }
       ],
-      "method": "GET",
-      "name": "/global",
-      "parameters": [],
-      "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/global"
+      "authentication": {
+        "type": "basic",
+        "username": "{{ httpUsername }}",
+        "password": "{{ httpPassword }}"
+      },
+      "_type": "request",
+      "_id": "req___WORKSPACE_ID__21946b60"
     },
     {
-      "_id": "req___WORKSPACE_ID__b410454b",
-      "_type": "request",
-      "authentication": {},
-      "body": {},
-      "headers": [],
-      "method": "GET",
+      "parentId": "__WORKSPACE_ID__",
       "name": "/override",
+      "url": "{{ base_url }}/override",
+      "body": {},
+      "method": "GET",
       "parameters": [
         {
-          "disabled": false,
           "name": "apiKeyHere",
+          "disabled": false,
           "value": "{{ apiKey }}"
         }
       ],
-      "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/override"
+      "headers": [],
+      "authentication": {},
+      "_type": "request",
+      "_id": "req___WORKSPACE_ID__b410454b"
     }
   ]
 }


### PR DESCRIPTION
The PR supports [HTTP Bearer security scheme](https://swagger.io/docs/specification/authentication/bearer-authentication/) in OpenAPI importer.

Please take a look. If you have any question or concern, please let me known.

Closes #1952
