### PR TITLE
Fix FileInputButton breaking when path is null

### DIFF
--- a/packages/insomnia-app/app/ui/components/base/file-input-button.js
+++ b/packages/insomnia-app/app/ui/components/base/file-input-button.js
@@ -78,7 +78,10 @@ class FileInputButton extends React.PureComponent<Props> {
 
   render() {
     const { showFileName, showFileIcon, path, name, ...extraProps } = this.props;
-    const fileName = pathBasename(path);
+
+    // NOTE: Basename fails if path is not a string, so let's make sure it is
+    const fileName = typeof path === 'string' ? pathBasename(path) : null;
+
     return (
       <button
         type="button"


### PR DESCRIPTION
Closes #2126

Quick one! Just adding a check to `<FileInputButton />` to ensure we call `path.basename()` with a valid string (otherwise it throws an exception).