### PR TITLE
Remove redundant help menu item

### DIFF
--- a/packages/insomnia-app/app/main/window-utils.js
+++ b/packages/insomnia-app/app/main/window-utils.js
@@ -298,13 +298,6 @@ export function createWindow() {
           shell.openExternal('https://insomnia.rest/license');
         },
       },
-      {
-        label: `Insomnia ${MNEMONIC_SYM}Help`,
-        accelerator: !isMac() ? 'F1' : null,
-        click: () => {
-          shell.openExternal('https://support.insomnia.rest');
-        },
-      },
     ],
   };
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Removes a redundant help menu item. Both Help and Support as well as Insomnia Help opens https://support.insomnia.rest. This PR removes the last menu item. See attached screenshots
![insomnia_before](https://user-images.githubusercontent.com/69011/97619259-48f19680-1a20-11eb-967e-b62fc72acbb6.png)
![insomnia_after](https://user-images.githubusercontent.com/69011/97619267-4c851d80-1a20-11eb-9e75-4f1d15730aef.png)


