### PR TITLE
Add bitbucket cloud docs, add documentation tooltip to git settings modal header

### DIFF
--- a/packages/insomnia-app/app/common/documentation.js
+++ b/packages/insomnia-app/app/common/documentation.js
@@ -7,7 +7,7 @@ export const docsBase = insomniaDocs('/');
 export const docsGitSync = insomniaDocs('/article/96-git-sync');
 export const docsGitAccessToken = {
   github:
-    'https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token',
+    'https://docs.github.com/github/authenticating-to-github/creating-a-personal-access-token',
   gitlab: 'https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html',
   bitbucket: 'https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/',
   bitbucketServer:

--- a/packages/insomnia-app/app/common/documentation.js
+++ b/packages/insomnia-app/app/common/documentation.js
@@ -5,3 +5,11 @@ function insomniaDocs(slug: string): string {
 
 export const docsBase = insomniaDocs('/');
 export const docsGitSync = insomniaDocs('/article/96-git-sync');
+export const docsGitAccessToken = {
+  github:
+    'https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token',
+  gitlab: 'https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html',
+  bitbucket: 'https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/',
+  bitbucketServer:
+    'https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html',
+};

--- a/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
@@ -8,6 +8,8 @@ import type { GitRepository } from '../../../models/git-repository';
 import ModalFooter from '../base/modal-footer';
 import * as models from '../../../models';
 import HelpTooltip from '../help-tooltip';
+import { docsGitAccessToken, docsGitSync } from '../../../common/documentation';
+import Link from '../base/link';
 
 type Props = {||};
 
@@ -135,10 +137,23 @@ class GitRepositorySettingsModal extends React.PureComponent<Props, State> {
   render() {
     const { inputs, gitRepository } = this.state;
 
+    const linkIcon = <i className="fa fa-external-link-square" />;
+
     return (
       <form onSubmit={this._handleSubmitEdit}>
         <Modal ref={this._setModalRef} {...this.props}>
-          <ModalHeader>Configure Repository</ModalHeader>
+          <ModalHeader>
+            Configure Repository{' '}
+            <HelpTooltip>
+              Sync and collaborate with Git{' '}
+              <Link href={docsGitSync}>
+                <span className="no-wrap">
+                  <br />
+                  Documentation <i className="fa fa-external-link" />
+                </span>
+              </Link>
+            </HelpTooltip>
+          </ModalHeader>
           <ModalBody key={gitRepository ? gitRepository._id : 'new'} className="pad">
             <div className="form-control form-control--outlined">
               <label>
@@ -201,19 +216,17 @@ class GitRepositorySettingsModal extends React.PureComponent<Props, State> {
                 <label>
                   Authentication Token
                   <HelpTooltip className="space-left">
-                    Create a personal access token (instructions for{' '}
-                    <a href="https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token">
-                      Github
-                    </a>{' '}
-                    |{' '}
-                    <a href="https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html">
-                      Gitlab
-                    </a>{' '}
-                    |{' '}
-                    <a href="https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html">
-                      Bitbucket
-                    </a>
-                    )
+                    Create a personal access token
+                    <br />
+                    <Link href={docsGitAccessToken.github}>Github {linkIcon}</Link>
+                    {' | '}
+                    <Link href={docsGitAccessToken.gitlab}>Gitlab {linkIcon}</Link>
+                    {' | '}
+                    <Link href={docsGitAccessToken.bitbucket}>Bitbucket {linkIcon}</Link>
+                    {' | '}
+                    <Link href={docsGitAccessToken.bitbucketServer}>
+                      Bitbucket Server {linkIcon}
+                    </Link>
                   </HelpTooltip>
                   <input
                     required

--- a/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
@@ -145,13 +145,9 @@ class GitRepositorySettingsModal extends React.PureComponent<Props, State> {
           <ModalHeader>
             Configure Repository{' '}
             <HelpTooltip>
-              Sync and collaborate with Git{' '}
-              <Link href={docsGitSync}>
-                <span className="no-wrap">
-                  <br />
-                  Documentation <i className="fa fa-external-link" />
-                </span>
-              </Link>
+              Sync and collaborate with Git
+              <br />
+              <Link href={docsGitSync}>Documentation {linkIcon}</Link>
             </HelpTooltip>
           </ModalHeader>
           <ModalBody key={gitRepository ? gitRepository._id : 'new'} className="pad">


### PR DESCRIPTION
Follow up to #2517

<img width="337" alt="image" src="https://user-images.githubusercontent.com/4312346/90324162-5a99d500-dfbf-11ea-9689-d71ddcbcb34a.png">


<img width="445" alt="image" src="https://user-images.githubusercontent.com/4312346/90324145-2e7e5400-dfbf-11ea-8e3f-60e75736cb03.png">
