### PR TITLE
Display nicer error message given empty input when installing plugins

### DIFF
--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -69,7 +69,7 @@ class Plugins extends React.PureComponent<Props, State> {
       await this._handleRefreshPlugins();
       newState.npmPluginValue = ''; // Clear input if successful install
     } catch (err) {
-      newState.error = err.message;
+      newState.error = `Failed to install ${this.state.npmPluginValue}`;
     }
 
     this.setState(newState);
@@ -268,7 +268,9 @@ class Plugins extends React.PureComponent<Props, State> {
               <i className="fa fa-times" />
             </button>
             <div className="selectable force-pre-wrap">
-              {`Search, discover, and install plugins from the Insomnia Plugin Hub: https://insomnia.rest/plugins/`}
+              <b>{error}</b>
+              {`\n\nThere may be an issue with the plugin itself, as a note you can discover and install plugins from the `}
+              <a href="https://insomnia.rest/plugins/">Plugin Hub.</a>
             </div>
           </div>
         )}

--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -65,14 +65,14 @@ class Plugins extends React.PureComponent<Props, State> {
     const newState: $Shape<State> = {
       isInstallingFromNpm: false,
       error: null,
-      installPluginErrMsg: ''
+      installPluginErrMsg: '',
     };
     try {
       await installPlugin(this.state.npmPluginValue.trim());
       await this._handleRefreshPlugins();
       newState.npmPluginValue = ''; // Clear input if successful install
     } catch (err) {
-      newState.installPluginErrMsg = `Failed to install ${this.state.npmPluginValue}`
+      newState.installPluginErrMsg = `Failed to install ${this.state.npmPluginValue}`;
       newState.error = err;
     }
 
@@ -206,7 +206,14 @@ class Plugins extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { plugins, error, installPluginErrMsg, isInstallingFromNpm, isRefreshingPlugins, npmPluginValue } = this.state;
+    const {
+      plugins,
+      error,
+      installPluginErrMsg,
+      isInstallingFromNpm,
+      isRefreshingPlugins,
+      npmPluginValue,
+    } = this.state;
 
     return (
       <div>
@@ -276,10 +283,10 @@ class Plugins extends React.PureComponent<Props, State> {
               {`\n\nThere may be an issue with the plugin itself, as a note you can discover and install plugins from the `}
               <a href="https://insomnia.rest/plugins/">Plugin Hub.</a>
               <details>
-                <summary>{`Additional Information`}</summary>
-                  <pre className="pad-top-sm force-wrap selectable">
-                    <code>{error.stack || error}</code>
-                  </pre>
+                <summary>Additionl Information</summary>
+                <pre className="pad-top-sm force-wrap selectable">
+                  <code>{error.stack || error}</code>
+                </pre>
               </details>
             </div>
           </div>

--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -20,7 +20,8 @@ import { showAlert, showPrompt } from '../modals';
 type State = {
   plugins: Array<Plugin>,
   npmPluginValue: string,
-  error: string,
+  error: Object,
+  installPluginErrMsg: string,
   isInstallingFromNpm: boolean,
   isRefreshingPlugins: boolean,
 };
@@ -39,14 +40,15 @@ class Plugins extends React.PureComponent<Props, State> {
     this.state = {
       plugins: [],
       npmPluginValue: '',
-      error: '',
+      error: null,
+      installPluginErrMsg: '',
       isInstallingFromNpm: false,
       isRefreshingPlugins: false,
     };
   }
 
   _handleClearError() {
-    this.setState({ error: '' });
+    this.setState({ error: null });
   }
 
   _handleAddNpmPluginChange(e: Event) {
@@ -62,14 +64,16 @@ class Plugins extends React.PureComponent<Props, State> {
 
     const newState: $Shape<State> = {
       isInstallingFromNpm: false,
-      error: '',
+      error: null,
+      installPluginErrMsg: ''
     };
     try {
       await installPlugin(this.state.npmPluginValue.trim());
       await this._handleRefreshPlugins();
       newState.npmPluginValue = ''; // Clear input if successful install
     } catch (err) {
-      newState.error = `Failed to install ${this.state.npmPluginValue}`;
+      newState.installPluginErrMsg = `Failed to install ${this.state.npmPluginValue}`
+      newState.error = err;
     }
 
     this.setState(newState);
@@ -202,7 +206,7 @@ class Plugins extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { plugins, error, isInstallingFromNpm, isRefreshingPlugins, npmPluginValue } = this.state;
+    const { plugins, error, installPluginErrMsg, isInstallingFromNpm, isRefreshingPlugins, npmPluginValue } = this.state;
 
     return (
       <div>
@@ -268,9 +272,15 @@ class Plugins extends React.PureComponent<Props, State> {
               <i className="fa fa-times" />
             </button>
             <div className="selectable force-pre-wrap">
-              <b>{error}</b>
+              <b>{installPluginErrMsg}</b>
               {`\n\nThere may be an issue with the plugin itself, as a note you can discover and install plugins from the `}
               <a href="https://insomnia.rest/plugins/">Plugin Hub.</a>
+              <details>
+                <summary>{`Additional Information`}</summary>
+                  <pre className="pad-top-sm force-wrap selectable">
+                    <code>{error.stack || error}</code>
+                  </pre>
+              </details>
             </div>
           </div>
         )}

--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -267,7 +267,9 @@ class Plugins extends React.PureComponent<Props, State> {
             <button className="pull-right icon" onClick={this._handleClearError}>
               <i className="fa fa-times" />
             </button>
-            <div className="selectable force-pre-wrap">{error}</div>
+            <div className="selectable force-pre-wrap">
+              {`Search, discover, and install plugins from the Insomnia Plugin Hub: https://insomnia.rest/plugins/`}
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
Closes #2208 

This PR implements a nicer error message when handling empty input when clicking install plugin. It points the user to https://insomnia.rest/plugins/ to get the package names

Previous:
![image](https://user-images.githubusercontent.com/10778130/83559405-86d6a700-a4e2-11ea-9c87-926224f07bc5.png)

With this PR:

<img width="777" alt="Screenshot 2020-06-02 15 00 17" src="https://user-images.githubusercontent.com/10778130/83559438-948c2c80-a4e2-11ea-9da6-632baccdbeac.png">
