### PR TITLE
Prioritize plugins correctly if the same type of plugin exists at different levels in OAS

### DIFF
--- a/packages/openapi-2-kong/src/common.js
+++ b/packages/openapi-2-kong/src/common.js
@@ -86,14 +86,12 @@ export const HttpMethod = {
   trace: 'TRACE',
 };
 
-export type HttpMethodKeys = $Values<typeof HttpMethod>;
-
 export function isHttpMethodKey(key: string): boolean {
   const uppercaseKey = key.toUpperCase();
   return Object.values(HttpMethod).some(m => m === uppercaseKey);
 }
 
-export function getMethodAnnotationName(method: HttpMethodKeys): string {
+export function getMethodAnnotationName(method: HttpMethodType): string {
   return `${method}-method`.toLowerCase();
 }
 

--- a/packages/openapi-2-kong/src/kubernetes/__tests__/index.test.js
+++ b/packages/openapi-2-kong/src/kubernetes/__tests__/index.test.js
@@ -489,12 +489,8 @@ describe('index', () => {
         keyAuthPluginDoc('s2'),
         dummyPluginDoc('s3'),
         ingressDoc([keyAuthName('g0')], 'api-0.insomnia.rest', 'my-api-s0'),
-        ingressDoc([keyAuthName('g0'), keyAuthName('s1')], 'api-1.insomnia.rest', 'my-api-s1'),
-        ingressDoc(
-          [keyAuthName('g0'), keyAuthName('s2'), dummyName('s3')],
-          'api-2.insomnia.rest',
-          'my-api-s2',
-        ),
+        ingressDoc([keyAuthName('s1')], 'api-1.insomnia.rest', 'my-api-s1'),
+        ingressDoc([keyAuthName('s2'), dummyName('s3')], 'api-2.insomnia.rest', 'my-api-s2'),
       ]);
     });
 
@@ -522,14 +518,9 @@ describe('index', () => {
         keyAuthPluginDoc('p2'),
         dummyPluginDoc('p3'),
         ingressDoc([keyAuthName('g0')], 'api.insomnia.rest', 'my-api-s0', '/no-plugin'),
+        ingressDoc([keyAuthName('p1')], 'api.insomnia.rest', 'my-api-s0', '/plugin-0'),
         ingressDoc(
-          [keyAuthName('g0'), keyAuthName('p1')],
-          'api.insomnia.rest',
-          'my-api-s0',
-          '/plugin-0',
-        ),
-        ingressDoc(
-          [keyAuthName('g0'), keyAuthName('p2'), dummyName('p3')],
+          [keyAuthName('p2'), dummyName('p3')],
           'api.insomnia.rest',
           'my-api-s0',
           '/plugin-1',
@@ -573,14 +564,14 @@ describe('index', () => {
           '/path',
         ),
         ingressDocWithOverride(
-          [keyAuthName('g0'), keyAuthName('m1')],
+          [keyAuthName('m1')],
           'put-method',
           'api.insomnia.rest',
           'my-api-s0',
           '/path',
         ),
         ingressDocWithOverride(
-          [keyAuthName('g0'), keyAuthName('m2'), dummyName('m3')],
+          [keyAuthName('m2'), dummyName('m3')],
           'post-method',
           'api.insomnia.rest',
           'my-api-s0',

--- a/packages/openapi-2-kong/src/kubernetes/__tests__/plugins.test.js
+++ b/packages/openapi-2-kong/src/kubernetes/__tests__/plugins.test.js
@@ -10,11 +10,14 @@ import {
   getServerPlugins,
   normalizeOperationPlugins,
   normalizePathPlugins,
+  distinctByProperty,
+  prioritizePlugins,
 } from '../plugins';
 import { HttpMethod } from '../../common';
 import {
   dummyPluginDoc,
   keyAuthPluginDoc,
+  pluginDocWithName,
   pluginDummy,
   pluginKeyAuth,
 } from './util/plugin-helpers';
@@ -592,6 +595,147 @@ describe('plugins', () => {
         keyAuthPluginDoc('p2'),
         keyAuthPluginDoc('m3'),
       ]);
+    });
+  });
+
+  describe('prioritizePlugins', () => {
+    it('should return empty array if no plugins', () => {
+      const global = [];
+      const server = [];
+      const path = [];
+      const operation = [];
+
+      const result = prioritizePlugins(global, server, path, operation);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should return all plugins if no two plugins are the same type', () => {
+      const p1 = pluginDocWithName('p1', 'custom-plugin-1');
+      const p2 = pluginDocWithName('p2', 'custom-plugin-2');
+      const p3 = pluginDocWithName('p3', 'custom-plugin-3');
+      const p4 = pluginDocWithName('p4', 'custom-plugin-4');
+
+      const global = [p1];
+      const server = [p2];
+      const path = [p3];
+      const operation = [p4];
+
+      const result = prioritizePlugins(global, server, path, operation);
+      expect(result).toEqual([...operation, ...path, ...server, ...global]);
+    });
+
+    it('should return operation plugin if same type exists in path, server and global', () => {
+      const pluginType = 'custom-plugin';
+      const p1 = pluginDocWithName('p1', pluginType);
+      const p2 = pluginDocWithName('p2', pluginType);
+      const p3 = pluginDocWithName('p3', pluginType);
+      const p4 = pluginDocWithName('p4', pluginType);
+
+      const global = [p1];
+      const server = [p2];
+      const path = [p3];
+      const operation = [p4];
+
+      const result = prioritizePlugins(global, server, path, operation);
+      expect(result).toEqual([...operation]);
+    });
+
+    it('should return path plugin if same type exists in server and global', () => {
+      const pluginType = 'custom-plugin';
+      const p1 = pluginDocWithName('p1', pluginType);
+      const p2 = pluginDocWithName('p2', pluginType);
+      const p3 = pluginDocWithName('p3', pluginType);
+
+      const global = [p1];
+      const server = [p2];
+      const path = [p3];
+      const operation = [];
+
+      const result = prioritizePlugins(global, server, path, operation);
+      expect(result).toEqual([...path]);
+    });
+
+    it('should return server plugin if same type exists in global', () => {
+      const pluginType = 'custom-plugin';
+      const p1 = pluginDocWithName('p1', pluginType);
+      const p2 = pluginDocWithName('p2', pluginType);
+
+      const global = [p1];
+      const server = [p2];
+      const path = [];
+      const operation = [];
+
+      const result = prioritizePlugins(global, server, path, operation);
+      expect(result).toEqual([...server]);
+    });
+
+    it('should prioritize as expected', () => {
+      const typeG = 'custom-plugin-1';
+      const typeS = 'custom-plugin-2';
+      const typeP = 'custom-plugin-3';
+      const typeO = 'custom-plugin-4';
+
+      // Note: the variable naming below is [applied-to][resolved-from]
+      // IE: po implies it is applied to a path, but that plugin type should be resolved by the operation
+      // Therefore, the result should only contain gg, ss, pp and oo. The others are duplicates
+      // of the same plugin type and should be filtered out due.
+      const gg = pluginDocWithName('gg', typeG);
+
+      const gs = pluginDocWithName('gs', typeS);
+      const ss = pluginDocWithName('ss', typeS);
+
+      const gp = pluginDocWithName('gp', typeP);
+      const sp = pluginDocWithName('sp', typeP);
+      const pp = pluginDocWithName('pp', typeP);
+
+      const go = pluginDocWithName('go', typeO);
+      const so = pluginDocWithName('so', typeO);
+      const po = pluginDocWithName('po', typeO);
+      const oo = pluginDocWithName('oo', typeO);
+
+      const global = [gg, gs, gp, go];
+      const server = [ss, sp, so];
+      const path = [pp, po];
+      const operation = [oo];
+
+      const result = prioritizePlugins(global, server, path, operation);
+      expect(result).toEqual([oo, pp, ss, gg]);
+    });
+  });
+
+  describe('distinctByProperty()', () => {
+    it('returns empty array if no truthy items', () => {
+      expect(distinctByProperty([], i => i)).toHaveLength(0);
+      expect(distinctByProperty([undefined], i => i)).toHaveLength(0);
+      expect(distinctByProperty([null, undefined, ''], i => i)).toHaveLength(0);
+    });
+
+    it('should remove objects with the same property selector - removes 2/4', () => {
+      const item1 = { name: 'a', value: 'first' };
+      const item2 = { name: 'a', value: 'second' };
+      const item3 = { name: 'b', value: 'third' };
+      const item4 = { name: 'b', value: 'fourth' };
+      const items = [item1, item2, item3, item4];
+
+      // distinct by the name property
+      const filtered = distinctByProperty(items, i => i.name);
+
+      // Should remove item2 and item4
+      expect(filtered).toEqual([item1, item3]);
+    });
+
+    it('should remove objects with the same property selector - removes none', () => {
+      const item1 = { name: 'a', value: 'first' };
+      const item2 = { name: 'a', value: 'second' };
+      const item3 = { name: 'b', value: 'third' };
+      const item4 = { name: 'b', value: 'fourth' };
+      const items = [item1, item2, item3, item4];
+
+      // distinct by the value property
+      const filtered = distinctByProperty(items, i => i.value);
+
+      // Should remove no items
+      expect(filtered).toEqual(items);
     });
   });
 });

--- a/packages/openapi-2-kong/src/kubernetes/__tests__/plugins.test.js
+++ b/packages/openapi-2-kong/src/kubernetes/__tests__/plugins.test.js
@@ -678,7 +678,7 @@ describe('plugins', () => {
       // Note: the variable naming below is [applied-to][resolved-from]
       // IE: po implies it is applied to a path, but that plugin type should be resolved by the operation
       // Therefore, the result should only contain gg, ss, pp and oo. The others are duplicates
-      // of the same plugin type and should be filtered out due.
+      // of the same plugin type and should be filtered out due to prioritization.
       const gg = pluginDocWithName('gg', typeG);
 
       const gs = pluginDocWithName('gs', typeS);

--- a/packages/openapi-2-kong/src/kubernetes/__tests__/util/plugin-helpers.js
+++ b/packages/openapi-2-kong/src/kubernetes/__tests__/util/plugin-helpers.js
@@ -17,6 +17,14 @@ export const pluginDummy = {
   },
 };
 
+export const pluginDocWithName = (name: string, pluginType: string) => ({
+  apiVersion: 'configuration.konghq.com/v1',
+  kind: 'KongPlugin',
+  metadata: {
+    name,
+  },
+  plugin: pluginType,
+});
 export const keyAuthPluginDoc = (suffix: string) => ({
   apiVersion: 'configuration.konghq.com/v1',
   config: {

--- a/packages/openapi-2-kong/src/kubernetes/index.js
+++ b/packages/openapi-2-kong/src/kubernetes/index.js
@@ -18,7 +18,7 @@ export function generateKongForKubernetesConfigFromSpec(
   // Initialize document collections
   const ingressDocuments = [];
 
-  const methodsThatNeedKongIngressDocuments: { [HttpMethodType]: boolean } = {};
+  const methodsThatNeedKongIngressDocuments: Set<HttpMethodType> = new Set<HttpMethodType>();
 
   // Iterate all global servers
   plugins.servers.forEach((sp, serverIndex) => {
@@ -37,7 +37,7 @@ export function generateKongForKubernetesConfigFromSpec(
         const method = o.method;
         if (method) {
           annotations.overrideName = getMethodAnnotationName(method);
-          methodsThatNeedKongIngressDocuments[method] = true;
+          methodsThatNeedKongIngressDocuments.add(method);
         }
 
         // Create metadata
@@ -58,7 +58,7 @@ export function generateKongForKubernetesConfigFromSpec(
     });
   });
 
-  const methodDocuments = Object.keys(methodsThatNeedKongIngressDocuments).map(
+  const methodDocuments = Array.from(methodsThatNeedKongIngressDocuments).map(
     generateK8sMethodDocuments,
   );
   const pluginDocuments = flattenPluginDocuments(plugins);

--- a/packages/openapi-2-kong/src/kubernetes/index.js
+++ b/packages/openapi-2-kong/src/kubernetes/index.js
@@ -7,6 +7,7 @@ import { pathVariablesToWildcard, resolveUrlVariables } from './variables';
 
 export function generateKongForKubernetesConfigFromSpec(
   api: OpenApi3Spec,
+  tags: Array<string>,
 ): KongForKubernetesResult {
   let _iterator = 0;
   const increment = (): number => _iterator++;

--- a/packages/openapi-2-kong/src/kubernetes/plugins.js
+++ b/packages/openapi-2-kong/src/kubernetes/plugins.js
@@ -197,3 +197,32 @@ export function normalizeOperationPlugins(operationPlugins: OperationPlugins): O
   const pluginsExist = operationPlugins.some(o => o.plugins.length);
   return pluginsExist ? operationPlugins : [blankOperation];
 }
+
+export function prioritizePlugins(
+  global: Array<KubernetesPluginConfig>,
+  server: Array<KubernetesPluginConfig>,
+  path: Array<KubernetesPluginConfig>,
+  operation: Array<KubernetesPluginConfig>,
+): Array<KubernetesPluginConfig> {
+  // Order in priority: operation > path > server > global
+  const plugins: Array<KubernetesPluginConfig> = [...operation, ...path, ...server, ...global];
+
+  // Select first of each type of plugin
+  return distinctByProperty(plugins, p => p.plugin);
+}
+
+export function distinctByProperty<T>(arr: Array<T>, propertySelector: (item: T) => any): Array<T> {
+  const result: Array<T> = [];
+  const map = new Map();
+
+  for (const item of arr.filter(i => i)) {
+    const selector = propertySelector(item);
+    if (map.has(selector)) {
+      continue;
+    }
+
+    map.set(selector, true);
+    result.push(item);
+  }
+  return result;
+}

--- a/packages/openapi-2-kong/src/kubernetes/plugins.js
+++ b/packages/openapi-2-kong/src/kubernetes/plugins.js
@@ -213,15 +213,15 @@ export function prioritizePlugins(
 
 export function distinctByProperty<T>(arr: Array<T>, propertySelector: (item: T) => any): Array<T> {
   const result: Array<T> = [];
-  const map = new Map();
+  const set = new Set();
 
   for (const item of arr.filter(i => i)) {
     const selector = propertySelector(item);
-    if (map.has(selector)) {
+    if (set.has(selector)) {
       continue;
     }
 
-    map.set(selector, true);
+    set.add(selector);
     result.push(item);
   }
   return result;

--- a/packages/openapi-2-kong/types/k8plugins.flow.js
+++ b/packages/openapi-2-kong/types/k8plugins.flow.js
@@ -1,9 +1,7 @@
 // @flow
 
-import type { HttpMethodKeys } from '../src/common';
-
 declare type OperationPlugins = Array<{
-  method: ?HttpMethodKeys,
+  method: ?HttpMethodType,
   plugins: Array<KubernetesPluginConfig>,
 }>;
 

--- a/packages/openapi-2-kong/types/kubernetes-config.flow.js
+++ b/packages/openapi-2-kong/types/kubernetes-config.flow.js
@@ -1,7 +1,5 @@
 // @flow
 
-import type { HttpMethodKeys } from '../src/common';
-
 declare type K8sAnnotations = {
   [string]: string,
 };
@@ -40,7 +38,7 @@ declare type KubernetesMethodConfig = {
     name: string,
   },
   route: {
-    methods: Array<HttpMethodKeys>,
+    methods: Array<HttpMethodType>,
   },
 };
 

--- a/packages/openapi-2-kong/types/openapi3.flow.js
+++ b/packages/openapi-2-kong/types/openapi3.flow.js
@@ -206,3 +206,13 @@ declare type OpenApi3Spec = {
   externalDocs?: OA3ExternalDocs,
   'x-kong-name'?: string,
 };
+
+declare type HttpMethodType =
+  | 'GET'
+  | 'PUT'
+  | 'POST'
+  | 'DELETE'
+  | 'OPTIONS'
+  | 'HEAD'
+  | 'PATCH'
+  | 'TRACE';

--- a/packages/openapi-2-kong/types/openapi3.flow.js
+++ b/packages/openapi-2-kong/types/openapi3.flow.js
@@ -207,12 +207,15 @@ declare type OpenApi3Spec = {
   'x-kong-name'?: string,
 };
 
-declare type HttpMethodType =
-  | 'GET'
-  | 'PUT'
-  | 'POST'
-  | 'DELETE'
-  | 'OPTIONS'
-  | 'HEAD'
-  | 'PATCH'
-  | 'TRACE';
+const HttpMethod = {
+  get: 'GET',
+  put: 'PUT',
+  post: 'POST',
+  delete: 'DELETE',
+  options: 'OPTIONS',
+  head: 'HEAD',
+  patch: 'PATCH',
+  trace: 'TRACE',
+};
+
+declare type HttpMethodType = $Values<typeof HttpMethod>;


### PR DESCRIPTION
This PR prioritizes which plugin instance to apply to an Ingress document when combining global, server, path and operation plugins. The rules are described in #2100

Closes #2100 😄 