### PR TITLE
Add back fsevents

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-runtime = electron
-target = 3.1.13
-disturl = https://electronjs.org/headers

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint . --ext .js,.html,.json",
     "lint:fix": "npm run lint -- --fix",
-    "bootstrap": "npm install && lerna bootstrap && lerna run --parallel --stream bootstrap && rimraf ./**/node_modules/fsevents",
+    "bootstrap": "npm install && lerna bootstrap && lerna run --parallel --stream bootstrap",
     "publish": "lerna publish",
     "clean": "lerna clean --yes && rimraf node_modules",
     "typecheck": "lerna run --parallel --stream typecheck",


### PR DESCRIPTION
This PR adds back support for `fsevents` to the root repo. I noticed high CPU usage when running the project because `fsevents` was missing. CPU levels should drop again to ~0% after this change.

- [x] Remove `rimraf ./**/node_modules/fsevents` from root `bootstrap`
- [x] Keep `rimraf ...` in `insomnia-app` package
- [x] Delete `.npmrc` from root repo since only `insomnia-app` needs to build with Electron headers

In summary, this change makes it so `fsevents` compiles directly for the host OS in the root package but everything in `insomnia-app` still compiles for Electron