### PR TITLE
Code block and render error coloring for dark/light themes

### DIFF
--- a/packages/insomnia-app/app/ui/css/components/spec-editor.less
+++ b/packages/insomnia-app/app/ui/css/components/spec-editor.less
@@ -82,6 +82,16 @@
     }
   }
 
+  .version-pragma {
+    color: var(--color-font);
+  }
+
+  code {
+    color: var(--color-font);
+    background-color: var(--hl-md);
+
+  }
+
   .scheme-container {
     background: none;
   }


### PR DESCRIPTION
Fix for the code block messaging while themed dark.

After:

![Screen Shot 2020-05-11 at 3 33 42 PM](https://user-images.githubusercontent.com/52717970/81603891-0fa76a80-939d-11ea-8441-956341889813.png)
![Screen Shot 2020-05-11 at 3 33 51 PM](https://user-images.githubusercontent.com/52717970/81603892-10400100-939d-11ea-9b3f-d359b83f0427.png)

