### PR TITLE
Alternate send request callback for app to use

### DIFF
--- a/packages/insomnia-app/send-request/index.js
+++ b/packages/insomnia-app/send-request/index.js
@@ -1,1 +1,1 @@
-export { getSendRequestCallback } from '../app/common/send-request';
+export { getSendRequestCallbackMemDb, getSendRequestCallback } from '../app/common/send-request';

--- a/packages/insomnia-cli/flow-typed/insomnia-send-request.js
+++ b/packages/insomnia-cli/flow-typed/insomnia-send-request.js
@@ -2,7 +2,8 @@
 
 declare module 'insomnia-send-request' {
   declare module.exports: {
-    getSendRequestCallback: (
+    getSendRequestCallback: ( environmentId: string ) => Promise<Object>,
+    getSendRequestCallbackMemDb: (
       environmentId: string,
       memDb: { [string]: Array<Object> },
     ) => Promise<Object>,

--- a/packages/insomnia-cli/src/commands/run-tests.js
+++ b/packages/insomnia-cli/src/commands/run-tests.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { generate, runTestsCli } from 'insomnia-testing';
-import { getSendRequestCallback } from 'insomnia-send-request';
+import { getSendRequestCallbackMemDb } from 'insomnia-send-request';
 import type { GlobalOptions } from '../util';
 import { loadDb } from '../db';
 
@@ -63,6 +63,6 @@ export async function runInsomniaTests(options: RunTestsOptions): Promise<boolea
 
   const environmentId = 'env_env_ca046a738f001eb3090261a537b1b78f86c2094c_sub';
   const testFileContents = await generate(suites);
-  const sendRequest = await getSendRequestCallback(environmentId, db);
+  const sendRequest = await getSendRequestCallbackMemDb(environmentId, db);
   return await runTestsCli(testFileContents, { reporter, bail, keepFile, sendRequest });
 }


### PR DESCRIPTION
This PR splits the `getSendRequestCallback` into two functions. One that accepts an in-memory DB, and one that doesn't. The one that doesn't, will be useful for the app code since it will not need an in-memory DB.