### PR TITLE
Fill missing arguments in tag data with defaults to make template tags backwards compatible

### DIFF
--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -300,6 +300,14 @@ class TagEditor extends React.PureComponent<Props, State> {
       };
     }
 
+    // Fill activeTagData arguments with defaults for missing arguments
+    if (tagDefinition && activeTagData.args.length !== tagDefinition.args.length) {
+      const defaultTagData = TagEditor._getDefaultTagData(tagDefinition);
+      defaultTagData.args
+        .slice(activeTagData.args.length)
+        .forEach(arg => activeTagData.args.push(arg));
+    }
+
     let template;
     if (activeTagData) {
       try {

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -301,7 +301,7 @@ class TagEditor extends React.PureComponent<Props, State> {
     }
 
     // Fill activeTagData arguments with defaults for missing arguments
-    if (tagDefinition && activeTagData.args.length !== tagDefinition.args.length) {
+    if (tagDefinition && activeTagData.args.length < tagDefinition.args.length) {
       const defaultTagData = TagEditor._getDefaultTagData(tagDefinition);
       defaultTagData.args
         .slice(activeTagData.args.length)


### PR DESCRIPTION
This can be fixed in the plugin (to access arguments safely), or can be fixed in the app for all plugins (to fill defaults when they are missing).

Feels like this is a bug in the app code - if a new argument is required by a template tag (with a default value), the app should provide that default value when rendering the legacy tag. That was my thought process for this fix.