### PR TITLE
Improve handling of absolute paths in inso

### DIFF
--- a/packages/insomnia-inso/src/__tests__/write-file.test.js
+++ b/packages/insomnia-inso/src/__tests__/write-file.test.js
@@ -4,6 +4,7 @@ import { writeFileWithCliOptions } from '../write-file';
 import mkdirp from 'mkdirp';
 import fs from 'fs';
 import { InsoError } from '../errors';
+import os from 'os';
 
 jest.mock('mkdirp', () => ({
   sync: jest.fn().mockResolvedValue(),
@@ -33,21 +34,23 @@ describe('writeFileWithCliOptions', () => {
   });
 
   it('should write to absolute output file', async () => {
-    const output = '/Users/me/dev/file.yaml';
+    const absolutePath = path.join(os.tmpdir(), 'dev', 'file.yaml');
+    const output = absolutePath;
     const contents = 'contents';
     const workingDir = undefined;
 
     const promise = writeFileWithCliOptions(output, contents, workingDir);
-    await expect(promise).resolves.toBe('/Users/me/dev/file.yaml');
+    await expect(promise).resolves.toBe(absolutePath);
   });
 
   it('should write to absolute output file and ignore working dir', async () => {
-    const output = '/Users/me/dev/file.yaml';
+    const absolutePath = path.join(os.tmpdir(), 'dev', 'file.yaml');
+    const output = absolutePath;
     const contents = 'contents';
     const workingDir = 'working/dir';
 
     const promise = writeFileWithCliOptions(output, contents, workingDir);
-    await expect(promise).resolves.toBe('/Users/me/dev/file.yaml');
+    await expect(promise).resolves.toBe(absolutePath);
   });
 
   it('should write to output file under working dir', async () => {

--- a/packages/insomnia-inso/src/__tests__/write-file.test.js
+++ b/packages/insomnia-inso/src/__tests__/write-file.test.js
@@ -32,6 +32,24 @@ describe('writeFileWithCliOptions', () => {
     await expect(promise).resolves.toBe('file.yaml');
   });
 
+  it('should write to absolute output file', async () => {
+    const output = '/Users/me/dev/file.yaml';
+    const contents = 'contents';
+    const workingDir = undefined;
+
+    const promise = writeFileWithCliOptions(output, contents, workingDir);
+    await expect(promise).resolves.toBe('/Users/me/dev/file.yaml');
+  });
+
+  it('should write to absolute output file and ignore working dir', async () => {
+    const output = '/Users/me/dev/file.yaml';
+    const contents = 'contents';
+    const workingDir = 'working/dir';
+
+    const promise = writeFileWithCliOptions(output, contents, workingDir);
+    await expect(promise).resolves.toBe('/Users/me/dev/file.yaml');
+  });
+
   it('should write to output file under working dir', async () => {
     const output = 'file.yaml';
     const contents = 'contents';

--- a/packages/insomnia-inso/src/commands/__tests__/generate-config.test.js
+++ b/packages/insomnia-inso/src/commands/__tests__/generate-config.test.js
@@ -6,6 +6,7 @@ import { writeFileWithCliOptions } from '../../write-file';
 import { globalBeforeAll, globalBeforeEach } from '../../../__jest__/before';
 import logger from '../../logger';
 import { InsoError } from '../../errors';
+import os from 'os';
 
 jest.mock('openapi-2-kong');
 jest.mock('../../write-file');
@@ -125,7 +126,9 @@ describe('generateConfig()', () => {
     const outputPath = 'this-is-the-output-path';
     mock(writeFileWithCliOptions).mockResolvedValue(outputPath);
 
-    const result = await generateConfig('/Users/me/dev/file.yaml', {
+    const absolutePath = path.join(os.tmpdir(), 'dev', 'file.yaml');
+
+    const result = await generateConfig(absolutePath, {
       type: 'kubernetes',
       workingDir: 'test/dir',
       output: 'output.yaml',
@@ -134,10 +137,7 @@ describe('generateConfig()', () => {
     expect(result).toBe(true);
 
     // Read from workingDir
-    expect(o2k.generate).toHaveBeenCalledWith(
-      path.normalize('/Users/me/dev/file.yaml'),
-      ConversionTypeMap.kubernetes,
-    );
+    expect(o2k.generate).toHaveBeenCalledWith(absolutePath, ConversionTypeMap.kubernetes);
 
     expect(logger.__getLogs().log).toEqual([`Configuration generated to "${outputPath}".`]);
   });

--- a/packages/insomnia-inso/src/commands/__tests__/generate-config.test.js
+++ b/packages/insomnia-inso/src/commands/__tests__/generate-config.test.js
@@ -120,6 +120,28 @@ describe('generateConfig()', () => {
     expect(logger.__getLogs().log).toEqual([`Configuration generated to "${outputPath}".`]);
   });
 
+  it('should generate documents using absolute path', async () => {
+    mock(o2k.generate).mockResolvedValue({ documents: ['a', 'b'] });
+    const outputPath = 'this-is-the-output-path';
+    mock(writeFileWithCliOptions).mockResolvedValue(outputPath);
+
+    const result = await generateConfig('/Users/me/dev/file.yaml', {
+      type: 'kubernetes',
+      workingDir: 'test/dir',
+      output: 'output.yaml',
+    });
+
+    expect(result).toBe(true);
+
+    // Read from workingDir
+    expect(o2k.generate).toHaveBeenCalledWith(
+      path.normalize('/Users/me/dev/file.yaml'),
+      ConversionTypeMap.kubernetes,
+    );
+
+    expect(logger.__getLogs().log).toEqual([`Configuration generated to "${outputPath}".`]);
+  });
+
   it('should throw InsoError if there is an error thrown by openapi-2-kong', async () => {
     const error = new Error('err');
     mock(o2k.generate).mockRejectedValue(error);

--- a/packages/insomnia-inso/src/commands/generate-config.js
+++ b/packages/insomnia-inso/src/commands/generate-config.js
@@ -52,7 +52,9 @@ export async function generateConfig(
       result = await o2k.generateFromString(specFromDb.contents, ConversionTypeMap[type]);
     } else if (identifier) {
       // try load as a file
-      const fileName = path.join(workingDir || '.', identifier);
+      const fileName = path.isAbsolute(identifier)
+        ? identifier
+        : path.join(workingDir || '.', identifier);
       logger.trace(`Generating config from file \`${fileName}\``);
       result = await o2k.generate(fileName, ConversionTypeMap[type]);
     }

--- a/packages/insomnia-inso/src/write-file.js
+++ b/packages/insomnia-inso/src/write-file.js
@@ -9,7 +9,7 @@ export async function writeFileWithCliOptions(
   contents: string,
   workingDir?: string,
 ): Promise<string> {
-  const outputPath = path.join(workingDir || '.', output);
+  const outputPath = path.isAbsolute(output) ? output : path.join(workingDir || '.', output);
   try {
     await mkdirp.sync(path.dirname(outputPath));
     await fs.promises.writeFile(outputPath, contents);


### PR DESCRIPTION
What is says on the tin, see new unit tests for the use cases.

In short, specifying an absolute path (both for input and output) was not handled as expected. The following should _not_ happen.

![image](https://user-images.githubusercontent.com/4312346/91692457-891dcf80-ebbd-11ea-8893-cff363b91d9c.png)
