### PR TITLE
Hide the active workspace when moving a folder

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
@@ -12,7 +12,7 @@ import HelpTooltip from '../help-tooltip';
 
 type Props = {
   workspaces: Array<Workspace>,
-  workspace: Workspace,
+  activeWorkspace: Workspace,
 };
 
 type State = {
@@ -79,7 +79,7 @@ class MoveRequestGroupModal extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { workspaces, workspace } = this.props;
+    const { workspaces, activeWorkspace } = this.props;
     const { selectedWorkspaceId } = this.state;
     return (
       <form onSubmit={this._handleSubmit}>
@@ -93,7 +93,7 @@ class MoveRequestGroupModal extends React.PureComponent<Props, State> {
                 <select onChange={this._handleChangeSelectedWorkspace} value={selectedWorkspaceId}>
                   <option value="n/a">-- Select Workspace --</option>
                   {workspaces.flatMap(w =>
-                    w._id === workspace._id ? (
+                    w._id === activeWorkspace._id ? (
                       []
                     ) : (
                       <option key={w._id} value={w._id}>

--- a/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
@@ -12,6 +12,7 @@ import HelpTooltip from '../help-tooltip';
 
 type Props = {
   workspaces: Array<Workspace>,
+  workspace: Workspace,
 };
 
 type State = {
@@ -78,7 +79,7 @@ class MoveRequestGroupModal extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { workspaces } = this.props;
+    const { workspaces, workspace } = this.props;
     const { selectedWorkspaceId } = this.state;
     return (
       <form onSubmit={this._handleSubmit}>
@@ -91,11 +92,15 @@ class MoveRequestGroupModal extends React.PureComponent<Props, State> {
                 <HelpTooltip>Folder will be moved to the root of the new workspace</HelpTooltip>
                 <select onChange={this._handleChangeSelectedWorkspace} value={selectedWorkspaceId}>
                   <option value="n/a">-- Select Workspace --</option>
-                  {workspaces.map(w => (
-                    <option key={w._id} value={w._id}>
-                      {w.name}
-                    </option>
-                  ))}
+                  {workspaces.flatMap(w =>
+                    w._id === workspace._id ? (
+                      []
+                    ) : (
+                      <option key={w._id} value={w._id}>
+                        {w.name}
+                      </option>
+                    ),
+                  )}
                 </select>
               </label>
             </div>

--- a/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
@@ -92,10 +92,8 @@ class MoveRequestGroupModal extends React.PureComponent<Props, State> {
                 <HelpTooltip>Folder will be moved to the root of the new workspace</HelpTooltip>
                 <select onChange={this._handleChangeSelectedWorkspace} value={selectedWorkspaceId}>
                   <option value="n/a">-- Select Workspace --</option>
-                  {workspaces.flatMap(w =>
-                    w._id === activeWorkspace._id ? (
-                      []
-                    ) : (
+                  {workspaces.map(w =>
+                    w._id === activeWorkspace._id ? null : (
                       <option key={w._id} value={w._id}>
                         {w.name}
                       </option>

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -644,7 +644,11 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
               workspace={activeWorkspace}
             />
 
-            <MoveRequestGroupModal ref={registerModal} workspaces={workspaces} />
+            <MoveRequestGroupModal
+              ref={registerModal}
+              workspaces={workspaces}
+              workspace={activeWorkspace}
+            />
 
             <WorkspaceSettingsModal
               ref={registerModal}

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -647,7 +647,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
             <MoveRequestGroupModal
               ref={registerModal}
               workspaces={workspaces}
-              workspace={activeWorkspace}
+              activeWorkspace={activeWorkspace}
             />
 
             <WorkspaceSettingsModal


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

Closes #2849

Before:
![before](https://user-images.githubusercontent.com/1396878/99766472-0880b800-2ab6-11eb-9f4a-932452e3bf64.PNG)

After:
![after](https://user-images.githubusercontent.com/1396878/99766487-0d456c00-2ab6-11eb-8f30-68ad494c1e8d.PNG)


This uses a `flatMap` which should have minimal impact on performance. I didn't see any tests for this specific component. If I missed them let me know and I can add some.