### PR TITLE
Handle empty security object in openapi3

### DIFF
--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -37,14 +37,16 @@ const MODELS = {
   [EXPORT_TYPE_API_SPEC]: models.apiSpec,
 };
 
+export type ImportResult = {
+  source: string,
+  error: Error | null,
+  summary: { [string]: Array<BaseModel> },
+};
+
 export async function importUri(
   getWorkspaceId: () => Promise<string | null>,
   uri: string,
-): Promise<{
-  source: string,
-  error: Error | null,
-  summary: {[string]: Array<BaseModel>},
-}> {
+): Promise<ImportResult> {
   let rawText;
 
   // If GH preview, force raw
@@ -100,11 +102,7 @@ export async function importUri(
 export async function importRaw(
   getWorkspaceId: () => Promise<string | null>,
   rawContent: string,
-): Promise<{
-  source: string,
-  error: Error | null,
-  summary: {[string]: Array<BaseModel>},
-}> {
+): Promise<ImportResult> {
   let results;
   try {
     results = await convert(rawContent);
@@ -119,7 +117,7 @@ export async function importRaw(
   const { data } = results;
 
   // Generate all the ids we may need
-  const generatedIds: {[string]: string | Function} = {};
+  const generatedIds: { [string]: string | Function } = {};
   for (const r of data.resources) {
     for (const key of r._id.match(REPLACE_ID_REGEX) || []) {
       generatedIds[key] = generateId(MODELS[r._type].prefix);

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -7,6 +7,7 @@ import path from 'path';
 import AskModal from '../../../ui/components/modals/ask-modal';
 import * as moment from 'moment';
 
+import type { ImportResult } from '../../../common/import';
 import * as importUtils from '../../../common/import';
 import AlertModal from '../../components/modals/alert-modal';
 import PaymentNotificationModal from '../../components/modals/payment-notification-modal';
@@ -29,7 +30,6 @@ import { reloadPlugins } from '../../../plugins';
 import { setTheme } from '../../../plugins/misc';
 import { setActivityAttribute } from '../../../common/misc';
 import { isDevelopment } from '../../../common/constants';
-import type { ImportResult } from '../../../common/import';
 import type { Workspace } from '../../../models/workspace';
 
 const LOCALSTORAGE_PREFIX = 'insomnia::meta';
@@ -279,7 +279,7 @@ export function importFile(workspaceId: string, forceToWorkspace?: ForceToWorksp
       }
 
       // Let's import all the paths!
-      const importedWorkspaces = [];
+      let importedWorkspaces = [];
       for (const p of paths) {
         try {
           const uri = `file://${p}`;
@@ -287,11 +287,10 @@ export function importFile(workspaceId: string, forceToWorkspace?: ForceToWorksp
             askToImportIntoWorkspace(workspaceId, forceToWorkspace),
             uri,
           );
-          const workspaces = handleImportResult(
+          importedWorkspaces = handleImportResult(
             result,
             'The file does not contain a valid specification.',
           );
-          importedWorkspaces.push(workspaces);
         } catch (err) {
           showModal(AlertModal, { title: 'Import Failed', message: err + '' });
         } finally {
@@ -329,17 +328,16 @@ export function importClipBoard(workspaceId: string, forceToWorkspace?: ForceToW
       return;
     }
     // Let's import all the paths!
-    const importedWorkspaces = [];
+    let importedWorkspaces = [];
     try {
       const result = await importUtils.importRaw(
         askToImportIntoWorkspace(workspaceId, forceToWorkspace),
         schema,
       );
-      const workspaces = handleImportResult(
+      importedWorkspaces = handleImportResult(
         result,
         'Your clipboard does not contain a valid specification.',
       );
-      importedWorkspaces.push(workspaces);
     } catch (err) {
       showModal(AlertModal, {
         title: 'Import Failed',
@@ -358,17 +356,16 @@ export function importUri(workspaceId: string, uri: string, forceToWorkspace?: F
   return async dispatch => {
     dispatch(loadStart());
 
-    const importedWorkspaces = [];
+    let importedWorkspaces = [];
     try {
       const result = await importUtils.importUri(
         askToImportIntoWorkspace(workspaceId, forceToWorkspace),
         uri,
       );
-      const workspaces = handleImportResult(
+      importedWorkspaces = handleImportResult(
         result,
         'The URI does not contain a valid specification.',
       );
-      importedWorkspaces.push(workspaces);
     } catch (err) {
       showModal(AlertModal, { title: 'Import Failed', message: err + '' });
     } finally {

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-input.yaml
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-input.yaml
@@ -39,6 +39,20 @@ components:
       in: query
 
 paths:
+  /none:
+    get:
+      security: []
+      responses:
+        '200':
+          description: OK
+  /none/basic:
+    get:
+      security:
+        - {}
+        - Basic: []
+      responses:
+        '200':
+          description: OK
   /basic:
     get:
       security:
@@ -80,6 +94,7 @@ paths:
   /all:
     get:
       security:
+        - {}
         - Basic: []
         - Key-Query: []
         - Key-Header: []

--- a/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/openapi3/endpoint-security-output.json
@@ -1,173 +1,201 @@
 {
-  "_type": "export",
+  "__export_date": "2020-05-13T23:55:24.712Z",
   "__export_format": 4,
-  "__export_date": "2020-02-19T03:47:33.193Z",
   "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
   "resources": [
     {
-      "_type": "workspace",
       "_id": "__WORKSPACE_ID__",
-      "parentId": null,
+      "_type": "workspace",
+      "description": "",
       "name": "Endpoint Security 1.2",
-      "description": ""
+      "parentId": null
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "Base environment",
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
       "data": {
         "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
       },
-      "_type": "environment",
-      "_id": "__BASE_ENVIRONMENT_ID__"
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_ID__"
     },
     {
-      "parentId": "__BASE_ENVIRONMENT_ID__",
-      "name": "OpenAPI env",
+      "_id": "env___BASE_ENVIRONMENT_ID___sub",
+      "_type": "environment",
       "data": {
-        "scheme": "https",
-        "base_path": "/v1",
-        "cookieName": "cookieName",
         "anotherCookieName": "anotherCookieName",
-        "key": "key",
         "anotherKey": "anotherKey",
+        "base_path": "/v1",
+        "bearerToken": "bearerToken",
+        "cookieName": "cookieName",
         "host": "api.server.test",
-        "httpUsername": "username",
         "httpPassword": "password",
+        "httpUsername": "username",
+        "key": "key",
+        "scheme": "https",
         "xApiKey": "xApiKey",
-        "xAppVersion": "xAppVersion",
-        "bearerToken": "bearerToken"
+        "xAppVersion": "xAppVersion"
       },
-      "_type": "environment",
-      "_id": "env___BASE_ENVIRONMENT_ID___sub"
+      "name": "OpenAPI env",
+      "parentId": "__BASE_ENVIRONMENT_ID__"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "/basic",
-      "url": "{{ base_url }}/basic",
+      "_id": "req___WORKSPACE_ID__05bfadcb",
+      "_type": "request",
+      "authentication": {},
       "body": {},
-      "method": "GET",
-      "parameters": [],
       "headers": [],
+      "method": "GET",
+      "name": "/none",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/none"
+    },
+    {
+      "_id": "req___WORKSPACE_ID__4112dc81",
+      "_type": "request",
       "authentication": {
+        "password": "{{ httpPassword }}",
         "type": "basic",
-        "username": "{{ httpUsername }}",
-        "password": "{{ httpPassword }}"
+        "username": "{{ httpUsername }}"
       },
-      "_type": "request",
-      "_id": "req___WORKSPACE_ID__4a563129"
-    },
-    {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "/bearer",
-      "url": "{{ base_url }}/bearer",
       "body": {},
-      "method": "GET",
-      "parameters": [],
       "headers": [],
-      "authentication": {
-        "type": "bearer",
-        "token": "{{bearerToken}}",
-        "prefix": ""
-      },
-      "_type": "request",
-      "_id": "req___WORKSPACE_ID__6ecf1fc2"
+      "method": "GET",
+      "name": "/none/basic",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/none/basic"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "/key/header",
-      "url": "{{ base_url }}/key/header",
+      "_id": "req___WORKSPACE_ID__4a563129",
+      "_type": "request",
+      "authentication": {
+        "password": "{{ httpPassword }}",
+        "type": "basic",
+        "username": "{{ httpUsername }}"
+      },
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "/basic",
       "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/basic"
+    },
+    {
+      "_id": "req___WORKSPACE_ID__6ecf1fc2",
+      "_type": "request",
+      "authentication": {
+        "prefix": "",
+        "token": "{{bearerToken}}",
+        "type": "bearer"
+      },
+      "body": {},
+      "headers": [],
+      "method": "GET",
+      "name": "/bearer",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/bearer"
+    },
+    {
+      "_id": "req___WORKSPACE_ID__48bba8a5",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
       "headers": [
         {
-          "name": "x-api_key",
           "disabled": false,
+          "name": "x-api_key",
           "value": "{{ xApiKey }}"
         },
         {
-          "name": "x-app-version",
           "disabled": false,
+          "name": "x-app-version",
           "value": "{{ xAppVersion }}"
         }
       ],
-      "authentication": {},
-      "_type": "request",
-      "_id": "req___WORKSPACE_ID__48bba8a5"
+      "method": "GET",
+      "name": "/key/header",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/key/header"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "/key/cookie",
-      "url": "{{ base_url }}/key/cookie",
+      "_id": "req___WORKSPACE_ID__2ea006cf",
+      "_type": "request",
+      "authentication": {},
       "body": {},
-      "method": "GET",
-      "parameters": [],
       "headers": [
         {
-          "name": "Cookie",
           "disabled": false,
+          "name": "Cookie",
           "value": "CookieName={{ cookieName }}; AnotherCookieName={{ anotherCookieName }}"
         }
       ],
-      "authentication": {},
-      "_type": "request",
-      "_id": "req___WORKSPACE_ID__2ea006cf"
+      "method": "GET",
+      "name": "/key/cookie",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/key/cookie"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "/key/query",
-      "url": "{{ base_url }}/key/query",
+      "_id": "req___WORKSPACE_ID__0a8d5285",
+      "_type": "request",
+      "authentication": {},
       "body": {},
+      "headers": [],
       "method": "GET",
+      "name": "/key/query",
       "parameters": [
         {
-          "name": "key",
           "disabled": false,
+          "name": "key",
           "value": "{{ key }}"
         },
         {
-          "name": "another_key",
           "disabled": false,
+          "name": "another_key",
           "value": "{{ anotherKey }}"
         }
       ],
-      "headers": [],
-      "authentication": {},
-      "_type": "request",
-      "_id": "req___WORKSPACE_ID__0a8d5285"
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/key/query"
     },
     {
-      "parentId": "__WORKSPACE_ID__",
-      "name": "/all",
-      "url": "{{ base_url }}/all",
+      "_id": "req___WORKSPACE_ID__e285189c",
+      "_type": "request",
+      "authentication": {
+        "password": "{{ httpPassword }}",
+        "type": "basic",
+        "username": "{{ httpUsername }}"
+      },
       "body": {},
-      "method": "GET",
-      "parameters": [
-        {
-          "name": "key",
-          "disabled": false,
-          "value": "{{ key }}"
-        }
-      ],
       "headers": [
         {
-          "name": "x-api_key",
           "disabled": false,
+          "name": "x-api_key",
           "value": "{{ xApiKey }}"
         },
         {
-          "name": "Cookie",
           "disabled": false,
+          "name": "Cookie",
           "value": "CookieName={{ cookieName }}"
         }
       ],
-      "authentication": {
-        "type": "basic",
-        "username": "{{ httpUsername }}",
-        "password": "{{ httpPassword }}"
-      },
-      "_type": "request",
-      "_id": "req___WORKSPACE_ID__e285189c"
+      "method": "GET",
+      "name": "/all",
+      "parameters": [
+        {
+          "disabled": false,
+          "name": "key",
+          "value": "{{ key }}"
+        }
+      ],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/all"
     }
   ]
 }

--- a/packages/insomnia-importers/src/importers/openapi3.js
+++ b/packages/insomnia-importers/src/importers/openapi3.js
@@ -285,7 +285,9 @@ function parseSecurity(security, securitySchemes) {
       const securityName = Object.keys(securityPolicy)[0];
       return securitySchemes[securityName];
     })
-    .filter(schemeDetails => SUPPORTED_SECURITY_TYPES.includes(schemeDetails.type));
+    .filter(schemeDetails => {
+      return schemeDetails && SUPPORTED_SECURITY_TYPES.includes(schemeDetails.type);
+    });
 
   const apiKeySchemes = supportedSchemes.filter(scheme => scheme.type === SECURITY_TYPE.API_KEY);
   const apiKeyHeaders = apiKeySchemes

--- a/packages/insomnia-importers/src/importers/openapi3.js
+++ b/packages/insomnia-importers/src/importers/openapi3.js
@@ -285,9 +285,9 @@ function parseSecurity(security, securitySchemes) {
       const securityName = Object.keys(securityPolicy)[0];
       return securitySchemes[securityName];
     })
-    .filter(schemeDetails => {
-      return schemeDetails && SUPPORTED_SECURITY_TYPES.includes(schemeDetails.type);
-    });
+    .filter(
+      schemeDetails => schemeDetails && SUPPORTED_SECURITY_TYPES.includes(schemeDetails.type),
+    );
 
   const apiKeySchemes = supportedSchemes.filter(scheme => scheme.type === SECURITY_TYPE.API_KEY);
   const apiKeyHeaders = apiKeySchemes


### PR DESCRIPTION
Closes #2167, to handle the case where a security object under a path contains an empty item.

Also updates the import to show an error dialog _before_ trying to extract workspaces, if there is a failure during import. This should give more informative error messages.

![image](https://user-images.githubusercontent.com/4312346/81878026-e3792d00-95da-11ea-8a67-97ae64eb6f1e.png)
