### PR TITLE
Remove hinting and hide copy/move buttons

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
@@ -49,12 +49,16 @@ class RequestCreateModal extends PureComponent {
     }
   }
 
+  _isGrpcSelected() {
+    return this.state.selectedMethod === METHOD_GRPC;
+  }
+
   async _handleSubmit(e) {
     e.preventDefault();
 
     const { parentId, selectedContentType, selectedMethod } = this.state;
     const requestName = this._input.value;
-    if (selectedMethod === METHOD_GRPC) {
+    if (this._isGrpcSelected()) {
       showModal(ProtoFilesModal, {
         onSave: async (protoFileId: string) => {
           const createdRequest = await models.grpcRequest.create({
@@ -172,9 +176,11 @@ class RequestCreateModal extends PureComponent {
           </form>
         </ModalBody>
         <ModalFooter>
-          <div className="margin-left italic txt-sm tall">
-            * Tip: paste Curl command into URL afterwards to import it
-          </div>
+          {!this._isGrpcSelected() && (
+            <div className="margin-left italic txt-sm tall">
+              * Tip: paste Curl command into URL afterwards to import it
+            </div>
+          )}
           <button className="btn" onClick={this._handleSubmit}>
             Create
           </button>

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
@@ -353,10 +353,65 @@ class RequestSettingsModal extends React.PureComponent<Props, State> {
     );
   }
 
-  renderModalBody(): React.Node {
+  _renderMoveCopy(): React.Node {
     const { workspaces } = this.props;
 
     const { activeWorkspaceIdToCopyTo, justMoved, justCopied, workspace, request } = this.state;
+
+    // Don't show move/copy items if it doesn't exist, or if it is a gRPC request
+    if (!request || isGrpcRequest(request)) {
+      return null;
+    }
+
+    return (
+      <div className="form-row">
+        <div className="form-control form-control--outlined">
+          <label>
+            Move/Copy to Workspace
+            <HelpTooltip position="top" className="space-left">
+              Copy or move the current request to a new workspace. It will be placed at the root of
+              the new workspace's folder structure.
+            </HelpTooltip>
+            <select
+              value={activeWorkspaceIdToCopyTo || '__NULL__'}
+              onChange={this._handleUpdateMoveCopyWorkspace}>
+              <option value="__NULL__">-- Select Workspace --</option>
+              {workspaces.map(w => {
+                if (workspace && workspace._id === w._id) {
+                  return null;
+                }
+
+                return (
+                  <option key={w._id} value={w._id}>
+                    {w.name}
+                  </option>
+                );
+              })}
+            </select>
+          </label>
+        </div>
+        <div className="form-control form-control--no-label width-auto">
+          <button
+            disabled={justCopied || !activeWorkspaceIdToCopyTo}
+            className="btn btn--clicky"
+            onClick={this._handleCopyToWorkspace}>
+            {justCopied ? 'Copied!' : 'Copy'}
+          </button>
+        </div>
+        <div className="form-control form-control--no-label width-auto">
+          <button
+            disabled={justMoved || !activeWorkspaceIdToCopyTo}
+            className="btn btn--clicky"
+            onClick={this._handleMoveToWorkspace}>
+            {justMoved ? 'Moved!' : 'Move'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  renderModalBody(): React.Node {
+    const { request } = this.state;
 
     if (!request) {
       return null;
@@ -380,49 +435,7 @@ class RequestSettingsModal extends React.PureComponent<Props, State> {
         {this._renderDescription()}
         {this._renderRequestSettings()}
         <hr />
-        <div className="form-row">
-          <div className="form-control form-control--outlined">
-            <label>
-              Move/Copy to Workspace
-              <HelpTooltip position="top" className="space-left">
-                Copy or move the current request to a new workspace. It will be placed at the root
-                of the new workspace's folder structure.
-              </HelpTooltip>
-              <select
-                value={activeWorkspaceIdToCopyTo || '__NULL__'}
-                onChange={this._handleUpdateMoveCopyWorkspace}>
-                <option value="__NULL__">-- Select Workspace --</option>
-                {workspaces.map(w => {
-                  if (workspace && workspace._id === w._id) {
-                    return null;
-                  }
-
-                  return (
-                    <option key={w._id} value={w._id}>
-                      {w.name}
-                    </option>
-                  );
-                })}
-              </select>
-            </label>
-          </div>
-          <div className="form-control form-control--no-label width-auto">
-            <button
-              disabled={justCopied || !activeWorkspaceIdToCopyTo}
-              className="btn btn--clicky"
-              onClick={this._handleCopyToWorkspace}>
-              {justCopied ? 'Copied!' : 'Copy'}
-            </button>
-          </div>
-          <div className="form-control form-control--no-label width-auto">
-            <button
-              disabled={justMoved || !activeWorkspaceIdToCopyTo}
-              className="btn btn--clicky"
-              onClick={this._handleMoveToWorkspace}>
-              {justMoved ? 'Moved!' : 'Move'}
-            </button>
-          </div>
-        </div>
+        {this._renderMoveCopy()}
       </div>
     );
   }

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
@@ -353,6 +353,22 @@ class RequestSettingsModal extends React.PureComponent<Props, State> {
     );
   }
 
+  _renderFeatureRequestPrompt(): React.Node {
+    const { request } = this.state;
+
+    // Don't show move/copy items if it doesn't exist, or if it is a gRPC request
+    if (request && isGrpcRequest(request)) {
+      return (
+        <p className="faint italic">
+          Are there any gRPC settings you expect to see? Create a{' '}
+          <a href={'https://github.com/Kong/insomnia/issues/new/choose'}>feature request</a>!
+        </p>
+      );
+    }
+
+    return null;
+  }
+
   _renderMoveCopy(): React.Node {
     const { workspaces } = this.props;
 
@@ -436,6 +452,7 @@ class RequestSettingsModal extends React.PureComponent<Props, State> {
         {this._renderRequestSettings()}
         <hr />
         {this._renderMoveCopy()}
+        {this._renderFeatureRequestPrompt()}
       </div>
     );
   }


### PR DESCRIPTION
No hinting with gRPC:

![image](https://user-images.githubusercontent.com/4312346/99749265-057fd900-2b43-11eb-9f56-f93b4db30127.png)

![image](https://user-images.githubusercontent.com/4312346/99749252-fdc03480-2b42-11eb-8a55-02e1abfcff0b.png)

Only a feature request prompt shown in gRPC request settings, with the move/copy logic hidden:

![image](https://user-images.githubusercontent.com/4312346/99762471-746a2b80-2b5d-11eb-8f4f-79a1e6dc0d70.png)

![image](https://user-images.githubusercontent.com/4312346/99762518-906dcd00-2b5d-11eb-8c38-1af2b71e6148.png)

Fixes INS-278, Fixes INS-306