### PR TITLE
Add file selector to upload a .proto file

### DIFF
--- a/packages/insomnia-app/app/ui/components/base/file-input-button.js
+++ b/packages/insomnia-app/app/ui/components/base/file-input-button.js
@@ -6,10 +6,10 @@ import { remote } from 'electron';
 
 type Props = {
   // Required
-  onChange: Function,
-  path: string,
+  onChange: (path: string) => void,
 
   // Optional
+  path?: string,
   itemtypes?: Array<string>,
   extensions?: Array<string>,
   showFileName?: boolean,

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -9,7 +9,6 @@ import autobind from 'autobind-decorator';
 import type { Workspace } from '../../../models/workspace';
 import Modal from '../base/modal';
 import ProtoFileList from '../proto-file/proto-file-list';
-import PromptButton from '../base/prompt-button';
 import FileInputButton from '../base/file-input-button';
 import { showError } from './index';
 import fs from 'fs';

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -12,6 +12,8 @@ import ProtoFileList from '../proto-file/proto-file-list';
 import PromptButton from '../base/prompt-button';
 import FileInputButton from '../base/file-input-button';
 import { showError } from './index';
+import fs from 'fs';
+import path from 'path';
 
 type Props = {|
   workspace: Workspace,
@@ -85,11 +87,14 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
     console.log(`delete ${protoFile._id}`);
   }
 
-  async _handleProtoFileUpload(path: string) {
+  async _handleProtoFileUpload(filePath: string) {
     const { workspace } = this.props;
 
     try {
-      await models.protoFile.create({ name: path, parentId: workspace._id });
+      const protoText = fs.readFileSync(filePath, 'utf-8');
+      const name = path.basename(filePath);
+      const newFile = await models.protoFile.create({ name, parentId: workspace._id, protoText });
+      this.setState({ selectedProtoFileId: newFile._id });
       await this._refresh();
     } catch (e) {
       showError({ error: e });
@@ -106,6 +111,8 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
           <div className="row-spaced">
             Files
             <FileInputButton
+              name=".proto file"
+              showFileIcon
               extensions={['.proto']}
               className="btn btn--clicky"
               onChange={this._handleProtoFileUpload}

--- a/packages/insomnia-app/app/ui/redux/modules/entities.js
+++ b/packages/insomnia-app/app/ui/redux/modules/entities.js
@@ -118,5 +118,6 @@ export async function allDocs() {
     ...(await models.unitTestSuite.all()),
     ...(await models.unitTest.all()),
     ...(await models.unitTestResult.all()),
+    ...(await models.protoFile.all()),
   ];
 }


### PR DESCRIPTION
- The file select dialog is filtered to `.proto` files
- The last uploaded file gets automatically selected (indicated by the background)
- The upload button text needs to be changed (by extending the `FileUploadButton` component), and I have opted to not do that until UI refinement

![2020-10-21 18 19 22](https://user-images.githubusercontent.com/4312346/96676644-4a8ce000-13ca-11eb-9257-00ecc11428b9.gif)


