### PR TITLE
Suppress lint on init when spec empty or default value

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -760,7 +760,7 @@ class CodeEditor extends React.Component {
   _codemirrorValueBeforeChange(doc, change) {
     const value = this.codeMirror.getDoc().getValue();
     // Suppress lint on empty doc or single space exists (default value)
-    if (value === '' || value === ' ') {
+    if (value.trim() === '') {
       this.codeMirror.setOption('lint', false);
     } else {
       this.codeMirror.setOption('lint', true);

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -759,8 +759,8 @@ class CodeEditor extends React.Component {
 
   _codemirrorValueBeforeChange(doc, change) {
     const value = this.codeMirror.getDoc().getValue();
-
-    if (value === '') {
+    // Suppress lint on empty doc or single space exists (default value)
+    if (value === '' || value === ' ') {
       this.codeMirror.setOption('lint', false);
     } else {
       this.codeMirror.setOption('lint', true);


### PR DESCRIPTION
Fixes regression where if the spec contains nothing OR the default value, we suppress linting.

Preview (notice lint indicator on empty doc):
![2020-04-29 09 22 40](https://user-images.githubusercontent.com/52717970/80602089-b0407680-89fc-11ea-9d95-b4cff0718415.gif)

Fix:
![2020-04-29 09 35 38](https://user-images.githubusercontent.com/52717970/80602227-da923400-89fc-11ea-8a34-251a5cf39b95.gif)

