### PR TITLE
Rename button label of the `Save and Download` action save dialog

### DIFF
--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -621,7 +621,7 @@ class App extends PureComponent {
   async _getDownloadLocation() {
     const options = {
       title: 'Select Download Location',
-      buttonLabel: 'Send and Save',
+      buttonLabel: 'Save',
     };
 
     const defaultPath = window.localStorage.getItem('insomnia.sendAndDownloadLocation');


### PR DESCRIPTION
The label was `Send and Save`, it is confusing because actually the request was already sent.

Before
<img width="367" alt="Screenshot 2020-10-15 at 20 03 29" src="https://user-images.githubusercontent.com/4171593/96169066-e24d8280-0f21-11eb-9567-1c5b8a913b1a.png">

After
<img width="369" alt="Screenshot 2020-10-15 at 20 05 14" src="https://user-images.githubusercontent.com/4171593/96169077-e7123680-0f21-11eb-8936-72ea9696cad8.png">

Related to #2721