### PR TITLE
fix: Added manual prettify for multipart editor

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/code-prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/code-prompt-modal.js
@@ -158,6 +158,7 @@ class CodePromptModal extends PureComponent {
               <div className="form-control form-control--outlined form-control--tall tall">
                 <CodeEditor
                   hideLineNumbers
+                  manualPrettify
                   className="tall"
                   defaultValue={defaultValue}
                   placeholder={placeholder}


### PR DESCRIPTION
Closes #2380 

<img width="500" height="600" alt="image" src="https://user-images.githubusercontent.com/16076136/91658690-17278680-eae8-11ea-937f-186e8579cc23.png">

Added Beautify option for JSON, XML and MDN file types.

