### PR TITLE
feat(response-viewer): Add automatic detection of HTML Scripts

### DIFF
--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
@@ -292,7 +292,8 @@ class ResponseViewer extends React.Component<Props, State> {
         .slice(0, 100)
         .toString()
         .trim()
-        .match(/^<!doctype html.*>/i);
+        .match(/^<!doctype html.*>|<script>/i);
+
       if (contentType.indexOf('text/html') !== 0 && isProbablyHTML) {
         contentType = 'text/html';
       }


### PR DESCRIPTION
Hi!

Sorry for not creating Issue first, but I think this is a really small change. I recently switched from Postman to Insomnia full-time. The one issue I have is the automatic detection of HTML Script. I'm using [symfony var_dumper component](https://symfony.com/doc/current/components/var_dumper.html), which is a part of debugging tools for PHP. When I'm testing API's a lot of projects have this var_dumper implemented in PHP by default, therefore when I'm using it, I have to still use postman, because It can show and force HTML preview. But when I'm using the Insomnia Preview, it can't detect plain scripts, so this is shown by default.

**How Insomnia rendered scripts before**
![Insomnia before](https://user-images.githubusercontent.com/16374732/99303944-00284300-2852-11eb-9d86-604a52503308.png)

After extending the regex match I can now render the script tag.

**How Insomnia render scripts now**
![Insomnia After](https://user-images.githubusercontent.com/16374732/99304228-60b78000-2852-11eb-8156-b8cda052f605.png)

**What do I want to achieve?**
I want to be able to open scripts, because I still think that `<script>` tag without `<!DOCTYPE html>` is still a valid HTML and a lot of people are using tools, to show only `<script>` tag. This will help, not either to have smarter HTML detection, but also saving some time so you don't have to debug it as plain text, and you can use tools which can help you to debug your API's. 

