### PR TITLE
Fix color picker display when updating an environment color

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
@@ -101,6 +101,7 @@ const SidebarList = SortableContainer(
 @autobind
 class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
   environmentEditorRef: ?EnvironmentEditor;
+  environmentColorInputRef: HTMLInputElement;
   colorChangeTimeout: any;
   saveTimeout: any;
   modal: Modal;
@@ -126,6 +127,10 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
 
   _setEditorRef(n: ?EnvironmentEditor) {
     this.environmentEditorRef = n;
+  }
+
+  _setInputColorRef(ref: HTMLInputElement | null) {
+    this.environmentColorInputRef = ref;
   }
 
   _setModalRef(n: Modal | null) {
@@ -329,33 +334,19 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
   }
 
   async _handleClickColorChange(environment: Environment) {
-    let el = document.querySelector('#env-color-picker');
-
-    // Remove existing child so we reset the event handlers. This
-    // was easier than trying to clean them up later.
-    if (el && el.parentNode) {
-      el.parentNode.removeChild(el);
-    }
-
-    el = document.createElement('input');
-    el.id = 'env-color-picker';
-    el.type = 'color';
-    document.body && document.body.appendChild(el);
-
     const color = environment.color || '#7d69cb';
-
     if (!environment.color) {
       await this._handleChangeEnvironmentColor(environment, color);
     }
 
-    el.setAttribute('value', color);
-    el.addEventListener('input', (e: Event) => {
-      if (e.target instanceof HTMLInputElement) {
-        this._handleChangeEnvironmentColor(environment, e.target && e.target.value);
-      }
-    });
+    this.environmentColorInputRef?.click();
+  }
 
-    el.click();
+  _handleInputColorChange(event: SyntheticEvent<HTMLInputElement>) {
+    this._handleChangeEnvironmentColor(
+      this._getActiveEnvironment(),
+      event.target && event.target.value,
+    );
   }
 
   _saveChanges() {
@@ -473,6 +464,14 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
 
               {activeEnvironment && rootEnvironment !== activeEnvironment ? (
                 <React.Fragment>
+                  <input
+                    className="hidden"
+                    type="color"
+                    value={activeEnvironment.color}
+                    ref={this._setInputColorRef}
+                    onInput={this._handleInputColorChange}
+                  />
+
                   <Dropdown className="space-right" right>
                     <DropdownButton className="btn btn--clicky">
                       {activeEnvironment.color && (

--- a/packages/insomnia-app/app/ui/css/layout/base.less
+++ b/packages/insomnia-app/app/ui/css/layout/base.less
@@ -501,6 +501,10 @@ blockquote {
   display: none;
 }
 
+.hidden {
+  visibility: hidden;
+}
+
 .relative {
   position: relative;
 }


### PR DESCRIPTION
We were removing the color picker to reset event handlers easily (fix #811).
It is possible to remove the listener quite easily by listening to the `change` event triggered when the color picker modal is closed.

There was still an issue with the 1st click on `Change color`. We were adding the `input` dynamically on the 1st click and we were having some race condition between the `click` and the `appendChild` 🤔 
To fix that, I've added the `input` element just before the `Color` dropdown. Besides, now we can open the color picker modal near the dropdown by making the `input` element invisible.

Before
![image](https://user-images.githubusercontent.com/4171593/96621595-17364c80-1309-11eb-8b67-505e0e542fdb.png)



After
![color-picker](https://user-images.githubusercontent.com/4171593/96622054-bc512500-1309-11eb-95cc-47ed64de1ce2.gif)



Closes #2647