### PR TITLE
Update insomnia-plugin-response for backwards compatibility

### DIFF
--- a/plugins/insomnia-plugin-response/index.js
+++ b/plugins/insomnia-plugin-response/index.js
@@ -62,6 +62,7 @@ module.exports.templateTags = [
         displayName: 'Trigger Behavior',
         help: 'Configure when to resend the dependent request',
         type: 'enum',
+        defaultValue: 'never',
         options: [
           {
             displayName: 'Never',
@@ -96,7 +97,7 @@ module.exports.templateTags = [
 
     async run(context, field, id, filter, resendBehavior, maxAgeSeconds) {
       filter = filter || '';
-      resendBehavior = (resendBehavior || 'never').toLowerCase();
+      resendBehavior = resendBehavior.toLowerCase();
 
       if (!['body', 'header', 'raw', 'url'].includes(field)) {
         throw new Error(`Invalid response field ${field}`);

--- a/plugins/insomnia-plugin-response/index.js
+++ b/plugins/insomnia-plugin-response/index.js
@@ -6,6 +6,8 @@ function isFilterableField(field) {
   return field !== 'raw' && field !== 'url';
 }
 
+const defaultTriggerBehaviour = 'never';
+
 module.exports.templateTags = [
   {
     name: 'response',
@@ -62,7 +64,7 @@ module.exports.templateTags = [
         displayName: 'Trigger Behavior',
         help: 'Configure when to resend the dependent request',
         type: 'enum',
-        defaultValue: 'never',
+        defaultValue: defaultTriggerBehaviour,
         options: [
           {
             displayName: 'Never',
@@ -97,7 +99,7 @@ module.exports.templateTags = [
 
     async run(context, field, id, filter, resendBehavior, maxAgeSeconds) {
       filter = filter || '';
-      resendBehavior = resendBehavior.toLowerCase();
+      resendBehavior = (resendBehavior || defaultTriggerBehaviour).toLowerCase();
 
       if (!['body', 'header', 'raw', 'url'].includes(field)) {
         throw new Error(`Invalid response field ${field}`);


### PR DESCRIPTION
A new "Max Age" argument was introduced as part of https://github.com/Kong/insomnia/pull/2284, and prior to that, the "Trigger Behavior" argument.

The visibility of "Max Age" is dependent on the presence of the "Trigger Behavior" argument. For example, in the following tag, `'never'` is the Trigger Behavior and `60` is the Max Age:
`{% response 'body', 'req_d8dffc4690bc450d9a7fe6ef47e1907d', 'b64::JC5hY2Nlc3NfdG9rZW4=::46b', 'never', 60 %}`

However, because both the Trigger Behavior and Max Age arguments were added _afterwards_, the new additions must be backwards compatible, with a tag that does _not_ provide those two arguments:
`{% response 'body', 'req_d8dffc4690bc450d9a7fe6ef47e1907d', 'b64::JC5hY2Nlc3NfdG9rZW4=::46b' %}`.

The problem lies in the fact that the Trigger Behavior argument is not making use of the defaultValue property; rather, defaulting the value in the `tag.run()` method. For this reason, `maxAge.hide()`, where the Trigger Behavior argument is also used, doesn't see the default.

This PR updates the argument definition of the "Trigger Behavior" argument, to set the `defaultValue` at a higher level.

Fixes #2414 