### PR TITLE
Mark kong plugins as private

### DIFF
--- a/plugins/insomnia-plugin-kong-bundle/package.json
+++ b/plugins/insomnia-plugin-kong-bundle/package.json
@@ -1,5 +1,6 @@
 {
   "name": "insomnia-plugin-kong-bundle",
+  "private": true,
   "version": "2.2.21",
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-kong-declarative-config/package.json
+++ b/plugins/insomnia-plugin-kong-declarative-config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "insomnia-plugin-kong-declarative-config",
+  "private": true,
   "version": "2.2.12",
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-kong-kubernetes-config/package.json
+++ b/plugins/insomnia-plugin-kong-kubernetes-config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "insomnia-plugin-kong-kubernetes-config",
+  "private": true,
   "version": "2.2.12",
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-kong-portal/package.json
+++ b/plugins/insomnia-plugin-kong-portal/package.json
@@ -1,5 +1,6 @@
 {
   "name": "insomnia-plugin-kong-portal",
+  "private": true,
   "version": "2.2.21",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
We don't want to publish these until the next version of the app has been released to production.