### PR TITLE
Fix Copy as CURL with Multipart

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/har.test.js
+++ b/packages/insomnia-app/app/common/__tests__/har.test.js
@@ -372,4 +372,58 @@ describe('exportHarWithRequest()', () => {
       settingEncodeUrl: true,
     });
   });
+
+  it('export multipart request with file', async () => {
+    const workspace = await models.workspace.create();
+    const request = Object.assign(models.request.init(), {
+      _id: 'req_123',
+      parentId: workspace._id,
+      headers: [{ name: 'Content-Type', value: 'multipart/form-data' }],
+      parameters: [],
+      method: 'POST',
+      body: {
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: 'a_file', value: '', fileName: '/tmp/my_file', type: 'file' },
+          { name: 'a_simple_field', value: 'a_simple_value' },
+          { name: 'a_second_file', value: '', fileName: '/tmp/my_file_2', type: 'file' },
+        ],
+      },
+      url: 'http://example.com/post',
+      authentication: {},
+    });
+
+    const renderedRequest = await render.getRenderedRequest(request);
+    const har = await harUtils.exportHarWithRequest(renderedRequest);
+
+    expect(har).toEqual({
+      bodySize: -1,
+      cookies: [],
+      headers: [{ name: 'Content-Type', value: 'multipart/form-data' }],
+      headersSize: -1,
+      httpVersion: 'HTTP/1.1',
+      method: 'POST',
+      postData: {
+        mimeType: 'multipart/form-data',
+        params: [
+          {
+            name: 'a_file',
+            fileName: '/tmp/my_file',
+          },
+          {
+            name: 'a_simple_field',
+            value: 'a_simple_value',
+          },
+          {
+            name: 'a_second_file',
+            fileName: '/tmp/my_file_2',
+          },
+        ],
+        text: '',
+      },
+      queryString: [],
+      url: 'http://example.com/post',
+      settingEncodeUrl: true,
+    });
+  });
 });

--- a/packages/insomnia-app/app/common/har.js
+++ b/packages/insomnia-app/app/common/har.js
@@ -489,6 +489,13 @@ function getRequestPostData(renderedRequest: RenderedRequest): HarPostData | voi
   let params = [];
   if (body.params) {
     params = body.params.map(param => {
+      if (param.type === 'file') {
+        return {
+          name: param.name,
+          fileName: param.fileName,
+        };
+      }
+
       return {
         name: param.name,
         value: param.value,


### PR DESCRIPTION
The issue was located in the `exportHar` function. It was not handled `file` param correctly.
For this type of file, the `value` attribute is empty. Therefore we should take instead of the `fileName`

The issue also impacted the `Generate code` feature.

Closes #2282

**Before**

```
curl --request POST \
  --url http://localhost:3000/multipart \
  --header 'Content-Type: multipart/form-data' \
  --header 'content-type: multipart/form-data; boundary=---011000010111000001101001' \
  --form my_file=\
  --form my_field=my_value
```

**After**

```
curl --request POST \
  --url http://localhost:3000/multipart \
  --header 'Content-Type: multipart/form-data' \
  --header 'content-type: multipart/form-data; boundary=---011000010111000001101001' \
  --form my_second_file=@/Users/jgiovaresco/Documents/AFTER.gif \
  --form my_first_file=@/Users/jgiovaresco/Documents/Untitled \
  --form 'a_simple_value=my value'
```
