### PR TITLE
CodeMirror debounce wait for smoke tests

### DIFF
--- a/packages/insomnia-smoke-test/modules/debug.js
+++ b/packages/insomnia-smoke-test/modules/debug.js
@@ -29,14 +29,17 @@ const createNewRequest = async (app, name = undefined) => {
 
 const typeUrl = async (app, url) => {
   const urlEditor = await app.client.$('.urlbar .editor .input');
-  await typeCodeMirror(urlEditor, url);
+  await typeCodeMirror(app, urlEditor, url, 150);
 };
 
-const typeCodeMirror = async (element, value) => {
+const typeCodeMirror = async (app, element, value, debounceWait) => {
   await element.click();
   const cm = await element.$('.CodeMirror');
   await cm.waitForExist();
   await cm.keys(value);
+
+  // Wait for the code-editor debounce
+  await app.client.pause(debounceWait);
 };
 
 const clickSendRequest = async app => {


### PR DESCRIPTION
Typing into a code-editor field is a little flaky, and I realized that the code-editor has a configurable debounce that is applied, which by default is 100ms.

I have added an artificial 150ms pause, in order to allow the debounce timeout to elapse before proceeding to the next step. Hopefully this makes typing into a code-editor a little less flaky, but I will monitor it.