### PR TITLE
Add file logging

### DIFF
--- a/packages/insomnia-app/app/common/log.js
+++ b/packages/insomnia-app/app/common/log.js
@@ -1,16 +1,21 @@
 import log from 'electron-log';
+import { isDevelopment } from './constants';
 
 export const initializeLogging = () => {
-  const fileTransport = log.transports.file;
-  const logFile = fileTransport.getFile();
+  if (isDevelopment()) {
+    // Disable file logging during development
+    log.transports.file.level = false;
+  } else {
+    const fileTransport = log.transports.file;
+    const logFile = fileTransport.getFile();
+    // Set the max log file size to 10mb
+    // When the log file exceeds this limit, it will be rotated to {file name}.old.log file.
+    fileTransport.maxSize = 1024 * 1024 * 10;
 
-  // Set the max log file size to 10mb
-  // When the log file exceeds this limit, it will be rotated to {file name}.old.log file.
-  fileTransport.maxSize = 1024 * 1024 * 10;
-
-  // Rotate the log file every time we start the app
-  fileTransport.archiveLog(logFile);
-  logFile.clear();
+    // Rotate the log file every time we start the app
+    fileTransport.archiveLog(logFile);
+    logFile.clear();
+  }
 
   // Overwrite the console.log/warn/etc methods
   Object.assign(console, log.functions);

--- a/packages/insomnia-app/app/common/log.js
+++ b/packages/insomnia-app/app/common/log.js
@@ -1,0 +1,19 @@
+import log from 'electron-log';
+
+export const initializeLogging = () => {
+  const fileTransport = log.transports.file;
+  const logFile = fileTransport.getFile();
+
+  // Set the max log file size to 10mb
+  // When the log file exceeds this limit, it will be rotated to {file name}.old.log file.
+  fileTransport.maxSize = 1024 * 1024 * 10;
+
+  // Rotate the log file every time we start the app
+  fileTransport.archiveLog(logFile);
+  logFile.clear();
+
+  // Overwrite the console.log/warn/etc methods
+  Object.assign(console, log.functions);
+};
+
+export default log;

--- a/packages/insomnia-app/app/main.development.js
+++ b/packages/insomnia-app/app/main.development.js
@@ -12,14 +12,19 @@ import { changelogUrl, getAppVersion, isDevelopment, isMac } from './common/cons
 import type { ToastNotification } from './ui/components/toast';
 import type { Stats } from './models/stats';
 import { trackNonInteractiveEventQueueable } from './common/analytics';
+import log, { initializeLogging } from './common/log';
 
 // Handle potential auto-update
 if (checkIfRestartNeeded()) {
   process.exit(0);
 }
 
+initializeLogging();
+
 const { app, ipcMain, session } = electron;
 const commandLineArgs = process.argv.slice(1);
+
+log.info(`Running version ${getAppVersion()}`);
 
 // Explicitly set userData folder from config because it's sketchy to
 // rely on electron-builder to use productName, which could be changed

--- a/packages/insomnia-app/app/ui/index.js
+++ b/packages/insomnia-app/app/ui/index.js
@@ -17,6 +17,9 @@ import { trackEvent } from '../common/analytics';
 import { APP_ID_DESIGNER, APP_ID_INSOMNIA } from '../../config';
 import * as styledComponents from 'styled-components';
 import { initNewOAuthSession } from '../network/o-auth-2/misc';
+import { initializeLogging } from '../common/log';
+
+initializeLogging();
 
 // Handy little helper
 document.body.setAttribute('data-platform', process.platform);
@@ -94,7 +97,7 @@ if (window && !isDevelopment()) {
     trackEvent('Error', 'Uncaught Error');
   });
 
-  window.addEventListener('unhandledRejection', e => {
+  window.addEventListener('unhandledrejection', e => {
     console.error('Unhandled Promise', e);
     trackEvent('Error', 'Uncaught Promise');
   });

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -7740,6 +7740,11 @@
 			"resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
 			"integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw=="
 		},
+		"electron-log": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.2.4.tgz",
+			"integrity": "sha512-CXbDU+Iwi+TjKzugKZmTRIORIPe3uQRqgChUl19fkW/reFUn5WP7dt+cNGT3bkLV8xfPilpkPFv33HgtmLLewQ=="
+		},
 		"electron-notarize": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-0.3.0.tgz",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -104,6 +104,7 @@
     "color": "^3.1.2",
     "deep-equal": "^1.0.1",
     "electron-context-menu": "^2.2.0",
+    "electron-log": "^4.2.4",
     "electron-updater": "^4.2.0",
     "font-scanner": "^0.1.2",
     "framer-motion": "^1.11.1",


### PR DESCRIPTION
This PR consolidates logs from both the renderer and the main process using [electron-log](https://github.com/megahertz/electron-log) and prints them to the console + logs them to file when the app is running in production mode.

It hijacks the `console.log/warn/etc` methods in order to handle all our current logs, but when adding new logs we should use the `./common/log` util instead moving forward.

For now, all log levels are printed and written to file, but we might want to change that in the future (for example, by setting different levels in development vs production builds, or have a setting in the app for more verbose logging)