### PR TITLE
Consistent trailing punctuation in README lists.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,8 +10,8 @@ to provide access to operating system features.
 
 There are a few more technologies and tools worth mentioning:
 
-- [`React`](https://reactjs.org/) is the library used for all UI components
-- [`Less`](http://lesscss.org/) is used for styling UI components
+- [`React`](https://reactjs.org/) is the library used for all UI components.
+- [`Less`](http://lesscss.org/) is used for styling UI components.
 - [`Electron Builder`](https://github.com/electron-userland/electron-builder) is used to help build,
   sign, and package Insomnia for distribution.
 - [`Flow`](https://flow.org/) is used for adding types to the codebase. Not everything is Flow but
@@ -19,8 +19,8 @@ There are a few more technologies and tools worth mentioning:
 - [`Webpack`](https://webpack.js.org/) is the bundler used to compile the JS/Less/babel/etc
   libcurl library that Insomnia uses to make requests. Libcurl is the HTTP client of choice because
   it allows the deepest amount of debuggability and control of HTTP requests.
-- [`nedb`](https://github.com/louischatriot/nedb) a local in-memory database
-- [`node-libcurl`](https://github.com/JCMais/node-libcurl) is a NodeJS wrapper around the native
+- [`nedb`](https://github.com/louischatriot/nedb) a local in-memory database.
+- [`node-libcurl`](https://github.com/JCMais/node-libcurl) is a NodeJS wrapper around the native.
 - [`Codemirror`](https://codemirror.net/) is a web-based, extendable, code editor used for 
   highlighting and linting of data formats like JSON, GraphQL, and XML.
 
@@ -29,8 +29,8 @@ There are a few more technologies and tools worth mentioning:
 Insomnia uses [`lerna`](https://lerna.js.org/) to manage multiple npm packages within a single 
 repository. There are currently two package locations:
 
-- `/packages` contains related packages that are consumed by `insomnia-app` or externally
-- `/plugins` contains plugin packages that are included by default with the application
+- `/packages` contains related packages that are consumed by `insomnia-app` or externally.
+- `/plugins` contains plugin packages that are included by default with the application.
 
 ## The `insomnia-app` Main Package
 
@@ -39,22 +39,22 @@ one.
 
 There are a few notable directories inside of it:
 
-- `/main.development.js` Entry for Electron
-- `/app/main` Stuff that runs inside Electron's main process
-- `/app/ui` React components and styling 
-- `/app/common` Utilities used across both main and render processes
-- `/app/plugins` Logic around installation and usage of plugins
-- `/app/models` DB models used to store user data
-- `/app/network` Sending requests and performing auth (eg. OAuth 2)
-- `/app/templating` Nunjucks and rendering related code
-- `/app/sync(-legacy)?` and `/app/accounts` Team sync and account stuff
+- `/main.development.js` Entry for Electron.
+- `/app/main` Stuff that runs inside Electron's main process.
+- `/app/ui` React components and styling .
+- `/app/common` Utilities used across both main and render processes.
+- `/app/plugins` Logic around installation and usage of plugins.
+- `/app/models` DB models used to store user data.
+- `/app/network` Sending requests and performing auth (eg. OAuth 2).
+- `/app/templating` Nunjucks and rendering related code.
+- `/app/sync(-legacy)?` and `/app/accounts` Team sync and account stuff.
 
 ## Data and State Architecture
 
 Insomnia stores data in a few places:
 
-- A local in-memory NeDB database stores data for data models (requests, folder, workspaces, etc)
-- A local Redux store contains an in-memory copy of all database entities
+- A local in-memory NeDB database stores data for data models (requests, folder, workspaces, etc).
+- A local Redux store contains an in-memory copy of all database entities.
 
 *Eventually, Redux could/should be removed, which would both reduce memory overhead and simplify
 the codebase. NeDB should essentially replace it*
@@ -63,12 +63,12 @@ the codebase. NeDB should essentially replace it*
 
 This is just brief summary of Insomnia's current technical debt.
 
-- Loading large responses (~20MB) can crash the app on weaker hardware
+- Loading large responses (~20MB) can crash the app on weaker hardware.
 - Redux stores an in-memory duplicate of the local DB, unnecessarily doubling memory usage. Moving
   forward, Redux shouldn't need to be considered much and may be able to be removed eventually.
 - Bundling `libcurl` (native module) has caused many weeks of headaches trying to get builds working
   across Windows, Mac, and Linux. More expertise here is definitely needed.
 - All input fields that support templating/autocomplete/etc are actually Codemirror instances. This
-  isn't really debt but may affect things going forward
+  isn't really debt but may affect things going forward.
 - Use of `libcurl` means Insomnia can't run in a web browser and can't support bidirectional socket
-  communication
+  communication.


### PR DESCRIPTION
We need sync for all line. Dot or none, we can't do like that.