### PR TITLE
gRPC URL bar spacing in Designer

### DIFF
--- a/packages/insomnia-app/app/ui/css/components/request-pane.less
+++ b/packages/insomnia-app/app/ui/css/components/request-pane.less
@@ -8,6 +8,6 @@
   }
 
   .form-control {
-    margin-top: var(--padding-xxs) !important;
+    margin-top: var(--padding-xxs);
   }
 }

--- a/packages/insomnia-app/app/ui/css/components/request-pane.less
+++ b/packages/insomnia-app/app/ui/css/components/request-pane.less
@@ -1,6 +1,13 @@
 .request-pane {
+  height: 100%;
+  grid-template-rows: var(--line-height-md) minmax(0, 1fr) !important;
+
   .request-pane__shortcuts-table {
     color: var(--hl-xl);
     text-align: left;
+  }
+
+  .form-control {
+    margin-top: var(--padding-xxs) !important;
   }
 }


### PR DESCRIPTION
This PR fixes the gRPC URL bar's vertical spacing issues within designer while tightening up the spacing in core. 

Result in both designer & core:

![Screen Shot 2020-11-23 at 11 43 24 AM](https://user-images.githubusercontent.com/52717970/99990164-7f9da100-2d81-11eb-92b4-1f834343a431.png)

![Screen Shot 2020-11-23 at 11 43 33 AM](https://user-images.githubusercontent.com/52717970/99990140-790f2980-2d81-11eb-998a-6f9e726e834c.png)

Fixes INS-311