### PR TITLE
Fix closing modal when pressed ESC while editing environment

### DIFF
--- a/packages/insomnia-app/app/ui/components/base/editable.js
+++ b/packages/insomnia-app/app/ui/components/base/editable.js
@@ -55,8 +55,7 @@ class Editable extends PureComponent {
       this._handleEditEnd();
     } else if (e.keyCode === 27) {
       // Pressed Escape
-      // NOTE: This blur causes a save because we save on blur
-      // TODO: Make escape blur without saving
+      this._input.value = this.props.value;
       this._input && this._input.blur();
     }
   }

--- a/packages/insomnia-app/app/ui/components/base/editable.js
+++ b/packages/insomnia-app/app/ui/components/base/editable.js
@@ -6,13 +6,10 @@ import autobind from 'autobind-decorator';
 class Editable extends PureComponent {
   constructor(props) {
     super(props);
+    this._input = React.createRef();
     this.state = {
       editing: false,
     };
-  }
-
-  _handleSetInputRef(n) {
-    this._input = n;
   }
 
   _handleSingleClickEditStart() {
@@ -25,8 +22,8 @@ class Editable extends PureComponent {
     this.setState({ editing: true });
 
     setTimeout(() => {
-      this._input && this._input.focus();
-      this._input && this._input.select();
+      this._input.current.focus();
+      this._input.current.select();
     });
 
     if (this.props.onEditStart) {
@@ -35,7 +32,7 @@ class Editable extends PureComponent {
   }
 
   _handleEditEnd() {
-    const value = this._input.value.trim();
+    const value = this._input.current.value.trim();
 
     if (!value) {
       // Don't do anything if it's empty
@@ -55,8 +52,8 @@ class Editable extends PureComponent {
       this._handleEditEnd();
     } else if (e.keyCode === 27) {
       // Pressed Escape
-      this._input.value = this.props.value;
-      this._input && this._input.blur();
+      this._input.current.value = this.props.value;
+      this._input.current.blur();
     }
   }
 
@@ -77,7 +74,7 @@ class Editable extends PureComponent {
           {...extra}
           className={`editable ${className || ''}`}
           type="text"
-          ref={this._handleSetInputRef}
+          ref={this._input}
           defaultValue={value}
           onKeyDown={this._handleEditKeyDown}
           onBlur={this._handleEditEnd}

--- a/packages/insomnia-app/app/ui/components/base/modal.js
+++ b/packages/insomnia-app/app/ui/components/base/modal.js
@@ -116,7 +116,7 @@ class Modal extends PureComponent {
   }
 
   render() {
-    const { tall, wide, noEscape, className, children } = this.props;
+    const { tall, wide, noEscape, className, children, scoped } = this.props;
     const { open, zIndex, forceRefreshCounter } = this.state;
 
     if (!open) {
@@ -138,7 +138,7 @@ class Modal extends PureComponent {
     }
 
     return (
-      <KeydownBinder stopMetaPropagation scoped onKeydown={this._handleKeyDown}>
+      <KeydownBinder stopMetaPropagation scoped={scoped} onKeydown={this._handleKeyDown}>
         <div
           ref={this._setModalRef}
           tabIndex="-1"
@@ -170,6 +170,10 @@ Modal.propTypes = {
   freshState: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
+};
+
+Modal.defaultProps = {
+  scoped: true,
 };
 
 export default Modal;

--- a/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
@@ -400,7 +400,7 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
     };
 
     return (
-      <Modal ref={this._setModalRef} wide tall {...(this.props: Object)}>
+      <Modal ref={this._setModalRef} wide tall noEscape {...(this.props: Object)}>
         <ModalHeader>Manage Environments</ModalHeader>
         <ModalBody noScroll className="env-modal">
           <div className="env-modal__sidebar">


### PR DESCRIPTION
While editing an environment variable, if user presses ESC key the modal closes and variable is saved. 

Modal shouldn't be closed and variable shouldn't be saved.

I've added `noEscape` prop as true to the Modal in `WorkspaceEnvironmentsEditModal` to prevent Modal from catching ESC key press. (`_handleKeyDown` method was catching ESC key.)

Also removed a TODO comment written 3 years ago by resetting environment variable to default if user hasn't saved while editing (presses ESC key).

Closes #2029 
