### PR TITLE
Add plugin hub/npm hyperlink to plugin listing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12014,7 +12014,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -12035,12 +12036,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12055,17 +12058,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -12182,7 +12188,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -12194,6 +12201,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -12208,6 +12216,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12215,12 +12224,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -12239,6 +12250,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -12300,7 +12312,8 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -12328,7 +12341,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -12340,6 +12354,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -12417,7 +12432,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -12453,6 +12469,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -12472,6 +12489,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -12515,12 +12533,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/insomnia-app/app/common/constants.js
+++ b/packages/insomnia-app/app/common/constants.js
@@ -137,6 +137,10 @@ export const UPDATE_URL_WINDOWS = 'https://updates.insomnia.rest/updates/win';
 // API
 export const API_BASE_URL = 'https://api.insomnia.rest';
 
+// PLUGINS
+export const PLUGIN_HUB_BASE = 'https://insomnia.rest/plugins';
+export const NPM_PACKAGE_BASE = 'https://www.npmjs.com/package';
+
 // UI Stuff
 export const MAX_SIDEBAR_REMS = 45;
 export const MIN_SIDEBAR_REMS = 0.75;
@@ -318,7 +322,7 @@ export const RESPONSE_CODE_DESCRIPTIONS = {
   403: 'Client does not have access rights to the content, so the server is rejecting to give proper response.',
   404: 'Server cannot find requested resource. This response code is probably the most famous one due to how frequently it occurs on the web.',
   405: 'The request method is known by the server but has been disabled and cannot be used.',
-  406: 'This response is sent when the web server, after performing server-driven content negotiation, doesn\'t find any content following the criteria given by the user agent.',
+  406: "This response is sent when the web server, after performing server-driven content negotiation, doesn't find any content following the criteria given by the user agent.",
   407: 'This is similar to 401 but authentication is needed to be done by a proxy.',
   408: 'This response is sent on an idle connection by some servers, even without any previous request by the client. It means that the server would like to shut down this unused connection. This response is used much more since some browsers, like Chrome or IE9, use HTTP pre-connection mechanisms to speed up surfing (see bug 881804, which tracks the future implementation of such a mechanism in Firefox). Also, note that some servers merely shut down the connection without sending this message.',
   409: 'This response is sent when a request conflicts with the current state of the server.',
@@ -328,22 +332,22 @@ export const RESPONSE_CODE_DESCRIPTIONS = {
   413: 'Request entity is larger than limits defined by the server; the server might close the connection or return a Retry-After header field.',
   414: 'The URI requested by the client is longer than the server is willing to interpret.',
   415: 'The media format of the requested data is not supported by the server, so the server is rejecting the request.',
-  416: 'The range specified by the Range header field in the request can\'t be fulfilled; it\'s possible that the range is outside the size of the target URI\'s data.',
-  417: 'This response code means the expectation indicated by the Expect request header field can\'t be met by the server.',
+  416: "The range specified by the Range header field in the request can't be fulfilled; it's possible that the range is outside the size of the target URI's data.",
+  417: "This response code means the expectation indicated by the Expect request header field can't be met by the server.",
   418: 'Any attempt to brew coffee with a teapot should result in the error code "418 I\'m a teapot". The resulting entity body MAY be short and stout.',
   421: 'The request was directed at a server that is not able to produce a response. This can be sent by a server that is not configured to produce responses for the combination of scheme and authority that are included in the request URI.',
   422: 'The request was well-formed but was unable to be followed due to semantic errors.',
   423: 'The resource that is being accessed is locked.',
   424: 'The request failed due to failure of a previous request.',
   426: 'The server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol. The server MUST send an Upgrade header field in a 426 response to indicate the required protocol(s) (Section 6.7 of [RFC7230]).',
-  428: 'The origin server requires the request to be conditional. Intended to prevent "the \'lost update\' problem, where a client GETs a resource\'s state, modifies it, and PUTs it back to the server, when meanwhile a third party has modified the state on the server, leading to a conflict."',
+  428: "The origin server requires the request to be conditional. Intended to prevent \"the 'lost update' problem, where a client GETs a resource's state, modifies it, and PUTs it back to the server, when meanwhile a third party has modified the state on the server, leading to a conflict.\"",
   429: 'The user has sent too many requests in a given amount of time ("rate limiting").',
   431: 'The server is unwilling to process the request because its header fields are too large. The request MAY be resubmitted after reducing the size of the request header fields.',
   451: 'The user requests an illegal resource, such as a web page censored by a government.',
 
   // 500s
 
-  500: 'The server has encountered a situation it doesn\'t know how to handle.',
+  500: "The server has encountered a situation it doesn't know how to handle.",
   501: 'The request method is not supported by the server and cannot be handled. The only methods that servers are required to support (and therefore that must not return this code) are GET and HEAD.',
   502: 'This error response means that the server, while working as a gateway to get a response needed to handle the request, got an invalid response.',
   503: 'The server is not ready to handle the request. Common causes are a server that is down for maintenance or that is overloaded. Note that together with this response, a user-friendly page explaining the problem should be sent. This responses should be used for temporary conditions and the Retry-After: HTTP header should, if possible, contain the estimated time before the recovery of the service. The webmaster must also take care about the caching-related headers that are sent along with this response, as these temporary condition responses should usually not be cached.',

--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -192,10 +192,7 @@ class Plugins extends React.PureComponent<Props, State> {
   renderLink(plugin: Plugin) {
     const { name } = plugin;
 
-    let base = NPM_PACKAGE_BASE;
-    if (/^insomnia-plugin-/.test(name)) {
-      base = PLUGIN_HUB_BASE;
-    }
+    const base = /^insomnia-plugin-/.test(name) ? PLUGIN_HUB_BASE : NPM_PACKAGE_BASE;
     const link = path.join(base, name);
 
     return (

--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -1,4 +1,5 @@
 // @flow
+import * as path from 'path';
 import type { Plugin } from '../../../plugins/index';
 import { getPlugins } from '../../../plugins/index';
 import * as React from 'react';
@@ -10,7 +11,7 @@ import installPlugin from '../../../plugins/install';
 import HelpTooltip from '../help-tooltip';
 import Link from '../base/link';
 import { delay } from '../../../common/misc';
-import { PLUGIN_PATH } from '../../../common/constants';
+import { NPM_PACKAGE_BASE, PLUGIN_HUB_BASE, PLUGIN_PATH } from '../../../common/constants';
 import type { PluginConfig, Settings } from '../../../models/settings';
 import ToggleSwitch from './toggle-switch';
 import { Button } from 'insomnia-components';
@@ -115,9 +116,8 @@ class Plugins extends React.PureComponent<Props, State> {
       submitName: 'Generate',
       label: 'Plugin Name',
       selectText: true,
-      validate: (name) => name.match(/^[a-z][a-z-]*[a-z]$/)
-        ? ''
-        : 'Plugin name must be of format my-plugin-name',
+      validate: name =>
+        name.match(/^[a-z][a-z-]*[a-z]$/) ? '' : 'Plugin name must be of format my-plugin-name',
       onComplete: async name => {
         // Remove insomnia-plugin- prefix if they accidentally typed it
         name = name.replace(/^insomnia-plugin-/, '');
@@ -188,6 +188,22 @@ class Plugins extends React.PureComponent<Props, State> {
     );
   }
 
+  renderLink(plugin: Plugin) {
+    const { name } = plugin;
+
+    let base = NPM_PACKAGE_BASE;
+    if (/^insomnia-plugin-/.test(name)) {
+      base = PLUGIN_HUB_BASE;
+    }
+    const link = path.join(base, name);
+
+    return (
+      <a className="space-left" href={link} title={link}>
+        <i className="fa fa-external-link-square" />
+      </a>
+    );
+  }
+
   render() {
     const { plugins, error, isInstallingFromNpm, isRefreshingPlugins } = this.state;
 
@@ -203,45 +219,48 @@ class Plugins extends React.PureComponent<Props, State> {
         ) : (
           <table className="table--fancy table--striped table--valign-middle margin-top margin-bottom">
             <thead>
-            <tr>
-              <th>Enable?</th>
-              <th>Name</th>
-              <th>Version</th>
-              <th>Folder</th>
-            </tr>
+              <tr>
+                <th>Enable?</th>
+                <th>Name</th>
+                <th>Version</th>
+                <th>Folder</th>
+              </tr>
             </thead>
             <tbody>
-            {plugins.map(plugin =>
-              !plugin.directory ? null : (
-                <tr key={plugin.name}>
-                  <td style={{ width: '4rem' }}>{this.renderToggleSwitch(plugin)}</td>
-                  <td>
-                    {plugin.name}
-                    {plugin.description && (
-                      <HelpTooltip info className="space-left">
-                        {plugin.description}
-                      </HelpTooltip>
-                    )}
-                  </td>
-                  <td>{plugin.version}</td>
-                  <td className="no-wrap" style={{ width: '10rem' }}>
-                    <CopyButton
-                      size="small"
-                      variant="contained"
-                      title={plugin.directory}
-                      content={plugin.directory}>
-                      Copy Path
-                    </CopyButton>{' '}
-                    <Button
-                      size="small"
-                      variant="contained"
-                      onClick={Plugins._handleOpenDirectory.bind(this, plugin.directory)}>
-                      Reveal Folder
-                    </Button>
-                  </td>
-                </tr>
-              ),
-            )}
+              {plugins.map(plugin =>
+                !plugin.directory ? null : (
+                  <tr key={plugin.name}>
+                    <td style={{ width: '4rem' }}>{this.renderToggleSwitch(plugin)}</td>
+                    <td>
+                      {plugin.name}
+                      {plugin.description && (
+                        <HelpTooltip info className="space-left">
+                          {plugin.description}
+                        </HelpTooltip>
+                      )}
+                    </td>
+                    <td>
+                      {plugin.version}
+                      {this.renderLink(plugin)}
+                    </td>
+                    <td className="no-wrap" style={{ width: '10rem' }}>
+                      <CopyButton
+                        size="small"
+                        variant="contained"
+                        title={plugin.directory}
+                        content={plugin.directory}>
+                        Copy Path
+                      </CopyButton>{' '}
+                      <Button
+                        size="small"
+                        variant="contained"
+                        onClick={Plugins._handleOpenDirectory.bind(this, plugin.directory)}>
+                        Reveal Folder
+                      </Button>
+                    </td>
+                  </tr>
+                ),
+              )}
             </tbody>
           </table>
         )}
@@ -277,12 +296,8 @@ class Plugins extends React.PureComponent<Props, State> {
         <hr />
 
         <div className="text-right">
-          <Button onClick={this._handleCreatePlugin}>
-            Generate New Plugin
-          </Button>
-          <Button
-            className="space-left"
-            onClick={Plugins._handleClickShowPluginsFolder}>
+          <Button onClick={this._handleCreatePlugin}>Generate New Plugin</Button>
+          <Button className="space-left" onClick={Plugins._handleClickShowPluginsFolder}>
             Reveal Plugins Folder
           </Button>
           <Button

--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -61,13 +61,14 @@ class Plugins extends React.PureComponent<Props, State> {
 
     this.setState({ isInstallingFromNpm: true });
 
-    const newState = {
+    const newState: $Shape<State> = {
       isInstallingFromNpm: false,
       error: '',
     };
     try {
       await installPlugin(this.state.npmPluginValue.trim());
       await this._handleRefreshPlugins();
+      newState.npmPluginValue = ''; // Clear input if successful install
     } catch (err) {
       newState.error = err.message;
     }
@@ -205,7 +206,7 @@ class Plugins extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { plugins, error, isInstallingFromNpm, isRefreshingPlugins } = this.state;
+    const { plugins, error, isInstallingFromNpm, isRefreshingPlugins, npmPluginValue } = this.state;
 
     return (
       <div>
@@ -282,6 +283,7 @@ class Plugins extends React.PureComponent<Props, State> {
                 disabled={isInstallingFromNpm}
                 type="text"
                 placeholder="npm-package-name"
+                value={npmPluginValue}
               />
             </div>
             <div className="form-control width-auto">

--- a/packages/openapi-2-kong/package-lock.json
+++ b/packages/openapi-2-kong/package-lock.json
@@ -1869,7 +1869,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1890,12 +1891,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1910,17 +1913,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2037,7 +2043,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2049,6 +2056,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2063,6 +2071,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2070,12 +2079,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2094,6 +2105,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2174,7 +2186,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2186,6 +2199,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2271,7 +2285,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2307,6 +2322,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2326,6 +2342,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2369,12 +2386,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
This PR adds an external link to see the documentation of installed plugins.

If a plugin is prefixed with `insomnia-plugin-` (therefore listed on the plugin hub), then the link leads to the plugin hub, otherwise leads to npm.

![image](https://user-images.githubusercontent.com/4312346/80895681-9fb13880-8d3b-11ea-892d-80b8a23f3699.png)

Cleanup: this PR also clears the package installer input field _if the plugin installed correctly_
