### PR TITLE
Refactor and reuse app launch logic, launch app with a fresh data directory, prepare for tests in release pipeline

### DIFF
--- a/packages/insomnia-smoke-test/core/app.test.js
+++ b/packages/insomnia-smoke-test/core/app.test.js
@@ -1,45 +1,17 @@
-import { Application } from 'spectron';
-import electronPath from '../../insomnia-app/node_modules/electron';
-import path from 'path';
 import * as debug from '../modules/debug';
 import * as client from '../modules/client';
+import { launchCore, stop } from '../modules/application';
 
 describe('Application launch', function() {
   jest.setTimeout(50000);
   let app = null;
 
   beforeEach(async () => {
-    app = new Application({
-      // Run installed app
-      // path: '/Applications/Insomnia.app/Contents/MacOS/Insomnia',
-
-      // Run after app-package - mac
-      // path: path.join(__dirname, '../insomnia-app/dist/com.insomnia.app/mac/Insomnia.app/Contents/MacOS/Insomnia'),
-
-      // Run after app-package - Windows
-      // path: path.join(__dirname, '../insomnia-app/dist/com.insomnia.app/win-unpacked/Insomnia.exe'),
-
-      // Run after app-build - mac, Windows, Linux
-      path: electronPath,
-      args: [path.join(__dirname, '../../insomnia-app/build/com.insomnia.app')],
-
-      // Don't ask why, but don't remove chromeDriverArgs
-      // https://github.com/electron-userland/spectron/issues/353#issuecomment-522846725
-      chromeDriverArgs: ['remote-debugging-port=9222'],
-    });
-    await app.start().then(async () => {
-      // Windows spawns two terminal windows when running spectron, and the only workaround
-      // is to focus the window on start.
-      // https://github.com/electron-userland/spectron/issues/60
-      await app.browserWindow.focus();
-      await app.browserWindow.setAlwaysOnTop(true);
-    });
+    app = await launchCore();
   });
 
   afterEach(async () => {
-    if (app && app.isRunning()) {
-      await app.stop();
-    }
+    await stop(app);
   });
 
   it('shows an initial window', async () => {

--- a/packages/insomnia-smoke-test/designer/app.test.js
+++ b/packages/insomnia-smoke-test/designer/app.test.js
@@ -2,46 +2,18 @@ import * as onboarding from '../modules/onboarding';
 import * as client from '../modules/client';
 import * as home from '../modules/home';
 
-import { Application } from 'spectron';
-import electronPath from '../../insomnia-app/node_modules/electron';
-import path from 'path';
+import { launchDesigner, stop } from '../modules/application';
 
 describe('Application launch', function() {
   jest.setTimeout(50000);
   let app = null;
 
   beforeEach(async () => {
-    app = new Application({
-      // Run installed app
-      // path: '/Applications/Insomnia.app/Contents/MacOS/Insomnia',
-
-      // Run after app-package - mac
-      // path: path.join(__dirname, '../insomnia-app/dist/com.insomnia.designer/mac/Insomnia.app/Contents/MacOS/Insomnia'),
-
-      // Run after app-package - Windows
-      // path: path.join(__dirname, '../insomnia-app/dist/com.insomnia.designer/win-unpacked/Insomnia.exe'),
-
-      // Run after app-build - mac, Windows, Linux
-      path: electronPath,
-      args: [path.join(__dirname, '../../insomnia-app/build/com.insomnia.designer')],
-
-      // Don't ask why, but don't remove chromeDriverArgs
-      // https://github.com/electron-userland/spectron/issues/353#issuecomment-522846725
-      chromeDriverArgs: ['remote-debugging-port=9222'],
-    });
-    await app.start().then(async () => {
-      // Windows spawns two terminal windows when running spectron, and the only workaround
-      // is to focus the window on start.
-      // https://github.com/electron-userland/spectron/issues/60
-      await app.browserWindow.focus();
-      await app.browserWindow.setAlwaysOnTop(true);
-    });
+    app = await launchDesigner();
   });
 
   afterEach(async () => {
-    if (app && app.isRunning()) {
-      await app.stop();
-    }
+    await stop(app);
   });
 
   it('can reset to and proceed through onboarding flow', async () => {

--- a/packages/insomnia-smoke-test/modules/application.js
+++ b/packages/insomnia-smoke-test/modules/application.js
@@ -1,0 +1,75 @@
+import { Application } from 'spectron';
+import path from 'path';
+import os from 'os';
+import electronPath from '../../insomnia-app/node_modules/electron';
+import { APP_ID_INSOMNIA, APP_ID_DESIGNER } from '../../insomnia-app/config';
+
+const getAppPlatform = () => process.platform;
+const isMac = () => getAppPlatform() === 'darwin';
+const isLinux = () => getAppPlatform() === 'linux';
+const isWindows = () => getAppPlatform() === 'win32';
+
+const spectronConfig = appId => {
+  let packagePathSuffix = '';
+  if (isWindows()) {
+    packagePathSuffix = 'win-unpacked/Insomnia.exe';
+  } else if (isMac()) {
+    packagePathSuffix = 'mac/Insomnia.app/Contents/MacOS/Insomnia';
+  } else if (isLinux()) {
+    packagePathSuffix = ''; // TODO: find out what this is
+  }
+
+  const buildPath = path.join(__dirname, '../../insomnia-app/build', appId);
+  const packagePath = path.join(__dirname, '../../insomnia-app/dist', appId, packagePathSuffix);
+  const dataPath = path.join(os.tmpdir(), 'insomnia-smoke-test', appId, `${Math.random()}`);
+
+  return { buildPath, packagePath, dataPath };
+};
+
+export const launchCore = async () => {
+  const config = spectronConfig(APP_ID_INSOMNIA);
+  return await launch(config);
+};
+
+export const launchDesigner = async () => {
+  const config = spectronConfig(APP_ID_DESIGNER);
+  return await launch(config);
+};
+
+const launch = async config => {
+  if (!config) {
+    throw new Error('Spectron config could not be loaded.');
+  }
+  const app = new Application({
+    // Run after app-package
+    // path: config.packagePath,
+
+    // Run after app-build - mac, Windows, Linux
+    path: electronPath,
+    args: [config.buildPath],
+
+    // Don't ask why, but don't remove chromeDriverArgs
+    // https://github.com/electron-userland/spectron/issues/353#issuecomment-522846725
+    chromeDriverArgs: ['remote-debugging-port=9222'],
+
+    env: {
+      INSOMNIA_DATA_PATH: config.dataPath,
+    },
+  });
+
+  await app.start().then(async () => {
+    // Windows spawns two terminal windows when running spectron, and the only workaround
+    // is to focus the window on start.
+    // https://github.com/electron-userland/spectron/issues/60
+    await app.browserWindow.focus();
+    await app.browserWindow.setAlwaysOnTop(true);
+  });
+
+  return app;
+};
+
+export const stop = async app => {
+  if (app && app.isRunning()) {
+    await app.stop();
+  }
+};


### PR DESCRIPTION
What it says on the tin. See the `app.test.js` files for usage.