### PR TITLE
Add TLS/SSL support

### DIFF
--- a/packages/insomnia-app/app/network/grpc/__tests__/parse-grpc-url.test.js
+++ b/packages/insomnia-app/app/network/grpc/__tests__/parse-grpc-url.test.js
@@ -1,0 +1,43 @@
+import parseGrpcUrl from '../parse-grpc-url';
+
+describe('parseGrpcUrl', () => {
+  it.each([
+    ['grpcb.in:9000', 'grpcb.in:9000'],
+    ['GRPCB.IN:9000', 'grpcb.in:9000'],
+    ['custom.co', 'custom.co'],
+  ])('should not enable tls with no protocol: %s', (input, expected) => {
+    expect(parseGrpcUrl(input)).toStrictEqual({
+      url: expected,
+      enableTls: false,
+    });
+  });
+
+  it.each([
+    ['grpcs://grpcb.in:9000', 'grpcb.in:9000'],
+    ['GRPCS://GRPCB.IN:9000', 'grpcb.in:9000'],
+    ['grpcs://custom.co', 'custom.co'],
+  ])('should enable tls with no grpcs:// protocol: %s', (input, expected) => {
+    expect(parseGrpcUrl(input)).toStrictEqual({
+      url: expected,
+      enableTls: true,
+    });
+  });
+
+  it.each([
+    ['grpc://grpcb.in:9000', 'grpcb.in:9000'],
+    ['GRPC://GRPCB.IN:9000', 'grpcb.in:9000'],
+    ['grpc://custom.co', 'custom.co'],
+  ])('should not enable tls with no grpc:// protocol: %s', (input, expected) => {
+    expect(parseGrpcUrl(input)).toStrictEqual({
+      url: expected,
+      enableTls: false,
+    });
+  });
+
+  it.each([null, undefined, ''])('can handle falsey values', input => {
+    expect(parseGrpcUrl(input)).toStrictEqual({
+      url: '',
+      enableTls: false,
+    });
+  });
+});

--- a/packages/insomnia-app/app/network/grpc/__tests__/parse-grpc-url.test.js
+++ b/packages/insomnia-app/app/network/grpc/__tests__/parse-grpc-url.test.js
@@ -16,7 +16,7 @@ describe('parseGrpcUrl', () => {
     ['grpcs://grpcb.in:9000', 'grpcb.in:9000'],
     ['GRPCS://GRPCB.IN:9000', 'grpcb.in:9000'],
     ['grpcs://custom.co', 'custom.co'],
-  ])('should enable tls with no grpcs:// protocol: %s', (input, expected) => {
+  ])('should enable tls with grpcs:// protocol: %s', (input, expected) => {
     expect(parseGrpcUrl(input)).toStrictEqual({
       url: expected,
       enableTls: true,
@@ -34,7 +34,7 @@ describe('parseGrpcUrl', () => {
     });
   });
 
-  it.each([null, undefined, ''])('can handle falsey values', input => {
+  it.each([null, undefined, ''])('can handle falsey urls', input => {
     expect(parseGrpcUrl(input)).toStrictEqual({
       url: '',
       enableTls: false,

--- a/packages/insomnia-app/app/network/grpc/index.js
+++ b/packages/insomnia-app/app/network/grpc/index.js
@@ -13,14 +13,14 @@ import parseGrpcUrl from './parse-grpc-url';
 const _createClient = (req: GrpcRequest, respond: ResponseCallbacks): Object | undefined => {
   const { url, enableTls } = parseGrpcUrl(req.url);
 
-  if (url) {
+  if (!url) {
     respond.sendError(req._id, new Error('gRPC url not specified'));
     return undefined;
   }
 
   const credentials = enableTls ? grpc.credentials.createSsl() : grpc.credentials.createInsecure();
 
-  console.log(`[gRPC] connecting to url=${url} ${enableTls ? 'with' : 'without'} TLSÏ`);
+  console.log(`[gRPC] connecting to url=${url} ${enableTls ? 'with' : 'without'} TLS`);
   const Client = grpc.makeGenericClientConstructor({});
   return new Client(url, credentials);
 };

--- a/packages/insomnia-app/app/network/grpc/index.js
+++ b/packages/insomnia-app/app/network/grpc/index.js
@@ -8,15 +8,21 @@ import callCache from './call-cache';
 import type { ServiceError } from './service-error';
 import { GrpcStatusEnum } from './service-error';
 import type { Call } from './call-cache';
+import parseGrpcUrl from './parse-grpc-url';
 
-const createClient = (req: GrpcRequest, respond: ResponseCallbacks): Object | undefined => {
-  if (!req.url) {
-    respond.sendError(req._id, new Error('gRPC url not specified')); // TODO: update wording
+const _createClient = (req: GrpcRequest, respond: ResponseCallbacks): Object | undefined => {
+  const { url, enableTls } = parseGrpcUrl(req.url);
+
+  if (url) {
+    respond.sendError(req._id, new Error('gRPC url not specified'));
     return undefined;
   }
-  console.log(`[gRPC] connecting to url=${req.url}`);
+
+  const credentials = enableTls ? grpc.credentials.createSsl() : grpc.credentials.createInsecure();
+
+  console.log(`[gRPC] connecting to url=${url} ${enableTls ? 'with' : 'without'} TLSÏ`);
   const Client = grpc.makeGenericClientConstructor({});
-  return new Client(req.url, grpc.credentials.createInsecure());
+  return new Client(url, credentials);
 };
 
 export const sendUnary = async (requestId: string, respond: ResponseCallbacks): Promise<void> => {
@@ -39,7 +45,7 @@ export const sendUnary = async (requestId: string, respond: ResponseCallbacks): 
   }
 
   // Create client
-  const client = createClient(req, respond);
+  const client = _createClient(req, respond);
 
   if (!client) {
     return;
@@ -81,7 +87,7 @@ export const startClientStreaming = async (
   }
 
   // Create client
-  const client = createClient(req, respond);
+  const client = _createClient(req, respond);
 
   if (!client) {
     return;

--- a/packages/insomnia-app/app/network/grpc/parse-grpc-url.js
+++ b/packages/insomnia-app/app/network/grpc/parse-grpc-url.js
@@ -1,0 +1,17 @@
+// @flow
+import url from 'url';
+
+const parseGrpcUrl = (grpcUrl?: string): { url: string, enableTls: boolean } => {
+  const { protocol, host, href } = url.parse(grpcUrl?.toLowerCase() || '');
+
+  switch (protocol) {
+    case 'grpcs:':
+      return { url: host, enableTls: true };
+    case 'grpc:':
+      return { url: host, enableTls: false };
+    default:
+      return { url: href, enableTls: false };
+  }
+};
+
+export default parseGrpcUrl;


### PR DESCRIPTION
What it says on the tin

- `grpcs://grpcb.in:9001` requires TLS
- `grpc://grpcb.in:9000` and `grpcb.in:9000` does not require TLS


The various permutations:

![image](https://user-images.githubusercontent.com/4312346/98737569-3eb19e00-240b-11eb-98c0-8928ec94ecd3.png)

![image](https://user-images.githubusercontent.com/4312346/98737585-45401580-240b-11eb-8395-3ed9511a7022.png)

![image](https://user-images.githubusercontent.com/4312346/98737628-525d0480-240b-11eb-8e55-f8c79cfbc4ce.png)

![image](https://user-images.githubusercontent.com/4312346/98737653-5e48c680-240b-11eb-9e4b-361110069238.png)
