### PR TITLE
Add fallback status messages for HTTP/2

### DIFF
--- a/packages/insomnia-app/app/common/constants.js
+++ b/packages/insomnia-app/app/common/constants.js
@@ -358,3 +358,84 @@ export const RESPONSE_CODE_DESCRIPTIONS = {
   510: 'Further extensions to the request are required for the server to fulfill it.',
   511: 'The 511 status code indicates that the client needs to authenticate to gain network access.',
 };
+
+export const RESPONSE_CODE_REASONS = {
+  // Special
+  [STATUS_CODE_PLUGIN_ERROR]: 'Plugin Error',
+
+  // 100s
+
+  100: 'Continue',
+  101: 'Switching Protocols',
+
+  // 200s
+
+  200: 'OK',
+  201: 'Created',
+  202: 'Accepted',
+  203: 'Non-Authoritative Information',
+  204: 'No Content',
+  205: 'Reset Content',
+  206: 'Partial Content',
+  207: 'Multi-Status',
+  208: 'Already Reported',
+  226: 'IM Used',
+
+  // 300s
+
+  300: 'Multiple Choices',
+  301: 'Moved Permanently',
+  302: 'Found',
+  303: 'See Other',
+  304: 'Not Modified',
+  305: 'Use Proxy',
+  306: 'Switch Proxy',
+  307: 'Temporary Redirect',
+  308: 'Permanent Redirect',
+
+  // 400s
+
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  402: 'Payment Required',
+  403: 'Forbidden',
+  404: 'Not Found',
+  405: 'Method Not Allowed',
+  406: 'Not Acceptable',
+  407: 'Proxy Authentication Required',
+  408: 'Request Timeout',
+  409: 'Conflict',
+  410: 'Gone',
+  411: 'Length Required',
+  412: 'Precondition Failed',
+  413: 'Payload Too Large',
+  414: 'URI Too Long',
+  415: 'Unsupported Media Type',
+  416: 'Range Not Satisfiable',
+  417: 'Expectation Failed',
+  418: "I'm a Teapot",
+  421: 'Misdirected Request',
+  422: 'Unprocessable Entity',
+  423: 'Locked',
+  424: 'Failed Dependency',
+  425: 'Too Early',
+  426: 'Upgrade Required',
+  428: 'Precondition Required',
+  429: 'Too Many Requests',
+  431: 'Request Header Fields Too Large',
+  451: 'Unavailable For Legal Reasons',
+
+  // 500s
+
+  500: 'Internal Server Error',
+  501: 'Not Implemented',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+  505: 'HTTP Version Not Supported',
+  506: 'Variant Also Negotiates',
+  507: 'Insufficient Storage',
+  508: 'Loop Detected',
+  510: 'Not Extended',
+  511: 'Network Authentication Required',
+};

--- a/packages/insomnia-app/app/ui/components/tags/status-tag.js
+++ b/packages/insomnia-app/app/ui/components/tags/status-tag.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import classnames from 'classnames';
-import { RESPONSE_CODE_DESCRIPTIONS } from '../../../common/constants';
+import { RESPONSE_CODE_DESCRIPTIONS, RESPONSE_CODE_REASONS } from '../../../common/constants';
 import Tooltip from '../tooltip';
 
 type Props = {
@@ -52,7 +52,8 @@ class StatusTag extends React.PureComponent<Props> {
     return (
       <div className={classnames('tag', colorClass, { 'tag--small': small })}>
         <Tooltip message={description} position="bottom" delay={tooltipDelay}>
-          <strong>{statusCodeToDisplay}</strong> {statusMessage}
+          <strong>{statusCodeToDisplay}</strong>{' '}
+          {statusMessage || RESPONSE_CODE_REASONS[statusCode]}
         </Tooltip>
       </div>
     );


### PR DESCRIPTION
Closes #2273

HTTP/2 removes the status message field for responses so Insomnia only shows the numeric status code in that case. This PR defines a set of default status messages that will be shown if one is not returned.

![image](https://user-images.githubusercontent.com/587576/84292666-839f7480-aafb-11ea-8d73-6484a689a350.png)
