### PR TITLE
Remove form-control styles from gRPC url bar

### DIFF
--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.js
@@ -48,16 +48,15 @@ const GrpcRequestPane = ({ activeRequest, forceRefreshKey, settings }: Props) =>
     <Pane type="request">
       <PaneHeader className="grpc-urlbar">
         <div className="method-grpc pad">gRPC</div>
-        <form className={'form-control form-control--outlined'}>
-          <OneLineEditor
-            key={uniquenessKey}
-            type="text"
-            forceEditor
-            defaultValue={activeRequest.url}
-            placeholder="grpcb.in:9000"
-            onChange={handleChange.url}
-          />
-        </form>
+        <OneLineEditor
+          className="urlbar__url-editor"
+          key={uniquenessKey}
+          type="text"
+          forceEditor
+          defaultValue={activeRequest.url}
+          placeholder="grpcb.in:9000"
+          onChange={handleChange.url}
+        />
         <GrpcMethodDropdown
           disabled={running}
           methods={methods}

--- a/packages/insomnia-app/app/ui/css/components/grpc-url-bar.less
+++ b/packages/insomnia-app/app/ui/css/components/grpc-url-bar.less
@@ -8,12 +8,8 @@
         justify-content: flex-start;
         align-items: center;
 
-        .form-control {
-            height: 100%;
-            flex: 1 0 auto;
-            align-self: auto;
-            margin-bottom: 0;
-            flex-basis: 4em; 
+        .urlbar__url-editor {
+            flex: 1 0 4em;
         }
         .dropdown {
             flex: 1 0 auto;
@@ -23,8 +19,6 @@
   button:focus,
   button:hover {
     background-color: var(--hl-xs);
-
-
   }
 
   & > .dropdown > button {

--- a/packages/insomnia-app/app/ui/css/components/request-pane.less
+++ b/packages/insomnia-app/app/ui/css/components/request-pane.less
@@ -1,13 +1,8 @@
 .request-pane {
   height: 100%;
-  grid-template-rows: var(--line-height-md) minmax(0, 1fr) !important;
 
   .request-pane__shortcuts-table {
     color: var(--hl-xl);
     text-align: left;
-  }
-
-  .form-control {
-    margin-top: var(--padding-xxs);
   }
 }


### PR DESCRIPTION
What it says on the tin!

Designer:
![image](https://user-images.githubusercontent.com/4312346/100031143-c4950680-2e59-11eb-874b-7b5c90ae9903.png)

Core:
![image](https://user-images.githubusercontent.com/4312346/100031151-ca8ae780-2e59-11eb-9f54-723ca7625bd6.png)
