### PR TITLE
New plugin API for showing custom UI inside a dialog

### DIFF
--- a/packages/insomnia-app/app/plugins/context/__tests__/app.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/app.test.js
@@ -10,6 +10,7 @@ describe('init()', () => {
     expect(Object.keys(result)).toEqual(['app']);
     expect(Object.keys(result.app).sort()).toEqual([
       'alert',
+      'dialog',
       'getPath',
       'prompt',
       'showGenericModalDialog',

--- a/packages/insomnia-app/app/plugins/context/app.js
+++ b/packages/insomnia-app/app/plugins/context/app.js
@@ -100,11 +100,12 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): { a
 
       /** @deprecated as it was never officially supported */
       showGenericModalDialog(title: string, options?: { html: string } = {}): void {
-        console.warn(
-          'app.showGenericModalDialog() is a deprecated plugin API. Use app.dialog() instead.',
-        );
+        console.warn('app.showGenericModalDialog() is deprecated. Use app.dialog() instead.');
+
+        // Create DOM node so we can adapt to the new dialog() method
         const body = document.createElement('div');
         body.innerHTML = options.html;
+
         return this.dialog(title, { body });
       },
     },

--- a/packages/insomnia-app/app/plugins/context/app.js
+++ b/packages/insomnia-app/app/plugins/context/app.js
@@ -26,9 +26,10 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): { a
       },
       dialog(
         title,
+        body: HTMLElement,
         options: {
-          body: HTMLElement,
           onHide?: () => void,
+          tall?: boolean,
         },
       ): void {
         if (renderPurpose !== RENDER_PURPOSE_SEND && renderPurpose !== RENDER_PURPOSE_NO_RENDER) {
@@ -37,7 +38,8 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): { a
 
         showModal(WrapperModal, {
           title,
-          body: <HtmlElementWrapper el={options.body} onUnmount={options.onHide} />,
+          body: <HtmlElementWrapper el={body} onUnmount={options.onHide} />,
+          tall: options.tall,
         });
       },
       prompt(
@@ -106,7 +108,7 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): { a
         const body = document.createElement('div');
         body.innerHTML = options.html;
 
-        return this.dialog(title, { body });
+        return this.dialog(title, body);
       },
     },
   };

--- a/packages/insomnia-app/app/plugins/context/app.js
+++ b/packages/insomnia-app/app/plugins/context/app.js
@@ -27,10 +27,10 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): { a
       dialog(
         title,
         body: HTMLElement,
-        options: {
+        options?: {
           onHide?: () => void,
           tall?: boolean,
-        },
+        } = {},
       ): void {
         if (renderPurpose !== RENDER_PURPOSE_SEND && renderPurpose !== RENDER_PURPOSE_NO_RENDER) {
           return;

--- a/packages/insomnia-app/app/plugins/context/app.js
+++ b/packages/insomnia-app/app/plugins/context/app.js
@@ -1,4 +1,5 @@
 // @flow
+import * as React from 'react';
 import * as electron from 'electron';
 import { showAlert, showModal, showPrompt } from '../../ui/components/modals';
 import type { RenderPurpose } from '../../common/render';
@@ -8,10 +9,12 @@ import {
   RENDER_PURPOSE_SEND,
 } from '../../common/render';
 import WrapperModal from '../../ui/components/modals/wrapper-modal';
+import HtmlElementWrapper from '../../ui/components/html-element-wrapper';
 
 export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): { app: Object } {
   const canShowDialogs =
     renderPurpose === RENDER_PURPOSE_SEND || renderPurpose === RENDER_PURPOSE_NO_RENDER;
+
   return {
     app: {
       alert(title: string, message?: string): Promise<void> {
@@ -21,12 +24,21 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): { a
 
         return showAlert({ title, message });
       },
-      showGenericModalDialog(title: string, options?: { html: string } = {}): Promise<void> {
+      dialog(
+        title,
+        options: {
+          body: HTMLElement,
+          onHide?: () => void,
+        },
+      ): void {
         if (renderPurpose !== RENDER_PURPOSE_SEND && renderPurpose !== RENDER_PURPOSE_NO_RENDER) {
-          return Promise.resolve();
+          return;
         }
 
-        return showModal(WrapperModal, { title, bodyHTML: options.html });
+        showModal(WrapperModal, {
+          title,
+          body: <HtmlElementWrapper el={options.body} onUnmount={options.onHide} />,
+        });
       },
       prompt(
         title: string,
@@ -80,6 +92,20 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): { a
             resolve(filename || null);
           });
         });
+      },
+
+      // ~~~~~~~~~~~~~~~~~~ //
+      // Deprecated Methods //
+      // ~~~~~~~~~~~~~~~~~~ //
+
+      /** @deprecated as it was never officially supported */
+      showGenericModalDialog(title: string, options?: { html: string } = {}): void {
+        console.warn(
+          'app.showGenericModalDialog() is a deprecated plugin API. Use app.dialog() instead.',
+        );
+        const body = document.createElement('div');
+        body.innerHTML = options.html;
+        return this.dialog(title, { body });
       },
     },
   };

--- a/packages/insomnia-app/app/ui/components/html-element-wrapper.js
+++ b/packages/insomnia-app/app/ui/components/html-element-wrapper.js
@@ -1,0 +1,39 @@
+// @flow
+import * as React from 'react';
+import autobind from 'autobind-decorator';
+
+type Props = {|
+  el: HTMLElement,
+  onUnmount?: () => void,
+|};
+
+/**
+ * This component provides an easy way to place a raw DOM node inside a React
+ * application. This was created to facilitate the layer between UI plugins
+ * and the Insomnia application.
+ */
+@autobind
+class HtmlElementWrapper extends React.Component<Props> {
+  _setRef(n: ?HTMLDivElement) {
+    if (!n) {
+      return;
+    }
+
+    // Add the element directly to the React ref
+    n.innerHTML = '';
+    n.appendChild(this.props.el);
+  }
+
+  componentWillUnmount() {
+    const { onUnmount } = this.props;
+    if (typeof onUnmount === 'function') {
+      onUnmount();
+    }
+  }
+
+  render() {
+    return <div ref={this._setRef} />;
+  }
+}
+
+export default HtmlElementWrapper;


### PR DESCRIPTION
This is the first step towards providing the ability for plugins to show custom (and dynamic) UI.

- [x] Add new `context.app.dialog()` API
- [x] Deprecate old (undocumented) `context.app.showGenericDialog` method

This PR adds a new `dialog()` method which can accept a DOM node to show inside the dialog's body. Having this be a DOM node instead of static HTML allows plugins to mount a UI framework (eg. React) to the node before showing.

Here's a code example of a plugin that shows the classic "counter example" inside of a `dialog()`

```js
// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //
// Sample Folder Action to show counter app //
// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ //

import React, { useState } from 'react';
import ReactDOM from 'react-dom';

export const requestGroupActions = [{
  label: 'React Demo',
  icon: 'fa-star',
  action: (context) => {
    const root = document.createElement('div');
    ReactDOM.render(<Counter />, root);

    context.app.dialog('React Counter App', root, {
      onHide: () => ReactDOM.unmountComponentAtNode(root),
    });
  },
}];

function Counter() {
  const [count, setCount] = useState(0);
  return (
    <React.Fragment>
      <p>You clicked {count} times!</p>
      <button onClick={() => setCount(count + 1)}>Increment</button>
    </React.Fragment>
  );
}

```