### PR TITLE
Hide gRPC from url bar method dropdown for standard requests

### DIFF
--- a/packages/insomnia-app/app/ui/components/dropdowns/method-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/method-dropdown.js
@@ -74,6 +74,7 @@ class MethodDropdown extends PureComponent {
       method,
       right,
       onChange, // eslint-disable-line no-unused-vars
+      showGrpc,
       ...extraProps
     } = this.props;
     const buttonLabel = method === METHOD_GRPC ? GRPC_LABEL : method;
@@ -92,10 +93,14 @@ class MethodDropdown extends PureComponent {
             {method}
           </DropdownItem>
         ))}
-        <DropdownDivider />
-        <DropdownItem className="method-grpc" onClick={this._handleChange} value={METHOD_GRPC}>
-          {GRPC_LABEL}
-        </DropdownItem>
+        {showGrpc && (
+          <>
+            <DropdownDivider />
+            <DropdownItem className="method-grpc" onClick={this._handleChange} value={METHOD_GRPC}>
+              {GRPC_LABEL}
+            </DropdownItem>
+          </>
+        )}
         <DropdownDivider />
         <DropdownItem
           className="http-method-custom"
@@ -115,6 +120,7 @@ MethodDropdown.propTypes = {
 
   // Optional
   right: PropTypes.bool,
+  showGrpc: PropTypes.bool,
 };
 
 export default MethodDropdown;

--- a/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
@@ -147,6 +147,7 @@ class RequestCreateModal extends PureComponent {
               <div className="form-control form-control--no-label" style={{ width: 'auto' }}>
                 <MethodDropdown
                   right
+                  showGrpc
                   className="btn btn--clicky no-wrap"
                   method={selectedMethod}
                   onChange={this._handleChangeSelectedMethod}


### PR DESCRIPTION
What it says on the tin

Can select gRPC when creating a new request
![image](https://user-images.githubusercontent.com/4312346/97392091-c399b380-1945-11eb-832c-e1513cd659b4.png)

No gRPC in the URL bar dropdown
![image](https://user-images.githubusercontent.com/4312346/97392070-b250a700-1945-11eb-8a71-e38239098fee.png)

Fixes INS-252