### PR TITLE
Auto focus filter and improve click targets in design sidebar

### DIFF
--- a/packages/insomnia-components/components/sidebar/index.js
+++ b/packages/insomnia-components/components/sidebar/index.js
@@ -46,7 +46,6 @@ const StyledSidebar: React.ComponentType<{}> = styled.div`
   color: var(--color-font);
   position: relative;
   svg {
-    font-size: var(--font-size-xl);
     fill: var(--hl-lg);
   }
   ul:first-child {

--- a/packages/insomnia-components/components/sidebar/index.js
+++ b/packages/insomnia-components/components/sidebar/index.js
@@ -155,7 +155,7 @@ function Sidebar(props: Props) {
               </DropdownItem>
             </Dropdown>
           </SidebarHeader>
-          <SidebarInfo childrenVisible={infoSec} info={info} />
+          <SidebarInfo childrenVisible={infoSec} info={info} onClick={props.onClick} />
         </StyledSection>
       )}
       {serversVisible && servers && <SidebarServers servers={servers} onClick={props.onClick} />}

--- a/packages/insomnia-components/components/sidebar/sidebar-filter.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-filter.js
@@ -42,6 +42,8 @@ const SidebarFilter = ({ filter, onChange }: Props) => {
   useLayoutEffect(() => {
     if (filterField.current && !filter) {
       filterField.current.value = '';
+    } else if (filterField.current) {
+      filterField.current.focus();
     }
   }, [filter, filterField]);
 

--- a/packages/insomnia-components/components/sidebar/sidebar-header.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-header.js
@@ -46,6 +46,7 @@ const StyledHeader: React.ComponentType<{}> = styled.li`
 
     svg {
       margin-left: var(--padding-sm);
+      font-size: var(--font-size-xl);
 
       &:hover {
         fill: var(--color-font);

--- a/packages/insomnia-components/components/sidebar/sidebar-header.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-header.js
@@ -22,7 +22,7 @@ const StyledHeader: React.ComponentType<{}> = styled.li`
   }
 
   h6 {
-    font-size: var(--font-size-xs);
+    font-size: var(--font-size-sm);
     display: flex;
     flex-grow: 1;
     &:hover {

--- a/packages/insomnia-components/components/sidebar/sidebar-headers.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-headers.js
@@ -33,11 +33,11 @@ export default class SidebarHeaders extends React.Component<Props> {
       <div>
         {filteredValues.map(header => (
           <React.Fragment key={header}>
-            <SidebarItem>
+            <SidebarItem onClick={() => onClick('components', 'headers', header)}>
               <div>
                 <SvgIcon icon={IconEnum.indentation} />
               </div>
-              <span onClick={() => onClick('components', 'headers', header)}>
+              <span>
                 <Tooltip message={headers[header].description} position="right">
                   {header}
                 </Tooltip>

--- a/packages/insomnia-components/components/sidebar/sidebar-info.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-info.js
@@ -7,7 +7,7 @@ import SidebarTextItem from './sidebar-text-item';
 type Props = {
   info: Object,
   childrenVisible: boolean,
-  onClick: (section: string, ...args: any) => void,
+  onClick: (section: string, ...args: Array<string>) => void,
 };
 
 function SidebarInfo(props: Props) {

--- a/packages/insomnia-components/components/sidebar/sidebar-info.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-info.js
@@ -7,29 +7,31 @@ import SidebarTextItem from './sidebar-text-item';
 type Props = {
   info: Object,
   childrenVisible: boolean,
+  onClick: (section: string, ...args: any) => void,
 };
 
 function SidebarInfo(props: Props) {
   const { title, description, version, license } = props.info;
+
   return (
     <SidebarPanel childrenVisible={props.childrenVisible}>
       {title && (
-        <SidebarItem>
+        <SidebarItem onClick={() => props.onClick('info', 'title')}>
           <SidebarTextItem label={'Title:'} headline={title} />
         </SidebarItem>
       )}
       {description && (
-        <SidebarItem>
+        <SidebarItem onClick={() => props.onClick('info', 'description')}>
           <SidebarTextItem label={'Description:'} headline={description} />
         </SidebarItem>
       )}
       {version && (
-        <SidebarItem>
+        <SidebarItem onClick={() => props.onClick('info', 'version')}>
           <SidebarTextItem label={'Version:'} headline={version} />
         </SidebarItem>
       )}
       {license && license.name && (
-        <SidebarItem>
+        <SidebarItem onClick={() => props.onClick('info', 'license')}>
           <SidebarTextItem label={'License:'} headline={license.name} />
         </SidebarItem>
       )}

--- a/packages/insomnia-components/components/sidebar/sidebar-item.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-item.js
@@ -9,9 +9,10 @@ type Props = {
 };
 
 const StyledBlockItem: React.ComponentType<{}> = styled.div`
-  padding: 0 var(--padding-md) var(--padding-sm) 0;
+  padding: var(--padding-xs) var(--padding-md) var(--padding-xs) 0;
   margin: 0;
   display: flex;
+  align-items: center;
   font-size: var(--font-size-md);
   line-height: var(--font-size-md);
   text-overflow: ellipsis;
@@ -26,7 +27,6 @@ const StyledBlockItem: React.ComponentType<{}> = styled.div`
   }
   span {
     margin: 0 0 0 var(--padding-xs);
-    padding-top: var(--padding-xxs);
   }
   div {
     display: inline;
@@ -43,11 +43,8 @@ const StyledBlockItem: React.ComponentType<{}> = styled.div`
 const StyledGridItem: React.ComponentType<{}> = styled.li`
   padding: 0 0 0 var(--padding-sm);
   margin: 0;
-  display: grid;
-  grid-template-columns: 0.25fr 5fr;
-  column-gap: var(--padding-xs);
-  grid-template-rows: 1fr;
-  align-items: start;
+  display: flex;
+  align-items: center;
   white-space: nowrap;
   font-size: var(--font-size-md);
   line-height: var(--font-size-sm);
@@ -55,7 +52,7 @@ const StyledGridItem: React.ComponentType<{}> = styled.li`
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    padding: 4px var(--padding-sm) var(--padding-xs) 0px;
+    padding: 4px var(--padding-sm) var(--padding-xs) var(--padding-xs);
   }
   a {
     color: var(--hl-xl);

--- a/packages/insomnia-components/components/sidebar/sidebar-item.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-item.js
@@ -18,6 +18,9 @@ const StyledBlockItem: React.ComponentType<{}> = styled.div`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  &:first-child {
+    margin-top: var(--padding-xxs);
+  }
   &:hover {
     background-color: var(--hl-xxs);
     cursor: default;
@@ -48,6 +51,9 @@ const StyledGridItem: React.ComponentType<{}> = styled.li`
   white-space: nowrap;
   font-size: var(--font-size-md);
   line-height: var(--font-size-sm);
+  &:first-child {
+    margin-top: var(--padding-xxs);
+  }
   span {
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/insomnia-components/components/sidebar/sidebar-item.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-item.js
@@ -11,7 +11,7 @@ type Props = {
 const StyledBlockItem: React.ComponentType<{}> = styled.div`
   padding: 0 var(--padding-md) var(--padding-sm) 0;
   margin: 0;
-  display: block;
+  display: flex;
   font-size: var(--font-size-md);
   line-height: var(--font-size-md);
   text-overflow: ellipsis;
@@ -26,6 +26,7 @@ const StyledBlockItem: React.ComponentType<{}> = styled.div`
   }
   span {
     margin: 0 0 0 var(--padding-xs);
+    padding-top: var(--padding-xxs);
   }
   div {
     display: inline;
@@ -44,7 +45,7 @@ const StyledGridItem: React.ComponentType<{}> = styled.li`
   margin: 0;
   display: grid;
   grid-template-columns: 0.25fr 5fr;
-  column-gap: var(--padding-sm);
+  column-gap: var(--padding-xs);
   grid-template-rows: 1fr;
   align-items: start;
   white-space: nowrap;

--- a/packages/insomnia-components/components/sidebar/sidebar-item.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-item.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 type Props = {
   children: React.Node,
   gridLayout?: boolean,
+  onClick?: () => void,
 };
 
 const StyledBlockItem: React.ComponentType<{}> = styled.div`
@@ -12,7 +13,7 @@ const StyledBlockItem: React.ComponentType<{}> = styled.div`
   margin: 0;
   display: block;
   font-size: var(--font-size-md);
-  line-height: var(--font-size-sm);
+  line-height: var(--font-size-md);
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -24,7 +25,7 @@ const StyledBlockItem: React.ComponentType<{}> = styled.div`
     margin-bottom: var(--padding-md);
   }
   span {
-    margin: 0 0 0 var(--padding-sm);
+    margin: 0 0 0 var(--padding-xs);
   }
   div {
     display: inline;
@@ -73,11 +74,11 @@ const StyledGridItem: React.ComponentType<{}> = styled.li`
   }
 `;
 
-const SidebarItem = ({ children, gridLayout }: Props) => {
+const SidebarItem = ({ children, gridLayout, onClick }: Props) => {
   if (gridLayout) {
-    return <StyledGridItem>{children}</StyledGridItem>;
+    return <StyledGridItem onClick={onClick}>{children}</StyledGridItem>;
   } else {
-    return <StyledBlockItem>{children}</StyledBlockItem>;
+    return <StyledBlockItem onClick={onClick}>{children}</StyledBlockItem>;
   }
 };
 

--- a/packages/insomnia-components/components/sidebar/sidebar-parameters.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-parameters.js
@@ -33,11 +33,11 @@ export default class SidebarParameters extends React.Component<Props> {
       <div>
         {filteredValues.map(parameter => (
           <React.Fragment key={parameter}>
-            <SidebarItem>
+            <SidebarItem onClick={() => onClick('components', 'parameters', parameter)}>
               <div>
                 <SvgIcon icon={IconEnum.indentation} />
               </div>
-              <span onClick={() => onClick('components', 'parameters', parameter)}>
+              <span>
                 <Tooltip message={parameters[parameter].description} position="right">
                   {parameter}
                 </Tooltip>

--- a/packages/insomnia-components/components/sidebar/sidebar-paths.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-paths.js
@@ -39,11 +39,11 @@ export default class SidebarPaths extends React.Component<Props> {
       <div>
         {filteredValues.map(([route, method]) => (
           <React.Fragment key={route}>
-            <SidebarItem gridLayout>
+            <SidebarItem gridLayout onClick={() => onClick('paths', route)}>
               <div>
                 <SvgIcon icon={IconEnum.indentation} />
               </div>
-              <span onClick={() => onClick('paths', route)}>{route}</span>
+              <span>{route}</span>
             </SidebarItem>
             <SidebarItem>
               <StyledMethods>

--- a/packages/insomnia-components/components/sidebar/sidebar-requests.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-requests.js
@@ -47,11 +47,13 @@ export default class SidebarRequests extends React.Component<Props> {
           const { description, content } = requests[requestName];
           return (
             <React.Fragment key={requestName}>
-              <SidebarItem gridLayout>
+              <SidebarItem
+                gridLayout
+                onClick={() => onClick('components', 'requestBodies', requestName)}>
                 <div>
                   <SvgIcon icon={IconEnum.folderOpen} />
                 </div>
-                <span onClick={() => onClick('components', 'requestBodies', requestName)}>
+                <span>
                   <Tooltip message={description} position="right">
                     {requestName}
                   </Tooltip>

--- a/packages/insomnia-components/components/sidebar/sidebar-responses.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-responses.js
@@ -32,11 +32,11 @@ export default class SidebarResponses extends React.Component<Props> {
     return (
       <div>
         {filteredValues.map(response => (
-          <SidebarItem key={response}>
+          <SidebarItem key={response} onClick={() => onClick('components', 'responses', response)}>
             <div>
               <SvgIcon icon={IconEnum.indentation} />
             </div>
-            <span onClick={() => onClick('components', 'responses', response)}>
+            <span>
               <Tooltip message={responses[response].description} position="right">
                 {response}
               </Tooltip>

--- a/packages/insomnia-components/components/sidebar/sidebar-schemas.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-schemas.js
@@ -31,11 +31,11 @@ export default class SidebarSchemas extends React.Component<Props> {
     return (
       <div>
         {filteredValues.map(schema => (
-          <SidebarItem key={schema}>
+          <SidebarItem key={schema} onClick={() => onClick('components', 'schemas', schema)}>
             <div>
               <SvgIcon icon={IconEnum.brackets} />
             </div>
-            <span onClick={() => onClick('components', 'schemas', schema)}>{schema}</span>
+            <span>{schema}</span>
           </SidebarItem>
         ))}
       </div>

--- a/packages/insomnia-components/components/sidebar/sidebar-security.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-security.js
@@ -32,11 +32,11 @@ export default class SidebarSecurity extends React.Component<Props> {
       <div>
         {filteredValues.map(scheme => (
           <React.Fragment key={scheme}>
-            <SidebarItem>
+            <SidebarItem onClick={() => onClick('components', 'securitySchemes', scheme)}>
               <div>
                 <SvgIcon icon={IconEnum.key} />
               </div>
-              <span onClick={() => onClick('components', 'securitySchemes', scheme)}>{scheme}</span>
+              <span>{scheme}</span>
             </SidebarItem>
           </React.Fragment>
         ))}

--- a/packages/insomnia-components/components/sidebar/sidebar-servers.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-servers.js
@@ -30,11 +30,11 @@ export default class SidebarServers extends React.Component<Props> {
       <div>
         {filteredValues.map((server, index) => (
           <React.Fragment key={server.url}>
-            <SidebarItem>
+            <SidebarItem onClick={() => onClick('servers', index)}>
               <div>
                 <SvgIcon icon={IconEnum.indentation} />
               </div>
-              <span onClick={() => onClick('servers', index)}>{server.url}</span>
+              <span>{server.url}</span>
             </SidebarItem>
           </React.Fragment>
         ))}

--- a/packages/insomnia-components/components/sidebar/sidebar-text-item.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-text-item.js
@@ -15,17 +15,10 @@ const StyledTextItem: React.ComponentType<{}> = styled.span`
   white-space: nowrap;
 `;
 
-let itemPath = [];
-const handleClick = items => {
-  itemPath.push('info');
-  itemPath.push.apply(itemPath, items);
-  itemPath = [];
-};
-
 const SidebarTextItem = ({ label, headline }: Props) => (
   <StyledTextItem>
     <strong>{label}</strong>
-    <span onClick={() => handleClick([headline])}>{headline}</span>
+    <span>{headline}</span>
   </StyledTextItem>
 );
 


### PR DESCRIPTION
This PR covers the default cursor focusing on the filter's input field upon click. See demo animation below:

![2020-09-15 12 55 01](https://user-images.githubusercontent.com/52717970/93240989-d0c26080-f752-11ea-893b-46d7d8cd27ac.gif)

FIXES INS-66