### PR TITLE
Force a view refresh on changing branches

### DIFF
--- a/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
@@ -79,7 +79,6 @@ class GitSyncDropdown extends React.PureComponent<Props, State> {
     const branches = await vcs.listBranches();
     const log = (await vcs.log()) || [];
     this.setState({ ...(otherState || {}), log, branch, branches });
-    handleGitBranchChanged(branch);
 
     const author = log[0] ? log[0].author : null;
     const cachedGitRepositoryBranch = branch;
@@ -92,6 +91,7 @@ class GitSyncDropdown extends React.PureComponent<Props, State> {
       cachedGitLastAuthor,
       cachedGitLastCommitTime,
     });
+    handleGitBranchChanged(branch);
   }
 
   async _handleOpen() {

--- a/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
@@ -79,7 +79,6 @@ class GitSyncDropdown extends React.PureComponent<Props, State> {
     const branches = await vcs.listBranches();
     const log = (await vcs.log()) || [];
     this.setState({ ...(otherState || {}), log, branch, branches });
-    console.log(branch);
     handleGitBranchChanged(branch);
 
     const author = log[0] ? log[0].author : null;

--- a/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
@@ -21,6 +21,7 @@ import { docsGitSync } from '../../../common/documentation';
 
 type Props = {|
   handleInitializeEntities: () => void,
+  handleGitBranchChanged: (branch: string) => void,
   workspace: Workspace,
   vcs: GitVCS,
   gitRepository: GitRepository | null,
@@ -60,7 +61,7 @@ class GitSyncDropdown extends React.PureComponent<Props, State> {
   }
 
   async _refreshState(otherState?: Object) {
-    const { vcs, workspace } = this.props;
+    const { vcs, workspace, handleGitBranchChanged } = this.props;
 
     const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(workspace._id);
 
@@ -78,6 +79,8 @@ class GitSyncDropdown extends React.PureComponent<Props, State> {
     const branches = await vcs.listBranches();
     const log = (await vcs.log()) || [];
     this.setState({ ...(otherState || {}), log, branch, branches });
+    console.log(branch);
+    handleGitBranchChanged(branch);
 
     const author = log[0] ? log[0].author : null;
     const cachedGitRepositoryBranch = branch;

--- a/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
@@ -20,7 +20,7 @@ import { trackEvent } from '../../../common/analytics';
 import { docsGitSync } from '../../../common/documentation';
 
 type Props = {|
-  handleInitializeEntities: () => void,
+  handleInitializeEntities: () => Promise<void>,
   handleGitBranchChanged: (branch: string) => void,
   workspace: Workspace,
   vcs: GitVCS,
@@ -215,7 +215,7 @@ class GitSyncDropdown extends React.PureComponent<Props, State> {
     }
     await db.flushChanges(bufferId, true);
 
-    handleInitializeEntities();
+    await handleInitializeEntities();
     await this._refreshState();
   }
 

--- a/packages/insomnia-app/app/ui/components/modals/git-branches-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-branches-modal.js
@@ -14,7 +14,7 @@ import ModalFooter from '../base/modal-footer';
 type Props = {|
   vcs: GitVCS,
   gitRepository: GitRepository,
-  handleInitializeEntities: () => void,
+  handleInitializeEntities: () => Promise<void>,
 |};
 
 type State = {|
@@ -155,7 +155,7 @@ class GitBranchesModal extends React.PureComponent<Props, State> {
       await vcs.checkout(branch);
       await db.flushChanges(bufferId, true);
 
-      handleInitializeEntities();
+      await handleInitializeEntities();
       await this._refreshState();
     });
   }

--- a/packages/insomnia-app/app/ui/components/modals/git-branches-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-branches-modal.js
@@ -15,6 +15,7 @@ type Props = {|
   vcs: GitVCS,
   gitRepository: GitRepository,
   handleInitializeEntities: () => Promise<void>,
+  handleGitBranchChanged: (branch: string) => void,
 |};
 
 type State = {|
@@ -72,7 +73,7 @@ class GitBranchesModal extends React.PureComponent<Props, State> {
   }
 
   async _refreshState(newState?: Object) {
-    const { vcs } = this.props;
+    const { vcs, handleGitBranchChanged } = this.props;
 
     const branch = await vcs.getBranch();
     const branches = await vcs.listBranches();
@@ -84,6 +85,7 @@ class GitBranchesModal extends React.PureComponent<Props, State> {
       remoteBranches,
       ...newState,
     });
+    handleGitBranchChanged(branch);
   }
 
   _handleClearError() {

--- a/packages/insomnia-app/app/ui/components/wrapper-debug.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-debug.js
@@ -42,7 +42,7 @@ type Props = {
   handleUpdateRequestUrl: Function,
   handleUpdateSettingsShowPasswords: Function,
   handleUpdateSettingsUseBulkHeaderEditor: Function,
-  handleSetDesignActivity: (workspaceId: string) => void,
+  handleSetDesignActivity: (workspaceId: string) => Promise<void>,
   wrapperProps: WrapperProps,
 };
 
@@ -52,12 +52,12 @@ class WrapperDebug extends React.PureComponent<Props> {
     this.props.wrapperProps.handleSetActiveActivity(ACTIVITY_HOME);
   }
 
-  _handleDesign() {
+  async _handleDesign() {
     const {
       handleSetDesignActivity,
       wrapperProps: { activeWorkspace },
     } = this.props;
-    handleSetDesignActivity(activeWorkspace._id);
+    await handleSetDesignActivity(activeWorkspace._id);
   }
 
   _renderPageHeader() {

--- a/packages/insomnia-app/app/ui/components/wrapper-debug.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-debug.js
@@ -52,7 +52,7 @@ class WrapperDebug extends React.PureComponent<Props> {
     this.props.wrapperProps.handleSetActiveActivity(ACTIVITY_HOME);
   }
 
-  async _handleDesign() {
+  async _handleDesign(): Promise<void> {
     const {
       handleSetDesignActivity,
       wrapperProps: { activeWorkspace },

--- a/packages/insomnia-app/app/ui/components/wrapper-design.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.js
@@ -27,8 +27,8 @@ const spectral = new Spectral();
 type Props = {|
   gitSyncDropdown: React.Node,
   wrapperProps: WrapperProps,
-  handleUpdateApiSpec: (s: ApiSpec) => any,
-  handleSetDebugActivity: (s: ApiSpec) => any,
+  handleUpdateApiSpec: (s: ApiSpec) => Promise<void>,
+  handleSetDebugActivity: (s: ApiSpec) => Promise<void>,
 |};
 
 type State = {|
@@ -52,6 +52,7 @@ class WrapperDesign extends React.PureComponent<Props, State> {
     this.state = {
       previewHidden: props.wrapperProps.activeWorkspaceMeta.previewHidden || false,
       lintMessages: [],
+      hasConfigPlugins: false,
     };
   }
 
@@ -70,7 +71,7 @@ class WrapperDesign extends React.PureComponent<Props, State> {
     showModal(GenerateConfigModal, { apiSpec: activeApiSpec });
   }
 
-  _handleDebugSpec(errors, e) {
+  async _handleDebugSpec(errors, e) {
     e.preventDefault();
     if (errors) {
       showModal(AlertModal, {
@@ -92,7 +93,7 @@ class WrapperDesign extends React.PureComponent<Props, State> {
         handleSetDebugActivity,
         wrapperProps: { activeApiSpec },
       } = this.props;
-      handleSetDebugActivity(activeApiSpec);
+      await handleSetDebugActivity(activeApiSpec);
     }
   }
 

--- a/packages/insomnia-app/app/ui/components/wrapper-design.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.js
@@ -71,7 +71,7 @@ class WrapperDesign extends React.PureComponent<Props, State> {
     showModal(GenerateConfigModal, { apiSpec: activeApiSpec });
   }
 
-  async _handleDebugSpec(errors, e) {
+  async _handleDebugSpec(errors, e): Pomise<void> {
     e.preventDefault();
     if (errors) {
       showModal(AlertModal, {
@@ -80,12 +80,12 @@ class WrapperDesign extends React.PureComponent<Props, State> {
           'Some requests may not be available due to errors found in the specification. We recommend fixing errors before proceeding. 🤗',
         okLabel: 'Proceed',
         addCancel: true,
-        onConfirm: () => {
+        onConfirm: async () => {
           const {
             handleSetDebugActivity,
             wrapperProps: { activeApiSpec },
           } = this.props;
-          handleSetDebugActivity(activeApiSpec);
+          await handleSetDebugActivity(activeApiSpec);
         },
       });
     } else {

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -38,7 +38,7 @@ import type { ForceToWorkspace } from '../redux/modules/helpers';
 import { ForceToWorkspaceKeys } from '../redux/modules/helpers';
 import designerLogo from '../images/insomnia-designer-logo.svg';
 import { MemPlugin } from '../../sync/git/mem-plugin';
-import GitVCS, {
+import {
   GIT_CLONE_DIR,
   GIT_INSOMNIA_DIR,
   GIT_INSOMNIA_DIR_NAME,
@@ -51,7 +51,6 @@ type Props = {|
   handleImportFile: (forceToWorkspace: ForceToWorkspace) => void,
   handleImportUri: (uri: string, forceToWorkspace: ForceToWorkspace) => void,
   handleImportClipboard: (forceToWorkspace: ForceToWorkspace) => void,
-  gitVCS: GitVCS | null,
 |};
 
 type State = {|

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -143,7 +143,6 @@ export type WrapperProps = {
   handleUpdateRequestMimeType: Function,
   handleUpdateDownloadPath: Function,
   handleSetActiveActivity: (activity: GlobalActivity) => void,
-  handleGitBranchChanged: (branch: string) => void,
 
   // Properties
   activity: GlobalActivity,
@@ -191,6 +190,7 @@ export type WrapperProps = {
 
 type State = {
   forceRefreshKey: number,
+  activeGitBranch: string,
 };
 
 const rUpdate = (request, ...args) => {
@@ -209,6 +209,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
     super(props);
     this.state = {
       forceRefreshKey: Date.now(),
+      activeGitBranch: 'no-vcs',
     };
   }
 
@@ -470,6 +471,10 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
     this.setState({ forceRefreshKey: Date.now() });
   }
 
+  _handleGitBranchChanged(branch) {
+    this.setState({ activeGitBranch: branch || 'no-vcs' });
+  }
+
   componentDidMount() {
     const { activity } = this.props;
     trackPageView(`/${activity || ''}`);
@@ -499,7 +504,6 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
       handleExportFile,
       handleExportRequestsToFile,
       handleGetRenderContext,
-      handleGitBranchChanged,
       handleInitializeEntities,
       handleRender,
       handleSetActiveWorkspace,
@@ -526,7 +530,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
           gitRepository={activeGitRepository}
           vcs={gitVCS}
           handleInitializeEntities={handleInitializeEntities}
-          handleGitBranchChanged={handleGitBranchChanged}
+          handleGitBranchChanged={this._handleGitBranchChanged}
           renderDropdownButton={children => (
             <DropdownButton className="btn--clicky-small btn-sync btn-utility">
               {children}
@@ -690,6 +694,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
                     vcs={gitVCS}
                     gitRepository={activeGitRepository}
                     handleInitializeEntities={handleInitializeEntities}
+                    handleGitBranchChanged={this._handleGitBranchChanged}
                   />
                 )}
               </React.Fragment>
@@ -742,67 +747,70 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
             />
           </ErrorBoundary>
         </div>
+        <React.Fragment key={`views::${this.state.activeGitBranch}`}>
+          {activity === ACTIVITY_HOME && (
+            <WrapperHome
+              wrapperProps={this.props}
+              handleImportFile={this._handleImportFile}
+              handleImportUri={this._handleImportUri}
+              handleImportClipboard={this._handleImportClipBoard}
+            />
+          )}
 
-        {activity === ACTIVITY_HOME && (
-          <WrapperHome
-            wrapperProps={this.props}
-            handleImportFile={this._handleImportFile}
-            handleImportUri={this._handleImportUri}
-            handleImportClipboard={this._handleImportClipBoard}
-          />
-        )}
+          {activity === ACTIVITY_SPEC && (
+            <WrapperDesign
+              gitSyncDropdown={gitSyncDropdown}
+              handleSetDebugActivity={this._handleSetDebugActivity}
+              handleUpdateApiSpec={this._handleUpdateApiSpec}
+              wrapperProps={this.props}
+            />
+          )}
 
-        {activity === ACTIVITY_SPEC && (
-          <WrapperDesign
-            gitSyncDropdown={gitSyncDropdown}
-            handleSetDebugActivity={this._handleSetDebugActivity}
-            handleUpdateApiSpec={this._handleUpdateApiSpec}
-            wrapperProps={this.props}
-          />
-        )}
+          {(activity === ACTIVITY_DEBUG || activity === ACTIVITY_INSOMNIA) && (
+            <WrapperDebug
+              forceRefreshKey={this.state.forceRefreshKey}
+              gitSyncDropdown={gitSyncDropdown}
+              handleSetDesignActivity={this._handleSetDesignActivity}
+              handleChangeEnvironment={this._handleChangeEnvironment}
+              handleDeleteResponse={this._handleDeleteResponse}
+              handleDeleteResponses={this._handleDeleteResponses}
+              handleForceUpdateRequest={this._handleForceUpdateRequest}
+              handleForceUpdateRequestHeaders={this._handleForceUpdateRequestHeaders}
+              handleImport={this._handleImport}
+              handleImportFile={this._handleImportFile}
+              handleRequestCreate={this._handleCreateRequestInWorkspace}
+              handleRequestGroupCreate={this._handleCreateRequestGroupInWorkspace}
+              handleSendAndDownloadRequestWithActiveEnvironment={
+                this._handleSendAndDownloadRequestWithActiveEnvironment
+              }
+              handleSendRequestWithActiveEnvironment={this._handleSendRequestWithActiveEnvironment}
+              handleSetActiveResponse={this._handleSetActiveResponse}
+              handleSetPreviewMode={this._handleSetPreviewMode}
+              handleSetResponseFilter={this._handleSetResponseFilter}
+              handleShowCookiesModal={this._handleShowCookiesModal}
+              handleShowRequestSettingsModal={this._handleShowRequestSettingsModal}
+              handleUpdateRequestAuthentication={Wrapper._handleUpdateRequestAuthentication}
+              handleUpdateRequestBody={Wrapper._handleUpdateRequestBody}
+              handleUpdateRequestHeaders={Wrapper._handleUpdateRequestHeaders}
+              handleUpdateRequestMethod={Wrapper._handleUpdateRequestMethod}
+              handleUpdateRequestParameters={Wrapper._handleUpdateRequestParameters}
+              handleUpdateRequestUrl={Wrapper._handleUpdateRequestUrl}
+              handleUpdateSettingsShowPasswords={this._handleUpdateSettingsShowPasswords}
+              handleUpdateSettingsUseBulkHeaderEditor={
+                this._handleUpdateSettingsUseBulkHeaderEditor
+              }
+              wrapperProps={this.props}
+            />
+          )}
 
-        {(activity === ACTIVITY_DEBUG || activity === ACTIVITY_INSOMNIA) && (
-          <WrapperDebug
-            forceRefreshKey={this.state.forceRefreshKey}
-            gitSyncDropdown={gitSyncDropdown}
-            handleSetDesignActivity={this._handleSetDesignActivity}
-            handleChangeEnvironment={this._handleChangeEnvironment}
-            handleDeleteResponse={this._handleDeleteResponse}
-            handleDeleteResponses={this._handleDeleteResponses}
-            handleForceUpdateRequest={this._handleForceUpdateRequest}
-            handleForceUpdateRequestHeaders={this._handleForceUpdateRequestHeaders}
-            handleImport={this._handleImport}
-            handleImportFile={this._handleImportFile}
-            handleRequestCreate={this._handleCreateRequestInWorkspace}
-            handleRequestGroupCreate={this._handleCreateRequestGroupInWorkspace}
-            handleSendAndDownloadRequestWithActiveEnvironment={
-              this._handleSendAndDownloadRequestWithActiveEnvironment
-            }
-            handleSendRequestWithActiveEnvironment={this._handleSendRequestWithActiveEnvironment}
-            handleSetActiveResponse={this._handleSetActiveResponse}
-            handleSetPreviewMode={this._handleSetPreviewMode}
-            handleSetResponseFilter={this._handleSetResponseFilter}
-            handleShowCookiesModal={this._handleShowCookiesModal}
-            handleShowRequestSettingsModal={this._handleShowRequestSettingsModal}
-            handleUpdateRequestAuthentication={Wrapper._handleUpdateRequestAuthentication}
-            handleUpdateRequestBody={Wrapper._handleUpdateRequestBody}
-            handleUpdateRequestHeaders={Wrapper._handleUpdateRequestHeaders}
-            handleUpdateRequestMethod={Wrapper._handleUpdateRequestMethod}
-            handleUpdateRequestParameters={Wrapper._handleUpdateRequestParameters}
-            handleUpdateRequestUrl={Wrapper._handleUpdateRequestUrl}
-            handleUpdateSettingsShowPasswords={this._handleUpdateSettingsShowPasswords}
-            handleUpdateSettingsUseBulkHeaderEditor={this._handleUpdateSettingsUseBulkHeaderEditor}
-            wrapperProps={this.props}
-          />
-        )}
-
-        {activity === null && (
-          <WrapperOnboarding
-            wrapperProps={this.props}
-            handleImportFile={this._handleImportFile}
-            handleImportUri={this._handleImportUri}
-          />
-        )}
+          {activity === null && (
+            <WrapperOnboarding
+              wrapperProps={this.props}
+              handleImportFile={this._handleImportFile}
+              handleImportUri={this._handleImportUri}
+            />
+          )}
+        </React.Fragment>
       </React.Fragment>
     );
   }

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -143,6 +143,7 @@ export type WrapperProps = {
   handleUpdateRequestMimeType: Function,
   handleUpdateDownloadPath: Function,
   handleSetActiveActivity: (activity: GlobalActivity) => void,
+  handleGitBranchChanged: (branch: string) => void,
 
   // Properties
   activity: GlobalActivity,
@@ -227,7 +228,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
     return this._handleForceUpdateRequest(r, { headers });
   }
 
-  async _handleUpdateApiSpec(s: ApiSpec) {
+  async _handleUpdateApiSpec(s: ApiSpec): Promise<void> {
     await models.apiSpec.update(s);
   }
 
@@ -297,11 +298,11 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
     await models.workspaceMeta.updateByParentId(workspaceId, { activeActivity: updatedActivity });
   }
 
-  async _handleSetDesignActivity(workspaceId: string) {
+  async _handleSetDesignActivity(workspaceId: string): Promise<void> {
     await this._handleWorkspaceActivityChange(workspaceId, ACTIVITY_SPEC);
   }
 
-  async _handleSetDebugActivity(apiSpec: ApiSpec) {
+  async _handleSetDebugActivity(apiSpec: ApiSpec): Promise<void> {
     const workspaceId = apiSpec.parentId;
     await this._handleWorkspaceActivityChange(workspaceId, ACTIVITY_DEBUG);
 
@@ -498,6 +499,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
       handleExportFile,
       handleExportRequestsToFile,
       handleGetRenderContext,
+      handleGitBranchChanged,
       handleInitializeEntities,
       handleRender,
       handleSetActiveWorkspace,
@@ -524,6 +526,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
           gitRepository={activeGitRepository}
           vcs={gitVCS}
           handleInitializeEntities={handleInitializeEntities}
+          handleGitBranchChanged={handleGitBranchChanged}
           renderDropdownButton={children => (
             <DropdownButton className="btn--clicky-small btn-sync btn-utility">
               {children}

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -101,7 +101,7 @@ export type WrapperProps = {
     uri: string,
     forceToWorkspace?: ForceToWorkspace,
   ) => void,
-  handleInitializeEntities: Function,
+  handleInitializeEntities: () => Promise<void>,
   handleExportFile: Function,
   handleShowExportRequestsModal: Function,
   handleShowSettingsModal: Function,

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -101,6 +101,7 @@ class App extends PureComponent {
       isVariableUncovered: props.isVariableUncovered || false,
       vcs: null,
       gitVCS: null,
+      activeGitBranch: 'no-vcs',
       forceRefreshCounter: 0,
       forceRefreshHeaderCounter: 0,
       isMigratingChildren: false,
@@ -1035,6 +1036,10 @@ class App extends PureComponent {
     this.setState({ gitVCS });
   }
 
+  _handleGitBranchChanged(branch) {
+    this.setState({ activeGitBranch: branch || 'no-vcs' });
+  }
+
   async _updateVCS() {
     const { activeWorkspace } = this.props;
 
@@ -1249,13 +1254,14 @@ class App extends PureComponent {
       sidebarWidth,
       isVariableUncovered,
       gitVCS,
+      activeGitBranch,
       vcs,
       forceRefreshCounter,
       forceRefreshHeaderCounter,
     } = this.state;
 
-    const uniquenessKey = `${forceRefreshCounter}::${activeWorkspace._id}`;
-
+    const uniquenessKey = `${forceRefreshCounter}::${activeWorkspace._id}::${activeGitBranch}`;
+    console.log(uniquenessKey);
     return (
       <KeydownBinder onKeydown={this._handleKeyDown}>
         <div className="app" key={uniquenessKey}>
@@ -1312,6 +1318,7 @@ class App extends PureComponent {
               headerEditorKey={forceRefreshHeaderCounter + ''}
               vcs={vcs}
               gitVCS={gitVCS}
+              handleGitBranchChanged={this._handleGitBranchChanged}
             />
           </ErrorBoundary>
 

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -101,7 +101,6 @@ class App extends PureComponent {
       isVariableUncovered: props.isVariableUncovered || false,
       vcs: null,
       gitVCS: null,
-      activeGitBranch: 'no-vcs',
       forceRefreshCounter: 0,
       forceRefreshHeaderCounter: 0,
       isMigratingChildren: false,
@@ -1036,10 +1035,6 @@ class App extends PureComponent {
     this.setState({ gitVCS });
   }
 
-  _handleGitBranchChanged(branch) {
-    this.setState({ activeGitBranch: branch || 'no-vcs' });
-  }
-
   async _updateVCS() {
     const { activeWorkspace } = this.props;
 
@@ -1254,13 +1249,12 @@ class App extends PureComponent {
       sidebarWidth,
       isVariableUncovered,
       gitVCS,
-      activeGitBranch,
       vcs,
       forceRefreshCounter,
       forceRefreshHeaderCounter,
     } = this.state;
 
-    const uniquenessKey = `${forceRefreshCounter}::${activeWorkspace._id}::${activeGitBranch}`;
+    const uniquenessKey = `${forceRefreshCounter}::${activeWorkspace._id}`;
     return (
       <KeydownBinder onKeydown={this._handleKeyDown}>
         <div className="app" key={uniquenessKey}>

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -1261,7 +1261,6 @@ class App extends PureComponent {
     } = this.state;
 
     const uniquenessKey = `${forceRefreshCounter}::${activeWorkspace._id}::${activeGitBranch}`;
-    console.log(uniquenessKey);
     return (
       <KeydownBinder onKeydown={this._handleKeyDown}>
         <div className="app" key={uniquenessKey}>

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -1255,6 +1255,7 @@ class App extends PureComponent {
     } = this.state;
 
     const uniquenessKey = `${forceRefreshCounter}::${activeWorkspace._id}`;
+
     return (
       <KeydownBinder onKeydown={this._handleKeyDown}>
         <div className="app" key={uniquenessKey}>
@@ -1311,7 +1312,6 @@ class App extends PureComponent {
               headerEditorKey={forceRefreshHeaderCounter + ''}
               vcs={vcs}
               gitVCS={gitVCS}
-              handleGitBranchChanged={this._handleGitBranchChanged}
             />
           </ErrorBoundary>
 


### PR DESCRIPTION
Closes #2224 

On changing branches, we should force an update to the views (excluding modals), because there could be some unknown areas that do not update but _should_ update. As per the linked issue, the initial observation was where the code editors were not updating correctly on changing branches.

On changing branches, `entities.initialize` is called. This is an async function, however it is not awaited, therefore allowing the UI to refresh before all of the data has been pushed through.

![2020-06-02 11 57 12](https://user-images.githubusercontent.com/4312346/83465502-479b5c80-a4c8-11ea-984d-1ae80c981e99.gif)

![2020-06-02 12 42 37](https://user-images.githubusercontent.com/4312346/83467622-9a781280-a4ce-11ea-9c43-d82d5a416381.gif)

> Note: the delay on switching back to master (with a full spec) is to do with linting I believe.