### PR TITLE
Add test:pre-release script that excludes CLI tests

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -23,8 +23,7 @@ jobs:
         with:
           node-version: 10
       - run: npm run bootstrap
-      # Don't run tests until we can get node-libcurl working with them
-      # - run: npm test
+      - run: npm test:pre-release
       - run: npm run app-release
         env:
           CSC_LINK: ${{ secrets.CORE_WINDOWS_CSC_LINK }}
@@ -38,8 +37,7 @@ jobs:
         with:
           node-version: 10
       - run: npm run bootstrap
-      # Don't run tests until we can get node-libcurl working with them
-      # - run: npm test
+      - run: npm test:pre-release
       - run: npm run app-release
         env:
           APPLE_ID: ${{ secrets.CORE_APPLE_ID }}
@@ -58,8 +56,7 @@ jobs:
         with:
           node-version: 10
       - run: npm run bootstrap
-      # Don't run tests until we can get node-libcurl working with them
-      # - run: npm test
+      - run: npm test:pre-release
       - run: npm run app-release
         env:
           BUILD_TARGETS: AppImage,deb,tar.gz,rpm,snap

--- a/.github/workflows/release-designer.yml
+++ b/.github/workflows/release-designer.yml
@@ -23,8 +23,7 @@ jobs:
         with:
           node-version: 10
       - run: npm run bootstrap
-      # Don't run tests until we can get node-libcurl working with them
-      # - run: npm test
+      - run: npm test:pre-release
       - run: npm run app-release
         env:
           CSC_LINK: ${{ secrets.DESIGNER_WINDOWS_CSC_LINK }}
@@ -38,8 +37,7 @@ jobs:
         with:
           node-version: 10
       - run: npm run bootstrap
-      # Don't run tests until we can get node-libcurl working with them
-      # - run: npm test
+      - run: npm test:pre-release
       - run: npm run app-release
         env:
           APPLE_ID: ${{ secrets.DESIGNER_APPLE_ID }}
@@ -58,8 +56,7 @@ jobs:
         with:
           node-version: 10
       - run: npm run bootstrap
-      # Don't run tests until we can get node-libcurl working with them
-      # - run: npm test
+      - run: npm test:pre-release
       - run: npm run app-release
         env:
           BUILD_TARGETS: AppImage,deb,tar.gz,rpm,snap

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean": "lerna clean --yes && rimraf node_modules",
     "typecheck": "lerna run --parallel --stream typecheck",
     "test": "npm run lint && npm run typecheck && lerna run --stream --parallel test",
-    "test:pre-release": "npm run lint && npm run typecheck && lerna run --stream --parallel --ignore insomnia-cli test",
+    "test:pre-release": "npm run test -- --ignore insomnia-cli",
     "cli-start": "npm start --prefix packages/insomnia-cli",
     "app-start": "npm start --prefix packages/insomnia-app",
     "app-build": "npm run build --prefix packages/insomnia-app",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clean": "lerna clean --yes && rimraf node_modules",
     "typecheck": "lerna run --parallel --stream typecheck",
     "test": "npm run lint && npm run typecheck && lerna run --stream --parallel test",
+    "test:pre-release": "npm run lint && npm run typecheck && lerna run --stream --parallel --ignore insomnia-cli test",
     "cli-start": "npm start --prefix packages/insomnia-cli",
     "app-start": "npm start --prefix packages/insomnia-app",
     "app-build": "npm run build --prefix packages/insomnia-app",


### PR DESCRIPTION
CLI tests currently fail importing `node-libcurl` if run in an Electron-environment (ie. app release), so this PR disables CLI tests for the release workflow