### PR TITLE
Yarn warnings wrongly treated as errors

### DIFF
--- a/packages/insomnia-app/app/__tests__/install.test.js
+++ b/packages/insomnia-app/app/__tests__/install.test.js
@@ -1,42 +1,71 @@
-import { isDeprecatedDependencies } from '../plugins/install';
+import { containsOnlyDeprecationWarnings, isDeprecatedDependencies } from '../plugins/install';
 
 describe('install.js', () => {
+  describe('containsOnlyDeprecationWarning', () => {
+    it('should return true when all lines in stderr are deprecation warnings', () => {
+      const stderr =
+        // Warning #1
+        'warning insomnia-plugin-xxx-yyy > xyz > xyz > xyz > xyz > xyz: ' +
+        'xyz is no longer maintained and not recommended for usage due to the number of issues. ' +
+        'Please, upgrade your dependencies to the actual version of xyz.\r\n' +
+        // Warning #2
+        'warning insomnia-plugin-xxx-yyy > xyz > xyz > xyz > xyz > xyz: ' +
+        'xyz is no longer maintained and not recommended for usage due to the number of issues. ' +
+        'Please, upgrade your dependencies to the actual version of xyz.\n' +
+        // Warning #3
+        'warning insomnia-plugin-xxx-yyy > xyz > xyz > xyz > xyz > xyz: ' +
+        'xyz is no longer maintained and not recommended for usage due to the number of issues. ' +
+        'Please, upgrade your dependencies to the actual version of xyz.';
+      expect(containsOnlyDeprecationWarnings(stderr)).toBe(true);
+    });
+    it('should return false when stderr contains a deprecation warning and an error', () => {
+      const stderr =
+        // Warning #1
+        'warning insomnia-plugin-xxx-yyy > xyz > xyz > xyz > xyz > xyz: ' +
+        'xyz is no longer maintained and not recommended for usage due to the number of issues. ' +
+        'Please, upgrade your dependencies to the actual version of xyz.\r\n' +
+        // Error #1
+        'error https://npm.example.net/@types%example/-/nello-1.3.5.tgz:' +
+        'Integrity check failed for "@types/example"' +
+        '(computed integrity doesn\'t match our records, got "sha512-z4kkSfaPg==")\n' +
+        // Warning #2
+        'warning insomnia-plugin-xxx-yyy > xyz > xyz > xyz > xyz > xyz: ' +
+        'xyz is no longer maintained and not recommended for usage due to the number of issues. ' +
+        'Please, upgrade your dependencies to the actual version of xyz.';
+      expect(containsOnlyDeprecationWarnings(stderr)).toBe(false);
+    });
+  });
   describe('isDeprecatedDependencies', () => {
-    it('invalid-dataset-0', () => {
+    it('should not match when the message is falsy', () => {
       expect(isDeprecatedDependencies('')).toBe(false);
-    });
-    it('invalid-dataset-1', () => {
       expect(isDeprecatedDependencies(null)).toBe(false);
-    });
-    it('invalid-dataset-2', () => {
       expect(isDeprecatedDependencies(undefined)).toBe(false);
     });
-    it('valid-warning-0', () => {
+    it('should match with multiple nested dependencies', () => {
       const msg =
         'warning insomnia-plugin-xxx-yyy > xyz > xyz > xyz > xyz > xyz: ' +
         'xyz is no longer maintained and not recommended for usage due to the number of issues. ' +
         'Please, upgrade your dependencies to the actual version of xyz.';
       expect(isDeprecatedDependencies(msg)).toBe(true);
     });
-    it('valid-warning-1', () => {
+    it('should match with one nested dependency', () => {
       const msg =
         'warning insomnia-plugin-xxx-yyy > xyz: ' +
         'xyz is no longer maintained and not recommended for usage due to the number of issues. ' +
         'Please, upgrade your dependencies to the actual version of xyz.';
       expect(isDeprecatedDependencies(msg)).toBe(true);
     });
-    it('invalid-warning', () => {
+    it('should not match with an unrelated warning', () => {
       const msg =
-        'warning You are using Node "6.0.0" which is not supported and may encounter bugs or unexpected behaviour.' +
+        'warning You are using Node "6.0.0" which is not supported and may encounter bugs or unexpected behaviour. ' +
         'Yarn supports the following server range: "^4.8.0 || ^5.7.0 || ^6.2.2 || >=8.0.0"';
       expect(isDeprecatedDependencies(msg)).toBe(false);
     });
-    it('invalid-error', () => {
+    it('should not match with an unrelated error', () => {
       const msg =
-        'error https://npm.example.net/@types%example/-/hello-1.3.5.tgz: ' +
+        'error https://npm.example.net/@types%example/-/nello-1.3.5.tgz: ' +
         'Integrity check failed for "@types/example" ' +
-        "(computed integrity doesn't match our records, " +
-        'got "sha512-z4kkSfaPg==")';
+        '(computed integrity doesn\'t match our records, got "sha512-z4kkSfaPg==")';
       expect(isDeprecatedDependencies(msg)).toBe(false);
     });
   });

--- a/packages/insomnia-app/app/__tests__/install.test.js
+++ b/packages/insomnia-app/app/__tests__/install.test.js
@@ -3,16 +3,13 @@ import { isDeprecatedDependencies } from '../plugins/install';
 describe('install.js', () => {
   describe('isDeprecatedDependencies', () => {
     it('invalid-dataset-0', () => {
-      const msg = '';
-      expect(isDeprecatedDependencies(msg)).toBe(false);
+      expect(isDeprecatedDependencies('')).toBe(false);
     });
     it('invalid-dataset-1', () => {
-      const msg = null;
-      expect(isDeprecatedDependencies(msg)).toBe(false);
+      expect(isDeprecatedDependencies(null)).toBe(false);
     });
     it('invalid-dataset-2', () => {
-      const msg = undefined;
-      expect(isDeprecatedDependencies(msg)).toBe(false);
+      expect(isDeprecatedDependencies(undefined)).toBe(false);
     });
     it('valid-warning-0', () => {
       const msg =

--- a/packages/insomnia-app/app/__tests__/install.test.js
+++ b/packages/insomnia-app/app/__tests__/install.test.js
@@ -2,6 +2,18 @@ import { isDeprecatedDependencies } from '../plugins/install';
 
 describe('install.js', () => {
   describe('isDeprecatedDependencies', () => {
+    it('invalid-dataset-0', () => {
+      const msg = '';
+      expect(isDeprecatedDependencies(msg)).toBe(false);
+    });
+    it('invalid-dataset-1', () => {
+      const msg = null;
+      expect(isDeprecatedDependencies(msg)).toBe(false);
+    });
+    it('invalid-dataset-2', () => {
+      const msg = undefined;
+      expect(isDeprecatedDependencies(msg)).toBe(false);
+    });
     it('valid-warning-0', () => {
       const msg =
         'warning insomnia-plugin-xxx-yyy > xyz > xyz > xyz > xyz > xyz: ' +

--- a/packages/insomnia-app/app/__tests__/install.test.js
+++ b/packages/insomnia-app/app/__tests__/install.test.js
@@ -1,0 +1,34 @@
+import { isDeprecatedDependencies } from '../plugins/install';
+
+describe('install.js', () => {
+  describe('isDeprecatedDependencies', () => {
+    it('valid-warning-0', () => {
+      const msg =
+        'warning insomnia-plugin-xxx-yyy > xyz > xyz > xyz > xyz > xyz: ' +
+        'xyz is no longer maintained and not recommended for usage due to the number of issues. ' +
+        'Please, upgrade your dependencies to the actual version of xyz.';
+      expect(isDeprecatedDependencies(msg)).toBe(true);
+    });
+    it('valid-warning-1', () => {
+      const msg =
+        'warning insomnia-plugin-xxx-yyy > xyz: ' +
+        'xyz is no longer maintained and not recommended for usage due to the number of issues. ' +
+        'Please, upgrade your dependencies to the actual version of xyz.';
+      expect(isDeprecatedDependencies(msg)).toBe(true);
+    });
+    it('invalid-warning', () => {
+      const msg =
+        'warning You are using Node "6.0.0" which is not supported and may encounter bugs or unexpected behaviour.' +
+        'Yarn supports the following server range: "^4.8.0 || ^5.7.0 || ^6.2.2 || >=8.0.0"';
+      expect(isDeprecatedDependencies(msg)).toBe(false);
+    });
+    it('invalid-error', () => {
+      const msg =
+        'error https://npm.example.net/@types%example/-/hello-1.3.5.tgz: ' +
+        'Integrity check failed for "@types/example" ' +
+        "(computed integrity doesn't match our records, " +
+        'got "sha512-z4kkSfaPg==")';
+      expect(isDeprecatedDependencies(msg)).toBe(false);
+    });
+  });
+});

--- a/packages/insomnia-app/app/plugins/install.js
+++ b/packages/insomnia-app/app/plugins/install.js
@@ -159,7 +159,7 @@ async function _installPluginToTmpDir(lookupName: string): Promise<{ tmpDir: str
           return;
         }
 
-        if (stderr) {
+        if (stderr && !isFalsePositive(stderr)) {
           reject(new Error(`Yarn error ${stderr.toString()}`));
           return;
         }
@@ -168,6 +168,43 @@ async function _installPluginToTmpDir(lookupName: string): Promise<{ tmpDir: str
       },
     );
   });
+}
+
+function isFalsePositive(stderr) {
+  // Let's assume is a false positive
+  let isFalsePositive: boolean = true;
+  // Split into array and remove falsy values (null, undefined, 0, -0, NaN, "", false)
+  const arr = stderr.split(/\r?\n/).filter(e => e);
+  // arr.find() stops and return the first match which is not a deprecated dependency warning
+  if (arr.find(e => !isDeprecatedDependencies(e))) isFalsePositive = false;
+
+  return isFalsePositive;
+}
+
+/**
+ * Provided a string, it checks for the following message:<br>
+ * <<[warning] xxx > yyy > zzz: yyy<n is [no longer maintained] and [not recommended for usage] <br>
+ * due to the number of issues. Please, [upgrade your dependencies] to xxx>> <br>
+ * @param str The error message
+ * @returns {boolean} Returns true if it's a deprecated warning
+ */
+function isDeprecatedDependencies(str: string): boolean {
+  // Search for: warning + dep-list + issue
+  const regex = /(?<keyword>warning)(?<dependencies>[^>:].+[>:])(?<issue>.+)/gm;
+  let result = false;
+  // The array[3](issue) contains the message as it is without the dependency list
+  const message = regex.exec(str)[3];
+  // Strict check, everything must be matched to be a false positive
+  if (
+    message &&
+    message.includes('no longer maintained') &&
+    message.includes('not recommended for usage') &&
+    message.includes('upgrade your dependencies')
+  ) {
+    result = true;
+  }
+
+  return result;
 }
 
 function _getYarnPath() {

--- a/packages/insomnia-app/app/plugins/install.js
+++ b/packages/insomnia-app/app/plugins/install.js
@@ -174,10 +174,10 @@ async function _installPluginToTmpDir(lookupName: string): Promise<{ tmpDir: str
 
 export function containsOnlyDeprecationWarnings(stderr) {
   // Split on line breaks
-  const arr = stderr.split(/\r?\n/);
+  const arr = stderr.split(/\r?\n/).filter(e => e);
   /* Retrieve all matching deprecated dependency warning and
   /* remove falsy values (null, undefined, 0, -0, NaN, "", false) */
-  const warnings = arr.filter(e => e && isDeprecatedDependencies(e));
+  const warnings = arr.filter(e => isDeprecatedDependencies(e));
   // Print each deprecation warnings to the console, so we don't hide them.
   warnings.forEach(e => console.log('[plugins] deprecation warning during installation: ', e));
   // If they mismatch, it means there are warnings and errors

--- a/packages/insomnia-app/app/plugins/install.js
+++ b/packages/insomnia-app/app/plugins/install.js
@@ -178,7 +178,7 @@ export function containsOnlyDeprecationWarnings(stderr) {
   // Retrieve all matching deprecated dependency warning
   const warnings = arr.filter(e => isDeprecatedDependencies(e));
   // Print each deprecation warnings to the console, so we don't hide them.
-  warnings.forEach(e => console.log('[plugins] deprecation warning during installation: ', e));
+  warnings.forEach(e => console.warn('[plugins] deprecation warning during installation: ', e));
   // If they mismatch, it means there are warnings and errors
   return warnings.length === arr.length;
 }

--- a/packages/insomnia-app/app/plugins/install.js
+++ b/packages/insomnia-app/app/plugins/install.js
@@ -173,10 +173,9 @@ async function _installPluginToTmpDir(lookupName: string): Promise<{ tmpDir: str
 }
 
 export function containsOnlyDeprecationWarnings(stderr) {
-  // Split on line breaks
+  // Split on line breaks and remove falsy values (null, undefined, 0, -0, NaN, "", false)
   const arr = stderr.split(/\r?\n/).filter(e => e);
-  /* Retrieve all matching deprecated dependency warning and
-  /* remove falsy values (null, undefined, 0, -0, NaN, "", false) */
+  // Retrieve all matching deprecated dependency warning
   const warnings = arr.filter(e => isDeprecatedDependencies(e));
   // Print each deprecation warnings to the console, so we don't hide them.
   warnings.forEach(e => console.log('[plugins] deprecation warning during installation: ', e));

--- a/packages/insomnia-app/app/plugins/install.js
+++ b/packages/insomnia-app/app/plugins/install.js
@@ -161,7 +161,7 @@ async function _installPluginToTmpDir(lookupName: string): Promise<{ tmpDir: str
           return;
         }
 
-        if (stderr && !isFalsePositive(stderr)) {
+        if (stderr && !containsOnlyDeprecationWarnings(stderr)) {
           reject(new Error(`Yarn error ${stderr.toString()}`));
           return;
         }
@@ -172,13 +172,14 @@ async function _installPluginToTmpDir(lookupName: string): Promise<{ tmpDir: str
   });
 }
 
-function isFalsePositive(stderr) {
-  // Split on line breaks and remove falsy values (null, undefined, 0, -0, NaN, "", false)
-  const arr = stderr.split(/\r?\n/).filter(e => e);
-  // Retrieve all matching deprecated dependency warning
-  const warnings = arr.filter(e => isDeprecatedDependencies(e));
+export function containsOnlyDeprecationWarnings(stderr) {
+  // Split on line breaks
+  const arr = stderr.split(/\r?\n/);
+  /* Retrieve all matching deprecated dependency warning and
+  /* remove falsy values (null, undefined, 0, -0, NaN, "", false) */
+  const warnings = arr.filter(e => e && isDeprecatedDependencies(e));
   // Print each deprecation warnings to the console, so we don't hide them.
-  warnings.forEach(e => console.log(e));
+  warnings.forEach(e => console.log('[plugins] deprecation warning during installation: ', e));
   // If they mismatch, it means there are warnings and errors
   return warnings.length === arr.length;
 }


### PR DESCRIPTION
Changes:

0. Modified if condition from `if (stderr)` to `if (stderr && !isFalsePositive(stderr))`
1. Added function `isFalsePositive(std_err)` which takes std as input, split it using `\r?\n` and run `isDeprecatedDependencies(str)` on each line.
2. Added function `isDeprecatedDependencies(str)` which checks if a given message is a plain warning, 
it's commented to better explains what it does.

Feedbacks ?

It resolves #2836 