### PR TITLE
Ignore x- keys for methods in the design sidebar paths section

### DIFF
--- a/packages/insomnia-components/components/sidebar/sidebar-paths.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-paths.js
@@ -15,6 +15,8 @@ const StyledMethods: React.ComponentType<{}> = styled.span`
   padding-left: var(--padding-lg);
 `;
 
+const isNotXDashKey = key => key.indexOf('x-') !== 0;
+
 // Implemented as a class component because of a caveat with render props
 // https://reactjs.org/docs/render-props.html#be-careful-when-using-render-props-with-reactpurecomponent
 export default class SidebarPaths extends React.Component<Props> {
@@ -37,7 +39,7 @@ export default class SidebarPaths extends React.Component<Props> {
 
     return (
       <div>
-        {filteredValues.map(([route, method]) => (
+        {filteredValues.map(([route, routeBody]) => (
           <React.Fragment key={route}>
             <SidebarItem gridLayout>
               <div>
@@ -47,8 +49,8 @@ export default class SidebarPaths extends React.Component<Props> {
             </SidebarItem>
             <SidebarItem>
               <StyledMethods>
-                {Object.keys((method: any))
-                  .filter(method => method.indexOf('x-') !== 0)
+                {Object.keys((routeBody: any))
+                  .filter(isNotXDashKey)
                   .map(method => (
                     <span
                       key={method}

--- a/packages/insomnia-components/components/sidebar/sidebar-paths.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-paths.js
@@ -47,14 +47,16 @@ export default class SidebarPaths extends React.Component<Props> {
             </SidebarItem>
             <SidebarItem>
               <StyledMethods>
-                {Object.keys((method: any)).map(method => (
-                  <span
-                    key={method}
-                    className={`method-${method}`}
-                    onClick={() => onClick('paths', route, method)}>
-                    {method}
-                  </span>
-                ))}
+                {Object.keys((method: any))
+                  .filter(method => method.indexOf('x-') !== 0)
+                  .map(method => (
+                    <span
+                      key={method}
+                      className={`method-${method}`}
+                      onClick={() => onClick('paths', route, method)}>
+                      {method}
+                    </span>
+                  ))}
               </StyledMethods>
             </SidebarItem>
           </React.Fragment>


### PR DESCRIPTION
What it says on the tin

The same logic is used to ignore `x-*` keys while importing an OpenAPI3 specification.

https://github.com/Kong/insomnia/blob/51d3a5de32043dcf429f66afab955e66b6ac7e76/packages/insomnia-importers/src/importers/openapi3.js#L191-L193

x- keys can be used, for example, to provide a unique name to a path for Kong

```yaml
...
paths:
  "/api/orders":
    x-kong-name: All Orders
    get:
      operationId: getAllOrders
```

Previously, `x-kong-name` would appear in white next to `get` in the sidebar

<img width="603" alt="image" src="https://user-images.githubusercontent.com/4312346/93320602-61896100-f865-11ea-88b0-7c459c82f41c.png">
