### PR TITLE
Bug in restoring code-folds

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint \"**/*.js\" \"**/*.html\" \"**/*.json\"",
-    "lint:fix": "eslint \"**/*.js\" \"**/*.html\" \"**/*.json\" --fix",
+    "lint": "eslint \"**/*.js\" \"**/*.html\" \"**/*.json\" --fix",
     "bootstrap": "npm install && lerna bootstrap && lerna run --parallel --stream bootstrap",
     "publish": "lerna publish",
     "clean": "lerna clean --yes && rimraf node_modules",
@@ -23,7 +23,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged && npm run lint:fix"
+      "pre-commit": "pretty-quick --staged && npm run lint"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint \"**/*.js\" \"**/*.html\" \"**/*.json\"",
-    "lint": "eslint \"**/*.js\" \"**/*.html\" \"**/*.json\" --fix",
+    "lint:fix": "eslint \"**/*.js\" \"**/*.html\" \"**/*.json\" --fix",
     "bootstrap": "npm install && lerna bootstrap && lerna run --parallel --stream bootstrap",
     "publish": "lerna publish",
     "clean": "lerna clean --yes && rimraf node_modules",

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -269,7 +269,7 @@ class CodeEditor extends React.Component {
     this.codeMirror.setSelections(selections, null, { scroll: false });
 
     // Restore marks one-by-one
-    for (const { from, to } in marks || []) {
+    for (const { from, to } of marks || []) {
       this.codeMirror.foldCode(from, to);
     }
   }
@@ -805,7 +805,8 @@ class CodeEditor extends React.Component {
     const value = this.codeMirror.getDoc().getValue();
 
     // Disable linting if the document reaches a maximum size or is empty
-    const shouldLint = (value.length > MAX_SIZE_FOR_LINTING || value.length === 0) ? false : !this.props.noLint;
+    const shouldLint =
+      value.length > MAX_SIZE_FOR_LINTING || value.length === 0 ? false : !this.props.noLint;
     const existingLint = this.codeMirror.options.lint || false;
     if (shouldLint !== existingLint) {
       const { lintOptions } = this.props;


### PR DESCRIPTION
When this section of code was changed from `marks && marks.forEach(...)`, it was converted to a `for...in` loop instead of `for...of`.

Currently, if you fold any code, navigate away, and come back, it causes a fatal failure. This has not been released into Core yet, however **Designer does have this bug**.

![fatal](https://user-images.githubusercontent.com/4312346/81021307-014de000-8ebf-11ea-96ba-2a8acc2ccb09.gif)

Note: unnecessary changes often get added in from linting. I changed `lint:fix` command in the pre-commit hook back to `lint`, because after fixing it does not stage the changes for the commit. Ideally, it _should_ stage those items. It would be cool to combine prettier, eslint, husky, and lint-staged, so that _all_ methods of fixing code use the exact same specification. Will do when we have downtime. 👍 