### PR TITLE
Fix re-uploading a protofile when it is not linked to a request

### DIFF
--- a/packages/insomnia-app/app/__mocks__/electron.js
+++ b/packages/insomnia-app/app/__mocks__/electron.js
@@ -55,6 +55,6 @@ module.exports = {
     on: jest.fn(),
     removeAllListeners: jest.fn(),
     once() {},
-    send() {},
+    send: jest.fn(),
   },
 };

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -141,8 +141,9 @@ class ProtoFilesModal extends React.PureComponent<Props, State> {
       if (protoFile) {
         await models.protoFile.update(protoFile, { name, protoText });
         const action = await grpcActions.invalidateMany(protoFile._id);
+
         grpcDispatch(action);
-        sendGrpcIpcMultiple(GrpcRequestEventEnum.cancelMultiple, action.requestIds);
+        sendGrpcIpcMultiple(GrpcRequestEventEnum.cancelMultiple, action?.requestIds);
       } else {
         const newFile = await models.protoFile.create({ name, parentId: workspace._id, protoText });
         this.setState({ selectedProtoFileId: newFile._id });

--- a/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-ipc-renderer.test.js
+++ b/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-ipc-renderer.test.js
@@ -1,11 +1,12 @@
 // @flow
 
 import { ipcRenderer } from 'electron';
-import { GrpcResponseEventEnum } from '../../../../common/grpc-events';
+import { GrpcRequestEventEnum, GrpcResponseEventEnum } from '../../../../common/grpc-events';
 import { grpcStatusObjectSchema } from '../__schemas__';
 import { createBuilder } from '@develohpanda/fluent-builder';
-import { grpcIpcRenderer } from '../grpc-ipc-renderer';
+import { grpcIpcRenderer, sendGrpcIpcMultiple, useGrpcIpc } from '../grpc-ipc-renderer';
 import { grpcActions } from '../grpc-actions';
+import { renderHook } from '@testing-library/react-hooks';
 
 jest.mock('../grpc-actions', () => ({
   grpcActions: {
@@ -97,4 +98,73 @@ describe('destroy', () => {
       expect(ipcRenderer.removeAllListeners).toHaveBeenCalledWith(channel);
     },
   );
+});
+
+describe('useGrpcIpc', () => {
+  const channel = GrpcRequestEventEnum.cancel;
+
+  it('should send request id on channel', () => {
+    const requestId = 'r1';
+
+    const { result } = renderHook(() => useGrpcIpc(requestId));
+
+    result.current(channel);
+
+    expect(ipcRenderer.send).toHaveBeenCalledTimes(1);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(channel, requestId);
+  });
+
+  it.each([undefined, null, ''])('should not send if request id is %o', rId => {
+    const { result } = renderHook(() => useGrpcIpc(rId));
+    result.current(channel);
+
+    expect(ipcRenderer.send).not.toHaveBeenCalled();
+  });
+
+  it('should update hook if request id changes', () => {
+    const { result, rerender } = renderHook(id => useGrpcIpc(id));
+    result.current(channel);
+
+    expect(ipcRenderer.send).not.toHaveBeenCalled();
+
+    const r1 = 'r1';
+    rerender(r1);
+    result.current(channel);
+
+    expect(ipcRenderer.send).toHaveBeenCalledTimes(1);
+    expect(ipcRenderer.send).toHaveBeenLastCalledWith(channel, r1);
+
+    const r2 = 'r2';
+    rerender(r2);
+    result.current(channel);
+
+    expect(ipcRenderer.send).toHaveBeenCalledTimes(2);
+    expect(ipcRenderer.send).toHaveBeenLastCalledWith(channel, r2);
+  });
+});
+
+describe('sendGrpcIpcMultiple', () => {
+  const channel = GrpcRequestEventEnum.cancelMultiple;
+
+  it('should send requestIds on channel', () => {
+    const requestIds = ['abc', '123'];
+    sendGrpcIpcMultiple(channel, requestIds);
+
+    expect(ipcRenderer.send).toHaveBeenCalledTimes(1);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(channel, requestIds);
+  });
+
+  it('should not send on channel when request ids is empty', () => {
+    sendGrpcIpcMultiple(channel, []);
+
+    expect(ipcRenderer.send).not.toHaveBeenCalled();
+  });
+
+  it('should not send on channel when request ids is undefined', () => {
+    sendGrpcIpcMultiple(channel, undefined);
+    sendGrpcIpcMultiple(channel, null);
+    sendGrpcIpcMultiple(channel);
+
+    expect(ipcRenderer.send).not.toHaveBeenCalled();
+  });
 });

--- a/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-reducer.test.js
+++ b/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-reducer.test.js
@@ -294,6 +294,30 @@ describe('grpcReducer actions', () => {
         [r3]: r3Expected,
       });
     });
+
+    it('should do nothing if no requests found for the proto file', async () => {
+      const parentId = 'wrk_1';
+
+      // Create a request not linked to the proto file
+      const pf = await models.protoFile.create({ parentId });
+
+      const r1 = 'r1';
+      await models.grpcRequest.create({ parentId, _id: r1 });
+
+      // Setup original state
+      const originalState: GrpcState = {
+        [r1]: requestStateBuilder
+          .reset()
+          .reloadMethods(false)
+          .build(),
+      };
+
+      // Dispatch an invalidateMany action, with the modified proto file id as an argument
+      const newState = grpcReducer(originalState, await grpcActions.invalidateMany(pf._id));
+
+      // Expect no state change
+      expect(newState).toStrictEqual(originalState);
+    });
   });
 
   describe('clear', () => {

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-actions.js
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-actions.js
@@ -120,12 +120,12 @@ const invalidate = (requestId: string): InvalidateAction => ({
   requestId,
 });
 
-const invalidateMany = async (protoFileId: string): Promise<InvalidateManyAction> => {
+const invalidateMany = async (protoFileId: string): Promise<InvalidateManyAction | undefined> => {
   const impacted = await models.grpcRequest.findByProtoFileId(protoFileId);
 
   // skip invalidation if no requests are linked to the proto file
   if (!impacted.length) {
-    return;
+    return undefined;
   }
 
   return {

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-ipc-renderer.js
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-ipc-renderer.js
@@ -60,10 +60,14 @@ export const grpcIpcRenderer = {
 export const useGrpcIpc: string => GrpcRequestEvent => void = requestId =>
   React.useCallback((channel: GrpcRequestEvent) => sendGrpcIpc(channel, requestId), [requestId]);
 
-const sendGrpcIpc = (channel: GrpcRequestEvent, requestId: string) => {
-  ipcRenderer.send(channel, requestId);
+const sendGrpcIpc = (channel: GrpcRequestEvent, requestId?: string) => {
+  if (requestId) {
+    ipcRenderer.send(channel, requestId);
+  }
 };
 
-export const sendGrpcIpcMultiple = (channel: GrpcRequestEvent, requestIds: Array<string>) => {
-  ipcRenderer.send(channel, requestIds);
+export const sendGrpcIpcMultiple = (channel: GrpcRequestEvent, requestIds?: Array<string>) => {
+  if (requestIds?.length) {
+    ipcRenderer.send(channel, requestIds);
+  }
 };


### PR DESCRIPTION
The logic in `proto-files-modal` is difficult to test, but I have added further control and tests with surrounding elements.

![2020-11-25 11 59 01](https://user-images.githubusercontent.com/4312346/100161165-cc19e580-2f15-11eb-912f-52a33e0a0635.gif)

Fixes INS-329