### PR TITLE
Add GrpcRequest and GrpcRequestMeta database models

### DIFF
--- a/packages/insomnia-app/app/models/__tests__/grpc-request-meta.test.js
+++ b/packages/insomnia-app/app/models/__tests__/grpc-request-meta.test.js
@@ -1,0 +1,57 @@
+import * as models from '../index';
+import { globalBeforeEach } from '../../__jest__/before-each';
+
+describe('init()', () => {
+  beforeEach(globalBeforeEach);
+  it('contains all required fields', async () => {
+    expect(models.grpcRequestMeta.init()).toEqual({
+      pinned: false,
+    });
+  });
+});
+
+describe('create()', () => {
+  beforeEach(globalBeforeEach);
+  it('creates a valid GrpcRequest', async () => {
+    Date.now = jest.fn().mockReturnValue(1478795580200);
+
+    const request = await models.grpcRequestMeta.create({
+      pinned: true,
+      parentId: 'greq_124',
+    });
+    const expected = {
+      _id: 'greqm_cc1dd2ca4275747aa88199e8efd42403',
+      created: 1478795580200,
+      modified: 1478795580200,
+      parentId: 'greq_124',
+      pinned: true,
+      type: 'GrpcRequestMeta',
+    };
+
+    expect(request).toEqual(expected);
+    expect(await models.grpcRequestMeta.getOrCreateByParentId(expected.parentId)).toEqual(expected);
+  });
+
+  it('creates a valid GrpcRequestMeta if it does not exist', async () => {
+    Date.now = jest.fn().mockReturnValue(1478795580200);
+
+    const request = await models.grpcRequestMeta.getOrCreateByParentId('greq_124');
+    const expected = {
+      _id: 'greqm_dd2ccc1a2745477a881a9e8ef9d42403',
+      created: 1478795580200,
+      modified: 1478795580200,
+      parentId: 'greq_124',
+      pinned: false,
+      type: 'GrpcRequestMeta',
+    };
+
+    expect(request).toEqual(expected);
+  });
+
+  it('fails when missing parentId', async () => {
+    Date.now = jest.fn().mockReturnValue(1478795580200);
+    expect(() => models.grpcRequestMeta.create({ pinned: true })).toThrow(
+      'New GrpcRequestMeta missing `parentId`',
+    );
+  });
+});

--- a/packages/insomnia-app/app/models/__tests__/grpc-request.test.js
+++ b/packages/insomnia-app/app/models/__tests__/grpc-request.test.js
@@ -51,7 +51,7 @@ describe('create()', () => {
   it('fails when missing parentId', async () => {
     Date.now = jest.fn().mockReturnValue(1478795580200);
     expect(() => models.grpcRequest.create({ name: 'no parentId' })).toThrow(
-      'New gRPC Request missing `parentId`',
+      'New GrpcRequest missing `parentId`',
     );
   });
 });

--- a/packages/insomnia-app/app/models/__tests__/grpc-request.test.js
+++ b/packages/insomnia-app/app/models/__tests__/grpc-request.test.js
@@ -1,0 +1,57 @@
+import * as models from '../index';
+import { globalBeforeEach } from '../../__jest__/before-each';
+
+describe('init()', () => {
+  beforeEach(globalBeforeEach);
+  it('contains all required fields', async () => {
+    Date.now = jest.fn().mockReturnValue(1478795580200);
+
+    expect(models.grpcRequest.init()).toEqual({
+      url: '',
+      name: 'New gRPC Request',
+      protoFileId: '',
+      protoServiceName: '',
+      protoMethodName: '',
+      body: {},
+      metaSortKey: -1478795580200,
+      idPrivate: false,
+    });
+  });
+});
+
+describe('create()', () => {
+  beforeEach(globalBeforeEach);
+  it('creates a valid GrpcRequest', async () => {
+    Date.now = jest.fn().mockReturnValue(1478795580200);
+
+    const request = await models.grpcRequest.create({
+      name: 'My request',
+      parentId: 'fld_124',
+    });
+    const expected = {
+      _id: 'greq_cc1dd2ca4275747aa88199e8efd42403',
+      created: 1478795580200,
+      modified: 1478795580200,
+      parentId: 'fld_124',
+      name: 'My request',
+      url: '',
+      protoFileId: '',
+      protoServiceName: '',
+      protoMethodName: '',
+      body: {},
+      metaSortKey: -1478795580200,
+      idPrivate: false,
+      type: 'GrpcRequest',
+    };
+
+    expect(request).toEqual(expected);
+    expect(await models.grpcRequest.getById(expected._id)).toEqual(expected);
+  });
+
+  it('fails when missing parentId', async () => {
+    Date.now = jest.fn().mockReturnValue(1478795580200);
+    expect(() => models.grpcRequest.create({ name: 'no parentId' })).toThrow(
+      'New gRPC Request missing `parentId`',
+    );
+  });
+});

--- a/packages/insomnia-app/app/models/__tests__/proto-file.test.js
+++ b/packages/insomnia-app/app/models/__tests__/proto-file.test.js
@@ -38,7 +38,7 @@ describe('create()', () => {
   it('fails when missing parentId', async () => {
     Date.now = jest.fn().mockReturnValue(1478795580200);
     expect(() => models.protoFile.create({ name: 'no parentId' })).toThrow(
-      'New Proto File missing `parentId`',
+      'New ProtoFile missing `parentId`',
     );
   });
 });

--- a/packages/insomnia-app/app/models/grpc-request-meta.js
+++ b/packages/insomnia-app/app/models/grpc-request-meta.js
@@ -1,0 +1,58 @@
+// @flow
+import * as db from '../common/database';
+import type { BaseModel } from './index';
+
+export const name = 'gRPC Request Meta';
+export const type = 'GrpcRequestMeta';
+export const prefix = 'greqm';
+export const canDuplicate = false;
+export const canSync = false;
+
+type BaseGrpcRequestMeta = {
+  pinned: boolean,
+};
+
+export type GrpcRequestMeta = BaseModel & BaseGrpcRequestMeta;
+
+export function init() {
+  return {
+    pinned: false,
+  };
+}
+
+export function migrate(doc: GrpcRequestMeta): GrpcRequestMeta {
+  return doc;
+}
+
+export function create(patch: $Shape<GrpcRequestMeta> = {}): Promise<GrpcRequestMeta> {
+  if (!patch.parentId) {
+    throw new Error('New GrpcRequestMeta missing `parentId`');
+  }
+
+  return db.docCreate(type, patch);
+}
+
+export function update(
+  requestMeta: GrpcRequestMeta,
+  patch: $Shape<GrpcRequestMeta>,
+): Promise<GrpcRequestMeta> {
+  return db.docUpdate(requestMeta, patch);
+}
+
+export function getByParentId(parentId: string): Promise<GrpcRequestMeta> {
+  return db.getWhere(type, { parentId });
+}
+
+export async function getOrCreateByParentId(parentId: string): Promise<GrpcRequestMeta> {
+  const requestMeta = await getByParentId(parentId);
+
+  if (requestMeta) {
+    return requestMeta;
+  }
+
+  return create({ parentId });
+}
+
+export function all(): Promise<Array<GrpcRequestMeta>> {
+  return db.all(type);
+}

--- a/packages/insomnia-app/app/models/grpc-request.js
+++ b/packages/insomnia-app/app/models/grpc-request.js
@@ -1,0 +1,71 @@
+// @flow
+import * as db from '../common/database';
+import type { BaseModel } from './index';
+
+export const name = 'gRPC Request';
+export const type = 'GrpcRequest';
+export const prefix = 'greq';
+export const canDuplicate = true;
+export const canSync = true;
+
+type RequestBody = {
+  text?: string,
+};
+
+type BaseGrpcRequest = {
+  name: string,
+  url: string,
+  protoFileId?: string,
+  protoServiceName?: string,
+  protoMethodName?: string,
+  body: RequestBody,
+  metaSortKey: number,
+  isPrivate: boolean,
+};
+
+export type GrpcRequest = BaseModel & BaseGrpcRequest;
+
+export function init(): BaseGrpcRequest {
+  return {
+    url: '',
+    name: 'New gRPC Request',
+    protoFileId: '',
+    protoServiceName: '',
+    protoMethodName: '',
+    body: {},
+    metaSortKey: -1 * Date.now(),
+    idPrivate: false,
+  };
+}
+
+export function migrate(doc: GrpcRequest): GrpcRequest {
+  return doc;
+}
+
+export function create(patch: $Shape<GrpcRequest> = {}): Promise<GrpcRequest> {
+  if (!patch.parentId) {
+    throw new Error('New gRPC Request missing `parentId`');
+  }
+
+  return db.docCreate(type, patch);
+}
+
+export function remove(obj: GrpcRequest): Promise<void> {
+  return db.remove(obj);
+}
+
+export function update(obj: GrpcRequest, patch: $Shape<GrpcRequest> = {}): Promise<GrpcRequest> {
+  return db.docUpdate(obj, patch);
+}
+
+export function getById(_id: string): Promise<GrpcRequest | null> {
+  return db.getWhere(type, { _id });
+}
+
+export function findByParentId(parentId: string): Promise<Array<GrpcRequest>> {
+  return db.find(type, { parentId });
+}
+
+export function all(): Promise<Array<GrpcRequest>> {
+  return db.all(type);
+}

--- a/packages/insomnia-app/app/models/grpc-request.js
+++ b/packages/insomnia-app/app/models/grpc-request.js
@@ -44,7 +44,7 @@ export function migrate(doc: GrpcRequest): GrpcRequest {
 
 export function create(patch: $Shape<GrpcRequest> = {}): Promise<GrpcRequest> {
   if (!patch.parentId) {
-    throw new Error('New gRPC Request missing `parentId`');
+    throw new Error('New GrpcRequest missing `parentId`');
   }
 
   return db.docCreate(type, patch);

--- a/packages/insomnia-app/app/models/index.js
+++ b/packages/insomnia-app/app/models/index.js
@@ -19,6 +19,7 @@ import * as _unitTestResult from './unit-test-result';
 import * as _unitTestSuite from './unit-test-suite';
 import * as _protoFile from './proto-file';
 import * as _grpcRequest from './grpc-request';
+import * as _grpcRequestMeta from './grpc-request-meta';
 import * as _workspace from './workspace';
 import * as _workspaceMeta from './workspace-meta';
 import { generateId } from '../common/misc';
@@ -52,6 +53,7 @@ export const unitTestSuite = _unitTestSuite;
 export const unitTestResult = _unitTestResult;
 export const protoFile = _protoFile;
 export const grpcRequest = _grpcRequest;
+export const grpcRequestMeta = _grpcRequestMeta;
 export const workspace = _workspace;
 export const workspaceMeta = _workspaceMeta;
 
@@ -79,6 +81,7 @@ export function all() {
     unitTest,
     protoFile,
     grpcRequest,
+    grpcRequestMeta,
   ];
 }
 

--- a/packages/insomnia-app/app/models/index.js
+++ b/packages/insomnia-app/app/models/index.js
@@ -18,6 +18,7 @@ import * as _unitTest from './unit-test';
 import * as _unitTestResult from './unit-test-result';
 import * as _unitTestSuite from './unit-test-suite';
 import * as _protoFile from './proto-file';
+import * as _grpcRequest from './grpc-request';
 import * as _workspace from './workspace';
 import * as _workspaceMeta from './workspace-meta';
 import { generateId } from '../common/misc';
@@ -50,6 +51,7 @@ export const unitTest = _unitTest;
 export const unitTestSuite = _unitTestSuite;
 export const unitTestResult = _unitTestResult;
 export const protoFile = _protoFile;
+export const grpcRequest = _grpcRequest;
 export const workspace = _workspace;
 export const workspaceMeta = _workspaceMeta;
 
@@ -76,6 +78,7 @@ export function all() {
     unitTestResult,
     unitTest,
     protoFile,
+    grpcRequest,
   ];
 }
 

--- a/packages/insomnia-app/app/models/proto-file.js
+++ b/packages/insomnia-app/app/models/proto-file.js
@@ -28,7 +28,7 @@ export function migrate(doc: ProtoFile): ProtoFile {
 
 export function create(patch: $Shape<ProtoFile> = {}): Promise<ProtoFile> {
   if (!patch.parentId) {
-    throw new Error('New Proto File missing `parentId`');
+    throw new Error('New ProtoFile missing `parentId`');
   }
 
   return db.docCreate(type, patch);

--- a/packages/insomnia-app/app/ui/redux/modules/entities.js
+++ b/packages/insomnia-app/app/ui/redux/modules/entities.js
@@ -120,5 +120,6 @@ export async function allDocs() {
     ...(await models.unitTestResult.all()),
     ...(await models.protoFile.all()),
     ...(await models.grpcRequest.all()),
+    ...(await models.grpcRequestMeta.all()),
   ];
 }

--- a/packages/insomnia-app/app/ui/redux/modules/entities.js
+++ b/packages/insomnia-app/app/ui/redux/modules/entities.js
@@ -119,5 +119,6 @@ export async function allDocs() {
     ...(await models.unitTest.all()),
     ...(await models.unitTestResult.all()),
     ...(await models.protoFile.all()),
+    ...(await models.grpcRequest.all()),
   ];
 }


### PR DESCRIPTION
What is says on the tin.

The `GrpcRequestMeta` model is a reduced version of the standard `RequestMeta`.