### PR TITLE
Add specification linting for files

### DIFF
--- a/packages/insomnia-inso/src/commands/__fixtures__/openapi-spec.yaml
+++ b/packages/insomnia-inso/src/commands/__fixtures__/openapi-spec.yaml
@@ -1,0 +1,21 @@
+openapi: '3.0.2'
+info:
+  title: Sample Spec
+  version: '1.2'
+servers:
+  - url: https://200.insomnia.rest
+tags:
+  - name: Folder
+paths:
+  /global:
+    get:
+      tags:
+        - Folder
+      responses:
+        '200':
+          description: OK
+  /override:
+    get:
+      responses:
+        '200':
+          description: OK

--- a/packages/insomnia-inso/src/commands/__tests__/lint-specification.test.js
+++ b/packages/insomnia-inso/src/commands/__tests__/lint-specification.test.js
@@ -25,33 +25,24 @@ describe('lint specification', () => {
   });
 
   it('should lint specification from file with relative path', async () => {
-    const result = await lintSpecification(
-      '.insomnia/ApiSpec/spc_46c5a4a40e83445a9bd9d9758b86c16c.yml',
-      {
-        workingDir: 'src/db/__fixtures__/git-repo',
-      },
-    );
+    const result = await lintSpecification('openapi-spec.yaml', {
+      workingDir: 'src/commands/__fixtures__',
+    });
 
     expect(result).toBe(true);
   });
 
   it('should lint specification from file with relative path and no working directory', async () => {
-    const result = await lintSpecification(
-      'src/db/__fixtures__/git-repo/.insomnia/ApiSpec/spc_46c5a4a40e83445a9bd9d9758b86c16c.yml',
-      {},
-    );
+    const result = await lintSpecification('src/commands/__fixtures__/openapi-spec.yaml', {});
 
     expect(result).toBe(true);
   });
 
   it('should lint specification from file with absolute path', async () => {
-    const directory = path.join(process.cwd(), '/src/db/__fixtures__/git-repo/');
-    const result = await lintSpecification(
-      path.join(directory, '.insomnia/ApiSpec/spc_46c5a4a40e83445a9bd9d9758b86c16c.yml'),
-      {
-        workingDir: 'src/db/__fixtures__/git-repo',
-      },
-    );
+    const directory = path.join(process.cwd(), 'src/commands/__fixtures__');
+    const result = await lintSpecification(path.join(directory, 'openapi-spec.yaml'), {
+      workingDir: 'src',
+    });
 
     expect(result).toBe(true);
   });
@@ -65,22 +56,18 @@ describe('lint specification', () => {
   });
 
   it('should return false if spec could not be found', async () => {
-    const result = await lintSpecification('not-found', {
-      workingDir: 'src/db/__fixtures__/git-repo',
-    });
+    const result = await lintSpecification('not-found', {});
+
+    expect(result).toBe(false);
+    const logs = logger.__getLogs();
+    expect(logs.fatal).toContain('Failed to read "not-found"');
+  });
+
+  it('should return false if spec was not specified', async () => {
+    const result = await lintSpecification('', {});
 
     expect(result).toBe(false);
     const logs = logger.__getLogs();
     expect(logs.fatal).toContain('Specification not found.');
-  });
-
-  it('should return false if spec was not specified', async () => {
-    const result = await lintSpecification('', {
-      workingDir: 'src/db/__fixtures__/git-repo',
-    });
-
-    expect(result).toBe(false);
-    const logs = logger.__getLogs();
-    expect(logs.fatal).toContain('Invalid specification.');
   });
 });

--- a/packages/insomnia-inso/src/commands/__tests__/lint-specification.test.js
+++ b/packages/insomnia-inso/src/commands/__tests__/lint-specification.test.js
@@ -1,4 +1,5 @@
 // @flow
+import path from 'path';
 import { lintSpecification } from '../lint-specification';
 import { globalBeforeAll, globalBeforeEach } from '../../../__jest__/before';
 import logger from '../../logger';
@@ -23,6 +24,38 @@ describe('lint specification', () => {
     expect(result).toBe(true);
   });
 
+  it('should lint specification from file with relative path', async () => {
+    const result = await lintSpecification(
+      '.insomnia/ApiSpec/spc_46c5a4a40e83445a9bd9d9758b86c16c.yml',
+      {
+        workingDir: 'src/db/__fixtures__/git-repo',
+      },
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('should lint specification from file with relative path and no working directory', async () => {
+    const result = await lintSpecification(
+      'src/db/__fixtures__/git-repo/.insomnia/ApiSpec/spc_46c5a4a40e83445a9bd9d9758b86c16c.yml',
+      {},
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('should lint specification from file with absolute path', async () => {
+    const directory = path.join(process.cwd(), '/src/db/__fixtures__/git-repo/');
+    const result = await lintSpecification(
+      path.join(directory, '.insomnia/ApiSpec/spc_46c5a4a40e83445a9bd9d9758b86c16c.yml'),
+      {
+        workingDir: 'src/db/__fixtures__/git-repo',
+      },
+    );
+
+    expect(result).toBe(true);
+  });
+
   it('should return false for linting failed', async () => {
     const result = await lintSpecification('spc_46c5a4a40e83445a9bd9d9758b86c16c', {
       workingDir: 'src/db/__fixtures__/git-repo-malformed-spec',
@@ -39,5 +72,15 @@ describe('lint specification', () => {
     expect(result).toBe(false);
     const logs = logger.__getLogs();
     expect(logs.fatal).toContain('Specification not found.');
+  });
+
+  it('should return false if spec was not specified', async () => {
+    const result = await lintSpecification('', {
+      workingDir: 'src/db/__fixtures__/git-repo',
+    });
+
+    expect(result).toBe(false);
+    const logs = logger.__getLogs();
+    expect(logs.fatal).toContain('Invalid specification.');
   });
 });

--- a/packages/insomnia-inso/src/commands/lint-specification.js
+++ b/packages/insomnia-inso/src/commands/lint-specification.js
@@ -29,14 +29,15 @@ export async function lintSpecification(
       const fileName = path.isAbsolute(identifier)
         ? identifier
         : path.join(workingDir || '.', identifier);
-      logger.trace(`Reading specification from file \`${fileName}\``);
+      logger.trace(`Linting specification from file \`${fileName}\``);
       try {
         specContent = (await fs.promises.readFile(fileName)).toString();
       } catch (e) {
-        throw new InsoError('Specification not found.');
+        throw new InsoError(`Failed to read "${fileName}"`, e);
       }
     } else {
-      throw new InsoError('Invalid specification.');
+      logger.fatal(`Specification not found.`);
+      return false;
     }
   } catch (e) {
     logger.fatal(e.message);

--- a/packages/insomnia-inso/src/commands/lint-specification.js
+++ b/packages/insomnia-inso/src/commands/lint-specification.js
@@ -4,6 +4,9 @@ import type { GlobalOptions } from '../get-options';
 import { loadDb } from '../db';
 import { loadApiSpec, promptApiSpec } from '../db/models/api-spec';
 import logger from '../logger';
+import { InsoError } from '../errors';
+import fs from 'fs';
+import path from 'path';
 
 export type LintSpecificationOptions = GlobalOptions;
 
@@ -15,13 +18,33 @@ export async function lintSpecification(
 
   const specFromDb = identifier ? loadApiSpec(db, identifier) : await promptApiSpec(db, !!ci);
 
-  if (!specFromDb) {
-    logger.fatal(`Specification not found.`);
+  let specContent: string = '';
+
+  try {
+    if (specFromDb?.contents) {
+      logger.trace('Linting specification from database contents');
+      specContent = specFromDb.contents;
+    } else if (identifier) {
+      // try load as a file
+      const fileName = path.isAbsolute(identifier)
+        ? identifier
+        : path.join(workingDir || '.', identifier);
+      logger.trace(`Reading specification from file \`${fileName}\``);
+      try {
+        specContent = (await fs.promises.readFile(fileName)).toString();
+      } catch (e) {
+        throw new InsoError('Specification not found.');
+      }
+    } else {
+      throw new InsoError('Invalid specification.');
+    }
+  } catch (e) {
+    logger.fatal(e.message);
     return false;
   }
 
   const spectral = new Spectral();
-  const results = await spectral.run(specFromDb.contents);
+  const results = await spectral.run(specContent);
 
   if (results.length) {
     logger.log(`${results.length} lint errors found. \n`);


### PR DESCRIPTION
Closes #2769

Adds support for linting a local specification file (e.g. `inso lint spec ./spec.yaml`).

#### Lint steps
1. Try to load from db
2. Try to load from file. The file path is resolved in the same way as `generate config`.
3. Trace log if the file path is blank or the file is not found and return `false`
4. Log linting results and return success