### PR TITLE
Add the ability to set "Automatically beautify request body" in settings

### DIFF
--- a/packages/insomnia-app/app/models/settings.js
+++ b/packages/insomnia-app/app/models/settings.js
@@ -16,6 +16,7 @@ export type PluginConfigMap = {
 type BaseSettings = {
   autoHideMenuBar: boolean,
   autocompleteDelay: number,
+  autoPrettify: boolean,
   deviceId: string | null,
   disableHtmlPreviewJs: boolean,
   disableResponsePreviewLinks: boolean,
@@ -72,6 +73,7 @@ export function init(): BaseSettings {
   return {
     autoHideMenuBar: false,
     autocompleteDelay: 1200,
+    autoPrettify: false,
     deviceId: null,
     disableHtmlPreviewJs: false,
     disableResponsePreviewLinks: false,

--- a/packages/insomnia-app/app/ui/components/editors/body/body-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/body-editor.js
@@ -180,6 +180,7 @@ class BodyEditor extends React.PureComponent<Props> {
       const contentType = getContentTypeFromHeaders(request.headers) || mimeType;
       return (
         <RawEditor
+          autoPrettify={settings.autoPrettify}
           uniquenessKey={uniqueKey}
           fontSize={settings.editorFontSize}
           indentSize={settings.editorIndentSize}

--- a/packages/insomnia-app/app/ui/components/editors/body/raw-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/raw-editor.js
@@ -20,6 +20,7 @@ class RawEditor extends PureComponent {
       isVariableUncovered,
       onChange,
       render,
+      autoPrettify,
       uniquenessKey,
     } = this.props;
 
@@ -27,6 +28,7 @@ class RawEditor extends PureComponent {
       <React.Fragment>
         <CodeEditor
           manualPrettify
+          autoPrettify={autoPrettify}
           uniquenessKey={uniquenessKey}
           fontSize={fontSize}
           indentSize={indentSize}

--- a/packages/insomnia-app/app/ui/components/settings/general.js
+++ b/packages/insomnia-app/app/ui/components/settings/general.js
@@ -196,6 +196,7 @@ class General extends React.PureComponent<Props, State> {
               'forceVerticalLayout',
               '',
             )}
+            {this.renderBooleanSetting('Automatically beautify request body', 'autoPrettify', '')}
           </div>
           <div>
             {this.renderBooleanSetting('Reveal passwords', 'showPasswords', '')}


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

This features adds a new option in the Preferences -> General tab named "Automatically beautify request body". This option is disabled by default to preserve backward compatibility for the users. If it's enabled, future request body imports will be automatically beautified. It's based on the existing property `autoPrettify` in `CodeEditor` class.

This feature could also be an alternative way of what pull request #2305 was looking for (which is then reverted in #2387 due to some side effects). However, it includes smaller changes and uses existing logic to achieve the same goal.

![Screenshot from 2020-10-17 01-56-42](https://user-images.githubusercontent.com/20307301/96319809-908a2280-101d-11eb-911a-6d71a7b642c4.png)
