### PR TITLE
Build and package to a folder prefixed by the application id

### DIFF
--- a/packages/insomnia-app/config/electronbuilder.core.json
+++ b/packages/insomnia-app/config/electronbuilder.core.json
@@ -9,7 +9,7 @@
       "filter": "yarn-standalone.js"
     },
     {
-      "from": "./build",
+      "from": "./build/__APP_ID__",
       "to": ".",
       "filter": "opensource-licenses.txt"
     }
@@ -25,14 +25,14 @@
   ],
   "fileAssociations": [],
   "directories": {
-    "app": "build",
-    "output": "dist"
+    "app": "build/__APP_ID__",
+    "output": "dist/__APP_ID__"
   },
   "mac": {
     "hardenedRuntime": true,
     "category": "public.app-category.developer-tools",
-    "entitlements": "./build/static/entitlements.mac.inherit.plist",
-    "requirements": "./build/static/signing-requirements.txt",
+    "entitlements": "./build/__APP_ID__/static/entitlements.mac.inherit.plist",
+    "requirements": "./build/__APP_ID__/static/signing-requirements.txt",
     "artifactName": "__BINARY_PREFIX__-${version}.${ext}",
     "target": [
       "dmg",
@@ -61,7 +61,7 @@
     ]
   },
   "win": {
-    "icon": "./build/icon.ico",
+    "icon": "./build/__APP_ID__/icon.ico",
     "target": [
       "squirrel",
       "zip"

--- a/packages/insomnia-app/config/electronbuilder.designer.json
+++ b/packages/insomnia-app/config/electronbuilder.designer.json
@@ -9,7 +9,7 @@
       "filter": "yarn-standalone.js"
     },
     {
-      "from": "./build",
+      "from": "./build/__APP_ID__",
       "to": ".",
       "filter": "opensource-licenses.txt"
     }
@@ -25,13 +25,13 @@
   ],
   "fileAssociations": [],
   "directories": {
-    "app": "build",
-    "output": "dist"
+    "app": "build/__APP_ID__",
+    "output": "dist/__APP_ID__"
   },
   "mac": {
     "hardenedRuntime": true,
     "category": "public.app-category.developer-tools",
-    "entitlements": "./build/static/entitlements.mac.inherit.plist",
+    "entitlements": "./build/__APP_ID__/static/entitlements.mac.inherit.plist",
     "artifactName": "__BINARY_PREFIX__-${version}.${ext}",
     "target": [
       "dmg",
@@ -61,7 +61,7 @@
   },
   "win": {
     "artifactName": "__BINARY_PREFIX__-${version}.${ext}",
-    "icon": "./build/icon.ico",
+    "icon": "./build/__APP_ID__/icon.ico",
     "target": [
       "squirrel",
       "zip"

--- a/packages/insomnia-app/scripts/build.js
+++ b/packages/insomnia-app/scripts/build.js
@@ -273,8 +273,8 @@ function getBuildContext() {
   const gitRef = GIT_TAG || GITHUB_REF || TRAVIS_TAG || TRAVIS_CURRENT_BRANCH || '';
   const tagMatch = gitRef.match(/(designer|core)@(\d{4}\.\d+\.\d+(-(alpha|beta)\.\d+)?)$/);
 
-  const app = tagMatch ? tagMatch[1] : 'core';
-  const version = tagMatch ? tagMatch[2] : '2020.4.0-beta.4';
+  const app = tagMatch ? tagMatch[1] : null;
+  const version = tagMatch ? tagMatch[2] : null;
   const channel = tagMatch ? tagMatch[4] : 'stable';
 
   return {

--- a/packages/insomnia-app/scripts/build.js
+++ b/packages/insomnia-app/scripts/build.js
@@ -45,6 +45,7 @@ module.exports.start = async function(forcedVersion = null) {
   // These must be required after APP_ID environment variable is set above
   const configRenderer = require('../webpack/webpack.config.production.babel');
   const configMain = require('../webpack/webpack.config.electron.babel');
+  const buildFolder = path.join('../build', appConfig().appId);
 
   console.log(`[build] Starting build for ref "${buildContext.gitRef}"`);
   console.log(`[build] npm: ${childProcess.spawnSync('npm', ['--version']).stdout}`.trim());
@@ -57,11 +58,11 @@ module.exports.start = async function(forcedVersion = null) {
 
   // Remove folders first
   console.log('[build] Removing existing directories');
-  await emptyDir('../build');
+  await emptyDir(buildFolder);
 
   // Build the things
   console.log('[build] Building license list');
-  await buildLicenseList('../', '../build/opensource-licenses.txt');
+  await buildLicenseList('../', path.join(buildFolder, 'opensource-licenses.txt'));
   console.log('[build] Building Webpack renderer');
   await buildWebpack(configRenderer);
   console.log('[build] Building Webpack main');
@@ -69,16 +70,20 @@ module.exports.start = async function(forcedVersion = null) {
 
   // Copy necessary files
   console.log('[build] Copying files');
-  await copyFiles('../bin', '../build/');
-  await copyFiles('../app/static', '../build/static');
-  await copyFiles(`../app/icons/${appConfig().appId}`, '../build/');
+  await copyFiles('../bin', buildFolder);
+  await copyFiles('../app/static', path.join(buildFolder, 'static'));
+  await copyFiles(`../app/icons/${appConfig().appId}`, buildFolder);
 
   // Generate necessary files needed by `electron-builder`
-  await generatePackageJson('../package.json', '../build/package.json', forcedVersion);
+  await generatePackageJson(
+    '../package.json',
+    path.join(buildFolder, 'package.json'),
+    forcedVersion,
+  );
 
   // Install Node modules
   console.log('[build] Installing dependencies');
-  await install('../build/');
+  await install(buildFolder);
 
   console.log('[build] Complete!');
   return buildContext;
@@ -268,8 +273,8 @@ function getBuildContext() {
   const gitRef = GIT_TAG || GITHUB_REF || TRAVIS_TAG || TRAVIS_CURRENT_BRANCH || '';
   const tagMatch = gitRef.match(/(designer|core)@(\d{4}\.\d+\.\d+(-(alpha|beta)\.\d+)?)$/);
 
-  const app = tagMatch ? tagMatch[1] : null;
-  const version = tagMatch ? tagMatch[2] : null;
+  const app = tagMatch ? tagMatch[1] : 'core';
+  const version = tagMatch ? tagMatch[2] : '2020.4.0-beta.4';
   const channel = tagMatch ? tagMatch[4] : 'stable';
 
   return {

--- a/packages/insomnia-app/scripts/package.js
+++ b/packages/insomnia-app/scripts/package.js
@@ -27,7 +27,8 @@ module.exports.start = async function() {
   console.log('[package] Removing existing directories');
 
   if (process.env.KEEP_DIST_FOLDER !== 'yes') {
-    await emptyDir('../dist/*');
+    const appId = appConfig().appId;
+    await emptyDir(path.join('..', 'dist', appId, '*'));
   }
 
   console.log('[package] Packaging app');

--- a/packages/insomnia-app/scripts/release.js
+++ b/packages/insomnia-app/scripts/release.js
@@ -27,16 +27,18 @@ if (require.main === module) {
 
 async function start(app, version) {
   console.log(`[release] Creating release for ${app} ${version}`);
+  const appId = appConfig().appId;
+  const distGlob = ext => path.join('dist', appId, '**', `*${ext}`);
 
   const assetGlobs = {
-    darwin: ['dist/**/*.zip', 'dist/**/*.dmg'],
-    win32: ['dist/squirrel-windows/*'],
+    darwin: [distGlob('.zip'), distGlob('.dmg')],
+    win32: [path.join('dist', appId, 'squirrel-windows', '*')],
     linux: [
-      'dist/**/*.snap',
-      'dist/**/*.rpm',
-      'dist/**/*.deb',
-      'dist/**/*.AppImage',
-      'dist/**/*.tar.gz',
+      distGlob('.snap'),
+      distGlob('.rpm'),
+      distGlob('.deb'),
+      distGlob('.AppImage'),
+      distGlob('.tar.gz'),
     ],
   };
 

--- a/packages/insomnia-app/webpack/webpack.config.base.babel.js
+++ b/packages/insomnia-app/webpack/webpack.config.base.babel.js
@@ -12,7 +12,7 @@ module.exports = {
   context: path.join(__dirname, '../app'),
   entry: ['./renderer.js', './renderer.html'],
   output: {
-    path: path.join(__dirname, '../build'),
+    path: path.join(__dirname, '../build', process.env.APP_ID),
     filename: 'bundle.js',
     libraryTarget: 'commonjs2',
   },

--- a/packages/insomnia-app/webpack/webpack.config.electron.babel.js
+++ b/packages/insomnia-app/webpack/webpack.config.electron.babel.js
@@ -24,7 +24,7 @@ if (process.env.NODE_ENV === 'development') {
     }),
   ];
 } else {
-  output.path = path.join(__dirname, '../build');
+  output.path = path.join(__dirname, '../build', process.env.APP_ID);
   devtool = productionConfig.devtool;
   plugins = productionConfig.plugins;
 }

--- a/packages/insomnia-smoke-test/spec.js
+++ b/packages/insomnia-smoke-test/spec.js
@@ -13,11 +13,11 @@ describe('Application launch', function() {
       // path: '/Applications/Insomnia.app/Contents/MacOS/Insomnia',
 
       // Run after app-package
-      // path: path.join(__dirname, '../insomnia-app/dist/mac/Insomnia.app/Contents/MacOS/Insomnia'),
+      // path: path.join(__dirname, '../insomnia-app/dist/com.insomnia.app/mac/Insomnia.app/Contents/MacOS/Insomnia'),
 
       // Run after app-build
       path: electronPath,
-      args: [path.join(__dirname, '../insomnia-app/build')],
+      args: [path.join(__dirname, '../insomnia-app/build/com.insomnia.app')],
 
       // Don't ask why, but don't remove chromeDriverArgs
       // https://github.com/electron-userland/spectron/issues/353#issuecomment-522846725


### PR DESCRIPTION
This will allow us to concurrently build and smoke test both applications, as their artifacts will end up in different directories instead of overwriting each other.

![image](https://user-images.githubusercontent.com/4312346/90838530-310af000-e3a9-11ea-945d-283b1ae0f57e.png)

- I was able to `npm run app-start` - development worked fine
- I was able to `npm run app-build` - see the artifacts in the expected directory and run smoke tests on them
- I was able to `npm run app-package` - see the artifacts in the expected directory and run smoke tests on them

Related to #2535 