### PR TITLE
Show scrollbar when horizontal tab list exceeds available width.

### DIFF
--- a/packages/insomnia-app/app/ui/css/components/tabs.less
+++ b/packages/insomnia-app/app/ui/css/components/tabs.less
@@ -62,7 +62,6 @@
     height: 100%;
     box-sizing: border-box;
     background-color: var(--color-bg);
-    overflow: auto;
 
     &::-webkit-scrollbar {
       height: var(--padding-sm);


### PR DESCRIPTION
PR fixes hidden scroll track-bar on horizontal tab lists whose width exceeds available real estate. Demo:

![2020-11-17 08 53 14](https://user-images.githubusercontent.com/52717970/99398563-95f3ba80-28b2-11eb-97a2-c00c82f40e3f.gif)

Fixes INS-290
