### PR TITLE
Add ability to generate theme plugin

### DIFF
--- a/packages/insomnia-app/app/common/misc.js
+++ b/packages/insomnia-app/app/common/misc.js
@@ -79,6 +79,11 @@ export function getContentTypeHeader<T: Header>(headers: Array<T>): T | null {
   return matches.length ? matches[0] : null;
 }
 
+export function getMethodOverrideHeader<T: Header>(headers: Array<T>): T | null {
+  const matches = filterHeaders(headers, 'x-http-method-override');
+  return matches.length ? matches[0] : null;
+}
+
 export function getHostHeader<T: Header>(headers: Array<T>): T | null {
   const matches = filterHeaders(headers, 'host');
   return matches.length ? matches[0] : null;

--- a/packages/insomnia-app/app/plugins/create.js
+++ b/packages/insomnia-app/app/plugins/create.js
@@ -1,0 +1,38 @@
+// @flow
+import fs from 'fs';
+import path from 'path';
+import mkdirp from 'mkdirp';
+import rimraf from 'rimraf';
+import { PLUGIN_PATH } from '../common/constants';
+
+export async function createPlugin(
+  moduleName: string,
+  version: string,
+  mainJs: string,
+): Promise<void> {
+  const pluginDir = path.join(PLUGIN_PATH, moduleName);
+
+  rimraf.sync(pluginDir);
+  mkdirp.sync(pluginDir);
+
+  // Write package.json
+  fs.writeFileSync(
+    path.join(pluginDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: moduleName,
+        version,
+        private: true,
+        insomnia: {
+          name: moduleName.replace(/^insomnia-plugin-/, ''),
+        },
+        main: 'main.js',
+      },
+      null,
+      2,
+    ),
+  );
+
+  // Write main JS file
+  fs.writeFileSync(path.join(pluginDir, 'main.js'), mainJs);
+}

--- a/packages/insomnia-app/app/plugins/index.js
+++ b/packages/insomnia-app/app/plugins/index.js
@@ -73,8 +73,7 @@ export type Theme = {
 let plugins: ?Array<Plugin> = null;
 
 export async function init(): Promise<void> {
-  // Force plugins to load.
-  await getPlugins(true);
+  await reloadPlugins();
 }
 
 async function _traversePluginPath(
@@ -180,6 +179,10 @@ export async function getPlugins(force: boolean = false): Promise<Array<Plugin>>
   }
 
   return plugins;
+}
+
+export async function reloadPlugins(): Promise<void> {
+  await getPlugins(true);
 }
 
 async function getActivePlugins(): Promise<Array<Plugin>> {

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.js
@@ -22,6 +22,7 @@ import * as session from '../../../account/session';
 
 export const TAB_INDEX_EXPORT = 1;
 export const TAB_INDEX_SHORTCUTS = 3;
+export const TAB_INDEX_THEMES = 2;
 export const TAB_INDEX_PLUGINS = 5;
 
 @autobind

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
@@ -12,6 +12,7 @@ import * as models from '../../../models';
 import { showModal } from '../modals/index';
 import RequestSettingsModal from '../modals/request-settings-modal';
 import { CONTENT_TYPE_GRAPHQL } from '../../../common/constants';
+import { getMethodOverrideHeader } from '../../../common/misc';
 
 @autobind
 class SidebarRequestRow extends PureComponent {
@@ -63,7 +64,7 @@ class SidebarRequestRow extends PureComponent {
   _getMethodOverrideHeaderValue() {
     const { request } = this.props;
 
-    const header = request.headers.find(h => h.name.toLowerCase() === 'x-http-method-override');
+    const header = getMethodOverrideHeader(request.headers);
 
     if (header) {
       return header.value;

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -867,7 +867,7 @@ class App extends PureComponent {
 
   async _handleReloadPlugins() {
     const { settings } = this.props;
-    await plugins.getPlugins(true);
+    await plugins.reloadPlugins();
     templating.reload();
     themes.setTheme(settings.theme);
     console.log('[plugins] reloaded');

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -14,8 +14,14 @@ import * as models from '../../../models';
 import SelectModal from '../../components/modals/select-modal';
 import { showError, showModal } from '../../components/modals/index';
 import * as db from '../../../common/database';
-import SettingsModal, { TAB_INDEX_PLUGINS } from '../../components/modals/settings-modal';
+import SettingsModal, {
+  TAB_INDEX_PLUGINS,
+  TAB_INDEX_THEMES,
+} from '../../components/modals/settings-modal';
 import install from '../../../plugins/install';
+import { createPlugin } from '../../../plugins/create';
+import { reloadPlugins } from '../../../plugins';
+import { setTheme } from '../../../plugins/misc';
 
 const LOCALSTORAGE_PREFIX = `insomnia::meta`;
 
@@ -30,6 +36,7 @@ const COMMAND_LOGIN = 'app/auth/login';
 const COMMAND_TRIAL_END = 'app/billing/trial-end';
 const COMMAND_IMPORT_URI = 'app/import';
 const COMMAND_PLUGIN_INSTALL = 'plugins/install';
+const COMMAND_PLUGIN_THEME = 'plugins/theme';
 
 // ~~~~~~~~ //
 // REDUCERS //
@@ -135,6 +142,38 @@ export function newCommand(command, args) {
                 error: err.message,
               });
             }
+          },
+        });
+        break;
+      case COMMAND_PLUGIN_THEME:
+        const parsedTheme = JSON.parse(decodeURIComponent(args.theme));
+        showModal(AskModal, {
+          title: 'Import Theme',
+          message: (
+            <React.Fragment>
+              Do you want to install <code>{parsedTheme.displayName}</code>?
+            </React.Fragment>
+          ),
+          yesText: 'Install',
+          noText: 'Cancel',
+          onDone: async isYes => {
+            if (!isYes) {
+              return;
+            }
+
+            const mainJsContent = `module.exports.themes = [${JSON.stringify(
+              parsedTheme,
+              null,
+              2,
+            )}];`;
+
+            await createPlugin(`theme-${parsedTheme.name}`, '0.0.1', mainJsContent);
+
+            const settings = await models.settings.getOrCreate();
+            await models.settings.update(settings, { theme: parsedTheme.name });
+            await reloadPlugins(true);
+            await setTheme(parsedTheme.name);
+            showModal(SettingsModal, TAB_INDEX_THEMES);
           },
         });
         break;

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -148,7 +148,7 @@ export function newCommand(command, args) {
       case COMMAND_PLUGIN_THEME:
         const parsedTheme = JSON.parse(decodeURIComponent(args.theme));
         showModal(AskModal, {
-          title: 'Import Theme',
+          title: 'Install Theme',
           message: (
             <React.Fragment>
               Do you want to install <code>{parsedTheme.displayName}</code>?

--- a/packages/insomnia-app/flow-typed/rimraf.js
+++ b/packages/insomnia-app/flow-typed/rimraf.js
@@ -1,0 +1,7 @@
+// @flow
+
+declare module 'rimraf' {
+  declare module.exports: {
+    sync: (path: string) => string | null,
+  };
+}


### PR DESCRIPTION
This PR adds the ability to create a theme from a URL handler. This enables external tools to easily import themes into Insomnia. 

Under the hood, Insomnia takes the theme data provided, generates the required plugin files, and stores it on the filesystem. The output is exactly the same as a typical Insomnia plugin hosted on NPM, except this sidesteps the need to actually deploy to NPM.

URL format for adding a theme: 

```
insomnia://plugins/theme?theme=<THEME_JSON>
```

Example theme:

```js
{
  "name": "gruvbox-dark",
  "displayName": "Gruvbox Dark",
  "theme": {
    "background": {
      "default": "#282828",
      "success": "#83a598",
      "notice": "#b8bb26",
      "warning": "#d79921",
      "danger": "#eb5746",
      "surprise": "#d3869b",
      "info": "#83a598"
    },
    "foreground": {
      "default": "#d9d1ce",
      "success": "#fff",
      "notice": "#fff",
      "warning": "#fff",
      "danger": "#fff",
      "surprise": "#fff",
      "info": "#fff"
    },
    "highlight": {
      "default": "rgb(140, 135, 131)",
      "xxs": "rgba(140, 135, 131, 0.05)",
      "xs": "rgba(140, 135, 131, 0.1)",
      "sm": "rgba(140, 135, 131, 0.2)",
      "md": "rgba(140, 135, 131, 0.4)",
      "lg": "rgba(140, 135, 131, 0.6)",
      "xl": "rgba(140, 135, 131, 0.8)"
    },
    "styles": {
      "dialog": {
        "background": {
          "default": "#3c3836"
        }
      },
      "transparentOverlay": {
        "background": {
          "default": "rgba(40, 40, 40, 0.8)"
        }
      }
    }
  }
}
```

And here's what it looks like when opened in Insomnia 

![image](https://user-images.githubusercontent.com/587576/76129964-da0d8c00-5fbd-11ea-9a2d-12a0a588c650.png)
![image](https://user-images.githubusercontent.com/587576/76129972-e42f8a80-5fbd-11ea-86da-445bbe627d04.png)
