### PR TITLE
Add "When Expired" setting for request resend trigger condition.

### DIFF
--- a/plugins/insomnia-plugin-response/__tests__/index.test.js
+++ b/plugins/insomnia-plugin-response/__tests__/index.test.js
@@ -470,6 +470,45 @@ describe('Response tag', () => {
       );
     });
 
+    it('sends when behavior=when-expired and no responses', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+      const responses = [];
+      const context = _genTestContext(requests, responses);
+
+      expect(await tag.run(context, 'raw', 'req_1', '', 'when-expired', 60)).toBe('Response res_1');
+    });
+
+    it('sends when behavior=when-expired and response is old', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+      const responses = [
+        {
+          created: Date.now() - 60000,
+        },
+      ];
+      const context = _genTestContext(requests, responses);
+
+      expect(await tag.run(context, 'raw', 'req_1', '', 'when-expired', 30)).toBe('Response res_2');
+    });
+
+    it('does not send when behavior=when-expired and response is new', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+      const responses = [
+        {
+          _id: 'res_existing',
+          parentId: 'req_1',
+          statusCode: 200,
+          contentType: 'text/plain',
+          _body: 'Response res_existing',
+          created: Date.now() - 60000,
+        },
+      ];
+      const context = _genTestContext(requests, responses);
+
+      expect(await tag.run(context, 'raw', 'req_1', '', 'when-expired', 90)).toBe(
+        'Response res_existing',
+      );
+    });
+
     it('does not send when behavior=never and no responses', async () => {
       const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
       const responses = [];


### PR DESCRIPTION
This adds a new trigger condition for re-sending a request for the
`response` plugin called "When Expired". This condition allows
specifying a maximum age of a response to use. This is very useful when
configuring a hierarchy of environment variables that ultimately depend
on an auth token that needs to be refreshed periodically.

Previous workarounds are:
1. Use "always refresh". This fails in cases where you must use the same
   auth token since it is refreshed for every request.
2. Use "no history" or "never" and manually refresh the token. This is
   inconvenient and requires pinning the token.

Alternative solutions are:
1. Add more sophisticated logic to determine when the token needs to be
   refreshed (e.g. refresh if the current request returns a `401` status
   code)
2. Write a custom response plugin to time out the token. I believe this
   functionality is small enough and general enough to be contributed
   back generally.

Fixes #1972

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
