### PR TITLE
Allow changing the protofile for a request

### DIFF
--- a/packages/insomnia-app/app/models/__tests__/grpc-request.test.js
+++ b/packages/insomnia-app/app/models/__tests__/grpc-request.test.js
@@ -12,7 +12,9 @@ describe('init()', () => {
       description: '',
       protoFileId: '',
       protoMethodName: '',
-      body: {},
+      body: {
+        text: '{}',
+      },
       metaSortKey: -1478795580200,
       idPrivate: false,
     });
@@ -38,7 +40,9 @@ describe('create()', () => {
       url: '',
       protoFileId: '',
       protoMethodName: '',
-      body: {},
+      body: {
+        text: '{}',
+      },
       metaSortKey: -1478795580200,
       idPrivate: false,
       type: 'GrpcRequest',

--- a/packages/insomnia-app/app/models/grpc-request.js
+++ b/packages/insomnia-app/app/models/grpc-request.js
@@ -32,7 +32,9 @@ export function init(): BaseGrpcRequest {
     description: '',
     protoFileId: '',
     protoMethodName: '',
-    body: {},
+    body: {
+      text: '{}',
+    },
     metaSortKey: -1 * Date.now(),
     idPrivate: false,
   };

--- a/packages/insomnia-app/app/network/grpc/__mocks__/proto-loader.js
+++ b/packages/insomnia-app/app/network/grpc/__mocks__/proto-loader.js
@@ -1,0 +1,3 @@
+module.exports = {
+  loadMethods: jest.fn(),
+};

--- a/packages/insomnia-app/app/network/grpc/index.js
+++ b/packages/insomnia-app/app/network/grpc/index.js
@@ -14,7 +14,7 @@ const _createClient = (req: GrpcRequest, respond: ResponseCallbacks): Object | u
   const { url, enableTls } = parseGrpcUrl(req.url);
 
   if (!url) {
-    respond.sendError(req._id, new Error('gRPC url not specified'));
+    respond.sendError(req._id, new Error('URL not specified'));
     return undefined;
   }
 
@@ -31,10 +31,7 @@ export const sendUnary = async (requestId: string, respond: ResponseCallbacks): 
   const selectedMethod = await protoLoader.getSelectedMethod(req);
 
   if (!selectedMethod) {
-    respond.sendError(
-      requestId,
-      new Error(`The gRPC method ${req.protoMethodName} could not be found`),
-    );
+    respond.sendError(requestId, new Error(`Method definition could not be found`));
     return;
   }
 
@@ -79,10 +76,7 @@ export const startClientStreaming = async (
   const selectedMethod = await protoLoader.getSelectedMethod(req);
 
   if (!selectedMethod) {
-    respond.sendError(
-      requestId,
-      new Error(`The gRPC method ${req.protoMethodName} could not be found`),
-    );
+    respond.sendError(requestId, new Error(`Method definition could not be found`));
     return;
   }
 

--- a/packages/insomnia-app/app/network/grpc/method.js
+++ b/packages/insomnia-app/app/network/grpc/method.js
@@ -45,5 +45,5 @@ export const GrpcMethodTypeName: { [GrpcMethodType]: string } = {
   [GrpcMethodTypeEnum.bidi]: 'Bi-directional Streaming',
 };
 
-export const canClientStream = (methodType: GrpcMethodType) =>
+export const canClientStream = (methodType?: GrpcMethodType) =>
   methodType === GrpcMethodTypeEnum.client || methodType === GrpcMethodTypeEnum.bidi;

--- a/packages/insomnia-app/app/network/grpc/proto-loader.js
+++ b/packages/insomnia-app/app/network/grpc/proto-loader.js
@@ -23,7 +23,13 @@ const isServiceDefinition = (obj: Object) => !isTypeOrEnumDefinition(obj);
 //  writing to a file in those cases, but it becomes more important to cache
 //  We also need to think about how to store a reference to a proto file and it's
 //  implications on import/export/sync - INS-271
-export const loadMethods = async (protoFile: ProtoFile): Promise<Array<GrpcMethodDefinition>> => {
+export const loadMethods = async (
+  protoFile: ProtoFile | undefined,
+): Promise<Array<GrpcMethodDefinition>> => {
+  if (!protoFile?.protoText) {
+    return [];
+  }
+
   const tempProtoFile = await writeProtoFile(protoFile.protoText);
   const definition = await protoLoader.load(tempProtoFile, GRPC_LOADER_OPTIONS);
 

--- a/packages/insomnia-app/app/network/grpc/proto-loader.js
+++ b/packages/insomnia-app/app/network/grpc/proto-loader.js
@@ -16,9 +16,6 @@ const GRPC_LOADER_OPTIONS = {
 const isTypeOrEnumDefinition = (obj: Object) => 'format' in obj; // same check exists internally in the grpc library
 const isServiceDefinition = (obj: Object) => !isTypeOrEnumDefinition(obj);
 
-// TODO: instead of writing to a temp file and loading the protoFile every time methods are required,
-//  add an in-memory caching strategy, indexed by the protoFile._id - INS-272
-
 // TODO: The file path for protoLoader.load can also be a URL, so we can avoid
 //  writing to a file in those cases, but it becomes more important to cache
 //  We also need to think about how to store a reference to a proto file and it's

--- a/packages/insomnia-app/app/ui/components/buttons/grpc-send-button.js
+++ b/packages/insomnia-app/app/ui/components/buttons/grpc-send-button.js
@@ -44,7 +44,7 @@ const GrpcSendButton = ({ requestId, methodType }: Props) => {
     return { text, onClick, disabled };
   }, [sendIpc, methodType]);
 
-  const [{ running }, grpcDispatch] = useGrpc(requestId);
+  const [{ running }, dispatch] = useGrpc(requestId);
 
   if (running) {
     return (
@@ -59,7 +59,7 @@ const GrpcSendButton = ({ requestId, methodType }: Props) => {
       className="urlbar__send-btn"
       onClick={() => {
         config.onClick();
-        grpcDispatch(grpcActions.reset(requestId));
+        grpcActions.clear(dispatch, requestId);
       }}
       disabled={config.disabled}>
       {config.text}

--- a/packages/insomnia-app/app/ui/components/buttons/grpc-send-button.js
+++ b/packages/insomnia-app/app/ui/components/buttons/grpc-send-button.js
@@ -59,7 +59,7 @@ const GrpcSendButton = ({ requestId, methodType }: Props) => {
       className="urlbar__send-btn"
       onClick={() => {
         config.onClick();
-        grpcActions.clear(dispatch, requestId);
+        dispatch(grpcActions.clear(requestId));
       }}
       disabled={config.disabled}>
       {config.text}

--- a/packages/insomnia-app/app/ui/components/dropdowns/grpc-method-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/grpc-method-dropdown.js
@@ -23,10 +23,8 @@ const GrpcMethodDropdown = ({
       {selectedMethod?.path || 'Select Method'}
       <i className="fa fa-caret-down" />
     </DropdownButton>
+    <DropdownItem onClick={handleChangeProtoFile}>Click to change proto file</DropdownItem>
     {!methods.length && <DropdownItem disabled>No methods found</DropdownItem>}
-    {methods.length && (
-      <DropdownItem onClick={handleChangeProtoFile}>Click to change proto file</DropdownItem>
-    )}
     {methods.map(({ path }) => (
       <DropdownItem key={path} onClick={handleChange} value={path} disabled={disabled}>
         {path === selectedMethod?.path && <i className="fa fa-check" />}

--- a/packages/insomnia-app/app/ui/components/dropdowns/grpc-method-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/grpc-method-dropdown.js
@@ -8,15 +8,25 @@ type Props = {
   methods: Array<GrpcMethodDefinition>,
   selectedMethod?: GrpcMethodDefinition,
   handleChange: string => Promise<void>,
+  handleChangeProtoFile: string => Promise<void>,
 };
 
-const GrpcMethodDropdown = ({ disabled, methods, selectedMethod, handleChange }: Props) => (
+const GrpcMethodDropdown = ({
+  disabled,
+  methods,
+  selectedMethod,
+  handleChange,
+  handleChangeProtoFile,
+}: Props) => (
   <Dropdown>
     <DropdownButton>
       {selectedMethod?.path || 'Select Method'}
       <i className="fa fa-caret-down" />
     </DropdownButton>
     {!methods.length && <DropdownItem disabled>No methods found</DropdownItem>}
+    {methods.length && (
+      <DropdownItem onClick={handleChangeProtoFile}>Click to change proto file</DropdownItem>
+    )}
     {methods.map(({ path }) => (
       <DropdownItem key={path} onClick={handleChange} value={path} disabled={disabled}>
         {path === selectedMethod?.path && <i className="fa fa-check" />}

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane.js
@@ -84,7 +84,7 @@ const useChangeHandlers = (request: GrpcRequest, dispatch: GrpcDispatch): Change
   }, [request, dispatch]);
 };
 
-const GrpcRequestPane = ({ activeRequest, forceRefreshKey, settings }: Props) => {
+const GrpcRequestPane = ({ activeRequest, forceRefreshKey, settings, activeProtoFiles }: Props) => {
   const [{ requestMessages, running }, grpcDispatch] = useGrpc(activeRequest._id);
 
   const [methods, setMethods] = React.useState<Array<GrpcMethodDefinition>>([]);
@@ -103,6 +103,13 @@ const GrpcRequestPane = ({ activeRequest, forceRefreshKey, settings }: Props) =>
     () => getMethodSelection(methods, activeRequest.protoMethodName),
     [methods, activeRequest.protoMethodName],
   );
+
+  // If there is no longer a method selected, reset the request state
+  React.useEffect(() => {
+    if (!selectedMethod) {
+      grpcDispatch(grpcActions.reset(activeRequest._id));
+    }
+  }, [activeRequest._id, grpcDispatch, selectedMethod]);
 
   const handleChange = useChangeHandlers(activeRequest, grpcDispatch);
 

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.js
@@ -37,9 +37,8 @@ const GrpcRequestPane = ({ activeRequest, forceRefreshKey, settings }: Props) =>
     func();
   }, [activeRequest._id, activeRequest.protoFileId, reloadMethods, grpcDispatch]);
 
-  const { method, methodType, methodTypeLabel, enableClientStream } = useSelectedMethod(
-    activeRequest,
-  );
+  const selection = useSelectedMethod(methods, activeRequest);
+  const { method, methodType, methodTypeLabel, enableClientStream } = selection;
 
   const handleChange = useChangeHandlers(activeRequest, grpcDispatch);
 

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.js
@@ -45,6 +45,13 @@ const GrpcRequestPane = ({ activeRequest, forceRefreshKey, settings }: Props) =>
 
   const sendIpc = useGrpcIpc(activeRequest._id);
 
+  const handleStream = React.useCallback(() => {
+    sendIpc(GrpcRequestEventEnum.sendMessage);
+    grpcDispatch(grpcActions.requestMessage(activeRequest._id, activeRequest.body.text));
+  }, [activeRequest._id, activeRequest.body.text, grpcDispatch, sendIpc]);
+
+  const handleCommit = React.useCallback(() => sendIpc(GrpcRequestEventEnum.commit), [sendIpc]);
+
   return (
     <Pane type="request">
       <PaneHeader className="grpc-urlbar">
@@ -55,7 +62,7 @@ const GrpcRequestPane = ({ activeRequest, forceRefreshKey, settings }: Props) =>
             type="text"
             forceEditor
             defaultValue={activeRequest.url}
-            placeholder="grpcb.in:9000"
+            placeholder="example.com:9000"
             onChange={handleChange.url}
           />
         </form>
@@ -89,13 +96,8 @@ const GrpcRequestPane = ({ activeRequest, forceRefreshKey, settings }: Props) =>
                 bodyText={activeRequest.body.text}
                 handleBodyChange={handleChange.body}
                 showActions={running && enableClientStream}
-                handleStream={() => {
-                  sendIpc(GrpcRequestEventEnum.sendMessage);
-                  grpcDispatch(
-                    grpcActions.requestMessage(activeRequest._id, activeRequest.body.text),
-                  );
-                }}
-                handleCommit={() => sendIpc(GrpcRequestEventEnum.commit)}
+                handleStream={handleStream}
+                handleCommit={handleCommit}
               />
             </TabPanel>
             <TabPanel className="react-tabs__tab-panel">

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.js
@@ -27,11 +27,8 @@ const GrpcRequestPane = ({ activeRequest, forceRefreshKey, settings }: Props) =>
   // Reload the methods, on first mount, or if the request protoFile changes
   React.useEffect(() => {
     const func = async () => {
-      await grpcActions.loadMethods(
-        grpcDispatch,
-        activeRequest._id,
-        activeRequest.protoFileId,
-        reloadMethods,
+      grpcDispatch(
+        await grpcActions.loadMethods(activeRequest._id, activeRequest.protoFileId, reloadMethods),
       );
     };
     func();

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-change-handlers.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-change-handlers.js
@@ -1,0 +1,57 @@
+// @flow
+
+import React from 'react';
+import type { GrpcRequest } from '../../../../models/grpc-request';
+import type { GrpcDispatch } from '../../../context/grpc/grpc-actions';
+import * as models from '../../../../models';
+import { grpcActions } from '../../../context/grpc';
+import { showModal } from '../../modals';
+import ProtoFilesModal from '../../modals/proto-files-modal';
+
+type ChangeHandlers = {
+  url: string => Promise<void>,
+  body: string => Promise<void>,
+  method: string => Promise<void>,
+  protoFile: string => Promise<void>,
+};
+
+// This will create memoized change handlers for the url, body and method selection
+const useChangeHandlers = (request: GrpcRequest, dispatch: GrpcDispatch): ChangeHandlers => {
+  return React.useMemo(() => {
+    const url = async (value: string) => {
+      await models.grpcRequest.update(request, { url: value });
+    };
+
+    const body = async (value: string) => {
+      await models.grpcRequest.update(request, { body: { ...request.body, text: value } });
+    };
+
+    const method = async (value: string) => {
+      await models.grpcRequest.update(request, { protoMethodName: value });
+      grpcActions.clear(dispatch, request._id);
+    };
+
+    const protoFile = async () => {
+      showModal(ProtoFilesModal, {
+        preselectProtoFileId: request.protoFileId,
+        onSave: async (protoFileId: string) => {
+          if (request.protoFileId !== protoFileId) {
+            const initial = models.grpcRequest.init();
+
+            // Reset the body as it is no longer relevant
+            await models.grpcRequest.update(request, {
+              protoFileId,
+              body: initial.body,
+              protoMethodName: initial.protoMethodName,
+            });
+            grpcActions.invalidate(dispatch, request._id);
+          }
+        },
+      });
+    };
+
+    return { url, body, method, protoFile };
+  }, [request, dispatch]);
+};
+
+export default useChangeHandlers;

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-change-handlers.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-change-handlers.js
@@ -28,7 +28,7 @@ const useChangeHandlers = (request: GrpcRequest, dispatch: GrpcDispatch): Change
 
     const method = async (value: string) => {
       await models.grpcRequest.update(request, { protoMethodName: value });
-      grpcActions.clear(dispatch, request._id);
+      dispatch(grpcActions.clear(request._id));
     };
 
     const protoFile = async () => {
@@ -44,7 +44,7 @@ const useChangeHandlers = (request: GrpcRequest, dispatch: GrpcDispatch): Change
               body: initial.body,
               protoMethodName: initial.protoMethodName,
             });
-            grpcActions.invalidate(dispatch, request._id);
+            dispatch(grpcActions.invalidate(request._id));
           }
         },
       });

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-selected-method.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-selected-method.js
@@ -1,0 +1,33 @@
+// @flow
+import React from 'react';
+import type { GrpcMethodDefinition, GrpcMethodType } from '../../../../network/grpc/method';
+import { useGrpcRequestState } from '../../../context/grpc';
+import {
+  canClientStream,
+  getMethodType,
+  GrpcMethodTypeName,
+} from '../../../../network/grpc/method';
+import type { GrpcRequest } from '../../../../models/grpc-request';
+
+type MethodSelection = {
+  method?: GrpcMethodDefinition,
+  methodType?: GrpcMethodType,
+  methodTypeLabel?: string,
+  enableClientStream?: boolean,
+};
+
+const useSelectedMethod = ({ _id, protoMethodName }: GrpcRequest): MethodSelection => {
+  const { methods } = useGrpcRequestState(_id);
+
+  return React.useMemo(() => {
+    const selectedMethod = methods.find(c => c.path === protoMethodName);
+
+    const methodType = selectedMethod && getMethodType(selectedMethod);
+    const methodTypeLabel = GrpcMethodTypeName[methodType];
+    const enableClientStream = canClientStream(methodType);
+
+    return { method: selectedMethod, methodType, methodTypeLabel, enableClientStream };
+  }, [methods, protoMethodName]);
+};
+
+export default useSelectedMethod;

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-selected-method.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-selected-method.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import type { GrpcMethodDefinition, GrpcMethodType } from '../../../../network/grpc/method';
-import { useGrpcRequestState } from '../../../context/grpc';
 import {
   canClientStream,
   getMethodType,
@@ -16,10 +15,11 @@ type MethodSelection = {
   enableClientStream?: boolean,
 };
 
-const useSelectedMethod = ({ _id, protoMethodName }: GrpcRequest): MethodSelection => {
-  const { methods } = useGrpcRequestState(_id);
-
-  return React.useMemo(() => {
+const useSelectedMethod = (
+  methods: Array<GrpcMethodDefinition>,
+  { _id, protoMethodName }: GrpcRequest,
+): MethodSelection =>
+  React.useMemo(() => {
     const selectedMethod = methods.find(c => c.path === protoMethodName);
 
     const methodType = selectedMethod && getMethodType(selectedMethod);
@@ -28,6 +28,5 @@ const useSelectedMethod = ({ _id, protoMethodName }: GrpcRequest): MethodSelecti
 
     return { method: selectedMethod, methodType, methodTypeLabel, enableClientStream };
   }, [methods, protoMethodName]);
-};
 
 export default useSelectedMethod;

--- a/packages/insomnia-app/app/ui/context/grpc/__schemas__/grpc-method-definition-schema.js
+++ b/packages/insomnia-app/app/ui/context/grpc/__schemas__/grpc-method-definition-schema.js
@@ -1,0 +1,12 @@
+// @flow
+import type { Schema } from '@develohpanda/fluent-builder';
+import type { GrpcMethodDefinition } from '../../../../network/grpc/method';
+
+export const grpcMethodDefinitionSchema: Schema<GrpcMethodDefinition> = {
+  path: () => '/package.service/method',
+  originalName: () => 'method',
+  responseStream: () => false,
+  requestStream: () => true,
+  requestSerialize: () => () => {}, // not using jest.fn to avoid the overhead
+  responseDeserialize: () => () => {}, // not using jest.fn to avoid the overhead
+};

--- a/packages/insomnia-app/app/ui/context/grpc/__schemas__/index.js
+++ b/packages/insomnia-app/app/ui/context/grpc/__schemas__/index.js
@@ -1,3 +1,4 @@
 export { grpcMessageSchema } from './grpc-message-schema';
 export { grpcStatusObjectSchema } from './grpc-status-object-schema';
 export { requestStateSchema } from './request-state-schema';
+export { grpcMethodDefinitionSchema } from './grpc-method-definition-schema';

--- a/packages/insomnia-app/app/ui/context/grpc/__schemas__/request-state-schema.js
+++ b/packages/insomnia-app/app/ui/context/grpc/__schemas__/request-state-schema.js
@@ -10,4 +10,5 @@ export const requestStateSchema: Schema<GrpcRequestState> = {
   status: () => undefined,
   error: () => undefined,
   methods: () => [],
+  reloadMethods: () => false,
 };

--- a/packages/insomnia-app/app/ui/context/grpc/__schemas__/request-state-schema.js
+++ b/packages/insomnia-app/app/ui/context/grpc/__schemas__/request-state-schema.js
@@ -9,4 +9,5 @@ export const requestStateSchema: Schema<GrpcRequestState> = {
   responseMessages: () => [],
   status: () => undefined,
   error: () => undefined,
+  methods: () => [],
 };

--- a/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-reducer.test.js
+++ b/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-reducer.test.js
@@ -1,13 +1,23 @@
 // @flow
 import { findGrpcRequestState, grpcReducer } from '../grpc-reducer';
-import type { GrpcRequestState } from '../grpc-reducer';
+import type { GrpcRequestState, GrpcState } from '../grpc-reducer';
 import { createBuilder } from '@develohpanda/fluent-builder';
-import { grpcMessageSchema, grpcStatusObjectSchema, requestStateSchema } from '../__schemas__';
+import {
+  grpcMessageSchema,
+  grpcMethodDefinitionSchema,
+  grpcStatusObjectSchema,
+  requestStateSchema,
+} from '../__schemas__';
 import { grpcActions } from '../grpc-actions';
+import { globalBeforeEach } from '../../../../__jest__/before-each';
+import * as protoLoader from '../../../../network/grpc/proto-loader';
+
+jest.mock('../../../../network/grpc/proto-loader');
 
 const messageBuilder = createBuilder(grpcMessageSchema);
 const requestStateBuilder = createBuilder(requestStateSchema);
-const grpcStatusBuilder = createBuilder(grpcStatusObjectSchema);
+const statusBuilder = createBuilder(grpcStatusObjectSchema);
+const methodBuilder = createBuilder(grpcMethodDefinitionSchema);
 
 const expectedInitialState: GrpcRequestState = {
   running: false,
@@ -15,6 +25,8 @@ const expectedInitialState: GrpcRequestState = {
   responseMessages: [],
   status: undefined,
   error: undefined,
+  methods: [],
+  reloadMethods: true,
 };
 
 describe('findGrpcRequestState', () => {
@@ -195,10 +207,114 @@ describe('grpcReducer actions', () => {
         b: requestStateBuilder.reset().build(),
       };
 
-      const status = grpcStatusBuilder.reset().build();
+      const status = statusBuilder.reset().build();
       const newState = grpcReducer(state, grpcActions.status('b', status));
 
       const expectedRequestState = { ...state.b, status };
+
+      expect(newState).toStrictEqual({
+        a: state.a,
+        b: expectedRequestState,
+      });
+    });
+  });
+
+  describe('invalidate', () => {
+    it('should set reloadMethods to true', () => {
+      const state: GrpcState = {
+        a: requestStateBuilder
+          .reset()
+          .reloadMethods(false)
+          .methods([])
+          .build(),
+        b: requestStateBuilder
+          .reset()
+          .reloadMethods(false)
+          .build(),
+      };
+
+      const newState = grpcReducer(state, grpcActions.invalidate('b'));
+
+      const expectedRequestState = { ...state.b, reloadMethods: true };
+
+      expect(newState).toStrictEqual({
+        a: state.a,
+        b: expectedRequestState,
+      });
+    });
+  });
+
+  describe('clear', () => {
+    it('should clear per-run state', () => {
+      const state: GrpcState = {
+        a: requestStateBuilder
+          .reset()
+          .running(true)
+          .build(),
+        b: requestStateBuilder
+          .reset()
+          .reloadMethods(true)
+          .methods([methodBuilder.reset().build()])
+          .running(true)
+          .requestMessages([messageBuilder.reset().build()])
+          .responseMessages([messageBuilder.reset().build()])
+          .status(statusBuilder.reset().build())
+          .error(new Error('error'))
+          .build(),
+      };
+
+      const newState = grpcReducer(state, grpcActions.clear('b'));
+
+      const expectedRequestState = {
+        ...state.b,
+        requestMessages: [],
+        responseMessages: [],
+        status: undefined,
+        error: undefined,
+      };
+
+      expect(newState).toStrictEqual({
+        a: state.a,
+        b: expectedRequestState,
+      });
+    });
+  });
+
+  describe('loadMethods', () => {
+    beforeEach(() => {
+      globalBeforeEach();
+    });
+
+    it('should clear per-run state when methods are loaded', async () => {
+      const state: GrpcState = {
+        a: requestStateBuilder
+          .reset()
+          .running(true)
+          .build(),
+        b: requestStateBuilder
+          .reset()
+          .running(true)
+          .requestMessages([messageBuilder.reset().build()])
+          .responseMessages([messageBuilder.reset().build()])
+          .methods([methodBuilder.reset().build()])
+          .status(statusBuilder.reset().build())
+          .error(new Error('error'))
+          .build(),
+      };
+
+      const newMethods = [methodBuilder.reset().build()];
+      protoLoader.loadMethods.mockResolvedValue(newMethods);
+
+      const newState = grpcReducer(state, await grpcActions.loadMethods('b', 'pfid', true));
+
+      const expectedRequestState: GrpcRequestState = {
+        ...state.b,
+        requestMessages: [],
+        responseMessages: [],
+        status: undefined,
+        error: undefined,
+        methods: newMethods,
+      };
 
       expect(newState).toStrictEqual({
         a: state.a,

--- a/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-reducer.test.js
+++ b/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-reducer.test.js
@@ -328,4 +328,8 @@ describe('grpcReducer actions', () => {
       'Unhandled action type: not-found',
     );
   });
+
+  it.each([null, undefined])('should do nothing if action is falsey', action => {
+    expect(grpcReducer({}, action)).toStrictEqual({});
+  });
 });

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-actions.js
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-actions.js
@@ -38,13 +38,14 @@ type ResetAction = Action<GrpcActionTypeEnum.reset>;
 type ClearAction = Action<GrpcActionTypeEnum.clear>;
 type StartAction = Action<GrpcActionTypeEnum.start>;
 type StopAction = Action<GrpcActionTypeEnum.stop>;
+type InvalidateAction = Action<GrpcActionTypeEnum.invalidate>;
 export type RequestMessageAction = Action<GrpcActionTypeEnum.requestMessage> & Payload<GrpcMessage>;
 export type ResponseMessageAction = Action<GrpcActionTypeEnum.responseMessage> &
   Payload<GrpcMessage>;
 export type ErrorAction = Action<GrpcActionTypeEnum.error> & Payload<ServiceError>;
-export type StatusAction = Action<GrpcActionTypeEnum.error> & Payload<GrpcStatusObject>;
+export type StatusAction = Action<GrpcActionTypeEnum.status> & Payload<GrpcStatusObject>;
 export type LoadMethodsAction = Action<GrpcActionTypeEnum.loadMethods> &
-  Payload<{ selectedMethod: GrpcMethodDefinition, methods: Array<GrpcMethodDefinition> }>;
+  Payload<Array<GrpcMethodDefinition>>;
 
 export type GrpcAction =
   | ClearAction
@@ -55,6 +56,7 @@ export type GrpcAction =
   | RequestMessageAction
   | ErrorAction
   | StatusAction
+  | InvalidateAction
   | LoadMethodsAction;
 
 export type GrpcDispatch = (action: GrpcAction) => void;

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-actions.js
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-actions.js
@@ -100,39 +100,34 @@ const status = (requestId: string, status: GrpcStatusObject): ErrorAction => ({
   payload: status,
 });
 
-const clear = (dispatch: GrpcDispatch, requestId: string) => {
-  dispatch({
-    type: GrpcActionTypeEnum.clear,
-    requestId,
-  });
-};
+const clear = (requestId: string): ClearAction => ({
+  type: GrpcActionTypeEnum.clear,
+  requestId,
+});
 
-const invalidate = (dispatch: GrpcDispatch, requestId: string) => {
-  dispatch({
-    type: GrpcActionTypeEnum.invalidate,
-    requestId,
-  });
-};
+const invalidate = (requestId: string): InvalidateAction => ({
+  type: GrpcActionTypeEnum.invalidate,
+  requestId,
+});
 
 const loadMethods = async (
-  dispatch: GrpcDispatch,
   requestId: string,
   protoFileId: string,
   reloadMethods: boolean,
-) => {
+): LoadMethodsAction | undefined => {
   if (!reloadMethods) {
-    return;
+    return undefined;
   }
 
-  console.log(`[gRPC] reloading proto file pf=${protoFileId}`);
+  console.log(`[gRPC] loading proto file methods pf=${protoFileId}`);
   const protoFile = await models.protoFile.getById(protoFileId);
   const methods = await protoLoader.loadMethods(protoFile);
 
-  dispatch({
+  return {
     type: GrpcActionTypeEnum.loadMethods,
     requestId,
     payload: methods,
-  });
+  };
 };
 
 export const grpcActions = {

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.js
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.js
@@ -10,7 +10,7 @@ import type {
   StatusAction,
 } from './grpc-actions';
 import { GrpcActionTypeEnum } from './grpc-actions';
-import type { ServiceError } from '../../../network/grpc/service-error';
+import type { GrpcStatusObject, ServiceError } from '../../../network/grpc/service-error';
 import type { GrpcMethodDefinition } from '../../../network/grpc/method';
 
 export type GrpcRequestState = {
@@ -35,7 +35,6 @@ const INITIAL_GRPC_REQUEST_STATE: GrpcRequestState = {
 };
 
 const CLEAR_GRPC_REQUEST_STATE: Shape<GrpcRequestState> = {
-  running: false,
   requestMessages: [],
   responseMessages: [],
   status: undefined,
@@ -51,7 +50,11 @@ export const findGrpcRequestState = (state: GrpcState, requestId: string): GrpcR
   return state[requestId] || INITIAL_GRPC_REQUEST_STATE;
 };
 
-export const grpcReducer = (state: GrpcState, action: GrpcAction): GrpcState => {
+export const grpcReducer = (state: GrpcState, action: GrpcAction | undefined): GrpcState => {
+  if (!action) {
+    return;
+  }
+
   const requestId = action.requestId;
   const oldState = findGrpcRequestState(state, requestId);
 

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.js
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.js
@@ -52,7 +52,7 @@ export const findGrpcRequestState = (state: GrpcState, requestId: string): GrpcR
 
 export const grpcReducer = (state: GrpcState, action: GrpcAction | undefined): GrpcState => {
   if (!action) {
-    return;
+    return state;
   }
 
   const requestId = action.requestId;


### PR DESCRIPTION
The selected method, and the body contents are reset when changing the proto file linked to a request. This PR also adds some edge case handling.

![2020-11-11 17 22 31](https://user-images.githubusercontent.com/4312346/98765266-9c151180-2442-11eb-8bda-f73b8fea320b.gif)

<details>
<summary>Proto file deletion edge case</summary>

@nijikokun there are edge cases that arise on deletion of a proto file, evident especially through this PR. When a request is activated or a message sent, the proto file is loaded again from the contents in the database. But if a proto file has been deleted, those contents are lost, and we can't fetch all of the information required in order to render the UI correctly (the tab title and method drop-downs, for example). In this case, when the protofile for the active request is deleted, the UI is not reset immediately, but on navigating away and returning to the request, the UI will be reset.

![2020-11-11 17 22 49](https://user-images.githubusercontent.com/4312346/98765606-64f33000-2443-11eb-8c59-c332ec187692.gif)

</details>

See collapsed comment above for some context about the following changes. The behavior was discussed with @nijikokun before being implemented.

Previously, the methods for a protofile linked to a request were saved in local state, meaning each time the user switched between requests in the sidebar, the methods would be reloaded from the protofile. Because of this, if the protofile for a given request has been deleted and a user tries to activate it, no UI can be rendered because the data no longer exists. Storing the method information itself against a request allows the UX to not be immediately broken (only on the next restart), and has a side-benefit of allowing the business logic and React logic to be more performant.

With this change, an additional action to invalidate the methods was introduced. Invalidating tells React that the next time you need methods, reload them instead of loading from state. Currently, methods are invalidated when a protofile is changed, which is the primary _feature_ introduced by this PR.

I suggest starting your review from the `grpc-reducer.js` file.

QA:
- smoke testing of requests in general: canceling, multiple streams, can make requests etc
- when switching methods, the UI should clear
- when changing protofile, the UI should clear
- if the protofile for a request is deleted, the UI (previous request/response information) should NOT clear
  - it will clear on restart, because it is only stored in memory

Note, if you were to upload the _same_ proto file twice, the application will treat it as two unique files as there is no de-duplication in place.

Fixes INS-211, Fixes INS-272