### PR TITLE
Add support for request action plugins

### DIFF
--- a/packages/insomnia-app/app/plugins/index.js
+++ b/packages/insomnia-app/app/plugins/index.js
@@ -41,6 +41,19 @@ export type RequestGroupAction = {
   icon?: string,
 };
 
+export type RequestAction = {
+  plugin: Plugin,
+  action: (
+    context: Object,
+    models: {
+      requestGroup: RequestGroup,
+      request: Array<Request>,
+    },
+  ) => void | Promise<void>,
+  label: string,
+  icon?: string,
+};
+
 export type WorkspaceAction = {
   plugin: Plugin,
   action: (
@@ -212,6 +225,16 @@ export async function getRequestGroupActions(): Promise<Array<RequestGroupAction
   let extensions = [];
   for (const plugin of await getActivePlugins()) {
     const actions = plugin.module.requestGroupActions || [];
+    extensions = [...extensions, ...actions.map(p => ({ plugin, ...p }))];
+  }
+
+  return extensions;
+}
+
+export async function getRequestActions(): Promise<Array<RequestAction>> {
+  let extensions = [];
+  for (const plugin of await getActivePlugins()) {
+    const actions = plugin.module.requestActions || [];
     extensions = [...extensions, ...actions.map(p => ({ plugin, ...p }))];
   }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
@@ -1,5 +1,6 @@
 // @flow
-import React from 'react';
+import React from 'react'; // @flow
+import PropTypes from 'prop-types';
 import autobind from 'autobind-decorator';
 import PromptButton from '../base/prompt-button';
 import {
@@ -87,7 +88,7 @@ class RequestActionsDropdown extends React.PureComponent<Props, State> {
     return requestOperations.remove(request);
   }
 
-  async onOpen() {
+  async _onOpen() {
     const plugins = await getRequestActions();
     this.setState({ actionPlugins: plugins });
   }
@@ -135,7 +136,7 @@ class RequestActionsDropdown extends React.PureComponent<Props, State> {
     const canGenerateCode = isRequest(request);
 
     return (
-      <Dropdown ref={this._setDropdownRef} onOpen={this.onOpen} {...other}>
+      <Dropdown ref={this._setDropdownRef} onOpen={this._onOpen} {...other}>
         <DropdownButton>
           <i className="fa fa-caret-down" />
         </DropdownButton>

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
@@ -97,7 +97,7 @@ class RequestActionsDropdown extends React.PureComponent<Props, State> {
   }
 
   async _handlePluginClick(p: RequestAction) {
-    this.setState((state) => ({ loadingActions: { ...state.loadingActions, [p.label]: true } }));
+    this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: true } }));
 
     try {
       const { activeEnvironment, request, requestGroup } = this.props;
@@ -117,7 +117,7 @@ class RequestActionsDropdown extends React.PureComponent<Props, State> {
       });
     }
 
-    this.setState((state) => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));
+    this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));
     this._dropdown && this._dropdown.hide();
   }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
@@ -174,7 +174,8 @@ class RequestActionsDropdown extends React.PureComponent<Props, State> {
         {actionPlugins.map((p: RequestAction) => (
           <DropdownItem
             key={`${p.plugin.name}::${p.label}`}
-            onClick={() => this._handlePluginClick(p)}
+            value={p}
+            onClick={this._handlePluginClick}
             stayOpenAfterClick>
             {loadingActions[p.label] ? (
               <i className="fa fa-refresh fa-spin" />

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
@@ -1,5 +1,5 @@
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
+// @flow
+import React from 'react';
 import autobind from 'autobind-decorator';
 import PromptButton from '../base/prompt-button';
 import {
@@ -15,8 +15,46 @@ import { isRequest } from '../../../models/helpers/is-model';
 import * as requestOperations from '../../../models/helpers/request-operations';
 import { incrementDeletedRequests } from '../../../models/stats';
 
+// Plugin action related imports
+import type { RequestAction, RequestGroupAction } from '../../../plugins';
+import type { HotKeyRegistry } from '../../../common/hotkeys';
+import type { Request } from '../../../models/request';
+import type { RequestGroup } from '../../../models/request-group';
+import type { Environment } from '../../../models/environment';
+import { getRequestActions } from '../../../plugins';
+import * as pluginContexts from '../../../plugins/context/index';
+import { showError } from '../modals';
+import { RENDER_PURPOSE_NO_RENDER } from '../../../common/render';
+import classnames from 'classnames';
+
+type Props = {
+  handleDuplicateRequest: Function,
+  handleGenerateCode: Function,
+  handleCopyAsCurl: Function,
+  handleShowSettings: Function,
+  isPinned: Boolean,
+  request: Request,
+  requestGroup: RequestGroup,
+  hotKeyRegistry: HotKeyRegistry,
+  handleSetRequestPinned: Function,
+  activeEnvironment: Environment | null,
+};
+
+// Setup state for plugin actions
+type State = {
+  actionPlugins: Array<RequestGroupAction>,
+  loadingActions: { [string]: boolean },
+};
+
 @autobind
-class RequestActionsDropdown extends PureComponent {
+class RequestActionsDropdown extends React.PureComponent<Props, State> {
+  _dropdown: ?Dropdown;
+
+  state = {
+    actionPlugins: [],
+    loadingActions: {},
+  };
+
   _setDropdownRef(n) {
     this._dropdown = n;
   }
@@ -49,8 +87,39 @@ class RequestActionsDropdown extends PureComponent {
     return requestOperations.remove(request);
   }
 
-  show() {
-    this._dropdown.show();
+  async onOpen() {
+    const plugins = await getRequestActions();
+    this.setState({ actionPlugins: plugins });
+  }
+
+  async show() {
+    this._dropdown && this._dropdown.show();
+  }
+
+  async _handlePluginClick(p: RequestAction) {
+    this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: true } }));
+
+    try {
+      const { activeEnvironment, request, requestGroup } = this.props;
+      const activeEnvironmentId = activeEnvironment ? activeEnvironment._id : null;
+
+      const context = {
+        ...(pluginContexts.app.init(RENDER_PURPOSE_NO_RENDER): Object),
+        ...(pluginContexts.data.init(): Object),
+        ...(pluginContexts.store.init(p.plugin): Object),
+        ...(pluginContexts.network.init(activeEnvironmentId): Object),
+      };
+
+      await p.action(context, { request, requestGroup });
+    } catch (err) {
+      showError({
+        title: 'Plugin Action Failed',
+        error: err,
+      });
+    }
+
+    this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));
+    this._dropdown && this._dropdown.hide();
   }
 
   render() {
@@ -61,11 +130,13 @@ class RequestActionsDropdown extends PureComponent {
       ...other
     } = this.props;
 
+    const { actionPlugins, loadingActions } = this.state;
+
     // Can only generate code for regular requests, not gRPC requests
     const canGenerateCode = isRequest(request);
 
     return (
-      <Dropdown ref={this._setDropdownRef} {...other}>
+      <Dropdown ref={this._setDropdownRef} onOpen={this.onOpen} {...other}>
         <DropdownButton>
           <i className="fa fa-caret-down" />
         </DropdownButton>
@@ -99,6 +170,18 @@ class RequestActionsDropdown extends PureComponent {
           <i className="fa fa-trash-o" /> Delete
           <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_DELETE.id]} />
         </DropdownItem>
+
+        {actionPlugins.length > 0 && <DropdownDivider>Plugins</DropdownDivider>}
+        {actionPlugins.map((p: RequestAction) => (
+          <DropdownItem key={p.label} onClick={() => this._handlePluginClick(p)} stayOpenAfterClick>
+            {loadingActions[p.label] ? (
+              <i className="fa fa-refresh fa-spin" />
+            ) : (
+              <i className={classnames('fa', p.icon || 'fa-code')} />
+            )}
+            {p.label}
+          </DropdownItem>
+        ))}
 
         <DropdownDivider />
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
@@ -97,7 +97,7 @@ class RequestActionsDropdown extends React.PureComponent<Props, State> {
   }
 
   async _handlePluginClick(p: RequestAction) {
-    this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: true } }));
+    this.setState((state) => ({ loadingActions: { ...state.loadingActions, [p.label]: true } }));
 
     try {
       const { activeEnvironment, request, requestGroup } = this.props;
@@ -117,7 +117,7 @@ class RequestActionsDropdown extends React.PureComponent<Props, State> {
       });
     }
 
-    this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));
+    this.setState((state) => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));
     this._dropdown && this._dropdown.hide();
   }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
@@ -99,24 +99,22 @@ class RequestActionsDropdown extends React.PureComponent<Props, State> {
   async _handlePluginClick(p: RequestAction) {
     this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: true } }));
 
-    if (p.action) {
-      try {
-        const { activeEnvironment, request, requestGroup } = this.props;
-        const activeEnvironmentId = activeEnvironment ? activeEnvironment._id : null;
-        const context = {
-          ...(pluginContexts.app.init(RENDER_PURPOSE_NO_RENDER): Object),
-          ...(pluginContexts.data.init(): Object),
-          ...(pluginContexts.store.init(p.plugin): Object),
-          ...(pluginContexts.network.init(activeEnvironmentId): Object),
-        };
+    try {
+      const { activeEnvironment, request, requestGroup } = this.props;
+      const activeEnvironmentId = activeEnvironment ? activeEnvironment._id : null;
+      const context = {
+        ...(pluginContexts.app.init(RENDER_PURPOSE_NO_RENDER): Object),
+        ...(pluginContexts.data.init(): Object),
+        ...(pluginContexts.store.init(p.plugin): Object),
+        ...(pluginContexts.network.init(activeEnvironmentId): Object),
+      };
 
-        await p.action(context, { request, requestGroup });
-      } catch (err) {
-        showError({
-          title: 'Plugin Action Failed',
-          error: err,
-        });
-      }
+      await p.action(context, { request, requestGroup });
+    } catch (err) {
+      showError({
+        title: 'Plugin Action Failed',
+        error: err,
+      });
     }
 
     this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'; // @flow
+import React from 'react';
 import PropTypes from 'prop-types';
 import autobind from 'autobind-decorator';
 import PromptButton from '../base/prompt-button';

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.js
@@ -122,6 +122,8 @@ class SidebarChildren extends React.PureComponent<Props> {
             request={child.doc}
             workspace={workspace}
             hotKeyRegistry={hotKeyRegistry}
+            // Necessary for plugin actions on requests
+            activeEnvironment={activeEnvironment}
           />
         );
       }

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
@@ -155,6 +155,8 @@ class SidebarRequestGroupRow extends PureComponent {
               filter={filter}
               hotKeyRegistry={hotKeyRegistry}
               isPinned={false}
+              // Necessary so that plugin actions work
+              activeEnvironment={activeEnvironment}
             />
           )}
         </ul>

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
@@ -158,6 +158,7 @@ class SidebarRequestRow extends PureComponent {
       isPinned,
       disableDragAndDrop,
       hotKeyRegistry,
+      activeEnvironment,
     } = this.props;
 
     const { dragDirection } = this.state;
@@ -232,6 +233,8 @@ class SidebarRequestRow extends PureComponent {
                 isPinned={isPinned}
                 requestGroup={requestGroup}
                 hotKeyRegistry={hotKeyRegistry}
+                // Necessary for plugin actions to have network capabilities
+                activeEnvironment={activeEnvironment}
               />
             </div>
             {isPinned && (


### PR DESCRIPTION
# Goal

This PR provides plugin developers the same type of action hook available to workspaces and request folders for individual requests. See the documentation and examples below.

# Backstory

While looking through a [recently submitted plugin](https://insomnia.rest/plugins/insomnia-plugin-swagerize-response) I realized that this individual was using the existence of a header property to create an action for a request. While it is an [ingenious work-around](https://user-images.githubusercontent.com/198276/94623922-28d88700-026a-11eb-8242-f253920d0f63.png), it showed that there is an obvious gap.

You can create actions on request folders, and on the workspace, but not the actual requests themselves.

# Documentation

## Request Actions

Actions can be added to the bottom of the request dropdown by defining a request action plugin.

```ts
type RequestAction = {
    label: string,
    action: (context: Context, { 
        requestGroup: RequestGroup, 
        request: Request
    }): void | Promise<void>,
    label: string,
    icon?: string,
};

// Request actions are exported as an array of objects
module.exports.requestActions = Array<RequestAction>
```

<details>
 <summary>Example: Plugin to get request details in a modal</summary>

> <img width="270" alt="Screen Shot" src="https://user-images.githubusercontent.com/198276/94622209-a00c1c00-0266-11eb-950f-6302209a0be0.png">
> <img width="1050" alt="Screen Shot 2020-09-29 at 2 50 13 PM" src="https://user-images.githubusercontent.com/198276/94622473-20cb1800-0267-11eb-9879-f4c06d85700a.png">
> 
> ```ts
> module.exports.requestActions = [
>   {
>     label: "See request data",
>     action: async (context, data) => {
>       const { request } = data;
>       const html = `<code>${JSON.stringify(request)}</code>`;
>       context.app.showGenericModalDialog("Results", { html });
>     },
>   },
> ];
> ```
</details>

<details>
 <summary>Example: Send request</summary>

> ```ts
> module.exports.requestActions = [
>   {
>     label: "Send request",
>     action: async (context, data) => {
>       const { request } = data;
>.      const response = await context.network.sendRequest(request);
>       const html = `<code>${request.name}: ${response.statusCode}</code>`;
>       context.app.showGenericModalDialog("Results", { html });
>     },
>   },
> ];
> ```
</details>

# Additional Details

- Replicates implementation of already existing feature `RequestGroupActions`
- Converts `RequestActionsDropdown` to be stateful component to support plugin actions
- Adds support for `activeEnvironment` to the `RequestActionsDropdown` for network requests

# Open questions

- What do you think about putting plugins above `settings` instead of below, this way we can slowly move actions over to being plugins, and their position does not jump around (Generate Code for example is an example).

Closes https://github.com/Kong/insomnia/issues/2119