### PR TITLE
gRPC with Insomnia export format V4

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/import.test.js
+++ b/packages/insomnia-app/app/common/__tests__/import.test.js
@@ -187,6 +187,24 @@ describe('export', () => {
       name: 'Request 1',
       parentId: w._id,
     });
+    const pf1 = await models.protoFile.create({
+      name: 'ProtoFile 1',
+      parentId: w._id,
+    });
+    const gr1 = await models.grpcRequest.create({
+      name: 'Grpc Request 1',
+      parentId: w._id,
+      protoFileId: pf1._id,
+    });
+    const pf2 = await models.protoFile.create({
+      name: 'ProtoFile 2',
+      parentId: w._id,
+    });
+    const gr2 = await models.grpcRequest.create({
+      name: 'Grpc Request 2',
+      parentId: w._id,
+      protoFileId: pf2._id,
+    });
     const f2 = await models.requestGroup.create({
       name: 'Folder 2',
       parentId: w._id,
@@ -229,13 +247,17 @@ describe('export', () => {
         expect.objectContaining({ _id: f2._id }),
         expect.objectContaining({ _id: r2._id }),
         expect.objectContaining({ _id: ePub._id }),
+        expect.objectContaining({ _id: gr1._id }),
+        expect.objectContaining({ _id: pf1._id }),
+        expect.objectContaining({ _id: gr2._id }),
+        expect.objectContaining({ _id: pf2._id }),
       ]),
     });
-    expect(exportWorkspacesDataJson.resources.length).toBe(8);
+    expect(exportWorkspacesDataJson.resources.length).toBe(12);
 
     // Test export some requests only.
-    const exportRequestsJson = await importUtil.exportRequestsData([r1], false, 'json');
-    const exportRequestsYaml = await importUtil.exportRequestsData([r1], false, 'yaml');
+    const exportRequestsJson = await importUtil.exportRequestsData([r1, gr1], false, 'json');
+    const exportRequestsYaml = await importUtil.exportRequestsData([r1, gr1], false, 'yaml');
     const exportRequestsDataJSON = JSON.parse(exportRequestsJson);
     const exportRequestsDataYAML = YAML.parse(exportRequestsYaml);
 
@@ -250,11 +272,14 @@ describe('export', () => {
         expect.objectContaining({ _id: jar._id }),
         expect.objectContaining({ _id: r1._id }),
         expect.objectContaining({ _id: ePub._id }),
+        expect.objectContaining({ _id: gr1._id }),
+        expect.objectContaining({ _id: pf1._id }),
+        expect.objectContaining({ _id: pf2._id }),
       ]),
     });
 
-    expect(exportRequestsDataJSON.resources.length).toBe(6);
-    expect(exportRequestsDataYAML.resources.length).toBe(6);
+    expect(exportRequestsDataJSON.resources.length).toBe(9);
+    expect(exportRequestsDataYAML.resources.length).toBe(9);
 
     // Ensure JSON and YAML are the same
     expect(exportRequestsDataJSON.resources).toEqual(exportRequestsDataYAML.resources);
@@ -266,9 +291,18 @@ describe('export', () => {
       contents: 'openapi: "3.0.0"',
     });
     const jar = await models.cookieJar.getOrCreateForParentId(w._id);
+    const pf1 = await models.protoFile.create({
+      name: 'ProtoFile 1',
+      parentId: w._id,
+    });
     const r1 = await models.request.create({
       name: 'Request 1',
       parentId: w._id,
+    });
+    const gr1 = await models.grpcRequest.create({
+      name: 'Grpc Request 1',
+      parentId: w._id,
+      protoFileId: pf1._id,
     });
     const f2 = await models.requestGroup.create({
       name: 'Folder 2',
@@ -277,6 +311,11 @@ describe('export', () => {
     const r2 = await models.request.create({
       name: 'Request 2',
       parentId: f2._id,
+    });
+    const gr2 = await models.grpcRequest.create({
+      name: 'Grpc Request 2',
+      parentId: f2._id,
+      protoFileId: pf1._id,
     });
     const uts1 = await models.unitTestSuite.create({
       name: 'Unit Test Suite One',
@@ -308,8 +347,11 @@ describe('export', () => {
         expect.objectContaining({ _id: w._id }),
         expect.objectContaining({ _id: eBase._id }),
         expect.objectContaining({ _id: jar._id }),
+        expect.objectContaining({ _id: pf1._id }),
         expect.objectContaining({ _id: r1._id }),
         expect.objectContaining({ _id: r2._id }),
+        expect.objectContaining({ _id: gr1._id }),
+        expect.objectContaining({ _id: gr2._id }),
         expect.objectContaining({ _id: uts1._id }),
         expect.objectContaining({ _id: ut1._id }),
         expect.objectContaining({ _id: ePub._id }),

--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -202,7 +202,7 @@ export async function importRaw(
     // Hack to switch to GraphQL based on finding `graphql` in the URL path
     // TODO: Support this in a better way
     if (
-      model.type === models.request.type &&
+      isRequest(model) &&
       resource.body &&
       typeof resource.body.text === 'string' &&
       typeof resource.url === 'string' &&

--- a/packages/insomnia-app/app/models/helpers/__tests__/is-model.test.js
+++ b/packages/insomnia-app/app/models/helpers/__tests__/is-model.test.js
@@ -3,6 +3,7 @@ import { difference } from 'lodash';
 import {
   isGrpcRequest,
   isGrpcRequestId,
+  isProtoFile,
   isRequest,
   isRequestGroup,
   isRequestId,
@@ -74,5 +75,18 @@ describe('isRequestGroup', () => {
 
   it.each(unsupported)('should return false: "%s"', type => {
     expect(isRequestGroup({ type })).toBe(false);
+  });
+});
+
+describe('isProtoFile', () => {
+  const supported = [models.protoFile.type];
+  const unsupported = difference(allTypes, supported);
+
+  it.each(supported)('should return true: "%s"', type => {
+    expect(isProtoFile({ type })).toBe(true);
+  });
+
+  it.each(unsupported)('should return false: "%s"', type => {
+    expect(isProtoFile({ type })).toBe(false);
   });
 });

--- a/packages/insomnia-app/app/models/helpers/is-model.js
+++ b/packages/insomnia-app/app/models/helpers/is-model.js
@@ -1,6 +1,6 @@
 // @flow
 import type { BaseModel } from '../index';
-import { grpcRequest, request, requestGroup } from '../index';
+import { grpcRequest, request, requestGroup, protoFile } from '../index';
 
 export function isGrpcRequest(obj: BaseModel): boolean {
   return obj.type === grpcRequest.type;
@@ -20,4 +20,8 @@ export function isRequestId(id: string): boolean {
 
 export function isRequestGroup(obj: BaseModel): boolean {
   return obj.type === requestGroup.type;
+}
+
+export function isProtoFile(obj: BaseModel): boolean {
+  return obj.type === protoFile.type;
 }

--- a/packages/insomnia-app/app/models/helpers/request-operations.js
+++ b/packages/insomnia-app/app/models/helpers/request-operations.js
@@ -1,6 +1,13 @@
 // @flow
 import * as models from '../index';
-import { isGrpcRequest } from './is-model';
+import { isGrpcRequest, isGrpcRequestId } from './is-model';
+import type { GrpcRequest } from '../grpc-request';
+
+export function getById(requestId: string): Promise<Request | GrpcRequest | null> {
+  return isGrpcRequestId(requestId)
+    ? models.grpcRequest.getById(requestId)
+    : models.request.getById(requestId);
+}
 
 export function remove<T>(request: T): Promise<void> {
   return isGrpcRequest(request)

--- a/packages/insomnia-app/app/ui/components/export-requests/request-row.js
+++ b/packages/insomnia-app/app/ui/components/export-requests/request-row.js
@@ -3,11 +3,14 @@ import React, { PureComponent } from 'react';
 import autobind from 'autobind-decorator';
 import MethodTag from '../tags/method-tag';
 import type { Request } from '../../../models/request';
+import type { GrpcRequest } from '../../../models/grpc-request';
+import { isGrpcRequest } from '../../../models/helpers/is-model';
+import GrpcTag from '../tags/grpc-tag';
 
 type Props = {
   handleSetItemSelected: Function,
   isSelected: boolean,
-  request: Request,
+  request: Request | GrpcRequest,
 };
 
 @autobind
@@ -21,6 +24,8 @@ class RequestRow extends PureComponent<Props> {
 
   render() {
     const { request, isSelected } = this.props;
+    const isGrpc = isGrpcRequest(request);
+
     return (
       <li className="tree__row">
         <div className="tree__item tree__item--request">
@@ -28,7 +33,7 @@ class RequestRow extends PureComponent<Props> {
             <input type="checkbox" checked={isSelected} onChange={this.handleSelect} />
           </div>
           <button className="wide">
-            <MethodTag method={request.method} />
+            {isGrpc ? <GrpcTag /> : <MethodTag method={request.method} />}
             <span className="inline-block">{request.name}</span>
           </button>
         </div>

--- a/packages/insomnia-app/app/ui/components/export-requests/tree.js
+++ b/packages/insomnia-app/app/ui/components/export-requests/tree.js
@@ -2,10 +2,11 @@
 import * as React from 'react';
 import RequestRow from './request-row';
 import RequestGroupRow from './request-group-row';
-import * as models from '../../../models/index';
 import type { Node } from '../modals/export-requests-modal';
 import type { Request } from '../../../models/request';
 import type { RequestGroup } from '../../../models/request-group';
+import { isGrpcRequest, isRequest } from '../../../models/helpers/is-model';
+import type { GrpcRequest } from '../../../models/grpc-request';
 
 type Props = {
   root: ?Node,
@@ -19,9 +20,9 @@ class Tree extends React.PureComponent<Props> {
       return null;
     }
 
-    if (node.doc.type === models.request.type) {
-      // Directly cast to Request will result in error, so cast it to any first.
-      const request: Request = ((node.doc: any): Request);
+    if (isRequest(node.doc) || isGrpcRequest(node.doc)) {
+      // Directly casting will result in error, so cast it to any first.
+      const request: Request | GrpcRequest = ((node.doc: any): Request | GrpcRequest);
       return (
         <RequestRow
           key={node.doc._id}

--- a/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
@@ -9,9 +9,11 @@ import Tree from '../export-requests/tree';
 import type { Request } from '../../../models/request';
 import type { RequestGroup } from '../../../models/request-group';
 import * as models from '../../../models';
+import type { GrpcRequest } from '../../../models/grpc-request';
+import { isGrpcRequest, isRequest, isRequestGroup } from '../../../models/helpers/is-model';
 
 export type Node = {
-  doc: Request | RequestGroup,
+  doc: Request | GrpcRequest | RequestGroup,
   children: Array<Node>,
   collapsed: boolean,
   totalRequests: number,
@@ -64,7 +66,8 @@ class ExportRequestsModal extends PureComponent<Props, State> {
   }
 
   getSelectedRequestIds(node: Node): Array<string> {
-    if (node.doc.type === models.request.type && node.selectedRequests === node.totalRequests) {
+    const docIsRequest = isRequest(node.doc) || isGrpcRequest(node.doc);
+    if (docIsRequest && node.selectedRequests === node.totalRequests) {
       return [node.doc._id];
     }
     const requestIds: Array<string> = [];
@@ -105,7 +108,9 @@ class ExportRequestsModal extends PureComponent<Props, State> {
     let totalRequests = children
       .map(child => child.totalRequests)
       .reduce((acc, totalRequests) => acc + totalRequests, 0);
-    if (item.doc.type === models.request.type) {
+
+    const docIsRequest = isRequest(item.doc) || isGrpcRequest(item.doc);
+    if (docIsRequest) {
       totalRequests++;
     }
     return {
@@ -146,7 +151,7 @@ class ExportRequestsModal extends PureComponent<Props, State> {
   }
 
   setRequestGroupCollapsed(node: Node, isCollapsed: boolean, requestGroupId: string): boolean {
-    if (node.doc.type !== models.requestGroup.type) {
+    if (!isRequestGroup(node.doc)) {
       return false;
     }
     if (node.doc._id === requestGroupId) {

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -13,6 +13,7 @@ import AlertModal from '../../components/modals/alert-modal';
 import PaymentNotificationModal from '../../components/modals/payment-notification-modal';
 import LoginModal from '../../components/modals/login-modal';
 import * as models from '../../../models';
+import * as requestOperations from '../../../models/helpers/request-operations';
 import SelectModal from '../../components/modals/select-modal';
 import { showError, showModal } from '../../components/modals/index';
 import * as db from '../../../common/database';
@@ -535,7 +536,7 @@ export function exportRequestsToFile(requestIds) {
         const privateEnvironments = [];
         const workspaceLookup = {};
         for (const requestId of requestIds) {
-          const request = await models.request.getById(requestId);
+          const request = await requestOperations.getById(requestId);
           if (request == null) {
             continue;
           }


### PR DESCRIPTION
This PR adds the `GrpcRequest` and `ProtoFile` models to the export/import logic for the V4 export format. This PR also introduces `GrpcRequest` to the export request selector modal.

![image](https://user-images.githubusercontent.com/4312346/99023526-a877a680-25c9-11eb-9984-0af331dfa5cf.png)

![2020-11-13 16 09 03](https://user-images.githubusercontent.com/4312346/99024005-a4985400-25ca-11eb-82f7-15dca2845486.gif)


Regarding backwards compatibility, no errors are presented to the user, and the workspace imports as best possible, warning about missing data models in the console window. The following screenshot is from 2020.4.2.

![image](https://user-images.githubusercontent.com/4312346/99023774-26d44880-25ca-11eb-8e3a-fc50896a9708.png)

QA:

You should be able to import [this workspace](https://gist.github.com/develohpanda/57f96270875fba0478f9dc2ffeaee738). It contains one gRPC request, one regular GET request, and after import you should be able to run the gRPC request with **no** changes.