### PR TITLE
Support for server and bidi streaming

### DIFF
--- a/packages/insomnia-app/app/common/grpc-events.js
+++ b/packages/insomnia-app/app/common/grpc-events.js
@@ -2,7 +2,9 @@
 
 export const GrpcRequestEventEnum = {
   sendUnary: 'GRPC_SEND_UNARY',
-  startStream: 'GRPC_START_STREAM',
+  startClientStream: 'GRPC_START_CLIENT_STREAM',
+  startServerStream: 'GRPC_START_SERVER_STREAM',
+  startBidiStream: 'GRPC_START_BIDI_STREAM',
   sendMessage: 'GRPC_SEND_MESSAGE',
   commit: 'GRPC_COMMIT',
   cancel: 'GRPC_CANCEL',

--- a/packages/insomnia-app/app/main/__tests__/grpc-ipc-main.test.js
+++ b/packages/insomnia-app/app/main/__tests__/grpc-ipc-main.test.js
@@ -28,19 +28,40 @@ describe('grpcIpcMain', () => {
     expect(grpc.sendUnary).toHaveBeenCalledWith(id, expect.any(ResponseCallbacks));
   });
 
-  it('should add expected listener for startStream', () => {
+  it('should add expected listener for startClientStream', () => {
     const [channel, listener] = ipcMain.on.mock.calls[1];
 
-    expect(channel).toBe(GrpcRequestEventEnum.startStream);
+    expect(channel).toBe(GrpcRequestEventEnum.startClientStream);
 
     // Execute the callback, and make sure the correct grpc method is called
     listener(event, id);
     expect(grpc.startClientStreaming).toHaveBeenCalledWith(id, expect.any(ResponseCallbacks));
   });
 
-  it('should add expected listener for sendMessage', () => {
+  it('should add expected listener for startServerStream', () => {
     const [channel, listener] = ipcMain.on.mock.calls[2];
 
+    expect(channel).toBe(GrpcRequestEventEnum.startServerStream);
+
+    // Execute the callback, and make sure the correct grpc method is called
+    listener(event, id);
+    expect(grpc.startServerStreaming).toHaveBeenCalledWith(id, expect.any(ResponseCallbacks));
+  });
+
+  it('should add expected listener for startBidiStream', () => {
+    const [channel, listener] = ipcMain.on.mock.calls[3];
+
+    expect(channel).toBe(GrpcRequestEventEnum.startBidiStream);
+
+    // Execute the callback, and make sure the correct grpc method is called
+    listener(event, id);
+    expect(grpc.startBidiStreaming).toHaveBeenCalledWith(id, expect.any(ResponseCallbacks));
+  });
+
+  it('should add expected listener for sendMessage', () => {
+    const [channel, listener] = ipcMain.on.mock.calls[4];
+
+    // Expect the sendUnary channel
     expect(channel).toBe(GrpcRequestEventEnum.sendMessage);
 
     // Execute the callback, and make sure the correct grpc method is called
@@ -49,7 +70,7 @@ describe('grpcIpcMain', () => {
   });
 
   it('should add expected listener for commit', () => {
-    const [channel, listener] = ipcMain.on.mock.calls[3];
+    const [channel, listener] = ipcMain.on.mock.calls[5];
 
     expect(channel).toBe(GrpcRequestEventEnum.commit);
 
@@ -59,7 +80,7 @@ describe('grpcIpcMain', () => {
   });
 
   it('should add expected listener for cancel', () => {
-    const [channel, listener] = ipcMain.on.mock.calls[4];
+    const [channel, listener] = ipcMain.on.mock.calls[6];
 
     expect(channel).toBe(GrpcRequestEventEnum.cancel);
 

--- a/packages/insomnia-app/app/main/__tests__/grpc-ipc-main.test.js
+++ b/packages/insomnia-app/app/main/__tests__/grpc-ipc-main.test.js
@@ -90,7 +90,7 @@ describe('grpcIpcMain', () => {
   });
 
   it('should add expected listener for cancel multiple', () => {
-    const [channel, listener] = ipcMain.on.mock.calls[5];
+    const [channel, listener] = ipcMain.on.mock.calls[7];
 
     expect(channel).toBe(GrpcRequestEventEnum.cancelMultiple);
 

--- a/packages/insomnia-app/app/main/grpc-ipc-main.js
+++ b/packages/insomnia-app/app/main/grpc-ipc-main.js
@@ -9,8 +9,14 @@ export function init() {
   ipcMain.on(GrpcRequestEventEnum.sendUnary, (e, requestId) =>
     grpc.sendUnary(requestId, new ResponseCallbacks(e)),
   );
-  ipcMain.on(GrpcRequestEventEnum.startStream, (e, requestId) =>
+  ipcMain.on(GrpcRequestEventEnum.startClientStream, (e, requestId) =>
     grpc.startClientStreaming(requestId, new ResponseCallbacks(e)),
+  );
+  ipcMain.on(GrpcRequestEventEnum.startServerStream, (e, requestId) =>
+    grpc.startServerStreaming(requestId, new ResponseCallbacks(e)),
+  );
+  ipcMain.on(GrpcRequestEventEnum.startBidiStream, (e, requestId) =>
+    grpc.startBidiStreaming(requestId, new ResponseCallbacks(e)),
   );
   ipcMain.on(GrpcRequestEventEnum.sendMessage, (e, requestId) =>
     grpc.sendMessage(requestId, new ResponseCallbacks(e)),

--- a/packages/insomnia-app/app/network/grpc/__mocks__/index.js
+++ b/packages/insomnia-app/app/network/grpc/__mocks__/index.js
@@ -1,6 +1,8 @@
 module.exports = {
   sendUnary: jest.fn(),
   startClientStreaming: jest.fn(),
+  startServerStreaming: jest.fn(),
+  startBidiStreaming: jest.fn(),
   sendMessage: jest.fn(),
   commit: jest.fn(),
   cancel: jest.fn(),

--- a/packages/insomnia-app/app/network/grpc/index.js
+++ b/packages/insomnia-app/app/network/grpc/index.js
@@ -43,7 +43,6 @@ export const sendUnary = async (requestId: string, respond: ResponseCallbacks): 
 
   // Create client
   const client = _createClient(req, respond);
-
   if (!client) {
     return;
   }
@@ -105,6 +104,90 @@ export const startClientStreaming = async (
   callCache.set(requestId, call);
 };
 
+export const startServerStreaming = async (
+  requestId: string,
+  respond: ResponseCallbacks,
+): Promise<void> => {
+  const req = await models.grpcRequest.getById(requestId);
+  const selectedMethod = await protoLoader.getSelectedMethod(req);
+
+  if (!selectedMethod) {
+    respond.sendError(
+      requestId,
+      new Error(`The gRPC method ${req.protoMethodName} could not be found`),
+    );
+    // TODO: sendEnd
+    return;
+  }
+
+  // Load initial message
+  const messageBody = _parseMessage(req, respond);
+  if (!messageBody) {
+    return;
+  }
+
+  // Create client
+  const client = createClient(req, respond);
+  if (!client) {
+    return;
+  }
+
+  // Make call
+  const call = client.makeServerStreamRequest(
+    selectedMethod.path,
+    selectedMethod.requestSerialize,
+    selectedMethod.responseDeserialize,
+    messageBody,
+  );
+
+  _setupStatusListener(call, requestId, respond);
+  _setupServerStreamListeners(call, requestId, respond);
+
+  respond.sendStart(requestId);
+
+  // Save call
+  callCache.set(requestId, call);
+};
+
+export const startBidiStreaming = async (
+  requestId: string,
+  respond: ResponseCallbacks,
+): Promise<void> => {
+  const req = await models.grpcRequest.getById(requestId);
+  const selectedMethod = await protoLoader.getSelectedMethod(req);
+
+  if (!selectedMethod) {
+    respond.sendError(
+      requestId,
+      new Error(`The gRPC method ${req.protoMethodName} could not be found`),
+    );
+    // TODO: sendEnd
+    return;
+  }
+
+  // Create client
+  const client = createClient(req, respond);
+
+  if (!client) {
+    return;
+  }
+
+  // Make call
+  const call = client.makeBidiStreamRequest(
+    selectedMethod.path,
+    selectedMethod.requestSerialize,
+    selectedMethod.responseDeserialize,
+  );
+
+  _setupStatusListener(call, requestId, respond);
+  _setupServerStreamListeners(call, requestId, respond);
+
+  respond.sendStart(requestId);
+
+  // Save call
+  callCache.set(requestId, call);
+};
+
 export const sendMessage = async (requestId: string, respond: ResponseCallbacks) => {
   const req = await models.grpcRequest.getById(requestId);
   const messageBody = _parseMessage(req, respond);
@@ -124,6 +207,22 @@ export const cancelMultiple = (requestIds: Array<string>) => requestIds.forEach(
 
 const _setupStatusListener = (call: Call, requestId: string, respond: ResponseCallbacks) => {
   call.on('status', s => respond.sendStatus(requestId, s));
+};
+
+const _setupServerStreamListeners = (call: Call, requestId: string, respond: ResponseCallbacks) => {
+  call.on('data', data => respond.sendData(requestId, data));
+
+  call.on('error', (error: ServiceError) => {
+    if (error?.code !== GrpcStatusEnum.CANCELLED) {
+      respond.sendError(requestId, error);
+
+      // Taken through inspiration from other implementation, needs validation
+      if (error.code === GrpcStatusEnum.UNKNOWN || error.code === GrpcStatusEnum.UNAVAILABLE) {
+        respond.sendEnd(requestId);
+      }
+    }
+  });
+  call.on('end', () => respond.sendEnd(requestId));
 };
 
 // This function returns a function

--- a/packages/insomnia-app/app/network/grpc/index.js
+++ b/packages/insomnia-app/app/network/grpc/index.js
@@ -127,7 +127,7 @@ export const startServerStreaming = async (
   }
 
   // Create client
-  const client = createClient(req, respond);
+  const client = _createClient(req, respond);
   if (!client) {
     return;
   }
@@ -166,7 +166,7 @@ export const startBidiStreaming = async (
   }
 
   // Create client
-  const client = createClient(req, respond);
+  const client = _createClient(req, respond);
 
   if (!client) {
     return;

--- a/packages/insomnia-app/app/network/grpc/index.js
+++ b/packages/insomnia-app/app/network/grpc/index.js
@@ -116,7 +116,6 @@ export const startServerStreaming = async (
       requestId,
       new Error(`The gRPC method ${req.protoMethodName} could not be found`),
     );
-    // TODO: sendEnd
     return;
   }
 
@@ -161,7 +160,6 @@ export const startBidiStreaming = async (
       requestId,
       new Error(`The gRPC method ${req.protoMethodName} could not be found`),
     );
-    // TODO: sendEnd
     return;
   }
 

--- a/packages/insomnia-app/app/ui/components/buttons/grpc-send-button.js
+++ b/packages/insomnia-app/app/ui/components/buttons/grpc-send-button.js
@@ -26,13 +26,17 @@ const GrpcSendButton = ({ requestId, methodType }: Props) => {
 
       case GrpcMethodTypeEnum.client:
         text = 'Start';
-        onClick = () => sendIpc(GrpcRequestEventEnum.startStream);
+        onClick = () => sendIpc(GrpcRequestEventEnum.startClientStream);
         break;
 
       case GrpcMethodTypeEnum.server:
+        text = 'Start';
+        onClick = () => sendIpc(GrpcRequestEventEnum.startServerStream);
+        break;
+
       case GrpcMethodTypeEnum.bidi:
-        text = 'Coming soon';
-        disabled = true;
+        text = 'Start';
+        onClick = () => sendIpc(GrpcRequestEventEnum.startBidiStream);
         break;
 
       default:

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.js
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.js
@@ -24,7 +24,7 @@ export type GrpcRequestState = {
   reloadMethods: boolean,
 };
 
-// TODO: delete from here when deleting a request
+// TODO: delete from here when deleting a request - INS-288
 export type GrpcState = { [requestId: string]: GrpcRequestState };
 
 const INITIAL_GRPC_REQUEST_STATE: GrpcRequestState = {

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.js
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.js
@@ -23,6 +23,8 @@ export type GrpcRequestState = {
   methods: Array<GrpcMethodDefinition>,
   reloadMethods: boolean,
 };
+
+// TODO: delete from here when deleting a request
 export type GrpcState = { [requestId: string]: GrpcRequestState };
 
 const INITIAL_GRPC_REQUEST_STATE: GrpcRequestState = {


### PR DESCRIPTION
![2020-11-16 16 53 17](https://user-images.githubusercontent.com/4312346/99211165-9ba6bd00-282c-11eb-8914-4cfa18a6bfd6.gif)

Nothing particular to note. There is a bit of duplication in the grpc network file for each streaming type. It's a little easier to understand, but it would be good to refactor and reuse when this work is revisited.

Fixes INS-282