### PR TITLE
Extract foundational components from request and response panes

### DIFF
--- a/packages/insomnia-app/app/ui/components/panes/blank-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/blank-pane.js
@@ -1,0 +1,16 @@
+// @flow
+import React from 'react';
+import { Pane, PaneBody, PaneHeader } from './pane';
+
+type Props = {
+  type: 'request' | 'response',
+};
+
+const BlankPane = ({ type }: Props) => (
+  <Pane type={type}>
+    <PaneHeader />
+    <PaneBody placeholder />
+  </Pane>
+);
+
+export default BlankPane;

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane.js
@@ -1,0 +1,7 @@
+// @flow
+import React from 'react';
+import BlankPane from './blank-pane';
+
+const GrpcRequestPane = () => <BlankPane type="request" />;
+
+export default GrpcRequestPane;

--- a/packages/insomnia-app/app/ui/components/panes/grpc-response-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-response-pane.js
@@ -1,0 +1,7 @@
+// @flow
+import React from 'react';
+import BlankPane from './blank-pane';
+
+const GrpcResponsePane = () => <BlankPane type="response" />;
+
+export default GrpcResponsePane;

--- a/packages/insomnia-app/app/ui/components/panes/pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/pane.js
@@ -1,0 +1,45 @@
+// @flow
+import classnames from 'classnames';
+import React from 'react';
+
+type PaneProps = {
+  className?: string,
+  type: 'request' | 'response',
+};
+
+type PaneHeaderProps = {
+  className?: string,
+};
+
+type PaneBodyProps = {
+  className?: string,
+  placeholder?: boolean,
+};
+
+export const Pane = ({ className, type, children }: PaneProps) => (
+  <section className={classnames(`${type}-pane`, 'theme--pane', 'pane', className)}>
+    {children}
+  </section>
+);
+
+export const PaneHeader = ({ className, children }: PaneHeaderProps) => (
+  <header className={classnames('pane__header', 'theme--pane__header', className)}>
+    {children}
+  </header>
+);
+
+export const paneBodyClasses = 'pane__body theme--pane__body';
+
+export const PaneBody = ({ placeholder, children }: PaneBodyProps) => (
+  <div className={classnames(paneBodyClasses, placeholder && 'pane__body--placeholder')}>
+    {children}
+  </div>
+);
+
+// This class component is needed in order to apply a ref to it for resizing
+// The component can be removed, once PR #2712 is merged
+export class ResizablePaneWrapper extends React.PureComponent {
+  render() {
+    return <>{this.props.children}</>;
+  }
+}

--- a/packages/insomnia-app/app/ui/components/panes/placeholder-request-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/placeholder-request-pane.js
@@ -1,0 +1,76 @@
+// @flow
+import React from 'react';
+import Hotkey from '../hotkey';
+import { hotKeyRefs } from '../../../common/hotkeys';
+import * as hotkeys from '../../../common/hotkeys';
+import type { Request } from '../../../models/request';
+import type { ForceToWorkspace } from '../../redux/modules/helpers';
+import { Pane, PaneBody, PaneHeader } from './pane';
+
+type Props = {
+  hotKeyRegistry: hotkeys.HotKeyRegistry,
+  handleImportFile: (forceToWorkspace?: ForceToWorkspace) => void,
+  handleCreateRequest: () => Promise<Request>,
+};
+
+const PlaceholderRequestPane = ({
+  hotKeyRegistry,
+  handleImportFile,
+  handleCreateRequest,
+}: Props) => (
+  <Pane type="request">
+    <PaneHeader />
+    <PaneBody placeholder>
+      <div>
+        <table className="table--fancy">
+          <tbody>
+            <tr>
+              <td>New Request</td>
+              <td className="text-right">
+                <code>
+                  <Hotkey
+                    keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_CREATE.id]}
+                    useFallbackMessage
+                  />
+                </code>
+              </td>
+            </tr>
+            <tr>
+              <td>Switch Requests</td>
+              <td className="text-right">
+                <code>
+                  <Hotkey
+                    keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_QUICK_SWITCH.id]}
+                    useFallbackMessage
+                  />
+                </code>
+              </td>
+            </tr>
+            <tr>
+              <td>Edit Environments</td>
+              <td className="text-right">
+                <code>
+                  <Hotkey
+                    keyBindings={hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]}
+                    useFallbackMessage
+                  />
+                </code>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div className="text-center pane__body--placeholder__cta">
+          <button className="btn inline-block btn--clicky" onClick={handleImportFile}>
+            Import from File
+          </button>
+          <button className="btn inline-block btn--clicky" onClick={handleCreateRequest}>
+            New Request
+          </button>
+        </div>
+      </div>
+    </PaneBody>
+  </Pane>
+);
+
+export default PlaceholderRequestPane;

--- a/packages/insomnia-app/app/ui/components/panes/placeholder-response-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/placeholder-response-pane.js
@@ -1,0 +1,71 @@
+// @flow
+import React from 'react';
+import Hotkey from '../hotkey';
+import { hotKeyRefs } from '../../../common/hotkeys';
+import * as hotkeys from '../../../common/hotkeys';
+import { Pane, PaneBody, PaneHeader } from './pane';
+
+type Props = {
+  hotKeyRegistry: hotkeys.HotKeyRegistry,
+};
+
+const PlaceholderResponsePane = ({ hotKeyRegistry, children }: Props) => (
+  <Pane type="response">
+    <PaneHeader />
+    <PaneBody placeholder>
+      <div>
+        <table className="table--fancy">
+          <tbody>
+            <tr>
+              <td>Send Request</td>
+              <td className="text-right">
+                <code>
+                  <Hotkey
+                    keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SEND.id]}
+                    useFallbackMessage
+                  />
+                </code>
+              </td>
+            </tr>
+            <tr>
+              <td>Focus Url Bar</td>
+              <td className="text-right">
+                <code>
+                  <Hotkey
+                    keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_FOCUS_URL.id]}
+                    useFallbackMessage
+                  />
+                </code>
+              </td>
+            </tr>
+            <tr>
+              <td>Manage Cookies</td>
+              <td className="text-right">
+                <code>
+                  <Hotkey
+                    keyBindings={hotKeyRegistry[hotKeyRefs.SHOW_COOKIES_EDITOR.id]}
+                    useFallbackMessage
+                  />
+                </code>
+              </td>
+            </tr>
+            <tr>
+              <td>Edit Environments</td>
+              <td className="text-right">
+                <code>
+                  <Hotkey
+                    keyBindings={hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]}
+                    useFallbackMessage
+                  />
+                </code>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </PaneBody>
+    {children}
+  </Pane>
+);
+
+export default PlaceholderResponsePane;

--- a/packages/insomnia-app/app/ui/components/panes/request-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/request-pane.js
@@ -5,31 +5,33 @@ import type {
   RequestBody,
   RequestHeader,
   RequestParameter,
-} from '../../models/request';
-import type { Workspace } from '../../models/workspace';
-import type { OAuth2Token } from '../../models/o-auth-2-token';
+} from '../../../models/request';
+import type { Workspace } from '../../../models/workspace';
+import type { OAuth2Token } from '../../../models/o-auth-2-token';
 import autobind from 'autobind-decorator';
 import { deconstructQueryStringToParams, extractQueryStringFromUrl } from 'insomnia-url';
 import * as React from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
-import { getAuthTypeName, getContentTypeName } from '../../common/constants';
-import * as db from '../../common/database';
-import { hotKeyRefs } from '../../common/hotkeys';
-import * as models from '../../models';
-import AuthDropdown from './dropdowns/auth-dropdown';
-import ContentTypeDropdown from './dropdowns/content-type-dropdown';
-import AuthWrapper from './editors/auth/auth-wrapper';
-import BodyEditor from './editors/body/body-editor';
-import RequestHeadersEditor from './editors/request-headers-editor';
-import ErrorBoundary from './error-boundary';
-import Hotkey from './hotkey';
-import MarkdownPreview from './markdown-preview';
-import { showModal } from './modals/index';
-import RequestSettingsModal from './modals/request-settings-modal';
-import RenderedQueryString from './rendered-query-string';
-import RequestUrlBar from './request-url-bar.js';
-import type { Settings } from '../../models/settings';
-import RequestParametersEditor from './editors/request-parameters-editor';
+import { getAuthTypeName, getContentTypeName } from '../../../common/constants';
+import * as db from '../../../common/database';
+import * as models from '../../../models';
+import AuthDropdown from '../dropdowns/auth-dropdown';
+import ContentTypeDropdown from '../dropdowns/content-type-dropdown';
+import AuthWrapper from '../editors/auth/auth-wrapper';
+import BodyEditor from '../editors/body/body-editor';
+import RequestHeadersEditor from '../editors/request-headers-editor';
+import ErrorBoundary from '../error-boundary';
+import MarkdownPreview from '../markdown-preview';
+import { showModal } from '../modals';
+import RequestSettingsModal from '../modals/request-settings-modal';
+import RenderedQueryString from '../rendered-query-string';
+import RequestUrlBar from '../request-url-bar.js';
+import type { Settings } from '../../../models/settings';
+import RequestParametersEditor from '../editors/request-parameters-editor';
+import type { ForceToWorkspace } from '../../redux/modules/helpers';
+import PlaceholderRequestPane from './placeholder-request-pane';
+import { Pane, paneBodyClasses, PaneHeader } from './pane';
+import classnames from 'classnames';
 
 type Props = {
   // Functions
@@ -53,7 +55,7 @@ type Props = {
   updateSettingsUseBulkHeaderEditor: Function,
   updateSettingsUseBulkParametersEditor: Function,
   handleImport: Function,
-  handleImportFile: Function,
+  handleImportFile: (forceToWorkspace?: ForceToWorkspace) => void,
 
   // Other
   workspace: Workspace,
@@ -109,14 +111,6 @@ class RequestPane extends React.PureComponent<Props> {
     updateSettingsUseBulkParametersEditor(!settings.useBulkParametersEditor);
   }
 
-  _handleImportFile() {
-    this.props.handleImportFile();
-  }
-
-  _handleCreateRequest() {
-    this.props.handleCreateRequest();
-  }
-
   _handleImportQueryFromUrl() {
     const { request, forceUpdateRequest } = this.props;
 
@@ -150,6 +144,8 @@ class RequestPane extends React.PureComponent<Props> {
       handleGenerateCode,
       handleGetRenderContext,
       handleImport,
+      handleImportFile,
+      handleCreateRequest,
       handleRender,
       handleSend,
       handleSendAndDownload,
@@ -172,69 +168,15 @@ class RequestPane extends React.PureComponent<Props> {
       downloadPath,
     } = this.props;
 
-    const paneClasses = 'request-pane theme--pane pane';
-    const paneHeaderClasses = 'pane__header theme--pane__header';
-    const paneBodyClasses = 'pane__body theme--pane__body';
-
     const hotKeyRegistry = settings.hotKeyRegistry;
 
     if (!request) {
       return (
-        <section className={paneClasses}>
-          <header className={paneHeaderClasses} />
-          <div className={paneBodyClasses + ' pane__body--placeholder'}>
-            <div>
-              <table className="table--fancy">
-                <tbody>
-                  <tr>
-                    <td>New Request</td>
-                    <td className="text-right">
-                      <code>
-                        <Hotkey
-                          keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_CREATE.id]}
-                          useFallbackMessage
-                        />
-                      </code>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Switch Requests</td>
-                    <td className="text-right">
-                      <code>
-                        <Hotkey
-                          keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_QUICK_SWITCH.id]}
-                          useFallbackMessage
-                        />
-                      </code>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Edit Environments</td>
-                    <td className="text-right">
-                      <code>
-                        <Hotkey
-                          keyBindings={hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]}
-                          useFallbackMessage
-                        />
-                      </code>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-
-              <div className="text-center pane__body--placeholder__cta">
-                <button className="btn inline-block btn--clicky" onClick={this._handleImportFile}>
-                  Import from File
-                </button>
-                <button
-                  className="btn inline-block btn--clicky"
-                  onClick={this._handleCreateRequest}>
-                  New Request
-                </button>
-              </div>
-            </div>
-          </div>
-        </section>
+        <PlaceholderRequestPane
+          hotKeyRegistry={hotKeyRegistry}
+          handleImportFile={handleImportFile}
+          handleCreateRequest={handleCreateRequest}
+        />
       );
     }
 
@@ -250,8 +192,8 @@ class RequestPane extends React.PureComponent<Props> {
     const uniqueKey = `${forceRefreshCounter}::${request._id}`;
 
     return (
-      <section className={paneClasses}>
-        <header className={paneHeaderClasses}>
+      <Pane type="request">
+        <PaneHeader>
           <ErrorBoundary errorClassName="font-error pad text-center">
             <RequestUrlBar
               uniquenessKey={uniqueKey}
@@ -272,8 +214,8 @@ class RequestPane extends React.PureComponent<Props> {
               downloadPath={downloadPath}
             />
           </ErrorBoundary>
-        </header>
-        <Tabs className={paneBodyClasses + ' react-tabs'} forceRenderTabPanel>
+        </PaneHeader>
+        <Tabs className={classnames(paneBodyClasses, 'react-tabs')} forceRenderTabPanel>
           <TabList>
             <Tab tabIndex="-1">
               <ContentTypeDropdown
@@ -459,7 +401,7 @@ class RequestPane extends React.PureComponent<Props> {
             )}
           </TabPanel>
         </Tabs>
-      </section>
+      </Pane>
     );
   }
 }


### PR DESCRIPTION
This PR does some refactoring of components, laying the groundwork to create gRPC panes.

### Nothing selected:
<img width="1352" alt="image" src="https://user-images.githubusercontent.com/4312346/97655578-4ba8c600-1aca-11eb-85b4-ea3a7e2153ca.png">

### HTTP selected:
<img width="1352" alt="image" src="https://user-images.githubusercontent.com/4312346/97655594-59f6e200-1aca-11eb-8bc1-af49831e27fb.png">

### gRPC selected:
<img width="1352" alt="image" src="https://user-images.githubusercontent.com/4312346/97655614-6a0ec180-1aca-11eb-81fe-6e41fcd00c22.png">

## QA:
There should be no material change to the debug tab in it's various states. I suggest running through QA with the live application and this branch running in parallel.
- no request selected
- request selected with no response history
- request sending (and timer is shown) with no previous response history
- request sending (and timer is shown) _with_ previous response shown
- request cancellation
- changing themes
- any other exploration