### PR TITLE
Unsafe deletion of a protofile

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -10,7 +10,7 @@ import type { Workspace } from '../../../models/workspace';
 import Modal from '../base/modal';
 import ProtoFileList from '../proto-file/proto-file-list';
 import FileInputButton from '../base/file-input-button';
-import { showError } from './index';
+import { showAlert, showError } from './index';
 import fs from 'fs';
 import path from 'path';
 
@@ -72,9 +72,25 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
     this.setState({ selectedProtoFileId: id });
   }
 
-  _handleDelete(protoFile: ProtoFile) {
-    // TODO: to be built in INS-209
-    console.log(`delete ${protoFile._id}`);
+  async _handleDelete(protoFile: ProtoFile) {
+    showAlert({
+      title: `Delete ${protoFile.name}`,
+      message: (
+        <span>
+          Really delete <strong>{protoFile.name}</strong>? All requests that use this proto file
+          will stop working.
+        </span>
+      ),
+      addCancel: true,
+      onConfirm: async () => {
+        await models.protoFile.remove(protoFile);
+
+        // if the deleted protoFile was previously selected, clear the selection
+        if (this.state.selectedProtoFileId === protoFile._id) {
+          this.setState({ selectedProtoFileId: '' });
+        }
+      },
+    });
   }
 
   async _handleProtoFileUpload(filePath: string) {

--- a/packages/insomnia-app/app/ui/components/proto-file/proto-file-list-item.js
+++ b/packages/insomnia-app/app/ui/components/proto-file/proto-file-list-item.js
@@ -2,13 +2,12 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import type { ProtoFile } from '../../../models/proto-file';
-import PromptButton from '../base/prompt-button';
 import type {
   DeleteProtoFileHandler,
   RenameProtoFileHandler,
   SelectProtoFileHandler,
 } from './proto-file-list';
-import { ListGroupItem } from '../../../../../insomnia-components';
+import { ListGroupItem, Button } from '../../../../../insomnia-components';
 import Editable from '../base/editable';
 
 type Props = {
@@ -55,15 +54,10 @@ const ProtoFileListItem = ({
   return (
     <SelectableListItem isSelected={isSelected} onClick={handleSelectCallback}>
       <div className="row-spaced">
-        <Editable onSubmit={handleRenameCallback} value={name} preventBlank />
-        <PromptButton
-          className="btn btn--super-compact btn--outlined"
-          addIcon
-          confirmMessage=""
-          onClick={handleDeleteCallback}
-          title="Delete Proto File">
+        <Editable className="wide" onSubmit={handleRenameCallback} value={name} preventBlank />
+        <Button size="small" title="Delete Proto File" onClick={handleDeleteCallback}>
           <i className="fa fa-trash-o" />
-        </PromptButton>
+        </Button>
       </div>
     </SelectableListItem>
   );


### PR DESCRIPTION
Behavior changes:
- Instead of the prompt button, we are using a modal because we would like to seek confirmation from the user after providing some context on repercussions
- After deleting, if that protofile was previously selected, we reset the selection

Screenshot of delete button change:
![image](https://user-images.githubusercontent.com/4312346/97645346-979b4100-1ab1-11eb-8c2f-a20a55f64088.png)

Screenshot of confirmation dialog:
![image](https://user-images.githubusercontent.com/4312346/97644611-a97be480-1aaf-11eb-8808-cd8467378917.png)

@nijikokun please advise on wording for the title, body and buttons of the confirmation modal. It will  also be possible to show a count of affected requests (eg. "10 requests that use proto file..."). Showing a list of items will need more work/design.

QA: 
- After deleting a selected protofile, the save button is disabled (because no protofile is selected)
- After deleting a protofile, loading protofiles for the workspace updates correctly

![2020-10-30 13 03 00](https://user-images.githubusercontent.com/4312346/97644978-93baef00-1ab0-11eb-9339-ca491809ed2a.gif)

Fixes INS-209