### PR TITLE
Fix for react-dom alias to @hot-loader/react-dom

### DIFF
--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -74,6 +74,7 @@
     "nunjucks",
     "pdfjs-dist",
     "prop-types",
+    "react",
     "react-animated-tree",
     "react-dnd",
     "react-dnd-html5-backend",

--- a/packages/insomnia-app/webpack/webpack.config.base.babel.js
+++ b/packages/insomnia-app/webpack/webpack.config.base.babel.js
@@ -46,7 +46,11 @@ module.exports = {
   },
   resolve: {
     alias: {
-      'react-dom': '@hot-loader/react-dom',
+      // Create aliases for react-hot-loader
+      // https://github.com/gaearon/react-hot-loader/tree/92961be0b44260d3d3f1b8864aa699766572a67c#linking
+      'react-hot-loader': path.resolve(path.join(__dirname, '../node_modules/react-hot-loader')),
+      'react': path.resolve(path.join(__dirname, '../node_modules/react')),
+      'react-dom': path.resolve(path.join(__dirname, '../node_modules/@hot-loader/react-dom')),
     },
     extensions: ['.js', '.json'],
     mainFields: ['webpack', 'browser', 'web', 'browserify', ['jam', 'main'], 'main'],

--- a/packages/insomnia-components/webpack.config.js
+++ b/packages/insomnia-components/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
     library: 'insomniaComponents',
     libraryTarget: 'commonjs2',
   },
-  externals: ['react'],
+  externals: ['react', 'react-dom'],
   module: {
     rules: [
       {


### PR DESCRIPTION
As I was testing out the fix for #2286 I stumbled upon this section of the `react-hot-loader` docs:

https://github.com/gaearon/react-hot-loader/tree/92961be0b44260d3d3f1b8864aa699766572a67c#linking

It specifies to use a different linking technique when using `npm link`. Since we're using Lerna, we need to follow this practice because Lerna uses linking heavily. 

For reference, the original error was that `insomnia-components` was unable to locate the `react-dom` module. Changing the way we alias resolves that issue.