### PR TITLE
Setting same sidebar item sorting for the Edit tag request dropdown

### DIFF
--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -472,16 +472,11 @@ class TagEditor extends React.PureComponent<Props, State> {
     return prefix;
   }
 
-  sortDocs(allDocs, parentId: string) {
+  sortDocs(requests: Array<any>, requestGroups: Array<any>, parentId: string) {
     let sortedDocs = [];
-    let requests = allDocs[models.request.type];
-    let requestGroups = allDocs[models.requestGroup.type];
-    if (!requests || !requestGroups) return [];
-
-    requests = requests.filter(request => request.parentId === parentId);
-    requestGroups = requestGroups.filter(requestGroup => requestGroup.parentId === parentId);
     requests
-      .concat(requestGroups)
+      .filter(request => request.parentId === parentId)
+      .concat(requestGroups.filter(requestGroup => requestGroup.parentId === parentId))
       .sort((a, b) => {
         if (a.metaSortKey === b.metaSortKey) {
           return a._id > b._id ? -1 : 1;
@@ -492,7 +487,7 @@ class TagEditor extends React.PureComponent<Props, State> {
       .map(doc => {
         if (doc.type === models.request.type) sortedDocs.push(doc);
         if (doc.type === models.requestGroup.type)
-          sortedDocs = sortedDocs.concat(this.sortDocs(allDocs, doc._id));
+          sortedDocs = sortedDocs.concat(this.sortDocs(requests, requestGroups, doc._id));
       });
 
     return sortedDocs;
@@ -500,8 +495,10 @@ class TagEditor extends React.PureComponent<Props, State> {
 
   renderArgModel(value: string, modelType: string) {
     const { allDocs, loadingDocs } = this.state;
-    const sortedDocs = this.sortDocs(allDocs, this.props.workspace._id);
-    const docs = sortedDocs !== [] ? sortedDocs : allDocs[modelType] || [];
+    const requests = allDocs[models.request.type] || [];
+    const requestGroups = allDocs[models.requestGroup.type] || [];
+    const sortedReqs = this.sortDocs(requests, requestGroups, this.props.workspace._id);
+    const docs = modelType === models.request.type ? sortedReqs : allDocs[modelType] || [];
     const id = value || 'n/a';
 
     if (loadingDocs) {

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -14,10 +14,11 @@ import * as db from '../../../common/database';
 import * as models from '../../../models';
 import HelpTooltip from '../help-tooltip';
 import { delay, fnOrString } from '../../../common/misc';
+import { metaSortKeySort } from '../../../common/sorting';
 import type { BaseModel } from '../../../models/index';
 import type { Workspace } from '../../../models/workspace';
 import type { Request } from '../../../models/request';
-import type { RequestGroup } from '../../../models/requestGroup';
+import type { RequestGroup } from '../../../models/request-group';
 import { isRequest, isRequestGroup } from '../../../models/helpers/is-model';
 import type { PluginArgumentEnumOption } from '../../../templating/extensions/index';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown/index';
@@ -116,10 +117,7 @@ class TagEditor extends React.PureComponent<Props, State> {
     let sortedModels = [];
     _models
       .filter(model => model.parentId === parentId)
-      .sort((a, b) => {
-        if (a.metaSortKey === b.metaSortKey) return a._id > b._id ? -1 : 1;
-        else return a.metaSortKey < b.metaSortKey ? -1 : 1;
-      })
+      .sort(metaSortKeySort)
       .map(model => {
         if (isRequest(model)) sortedModels.push(model);
         if (isRequestGroup(model))

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -472,32 +472,28 @@ class TagEditor extends React.PureComponent<Props, State> {
     return prefix;
   }
 
-  sortDocs(requests: Array<any>, requestGroups: Array<any>, parentId: string) {
-    let sortedDocs = [];
+  sortDocs(requests: Array<any>, parentId: string) {
+    let sortedReqs = [];
     requests
       .filter(request => request.parentId === parentId)
-      .concat(requestGroups.filter(requestGroup => requestGroup.parentId === parentId))
       .sort((a, b) => {
-        if (a.metaSortKey === b.metaSortKey) {
-          return a._id > b._id ? -1 : 1;
-        } else {
-          return a.metaSortKey < b.metaSortKey ? -1 : 1;
-        }
+        if (a.metaSortKey === b.metaSortKey) return a._id > b._id ? -1 : 1;
+        else return a.metaSortKey < b.metaSortKey ? -1 : 1;
       })
-      .map(doc => {
-        if (doc.type === models.request.type) sortedDocs.push(doc);
-        if (doc.type === models.requestGroup.type)
-          sortedDocs = sortedDocs.concat(this.sortDocs(requests, requestGroups, doc._id));
+      .map(request => {
+        if (request.type === models.request.type) sortedReqs.push(request);
+        if (request.type === models.requestGroup.type)
+          sortedReqs = sortedReqs.concat(this.sortDocs(requests, request._id));
       });
 
-    return sortedDocs;
+    return sortedReqs;
   }
 
   renderArgModel(value: string, modelType: string) {
     const { allDocs, loadingDocs } = this.state;
     const requests = allDocs[models.request.type] || [];
     const requestGroups = allDocs[models.requestGroup.type] || [];
-    const sortedReqs = this.sortDocs(requests, requestGroups, this.props.workspace._id);
+    const sortedReqs = this.sortDocs(requests.concat(requestGroups), this.props.workspace._id);
     const docs = modelType === models.request.type ? sortedReqs : allDocs[modelType] || [];
     const id = value || 'n/a';
 

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -118,7 +118,7 @@ class TagEditor extends React.PureComponent<Props, State> {
     _models
       .filter(model => model.parentId === parentId)
       .sort(metaSortKeySort)
-      .map(model => {
+      .forEach(model => {
         if (isRequest(model)) sortedModels.push(model);
         if (isRequestGroup(model))
           sortedModels = sortedModels.concat(this._sortRequests(_models, model._id));

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -491,7 +491,6 @@ class TagEditor extends React.PureComponent<Props, State> {
       })
       .map(doc => {
         if (doc.type === models.request.type) sortedDocs.push(doc);
-
         if (doc.type === models.requestGroup.type)
           sortedDocs = sortedDocs.concat(this.sortDocs(allDocs, doc._id));
       });

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -109,7 +109,7 @@ class TagEditor extends React.PureComponent<Props, State> {
     );
   }
 
-  _sortRequests(requests: Array<any>, parentId: string) {
+  _sortRequests(requests: Array<models.request.type | models.requestGroup.type>, parentId: string) {
     let sortedReqs = [];
     requests
       .filter(request => request.parentId === parentId)

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -16,6 +16,9 @@ import HelpTooltip from '../help-tooltip';
 import { delay, fnOrString } from '../../../common/misc';
 import type { BaseModel } from '../../../models/index';
 import type { Workspace } from '../../../models/workspace';
+import type { Request } from '../../../models/request';
+import type { RequestGroup } from '../../../models/requestGroup';
+import { isRequest, isRequestGroup } from '../../../models/helpers/is-model';
 import type { PluginArgumentEnumOption } from '../../../templating/extensions/index';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown/index';
 import FileInputButton from '../base/file-input-button';
@@ -109,21 +112,21 @@ class TagEditor extends React.PureComponent<Props, State> {
     );
   }
 
-  _sortRequests(requests: Array<models.request.type | models.requestGroup.type>, parentId: string) {
-    let sortedReqs = [];
-    requests
-      .filter(request => request.parentId === parentId)
+  _sortRequests(_models: Array<Request | RequestGroup>, parentId: string) {
+    let sortedModels = [];
+    _models
+      .filter(model => model.parentId === parentId)
       .sort((a, b) => {
         if (a.metaSortKey === b.metaSortKey) return a._id > b._id ? -1 : 1;
         else return a.metaSortKey < b.metaSortKey ? -1 : 1;
       })
-      .map(request => {
-        if (request.type === models.request.type) sortedReqs.push(request);
-        if (request.type === models.requestGroup.type)
-          sortedReqs = sortedReqs.concat(this._sortRequests(requests, request._id));
+      .map(model => {
+        if (isRequest(model)) sortedModels.push(model);
+        if (isRequestGroup(model))
+          sortedModels = sortedModels.concat(this._sortRequests(_models, model._id));
       });
 
-    return sortedReqs;
+    return sortedModels;
   }
 
   async _refreshModels(workspace: Workspace) {


### PR DESCRIPTION
This PR is adding a method to get the same item sorting as is in the request left sideBar, for the tag requests dropdown. For the item sorting I'm using the same sorting criteria found in this [selector code](https://github.com/Kong/insomnia/blob/af6a9b6a78a46402bc254e709b31d8dfa9e4b314/packages/insomnia-app/app/ui/redux/selectors.js#L165-L175).
And as you can see if the sidebar item sorting is rearranged, the change will be reflected in the tag requests dropdown too.
![tagReqsSorted](https://user-images.githubusercontent.com/28495651/97093769-d6964600-161c-11eb-8998-829e907a1a30.gif)
This would close #2745 