### PR TITLE
'Open logs folder' help menu option

### DIFF
--- a/packages/insomnia-app/app/common/log.js
+++ b/packages/insomnia-app/app/common/log.js
@@ -21,4 +21,6 @@ export const initializeLogging = () => {
   Object.assign(console, log.functions);
 };
 
+export const getLogsDirectory = () => log.transports.file.getFile().path;
+
 export default log;

--- a/packages/insomnia-app/app/main/window-utils.js
+++ b/packages/insomnia-app/app/main/window-utils.js
@@ -14,6 +14,7 @@ import {
   isMac,
   MNEMONIC_SYM,
 } from '../common/constants';
+import { getLogsDirectory } from '../common/log';
 import * as misc from '../common/misc';
 import * as os from 'os';
 import { docsBase } from '../common/documentation';
@@ -269,6 +270,13 @@ export function createWindow() {
         click: (menuItem, w, e) => {
           const directory = misc.getDataDirectory();
           shell.showItemInFolder(directory);
+        },
+      },
+      {
+        label: `Show App ${MNEMONIC_SYM}Logs Folder`,
+        click: (menuItem, w, e) => {
+          const logsDirectory = getLogsDirectory();
+          shell.showItemInFolder(logsDirectory);
         },
       },
       {


### PR DESCRIPTION
This PR is adding the function and the menu item option to open the logs folder.
![openLogs](https://user-images.githubusercontent.com/28495651/96214227-ea6ce880-0f48-11eb-9036-076c3ed1f2b4.gif)
Closes #2719 
JIC. I sent the same PR before, but as it was adding some unnecessary commits I decided to close the previous PR and send this cleaner one.