### PR TITLE
Return 'dev' as the version if running in development

### DIFF
--- a/packages/insomnia-inso/src/__tests__/cli.test.js
+++ b/packages/insomnia-inso/src/__tests__/cli.test.js
@@ -5,6 +5,7 @@ import { lintSpecification } from '../commands/lint-specification';
 import { runInsomniaTests } from '../commands/run-tests';
 import { exportSpecification } from '../commands/export-specification';
 import { parseArgsStringToArgv } from 'string-argv';
+import * as packageJson from '../../package.json';
 
 jest.mock('../commands/generate-config');
 jest.mock('../commands/lint-specification');
@@ -42,6 +43,20 @@ describe('cli', () => {
 
     it('should throw error if working dir argument is missing', () => {
       expect(() => inso('-w')).toThrowError();
+    });
+
+    it.each(['-v', '--version'])('inso %s should print version from package.json', args => {
+      jest.spyOn(console, 'log').mockImplementation(() => {});
+      expect(() => inso(args)).toThrowError(packageJson.version);
+    });
+
+    it.each(['-v', '--version'])('inso %s should print "dev" if running in development', args => {
+      const oldNodeEnv = process.env.NODE_ENV;
+
+      process.env.NODE_ENV = 'development';
+      expect(() => inso(args)).toThrowError('dev');
+
+      process.env.NODE_ENV = oldNodeEnv;
     });
   });
 

--- a/packages/insomnia-inso/src/__tests__/inso-snapshot.test.js
+++ b/packages/insomnia-inso/src/__tests__/inso-snapshot.test.js
@@ -1,7 +1,6 @@
 // @flow
 import execa from 'execa';
 import { getBinPathSync } from 'get-bin-path';
-import * as packageJson from '../../package.json';
 
 // MAKE SURE YOU BUILD THE PROJECT BEFORE RUNNING THESE TESTS.
 // These tests use the executable /bin/inso, which relies on /dist.
@@ -24,17 +23,6 @@ describe('Snapshot for', () => {
     async args => {
       const { stdout } = await execa(getBinPathSync(), args.split(' '));
       expect(stdout).toMatchSnapshot();
-    },
-    30000,
-  );
-});
-
-describe('Inso version', () => {
-  it.each(['-v', '--version'])(
-    'inso %s should print version from package.json',
-    async args => {
-      const { stdout } = await execa(getBinPathSync(), args.split(' '));
-      expect(stdout).toBe(packageJson.version);
     },
     30000,
   );

--- a/packages/insomnia-inso/src/__tests__/util.test.js
+++ b/packages/insomnia-inso/src/__tests__/util.test.js
@@ -1,5 +1,6 @@
 // @flow
-import { exit, logErrorExit1, getDefaultAppDataDir } from '../util';
+import { exit, logErrorExit1, getDefaultAppDataDir, getVersion, isDevelopment } from '../util';
+import * as packageJson from '../../package.json';
 
 describe('exit()', () => {
   it('should exit 0 if successful result', async () => {
@@ -67,4 +68,41 @@ describe('getDefaultAppDataDir()', () => {
       'Environment variable DEFAULT_APP_DATA_DIR is not set.',
     );
   });
+});
+
+describe('getVersion()', () => {
+  it('should return version from packageJson', () => {
+    expect(getVersion()).toBe(packageJson.version);
+  });
+
+  it('should return dev if running in development', () => {
+    const oldNodeEnv = process.env.NODE_ENV;
+
+    process.env.NODE_ENV = 'development';
+    expect(getVersion()).toBe('dev');
+
+    process.env.NODE_ENV = oldNodeEnv;
+  });
+});
+
+describe('isDevelopment()', () => {
+  it('should return true if NODE_ENV is development', () => {
+    const oldNodeEnv = process.env.NODE_ENV;
+
+    process.env.NODE_ENV = 'development';
+    expect(isDevelopment()).toBe(true);
+
+    process.env.NODE_ENV = oldNodeEnv;
+  });
+
+  it('should return false if NODE_ENV is not development', () => {
+    const oldNodeEnv = process.env.NODE_ENV;
+
+    process.env.NODE_ENV = 'production';
+    expect(isDevelopment()).toBe(false);
+
+    process.env.NODE_ENV = oldNodeEnv;
+  });
+
+  it('should return dev if running in development', () => {});
 });

--- a/packages/insomnia-inso/src/util.js
+++ b/packages/insomnia-inso/src/util.js
@@ -2,7 +2,11 @@
 import * as packageJson from '../package.json';
 
 export function getVersion() {
-  return packageJson.version;
+  return isDevelopment() ? 'dev' : packageJson.version;
+}
+
+export function isDevelopment() {
+  return process.env.NODE_ENV === 'development';
 }
 
 export function logErrorExit1(err: Error) {


### PR DESCRIPTION
It gets difficult to identify which version of inso is installed locally, so the `inso -v` option will not identify whether the version is live (packageJson.version) or development (dev).

![image](https://user-images.githubusercontent.com/4312346/88746934-d3b4c200-d1a1-11ea-889a-9b4ed51df63e.png)
