### PR TITLE
Fetch workspace protofiles from redux instead of refreshing after every action

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -16,10 +16,10 @@ import path from 'path';
 
 type Props = {|
   workspace: Workspace,
+  protoFiles: Array<ProtoFile>,
 |};
 
 type State = {|
-  protoFiles: Array<ProtoFile>,
   selectedProtoFileId: string,
 |};
 
@@ -29,7 +29,6 @@ type ProtoFilesModalOptions = {|
 |};
 
 const INITIAL_STATE: State = {
-  protoFiles: [],
   selectedProtoFileId: '',
 };
 
@@ -51,17 +50,9 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
 
   async show(options: ProtoFilesModalOptions) {
     this.onSave = options.onSave;
-    this.setState({ ...INITIAL_STATE, selectedProtoFileId: options.preselectProtoFileId });
+    this.setState({ selectedProtoFileId: options.preselectProtoFileId });
 
     this.modal && this.modal.show();
-    await this._refresh();
-  }
-
-  async _refresh() {
-    const { workspace } = this.props;
-    const protoFilesForWorkspace = await models.protoFile.findByParentId(workspace._id);
-
-    this.setState({ protoFiles: protoFilesForWorkspace });
   }
 
   async _handleSave(e: SyntheticEvent<HTMLButtonElement>) {
@@ -94,7 +85,6 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
       const name = path.basename(filePath);
       const newFile = await models.protoFile.create({ name, parentId: workspace._id, protoText });
       this.setState({ selectedProtoFileId: newFile._id });
-      await this._refresh();
     } catch (e) {
       showError({ error: e });
     }
@@ -102,11 +92,11 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
 
   async _handleRename(protoFile: ProtoFile, name: string): Promise<void> {
     await models.protoFile.update(protoFile, { name });
-    await this._refresh();
   }
 
   render() {
-    const { protoFiles, selectedProtoFileId } = this.state;
+    const { protoFiles } = this.props;
+    const { selectedProtoFileId } = this.state;
 
     return (
       <Modal ref={this._setModalRef}>

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -182,6 +182,7 @@ export type WrapperProps = {
   activeCookieJar: CookieJar,
   activeEnvironment: Environment | null,
   activeGitRepository: GitRepository | null,
+  activeProtoFiles: Array<ProtoFile>,
   activeUnitTestResult: UnitTestResult | null,
   activeUnitTestSuites: Array<UnitTestSuite>,
   activeUnitTests: Array<UnitTest>,
@@ -520,6 +521,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
       activeCookieJar,
       activeEnvironment,
       activeGitRepository,
+      activeProtoFiles,
       activeRequest,
       activeWorkspace,
       activeWorkspaceClientCertificates,
@@ -772,7 +774,11 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
               handleExportRequestsToFile={handleExportRequestsToFile}
             />
 
-            <ProtoFilesModal ref={registerModal} workspace={activeWorkspace} />
+            <ProtoFilesModal
+              ref={registerModal}
+              workspace={activeWorkspace}
+              protoFiles={activeProtoFiles}
+            />
           </ErrorBoundary>
         </div>
         <React.Fragment key={`views::${this.state.activeGitBranch}`}>

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -39,6 +39,7 @@ import {
   selectActiveCookieJar,
   selectActiveGitRepository,
   selectActiveOAuth2Token,
+  selectActiveProtoFiles,
   selectActiveRequest,
   selectActiveRequestMeta,
   selectActiveRequestResponses,
@@ -1447,12 +1448,16 @@ function mapStateToProps(state, props) {
   const activeUnitTestSuites = selectActiveUnitTestSuites(state, props);
   const activeUnitTestResult = selectActiveUnitTestResult(state, props);
 
+  // Proto file stuff
+  const activeProtoFiles = selectActiveProtoFiles(state, props);
+
   return Object.assign({}, state, {
     activity: activeActivity,
     activeApiSpec,
     activeCookieJar,
     activeEnvironment,
     activeGitRepository,
+    activeProtoFiles,
     activeRequest,
     activeRequestResponses,
     activeResponse,

--- a/packages/insomnia-app/app/ui/redux/selectors.js
+++ b/packages/insomnia-app/app/ui/redux/selectors.js
@@ -249,6 +249,14 @@ export const selectActiveRequest = createSelector(
   },
 );
 
+export const selectActiveProtoFiles = createSelector(
+  selectEntitiesLists,
+  selectActiveWorkspace,
+  (entities, workspace) => {
+    return entities.protoFiles.filter(pf => pf.parentId === workspace._id);
+  },
+);
+
 export const selectActiveCookieJar = createSelector(
   selectEntitiesLists,
   selectActiveWorkspace,


### PR DESCRIPTION
Demo shows protofiles are correctly scoped between workspaces

![2020-10-22 17 08 06](https://user-images.githubusercontent.com/4312346/96823655-6905e080-1489-11eb-887b-b40421182814.gif)
