### PR TITLE
fix: correct curl import to support multi -d params

### DIFF
--- a/packages/insomnia-importers/src/__tests__/fixtures/curl/multi-data-input.sh
+++ b/packages/insomnia-importers/src/__tests__/fixtures/curl/multi-data-input.sh
@@ -1,0 +1,4 @@
+curl -X POST https://insomnia.rest/ \
+  --data "foo=bar" \
+  --data "baz=qux" \
+  -H Content-Type:application/x-www-form-urlencoded

--- a/packages/insomnia-importers/src/__tests__/fixtures/curl/multi-data-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/curl/multi-data-output.json
@@ -1,0 +1,37 @@
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2016-11-18T22:34:51.526Z",
+  "__export_source": "insomnia.importers:v0.1.0",
+  "resources": [
+    {
+      "_id": "__REQ_1__",
+      "_type": "request",
+      "parentId": "__WORKSPACE_ID__",
+      "url": "https://insomnia.rest",
+      "name": "https://insomnia.rest",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/x-www-form-urlencoded",
+        "params": [
+          {
+            "name": "foo",
+            "value": "bar"
+          },
+          {
+            "name": "baz",
+            "value": "qux"
+          }
+        ]
+      },
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/x-www-form-urlencoded"
+        }
+      ],
+      "authentication": {}
+    }
+  ]
+}

--- a/packages/insomnia-importers/src/importers/curl.js
+++ b/packages/insomnia-importers/src/importers/curl.js
@@ -174,16 +174,23 @@ function importArgs(args) {
 
   // Body (Text or Blob)
   const bodyAsGET = getPairValue(pairs, false, 'G', 'get');
-  const textBody = getPairValue(
-    pairs,
-    null,
+
+  let textBodyParams = [];
+  for (const paramName of [
     'd',
     'data',
     'data-raw',
     'data-urlencode',
     'data-binary',
     'data-ascii',
-  );
+  ]) {
+    if (pairs[paramName] && pairs[paramName].length) {
+      textBodyParams = textBodyParams.concat(pairs[paramName]);
+    }
+  }
+  // join params to make body
+  const textBody = textBodyParams.join('&');
+
   const contentTypeHeader = headers.find(h => h.name.toLowerCase() === 'content-type');
   const mimeType = contentTypeHeader ? contentTypeHeader.value.split(';')[0] : null;
 


### PR DESCRIPTION
when importing curl -d or --data params, take more than the first one.
fix #2057

```
curl --request POST \
  --url http://example.com/ \
  --header 'content-type: application/x-www-form-urlencoded' \
  --data Hello=world \
  --data foo=baz
```
is correctly imported

<img width="523" alt="image" src="https://user-images.githubusercontent.com/177003/80413346-a4a36180-88cf-11ea-9733-df812e48c225.png">
