### PR TITLE
Request History: Set dropdown value to the response instead of null

### DIFF
--- a/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
@@ -55,7 +55,7 @@ class ResponseHistoryDropdown extends PureComponent<Props> {
     });
   }
 
-  renderDropdownItem(response: Response, i: number) {
+  renderDropdownItem(response: Response) {
     const { activeResponse, requestVersions } = this.props;
     const activeResponseId = activeResponse ? activeResponse._id : 'n/a';
     const active = response._id === activeResponseId;

--- a/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
@@ -68,7 +68,7 @@ class ResponseHistoryDropdown extends PureComponent<Props> {
       <DropdownItem
         key={response._id}
         disabled={active}
-        value={i === 0 ? null : response}
+        value={response}
         onClick={this._handleSetActiveResponse}
       >
         {active ? <i className="fa fa-thumb-tack" /> : <i className="fa fa-empty" />}{' '}


### PR DESCRIPTION
- Closes: #2675, Closes #1985, Closes INS-913
- Currently there can be cases where selecting the request history drop down returns an incorrect request
![image](https://user-images.githubusercontent.com/892961/96338173-dea33280-10be-11eb-89c3-835093e255f7.png)
- This is due to code returning a `null` instead of the `response` when `i == 0`
- As the code uses `response.id` as the key it seems like we will always have a `response` object.

**Before (current broken behaviour)**
![before](https://user-images.githubusercontent.com/892961/96338226-20cc7400-10bf-11eb-9850-af313894b0ee.gif)

**After (which this fix)**
![after](https://user-images.githubusercontent.com/892961/96338228-22963780-10bf-11eb-9f87-16eac3123c8f.gif)


**Context of the bug**
- So the bug is due to this section of code
https://github.com/Kong/insomnia/blob/5a128ed25be4bc0d253507199e31eb8a861dc532/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.js#L125-L137
- Each `.map` will start at index of `0` so the first item in the new grouping would cause the issue