### PR TITLE
feat: Add workspace ID on sidebar and dropdown

### DIFF
--- a/packages/insomnia-app/app/ui/components/base/dropdown/dropdown-id.js
+++ b/packages/insomnia-app/app/ui/components/base/dropdown/dropdown-id.js
@@ -1,0 +1,16 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+class DropdownId extends PureComponent {
+  render() {
+    const { children } = this.props;
+
+    return <span className="dropdown__id">{children}</span>;
+  }
+}
+
+DropdownId.propTypes = {
+  children: PropTypes.node,
+};
+
+export default DropdownId;

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
@@ -34,6 +34,7 @@ import { getWorkspaceActions } from '../../../plugins';
 import * as pluginContexts from '../../../plugins/context';
 import { RENDER_PURPOSE_NO_RENDER } from '../../../common/render';
 import type { Environment } from '../../../models/environment';
+import DropdownId from '../base/dropdown/dropdown-id';
 
 type Props = {
   activeEnvironment: Environment | null,
@@ -294,7 +295,8 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
                 )}
                 <i className="fa fa-caret-down space-left" />
               </div>
-              {activeWorkspace.name}
+              {activeWorkspace.name}{' '}
+              <DropdownId>({activeWorkspace._id.substring(0, 8)})</DropdownId>
             </h1>
           </DropdownButton>
           <DropdownDivider>{activeWorkspace.name}</DropdownDivider>
@@ -313,7 +315,8 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
             const isUnseen = !!unseenWorkspaces.find(v => v._id === w._id);
             return (
               <DropdownItem key={w._id} onClick={handleSetActiveWorkspace} value={w._id}>
-                <i className="fa fa-random" /> To <strong>{w.name}</strong>
+                <i className="fa fa-random" /> To <strong>{w.name}</strong>{' '}
+                <i className="f">({w._id.substring(0, 8)})</i>
                 {isUnseen && (
                   <Tooltip message="You haven't seen this workspace before" position="top">
                     <i className="width-auto fa fa-asterisk surprise" />

--- a/packages/insomnia-app/app/ui/css/components/sidebar.less
+++ b/packages/insomnia-app/app/ui/css/components/sidebar.less
@@ -50,6 +50,11 @@
     h1 * {
       font-size: var(--font-size-xl);
     }
+
+    .dropdown__id {
+      font-size: var(--font-size-md);
+      font-style: italic;
+    }
   }
 
   // ~~~~~~~~~~~~~~~ //


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Closes #2561 

<img width="758" alt="Captura de Pantalla 2020-10-18 a la(s) 11 03 45" src="https://user-images.githubusercontent.com/12776211/96369681-cfa99800-1131-11eb-97d1-c98b619e6982.png">

I've added workspace id to the sidebar title and sidebar dropdown cutting it off to 8 digits to keep the UI as clean as possible but let me know if you think there is a better way to achieve this.
