### PR TITLE
OpenAPI v3 import robustness

### DIFF
--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/example-without-servers-input.yaml
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/example-without-servers-input.yaml
@@ -1,0 +1,167 @@
+openapi: "3.0.0"
+info:
+  title: Simple API overview
+  version: 2.0.0
+paths:
+  /:
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value: {
+                    "versions": [
+                      {
+                        "status": "CURRENT",
+                        "updated": "2011-01-21T11:33:21Z",
+                        "id": "v2.0",
+                        "links": [
+                        {
+                          "href": "http://127.0.0.1:8774/v2/",
+                          "rel": "self"
+                        }
+                        ]
+                      },
+                      {
+                        "status": "EXPERIMENTAL",
+                        "updated": "2013-07-23T11:33:21Z",
+                        "id": "v3.0",
+                        "links": [
+                        {
+                          "href": "http://127.0.0.1:8774/v3/",
+                          "rel": "self"
+                        }
+                        ]
+                      }
+                    ]
+                  }
+        '300':
+          description: |-
+            300 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value: |
+                    {
+                     "versions": [
+                           {
+                             "status": "CURRENT",
+                             "updated": "2011-01-21T11:33:21Z",
+                             "id": "v2.0",
+                             "links": [
+                                 {
+                                     "href": "http://127.0.0.1:8774/v2/",
+                                     "rel": "self"
+                                 }
+                             ]
+                         },
+                         {
+                             "status": "EXPERIMENTAL",
+                             "updated": "2013-07-23T11:33:21Z",
+                             "id": "v3.0",
+                             "links": [
+                                 {
+                                     "href": "http://127.0.0.1:8774/v3/",
+                                     "rel": "self"
+                                 }
+                             ]
+                         }
+                     ]
+                    }
+  /v2:
+    get:
+      operationId: getVersionDetailsv2
+      summary: Show API version details
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value: {
+                    "version": {
+                      "status": "CURRENT",
+                      "updated": "2011-01-21T11:33:21Z",
+                      "media-types": [
+                      {
+                        "base": "application/xml",
+                        "type": "application/vnd.openstack.compute+xml;version=2"
+                      },
+                      {
+                        "base": "application/json",
+                        "type": "application/vnd.openstack.compute+json;version=2"
+                      }
+                      ],
+                      "id": "v2.0",
+                      "links": [
+                      {
+                        "href": "http://127.0.0.1:8774/v2/",
+                        "rel": "self"
+                      },
+                      {
+                        "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                        "type": "application/pdf",
+                        "rel": "describedby"
+                      },
+                      {
+                        "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                        "type": "application/vnd.sun.wadl+xml",
+                        "rel": "describedby"
+                      },
+                      {
+                        "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                        "type": "application/vnd.sun.wadl+xml",
+                        "rel": "describedby"
+                      }
+                      ]
+                    }
+                  }
+        '203':
+          description: |-
+            203 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value: {
+                    "version": {
+                      "status": "CURRENT",
+                      "updated": "2011-01-21T11:33:21Z",
+                      "media-types": [
+                      {
+                        "base": "application/xml",
+                        "type": "application/vnd.openstack.compute+xml;version=2"
+                      },
+                      {
+                        "base": "application/json",
+                        "type": "application/vnd.openstack.compute+json;version=2"
+                      }
+                      ],
+                      "id": "v2.0",
+                      "links": [
+                      {
+                        "href": "http://23.253.228.211:8774/v2/",
+                        "rel": "self"
+                      },
+                      {
+                        "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                        "type": "application/pdf",
+                        "rel": "describedby"
+                      },
+                      {
+                        "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                        "type": "application/vnd.sun.wadl+xml",
+                        "rel": "describedby"
+                      }
+                      ]
+                    }
+                  }

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/example-without-servers-input.yaml
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/example-without-servers-input.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: '3.0.0'
 info:
   title: Simple API overview
   version: 2.0.0
@@ -15,8 +15,9 @@ paths:
             application/json:
               examples:
                 foo:
-                  value: {
-                    "versions": [
+                  value: |
+                    {
+                      "versions": [
                       {
                         "status": "CURRENT",
                         "updated": "2011-01-21T11:33:21Z",
@@ -25,8 +26,7 @@ paths:
                         {
                           "href": "http://127.0.0.1:8774/v2/",
                           "rel": "self"
-                        }
-                        ]
+                        }]
                       },
                       {
                         "status": "EXPERIMENTAL",
@@ -36,11 +36,9 @@ paths:
                         {
                           "href": "http://127.0.0.1:8774/v3/",
                           "rel": "self"
-                        }
-                        ]
-                      }
-                    ]
-                  }
+                        }]
+                      }]
+                    }
         '300':
           description: |-
             300 response
@@ -50,30 +48,27 @@ paths:
                 foo:
                   value: |
                     {
-                     "versions": [
-                           {
-                             "status": "CURRENT",
-                             "updated": "2011-01-21T11:33:21Z",
-                             "id": "v2.0",
-                             "links": [
-                                 {
-                                     "href": "http://127.0.0.1:8774/v2/",
-                                     "rel": "self"
-                                 }
-                             ]
-                         },
-                         {
-                             "status": "EXPERIMENTAL",
-                             "updated": "2013-07-23T11:33:21Z",
-                             "id": "v3.0",
-                             "links": [
-                                 {
-                                     "href": "http://127.0.0.1:8774/v3/",
-                                     "rel": "self"
-                                 }
-                             ]
-                         }
-                     ]
+                      "versions": [
+                      {
+                        "status": "CURRENT",
+                        "updated": "2011-01-21T11:33:21Z",
+                        "id": "v2.0",
+                        "links": [
+                        {
+                          "href": "http://127.0.0.1:8774/v2/",
+                          "rel": "self"
+                        }]
+                      },
+                      {
+                        "status": "EXPERIMENTAL",
+                        "updated": "2013-07-23T11:33:21Z",
+                        "id": "v3.0",
+                        "links": [
+                        {
+                          "href": "http://127.0.0.1:8774/v3/",
+                          "rel": "self"
+                        }]
+                      }]
                     }
   /v2:
     get:
@@ -87,44 +82,44 @@ paths:
             application/json:
               examples:
                 foo:
-                  value: {
-                    "version": {
-                      "status": "CURRENT",
-                      "updated": "2011-01-21T11:33:21Z",
-                      "media-types": [
+                  value: |
+                    {
+                      "version":
                       {
-                        "base": "application/xml",
-                        "type": "application/vnd.openstack.compute+xml;version=2"
-                      },
-                      {
-                        "base": "application/json",
-                        "type": "application/vnd.openstack.compute+json;version=2"
+                        "status": "CURRENT",
+                        "updated": "2011-01-21T11:33:21Z",
+                        "media-types": [
+                        {
+                          "base": "application/xml",
+                          "type": "application/vnd.openstack.compute+xml;version=2"
+                        },
+                        {
+                          "base": "application/json",
+                          "type": "application/vnd.openstack.compute+json;version=2"
+                        }],
+                        "id": "v2.0",
+                        "links": [
+                        {
+                          "href": "http://127.0.0.1:8774/v2/",
+                          "rel": "self"
+                        },
+                        {
+                          "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                          "type": "application/pdf",
+                          "rel": "describedby"
+                        },
+                        {
+                          "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                          "type": "application/vnd.sun.wadl+xml",
+                          "rel": "describedby"
+                        },
+                        {
+                          "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                          "type": "application/vnd.sun.wadl+xml",
+                          "rel": "describedby"
+                        }]
                       }
-                      ],
-                      "id": "v2.0",
-                      "links": [
-                      {
-                        "href": "http://127.0.0.1:8774/v2/",
-                        "rel": "self"
-                      },
-                      {
-                        "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
-                        "type": "application/pdf",
-                        "rel": "describedby"
-                      },
-                      {
-                        "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
-                        "type": "application/vnd.sun.wadl+xml",
-                        "rel": "describedby"
-                      },
-                      {
-                        "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
-                        "type": "application/vnd.sun.wadl+xml",
-                        "rel": "describedby"
-                      }
-                      ]
                     }
-                  }
         '203':
           description: |-
             203 response
@@ -132,36 +127,36 @@ paths:
             application/json:
               examples:
                 foo:
-                  value: {
-                    "version": {
-                      "status": "CURRENT",
-                      "updated": "2011-01-21T11:33:21Z",
-                      "media-types": [
+                  value: |
+                    {
+                      "version":
                       {
-                        "base": "application/xml",
-                        "type": "application/vnd.openstack.compute+xml;version=2"
-                      },
-                      {
-                        "base": "application/json",
-                        "type": "application/vnd.openstack.compute+json;version=2"
+                        "status": "CURRENT",
+                        "updated": "2011-01-21T11:33:21Z",
+                        "media-types": [
+                        {
+                          "base": "application/xml",
+                          "type": "application/vnd.openstack.compute+xml;version=2"
+                        },
+                        {
+                          "base": "application/json",
+                          "type": "application/vnd.openstack.compute+json;version=2"
+                        }],
+                        "id": "v2.0",
+                        "links": [
+                        {
+                          "href": "http://23.253.228.211:8774/v2/",
+                          "rel": "self"
+                        },
+                        {
+                          "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                          "type": "application/pdf",
+                          "rel": "describedby"
+                        },
+                        {
+                          "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                          "type": "application/vnd.sun.wadl+xml",
+                          "rel": "describedby"
+                        }]
                       }
-                      ],
-                      "id": "v2.0",
-                      "links": [
-                      {
-                        "href": "http://23.253.228.211:8774/v2/",
-                        "rel": "self"
-                      },
-                      {
-                        "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
-                        "type": "application/pdf",
-                        "rel": "describedby"
-                      },
-                      {
-                        "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
-                        "type": "application/vnd.sun.wadl+xml",
-                        "rel": "describedby"
-                      }
-                      ]
                     }
-                  }

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/example-without-servers-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/example-without-servers-output.json
@@ -1,0 +1,59 @@
+{
+  "__export_date": "2020-03-24T06:16:20.516Z",
+  "__export_format": 4,
+  "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
+  "resources": [
+    {
+      "_id": "__WORKSPACE_ID__",
+      "_type": "workspace",
+      "description": "",
+      "name": "Simple API overview 2.0.0",
+      "parentId": null
+    },
+    {
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
+      "data": {
+        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+      },
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_ID__"
+    },
+    {
+      "_id": "env___BASE_ENVIRONMENT_ID___sub",
+      "_type": "environment",
+      "data": {
+        "base_path": "",
+        "host": "example.com",
+        "scheme": "http"
+      },
+      "name": "OpenAPI env",
+      "parentId": "__BASE_ENVIRONMENT_ID__"
+    },
+    {
+      "_id": "req___WORKSPACE_ID__316fc296",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
+      "name": "List API versions",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/"
+    },
+    {
+      "_id": "req___WORKSPACE_ID__4dd01204",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [],
+      "method": "GET",
+      "name": "Show API version details",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/v2"
+    }
+  ]
+}

--- a/packages/insomnia-importers/src/importers/openapi3.js
+++ b/packages/insomnia-importers/src/importers/openapi3.js
@@ -65,8 +65,9 @@ module.exports.convert = async function(rawData) {
     },
   };
 
-  const servers = api.servers.map(s => urlParse(s.url));
-  const defaultServer = servers[0] || urlParse('http://example.com/');
+  const servers = api.servers || [];
+  const serverUrls = servers.map(s => urlParse(s.url));
+  const defaultServer = serverUrls[0] || urlParse('http://example.com/');
   const securityVariables = getSecurityEnvVariables(
     api.components && api.components.securitySchemes,
   );


### PR DESCRIPTION
If importing a spec which does not have the `servers` top level tag defined, the import fails.

An example of one such spec is https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/api-with-examples.yaml. This was added as a fixture test, to validate the 🐛 was fixed.

![](https://media2.giphy.com/media/HgycnYQCMeJXO/giphy.gif)

Closes #2038.