### PR TITLE
Fix curl importers when input contains escaped array params

### DIFF
--- a/packages/insomnia-importers/src/__tests__/fixtures/curl/from-chrome-windows-input.sh
+++ b/packages/insomnia-importers/src/__tests__/fixtures/curl/from-chrome-windows-input.sh
@@ -1,0 +1,11 @@
+curl 'http://example.com/?a\[0\]=1&a\[1\]=1' \
+  -H 'Connection: keep-alive' \
+  -H 'Cache-Control: max-age=0' \
+  -H 'Upgrade-Insecure-Requests: 1' \
+  -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.193 Safari/537.36' \
+  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9' \
+  -H 'Accept-Language: fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7' \
+  -H 'If-None-Match: "3147526947+ident"' \
+  -H 'If-Modified-Since: Thu, 17 Oct 2019 07:18:26 GMT' \
+  --compressed \
+  --insecure

--- a/packages/insomnia-importers/src/__tests__/fixtures/curl/from-chrome-windows-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/curl/from-chrome-windows-output.json
@@ -1,0 +1,64 @@
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2016-11-18T22:34:51.526Z",
+  "__export_source": "insomnia.importers:v0.1.0",
+  "resources": [
+    {
+      "_id": "__REQ_1__",
+      "_type": "request",
+      "parentId": "__WORKSPACE_ID__",
+      "url": "http://example.com",
+      "name": "http://example.com",
+      "method": "GET",
+      "body": {},
+      "parameters": [
+        {
+          "disabled": false,
+          "name": "a[0]",
+          "value": "1"
+        },
+        {
+          "disabled": false,
+          "name": "a[1]",
+          "value": "1"
+        }
+      ],
+      "headers": [
+        {
+          "name": "Connection",
+          "value": "keep-alive"
+        },
+        {
+          "name": "Cache-Control",
+          "value": "max-age=0"
+        },
+        {
+          "name": "Upgrade-Insecure-Requests",
+          "value": "1"
+        },
+        {
+          "name": "User-Agent",
+          "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.193 Safari/537.36"
+        },
+        {
+          "name": "Accept",
+          "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+        },
+        {
+          "name": "Accept-Language",
+          "value": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7"
+        },
+        {
+          "name": "If-None-Match",
+          "value": "\"3147526947+ident\""
+        },
+        {
+          "name": "If-Modified-Since",
+          "value": "Thu, 17 Oct 2019 07:18:26 GMT"
+        }
+      ],
+      "authentication": {}
+    }
+  ]
+}

--- a/packages/insomnia-importers/src/__tests__/fixtures/curl/query-string-input.sh
+++ b/packages/insomnia-importers/src/__tests__/fixtures/curl/query-string-input.sh
@@ -1,0 +1,1 @@
+curl 'http://localhost/get?message=Hello&params[0]=value0&params[1]=value1'

--- a/packages/insomnia-importers/src/__tests__/fixtures/curl/query-string-output.json
+++ b/packages/insomnia-importers/src/__tests__/fixtures/curl/query-string-output.json
@@ -1,0 +1,36 @@
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2016-11-18T22:34:51.526Z",
+  "__export_source": "insomnia.importers:v0.1.0",
+  "resources": [
+    {
+      "_id": "__REQ_1__",
+      "_type": "request",
+      "parentId": "__WORKSPACE_ID__",
+      "url": "http://localhost/get",
+      "name": "http://localhost/get",
+      "method": "GET",
+      "body": {},
+      "parameters": [
+        {
+          "name": "message",
+          "disabled": false,
+          "value": "Hello"
+        },
+        {
+          "name": "params[0]",
+          "disabled": false,
+          "value": "value0"
+        },
+        {
+          "name": "params[1]",
+          "disabled": false,
+          "value": "value1"
+        }
+      ],
+      "headers": [],
+      "authentication": {}
+    }
+  ]
+}

--- a/packages/insomnia-importers/src/importers/curl.js
+++ b/packages/insomnia-importers/src/importers/curl.js
@@ -136,7 +136,7 @@ function importArgs(args) {
   try {
     const urlObject = new URL(getPairValue(pairs, singletons[0] || '', 'url'));
     parameters = Array.from(urlObject.searchParams.entries()).map(([key, value]) => ({
-      name: key,
+      name: key.replace('\\[', '[').replace('\\]', ']'),
       value,
       disabled: false,
     }));


### PR DESCRIPTION
In Chrome on Windows, the `Copy as cURL (bash)` action is escaping array query params.
We are getting the following url: `'http://example.com/?a\[0\]=1&a\[1\]=1'`

Unfortunately, the importers will parse the params without unescaping the keys, which will create incorrect params:

```
{
  "disabled": false,
  "name": "a\[0\]",
  "value": "1"
}
```

To fix it, I did a simple change replacing any `\[ \]` into non-escaped value `[ ]` in the key name.

Closes #1963

![image](https://user-images.githubusercontent.com/4171593/99153905-0aa8d800-26ac-11eb-9216-08adfa9ee3c0.png)
