### PR TITLE
Add required annotation to Kubernetes config

### DIFF
--- a/packages/openapi-2-kong/README.md
+++ b/packages/openapi-2-kong/README.md
@@ -226,6 +226,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: insomnia-api-1
+  annotations:
+    kubernetes.io/ingress.class: "kong"
 spec:
   rules:
     - host: one.insomnia.rest
@@ -240,6 +242,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: insomnia-api-2
+  annotations:
+    kubernetes.io/ingress.class: "kong"
 spec:
   rules:
     - host: two.insomnia.rest
@@ -263,7 +267,6 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: insomnia-api
-spec:
 ...
 ```
 
@@ -408,6 +411,7 @@ kind: Ingress
 metadata:
   name: insomnia-api-0
   annotations:
+    kubernetes.io/ingress.class: "kong"
     example: example                            # annotation from x-kong-ingress-metadata
     konghq.com/plugins: add-custom-global-g0    # only global plugin
 spec:
@@ -425,6 +429,7 @@ kind: Ingress
 metadata:
   name: insomnia-api-1
   annotations:
+    kubernetes.io/ingress.class: "kong"
     example: example
     konghq.com/plugins: add-custom-global-g0, add-key-auth-m2   # global and operation plugin, no server or path
     konghq.com/override: get-method             # restrict document to be for specified operation (due to plugin)
@@ -443,6 +448,7 @@ kind: Ingress
 metadata:
   name: insomnia-api-2
   annotations:
+    kubernetes.io/ingress.class: "kong"
     example: example
     konghq.com/plugins: add-custom-global-g0, add-custom-server-s1    # global and server 1 plugin, no path or operation
 spec:
@@ -460,6 +466,7 @@ kind: Ingress
 metadata:
   name: insomnia-api-3
   annotations:
+    kubernetes.io/ingress.class: "kong"
     example: example
     konghq.com/plugins: add-custom-global-g0, add-custom-server-s1, add-key-auth-m2   # global, server 1, and operation plugin, no path
     konghq.com/override: get-method             # restrict document to be for specified operation (due to plugin)

--- a/packages/openapi-2-kong/src/kubernetes/__tests__/index.test.js
+++ b/packages/openapi-2-kong/src/kubernetes/__tests__/index.test.js
@@ -81,23 +81,30 @@ describe('index', () => {
       const result = generateMetadataAnnotations(api, { pluginNames: [] });
 
       expect(result).toEqual({
+        'kubernetes.io/ingress.class': 'kong',
         'nginx.ingress.kubernetes.io/rewrite-target': '/',
       });
     });
 
-    it('gets no annotations', () => {
+    it('gets only core annotation(s)', () => {
       const result = generateMetadataAnnotations(spec, { pluginNames: [] });
-      expect(result).toBe(null);
+      expect(result).toEqual({ 'kubernetes.io/ingress.class': 'kong' });
     });
 
     it('gets plugin annotations correctly', () => {
       const result = generateMetadataAnnotations(spec, { pluginNames: ['one', 'two'] });
-      expect(result).toEqual({ 'konghq.com/plugins': 'one, two' });
+      expect(result).toEqual({
+        'kubernetes.io/ingress.class': 'kong',
+        'konghq.com/plugins': 'one, two',
+      });
     });
 
     it('gets override annotation correctly', () => {
       const result = generateMetadataAnnotations(spec, { pluginNames: [], overrideName: 'name' });
-      expect(result).toEqual({ 'konghq.com/override': 'name' });
+      expect(result).toEqual({
+        'kubernetes.io/ingress.class': 'kong',
+        'konghq.com/override': 'name',
+      });
     });
 
     it('gets all annotations correctly', () => {
@@ -120,6 +127,7 @@ describe('index', () => {
         overrideName: 'name',
       });
       expect(result).toEqual({
+        'kubernetes.io/ingress.class': 'kong',
         'nginx.ingress.kubernetes.io/rewrite-target': '/',
         'konghq.com/plugins': 'one, two',
         'konghq.com/override': 'name',

--- a/packages/openapi-2-kong/src/kubernetes/__tests__/util/plugin-helpers.js
+++ b/packages/openapi-2-kong/src/kubernetes/__tests__/util/plugin-helpers.js
@@ -75,6 +75,7 @@ export const ingressDoc = (
     kind: 'Ingress',
     metadata: {
       annotations: {
+        'kubernetes.io/ingress.class': 'kong',
         'konghq.com/plugins': plugins.join(', '),
       },
       name: `my-api-${index}`,
@@ -104,6 +105,7 @@ export const ingressDocWithOverride = (
   kind: 'Ingress',
   metadata: {
     annotations: {
+      'kubernetes.io/ingress.class': 'kong',
       'konghq.com/plugins': plugins.join(', '),
       'konghq.com/override': override,
     },

--- a/packages/openapi-2-kong/types/kubernetes-config.flow.js
+++ b/packages/openapi-2-kong/types/kubernetes-config.flow.js
@@ -1,12 +1,13 @@
 // @flow
 
 declare type K8sAnnotations = {
+  'kubernetes.io/ingress.class': 'kong',
   [string]: string,
 };
 
 declare type K8sMetadata = {
   name: string,
-  annotations?: K8sAnnotations,
+  annotations: K8sAnnotations,
 };
 
 declare type K8sBackend = {


### PR DESCRIPTION
This fixes #2706, and adds the [required `kubernetes.io/ingress.class` annotation](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/references/annotations.md#kubernetesioingressclass) to generated Kubernetes configs.


This is my first PR here, so please let me know if there's anything I should be doing differently. (Also, while I was able to run the unit tests, I could not figure out how to test this using either the `inso` CLI, or the plugin inside of Designer. If someone could point me in the right direction for getting either the CLI or the plugin/designer built with my newly modified version of `openapi-2-kong`, it would be greatly appreciated 😄).
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->