### PR TITLE
WIP - git sync failures on Windows - change root directory from / to /repo

### DIFF
--- a/packages/insomnia-app/app/common/constants.js
+++ b/packages/insomnia-app/app/common/constants.js
@@ -74,6 +74,10 @@ export function getTempDir() {
   return dir;
 }
 
+export function getGitSyncRepoDir() {
+  return isWindows() ? '/repo' : '/';
+}
+
 export function isMac() {
   return getAppPlatform() === 'darwin';
 }

--- a/packages/insomnia-app/app/sync/git/__tests__/ne-db-plugin.test.js
+++ b/packages/insomnia-app/app/sync/git/__tests__/ne-db-plugin.test.js
@@ -5,7 +5,9 @@ import { assertAsyncError, setupDateMocks } from './util';
 import NeDBPlugin from '../ne-db-plugin';
 import { GIT_NAMESPACE_DIR } from '../git-vcs';
 
-describe('NeDBPlugin', () => {
+describe.each(['/', '/repo'])("NeDBPlugin with parentDirectory ['%o']", parentDir => {
+  const namespaceDir = `${parentDir}/${GIT_NAMESPACE_DIR}`;
+
   beforeEach(async () => {
     await globalBeforeEach();
 
@@ -22,55 +24,50 @@ describe('NeDBPlugin', () => {
 
   describe('readdir()', () => {
     it('reads model IDs from model type folders', async () => {
-      const pNeDB = new NeDBPlugin('wrk_1');
+      const pNeDB = new NeDBPlugin('wrk_1', parentDir);
 
-      expect(await pNeDB.readdir('/')).toEqual([GIT_NAMESPACE_DIR]);
-      expect(await pNeDB.readdir(`/${GIT_NAMESPACE_DIR}`)).toEqual([
+      expect(await pNeDB.readdir(parentDir)).toEqual([GIT_NAMESPACE_DIR]);
+      expect(await pNeDB.readdir(namespaceDir)).toEqual([
         'ApiSpec',
         'Environment',
         'Request',
         'RequestGroup',
         'Workspace',
       ]);
-      expect(await pNeDB.readdir(`/${GIT_NAMESPACE_DIR}/Request`)).toEqual([
-        'req_1.yml',
-        'req_2.yml',
-      ]);
-      expect(await pNeDB.readdir(`/${GIT_NAMESPACE_DIR}/Workspace`)).toEqual(['wrk_1.yml']);
+      expect(await pNeDB.readdir(`${namespaceDir}/Request`)).toEqual(['req_1.yml', 'req_2.yml']);
+      expect(await pNeDB.readdir(`${namespaceDir}/Workspace`)).toEqual(['wrk_1.yml']);
     });
   });
 
   describe('readFile()', () => {
     it('reads file from model/id folders', async () => {
-      const pNeDB = new NeDBPlugin('wrk_1');
+      const pNeDB = new NeDBPlugin('wrk_1', parentDir);
 
       expect(
-        YAML.parse(await pNeDB.readFile(`/${GIT_NAMESPACE_DIR}/Workspace/wrk_1.yml`, 'utf8')),
+        YAML.parse(await pNeDB.readFile(`${namespaceDir}/Workspace/wrk_1.yml`, 'utf8')),
       ).toEqual(expect.objectContaining({ _id: 'wrk_1', parentId: null }));
 
-      expect(
-        YAML.parse(await pNeDB.readFile(`/${GIT_NAMESPACE_DIR}/Request/req_1.yml`, 'utf8')),
-      ).toEqual(expect.objectContaining({ _id: 'req_1', parentId: 'wrk_1' }));
+      expect(YAML.parse(await pNeDB.readFile(`${namespaceDir}/Request/req_1.yml`, 'utf8'))).toEqual(
+        expect.objectContaining({ _id: 'req_1', parentId: 'wrk_1' }),
+      );
 
-      await assertAsyncError(pNeDB.readFile(`/${GIT_NAMESPACE_DIR}/Request/req_x.yml`));
+      await assertAsyncError(pNeDB.readFile(`${namespaceDir}/Request/req_x.yml`));
     });
   });
 
   describe('stat()', () => {
     it('stats a dir', async () => {
-      const pNeDB = new NeDBPlugin('wrk_1');
+      const pNeDB = new NeDBPlugin('wrk_1', parentDir);
 
       expect(await pNeDB.stat('/')).toEqual(expect.objectContaining({ type: 'dir' }));
-      expect(await pNeDB.stat(`/${GIT_NAMESPACE_DIR}`)).toEqual(
-        expect.objectContaining({ type: 'dir' }),
-      );
-      expect(await pNeDB.stat(`/${GIT_NAMESPACE_DIR}/Workspace/wrk_1.yml`)).toEqual(
+      expect(await pNeDB.stat(`${namespaceDir}`)).toEqual(expect.objectContaining({ type: 'dir' }));
+      expect(await pNeDB.stat(`${namespaceDir}/Workspace/wrk_1.yml`)).toEqual(
         expect.objectContaining({ type: 'file' }),
       );
-      expect(await pNeDB.stat(`/${GIT_NAMESPACE_DIR}/Request`)).toEqual(
+      expect(await pNeDB.stat(`${namespaceDir}/Request`)).toEqual(
         expect.objectContaining({ type: 'dir' }),
       );
-      expect(await pNeDB.stat(`/${GIT_NAMESPACE_DIR}/Request/req_2.yml`)).toEqual(
+      expect(await pNeDB.stat(`${namespaceDir}/Request/req_2.yml`)).toEqual(
         expect.objectContaining({ type: 'file' }),
       );
     });

--- a/packages/insomnia-app/app/sync/git/ne-db-plugin.js
+++ b/packages/insomnia-app/app/sync/git/ne-db-plugin.js
@@ -8,17 +8,20 @@ import { GIT_NAMESPACE_DIR } from './git-vcs';
 
 export default class NeDBPlugin {
   _workspaceId: string;
+  _parentDirRegExp: RegExp;
 
-  constructor(workspaceId: string) {
+  constructor(workspaceId: string, parentDir: string = '/') {
     if (!workspaceId) {
       throw new Error('Cannot use NeDBPlugin without workspace ID');
     }
+
     this._workspaceId = workspaceId;
+    this._parentDirRegExp = new RegExp(`^${parentDir}`);
   }
 
-  static createPlugin(workspaceId: string) {
+  static createPlugin(workspaceId: string, repoDir: string = '/') {
     return {
-      promises: new NeDBPlugin(workspaceId),
+      promises: new NeDBPlugin(workspaceId, repoDir),
     };
   }
 
@@ -200,11 +203,9 @@ export default class NeDBPlugin {
 
   _parsePath(filePath: string): { root: string | null, type: string | null, id: string | null } {
     filePath = path.normalize(filePath);
+    filePath = filePath.replace(this._parentDirRegExp, '');
 
-    const [idRaw, type, ...root] = filePath
-      .split(path.sep)
-      .filter(s => s !== '')
-      .reverse();
+    const [root, type, idRaw] = filePath.split(path.sep).filter(s => s !== '');
 
     const id = typeof idRaw === 'string' ? idRaw.replace(/\.(json|yml)$/, '') : idRaw;
 

--- a/packages/insomnia-app/app/sync/git/ne-db-plugin.js
+++ b/packages/insomnia-app/app/sync/git/ne-db-plugin.js
@@ -111,7 +111,7 @@ export default class NeDBPlugin {
 
     let docs = [];
     let otherFolders = [];
-    if (root === null && id === null && type === null) {
+    if ((root === null || root === 'repo') && id === null && type === null) {
       otherFolders = [GIT_NAMESPACE_DIR];
     } else if (id === null && type === null) {
       otherFolders = [

--- a/packages/insomnia-app/app/sync/git/ne-db-plugin.js
+++ b/packages/insomnia-app/app/sync/git/ne-db-plugin.js
@@ -111,7 +111,7 @@ export default class NeDBPlugin {
 
     let docs = [];
     let otherFolders = [];
-    if ((root === null || root === 'repo') && id === null && type === null) {
+    if (root === null && id === null && type === null) {
       otherFolders = [GIT_NAMESPACE_DIR];
     } else if (id === null && type === null) {
       otherFolders = [
@@ -201,7 +201,10 @@ export default class NeDBPlugin {
   _parsePath(filePath: string): { root: string | null, type: string | null, id: string | null } {
     filePath = path.normalize(filePath);
 
-    const [root, type, idRaw] = filePath.split(path.sep).filter(s => s !== '');
+    const [idRaw, type, ...root] = filePath
+      .split(path.sep)
+      .filter(s => s !== '')
+      .reverse();
 
     const id = typeof idRaw === 'string' ? idRaw.replace(/\.(json|yml)$/, '') : idRaw;
 

--- a/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
@@ -110,10 +110,9 @@ class GitRepositorySettingsModal extends React.PureComponent<Props, State> {
     const inputs = {};
 
     if (gitRepository) {
-      const creds = gitRepository.credentials || {};
-      inputs.token = typeof creds.token === 'string' ? creds.token : '';
       inputs.authorEmail = gitRepository.author.email;
       inputs.authorName = gitRepository.author.name;
+      inputs.username = gitRepository.credentials?.username || '';
       inputs.uri = gitRepository.uri;
     }
 

--- a/packages/insomnia-app/app/ui/components/modals/git-staging-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-staging-modal.js
@@ -13,6 +13,7 @@ import { withDescendants } from '../../../common/database';
 import IndeterminateCheckbox from '../base/indeterminate-checkbox';
 import ModalFooter from '../base/modal-footer';
 import Tooltip from '../tooltip';
+import { getGitSyncRepoDir } from '../../../common/constants';
 
 type Props = {|
   workspace: Workspace,
@@ -129,7 +130,7 @@ class GitStagingModal extends React.PureComponent<Props, State> {
     const { vcs } = this.props;
 
     const f = vcs.getFs().promises;
-    const rootDir = path.join('/', GIT_NAMESPACE_DIR);
+    const rootDir = path.join(getGitSyncRepoDir(), GIT_NAMESPACE_DIR);
 
     const fsPaths = [];
     for (const type of await f.readdir(rootDir)) {

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -40,6 +40,7 @@ import designerLogo from '../images/insomnia-designer-logo.svg';
 import { MemPlugin } from '../../sync/git/mem-plugin';
 import GitVCS, { GIT_NAMESPACE_DIR } from '../../sync/git/git-vcs';
 import { parseApiSpec } from '../../common/api-specs';
+import { getGitSyncRepoDir } from '../../common/constants';
 
 type Props = {|
   wrapperProps: WrapperProps,
@@ -115,7 +116,8 @@ class WrapperHome extends React.PureComponent<Props, State> {
         trackEvent('Git', 'Clone');
 
         const core = Math.random() + '';
-        const rootDir = path.join('/', GIT_NAMESPACE_DIR);
+        const repoDir = getGitSyncRepoDir();
+        const rootDir = path.join(repoDir, GIT_NAMESPACE_DIR);
 
         // Create in-memory filesystem to perform clone
         const plugins = git.cores.create(core);
@@ -127,7 +129,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
         try {
           await git.clone({
             core,
-            dir: '/',
+            dir: repoDir,
             singleBranch: true,
             url,
             ...credentials,
@@ -161,7 +163,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
           return false;
         };
 
-        if (!(await ensureDir('/', GIT_NAMESPACE_DIR))) {
+        if (!(await ensureDir(repoDir, GIT_NAMESPACE_DIR))) {
           return;
         }
 

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -996,11 +996,11 @@ class App extends PureComponent {
         getDataDirectory(),
         `version-control/git/${activeGitRepository._id}`,
       );
-      const pNeDb = NeDBPlugin.createPlugin(activeWorkspace._id);
+      const repoDir = getGitSyncRepoDir();
+      const pNeDb = NeDBPlugin.createPlugin(activeWorkspace._id, repoDir);
       const pGitData = FSPlugin.createPlugin(baseDir);
       const pOtherData = FSPlugin.createPlugin(path.join(baseDir, 'other'));
       const gitSubDir = '/git';
-      const repoDir = getGitSyncRepoDir();
 
       const fsPlugin = routableFSPlugin(
         // All data outside the directories listed below will be stored in an 'other'

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -29,6 +29,7 @@ import {
   PREVIEW_MODE_SOURCE,
   getAppName,
   getAppId,
+  getGitSyncRepoDir,
 } from '../../common/constants';
 import * as globalActions from '../redux/modules/global';
 import * as entitiesActions from '../redux/modules/entities';
@@ -999,6 +1000,7 @@ class App extends PureComponent {
       const pGitData = FSPlugin.createPlugin(baseDir);
       const pOtherData = FSPlugin.createPlugin(path.join(baseDir, 'other'));
       const gitSubDir = '/git';
+      const repoDir = getGitSyncRepoDir();
 
       const fsPlugin = routableFSPlugin(
         // All data outside the directories listed below will be stored in an 'other'
@@ -1008,7 +1010,7 @@ class App extends PureComponent {
         {
           // All app data is stored within the a namespaced directory at the root of the
           // repository and is read/written from the local NeDB database
-          [`/${GIT_NAMESPACE_DIR}`]: pNeDb,
+          [path.join(repoDir, GIT_NAMESPACE_DIR)]: pNeDb,
 
           // All git metadata is stored in a git/ directory on the filesystem
           [gitSubDir]: pGitData,
@@ -1019,9 +1021,9 @@ class App extends PureComponent {
       if (activeGitRepository.needsFullClone) {
         await models.gitRepository.update(activeGitRepository, { needsFullClone: false });
         const { credentials, uri } = activeGitRepository;
-        await gitVCS.initFromClone(uri, credentials, '/', fsPlugin, gitSubDir);
+        await gitVCS.initFromClone(uri, credentials, repoDir, fsPlugin, gitSubDir);
       } else {
-        await gitVCS.init('/', fsPlugin, gitSubDir);
+        await gitVCS.init(repoDir, fsPlugin, gitSubDir);
       }
 
       // Configure basic info


### PR DESCRIPTION
Initial approach is to set `/repo` as the base dir. Windows cannot handle the double slash route (eg `//.insomnia/ApiSpec/`) that gets created by using `/` as the base dir.

Further notes in the linked issue.