### PR TITLE
Fix infinite request spinner when cancelling "Send and Download"

### DIFF
--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -713,15 +713,15 @@ class App extends PureComponent {
           </div>
         ),
       });
+    } finally {
+      // Unset active response because we just made a new one
+      await App._updateRequestMetaByParentId(requestId, {
+        activeResponseId: null,
+      });
+
+      // Stop loading
+      handleStopLoading(requestId);
     }
-
-    // Unset active response because we just made a new one
-    await App._updateRequestMetaByParentId(requestId, {
-      activeResponseId: null,
-    });
-
-    // Stop loading
-    handleStopLoading(requestId);
   }
 
   async _handleSendRequestWithEnvironment(requestId, environmentId) {


### PR DESCRIPTION
We were hiding the spinner at the end of the `_handleSendAndDownloadRequestWithEnvironment` method. However, we
were exiting early we the user cancel the save dialog (L672).

To prevent that, I've moved the code in a finally block, therefore we make sure that the spinner will be hidden

Closes #2718

Before
![BEFORE](https://user-images.githubusercontent.com/4171593/96155838-acec6900-0f10-11eb-8068-e5ed9a329b0b.gif)

After
![AFTER](https://user-images.githubusercontent.com/4171593/96155897-bf66a280-0f10-11eb-8920-0c30b66a0d4d.gif)
