### PR TITLE
Allow users to delete synced workspaces from the API

### DIFF
--- a/packages/insomnia-app/app/sync/vcs/index.js
+++ b/packages/insomnia-app/app/sync/vcs/index.js
@@ -85,6 +85,13 @@ export default class VCS {
     }
   }
 
+  async archiveProject(): Promise<void> {
+    const projectId = this._projectId();
+    await this._queryProjectArchive(projectId);
+    await this._store.removeItem(paths.project(projectId));
+    this._project = null;
+  }
+
   async switchProject(rootDocumentId: string): Promise<void> {
     const project = await this._getProjectByRootDocument(rootDocumentId);
     if (project !== null) {
@@ -1484,6 +1491,22 @@ export default class VCS {
 
   async _hasBlob(id: string): Promise<boolean> {
     return this._store.hasItem(paths.blob(this._projectId(), id));
+  }
+
+  async _queryProjectArchive(projectId: string): Promise<void> {
+    await this._runGraphQL(
+      `
+        mutation ($id: ID!) {
+          projectArchive(id: $id)
+        }
+      `,
+      {
+        id: projectId,
+      },
+      'projectArchive',
+    );
+
+    console.log(`[sync] Archived remote project ${projectId}`);
   }
 }
 

--- a/packages/insomnia-app/app/sync/vcs/index.js
+++ b/packages/insomnia-app/app/sync/vcs/index.js
@@ -717,7 +717,7 @@ export default class VCS {
 
     if (errors && errors.length) {
       console.log(`[sync] Failed to query ${name}`, errors);
-      throw new Error(`Failed to query ${name}`);
+      throw new Error(`Failed to query ${name}: ${errors[0].message}`);
     }
 
     return data;

--- a/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
@@ -11,6 +11,7 @@ import Link from '../base/link';
 import SyncHistoryModal from '../modals/sync-history-modal';
 import SyncShareModal from '../modals/sync-share-modal';
 import SyncBranchesModal from '../modals/sync-branches-modal';
+import SyncDeleteModal from '../modals/sync-delete-modal';
 import VCS from '../../../sync/vcs';
 import type { Project, Snapshot, Status, StatusCandidate } from '../../../sync/types';
 import ErrorModal from '../modals/error-modal';
@@ -253,6 +254,12 @@ class SyncDropdown extends React.PureComponent<Props, State> {
   async _handleEnableSync() {
     const { vcs, workspace } = this.props;
     await vcs.switchAndCreateProjectIfNotExist(workspace._id, workspace.name);
+  }
+
+  _handleShowDeleteModal() {
+    showModal(SyncDeleteModal, {
+      onHide: this.refreshMainAttributes,
+    });
   }
 
   async _handleSetProject(p: Project) {
@@ -509,6 +516,11 @@ class SyncDropdown extends React.PureComponent<Props, State> {
           <DropdownItem onClick={this._handleShowBranchesModal}>
             <i className="fa fa-code-fork" />
             Branches
+          </DropdownItem>
+
+          <DropdownItem onClick={this._handleShowDeleteModal} disabled={historyCount === 0}>
+            <i className="fa fa-remove" />
+            Delete Workspace
           </DropdownItem>
 
           <DropdownDivider>Local Branches</DropdownDivider>

--- a/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.js
@@ -1,0 +1,115 @@
+// @flow
+
+import * as React from 'react';
+import autobind from 'autobind-decorator';
+import Modal from '../base/modal';
+import ModalBody from '../base/modal-body';
+import ModalHeader from '../base/modal-header';
+import type { Workspace } from '../../../models/workspace';
+import VCS from '../../../sync/vcs';
+import { Button } from 'insomnia-components';
+
+type Props = {
+  workspace: Workspace,
+  vcs: VCS,
+};
+
+type State = {
+  error: string,
+  workspaceName: string,
+};
+
+const INITIAL_STATE: State = {
+  error: '',
+  workspaceName: '',
+};
+
+@autobind
+class SyncDeleteModal extends React.PureComponent<Props, State> {
+  modal: ?Modal;
+  input: ?HTMLInputElement;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = INITIAL_STATE;
+  }
+
+  _setModalRef(n: ?Modal) {
+    this.modal = n;
+  }
+
+  _setInputRef(m: ?HTMLInputElement) {
+    this.input = m;
+  }
+
+  _updateWorkspaceName(e: SyntheticEvent<HTMLInputElement>) {
+    this.setState({ workspaceName: e.currentTarget.value });
+  }
+
+  async _handleDelete(e: SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const { vcs } = this.props;
+
+    try {
+      await vcs.archiveProject();
+      this.hide();
+    } catch (err) {
+      this.setState({
+        error: err.message,
+      });
+    }
+  }
+
+  async show(options: { onHide: Function }) {
+    this.modal && this.modal.show({ onHide: options.onHide });
+
+    // Reset state
+    this.setState(INITIAL_STATE);
+
+    // Focus input when modal shows
+    setTimeout(() => {
+      this.input && this.input.focus();
+    }, 100);
+  }
+
+  hide() {
+    this.modal && this.modal.hide();
+  }
+
+  render() {
+    const { error, workspaceName } = this.state;
+    const { workspace } = this.props;
+
+    return (
+      <Modal ref={this._setModalRef} skinny>
+        <ModalHeader>Delete Workspace</ModalHeader>
+        <ModalBody className="wide pad-left pad-right text-center" noScroll>
+          {error && <p className="notice error margin-bottom-sm no-margin-top">{error}</p>}
+          <p>
+            This will permanently delete the <strong>{workspace.name}</strong> workspace remotely.
+          </p>
+          <p>
+            Please type <strong>{workspace.name}</strong> to confirm.
+          </p>
+
+          <form onSubmit={this._handleDelete}>
+            <div className="form-control form-control--outlined">
+              <input
+                ref={this._setInputRef}
+                type="text"
+                onChange={this._updateWorkspaceName}
+                value={workspaceName}
+              />
+              <Button bg="danger" disabled={workspaceName !== workspace.name}>
+                Delete Workspace
+              </Button>
+            </div>
+          </form>
+        </ModalBody>
+      </Modal>
+    );
+  }
+}
+
+export default SyncDeleteModal;

--- a/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.js
@@ -86,11 +86,13 @@ class SyncDeleteModal extends React.PureComponent<Props, State> {
         <ModalHeader>Delete Workspace</ModalHeader>
         <ModalBody className="wide pad-left pad-right text-center" noScroll>
           {error && <p className="notice error margin-bottom-sm no-margin-top">{error}</p>}
-          <p>
-            This will permanently delete the <strong>{workspace.name}</strong> workspace remotely.
+          <p className="selectable">
+            This will permanently delete the{' '}
+            <strong style={{ whiteSpace: 'pre-wrap' }}>{workspace.name}</strong> workspace remotely.
           </p>
-          <p>
-            Please type <strong>{workspace.name}</strong> to confirm.
+          <p className="selectable">
+            Please type <strong style={{ whiteSpace: 'pre-wrap' }}>{workspace.name}</strong> to
+            confirm.
           </p>
 
           <form onSubmit={this._handleDelete}>

--- a/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.js
@@ -81,19 +81,19 @@ class SyncDeleteModal extends React.PureComponent<Props, State> {
     const { error, workspaceName } = this.state;
     const { workspace } = this.props;
 
+    const workspaceNameElement = (
+      <strong style={{ whiteSpace: 'pre-wrap' }}>{workspace.name}</strong>
+    );
+
     return (
       <Modal ref={this._setModalRef} skinny>
         <ModalHeader>Delete Workspace</ModalHeader>
         <ModalBody className="wide pad-left pad-right text-center" noScroll>
           {error && <p className="notice error margin-bottom-sm no-margin-top">{error}</p>}
           <p className="selectable">
-            This will permanently delete the{' '}
-            <strong style={{ whiteSpace: 'pre-wrap' }}>{workspace.name}</strong> workspace remotely.
+            This will permanently delete the {workspaceNameElement} workspace remotely.
           </p>
-          <p className="selectable">
-            Please type <strong style={{ whiteSpace: 'pre-wrap' }}>{workspace.name}</strong> to
-            confirm.
-          </p>
+          <p className="selectable">Please type {workspaceNameElement} to confirm.</p>
 
           <form onSubmit={this._handleDelete}>
             <div className="form-control form-control--outlined">

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -45,6 +45,7 @@ import SyncMergeModal from './modals/sync-merge-modal';
 import SyncHistoryModal from './modals/sync-history-modal';
 import SyncShareModal from './modals/sync-share-modal';
 import SyncBranchesModal from './modals/sync-branches-modal';
+import SyncDeleteModal from './modals/sync-delete-modal';
 import RequestRenderErrorModal from './modals/request-render-error-modal';
 import WorkspaceEnvironmentsEditModal from './modals/workspace-environments-edit-modal';
 import WorkspaceSettingsModal from './modals/workspace-settings-modal';
@@ -748,6 +749,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
                   vcs={vcs}
                   syncItems={syncItems}
                 />
+                <SyncDeleteModal ref={registerModal} workspace={activeWorkspace} vcs={vcs} />
                 <SyncHistoryModal ref={registerModal} workspace={activeWorkspace} vcs={vcs} />
                 <SyncShareModal ref={registerModal} workspace={activeWorkspace} vcs={vcs} />
               </React.Fragment>


### PR DESCRIPTION
This allows users to remove synced projects from the API, by adding a new item to the sync dropdown menu.

![2020-10-29 17 57 00](https://user-images.githubusercontent.com/174626/97606938-a1209c80-1a10-11eb-8a4a-937559b6d73c.gif)

@nijikokun I know you had some thoughts around the wording/messaging, wasn't sure of a good way to communicate that the workspace will be deleted from the API, but not locally.
Please look it over and let me know what wording you'd prefer.

Fixes INS-236

**Testing**
1. Enable beta sync in the app
2. Create a workspace, set up sync, commit and push
3. Choose "Delete Workspace" from the sync dropdown, and run through the flow.
4. Delete the workspace locally as well, and verify that it no longer shows up in the workspace dropdown under "Remote projects".