### PR TITLE
Consistent export dropdown verbiage

### DIFF
--- a/packages/insomnia-app/app/common/strings.js
+++ b/packages/insomnia-app/app/common/strings.js
@@ -3,5 +3,6 @@ import { APP_ID_INSOMNIA } from '../../config';
 
 export default {
   workspace: getAppId() === APP_ID_INSOMNIA ? 'Workspace' : 'Document',
+  workspaces: getAppId() === APP_ID_INSOMNIA ? 'Workspaces' : 'Documents',
   apiSpec: 'Document',
 };

--- a/packages/insomnia-app/app/ui/components/settings/import-export.js
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.js
@@ -4,6 +4,7 @@ import autobind from 'autobind-decorator';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import Link from '../base/link';
 import { showPrompt } from '../modals/index';
+import Strings from '../../../common/strings';
 
 @autobind
 class ImportExport extends PureComponent {
@@ -48,11 +49,11 @@ class ImportExport extends PureComponent {
             <DropdownDivider>Choose Export Type</DropdownDivider>
             <DropdownItem onClick={handleShowExportRequestsModal}>
               <i className="fa fa-home" />
-              Current Workspace
+              Current {Strings.workspace}
             </DropdownItem>
             <DropdownItem onClick={handleExportAll}>
               <i className="fa fa-empty" />
-              All Workspaces
+              All {Strings.workspace}
             </DropdownItem>
           </Dropdown>
           &nbsp;&nbsp;

--- a/packages/insomnia-app/app/ui/components/settings/import-export.js
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.js
@@ -53,7 +53,7 @@ class ImportExport extends PureComponent {
             </DropdownItem>
             <DropdownItem onClick={handleExportAll}>
               <i className="fa fa-empty" />
-              All {Strings.workspace}
+              All {Strings.workspaces}
             </DropdownItem>
           </Dropdown>
           &nbsp;&nbsp;


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

Fixes #2098

Thanks for the instructions in the PR, it's quite clear and helpful.

I follow the naming convention here: [insomnia/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js](https://github.com/Kong/insomnia/blob/443d6df08d50c0912c11b039d46739d70790d9be/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js#L12), use `import Strings from '../../../common/strings';` 

It works as expected now, display "document" for Designger.

<img width="509" alt="螢幕快照 2020-08-01 下午4 01 36" src="https://user-images.githubusercontent.com/2755720/89097297-56db4f80-d410-11ea-8648-35ce27906c27.png">
