### PR TITLE
Expose network context to requestHook & responseHook scopes

### DIFF
--- a/packages/insomnia-app/app/network/network.js
+++ b/packages/insomnia-app/app/network/network.js
@@ -997,11 +997,11 @@ async function _applyRequestPluginHooks(
 
 async function _applyResponsePluginHooks(
   response: ResponsePatch,
-  request: RenderedRequest,
-  renderContext: Object,
+  renderedRequest: RenderedRequest,
+  renderedContext: Object,
 ): Promise<ResponsePatch> {
   const newResponse = clone(response);
-  const newRequest = clone(request);
+  const newRequest = clone(renderedRequest);
 
   for (const { plugin, hook } of await plugins.getResponseHooks()) {
     const context = {
@@ -1009,8 +1009,8 @@ async function _applyResponsePluginHooks(
       ...(pluginContexts.data.init(): Object),
       ...(pluginContexts.store.init(plugin): Object),
       ...(pluginContexts.response.init(newResponse): Object),
-      ...(pluginContexts.request.init(newRequest, renderContext, true): Object),
-      ...(pluginContexts.network.init(renderContext.getEnvironmentId()): Object),
+      ...(pluginContexts.request.init(newRequest, renderedContext, true): Object),
+      ...(pluginContexts.network.init(renderedContext.getEnvironmentId()): Object),
     };
 
     try {

--- a/packages/insomnia-app/app/network/network.js
+++ b/packages/insomnia-app/app/network/network.js
@@ -981,6 +981,7 @@ async function _applyRequestPluginHooks(
       ...(pluginContexts.data.init(): Object),
       ...(pluginContexts.store.init(plugin): Object),
       ...(pluginContexts.request.init(newRenderedRequest, renderedContext): Object),
+      ...(pluginContexts.network.init(renderedContext.getEnvironmentId()): Object),
     };
 
     try {

--- a/packages/insomnia-app/app/network/network.js
+++ b/packages/insomnia-app/app/network/network.js
@@ -1009,6 +1009,7 @@ async function _applyResponsePluginHooks(
       ...(pluginContexts.store.init(plugin): Object),
       ...(pluginContexts.response.init(newResponse): Object),
       ...(pluginContexts.request.init(newRequest, renderContext, true): Object),
+      ...(pluginContexts.network.init(renderContext.getEnvironmentId()): Object),
     };
 
     try {


### PR DESCRIPTION
The issue #2012 was talking about exposing the `network` context to the `responseHook` scope to be able to send new request from there.

I took the opportunity to expose the `network` context to the `requestHook` also to be able to send request in request hook. Personally I am interested by this to create a plugin to login automatically to a private api. If you prefer I can move the commit in another PR ;)

Closes #2012