### PR TITLE
Set solarized background and foreground colors to spec

### DIFF
--- a/plugins/insomnia-plugin-core-themes/themes/solarized-dark.js
+++ b/plugins/insomnia-plugin-core-themes/themes/solarized-dark.js
@@ -3,7 +3,7 @@ module.exports = {
   displayName: 'Solarized Dark',
   theme: {
     background: {
-      default: '#073642',
+      default: '#002b36',
       success: '#859900',
       notice: '#b58900',
       warning: '#cb4b16',
@@ -12,7 +12,7 @@ module.exports = {
       info: '#2aa198',
     },
     foreground: {
-      default: '#98aaac',
+      default: '#839496',
     },
     highlight: {
       default: 'rgb(142, 149, 146)',

--- a/plugins/insomnia-plugin-core-themes/themes/solarized-light.js
+++ b/plugins/insomnia-plugin-core-themes/themes/solarized-light.js
@@ -12,7 +12,7 @@ module.exports = {
       info: '#2aa198',
     },
     foreground: {
-      default: '#586d75',
+      default: '#657b83',
     },
     highlight: {
       default: 'rgb(142, 149, 146)',

--- a/plugins/insomnia-plugin-core-themes/themes/solarized.js
+++ b/plugins/insomnia-plugin-core-themes/themes/solarized.js
@@ -26,10 +26,10 @@ module.exports = {
     styles: {
       sidebar: {
         background: {
-          default: '#073642',
+          default: '#002b36',
         },
         foreground: {
-          default: '#9cafb1',
+          default: '#839496',
         },
       },
     },


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Fixes the font and background colors of the solarized themes to match the spec. Closes https://github.com/Kong/insomnia/issues/1990
