### PR TITLE
Update pdfjs-dist

### DIFF
--- a/packages/insomnia-app/app/ui/components/viewers/response-pdf-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-pdf-viewer.js
@@ -34,11 +34,10 @@ class ResponsePDFViewer extends React.PureComponent<Props, State> {
       container.innerHTML = '';
 
       const containerWidth = container.clientWidth;
-      const loadingTask = PDF.getDocument({
+      const pdf = await PDF.getDocument({
         data: this.props.body.toString('binary'),
-      });
+      }).promise;
 
-      const pdf = await loadingTask.promise;
       for (let i = 1; i <= pdf.numPages; i++) {
         const page = await pdf.getPage(i);
         const density = window.devicePixelRatio || 1;
@@ -67,8 +66,7 @@ class ResponsePDFViewer extends React.PureComponent<Props, State> {
           viewport: viewport,
         };
 
-        const renderTask = page.render(renderContext);
-        await renderTask.promise;
+        await page.render(renderContext).promise;
       }
     }, 100);
   }

--- a/packages/insomnia-app/app/ui/components/viewers/response-pdf-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-pdf-viewer.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import autobind from 'autobind-decorator';
-import PDF from 'pdfjs-dist/webpack';
+import * as PDF from 'pdfjs-dist/webpack';
 
 type Props = {
   body: Buffer,
@@ -34,17 +34,19 @@ class ResponsePDFViewer extends React.PureComponent<Props, State> {
       container.innerHTML = '';
 
       const containerWidth = container.clientWidth;
-      const pdf = await PDF.getDocument({
+      const loadingTask = PDF.getDocument({
         data: this.props.body.toString('binary'),
       });
+
+      const pdf = await loadingTask.promise;
       for (let i = 1; i <= pdf.numPages; i++) {
         const page = await pdf.getPage(i);
         const density = window.devicePixelRatio || 1;
 
-        const { width: pdfWidth, height: pdfHeight } = page.getViewport(1);
+        const { width: pdfWidth, height: pdfHeight } = page.getViewport({ scale: 1 });
         const ratio = pdfHeight / pdfWidth;
         const scale = containerWidth / pdfWidth;
-        const viewport = page.getViewport(scale * density);
+        const viewport = page.getViewport({ scale: scale * density });
 
         // set canvas for page
         const canvas = document.createElement('canvas');
@@ -65,7 +67,8 @@ class ResponsePDFViewer extends React.PureComponent<Props, State> {
           viewport: viewport,
         };
 
-        page.render(renderContext);
+        const renderTask = page.render(renderContext);
+        await renderTask.promise;
       }
     }, 100);
   }

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -14529,9 +14529,9 @@
 			"dev": true
 		},
 		"pdfjs-dist": {
-			"version": "2.4.456",
-			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.4.456.tgz",
-			"integrity": "sha512-yckJEHq3F48hcp6wStEpbN9McOj328Ib09UrBlGAKxvN2k+qYPN5iq6TH6jD1C0pso7zTep+g/CKsYgdrQd5QA=="
+			"version": "2.5.207",
+			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.5.207.tgz",
+			"integrity": "sha512-xGDUhnCYPfHy+unMXCLCJtlpZaaZ17Ew3WIL0tnSgKFUZXHAPD49GO9xScyszSsQMoutNDgRb+rfBXIaX/lJbw=="
 		},
 		"pend": {
 			"version": "1.2.0",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -152,7 +152,7 @@
     "oauth-1.0a": "^2.2.2",
     "openapi-2-kong": "^2.2.22",
     "papaparse": "^5.2.0",
-    "pdfjs-dist": "^2.2.228",
+    "pdfjs-dist": "^2.5.207",
     "prop-types": "^15.6.1",
     "react": "^16.8.6",
     "react-animated-tree": "^1.0.10",

--- a/packages/insomnia-smoke-test/core/app.test.js
+++ b/packages/insomnia-smoke-test/core/app.test.js
@@ -79,7 +79,7 @@ describe('Application launch', function() {
     await expect(csvViewer.getText()).resolves.toBe('a b c\n1 2 3');
   });
 
-  fit('sends PDF request and shows rich response', async () => {
+  it('sends PDF request and shows rich response', async () => {
     const pdfUrl = 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf';
     await debug.workspaceDropdownExists(app);
     await debug.createNewRequest(app);

--- a/packages/insomnia-smoke-test/core/app.test.js
+++ b/packages/insomnia-smoke-test/core/app.test.js
@@ -78,4 +78,17 @@ describe('Application launch', function() {
     const csvViewer = await debug.getCsvViewer(app);
     await expect(csvViewer.getText()).resolves.toBe('a b c\n1 2 3');
   });
+
+  fit('sends PDF request and shows rich response', async () => {
+    const pdfUrl = 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf';
+    await debug.workspaceDropdownExists(app);
+    await debug.createNewRequest(app);
+    await debug.typeUrl(app, pdfUrl);
+    await debug.clickSendRequest(app);
+
+    await debug.expect200(app);
+    const pdfCanvas = await debug.getPdfCanvas(app);
+    await expect(pdfCanvas.getAttribute('width')).resolves.toBe('1018');
+    await expect(pdfCanvas.getAttribute('height')).resolves.toBe('1440');
+  });
 });

--- a/packages/insomnia-smoke-test/core/app.test.js
+++ b/packages/insomnia-smoke-test/core/app.test.js
@@ -88,7 +88,6 @@ describe('Application launch', function() {
 
     await debug.expect200(app);
     const pdfCanvas = await debug.getPdfCanvas(app);
-    await expect(pdfCanvas.getAttribute('width')).resolves.toBe('1018');
-    await expect(pdfCanvas.getAttribute('height')).resolves.toBe('1440');
+    await expect(pdfCanvas.isExisting()).resolves.toBe(true);
   });
 });

--- a/packages/insomnia-smoke-test/core/app.test.js
+++ b/packages/insomnia-smoke-test/core/app.test.js
@@ -80,6 +80,8 @@ describe('Application launch', function() {
   });
 
   it('sends PDF request and shows rich response', async () => {
+    // Cannot mock the pdf response using Prism because it is not yet supported
+    // https://github.com/stoplightio/prism/issues/1248#issuecomment-646056440
     const pdfUrl = 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf';
     await debug.workspaceDropdownExists(app);
     await debug.createNewRequest(app);
@@ -88,6 +90,7 @@ describe('Application launch', function() {
 
     await debug.expect200(app);
     const pdfCanvas = await debug.getPdfCanvas(app);
+    // Investigate how we can extract text from the canvas, or compare images
     await expect(pdfCanvas.isExisting()).resolves.toBe(true);
   });
 });

--- a/packages/insomnia-smoke-test/modules/debug.js
+++ b/packages/insomnia-smoke-test/modules/debug.js
@@ -55,6 +55,14 @@ const getCsvViewer = async app => {
   return csvViewer;
 };
 
+const getPdfCanvas = async app => {
+  const pdfViewer = await app.client.react$('ResponsePDFViewer');
+  await pdfViewer.waitForDisplayed();
+  const canvas = await pdfViewer.$('.S-PDF-ID canvas');
+  await canvas.waitForDisplayed();
+  return canvas;
+};
+
 module.exports = {
   workspaceDropdownExists,
   createNewRequest,
@@ -62,4 +70,5 @@ module.exports = {
   clickSendRequest,
   expect200,
   getCsvViewer,
+  getPdfCanvas,
 };


### PR DESCRIPTION
This PR updates pdfjs-dist and fixes our usage to bring it in line with the interfaces in the latest version.

This PR also adds an E2E test, which currently loads [this](https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf) PDF. Adding in a mock PDF response through Prism wasn't working/isn't supported yet, and we may need to spin up our own local server to present mock data. We can remove this test if it becomes flaky.

<img width="1648" alt="image" src="https://user-images.githubusercontent.com/4312346/93743735-af76de00-fc44-11ea-8e02-d487a5341edb.png">

Closes #2623 