### PR TITLE
Bump up `httpsnippet` to 1.22.0 for Kotlin and Axios code generation support

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -713,6 +713,8 @@ class CodeEditor extends React.Component {
       return 'application/edn';
     } else if (CodeEditor._isXML(mimeType)) {
       return 'application/xml';
+    } else if (mimeType.includes('kotlin')) {
+      return 'text/x-kotlin';
     } else {
       return mimeType;
     }

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -10579,9 +10579,9 @@
 			}
 		},
 		"httpsnippet": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-1.21.0.tgz",
-			"integrity": "sha512-Gki7XjvHvo7bqA7b5bzXVAVG4FSTAQNTmprqMe2urLqtjKzxHiEuz5bQt9zAsg56pEGd6vGOR49cWjtXufBKKQ==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-1.22.0.tgz",
+			"integrity": "sha512-umtG+usjz5JCtevTX2EgmSfwNnJOhMKF9HzF4rHecUY+CLoLZzZwOwyxUsvcAtB4l+VWjTbWMCIVZkprUBkPMw==",
 			"requires": {
 				"chalk": "^1.1.1",
 				"commander": "^2.9.0",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -113,7 +113,7 @@
     "highlight.js": "^9.12.0",
     "hkdf": "^0.0.2",
     "html-entities": "^1.2.0",
-    "httpsnippet": "^1.19.1",
+    "httpsnippet": "^1.22.0",
     "iconv-lite": "^0.4.15",
     "insomnia-components": "^2.2.21",
     "insomnia-cookies": "^2.2.10",

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -847,9 +847,9 @@
 			}
 		},
 		"duplexer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
@@ -1527,9 +1527,9 @@
 			}
 		},
 		"httpsnippet": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-1.21.0.tgz",
-			"integrity": "sha512-Gki7XjvHvo7bqA7b5bzXVAVG4FSTAQNTmprqMe2urLqtjKzxHiEuz5bQt9zAsg56pEGd6vGOR49cWjtXufBKKQ==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-1.22.0.tgz",
+			"integrity": "sha512-umtG+usjz5JCtevTX2EgmSfwNnJOhMKF9HzF4rHecUY+CLoLZzZwOwyxUsvcAtB4l+VWjTbWMCIVZkprUBkPMw==",
 			"requires": {
 				"chalk": "^1.1.1",
 				"commander": "^2.9.0",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -14,7 +14,7 @@
     "hawk": "^7.0.10",
     "hkdf": "0.0.2",
     "html-entities": "^1.3.1",
-    "httpsnippet": "^1.20.0",
+    "httpsnippet": "^1.22.0",
     "insomnia-importers": "^2.2.20",
     "insomnia-testing": "^2.2.15",
     "isomorphic-git": "^1.5.0",


### PR DESCRIPTION
Closes #2516 

`httpsnippet@1.22.0` comes with Kotlin and Axios code generation.