### PR TITLE
Fix version control beta merge conflicts where objects have been deleted

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.js
@@ -47,7 +47,7 @@ class SyncMergeModal extends React.PureComponent<Props, State> {
         return c;
       }
 
-      return { ...c, choose: e.currentTarget.value };
+      return { ...c, choose: e.currentTarget.value || null };
     });
 
     this.setState({ conflicts });
@@ -93,7 +93,7 @@ class SyncMergeModal extends React.PureComponent<Props, State> {
                       Mine{' '}
                       <input
                         type="radio"
-                        value={conflict.mineBlob}
+                        value={conflict.mineBlob || ''}
                         checked={conflict.choose === conflict.mineBlob}
                         onChange={e => this._handleToggleSelect(conflict.key, e)}
                       />
@@ -102,7 +102,7 @@ class SyncMergeModal extends React.PureComponent<Props, State> {
                       Theirs{' '}
                       <input
                         type="radio"
-                        value={conflict.theirsBlob}
+                        value={conflict.theirsBlob || ''}
                         checked={conflict.choose === conflict.theirsBlob}
                         onChange={e => this._handleToggleSelect(conflict.key, e)}
                       />


### PR DESCRIPTION
When resolving a merge conflict where an object had been deleted on one side, selecting the side that had been deleted resulted in the visual state of nothing having been selected.

![image](https://user-images.githubusercontent.com/174626/97313556-105a8d00-1867-11eb-9f50-e07674b385c3.png)

If pressing "Submit Resolutions" in this state, it would corrupt the local sync state for the workspace, causing the `version-control` folder to need to be deleted from the file-system in order to be able to sync the workspace again.

![image](https://user-images.githubusercontent.com/174626/97313343-ca052e00-1866-11eb-8757-d7acfdff810b.png)

This was due to us passing an empty string instead of null as the choice to the conflict handling logic.

**Testing**:
In order to test this, two instances of the app are required, in order to cause a merge conflict.
I've been testing this by running the latest release of the app alongside this branch.

1. Enable the "version control beta" in both apps
2. Sign in to your account in both apps
3. In the production app, create a new workspace and add a request to it, set up sync, create a snapshot and push it.
4. In the development app, pull the workspace from the workspace dropdown, change the name of the request in the workspace, create a snapshot for it, but do not push the snapshot.
5. In the production app, delete the request, create a snapshot and push it.
6. In the development app, pull the latest changes to the workspace, select "Theirs" in the resulting merge conflict, and verify that the request has been deleted.

For further testing, verify that other types of merges (not involving deletion) still work correctly as well.

Fixes INS-254