### PR TITLE
Fix sync issues when switching between workspaces

### DIFF
--- a/packages/insomnia-app/app/ui/components/wrapper-debug.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-debug.js
@@ -124,7 +124,6 @@ class WrapperDebug extends React.PureComponent<Props> {
       activeUnitTestResult,
       activeWorkspace,
       environments,
-      enableSyncBeta,
       handleActivateRequest,
       handleSetActiveWorkspace,
       handleCopyAsCurl,
@@ -188,7 +187,7 @@ class WrapperDebug extends React.PureComponent<Props> {
                 unseenWorkspaces={unseenWorkspaces}
                 hotKeyRegistry={settings.hotKeyRegistry}
                 handleSetActiveWorkspace={handleSetActiveWorkspace}
-                enableSyncBeta={enableSyncBeta}
+                enableSyncBeta={settings.enableSyncBeta}
                 isLoading={isLoading}
                 vcs={vcs}
               />

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -1085,7 +1085,7 @@ class App extends PureComponent {
 
     await vcs.switchProject(activeWorkspace._id);
 
-    // Prevent a potential race-condition when _updateVCS() gets called for different projects in rapid succession
+    // Prevent a potential race-condition when _updateVCS() gets called for different workspaces in rapid succession
     if (this._updateVCSLock === lock) {
       this.setState({ vcs });
     }


### PR DESCRIPTION
When using beta sync and switching between multiple workspaces that has sync enabled, there is a race condition, causing the wrong workspace to be selected as active in the VCS engine.

In order to solve this, I added a lock to `_updateVCS()`, to ensure that we only update the component state to the result of the most recent call. 
This means that if `_updateVCS` gets called while it's already running, the result of the first call will be discarded.
This should be a sufficient guard against the race conditions we were seeing, as running multiple of these vcs operations in parallel should be safe, so the only concern is the component state.

This is not an ideal solution, it would be better to move this state management into Redux instead, but that is a much larger change, which is why I opted for this approach. 
Open to suggestions for alternative solutions.

I also stopped triggering `_updateVCS()` in `UNSAFE_componentWillReceiveProps`, as this should not be needed, as we trigger it on both `componentDidMount` and `componentDidUpdate`.