### PR TITLE
Fix template tag enums not being quoted

### DIFF
--- a/packages/insomnia-app/app/templating/__tests__/utils.test.js
+++ b/packages/insomnia-app/app/templating/__tests__/utils.test.js
@@ -153,6 +153,28 @@ describe('unTokenizeTag()', () => {
     expect(result).toEqual('{% name bar, "baz \\"qux\\"", 1 + 5, \'hi\' %}');
   });
 
+  it('quotes for all necessary types', () => {
+    const tagData = {
+      name: 'name',
+      args: [
+        { type: 'boolean', value: 'true' },
+        { type: 'enum', value: 'foo' },
+        { type: 'expression', value: 'foo.length' },
+        { type: 'file', value: 'foo/bar/baz' },
+        { type: 'model', value: 'id_123' },
+        { type: 'number', value: '10' },
+        { type: 'string', value: 'foo' },
+        { type: 'variable', value: 'var' },
+      ],
+    };
+
+    const result = utils.unTokenizeTag(tagData);
+
+    expect(result).toEqual(
+      "{% name true, 'foo', foo.length, 'foo/bar/baz', 'id_123', 10, 'foo', var %}",
+    );
+  });
+
   it('fixes missing quotedBy attribute', () => {
     const tagData = {
       name: 'name',

--- a/packages/insomnia-app/app/templating/utils.js
+++ b/packages/insomnia-app/app/templating/utils.js
@@ -3,16 +3,7 @@
 import type { PluginArgumentEnumOption } from './extensions';
 
 export type NunjucksParsedTagArg = {
-  type:
-    | 'string'
-    | 'number'
-    | 'boolean'
-    | 'number'
-    | 'variable'
-    | 'expression'
-    | 'enum'
-    | 'file'
-    | 'model',
+  type: 'string' | 'number' | 'boolean' | 'variable' | 'expression' | 'enum' | 'file' | 'model',
   encoding?: 'base64',
   value: string | number | boolean,
   defaultValue?: string | number | boolean,
@@ -169,7 +160,7 @@ export function tokenizeTag(tagStr: string): NunjucksParsedTag {
 export function unTokenizeTag(tagData: NunjucksParsedTag): string {
   const args = [];
   for (const arg of tagData.args) {
-    if (['string', 'model', 'file'].includes(arg.type)) {
+    if (['string', 'model', 'file', 'enum'].includes(arg.type)) {
       const q = arg.quotedBy || "'";
       const re = new RegExp(`([^\\\\])${q}`, 'g');
       const str = arg.value.toString().replace(re, `$1\\${q}`);

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -115,7 +115,10 @@ class TagEditor extends React.PureComponent<Props, State> {
       allDocs[doc.type].push(doc);
     }
 
-    this.setState({ allDocs, loadingDocs: false });
+    this.setState({
+      allDocs,
+      loadingDocs: false,
+    });
   }
 
   async _updateArg(
@@ -155,7 +158,10 @@ class TagEditor extends React.PureComponent<Props, State> {
 
     if (!argData) {
       // Should never happen
-      console.warn('Could not find arg data to update', { tagData, argIndex });
+      console.warn('Could not find arg data to update', {
+        tagData,
+        argIndex,
+      });
       return;
     }
 
@@ -400,8 +406,15 @@ class TagEditor extends React.PureComponent<Props, State> {
 
   renderArgEnum(value: string, options: Array<PluginArgumentEnumOption>) {
     const argDatas = this.state.activeTagData ? this.state.activeTagData.args : [];
+
+    let unsetOption = null;
+    if (!options.find(o => o.value === value)) {
+      unsetOption = <option value="">-- Select Option --</option>;
+    }
+
     return (
       <select value={value} onChange={this._handleChange}>
+        {unsetOption}
         {options.map(option => {
           let label: string;
           const { description } = option;
@@ -591,12 +604,18 @@ class TagEditor extends React.PureComponent<Props, State> {
               </DropdownButton>
               <DropdownDivider>Input Type</DropdownDivider>
               <DropdownItem
-                value={{ variable: false, argIndex }}
+                value={{
+                  variable: false,
+                  argIndex,
+                }}
                 onClick={this._handleChangeArgVariable}>
                 <i className={'fa ' + (isVariable ? '' : 'fa-check')} /> Static Value
               </DropdownItem>
               <DropdownItem
-                value={{ variable: true, argIndex }}
+                value={{
+                  variable: true,
+                  argIndex,
+                }}
                 onClick={this._handleChangeArgVariable}>
                 <i className={'fa ' + (isVariable ? 'fa-check' : '')} /> Environment Variable
               </DropdownItem>
@@ -669,7 +688,10 @@ class TagEditor extends React.PureComponent<Props, State> {
           <div className="form-control form-control--outlined">
             <button
               type="button"
-              style={{ zIndex: 10, position: 'relative' }}
+              style={{
+                zIndex: 10,
+                position: 'relative',
+              }}
               className="txt-sm pull-right icon inline-block"
               onClick={this._handleRefresh}>
               refresh{' '}


### PR DESCRIPTION
Closes #2235

This PR fixes the problem outlined in #2235 by doing the following:

- [x] Add `enum` template tag argument type to the list of quotable types
- [x] Add test case for quoting `enum` type
- [x] Add `<option>-- Select Option --</option>` option if an enum value is set that doesn't exist in the list of options (see screenshot)

![image](https://user-images.githubusercontent.com/587576/83562378-4ec56900-a4ce-11ea-8488-421cc70104df.png)
