### PR TITLE
Change bulk header editor setting verbiage

### DIFF
--- a/packages/insomnia-app/app/ui/components/settings/general.js
+++ b/packages/insomnia-app/app/ui/components/settings/general.js
@@ -190,7 +190,7 @@ class General extends React.PureComponent<Props, State> {
       <div className="pad-bottom">
         <div className="row-fill row-fill--top">
           <div>
-            {this.renderBooleanSetting('Force bulk header editor', 'useBulkHeaderEditor', '')}
+            {this.renderBooleanSetting('Use bulk header editor', 'useBulkHeaderEditor', '')}
             {this.renderBooleanSetting(
               'Vertical request/response layout',
               'forceVerticalLayout',


### PR DESCRIPTION
This changes the "Force bulk header editor" setting text to read "Use bulk header editor" instead, as it is less forceful, and to be consistent with #2713.
