### PR TITLE
Trigger test workflow on external PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: push
+on: [push, pull_request]
 
 jobs:
   Test:


### PR DESCRIPTION
Currently, git workflows do not trigger for external PRs. Following [this](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-a-list-of-events) example.