### PR TITLE
Modal prompt to select protofile

### DIFF
--- a/packages/insomnia-app/app/models/proto-file.js
+++ b/packages/insomnia-app/app/models/proto-file.js
@@ -46,8 +46,8 @@ export function getById(_id: string): Promise<ProtoFile | null> {
   return db.getWhere(type, { _id });
 }
 
-export function getByParentId(parentId: string): Promise<ProtoFile | null> {
-  return db.getWhere(type, { parentId });
+export function findByParentId(parentId: string): Promise<Array<ProtoFile>> {
+  return db.find(type, { parentId });
 }
 
 export function all(): Promise<Array<ProtoFile>> {

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -21,7 +21,7 @@ type State = {|
 
 type ProtoFilesModalOptions = {|
   preselectProtoFileId?: string,
-  onSave?: string => Promise<void>,
+  onSave: string => Promise<void>,
 |};
 
 const INITIAL_STATE: State = {
@@ -46,7 +46,7 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
   }
 
   async show(options: ProtoFilesModalOptions) {
-    this.onSave = options.onSave || null;
+    this.onSave = options.onSave;
     this.setState({ ...INITIAL_STATE });
 
     this.modal && this.modal.show();

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -86,9 +86,9 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
     this.setState({ selectedProtoFileId: id });
   }
 
-  _handleDelete(id: string) {
+  _handleDelete(protoFile: ProtoFile) {
     // TODO: to be built in INS-209
-    console.log(`delete ${id}`);
+    console.log(`delete ${protoFile._id}`);
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -1,0 +1,119 @@
+// @flow
+import * as React from 'react';
+import * as models from '../../../models';
+import type { ProtoFile } from '../../../models/proto-file';
+import ModalHeader from '../base/modal-header';
+import ModalBody from '../base/modal-body';
+import ModalFooter from '../base/modal-footer';
+import autobind from 'autobind-decorator';
+import { ListGroup, ListGroupItem } from 'insomnia-components';
+import type { Workspace } from '../../../models/workspace';
+import styled from 'styled-components';
+
+type Props = {|
+  workspace: Workspace,
+|};
+
+type State = {|
+  protoFiles: Array<ProtoFile>,
+  selectedProtoFileId: string,
+|};
+
+type ProtoFilesModalOptions = {|
+  preselectProtoFileId?: string,
+  onSave?: string => void,
+|};
+
+const SelectableListItem: React.PureComponent<{ selected?: boolean }> = styled(ListGroupItem)`
+  &:hover {
+    background-color: var(--hl-sm) !important;
+  }
+
+  background-color: ${props => props.selected && 'var(--hl-sm) !important'};
+`;
+
+@autobind
+class ProtoFilesModal extends React.PureComponent<Props, State> {
+  modal: Modal | null;
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      protoFiles: [],
+      selectedProtoFileId: '',
+    };
+  }
+
+  _setModalRef(n: React.Component<*> | null) {
+    this.modal = n;
+  }
+
+  async show(options: ProtoFilesModalOptions) {
+    this.onSave = options.onSave || null;
+    this.setState({ selectedProtoFileId: options.preselectProtoFileId });
+
+    this.modal && this.modal.show();
+    await this._refresh(options.preselectProtoFileId);
+  }
+
+  async _refresh(preselectProtoFileId?: string) {
+    const { workspaceId } = this.props;
+    const protofilesForWorkspace = await models.protoFile.findByParentId(workspaceId);
+
+    this.setState({ protoFiles: protofilesForWorkspace });
+  }
+
+  async _handleSave() {
+    this.hide();
+
+    if (typeof this.onSave === 'function') {
+      this.onSave(this.state.selectedProtoFileId);
+    }
+  }
+
+  hide() {
+    this.modal && this.modal.hide();
+  }
+
+  renderProtofile(p: ProtoFile) {
+    const { selectedProtoFileId } = this.state;
+
+    return (
+      <SelectableListItem key={p._id} selected={p._id === selectedProtoFileId}>
+        <div className="row-spaced">
+          {p.name}
+          <div>Delete</div>
+        </div>
+      </SelectableListItem>
+    );
+  }
+
+  render() {
+    const { protoFiles } = this.state;
+
+    return (
+      <Modal ref={this._setModalRef}>
+        <ModalHeader>Select Protofile</ModalHeader>
+        <ModalBody className="wide pad">
+          Files
+          <ListGroup>
+            {!protoFiles.length && (
+              <ListGroupItem>No proto files exist for this workspace</ListGroupItem>
+            )}
+            {protoFiles.map(this.renderProtofile)}
+          </ListGroup>
+        </ModalBody>
+        <ModalFooter>
+          <div>
+            <button className="btn" onClick={this._handleSave}>
+              Save
+            </button>
+          </div>
+        </ModalFooter>
+      </Modal>
+    );
+  }
+}
+
+export default ProtoFilesModal;

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -8,7 +8,7 @@ import ModalFooter from '../base/modal-footer';
 import autobind from 'autobind-decorator';
 import type { Workspace } from '../../../models/workspace';
 import Modal from '../base/modal';
-import ProtoFileList from '../proto-file-list';
+import ProtoFileList from '../proto-file/proto-file-list';
 
 type Props = {|
   workspace: Workspace,

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -6,11 +6,9 @@ import ModalHeader from '../base/modal-header';
 import ModalBody from '../base/modal-body';
 import ModalFooter from '../base/modal-footer';
 import autobind from 'autobind-decorator';
-import { ListGroup, ListGroupItem } from 'insomnia-components';
 import type { Workspace } from '../../../models/workspace';
-import styled from 'styled-components';
 import Modal from '../base/modal';
-import PromptButton from '../base/prompt-button';
+import ProtoFileList from '../proto-file-list';
 
 type Props = {|
   workspace: Workspace,
@@ -25,50 +23,6 @@ type ProtoFilesModalOptions = {|
   preselectProtoFileId?: string,
   onSave?: string => Promise<void>,
 |};
-
-const SelectableListItem: React.PureComponent<{ selected?: boolean }> = styled(ListGroupItem)`
-  &:hover {
-    background-color: var(--hl-sm) !important;
-  }
-
-  background-color: ${props => props.selected && 'var(--hl-sm) !important'};
-`;
-
-const ProtoFileListItem = (props: {
-  protoFile: ProtoFile,
-  selected?: boolean,
-  onClick: (id: string) => void,
-  onDelete: (id: string) => Promise<void>,
-  onRename: (id: string, name: string) => Promise<void>,
-}) => {
-  const { protoFile, selected, onClick, onDelete } = props;
-  const { name, _id } = protoFile;
-
-  const onClickCallback = React.useCallback(() => onClick(_id), [onClick, _id]);
-  const onDeleteCallback = React.useCallback(
-    async (e: SyntheticEvent<HTMLButtonElement>) => {
-      e.stopPropagation();
-      await onDelete(_id);
-    },
-    [onDelete, _id],
-  );
-
-  return (
-    <SelectableListItem selected={selected} onClick={onClickCallback}>
-      <div className="row-spaced">
-        {name}
-        <PromptButton
-          className="btn btn--super-compact btn--outlined"
-          addIcon
-          confirmMessage=""
-          onClick={onDeleteCallback}
-          title="Delete Proto File">
-          <i className="fa fa-trash-o" />
-        </PromptButton>
-      </div>
-    </SelectableListItem>
-  );
-};
 
 const INITIAL_STATE: State = {
   protoFiles: [],
@@ -128,19 +82,13 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
     this.modal && this.modal.hide();
   }
 
-  renderProtofile(p: ProtoFile) {
-    const { selectedProtoFileId } = this.state;
+  _handleSelect(id: string) {
+    this.setState({ selectedProtoFileId: id });
+  }
 
-    return (
-      <ProtoFileListItem
-        key={p.id}
-        protoFile={p}
-        selected={p._id === selectedProtoFileId}
-        onClick={id => this.setState({ selectedProtoFileId: id })}
-        onDelete={id => console.log(`delete ${id}`)}
-        onRename={id => console.log(`rename ${id}`)}
-      />
-    );
+  _handleDelete(id: string) {
+    // TODO: to be built in INS-209
+    console.log(`delete ${id}`);
   }
 
   render() {
@@ -151,12 +99,12 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
         <ModalHeader>Select Protofile</ModalHeader>
         <ModalBody className="wide pad">
           Files
-          <ListGroup>
-            {!protoFiles.length && (
-              <ListGroupItem>No proto files exist for this workspace</ListGroupItem>
-            )}
-            {protoFiles.map(this.renderProtofile)}
-          </ListGroup>
+          <ProtoFileList
+            protoFiles={protoFiles}
+            selectedId={selectedProtoFileId}
+            handleSelect={this._handleSelect}
+            handleDelete={this._handleDelete}
+          />
         </ModalBody>
         <ModalFooter>
           <div>

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -144,7 +144,7 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { protoFiles } = this.state;
+    const { protoFiles, selectedProtoFileId } = this.state;
 
     return (
       <Modal ref={this._setModalRef}>
@@ -160,7 +160,7 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
         </ModalBody>
         <ModalFooter>
           <div>
-            <button className="btn" onClick={this._handleSave}>
+            <button className="btn" onClick={this._handleSave} disabled={!selectedProtoFileId}>
               Save
             </button>
           </div>

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -54,8 +54,8 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
   }
 
   async _refresh(preselectProtoFileId?: string) {
-    const { workspaceId } = this.props;
-    const protoFilesForWorkspace = await models.protoFile.findByParentId(workspaceId);
+    const { workspace } = this.props;
+    const protoFilesForWorkspace = await models.protoFile.findByParentId(workspace._id);
 
     protoFilesForWorkspace.push(
       { _id: 'pf_123', name: 'File 1' },

--- a/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
@@ -17,7 +17,8 @@ import {
 } from '../../../common/constants';
 import * as models from '../../../models/index';
 import { trackEvent } from '../../../common/analytics';
-import { showAlert } from './index';
+import { showModal } from './index';
+import ProtoFilesModal from './proto-files-modal';
 
 type RequestCreateModalOptions = {
   parentId: string,
@@ -54,13 +55,15 @@ class RequestCreateModal extends PureComponent {
     const { parentId, selectedContentType, selectedMethod } = this.state;
     const requestName = this._input.value;
     if (selectedMethod === METHOD_GRPC) {
-      // TODO: Create new grpc request with the name - INS-198
+      showModal(ProtoFilesModal, {
+        onSave: async protofileId => {
+          // TODO: Create new grpc request with the name and selected proto file - INS-198
+          console.log(`Create request name: [${requestName}], and protofileId: [${protofileId}]`);
 
-      const id = 'gr_123';
-      this._onComplete(id);
-
-      // TODO: Show protofile selection modal - INS-188
-      showAlert({ title: 'Select protofile', message: 'To be built', okLabel: 'ok' });
+          const createdRequestId = 'gr_123';
+          this._onComplete(createdRequestId);
+        },
+      });
     } else {
       const request = await models.initModel(models.request.type, {
         parentId,

--- a/packages/insomnia-app/app/ui/components/proto-file-list.js
+++ b/packages/insomnia-app/app/ui/components/proto-file-list.js
@@ -1,0 +1,77 @@
+// @flow
+import React from 'react';
+import type { ProtoFile } from '../../models/proto-file';
+import styled from 'styled-components';
+import { ListGroup, ListGroupItem } from 'insomnia-components';
+import PromptButton from './base/prompt-button';
+
+type SelectProtoFileHandler = (id: string) => void;
+type DeleteProtoFileHandler = (id: string) => Promise<void>;
+
+type Props = {
+  protoFiles: Array<ProtoFile>,
+  selectedId?: string,
+  handleSelect: SelectProtoFileHandler,
+  handleDelete: DeleteProtoFileHandler,
+};
+
+const SelectableListItem: React.PureComponent<{ isSelected?: boolean }> = styled(ListGroupItem)`
+  &:hover {
+    background-color: var(--hl-sm) !important;
+  }
+
+  background-color: ${({ isSelected }) => isSelected && 'var(--hl-sm) !important'};
+`;
+
+const ProtoFileListItem = (props: {
+  protoFile: ProtoFile,
+  isSelected?: boolean,
+  handleSelect: SelectProtoFileHandler,
+  handleDelete: DeleteProtoFileHandler,
+}) => {
+  const { protoFile, isSelected, handleSelect, handleDelete } = props;
+  const { name, _id } = protoFile;
+
+  // Don't re-instantiate the callbacks if the dependencies have not changed
+  const handleSelectCallback = React.useCallback(() => handleSelect(_id), [handleSelect, _id]);
+  const handleDeleteCallback = React.useCallback(
+    async (e: SyntheticEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      await handleDelete(_id);
+    },
+    [handleDelete, _id],
+  );
+
+  return (
+    <SelectableListItem isSelected={isSelected} onClick={handleSelectCallback}>
+      <div className="row-spaced">
+        {name}
+        <PromptButton
+          className="btn btn--super-compact btn--outlined"
+          addIcon
+          confirmMessage=""
+          onClick={handleDeleteCallback}
+          title="Delete Proto File">
+          <i className="fa fa-trash-o" />
+        </PromptButton>
+      </div>
+    </SelectableListItem>
+  );
+};
+
+const ProtoFileList = ({ protoFiles, selectedId, handleSelect, handleDelete }: Props) => (
+  <ListGroup>
+    {!protoFiles.length && <ListGroupItem>No proto files exist for this workspace</ListGroupItem>}
+    {protoFiles.map(p => (
+      <ProtoFileListItem
+        key={p.id}
+        protoFile={p}
+        isSelected={p._id === selectedId}
+        handleSelect={handleSelect}
+        handleDelete={handleDelete}
+      />
+    ))}
+  </ListGroup>
+);
+
+export default ProtoFileList;

--- a/packages/insomnia-app/app/ui/components/proto-file/proto-file-list-item.js
+++ b/packages/insomnia-app/app/ui/components/proto-file/proto-file-list-item.js
@@ -1,16 +1,14 @@
 // @flow
 import React from 'react';
-import type { ProtoFile } from '../../models/proto-file';
 import styled from 'styled-components';
-import { ListGroup, ListGroupItem } from 'insomnia-components';
-import PromptButton from './base/prompt-button';
-
-type SelectProtoFileHandler = (id: string) => void;
-type DeleteProtoFileHandler = (id: string) => Promise<void>;
+import type { ProtoFile } from '../../../models/proto-file';
+import PromptButton from '../base/prompt-button';
+import type { DeleteProtoFileHandler, SelectProtoFileHandler } from './proto-file-list';
+import { ListGroupItem } from '../../../../../insomnia-components';
 
 type Props = {
-  protoFiles: Array<ProtoFile>,
-  selectedId?: string,
+  protoFile: ProtoFile,
+  isSelected?: boolean,
   handleSelect: SelectProtoFileHandler,
   handleDelete: DeleteProtoFileHandler,
 };
@@ -23,13 +21,7 @@ const SelectableListItem: React.PureComponent<{ isSelected?: boolean }> = styled
   background-color: ${({ isSelected }) => isSelected && 'var(--hl-sm) !important'};
 `;
 
-const ProtoFileListItem = (props: {
-  protoFile: ProtoFile,
-  isSelected?: boolean,
-  handleSelect: SelectProtoFileHandler,
-  handleDelete: DeleteProtoFileHandler,
-}) => {
-  const { protoFile, isSelected, handleSelect, handleDelete } = props;
+const ProtoFileListItem = ({ protoFile, isSelected, handleSelect, handleDelete }: Props) => {
   const { name, _id } = protoFile;
 
   // Don't re-instantiate the callbacks if the dependencies have not changed
@@ -59,19 +51,4 @@ const ProtoFileListItem = (props: {
   );
 };
 
-const ProtoFileList = ({ protoFiles, selectedId, handleSelect, handleDelete }: Props) => (
-  <ListGroup>
-    {!protoFiles.length && <ListGroupItem>No proto files exist for this workspace</ListGroupItem>}
-    {protoFiles.map(p => (
-      <ProtoFileListItem
-        key={p.id}
-        protoFile={p}
-        isSelected={p._id === selectedId}
-        handleSelect={handleSelect}
-        handleDelete={handleDelete}
-      />
-    ))}
-  </ListGroup>
-);
-
-export default ProtoFileList;
+export default ProtoFileListItem;

--- a/packages/insomnia-app/app/ui/components/proto-file/proto-file-list-item.js
+++ b/packages/insomnia-app/app/ui/components/proto-file/proto-file-list-item.js
@@ -29,9 +29,9 @@ const ProtoFileListItem = ({ protoFile, isSelected, handleSelect, handleDelete }
   const handleDeleteCallback = React.useCallback(
     async (e: SyntheticEvent<HTMLButtonElement>) => {
       e.stopPropagation();
-      await handleDelete(_id);
+      await handleDelete(protoFile);
     },
-    [handleDelete, _id],
+    [handleDelete, protoFile],
   );
 
   return (

--- a/packages/insomnia-app/app/ui/components/proto-file/proto-file-list.js
+++ b/packages/insomnia-app/app/ui/components/proto-file/proto-file-list.js
@@ -5,7 +5,7 @@ import { ListGroup, ListGroupItem } from 'insomnia-components';
 import ProtoFileListItem from './proto-file-list-item';
 
 export type SelectProtoFileHandler = (id: string) => void;
-export type DeleteProtoFileHandler = (id: string) => Promise<void>;
+export type DeleteProtoFileHandler = (protofile: ProtoFile) => Promise<void>;
 
 type Props = {
   protoFiles: Array<ProtoFile>,

--- a/packages/insomnia-app/app/ui/components/proto-file/proto-file-list.js
+++ b/packages/insomnia-app/app/ui/components/proto-file/proto-file-list.js
@@ -1,0 +1,32 @@
+// @flow
+import React from 'react';
+import type { ProtoFile } from '../../../models/proto-file';
+import { ListGroup, ListGroupItem } from 'insomnia-components';
+import ProtoFileListItem from './proto-file-list-item';
+
+export type SelectProtoFileHandler = (id: string) => void;
+export type DeleteProtoFileHandler = (id: string) => Promise<void>;
+
+type Props = {
+  protoFiles: Array<ProtoFile>,
+  selectedId?: string,
+  handleSelect: SelectProtoFileHandler,
+  handleDelete: DeleteProtoFileHandler,
+};
+
+const ProtoFileList = ({ protoFiles, selectedId, handleSelect, handleDelete }: Props) => (
+  <ListGroup>
+    {!protoFiles.length && <ListGroupItem>No proto files exist for this workspace</ListGroupItem>}
+    {protoFiles.map(p => (
+      <ProtoFileListItem
+        key={p.id}
+        protoFile={p}
+        isSelected={p._id === selectedId}
+        handleSelect={handleSelect}
+        handleDelete={handleDelete}
+      />
+    ))}
+  </ListGroup>
+);
+
+export default ProtoFileList;

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -90,6 +90,7 @@ import {
   getAppName,
 } from '../../common/constants';
 import { Spectral } from '@stoplight/spectral';
+import ProtoFilesModal from './modals/proto-files-modal';
 
 const spectral = new Spectral();
 
@@ -770,6 +771,8 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
               childObjects={sidebarChildren.all}
               handleExportRequestsToFile={handleExportRequestsToFile}
             />
+
+            <ProtoFilesModal ref={registerModal} workspace={activeWorkspace} />
           </ErrorBoundary>
         </div>
         <React.Fragment key={`views::${this.state.activeGitBranch}`}>


### PR DESCRIPTION
This PR adds the ability to show protofiles uploaded for a particular workspace (but uses dummy data, because the functionality to _upload_ a protofile comes in a subsequent PR).

Logic to handle an empty state:
![image](https://user-images.githubusercontent.com/4312346/96677297-cc313d80-13cb-11eb-89f7-85ccdef46c9d.png)

Save button is disabled when no item is selected:
![image](https://user-images.githubusercontent.com/4312346/96677183-8e341980-13cb-11eb-958a-d891a2323ddd.png)

And enabled once an item _is_ selected:
![image](https://user-images.githubusercontent.com/4312346/96677265-b754aa00-13cb-11eb-8446-d0da71dc24dc.png)

The requestName and selected protofileId is available in the same place after clicking save
![image](https://user-images.githubusercontent.com/4312346/96677493-3518b580-13cc-11eb-825e-3c403d941881.png)