### PR TITLE
Fix contrast ratio of lists and heading h3

### DIFF
--- a/packages/insomnia-app/app/ui/css/components/spec-editor.less
+++ b/packages/insomnia-app/app/ui/css/components/spec-editor.less
@@ -57,8 +57,10 @@
   .nostyle,
   .renderedMarkdown,
   h2,
+  h3,
   h4,
   p,
+  li,
   .model-box,
   .model-title,
   .opblock-summary-description,
@@ -110,6 +112,14 @@
 
     .auth-wrapper {
       padding-top: var(--padding-sm);
+    }
+  }
+
+  ul {
+    padding-left: var(--padding-md);
+
+    li {
+      list-style-type: disc;
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/Kong/insomnia/issues/2280

This PR apply color theming for lists and _additionally_ heading level 3

All dark themes had that issue

![Screenshot 2020-06-12 at 12 48 47](https://user-images.githubusercontent.com/1914249/84495365-585b8780-acab-11ea-9449-ca27ffd10e11.png)
