### PR TITLE
Allow checkbox input type in prompt dialog

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
@@ -235,21 +235,22 @@ class PromptModal extends React.PureComponent<Props, State> {
     let field;
     if (inputType === 'checkbox') {
       field = (
-        <div>
-          {input}
-          <label htmlFor="prompt-input" className="label--checkbox">
-            {label}
+        <div className="form-control form-control--wide">
+          <label htmlFor="prompt-input" className="inline-block">
+            {label} {input}
           </label>
         </div>
       );
     } else if (label) {
       field = (
-        <label>
-          {label} {input}
-        </label>
+        <div className="form-control form-control--outlined form-control--wide">
+          <label htmlFor="prompt-input">
+            {label} {input}
+          </label>
+        </div>
       );
     } else {
-      field = input;
+      field = <div className="form-control form-control--outlined form-control--wide">{input}</div>;
     }
 
     return (
@@ -257,7 +258,7 @@ class PromptModal extends React.PureComponent<Props, State> {
         <ModalHeader>{title}</ModalHeader>
         <ModalBody className="wide">
           <form onSubmit={this._handleSubmit} className="wide pad">
-            <div className="form-control form-control--outlined form-control--wide">{field}</div>
+            {field}
             {sanitizedHints}
           </form>
         </ModalBody>

--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
@@ -87,7 +87,8 @@ class PromptModal extends React.PureComponent<Props, State> {
     e.preventDefault();
 
     if (this._input) {
-      const result = this._input.type === 'checkbox' ? this._input.checked : this._input.value;
+      const result =
+        this._input.type === 'checkbox' ? this._input.checked.toString() : this._input.value;
       this._done(result);
     }
   }

--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
@@ -87,7 +87,8 @@ class PromptModal extends React.PureComponent<Props, State> {
     e.preventDefault();
 
     if (this._input) {
-      this._done(this._input.value);
+      const result = this._input.type === 'checkbox' ? this._input.checked : this._input.value;
+      this._done(result);
     }
   }
 
@@ -165,7 +166,11 @@ class PromptModal extends React.PureComponent<Props, State> {
       if (!this._input) {
         return;
       }
-      this._input.value = defaultValue || '';
+      if (inputType === 'checkbox') {
+        this._input.checked = !!defaultValue;
+      } else {
+        this._input.value = defaultValue || '';
+      }
       this._input.focus();
       selectText && this._input && this._input.select();
     }, 100);
@@ -226,21 +231,32 @@ class PromptModal extends React.PureComponent<Props, State> {
       sanitizedHints = hints.slice(0, 15).map(this._renderHintButton);
     }
 
+    let field;
+    if (inputType === 'checkbox') {
+      field = (
+        <div>
+          {input}
+          <label htmlFor="prompt-input" className="label--checkbox">
+            {label}
+          </label>
+        </div>
+      );
+    } else if (label) {
+      field = (
+        <label>
+          {label} {input}
+        </label>
+      );
+    } else {
+      field = input;
+    }
+
     return (
       <Modal ref={this._setModalRef} noEscape={!cancelable} onCancel={onCancel}>
         <ModalHeader>{title}</ModalHeader>
         <ModalBody className="wide">
           <form onSubmit={this._handleSubmit} className="wide pad">
-            <div className="form-control form-control--outlined form-control--wide">
-              {label ? (
-                <label>
-                  {label}
-                  {input}
-                </label>
-              ) : (
-                input
-              )}
-            </div>
+            <div className="form-control form-control--outlined form-control--wide">{field}</div>
             {sanitizedHints}
           </form>
         </ModalBody>

--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
@@ -232,33 +232,27 @@ class PromptModal extends React.PureComponent<Props, State> {
       sanitizedHints = hints.slice(0, 15).map(this._renderHintButton);
     }
 
-    let field;
-    if (inputType === 'checkbox') {
+    let field = input;
+    if (label) {
+      const labelClasses = classnames({
+        'inline-block': inputType === 'checkbox',
+      });
       field = (
-        <div className="form-control form-control--wide">
-          <label htmlFor="prompt-input" className="inline-block">
-            {label} {input}
-          </label>
-        </div>
+        <label htmlFor="prompt-input" className={labelClasses}>
+          {label} {input}
+        </label>
       );
-    } else if (label) {
-      field = (
-        <div className="form-control form-control--outlined form-control--wide">
-          <label htmlFor="prompt-input">
-            {label} {input}
-          </label>
-        </div>
-      );
-    } else {
-      field = <div className="form-control form-control--outlined form-control--wide">{input}</div>;
     }
 
+    const divClassnames = classnames('form-control form-control--wide', {
+      'form-control--outlined': inputType !== 'checkbox',
+    });
     return (
       <Modal ref={this._setModalRef} noEscape={!cancelable} onCancel={onCancel}>
         <ModalHeader>{title}</ModalHeader>
         <ModalBody className="wide">
           <form onSubmit={this._handleSubmit} className="wide pad">
-            {field}
+            <div className={divClassnames}>{field}</div>
             {sanitizedHints}
           </form>
         </ModalBody>

--- a/packages/insomnia-app/app/ui/css/components/forms.less
+++ b/packages/insomnia-app/app/ui/css/components/forms.less
@@ -78,10 +78,6 @@
     }
   }
 
-  .label--checkbox {
-    line-height: var(--line-height-xs);
-  }
-
   &.form-control--thin {
     label {
       font-weight: normal;

--- a/packages/insomnia-app/app/ui/css/components/forms.less
+++ b/packages/insomnia-app/app/ui/css/components/forms.less
@@ -78,6 +78,10 @@
     }
   }
 
+  .label--checkbox {
+    line-height: var(--line-height-xs);
+  }
+
   &.form-control--thin {
     label {
       font-weight: normal;


### PR DESCRIPTION
This PR allows the Prompt modal dialog to show `<input type="checkbox">` elements.

You only have to call it by setting `inputType` to `checkbox`. You can also set `defaultValue` to `false`/`true` to uncheck/check the checkbox, respectively.

The modal will return the string value `"true"` if the the checkbox was checked and `"false"` otherwise.

![imagen](https://user-images.githubusercontent.com/231822/75825283-5416f880-5da5-11ea-8c22-34c86f2e7728.png).
