### PR TITLE
Add shortcuts to foldAll and unfoldAll JSON nodes

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -66,6 +66,9 @@ const BASE_CODEMIRROR_OPTIONS = {
     // search box stays open after pressing Enter
     [isMac() ? 'Cmd-F' : 'Ctrl-F']: 'findPersistent',
 
+    [isMac() ? 'Shift-Cmd--' : 'Shift-Ctrl--']: 'foldAll',
+    [isMac() ? 'Shift-Cmd-=' : 'Shift-Ctrl-=']: 'unfoldAll',
+
     'Shift-Tab': 'indentLess',
     Tab: 'indentMore',
   }),


### PR DESCRIPTION
Use `Shift Cmd -` or `Shift Ctrl -` to fold all nodes
Use `Shift Cmd =` or `Shift Ctrl =` to unfold all nodes

I've chosen my usual shortcuts I'm using with JetBrains tools. 

I didn't found if there were tests covering shortcuts declaration 🤔 

Closes #2252
