### PR TITLE
Unit testing sticky headers

### DIFF
--- a/packages/insomnia-app/app/ui/css/components/unit-tests.less
+++ b/packages/insomnia-app/app/ui/css/components/unit-tests.less
@@ -19,8 +19,7 @@
     color: var(--color-font);
     overflow-y: auto;
     box-sizing: border-box;
-    --scrollbar-width: calc(var(--font-size) * 0.4);
-    scrollbar-color: light;
+
     &__block {
       height: auto;
       width: 100%;
@@ -86,6 +85,7 @@
     background: var(--color-bg);
     color: var(--color-font);
     overflow-y: auto;
+    box-sizing: border-box;
 
     ul {
       padding-top: var(--padding-sm);
@@ -144,7 +144,8 @@
     border-bottom: 1px solid var(--hl-md);
     display: flex;
     position: sticky;
-    z-index: 999;
+    // Double that of CodeMirror's topmost element.
+    z-index: 20;
     top: 0;
     align-items: center;
     background: var(--color-bg);

--- a/packages/insomnia-app/app/ui/css/components/unit-tests.less
+++ b/packages/insomnia-app/app/ui/css/components/unit-tests.less
@@ -19,7 +19,8 @@
     color: var(--color-font);
     overflow-y: auto;
     box-sizing: border-box;
-
+    --scrollbar-width: calc(var(--font-size) * 0.4);
+    scrollbar-color: light;
     &__block {
       height: auto;
       width: 100%;
@@ -142,7 +143,11 @@
     padding-right: 0;
     border-bottom: 1px solid var(--hl-md);
     display: flex;
+    position: sticky;
+    z-index: 999;
+    top: 0;
     align-items: center;
+    background: var(--color-bg);
 
     button {
       flex: 0 0 auto;

--- a/packages/insomnia-components/components/list-group/list-group.stories.js
+++ b/packages/insomnia-components/components/list-group/list-group.stories.js
@@ -1,20 +1,20 @@
 // @flow
 import React from 'react';
+import styled from 'styled-components';
+import { motion } from 'framer-motion';
 import ListGroupItem from './list-group-item';
 import ListGroup from './list-group';
 import UnitTestResultItem from './unit-test-result-item';
 
 export default { title: 'Lists | List Group' };
 
-export const _default = () => (
-  <div style={{ width: '350px' }}>
-    <ListGroup>
-      <ListGroupItem>List</ListGroupItem>
-      <ListGroupItem>of</ListGroupItem>
-      <ListGroupItem>things...</ListGroupItem>
-    </ListGroup>
-  </div>
-);
+const StyledContent: React.ComponentType<{}> = styled(motion.div)`
+  display: block;
+  height: 1px;
+  padding: var(--padding-sm);
+  border: 1px solid #ccc;
+  margin: var(--padding-md) 0px;
+`;
 
 const tests = [
   {
@@ -46,6 +46,45 @@ const tests = [
     },
   },
 ];
+
+export const _default = () => {
+  const [items, setItems] = React.useState([]);
+  const newItems = [];
+  const _handleItemClick = position => {
+    setItems([]);
+    tests.map((test, i) => {
+      let visible = false;
+      if (position === i) {
+        visible = true;
+      }
+      newItems.push({ position: i, visible: visible });
+    });
+    setItems(newItems);
+  };
+
+  return (
+    <div style={{ width: '350px' }}>
+      <ListGroup>
+        {tests.map((test, i) => (
+          <ListGroupItem
+            key={i}
+            onClick={() => {
+              _handleItemClick(i);
+            }}>
+            {test.title}
+            {items && items.length > 1 && items[i].position === i && items[i].visible === true && (
+              <StyledContent
+                initial={{ height: items[i].visible ? '0px' : '0px' }}
+                animate={{ height: items[i].visible ? '100px' : '0px' }}>
+                Item: {items[i].position}
+              </StyledContent>
+            )}
+          </ListGroupItem>
+        ))}
+      </ListGroup>
+    </div>
+  );
+};
 
 export const _unitTestResults = () => (
   <div style={{ width: '350px' }}>

--- a/packages/insomnia-components/components/list-group/list-group.stories.js
+++ b/packages/insomnia-components/components/list-group/list-group.stories.js
@@ -1,20 +1,20 @@
 // @flow
 import React from 'react';
-import styled from 'styled-components';
-import { motion } from 'framer-motion';
 import ListGroupItem from './list-group-item';
 import ListGroup from './list-group';
 import UnitTestResultItem from './unit-test-result-item';
 
 export default { title: 'Lists | List Group' };
 
-const StyledContent: React.ComponentType<{}> = styled(motion.div)`
-  display: block;
-  height: 1px;
-  padding: var(--padding-sm);
-  border: 1px solid #ccc;
-  margin: var(--padding-md) 0px;
-`;
+export const _default = () => (
+  <div style={{ width: '350px' }}>
+    <ListGroup>
+      <ListGroupItem>List</ListGroupItem>
+      <ListGroupItem>of</ListGroupItem>
+      <ListGroupItem>things...</ListGroupItem>
+    </ListGroup>
+  </div>
+);
 
 const tests = [
   {
@@ -46,45 +46,6 @@ const tests = [
     },
   },
 ];
-
-export const _default = () => {
-  const [items, setItems] = React.useState([]);
-  const newItems = [];
-  const _handleItemClick = position => {
-    setItems([]);
-    tests.map((test, i) => {
-      let visible = false;
-      if (position === i) {
-        visible = true;
-      }
-      newItems.push({ position: i, visible: visible });
-    });
-    setItems(newItems);
-  };
-
-  return (
-    <div style={{ width: '350px' }}>
-      <ListGroup>
-        {tests.map((test, i) => (
-          <ListGroupItem
-            key={i}
-            onClick={() => {
-              _handleItemClick(i);
-            }}>
-            {test.title}
-            {items && items.length > 1 && items[i].position === i && items[i].visible === true && (
-              <StyledContent
-                initial={{ height: items[i].visible ? '0px' : '0px' }}
-                animate={{ height: items[i].visible ? '100px' : '0px' }}>
-                Item: {items[i].position}
-              </StyledContent>
-            )}
-          </ListGroupItem>
-        ))}
-      </ListGroup>
-    </div>
-  );
-};
 
 export const _unitTestResults = () => (
   <div style={{ width: '350px' }}>


### PR DESCRIPTION
This change prevents the user from losing the test and test output headers when having to scroll.

Demo below:
![2020-09-04 09 11 01](https://user-images.githubusercontent.com/52717970/92242972-a4732e00-ee8e-11ea-9136-08be2b759fc0.gif)

Fixes INS-49
