### PR TITLE
Add timeout to spectron steps in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Build designer for smoke tests
         run: npm run app-build:smoke:designer
       - name: Run core smoke tests
-        timeout-minutes: 5 # sometimes jest fails to exit - https://github.com/facebook/jest/issues/6423#issuecomment-620407580
+        timeout-minutes: 10 # sometimes jest fails to exit - https://github.com/facebook/jest/issues/6423#issuecomment-620407580
         run: npm run test:smoke:core:build
       - name: Run designer smoke tests
-        timeout-minutes: 5 # sometimes jest fails to exit - https://github.com/facebook/jest/issues/6423#issuecomment-620407580
+        timeout-minutes: 10 # sometimes jest fails to exit - https://github.com/facebook/jest/issues/6423#issuecomment-620407580
         run: npm run test:smoke:designer:build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   OS:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   OS:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +35,8 @@ jobs:
       - name: Build designer for smoke tests
         run: npm run app-build:smoke:designer
       - name: Run core smoke tests
+        timeout-minutes: 5 # sometimes jest fails to exit - https://github.com/facebook/jest/issues/6423#issuecomment-620407580
         run: npm run test:smoke:core:build
       - name: Run designer smoke tests
+        timeout-minutes: 5 # sometimes jest fails to exit - https://github.com/facebook/jest/issues/6423#issuecomment-620407580
         run: npm run test:smoke:designer:build


### PR DESCRIPTION
Sometimes jest fails to exit because there is an open handle from Spectron. I haven't found a reliable fix to this, but [here ](https://github.com/facebook/jest/issues/6423#issuecomment-620407580) are some notes about it.

I just add a timeout to each test step for now.