### PR TITLE
Bring path validation into paths component. Error boundary around sidebar.

### DIFF
--- a/packages/insomnia-app/app/ui/components/wrapper-design.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.js
@@ -223,10 +223,12 @@ class WrapperDesign extends React.PureComponent<Props, State> {
               <ErrorBoundary
                 invalidationKey={activeApiSpec.contents}
                 renderError={() => (
-                  <div className="text-center margin">
+                  <div className="text-left margin pad">
                     <h3>An error occurred while trying to render Swagger UI 😢</h3>
-                    This preview will automatically refresh, once you have a valid specification
-                    that can be previewed.
+                    <p>
+                      This preview will automatically refresh, once you have a valid specification
+                      that can be previewed.
+                    </p>
                   </div>
                 )}>
                 <SwaggerUI
@@ -265,7 +267,17 @@ class WrapperDesign extends React.PureComponent<Props, State> {
           </div>
         )}
         renderPageSidebar={() => (
-          <ErrorBoundary showAlert>
+          <ErrorBoundary
+            invalidationKey={activeApiSpec.contents}
+            renderError={() => (
+              <div className="text-left margin pad">
+                <h4>An error occurred while trying to render your spec's navigation. 😢</h4>
+                <p>
+                  This navigation will automatically refresh, once you have a valid specification
+                  that can be rendered.
+                </p>
+              </div>
+            )}>
             <SpecEditorSidebar
               apiSpec={activeApiSpec}
               handleSetSelection={this._handleSetSelection}

--- a/packages/insomnia-components/components/sidebar/index.js
+++ b/packages/insomnia-components/components/sidebar/index.js
@@ -85,10 +85,6 @@ function Sidebar(props: Props) {
   const { servers, info, paths } = props.jsonData || {};
   const { requestBodies, responses, parameters, headers, schemas, securitySchemes } =
     props.jsonData.components || {};
-  let pathItems = {};
-  if (typeof paths !== 'string') {
-    pathItems = Object.entries(paths || {});
-  }
 
   return (
     <StyledSidebar className="theme--sidebar">
@@ -163,9 +159,7 @@ function Sidebar(props: Props) {
         </StyledSection>
       )}
       {serversVisible && servers && <SidebarServers servers={servers} onClick={props.onClick} />}
-      {pathsVisible && pathItems && pathItems.length && (
-        <SidebarPaths paths={pathItems} onClick={props.onClick} />
-      )}
+      {pathsVisible && paths && <SidebarPaths paths={paths} onClick={props.onClick} />}
       {requestsVisible && requestBodies && (
         <SidebarRequests requests={requestBodies} onClick={props.onClick} />
       )}

--- a/packages/insomnia-components/components/sidebar/sidebar-paths.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-paths.js
@@ -20,10 +20,14 @@ const StyledMethods: React.ComponentType<{}> = styled.span`
 export default class SidebarPaths extends React.Component<Props> {
   renderBody = (filter: string): null | React.Node => {
     const { paths, onClick } = this.props;
-    if (Object.prototype.toString.call(paths) !== '[object Array]') {
+    let pathItems = {};
+    if (typeof paths !== 'string') {
+      pathItems = Object.entries(paths || {});
+    }
+    if (Object.prototype.toString.call(pathItems) !== '[object Array]') {
       return <StyledInvalidSection name={'path'} />;
     }
-    const filteredValues = paths.filter(pathDetail =>
+    const filteredValues = pathItems.filter(pathDetail =>
       pathDetail[0].toLowerCase().includes(filter.toLocaleLowerCase()),
     );
 


### PR DESCRIPTION
This moves path validation and array creation out of sidebar root into the paths component itself. This also wraps the sidebar with our error boundary component rounding out or validation approach for sidebar components.

If a component (i.e. servers, paths, requests, etc.) is entirely missing, it is not rendered.
If a component named entry is present but its properties are invalid or missing, we show a warning contextually.
If the spec itself is invalid, we catch and show our error boundary > messaging.

In all scenarios, once fixed, the sidebar re-renders.

All cases can be scene here:
![2020-08-04 11 05 09](https://user-images.githubusercontent.com/52717970/89311925-a013e500-d644-11ea-8c06-7b385b3ca8b9.gif)

