### PR TITLE
Control code-editor indenting by tab and shift-tab

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -65,6 +65,9 @@ const BASE_CODEMIRROR_OPTIONS = {
     // Change default find command from "find" to "findPersistent" so the
     // search box stays open after pressing Enter
     [isMac() ? 'Cmd-F' : 'Ctrl-F']: 'findPersistent',
+
+    'Shift-Tab': 'indentLess',
+    Tab: 'indentMore',
   }),
 
   // NOTE: Because the lint mode is initialized immediately, the lint gutter needs to


### PR DESCRIPTION
CodeMirror defaults `Shift-Tab` to `indentAuto` instead of `indentLess`, whereas most code editors use the latter.

This PR updates the keymap defaults used by Insomnia and designer. I know @nijikokun will like this one 😉  Worth pulling locally and testing to ensure this is desired behavior.

Any proposition for a custom keymap to `indentAuto`, now that we have overwritten `Shift-Tab`?

![indenting](https://user-images.githubusercontent.com/4312346/80446180-44153280-896a-11ea-823f-4aee72b460d2.gif)

From CodeMirror [manual](https://codemirror.net/doc/manual.html)
![image](https://user-images.githubusercontent.com/4312346/80446490-15e42280-896b-11ea-812b-7dd0450aa44f.png)