### PR TITLE
fix: disable link when plugin has not modules

### DIFF
--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -197,9 +197,10 @@ class Plugins extends React.PureComponent<Props, State> {
 
     const base = /^insomnia-plugin-/.test(name) ? PLUGIN_HUB_BASE : NPM_PACKAGE_BASE;
     const link = path.join(base, name);
+    const disabled = Object.keys(plugin.module).length === 0;
 
     return (
-      <a className="space-left" href={link} title={link}>
+      <a className={`space-left ${disabled ? 'disabled' : ''}`} href={link} title={link}>
         <i className="fa fa-external-link-square" />
       </a>
     );

--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -197,10 +197,12 @@ class Plugins extends React.PureComponent<Props, State> {
 
     const base = /^insomnia-plugin-/.test(name) ? PLUGIN_HUB_BASE : NPM_PACKAGE_BASE;
     const link = path.join(base, name);
-    const disabled = Object.keys(plugin.module).length === 0;
+
+    // Don't render link to doc when has not modules.
+    if (Object.keys(plugin.module).length === 0) return null;
 
     return (
-      <a className={`space-left ${disabled ? 'disabled' : ''}`} href={link} title={link}>
+      <a className="space-left" href={link} title={link}>
         <i className="fa fa-external-link-square" />
       </a>
     );

--- a/packages/insomnia-app/app/ui/css/components/links.less
+++ b/packages/insomnia-app/app/ui/css/components/links.less
@@ -9,4 +9,9 @@ a {
   &:hover {
     text-decoration: underline;
   }
+
+  &.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
 }

--- a/packages/insomnia-app/app/ui/css/components/links.less
+++ b/packages/insomnia-app/app/ui/css/components/links.less
@@ -9,9 +9,4 @@ a {
   &:hover {
     text-decoration: underline;
   }
-
-  &.disabled {
-    opacity: 0.5;
-    pointer-events: none;
-  }
 }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

Closes #2579 

<img width="800" alt="Captura de Pantalla 2020-10-19 a la(s) 17 41 50" src="https://user-images.githubusercontent.com/12776211/96509554-93aa2c00-1232-11eb-9139-6e9d53b8cab7.png">

I've validated by empty modules but let me know If this is not correct.