### PR TITLE
Cater for missing argument in max age hide callback

### DIFF
--- a/plugins/insomnia-plugin-response/__tests__/index.test.js
+++ b/plugins/insomnia-plugin-response/__tests__/index.test.js
@@ -559,8 +559,13 @@ describe('Response tag', () => {
   });
 
   describe('Max Age', () => {
-    const maxAgeArg = tag.args.find(c => c.displayName === 'Max age (seconds)');
+    const maxAgeArg = tag.args[4];
     const toValueObj = value => ({ value });
+
+    it('should ensure fourth argument is maxAge', () => {
+      expect(maxAgeArg.displayName).toBe('Max age (seconds)');
+    });
+
     it('should hide when behavior and max age arguments are missing - backward compatibility', () => {
       const args = ['raw', 'req_1', ''].map(toValueObj);
       const hidden = maxAgeArg.hide(args);

--- a/plugins/insomnia-plugin-response/__tests__/index.test.js
+++ b/plugins/insomnia-plugin-response/__tests__/index.test.js
@@ -557,6 +557,40 @@ describe('Response tag', () => {
       throw new Error('Running tag should have thrown exception');
     });
   });
+
+  describe('Max Age', () => {
+    const maxAgeArg = tag.args.find(c => c.displayName === 'Max age (seconds)');
+    const toValueObj = value => ({ value });
+    it('should hide when behavior and max age arguments are missing - backward compatibility', () => {
+      const args = ['raw', 'req_1', ''].map(toValueObj);
+      const hidden = maxAgeArg.hide(args);
+      expect(hidden).toBe(true);
+    });
+
+    it('should hide when behavior=no-history and max age argument is missing - backward compatibility', () => {
+      const args = ['raw', 'req_1', '', 'no-history'].map(toValueObj);
+      const hidden = maxAgeArg.hide(args);
+      expect(hidden).toBe(true);
+    });
+
+    it('should show when behavior=when-expired and max age argument is missing - backward compatibility', () => {
+      const args = ['raw', 'req_1', '', 'when-expired'].map(toValueObj);
+      const hidden = maxAgeArg.hide(args);
+      expect(hidden).toBe(false);
+    });
+
+    it('should hide when behavior=always', () => {
+      const args = ['raw', 'req_1', '', 'always', 60].map(toValueObj);
+      const hidden = maxAgeArg.hide(args);
+      expect(hidden).toBe(true);
+    });
+
+    it('should show when behavior=when-expired', () => {
+      const args = ['raw', 'req_1', '', 'when-expired', 60].map(toValueObj);
+      const hidden = maxAgeArg.hide(args);
+      expect(hidden).toBe(false);
+    });
+  });
 });
 
 function _genTestContext(requests, responses, extraInfoRoot) {

--- a/plugins/insomnia-plugin-response/index.js
+++ b/plugins/insomnia-plugin-response/index.js
@@ -92,7 +92,10 @@ module.exports.templateTags = [
         displayName: 'Max age (seconds)',
         help: 'The maximum age of a response to use before it expires',
         type: 'number',
-        hide: args => args[3].value !== 'when-expired',
+        hide: args => {
+          const triggerBehavior = (args[3] && args[3].value) || defaultTriggerBehaviour;
+          return triggerBehavior !== 'when-expired';
+        },
         defaultValue: 60,
       },
     ],


### PR DESCRIPTION
Fixes #2414 specifically - #2650 updates the plugin API to cater for missing arguments and filling them with defaults