### PR TITLE
Backwards compitibility in beta sync

### DIFF
--- a/packages/insomnia-app/app/models/index.js
+++ b/packages/insomnia-app/app/models/index.js
@@ -85,7 +85,7 @@ export function all() {
   ];
 }
 
-export function types(): Array<any> {
+export function types(): Array<string> {
   return all().map(model => model.type);
 }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
@@ -195,7 +195,6 @@ class SyncDropdown extends React.PureComponent<Props, State> {
     } catch (err) {
       showError({
         title: 'Push Error',
-        message: err.message,
         error: err,
       });
     }
@@ -214,7 +213,6 @@ class SyncDropdown extends React.PureComponent<Props, State> {
     } catch (err) {
       showError({
         title: 'Pull Error',
-        message: err.message,
         error: err,
       });
     }
@@ -237,7 +235,6 @@ class SyncDropdown extends React.PureComponent<Props, State> {
     } catch (err) {
       showError({
         title: 'Revert Error',
-        message: err.message,
         error: err,
       });
     }
@@ -323,7 +320,6 @@ class SyncDropdown extends React.PureComponent<Props, State> {
     } catch (err) {
       showError({
         title: 'Branch Switch Error',
-        message: err.message,
         error: err,
       });
     }


### PR DESCRIPTION
When a new model is introduced and pushed from a particular version of the app, it becomes impossible to pull a snapshot or workspace in an older version of the application, because there are no checks to ensure a model exists before trying to write to it.

I pushed a snapshot from develop, and pulled it in 2020.4.2, and saw the following error.

![image](https://user-images.githubusercontent.com/4312346/99025477-c810ce00-25cd-11eb-97c3-86b076e0b62f.png)

I traced this error to the following piece of code, but only through navigating the code as the stack trace is swallowed https://github.com/Kong/insomnia/blob/8f8acf83f2058abf1e18efccd7964e529bac90a4/packages/insomnia-app/app/common/database.js#L284-L285

Note, this was probably an issue with unit testing models as well. 😅 

I'm not quite sure how to validate this fix... 🤔 re-base it on the commit for 2020.4.2 and try to pull a workspace or snapshot that contains gRPC models, and see how it behaves?

**Do we need to address this backwards compatibility case at all? (I think we do)**