### PR TITLE
Add tooltip with docs for git authentication key generation

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
@@ -7,6 +7,7 @@ import ModalHeader from '../base/modal-header';
 import type { GitRepository } from '../../../models/git-repository';
 import ModalFooter from '../base/modal-footer';
 import * as models from '../../../models';
+import HelpTooltip from '../help-tooltip';
 
 type Props = {||};
 
@@ -199,6 +200,21 @@ class GitRepositorySettingsModal extends React.PureComponent<Props, State> {
               <div className="form-control form-control--outlined">
                 <label>
                   Authentication Token
+                  <HelpTooltip className="space-left">
+                    Create a personal access token (instructions for{' '}
+                    <a href="https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token">
+                      Github
+                    </a>{' '}
+                    |{' '}
+                    <a href="https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html">
+                      Gitlab
+                    </a>{' '}
+                    |{' '}
+                    <a href="https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html">
+                      Bitbucket
+                    </a>
+                    )
+                  </HelpTooltip>
                   <input
                     required
                     type="password"


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

I added a tooltip message for the Authentication Token field. Here is a screenshot preview:

![Screenshot 2020-08-15 at 13 52 55](https://user-images.githubusercontent.com/36109955/90312507-4e514180-df05-11ea-8299-f5f77f859726.png)

It would be useful to add some helpful hint like messages on error dialogs as also mentioned in issue #2172. For example, I forgot to allow permission for the private repositories when creating an access token. The message I got was just "Error 404: Not found", which could be a little bit confusing if you've never created access tokens before.

Closes #2172 