### PR TITLE
Set filename of apiSpec using Workspace name during db repair

### DIFF
--- a/packages/insomnia-app/app/models/api-spec.js
+++ b/packages/insomnia-app/app/models/api-spec.js
@@ -9,7 +9,6 @@ export const canDuplicate = true;
 export const canSync = false;
 
 type BaseApiSpec = {
-  name: string,
   fileName: string,
   contentType: 'json' | 'yaml',
   contents: string,
@@ -19,7 +18,6 @@ export type ApiSpec = BaseModel & BaseApiSpec;
 
 export function init(): BaseApiSpec {
   return {
-    name: '',
     fileName: 'Insomnia Designer',
     contents: '',
     contentType: 'yaml',

--- a/packages/insomnia-app/app/models/api-spec.js
+++ b/packages/insomnia-app/app/models/api-spec.js
@@ -9,6 +9,7 @@ export const canDuplicate = true;
 export const canSync = false;
 
 type BaseApiSpec = {
+  name: string,
   fileName: string,
   contentType: 'json' | 'yaml',
   contents: string,
@@ -18,6 +19,7 @@ export type ApiSpec = BaseModel & BaseApiSpec;
 
 export function init(): BaseApiSpec {
   return {
+    name: '',
     fileName: 'Insomnia Designer',
     contents: '',
     contentType: 'yaml',


### PR DESCRIPTION
Went onto develop, and reset all ApiSpec filenames to be an empty string
![image](https://user-images.githubusercontent.com/4312346/80592797-22a06d80-8a74-11ea-9a21-a93963d5ae28.png)

Went onto this branch, and after launching, ensure `apiSpec.fileName` = `workspace.name`.
![image](https://user-images.githubusercontent.com/4312346/80593319-1d8fee00-8a75-11ea-862b-4ec0e213c7f0.png)

This will recover the fileNames for any documents that are called 'Insomnia Designer', but that'll be updated in future to only recover names of those that are missing a fileName. 

Feel free to merge if there is pressing need for this.