### PR TITLE
Persist tab selection per document

### DIFF
--- a/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
@@ -66,7 +66,7 @@ class GitSyncDropdown extends React.PureComponent<Props, State> {
 
     // Clear cached items and return if no state
     if (!vcs.isInitialized() || !workspaceMeta.gitRepositoryId) {
-      await models.workspaceMeta.update(workspaceMeta, {
+      await models.workspaceMeta.updateByParentId(workspace._id, {
         cachedGitRepositoryBranch: null,
         cachedGitLastAuthor: null,
         cachedGitLastCommitTime: null,
@@ -85,7 +85,7 @@ class GitSyncDropdown extends React.PureComponent<Props, State> {
 
     // NOTE: We're converting timestamp to ms here
     const cachedGitLastCommitTime = author ? author.timestamp * 1000 : null;
-    await models.workspaceMeta.update(workspaceMeta, {
+    await models.workspaceMeta.updateByParentId(workspace._id, {
       cachedGitRepositoryBranch,
       cachedGitLastAuthor,
       cachedGitLastCommitTime,


### PR DESCRIPTION
Closes #2229.

`wrapper > _handleWorkspaceActivityChange` sets `workspaceMeta.activeActivity` when changing between tabs.

https://github.com/Kong/insomnia/blob/819f4b9cf57f433378cb9620ca671e51db365067/packages/insomnia-app/app/ui/components/wrapper.js#L295-L298

`git-sync-dropdown > componentDidMount > _refreshState()` is currently updating `workspaceMeta`, but with a stale object where it resets `workspaceMeta.activeActivity` back to `null`.

https://github.com/Kong/insomnia/blob/819f4b9cf57f433378cb9620ca671e51db365067/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js#L62-L75

There is a sequencing issue in which both of these run at approx. the same time. Changing the logic from `workspaceMeta.update` to `workspaceMeta.updateByParentId` fixes this, ~but I do not know _why_, given the unfolded logic is all very similar~. `updateByParentId` does a read immediately before updating, and the `activeActivity` change is included in that.

![2020-06-01 16 25 15](https://user-images.githubusercontent.com/4312346/83375883-8546a980-a424-11ea-98ff-29e98733daca.gif)

OT: I tried to set up Spectron for a UI test but couldn't get it working in my timebox. 😢 