### PR TITLE
Reloading GraphQL docs on schema reload

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
@@ -544,6 +544,7 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
       automaticFetch,
       activeReference,
       explorerVisible,
+      schemaLastFetchTime,
     } = this.state;
 
     const { query, variables: variablesObject } = GraphQLEditor._stringToGraphQL(content);
@@ -556,6 +557,7 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
     const graphQLExplorerPortal = ReactDOM.createPortal(
       <GraphqlExplorer
         schema={schema}
+        key={schemaLastFetchTime}
         visible={explorerVisible}
         reference={activeReference}
         handleClose={this._handleCloseExplorer}


### PR DESCRIPTION
#1966 states that the GraphQL docs are not being properly reloaded on a schema reload. Well with this PR the entire docs component would be reloaded on a schema reload.
![schemaReload](https://user-images.githubusercontent.com/28495651/96519662-7d549e00-123b-11eb-9c43-b013341cd48a.gif)

