### PR TITLE
feature: Generate Variable Name from SecuritySchemas name parameter.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7575,6 +7575,15 @@
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
+    "camel-case": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+      "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+      "requires": {
+        "pascal-case": "^3.1.1",
+        "tslib": "^1.10.0"
+      }
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -7606,6 +7615,16 @@
       "integrity": "sha512-8wxNrjAzyiHcLXN/iunskqQnJquQQ6VX8JHfW5kLgAPRSiSuKZiNfmIkP5j7jgyXqAQBSoXyJxfnbCFS0ThSiQ==",
       "dev": true
     },
+    "capital-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.3.tgz",
+      "integrity": "sha512-OlUSJpUr7SY0uZFOxcwnDOU7/MpHlKTZx2mqnDYQFrDudXLFm0JJ9wr/l4csB+rh2Ug0OPuoSO53PqiZBqno9A==",
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0",
+        "upper-case-first": "^2.0.1"
+      }
+    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -7630,6 +7649,25 @@
         "ansi-styles": "^3.1.0",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^4.0.0"
+      }
+    },
+    "change-case": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.1.tgz",
+      "integrity": "sha512-qRlUWn/hXnX1R1LBDF/RelJLiqNjKjUqlmuBVSEIyye8kq49CXqkZWKmi8XeUAdDXWFOcGLUMZ+aHn3Q5lzUXw==",
+      "requires": {
+        "camel-case": "^4.1.1",
+        "capital-case": "^1.0.3",
+        "constant-case": "^3.0.3",
+        "dot-case": "^3.0.3",
+        "header-case": "^2.0.3",
+        "no-case": "^3.0.3",
+        "param-case": "^3.0.3",
+        "pascal-case": "^3.1.1",
+        "path-case": "^3.0.3",
+        "sentence-case": "^3.0.3",
+        "snake-case": "^3.0.3",
+        "tslib": "^1.10.0"
       }
     },
     "chardet": {
@@ -7941,6 +7979,16 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
+    },
+    "constant-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.3.tgz",
+      "integrity": "sha512-FXtsSnnrFYpzDmvwDGQW+l8XK3GV1coLyBN0eBz16ZUzGaZcT2ANVCJmLeuw2GQgxKHQIe9e0w2dzkSfaRlUmA==",
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0",
+        "upper-case": "^2.0.1"
+      }
     },
     "contains-path": {
       "version": "0.1.0",
@@ -8641,6 +8689,15 @@
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
+      }
+    },
+    "dot-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
       }
     },
     "dot-prop": {
@@ -11034,6 +11091,15 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "header-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.3.tgz",
+      "integrity": "sha512-LChe/V32mnUQnTwTxd3aAlNMk8ia9tjCDb/LjYtoMrdAPApxLB+azejUk5ERZIZdIqvinwv6BAUuFXH/tQPdZA==",
+      "requires": {
+        "capital-case": "^1.0.3",
+        "tslib": "^1.10.0"
       }
     },
     "hosted-git-info": {
@@ -14595,6 +14661,14 @@
         "signal-exit": "^3.0.0"
       }
     },
+    "lower-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
+    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -15053,6 +15127,15 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "no-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+      "requires": {
+        "lower-case": "^2.0.1",
+        "tslib": "^1.10.0"
+      }
     },
     "node-fetch": {
       "version": "2.6.0",
@@ -15645,6 +15728,15 @@
         "readable-stream": "^2.1.5"
       }
     },
+    "param-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
+      "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
+      "requires": {
+        "dot-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
+    },
     "parse-github-repo-url": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
@@ -15689,11 +15781,29 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
+    "pascal-case": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
+    },
+    "path-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.3.tgz",
+      "integrity": "sha512-UMFU6UETFpCNWbIWNczshPrnK/7JAXBP2NYw80ojElbQ2+JYxdqWDBkvvqM93u4u6oLmuJ/tPOf2tM8KtXv4eg==",
+      "requires": {
+        "dot-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -17122,6 +17232,16 @@
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
+    "sentence-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.3.tgz",
+      "integrity": "sha512-ZPr4dgTcNkEfcGOMFQyDdJrTU9uQO1nb1cjf+nuzb6FxgMDgKddZOM29qEsB7jvsZSMruLRcL2KfM4ypKpa0LA==",
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0",
+        "upper-case-first": "^2.0.1"
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -17235,6 +17355,15 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
       "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
       "dev": true
+    },
+    "snake-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.3.tgz",
+      "integrity": "sha512-WM1sIXEO+rsAHBKjGf/6R1HBBcgbncKS08d2Aqec/mrDSpU80SiOU41hO7ny6DToHSyrlwTYzQBIK1FPSx4Y3Q==",
+      "requires": {
+        "dot-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -18298,6 +18427,22 @@
       "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
       "dev": true,
       "optional": true
+    },
+    "upper-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.1.tgz",
+      "integrity": "sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
+    },
+    "upper-case-first": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.1.tgz",
+      "integrity": "sha512-105J8XqQ+9RxW3l9gHZtgve5oaiR9TIwvmZAMAIZWRHe00T21cdvewKORTlOJf/zXW6VukuTshM+HXZNWz7N5w==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",
     "rimraf": "^2.6.3"
+  },
+  "dependencies": {
+    "change-case": "^4.1.1"
   }
 }

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-input.yaml
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-input.yaml
@@ -17,13 +17,25 @@ components:
       type: apiKey
       name: x-api_key
       in: header
+    AnotherKey-Header:
+      type: apiKey
+      name: x-app-version
+      in: header
     Key-Cookie:
       type: apiKey
       name: CookieName
       in: cookie
+    AnotherKey-Cookie:
+      type: apiKey
+      name: AnotherCookieName
+      in: cookie
     Key-Query:
       type: apiKey
       name: key
+      in: query
+    AnotherKey-Query:
+      type: apiKey
+      name: another_key
       in: query
 
 paths:
@@ -45,6 +57,7 @@ paths:
     get:
       security:
         - Key-Header: []
+        - AnotherKey-Header: []
       responses:
         '200':
           description: OK
@@ -52,6 +65,7 @@ paths:
     get:
       security:
         - Key-Cookie: []
+        - AnotherKey-Cookie: []
       responses:
         '200':
           description: OK
@@ -59,6 +73,7 @@ paths:
     get:
       security:
         - Key-Query: []
+        - AnotherKey-Query: []
       responses:
         '200':
           description: OK

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-output.json
@@ -26,10 +26,15 @@
       "data": {
         "scheme": "https",
         "base_path": "/v1",
+        "cookieName": "cookieName",
+        "anotherCookieName": "anotherCookieName",
+        "key": "key",
+        "anotherKey": "anotherKey",
         "host": "api.server.test",
-        "apiKey": "apiKey",
         "httpUsername": "username",
         "httpPassword": "password",
+        "xApiKey": "xApiKey",
+        "xAppVersion": "xAppVersion",
         "bearerToken": "bearerToken"
       },
       "_type": "environment",
@@ -78,7 +83,12 @@
         {
           "name": "x-api_key",
           "disabled": false,
-          "value": "{{ apiKey }}"
+          "value": "{{ xApiKey }}"
+        },
+        {
+          "name": "x-app-version",
+          "disabled": false,
+          "value": "{{ xAppVersion }}"
         }
       ],
       "authentication": {},
@@ -96,7 +106,7 @@
         {
           "name": "Cookie",
           "disabled": false,
-          "value": "CookieName={{ apiKey }}"
+          "value": "CookieName={{ cookieName }}; AnotherCookieName={{ anotherCookieName }}"
         }
       ],
       "authentication": {},
@@ -113,7 +123,12 @@
         {
           "name": "key",
           "disabled": false,
-          "value": "{{ apiKey }}"
+          "value": "{{ key }}"
+        },
+        {
+          "name": "another_key",
+          "disabled": false,
+          "value": "{{ anotherKey }}"
         }
       ],
       "headers": [],
@@ -131,19 +146,19 @@
         {
           "name": "key",
           "disabled": false,
-          "value": "{{ apiKey }}"
+          "value": "{{ key }}"
         }
       ],
       "headers": [
         {
           "name": "x-api_key",
           "disabled": false,
-          "value": "{{ apiKey }}"
+          "value": "{{ xApiKey }}"
         },
         {
           "name": "Cookie",
           "disabled": false,
-          "value": "CookieName={{ apiKey }}"
+          "value": "CookieName={{ cookieName }}"
         }
       ],
       "authentication": {

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/global-security-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/global-security-output.json
@@ -25,12 +25,14 @@
       "name": "OpenAPI env",
       "data": {
         "scheme": "https",
+        "apiKeyHere": "apiKeyHere",
+        "cookieName": "cookieName",
         "base_path": "/v1",
         "host": "api.server.test",
-        "apiKey": "apiKey",
         "httpUsername": "username",
         "httpPassword": "password",
-        "bearerToken": "bearerToken"
+        "bearerToken": "bearerToken",
+        "xApiKey": "xApiKey"
       },
       "_type": "environment",
       "_id": "env___BASE_ENVIRONMENT_ID___sub"
@@ -46,7 +48,7 @@
         {
           "name": "x-api_key",
           "disabled": false,
-          "value": "{{ apiKey }}"
+          "value": "{{ xApiKey }}"
         }
       ],
       "authentication": {
@@ -67,7 +69,7 @@
         {
           "name": "apiKeyHere",
           "disabled": false,
-          "value": "{{ apiKey }}"
+          "value": "{{ apiKeyHere }}"
         }
       ],
       "headers": [],


### PR DESCRIPTION
# Background
Some of my api requires multiple securitySchema simultaneously:

```openapi.yml
securitySchemes:
    AuthToken:
      type: apiKey
      description: JWT Token for authorizations.
      name: X-AuthToken
      in: header
    AppType:
      type: apiKey
      description: Application platform
      name: X-AppType
      in: header
    AppVersion:
      type: apiKey
      description: Application semantic version.
      name: X-AppVersion
      in: header
```

```yaml
/sample/endpoint.json:
    patch:
      security:
        - AuthToken: []
        - AppVersion: []
        - AppType: []
```

# Problem
Currently Insomnia merge this security schemas into same variable `apiKey`.
But I need to setup these variables separately.

# Feature
In this PR I'v changed variable name generation process.
And use security schemas `name` parameter to generate variable.

```yaml
components:
  securitySchemes:
    Key-Header-With-Variable:
      type: apiKey
      name: x-api_key
      in: header
paths:
  /key/header:
    get:
      security:
        - Key-Header-With-Variable: []
      responses:
        '200':
          description: OK
```

will generate

```json
{
      "_id": "env___BASE_ENVIRONMENT_ID___sub",
      "_type": "environment",
      "data": {
        "xApiKey": "xApiKey", // Automatically generated instead of apiKey variable.
        "base_path": "/v1",
        "host": "api.server.test",
        "httpPassword": "password",
        "httpUsername": "username",
        "scheme": "https"
      },
      "name": "OpenAPI env",
      "parentId": "__BASE_ENVIRONMENT_ID__"
 },
{
      "_id": "req___WORKSPACE_ID__48bba8a5",
      "_type": "request",
      "authentication": {},
      "body": {},
      "headers": [
        {
          "disabled": false,
          "name": "x-api_key",
          "value": "{{ xApiKey }}"
        }
      ],
      "method": "GET",
      "name": "/key/header",
      "parameters": [],
      "parentId": "__WORKSPACE_ID__",
      "url": "{{ base_url }}/key/header"
 },
```

