### PR TITLE
Sidebar filter display

### DIFF
--- a/packages/insomnia-components/components/sidebar/sidebar-header.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-header.js
@@ -12,6 +12,19 @@ type Props = {
   children?: React.Node,
 };
 
+const filterTriggerDisplay = {
+  expanded: {
+    opacity: 0.6,
+    display: 'inline',
+  },
+  collapsed: {
+    opacity: 0,
+    transitionEnd: {
+      display: 'none',
+    },
+  },
+};
+
 const StyledHeader: React.ComponentType<{}> = styled.li`
   display: flex;
   justify-content: space-between;
@@ -69,8 +82,9 @@ const SidebarHeader = ({
       {children || (
         <motion.span
           onClick={toggleFilter}
-          initial={{ opacity: sectionVisible ? 0.6 : 0 }}
-          animate={{ opacity: sectionVisible ? 0.6 : 0 }}>
+          initial={sectionVisible ? 'expanded' : 'collapsed'}
+          animate={sectionVisible ? 'expanded' : 'collapsed'}
+          variants={filterTriggerDisplay}>
           <SvgIcon icon={IconEnum.search} />
         </motion.span>
       )}

--- a/packages/insomnia-components/components/sidebar/sidebar-header.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-header.js
@@ -15,12 +15,12 @@ type Props = {
 const filterTriggerDisplay = {
   expanded: {
     opacity: 0.6,
-    display: 'inline',
+    pointerEvents: 'auto',
   },
   collapsed: {
     opacity: 0,
     transitionEnd: {
-      display: 'none',
+      pointerEvents: 'none',
     },
   },
 };


### PR DESCRIPTION
This PR fixes a bug where despite the sidebar filters search icon being hidden, it still accepts click events. Fixed demo:

![2020-11-25 02 29 45](https://user-images.githubusercontent.com/52717970/100196064-533f6d00-2ec6-11eb-9252-af9b3ec3a15e.gif)

FIXES INS-331