### PR TITLE
Rename emptyValue props to blankValue

### DIFF
--- a/packages/insomnia-app/app/ui/components/base/editable.js
+++ b/packages/insomnia-app/app/ui/components/base/editable.js
@@ -70,7 +70,7 @@ class Editable extends PureComponent {
     const {
       value,
       fallbackValue,
-      emptyValue,
+      blankValue,
       singleClick,
       onEditStart, // eslint-disable-line no-unused-vars
       className,
@@ -101,14 +101,14 @@ class Editable extends PureComponent {
         title: singleClick ? 'Click to edit' : 'Double click to edit',
         onClick: this._handleSingleClickEditStart,
         onDoubleClick: this._handleEditStart,
-        emptyValue,
+        blankValue,
         ...extra,
       };
 
       if (renderReadView) {
         return renderReadView(initialValue, readViewProps);
       } else {
-        return <span {...readViewProps}>{initialValue || emptyValue}</span>;
+        return <span {...readViewProps}>{initialValue || blankValue}</span>;
       }
     }
   }
@@ -120,7 +120,7 @@ Editable.propTypes = {
 
   // Optional
   fallbackValue: PropTypes.string,
-  emptyValue: PropTypes.string,
+  blankValue: PropTypes.string,
   renderReadView: PropTypes.func,
   singleClick: PropTypes.bool,
   onEditStart: PropTypes.func,

--- a/packages/insomnia-app/app/ui/components/base/highlight.js
+++ b/packages/insomnia-app/app/ui/components/base/highlight.js
@@ -7,18 +7,19 @@ import { fuzzyMatch } from '../../../common/misc';
 type Props = {|
   search: string,
   text: string,
+  blankValue?: String,
 |};
 
 @autobind
 class Highlight extends React.PureComponent<Props> {
   render() {
-    const { search, text, emptyValue, ...otherProps } = this.props;
+    const { search, text, blankValue, ...otherProps } = this.props;
 
     // Match loose here to make sure our highlighting always works
     const result = fuzzyMatch(search, text, { splitSpace: true, loose: true });
 
     if (!result) {
-      return <span {...otherProps}>{text || emptyValue || ''}</span>;
+      return <span {...otherProps}>{text || blankValue || ''}</span>;
     }
 
     return (

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
@@ -191,7 +191,7 @@ class SidebarRequestRow extends PureComponent {
                 <Editable
                   value={request.name}
                   fallbackValue={this.state.renderedUrl}
-                  emptyValue="Empty"
+                  blankValue="Empty"
                   className="inline-block"
                   onEditStart={this._handleEditStart}
                   onSubmit={this._handleRequestUpdateName}


### PR DESCRIPTION
It turns out `emptyValue` is a reserved thing in React, so this PR renames usages of it to `blankValue` instead.

Here's the error from React that prompted this change.

![image](https://user-images.githubusercontent.com/587576/86186653-78ce7300-baee-11ea-8f61-4e598ee84690.png)
