### PR TITLE
Introduce flow `$Shape<T>` to db models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7571,7 +7571,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
@@ -16664,7 +16664,7 @@
     },
     "resolve": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
@@ -17104,7 +17104,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/packages/insomnia-app/app/models/client-certificate.js
+++ b/packages/insomnia-app/app/models/client-certificate.js
@@ -40,7 +40,7 @@ export async function migrate(doc: ClientCertificate) {
   return doc;
 }
 
-export function create(patch: Object = {}): Promise<ClientCertificate> {
+export function create(patch: $Shape<ClientCertificate> = {}): Promise<ClientCertificate> {
   if (!patch.parentId) {
     throw new Error('New ClientCertificate missing `parentId`: ' + JSON.stringify(patch));
   }
@@ -48,7 +48,10 @@ export function create(patch: Object = {}): Promise<ClientCertificate> {
   return db.docCreate(type, patch);
 }
 
-export function update(cert: ClientCertificate, patch: Object = {}): Promise<ClientCertificate> {
+export function update(
+  cert: ClientCertificate,
+  patch: $Shape<ClientCertificate> = {},
+): Promise<ClientCertificate> {
   return db.docUpdate(cert, patch);
 }
 

--- a/packages/insomnia-app/app/models/cookie-jar.js
+++ b/packages/insomnia-app/app/models/cookie-jar.js
@@ -46,7 +46,7 @@ export function migrate(doc: CookieJar): CookieJar {
   return doc;
 }
 
-export async function create(patch: $Shape<Cookie> = {}) {
+export async function create(patch: $Shape<CookieJar>) {
   if (!patch.parentId) {
     throw new Error(`New CookieJar missing \`parentId\`: ${JSON.stringify(patch)}`);
   }
@@ -80,7 +80,7 @@ export async function getById(id: string) {
   return db.get(type, id);
 }
 
-export async function update(cookieJar: CookieJar, patch: $Shape<Cookie> = {}) {
+export async function update(cookieJar: CookieJar, patch: $Shape<CookieJar> = {}) {
   return db.docUpdate(cookieJar, patch);
 }
 

--- a/packages/insomnia-app/app/models/cookie-jar.js
+++ b/packages/insomnia-app/app/models/cookie-jar.js
@@ -46,7 +46,7 @@ export function migrate(doc: CookieJar): CookieJar {
   return doc;
 }
 
-export async function create(patch: Object = {}) {
+export async function create(patch: $Shape<Cookie> = {}) {
   if (!patch.parentId) {
     throw new Error(`New CookieJar missing \`parentId\`: ${JSON.stringify(patch)}`);
   }
@@ -80,7 +80,7 @@ export async function getById(id: string) {
   return db.get(type, id);
 }
 
-export async function update(cookieJar: CookieJar, patch: Object = {}) {
+export async function update(cookieJar: CookieJar, patch: $Shape<Cookie> = {}) {
   return db.docUpdate(cookieJar, patch);
 }
 

--- a/packages/insomnia-app/app/models/environment.js
+++ b/packages/insomnia-app/app/models/environment.js
@@ -38,7 +38,7 @@ export function migrate(doc: Environment): Environment {
   return doc;
 }
 
-export function create(patch: Object = {}): Promise<Environment> {
+export function create(patch: $Shape<Environment> = {}): Promise<Environment> {
   if (!patch.parentId) {
     throw new Error(`New Environment missing \`parentId\`: ${JSON.stringify(patch)}`);
   }
@@ -46,7 +46,7 @@ export function create(patch: Object = {}): Promise<Environment> {
   return db.docCreate(type, patch);
 }
 
-export function update(environment: Environment, patch: Object): Promise<Environment> {
+export function update(environment: Environment, patch: $Shape<Environment>): Promise<Environment> {
   return db.docUpdate(environment, patch);
 }
 

--- a/packages/insomnia-app/app/models/o-auth-2-token.js
+++ b/packages/insomnia-app/app/models/o-auth-2-token.js
@@ -47,7 +47,7 @@ export function migrate<T>(doc: T): T {
   return doc;
 }
 
-export function create(patch: Object = {}): Promise<OAuth2Token> {
+export function create(patch: $Shape<OAuth2Token> = {}): Promise<OAuth2Token> {
   if (!patch.parentId) {
     throw new Error(`New OAuth2Token missing \`parentId\` ${JSON.stringify(patch)}`);
   }
@@ -55,7 +55,7 @@ export function create(patch: Object = {}): Promise<OAuth2Token> {
   return db.docCreate(type, patch);
 }
 
-export function update(token: OAuth2Token, patch: Object): Promise<OAuth2Token> {
+export function update(token: OAuth2Token, patch: $Shape<OAuth2Token>): Promise<OAuth2Token> {
   return db.docUpdate(token, patch);
 }
 

--- a/packages/insomnia-app/app/models/plugin-data.js
+++ b/packages/insomnia-app/app/models/plugin-data.js
@@ -28,11 +28,11 @@ export function migrate(doc: PluginData): PluginData {
   return doc;
 }
 
-export function create(patch: Object = {}): Promise<PluginData> {
+export function create(patch: $Shape<PluginData> = {}): Promise<PluginData> {
   return db.docCreate(type, patch);
 }
 
-export async function update(doc: PluginData, patch: Object): Promise<PluginData> {
+export async function update(doc: PluginData, patch: $Shape<PluginData>): Promise<PluginData> {
   return db.docUpdate(doc, patch);
 }
 

--- a/packages/insomnia-app/app/models/request-group-meta.js
+++ b/packages/insomnia-app/app/models/request-group-meta.js
@@ -1,10 +1,19 @@
+// @flow
+
 import * as db from '../common/database';
+import type { BaseModel } from './index';
 
 export const name = 'Folder Meta';
 export const type = 'RequestGroupMeta';
 export const prefix = 'fldm';
 export const canDuplicate = false;
 export const canSync = false;
+
+type BaseRequestGroupMeta = {
+  collapsed: boolean,
+};
+
+export type RequestGroupMeta = BaseModel & BaseRequestGroupMeta;
 
 export function init() {
   return {
@@ -13,11 +22,11 @@ export function init() {
   };
 }
 
-export function migrate(doc) {
+export function migrate(doc: RequestGroupMeta): RequestGroupMeta {
   return doc;
 }
 
-export function create(patch = {}) {
+export function create(patch: $Shape<RequestGroupMeta> = {}): Promise<RequestGroupMeta> {
   if (!patch.parentId) {
     throw new Error('New RequestGroupMeta missing `parentId`', patch);
   }
@@ -25,14 +34,17 @@ export function create(patch = {}) {
   return db.docCreate(type, patch);
 }
 
-export function update(requestGroupMeta, patch) {
+export function update(
+  requestGroupMeta: RequestGroupMeta,
+  patch: $Shape<RequestGroupMeta>,
+): Promise<RequestGroupMeta> {
   return db.docUpdate(requestGroupMeta, patch);
 }
 
-export function getByParentId(parentId) {
+export function getByParentId(parentId: string): Promise<RequestGroupMeta> {
   return db.getWhere(type, { parentId });
 }
 
-export function all() {
+export function all(): Promise<Array<RequestGroupMeta>> {
   return db.all(type);
 }

--- a/packages/insomnia-app/app/models/request-group-meta.js
+++ b/packages/insomnia-app/app/models/request-group-meta.js
@@ -28,7 +28,7 @@ export function migrate(doc: RequestGroupMeta): RequestGroupMeta {
 
 export function create(patch: $Shape<RequestGroupMeta> = {}): Promise<RequestGroupMeta> {
   if (!patch.parentId) {
-    throw new Error('New RequestGroupMeta missing `parentId`', patch);
+    throw new Error('New RequestGroupMeta missing `parentId`: ' + JSON.stringify(patch));
   }
 
   return db.docCreate(type, patch);
@@ -41,7 +41,7 @@ export function update(
   return db.docUpdate(requestGroupMeta, patch);
 }
 
-export function getByParentId(parentId: string): Promise<RequestGroupMeta> {
+export function getByParentId(parentId: string): Promise<RequestGroupMeta | null> {
   return db.getWhere(type, { parentId });
 }
 

--- a/packages/insomnia-app/app/models/request-group.js
+++ b/packages/insomnia-app/app/models/request-group.js
@@ -32,7 +32,7 @@ export function migrate(doc: RequestGroup) {
   return doc;
 }
 
-export function create(patch: Object = {}): Promise<RequestGroup> {
+export function create(patch: $Shape<RequestGroup> = {}): Promise<RequestGroup> {
   if (!patch.parentId) {
     throw new Error('New RequestGroup missing `parentId`: ' + JSON.stringify(patch));
   }
@@ -40,7 +40,10 @@ export function create(patch: Object = {}): Promise<RequestGroup> {
   return db.docCreate(type, patch);
 }
 
-export function update(requestGroup: RequestGroup, patch: Object = {}): Promise<RequestGroup> {
+export function update(
+  requestGroup: RequestGroup,
+  patch: $Shape<RequestGroup> = {},
+): Promise<RequestGroup> {
   return db.docUpdate(requestGroup, patch);
 }
 
@@ -62,7 +65,7 @@ export function all(): Promise<Array<RequestGroup>> {
 
 export async function duplicate(
   requestGroup: RequestGroup,
-  patch: Object = {},
+  patch: $Shape<RequestGroup> = {},
 ): Promise<RequestGroup> {
   if (!patch.name) {
     patch.name = `${requestGroup.name} (Copy)`;

--- a/packages/insomnia-app/app/models/request-meta.js
+++ b/packages/insomnia-app/app/models/request-meta.js
@@ -41,7 +41,7 @@ export function migrate(doc: RequestMeta): RequestMeta {
   return doc;
 }
 
-export function create(patch: Object = {}) {
+export function create(patch: $Shape<RequestMeta> = {}) {
   if (!patch.parentId) {
     throw new Error('New RequestMeta missing `parentId` ' + JSON.stringify(patch));
   }
@@ -49,7 +49,7 @@ export function create(patch: Object = {}) {
   return db.docCreate(type, patch);
 }
 
-export function update(requestMeta: RequestMeta, patch: Object) {
+export function update(requestMeta: RequestMeta, patch: $Shape<RequestMeta>) {
   return db.docUpdate(requestMeta, patch);
 }
 

--- a/packages/insomnia-app/app/models/request.js
+++ b/packages/insomnia-app/app/models/request.js
@@ -232,7 +232,7 @@ export function migrate(doc: Request): Request {
   return doc;
 }
 
-export function create(patch: Object = {}): Promise<Request> {
+export function create(patch: $Shape<Request> = {}): Promise<Request> {
   if (!patch.parentId) {
     throw new Error(`New Requests missing \`parentId\`: ${JSON.stringify(patch)}`);
   }
@@ -248,7 +248,7 @@ export function findByParentId(parentId: string): Promise<Array<Request>> {
   return db.find(type, { parentId: parentId });
 }
 
-export function update(request: Request, patch: Object): Promise<Request> {
+export function update(request: Request, patch: $Shape<Request>): Promise<Request> {
   return db.docUpdate(request, patch);
 }
 
@@ -341,7 +341,7 @@ export function updateMimeType(
   }
 }
 
-export async function duplicate(request: Request, patch: Object = {}): Promise<Request> {
+export async function duplicate(request: Request, patch: $Shape<Request> = {}): Promise<Request> {
   if (!patch.name) {
     patch.name = `${request.name} (Copy)`;
   }

--- a/packages/insomnia-app/app/models/response.js
+++ b/packages/insomnia-app/app/models/response.js
@@ -78,7 +78,7 @@ export function init(): BaseResponse {
   };
 }
 
-export async function migrate(doc: $Shape<Response>) {
+export async function migrate(doc: Object) {
   doc = await migrateBodyToFileSystem(doc);
   doc = await migrateBodyCompression(doc);
   doc = await migrateTimelineToFileSystem(doc);
@@ -111,7 +111,7 @@ export async function all(): Promise<Array<Response>> {
 
 export async function removeForRequest(parentId: string, environmentId?: string | null) {
   const settings = await models.settings.getOrCreate();
-  const query: $Shape<Response> = {
+  const query: Object = {
     parentId,
   };
 
@@ -136,7 +136,7 @@ async function _findRecentForRequest(
   environmentId: string | null,
   limit: number,
 ): Promise<Array<Response>> {
-  const query: $Shape<Response> = {
+  const query: Object = {
     parentId: requestId,
   };
 
@@ -157,7 +157,7 @@ export async function getLatestForRequest(
   return response || null;
 }
 
-export async function create(patch: $Shape<Response> = {}, maxResponses: number = 20) {
+export async function create(patch: Object = {}, maxResponses: number = 20) {
   if (!patch.parentId) {
     throw new Error('New Response missing `parentId`');
   }
@@ -170,7 +170,7 @@ export async function create(patch: $Shape<Response> = {}, maxResponses: number 
   patch.requestVersionId = requestVersion ? requestVersion._id : null;
 
   // Filter responses by environment if setting is enabled
-  const query: $Shape<Response> = { parentId };
+  const query: Object = { parentId };
   if (
     (await models.settings.getOrCreate()).filterResponsesByEnv &&
     patch.hasOwnProperty('environmentId')
@@ -193,21 +193,15 @@ export function getLatestByParentId(parentId: string) {
   return db.getMostRecentlyModified(type, { parentId });
 }
 
-export function getBodyStream<T>(
-  response: $Shape<Response>,
-  readFailureValue: ?T,
-): Readable | null | T {
+export function getBodyStream<T>(response: Object, readFailureValue: ?T): Readable | null | T {
   return getBodyStreamFromPath(response.bodyPath || '', response.bodyCompression, readFailureValue);
 }
 
-export function getBodyBuffer<T>(
-  response: $Shape<Response>,
-  readFailureValue: ?T,
-): Buffer | T | null {
+export function getBodyBuffer<T>(response: Object, readFailureValue: ?T): Buffer | T | null {
   return getBodyBufferFromPath(response.bodyPath || '', response.bodyCompression, readFailureValue);
 }
 
-export function getTimeline(response: $Shape<Response>): Array<ResponseTimelineEntry> {
+export function getTimeline(response: Object): Array<ResponseTimelineEntry> {
   return getTimelineFromPath(response.timelinePath || '');
 }
 
@@ -274,7 +268,7 @@ function getTimelineFromPath(timelinePath: string): Array<ResponseTimelineEntry>
   }
 }
 
-async function migrateBodyToFileSystem(doc: $Shape<Response>) {
+async function migrateBodyToFileSystem(doc: Object) {
   if (doc.hasOwnProperty('body') && doc._id && !doc.bodyPath) {
     const bodyBuffer = Buffer.from(doc.body, doc.encoding || 'utf8');
     const dir = path.join(getDataDirectory(), 'responses');
@@ -300,7 +294,7 @@ async function migrateBodyToFileSystem(doc: $Shape<Response>) {
   }
 }
 
-function migrateBodyCompression(doc: $Shape<Response>) {
+function migrateBodyCompression(doc: Object) {
   if (doc.bodyCompression === '__NEEDS_MIGRATION__') {
     doc.bodyCompression = 'zip';
   }
@@ -308,7 +302,7 @@ function migrateBodyCompression(doc: $Shape<Response>) {
   return doc;
 }
 
-async function migrateTimelineToFileSystem(doc: $Shape<Response>) {
+async function migrateTimelineToFileSystem(doc: Object) {
   if (doc.hasOwnProperty('timeline') && doc._id && !doc.timelinePath) {
     const dir = path.join(getDataDirectory(), 'responses');
 

--- a/packages/insomnia-app/app/models/response.js
+++ b/packages/insomnia-app/app/models/response.js
@@ -78,7 +78,7 @@ export function init(): BaseResponse {
   };
 }
 
-export async function migrate(doc: Object) {
+export async function migrate(doc: $Shape<Response>) {
   doc = await migrateBodyToFileSystem(doc);
   doc = await migrateBodyCompression(doc);
   doc = await migrateTimelineToFileSystem(doc);
@@ -111,7 +111,7 @@ export async function all(): Promise<Array<Response>> {
 
 export async function removeForRequest(parentId: string, environmentId?: string | null) {
   const settings = await models.settings.getOrCreate();
-  const query: Object = {
+  const query: $Shape<Response> = {
     parentId,
   };
 
@@ -136,7 +136,7 @@ async function _findRecentForRequest(
   environmentId: string | null,
   limit: number,
 ): Promise<Array<Response>> {
-  const query: Object = {
+  const query: $Shape<Response> = {
     parentId: requestId,
   };
 
@@ -157,7 +157,7 @@ export async function getLatestForRequest(
   return response || null;
 }
 
-export async function create(patch: Object = {}, maxResponses: number = 20) {
+export async function create(patch: $Shape<Response> = {}, maxResponses: number = 20) {
   if (!patch.parentId) {
     throw new Error('New Response missing `parentId`');
   }
@@ -170,7 +170,7 @@ export async function create(patch: Object = {}, maxResponses: number = 20) {
   patch.requestVersionId = requestVersion ? requestVersion._id : null;
 
   // Filter responses by environment if setting is enabled
-  const query: Object = { parentId };
+  const query: $Shape<Response> = { parentId };
   if (
     (await models.settings.getOrCreate()).filterResponsesByEnv &&
     patch.hasOwnProperty('environmentId')
@@ -193,15 +193,21 @@ export function getLatestByParentId(parentId: string) {
   return db.getMostRecentlyModified(type, { parentId });
 }
 
-export function getBodyStream<T>(response: Object, readFailureValue: ?T): Readable | null | T {
+export function getBodyStream<T>(
+  response: $Shape<Response>,
+  readFailureValue: ?T,
+): Readable | null | T {
   return getBodyStreamFromPath(response.bodyPath || '', response.bodyCompression, readFailureValue);
 }
 
-export function getBodyBuffer<T>(response: Object, readFailureValue: ?T): Buffer | T | null {
+export function getBodyBuffer<T>(
+  response: $Shape<Response>,
+  readFailureValue: ?T,
+): Buffer | T | null {
   return getBodyBufferFromPath(response.bodyPath || '', response.bodyCompression, readFailureValue);
 }
 
-export function getTimeline(response: Object): Array<ResponseTimelineEntry> {
+export function getTimeline(response: $Shape<Response>): Array<ResponseTimelineEntry> {
   return getTimelineFromPath(response.timelinePath || '');
 }
 
@@ -268,7 +274,7 @@ function getTimelineFromPath(timelinePath: string): Array<ResponseTimelineEntry>
   }
 }
 
-async function migrateBodyToFileSystem(doc: Object) {
+async function migrateBodyToFileSystem(doc: $Shape<Response>) {
   if (doc.hasOwnProperty('body') && doc._id && !doc.bodyPath) {
     const bodyBuffer = Buffer.from(doc.body, doc.encoding || 'utf8');
     const dir = path.join(getDataDirectory(), 'responses');
@@ -294,7 +300,7 @@ async function migrateBodyToFileSystem(doc: Object) {
   }
 }
 
-function migrateBodyCompression(doc: Object) {
+function migrateBodyCompression(doc: $Shape<Response>) {
   if (doc.bodyCompression === '__NEEDS_MIGRATION__') {
     doc.bodyCompression = 'zip';
   }
@@ -302,7 +308,7 @@ function migrateBodyCompression(doc: Object) {
   return doc;
 }
 
-async function migrateTimelineToFileSystem(doc: Object) {
+async function migrateTimelineToFileSystem(doc: $Shape<Response>) {
   if (doc.hasOwnProperty('timeline') && doc._id && !doc.timelinePath) {
     const dir = path.join(getDataDirectory(), 'responses');
 

--- a/packages/insomnia-app/app/models/settings.js
+++ b/packages/insomnia-app/app/models/settings.js
@@ -116,7 +116,7 @@ export function migrate(doc: Settings): Settings {
   return doc;
 }
 
-export async function all(patch: Object = {}): Promise<Array<Settings>> {
+export async function all(patch: $Shape<Settings> = {}): Promise<Array<Settings>> {
   const settings = await db.all(type);
   if (settings.length === 0) {
     return [await getOrCreate()];
@@ -125,15 +125,15 @@ export async function all(patch: Object = {}): Promise<Array<Settings>> {
   }
 }
 
-export async function create(patch: Object = {}): Promise<Settings> {
+export async function create(patch: $Shape<Settings> = {}): Promise<Settings> {
   return db.docCreate(type, patch);
 }
 
-export async function update(settings: Settings, patch: Object): Promise<Settings> {
+export async function update(settings: Settings, patch: $Shape<Settings>): Promise<Settings> {
   return db.docUpdate(settings, patch);
 }
 
-export async function getOrCreate(patch: Object = {}): Promise<Settings> {
+export async function getOrCreate(patch: $Shape<Settings> = {}): Promise<Settings> {
   const results = await db.all(type);
   if (results.length === 0) {
     return create(patch);

--- a/packages/insomnia-app/app/models/stats.js
+++ b/packages/insomnia-app/app/models/stats.js
@@ -32,11 +32,11 @@ export function migrate(doc: Stats): Stats {
   return doc;
 }
 
-export function create(patch: Object = {}): Promise<Stats> {
+export function create(patch: $Shape<Stats> = {}): Promise<Stats> {
   return db.docCreate(type, patch);
 }
 
-export async function update(patch: Object): Promise<Stats> {
+export async function update(patch: $Shape<Stats>): Promise<Stats> {
   const stats = await get();
   return db.docUpdate(stats, patch);
 }

--- a/packages/insomnia-app/app/models/workspace-meta.js
+++ b/packages/insomnia-app/app/models/workspace-meta.js
@@ -44,7 +44,7 @@ export function migrate(doc: WorkspaceMeta): WorkspaceMeta {
   return doc;
 }
 
-export function create(patch: Object = {}): Promise<WorkspaceMeta> {
+export function create(patch: $Shape<WorkspaceMeta> = {}): Promise<WorkspaceMeta> {
   if (!patch.parentId) {
     throw new Error(`New WorkspaceMeta missing parentId ${JSON.stringify(patch)}`);
   }
@@ -52,7 +52,10 @@ export function create(patch: Object = {}): Promise<WorkspaceMeta> {
   return db.docCreate(type, patch);
 }
 
-export function update(workspaceMeta: WorkspaceMeta, patch: Object = {}): Promise<WorkspaceMeta> {
+export function update(
+  workspaceMeta: WorkspaceMeta,
+  patch: $Shape<WorkspaceMeta> = {},
+): Promise<WorkspaceMeta> {
   return db.docUpdate(workspaceMeta, patch);
 }
 

--- a/packages/insomnia-app/app/models/workspace.js
+++ b/packages/insomnia-app/app/models/workspace.js
@@ -31,7 +31,7 @@ export function getById(id: string): Promise<Workspace | null> {
   return db.get(type, id);
 }
 
-export async function create(patch: Object = {}): Promise<Workspace> {
+export async function create(patch: $Shape<Workspace> = {}): Promise<Workspace> {
   return db.docCreate(type, patch);
 }
 
@@ -50,7 +50,7 @@ export function count() {
   return db.count(type);
 }
 
-export function update(workspace: Workspace, patch: Object): Promise<Workspace> {
+export function update(workspace: Workspace, patch: $Shape<Workspace>): Promise<Workspace> {
   return db.docUpdate(workspace, patch);
 }
 

--- a/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
@@ -40,18 +40,18 @@ class MoveRequestGroupModal extends React.PureComponent<Props, State> {
     e.preventDefault();
 
     const { requestGroup, selectedWorkspaceId } = this.state;
-    if (!requestGroup) {
+    if (!requestGroup || !selectedWorkspaceId) {
       return;
     }
 
-    const workspace = await models.workspace.getById(selectedWorkspaceId || 'n/a');
+    const workspace = await models.workspace.getById(selectedWorkspaceId);
     if (!workspace) {
       return;
     }
 
     const newRequestGroup = await models.requestGroup.duplicate(requestGroup);
     await models.requestGroup.update(newRequestGroup, {
-      sortKey: -1e9,
+      metaSortKey: -1e9,
       parentId: selectedWorkspaceId,
       name: requestGroup.name, // Because duplicating will add (Copy) suffix
     });

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
@@ -119,17 +119,17 @@ class RequestSettingsModal extends React.PureComponent<Props, State> {
 
   async _handleMoveToWorkspace() {
     const { activeWorkspaceIdToCopyTo, request } = this.state;
-    if (!request) {
+    if (!request || !activeWorkspaceIdToCopyTo) {
       return;
     }
 
-    const workspace = await models.workspace.getById(activeWorkspaceIdToCopyTo || 'n/a');
+    const workspace = await models.workspace.getById(activeWorkspaceIdToCopyTo);
     if (!workspace) {
       return;
     }
 
     await models.request.update(request, {
-      sortKey: -1e9, // Move to top of sort order
+      metaSortKey: -1e9, // Move to top of sort order
       parentId: activeWorkspaceIdToCopyTo,
     });
 
@@ -141,18 +141,18 @@ class RequestSettingsModal extends React.PureComponent<Props, State> {
 
   async _handleCopyToWorkspace() {
     const { activeWorkspaceIdToCopyTo, request } = this.state;
-    if (!request) {
+    if (!request || !activeWorkspaceIdToCopyTo) {
       return;
     }
 
-    const workspace = await models.workspace.getById(activeWorkspaceIdToCopyTo || 'n/a');
+    const workspace = await models.workspace.getById(activeWorkspaceIdToCopyTo);
     if (!workspace) {
       return;
     }
 
     const newRequest = await models.request.duplicate(request);
     await models.request.update(newRequest, {
-      sortKey: -1e9, // Move to top of sort order
+      metaSortKey: -1e9, // Move to top of sort order
       name: request.name, // Because duplicate will add (Copy) suffix
       parentId: activeWorkspaceIdToCopyTo,
     });


### PR DESCRIPTION
[`$Shape<T>`](https://flow.org/en/docs/types/utilities/#toc-shape) in Flow allows autocomplete to work nicely and makes it safer to consume the data model functions 🎉

- I have reverted any changes to `models/response.js` because updating that was proving to be quite tricky and it would be better of to do that as a standalone change-set.
- `request-group-meta.js` had no typings so I introduced them as part of this PR.