### PR TITLE
Fix dollar not correctly handled on URI

### DIFF
--- a/packages/insomnia-url/src/querystring.test.ts
+++ b/packages/insomnia-url/src/querystring.test.ts
@@ -178,13 +178,13 @@ describe('querystring', () => {
     });
 
     it('leaves already encoded pathname', () => {
-      const url = smartEncodeUrl('https://google.com/foo%20bar%20baz/100%25/foo');
-      expect(url).toBe('https://google.com/foo%20bar%20baz/100%25/foo');
+      const url = smartEncodeUrl('https://google.com/foo%20bar%20baz/100%25/foo/%24');
+      expect(url).toBe('https://google.com/foo%20bar%20baz/100%25/foo/%24');
     });
 
     it('encodes querystring', () => {
-      const url = smartEncodeUrl('https://google.com?s=foo bar 100%&hi');
-      expect(url).toBe('https://google.com/?s=foo%20bar%20100%25&hi');
+      const url = smartEncodeUrl('https://google.com?s=foo bar 100%&hi$');
+      expect(url).toBe('https://google.com/?s=foo%20bar%20100%25&hi%24');
     });
 
     it('encodes querystring with mixed spaces', () => {
@@ -205,6 +205,14 @@ describe('querystring', () => {
       // Encoded should skip encoded versions of @ ; ,
       const url2 = smartEncodeUrl('https://google.com/%40%3B%2C%26%5E');
       expect(url2).toBe('https://google.com/%40%3B%2C%26%5E');
+
+      // Encoded should skip raw versions of $
+      const url3 = smartEncodeUrl('https://google.com/$myservice');
+      expect(url3).toBe('https://google.com/$myservice');
+
+      // Encoded should skip encoded versions of $
+      const url4 = smartEncodeUrl('https://google.com/%24myservice');
+      expect(url4).toBe('https://google.com/%24myservice');
     });
 
     it('leaves already encoded characters alone', () => {

--- a/packages/insomnia-url/src/querystring.ts
+++ b/packages/insomnia-url/src/querystring.ts
@@ -2,7 +2,15 @@ import { parse as urlParse, format as urlFormat } from 'url';
 import { setDefaultProtocol } from './protocol';
 
 const ESCAPE_REGEX_MATCH = /[-[\]/{}()*+?.\\^$|]/g;
-const URL_PATH_CHARACTER_WHITELIST = '+,;@=:$';
+
+/** see list of allowed characters https://datatracker.ietf.org/doc/html/rfc3986#section-2.2 */
+const RFC_3986_GENERAL_DELIMITERS = ':@'; // (unintentionally?) missing: /?#[]
+
+/** see list of allowed characters https://datatracker.ietf.org/doc/html/rfc3986#section-2.2 */
+const RFC_3986_SUB_DELIMITERS = '$+,;='; // (unintentionally?) missing: !&'()*
+
+/** see list of allowed characters https://datatracker.ietf.org/doc/html/rfc3986#section-2.2 */
+const URL_PATH_CHARACTER_WHITELIST = `${RFC_3986_GENERAL_DELIMITERS}${RFC_3986_SUB_DELIMITERS}`;
 
 export const getJoiner = (url: string) => {
   url = url || '';

--- a/packages/insomnia-url/src/querystring.ts
+++ b/packages/insomnia-url/src/querystring.ts
@@ -2,7 +2,7 @@ import { parse as urlParse, format as urlFormat } from 'url';
 import { setDefaultProtocol } from './protocol';
 
 const ESCAPE_REGEX_MATCH = /[-[\]/{}()*+?.\\^$|]/g;
-const URL_PATH_CHARACTER_WHITELIST = '+,;@=:';
+const URL_PATH_CHARACTER_WHITELIST = '+,;@=:$';
 
 export const getJoiner = (url: string) => {
   url = url || '';


### PR DESCRIPTION
Added dollar sign on `URL_PATH_CHARACTER_WHITELIST`.
I don't know if there is a better place but seems working as expected.

On query parameters dollars it's still escaped as it should be.

**Before**
![Schermata 2020-11-23 alle 22 52 58](https://user-images.githubusercontent.com/20780192/100125418-0f744580-2e7d-11eb-889c-b80a8227829a.png)

**After**
![Schermata 2020-11-23 alle 22 52 00](https://user-images.githubusercontent.com/20780192/100125392-05eadd80-2e7d-11eb-815e-d8c1cba4e932.png)


It closes #2850 
