### PR TITLE
Fix for warning not displaying when using an environment variable with '-'

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/environment-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/environment-editor.js
@@ -54,7 +54,7 @@ class EnvironmentEditor extends React.PureComponent<Props, State> {
 
     // Check for invalid key names
     if (value) {
-      for (const key of Object.keys(value)) {
+      for (const key of Object.keys(value.object)) {
         if (!key.match(/^[a-zA-Z_$][0-9a-zA-Z_$]*$/)) {
           warning = `"${key}" must only contain letters, numbers, and underscores`;
           break;

--- a/packages/insomnia-app/app/ui/components/editors/environment-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/environment-editor.js
@@ -53,7 +53,7 @@ class EnvironmentEditor extends React.PureComponent<Props, State> {
     }
 
     // Check for invalid key names
-    if (value) {
+    if (value && value.object) {
       for (const key of Object.keys(value.object)) {
         if (!key.match(/^[a-zA-Z_$][0-9a-zA-Z_$]*$/)) {
           warning = `"${key}" must only contain letters, numbers, and underscores`;


### PR DESCRIPTION
This is a follow up to this bug report (closes #2207). I would suggest reading this bug report before reading the rest of this message.

I figured dash ( "-" )should not be allowed in environmental variables, as I found the error message saying that "_Keys must only contain letters, numbers, and underscores_".

![image](https://user-images.githubusercontent.com/10408782/82739118-e8ee1a00-9d34-11ea-9ce2-2acd575f8e3a.png)

Nevertheless, this ```if (!key.match(...))```  block never shows this error message when a user is using illegal characters. It was due to ```Object.keys(value)``` part.

```value``` is an object of EnvironmentInfo class. 
```
export type EnvironmentInfo = {
  object: Object,
  propertyOrder: Object | null,
};
```
So, ```Object.keys(value)``` returns ["object", "propertyOrder"]. However, Environment variables are stored as key-value pairs in the ```object``` field of  ```EnvironmentInfo``` class. So to check keys in environmental variables I needed to change 
``` 
Object.keys(value)
```
to
``` 
Object.keys(value.object)
```