### PR TITLE
Remove unrelated items from request actions and request settings

### DIFF
--- a/packages/insomnia-app/app/models/__tests__/grpc-request.test.js
+++ b/packages/insomnia-app/app/models/__tests__/grpc-request.test.js
@@ -9,6 +9,7 @@ describe('init()', () => {
     expect(models.grpcRequest.init()).toEqual({
       url: '',
       name: 'New gRPC Request',
+      description: '',
       protoFileId: '',
       protoServiceName: '',
       protoMethodName: '',
@@ -34,6 +35,7 @@ describe('create()', () => {
       modified: 1478795580200,
       parentId: 'fld_124',
       name: 'My request',
+      description: '',
       url: '',
       protoFileId: '',
       protoServiceName: '',

--- a/packages/insomnia-app/app/models/grpc-request.js
+++ b/packages/insomnia-app/app/models/grpc-request.js
@@ -15,6 +15,7 @@ type RequestBody = {
 type BaseGrpcRequest = {
   name: string,
   url: string,
+  description: string,
   protoFileId?: string,
   protoServiceName?: string,
   protoMethodName?: string,
@@ -29,6 +30,7 @@ export function init(): BaseGrpcRequest {
   return {
     url: '',
     name: 'New gRPC Request',
+    description: '',
     protoFileId: '',
     protoServiceName: '',
     protoMethodName: '',

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
@@ -57,6 +57,9 @@ class RequestActionsDropdown extends PureComponent {
       ...other
     } = this.props;
 
+    const isGrpc = request.type === models.grpcRequest.type;
+    const canGenerateCode = !isGrpc;
+
     return (
       <Dropdown ref={this._setDropdownRef} {...other}>
         <DropdownButton>
@@ -68,21 +71,25 @@ class RequestActionsDropdown extends PureComponent {
           <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_DUPLICATE.id]} />
         </DropdownItem>
 
-        <DropdownItem onClick={this._handleGenerateCode}>
-          <i className="fa fa-code" /> Generate Code
-          <DropdownHint
-            keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_GENERATE_CODE_EDITOR.id]}
-          />
-        </DropdownItem>
+        {canGenerateCode && (
+          <DropdownItem onClick={this._handleGenerateCode}>
+            <i className="fa fa-code" /> Generate Code
+            <DropdownHint
+              keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_GENERATE_CODE_EDITOR.id]}
+            />
+          </DropdownItem>
+        )}
 
         <DropdownItem onClick={this._handleSetRequestPinned}>
           <i className="fa fa-thumb-tack" /> {this.props.isPinned ? 'Unpin' : 'Pin'}
           <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_TOGGLE_PIN.id]} />
         </DropdownItem>
 
-        <DropdownItem onClick={this._handleCopyAsCurl}>
-          <i className="fa fa-copy" /> Copy as Curl
-        </DropdownItem>
+        {canGenerateCode && (
+          <DropdownItem onClick={this._handleCopyAsCurl}>
+            <i className="fa fa-copy" /> Copy as Curl
+          </DropdownItem>
+        )}
 
         <DropdownItem buttonClass={PromptButton} onClick={this._handleRemove} addIcon>
           <i className="fa fa-trash-o" /> Delete
@@ -106,7 +113,7 @@ RequestActionsDropdown.propTypes = {
   handleCopyAsCurl: PropTypes.func.isRequired,
   handleShowSettings: PropTypes.func.isRequired,
   isPinned: PropTypes.bool.isRequired,
-  request: PropTypes.object.isRequired,
+  request: PropTypes.object.isRequired, // can be Request or GrpcRequest
   hotKeyRegistry: PropTypes.object.isRequired,
   handleSetRequestPinned: PropTypes.func.isRequired,
 };

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
@@ -25,13 +25,18 @@ type Props = {
 };
 
 type State = {
-  request: Request | null,
+  request: Request | GrpcRequest | null,
   showDescription: boolean,
   defaultPreviewMode: boolean,
   activeWorkspaceIdToCopyTo: string | null,
   workspace: Workspace | null,
   justCopied: boolean,
   justMoved: boolean,
+};
+
+type RequestSettingsModalOptions = {
+  request: Request | GrpcRequest,
+  forceEditMode: boolean,
 };
 
 @autobind
@@ -163,7 +168,7 @@ class RequestSettingsModal extends React.PureComponent<Props, State> {
     }, 2000);
   }
 
-  async show({ request, forceEditMode }: { request: Request, forceEditMode: boolean }) {
+  async show({ request, forceEditMode }: RequestSettingsModalOptions) {
     const { workspaces } = this.props;
 
     const hasDescription = !!request.description;


### PR DESCRIPTION
This PR is only removing the `generate code` and `copy as curl` options from the drop-down, and hiding all settings in the request settings modal. There are separate Linear tickets to make sure that each database action (rename, delete, filter, copy/move, drag-drop) work as expected.

(I suggest reviewing with white-space hidden)

Fixes INS-259
Fixes INS-260

Regular request actions dropdown:
![image](https://user-images.githubusercontent.com/4312346/97395966-fd20ed80-194a-11eb-8251-0bea4eaeb75c.png)

Regular request settings:
![image](https://user-images.githubusercontent.com/4312346/97395989-090caf80-194b-11eb-8fee-7e3ee668e413.png)

gRPC request actions dropdown:
![image](https://user-images.githubusercontent.com/4312346/97396028-1b86e900-194b-11eb-8f55-06e58a218f47.png)

gRPC request settings (note the id):
![image](https://user-images.githubusercontent.com/4312346/97396041-25105100-194b-11eb-985a-62019f92bf2c.png)