### PR TITLE
Fixing a race condition when deleting the only workspace

### DIFF
--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -337,7 +337,7 @@ class Wrapper extends React.PureComponent<Props, State> {
         message: 'Since you deleted your only workspace, a new one has been created for you.',
       });
 
-      models.workspace.create({ name: 'Insomnia' });
+      await models.workspace.create({ name: 'Insomnia' });
     }
 
     await models.workspace.remove(activeWorkspace);


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

When deleting the only workspace, a race condition occurs between creating the new one, deleting the old one, and rendering the workspace selector in the top left (app blows up when accessing `_id` on a non-existent `activeWorkspace` [here](https://github.com/Kong/insomnia/blob/develop/packages/insomnia-app/app/ui/redux/selectors.js#L206). By forcing the code to wait for the new workspace to be created, we eliminate the race condition. Closes https://github.com/Kong/insomnia/issues/1994
