### PR TITLE
Fix responses not being found if deleted active environment

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
@@ -24,6 +24,7 @@ import Tooltip from '../tooltip';
 const ROOT_ENVIRONMENT_NAME = 'Base Environment';
 
 type Props = {
+  handleChangeEnvironment: (id: string | null) => Promise<void>,
   activeEnvironmentId: string | null,
   editorFontSize: number,
   editorIndentSize: number,
@@ -208,10 +209,11 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
   async _handleDuplicateEnvironment(environment: Environment) {
     const { workspace } = this.state;
     const newEnvironment = await models.environment.duplicate(environment);
-    this._load(workspace, newEnvironment);
+    await this._load(workspace, newEnvironment);
   }
 
   async _handleDeleteEnvironment(environment: Environment) {
+    const { handleChangeEnvironment } = this.props;
     const { rootEnvironment, workspace } = this.state;
 
     // Don't delete the root environment
@@ -219,8 +221,9 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
       return;
     }
 
-    // Delete the current one, then activate the root environment
+    // Delete the current one, then unset active environment
     await models.environment.remove(environment);
+    await handleChangeEnvironment(null);
     await this._load(workspace, rootEnvironment);
   }
 

--- a/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
@@ -213,7 +213,7 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
   }
 
   async _handleDeleteEnvironment(environment: Environment) {
-    const { handleChangeEnvironment } = this.props;
+    const { handleChangeEnvironment, activeEnvironmentId } = this.props;
     const { rootEnvironment, workspace } = this.state;
 
     // Don't delete the root environment
@@ -221,9 +221,14 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
       return;
     }
 
-    // Delete the current one, then unset active environment
+    // Unset active environment if it's being deleted
+    if (activeEnvironmentId === environment._id) {
+      await handleChangeEnvironment(null);
+    }
+
+    // Delete the current one
     await models.environment.remove(environment);
-    await handleChangeEnvironment(null);
+
     await this._load(workspace, rootEnvironment);
   }
 

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -106,7 +106,7 @@ export type WrapperProps = {
   handleShowExportRequestsModal: Function,
   handleShowSettingsModal: Function,
   handleExportRequestsToFile: Function,
-  handleSetActiveWorkspace: (workspaceId: string) => void,
+  handleSetActiveWorkspace: (workspaceId: string | null) => void,
   handleSetActiveEnvironment: Function,
   handleMoveDoc: Function,
   handleCreateRequest: Function,
@@ -462,7 +462,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
     handleCreateRequestGroup(activeWorkspace._id);
   }
 
-  _handleChangeEnvironment(id: string) {
+  _handleChangeEnvironment(id: string | null) {
     const { handleSetActiveEnvironment } = this.props;
     handleSetActiveEnvironment(id);
   }
@@ -727,7 +727,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
 
             <WorkspaceEnvironmentsEditModal
               ref={registerModal}
-              onChange={models.workspace.update}
+              handleChangeEnvironment={this._handleChangeEnvironment}
               lineWrapping={settings.editorLineWrapping}
               editorFontSize={settings.editorFontSize}
               editorIndentSize={settings.editorIndentSize}


### PR DESCRIPTION
Closes #2237

This PR handles the case where an active environment ID is set, but the environment no longer exists.

- [x] Ensure the active environment actually exists in the Redux selector
- [x] Set active environment to `null` if we're deleting it