### PR TITLE
Add support for snippets in autocomplete

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -511,6 +511,7 @@ class CodeEditor extends React.Component {
       autoCloseBrackets,
       dynamicHeight,
       getAutocompleteConstants,
+      getAutocompleteSnippets,
       getRenderContext,
       hideGutters,
       hideLineNumbers,
@@ -605,7 +606,7 @@ class CodeEditor extends React.Component {
     }
 
     // Setup the hint options
-    if (getRenderContext || getAutocompleteConstants) {
+    if (getRenderContext || getAutocompleteConstants || getAutocompleteSnippets) {
       let getVariables = null;
       let getTags = null;
       if (getRenderContext) {
@@ -641,6 +642,7 @@ class CodeEditor extends React.Component {
         getVariables,
         getTags,
         getConstants: getAutocompleteConstants,
+        getSnippets: getAutocompleteSnippets,
       };
     }
 
@@ -779,7 +781,7 @@ class CodeEditor extends React.Component {
     if (value.trim() === '') {
       this._codemirrorSmartSetOption('lint', false);
     } else {
-      this._codemirrorSmartSetOption('lint', true);
+      this._codemirrorSmartSetOption('lint', this.props.lintOptions || true);
       // If we're in single-line mode, merge all changed lines into one
       if (this.props.singleLine && change.text && change.text.length > 1) {
         const text = change.text
@@ -1031,6 +1033,7 @@ CodeEditor.propTypes = {
   nunjucksPowerUserMode: PropTypes.bool,
   getRenderContext: PropTypes.func,
   getAutocompleteConstants: PropTypes.func,
+  getAutocompleteSnippets: PropTypes.func,
   keyMap: PropTypes.string,
   mode: PropTypes.string,
   id: PropTypes.string,

--- a/packages/insomnia-app/app/ui/components/codemirror/extensions/autocomplete.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/extensions/autocomplete.js
@@ -15,14 +15,17 @@ const MAX_HINT_LOOK_BACK = 100;
 const TYPE_VARIABLE = 'variable';
 const TYPE_TAG = 'tag';
 const TYPE_CONSTANT = 'constant';
+const TYPE_SNIPPET = 'snippet';
 const MAX_CONSTANTS = -1;
+const MAX_SNIPPETS = -1;
 const MAX_VARIABLES = -1;
 const MAX_TAGS = -1;
 
 const ICONS = {
-  [TYPE_CONSTANT]: { char: '&#x1d484;', title: 'Constant' },
-  [TYPE_VARIABLE]: { char: '&#x1d465;', title: 'Environment Variable' },
-  [TYPE_TAG]: { char: '&fnof;', title: 'Generator Tag' },
+  [TYPE_CONSTANT]: { char: '𝒄', title: 'Constant' },
+  [TYPE_SNIPPET]: { char: '§', title: 'Snippet' },
+  [TYPE_VARIABLE]: { char: '𝑥', title: 'Environment Variable' },
+  [TYPE_TAG]: { char: 'ƒ', title: 'Generator Tag' },
 };
 
 CodeMirror.defineExtension('isHintDropdownActive', function() {
@@ -65,6 +68,7 @@ CodeMirror.defineOption('environmentAutocomplete', null, (cm, options) => {
 
     const constants = options.getConstants ? await options.getConstants() : null;
     const variables = options.getVariables ? await options.getVariables() : null;
+    const snippets = options.getSnippets ? await options.getSnippets() : null;
     const tags = options.getTags ? await options.getTags() : null;
 
     // Actually show the hint
@@ -72,6 +76,7 @@ CodeMirror.defineOption('environmentAutocomplete', null, (cm, options) => {
       // Insomnia-specific options
       constants: constants || [],
       variables: variables || [],
+      snippets: snippets || [],
       tags: tags || [],
       showAllOnNoMatch,
 
@@ -181,6 +186,7 @@ CodeMirror.defineOption('environmentAutocomplete', null, (cm, options) => {
 function hint(cm, options) {
   const variablesToMatch = options.variables || [];
   const constantsToMatch = options.constants || [];
+  const snippetsToMatch = options.snippets || [];
   const tagsToMatch = options.tags || [];
 
   // Get the text from the cursor back
@@ -271,6 +277,10 @@ function hint(cm, options) {
     );
   }
 
+  matchSegments(snippetsToMatch, nameSegment, TYPE_SNIPPET, MAX_SNIPPETS).forEach(m =>
+    highPriorityMatches.push(m),
+  );
+
   const matches = [...highPriorityMatches, ...lowPriorityMatches];
 
   // Autocomplete from longest matched segment
@@ -295,7 +305,11 @@ function hint(cm, options) {
  * @param self
  * @param data
  */
-function replaceHintMatch(cm, self, data) {
+async function replaceHintMatch(cm, self, data) {
+  if (typeof data.text === 'function') {
+    data.text = await data.text();
+  }
+
   const cur = cm.getCursor();
   const from = CodeMirror.Pos(cur.line, cur.ch - data.segment.length);
   const to = CodeMirror.Pos(cur.line, cur.ch);
@@ -355,7 +369,16 @@ function matchSegments(listOfThings, segment, type, limit = -1) {
     const name = typeof t === 'string' ? t : t.name;
     const value = typeof t === 'string' ? '' : t.value;
     const displayName = t.displayName || name;
-    const defaultFill = typeof t === 'string' ? name : getDefaultFill(t.name, t.args);
+
+    // Generate the value we'll fill it with
+    let defaultFill;
+    if (t.args) {
+      defaultFill = getDefaultFill(t.name, t.args);
+    } else if (t.value) {
+      defaultFill = t.value;
+    } else {
+      defaultFill = name;
+    }
 
     const matchSegment = segment.toLowerCase();
     const matchName = displayName.toLowerCase();
@@ -365,12 +388,17 @@ function matchSegments(listOfThings, segment, type, limit = -1) {
       continue;
     }
 
+    let displayValue = t.displayValue;
+    if (typeof displayValue !== 'string' && typeof value !== 'function') {
+      displayValue = JSON.stringify(value);
+    }
+
     matches.push({
       // Custom Insomnia keys
       type,
       segment,
+      displayValue,
       comment: value,
-      displayValue: value ? JSON.stringify(value) : '',
       score: name.length, // In case we want to sort by this
 
       // CodeMirror

--- a/packages/insomnia-app/app/ui/css/editor/hints.less
+++ b/packages/insomnia-app/app/ui/css/editor/hints.less
@@ -44,7 +44,7 @@
     &.type--snippet {
       .label {
         background: var(--color-notice);
-        color: var(--color-font-success);
+        color: var(--color-font-notice);
       }
     }
 

--- a/packages/insomnia-app/app/ui/css/editor/hints.less
+++ b/packages/insomnia-app/app/ui/css/editor/hints.less
@@ -41,6 +41,13 @@
       }
     }
 
+    &.type--snippet {
+      .label {
+        background: var(--color-notice);
+        color: var(--color-font-success);
+      }
+    }
+
     &:not(.fancy-hint)::before {
       margin-left: calc(var(--padding-sm) * -1);
       content: '\1d43a';


### PR DESCRIPTION
This PR enables the ability to add snippets to the autocomplete, similar how we can pass constants.

```js
<CodeEditor
  // ...
  getAutocompleteSnippets={() => [{
    name: 'Snippet', 
    displayValue: '', 
    value: async () => 'Can do anything here'
  }]}
/>
```

![image](https://user-images.githubusercontent.com/587576/86178976-3f8e0700-bade-11ea-9f09-8c29fce518e3.png)
