### PR TITLE
Handle non-string types in filterHeaders()

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/misc.test.js
+++ b/packages/insomnia-app/app/common/__tests__/misc.test.js
@@ -43,6 +43,7 @@ describe('filterHeaders()', () => {
     expect(misc.filterHeaders(['bad'], null)).toEqual([]);
     expect(misc.filterHeaders(['bad'], 'good')).toEqual([]);
     expect(misc.filterHeaders(null, 'good')).toEqual([]);
+    expect(misc.filterHeaders([{ name: '', value: 'valid' }], '')).toEqual([]);
     expect(misc.filterHeaders([{ name: 123, value: 123 }], 123)).toEqual([]);
     expect(misc.filterHeaders([{ name: 'good', value: 'valid' }], 123)).toEqual([]);
     expect(misc.filterHeaders([{ name: 'good', value: 'valid' }], null)).toEqual([]);

--- a/packages/insomnia-app/app/common/__tests__/misc.test.js
+++ b/packages/insomnia-app/app/common/__tests__/misc.test.js
@@ -43,6 +43,8 @@ describe('filterHeaders()', () => {
     expect(misc.filterHeaders(['bad'], null)).toEqual([]);
     expect(misc.filterHeaders(['bad'], 'good')).toEqual([]);
     expect(misc.filterHeaders(null, 'good')).toEqual([]);
+    expect(misc.filterHeaders([{ name: 123, value: 123 }], 123)).toEqual([]);
+    expect(misc.filterHeaders([{ name: 'good', value: 'valid' }], 123)).toEqual([]);
     expect(misc.filterHeaders([{ name: 'good', value: 'valid' }], null)).toEqual([]);
     expect(misc.filterHeaders([{ name: 'good', value: 'valid' }], 'good')).toEqual([
       { name: 'good', value: 'valid' },

--- a/packages/insomnia-app/app/common/misc.js
+++ b/packages/insomnia-app/app/common/misc.js
@@ -29,7 +29,7 @@ export function filterParameters<T: Parameter>(parameters: Array<T>, name: strin
 }
 
 export function filterHeaders<T: Header>(headers: Array<T>, name: string): Array<T> {
-  if (!Array.isArray(headers) || !(typeof name === 'string')) {
+  if (!Array.isArray(headers) || !name || !(typeof name === 'string')) {
     return [];
   }
 

--- a/packages/insomnia-app/app/common/misc.js
+++ b/packages/insomnia-app/app/common/misc.js
@@ -34,11 +34,12 @@ export function filterHeaders<T: Header>(headers: Array<T>, name: string): Array
   }
 
   return headers.filter(h => {
-    if (!h || !(typeof h.name === 'string')) {
+    // Never match against invalid headers
+    if (!h || !h.name || typeof h.name !== 'string') {
       return false;
-    } else {
-      return h.name.toLowerCase() === name.toLowerCase();
     }
+
+    return h.name.toLowerCase() === name.toLowerCase();
   });
 }
 
@@ -166,7 +167,7 @@ export function describeByteSize(bytes: number, long: boolean = false): string {
   // NOTE: We multiply these by 2 so we don't end up with
   // values like 0 GB
 
-  let unit = long ? 'bytes' : 'B';
+  let unit;
   if (bytes < 1024 * 2) {
     size = bytes;
     unit = long ? 'bytes' : 'B';
@@ -253,16 +254,16 @@ export function escapeRegex(str: string): string {
 export function fuzzyMatch(
   searchString: string,
   text: string,
-  options: { splitSpace?: boolean, loose?: boolean } = {},
-): null | { score: number, indexes: Array<number> } {
+  options: {splitSpace?: boolean, loose?: boolean} = {},
+): null | {score: number, indexes: Array<number>} {
   return fuzzyMatchAll(searchString, [text], options);
 }
 
 export function fuzzyMatchAll(
   searchString: string,
   allText: Array<string>,
-  options: { splitSpace?: boolean, loose?: boolean } = {},
-): null | { score: number, indexes: Array<number> } {
+  options: {splitSpace?: boolean, loose?: boolean} = {},
+): null | {score: number, indexes: Array<number>} {
   if (!searchString || !searchString.trim()) {
     return null;
   }
@@ -308,7 +309,11 @@ export function fuzzyMatchAll(
     return null;
   }
 
-  return { score: maxScore, indexes, target: allText.join(' ') };
+  return {
+    score: maxScore,
+    indexes,
+    target: allText.join(' '),
+  };
 }
 
 export function getViewportSize(): string | null {

--- a/packages/insomnia-app/app/common/misc.js
+++ b/packages/insomnia-app/app/common/misc.js
@@ -29,12 +29,12 @@ export function filterParameters<T: Parameter>(parameters: Array<T>, name: strin
 }
 
 export function filterHeaders<T: Header>(headers: Array<T>, name: string): Array<T> {
-  if (!Array.isArray(headers) || !name) {
+  if (!Array.isArray(headers) || !(typeof name === 'string')) {
     return [];
   }
 
   return headers.filter(h => {
-    if (!h || !h.name) {
+    if (!h || !(typeof h.name === 'string')) {
       return false;
     } else {
       return h.name.toLowerCase() === name.toLowerCase();


### PR DESCRIPTION
This is a small fix for a bug report that was submitted to support. I'm not sure how it happened, but somehow the user ended up with a request header with a non-string name.