### PR TITLE
Mask template tag title popup when preview is disabled

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.js
@@ -268,7 +268,8 @@ async function _updateElementText(render, mark, text, renderContext, isVariableU
         } else {
           innerHTML = tagDefinition.displayName || tagData.name;
         }
-        title = await render(text);
+        const preview = await render(text);
+        title = tagDefinition.disablePreview(tagData.args) ? preview.replace(/./g, '*') : preview;
       } else {
         innerHTML = cleanedStr;
         title = 'Unrecognized tag';


### PR DESCRIPTION
I found a bug that causes a template tag to display its rendered value even when the template tag disables the preview. For example, the Prompt template tag disables the preview when the user checks the Mask Text checkbox.

This works well in the template dialog's Live Preview, but you can still seeing the value if you move the mouse over the tag:

![image](https://user-images.githubusercontent.com/231822/76562587-f28e1280-64a5-11ea-9bf6-78ec634a7ded.png)

This PR fixes this by masking rendered values when the template tag disables the preview, as it's done with the Live Preview.

![image](https://user-images.githubusercontent.com/231822/76562702-37b24480-64a6-11ea-8b36-a2b3b615739e.png)

