### PR TITLE
Import graphql postman collection v2.x

### DIFF
--- a/packages/insomnia-importers/src/importers/fixtures/postman/complex-v2_0-input.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/complex-v2_0-input.json
@@ -111,6 +111,22 @@
         "description": "Request with unknown body"
       },
       "response": []
+    },
+    {
+      "name": "Test Request GraphQL Body",
+      "request": {
+        "url": "{{base_url}}/graphql/",
+        "method": "POST",
+        "body": {
+          "mode": "graphql",
+          "graphql": {
+            "query": "mutation loginUser($username: String!, $password: String!) {\n  login(username: $username, password: $password) {\n    token\n    status {\n      success\n    }\n  }\n}\n",
+            "variables": "{\n    \"password\": \"{{password}}\",\n    \"username\": \"{{username}}\"\n}"
+          }
+        },
+        "description": "Request with graphql body"
+      },
+      "response": []
     }
   ]
 }

--- a/packages/insomnia-importers/src/importers/fixtures/postman/complex-v2_0-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/complex-v2_0-output.json
@@ -122,6 +122,22 @@
       "parameters": [],
       "headers": [],
       "authentication": {}
+    },
+    {
+      "_id": "__REQ_6__",
+      "_type": "request",
+      "parentId": "__GRP_1__",
+      "url": "{{base_url}}/graphql/",
+      "name": "Test Request GraphQL Body",
+      "description": "Request with graphql body",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/graphql",
+        "text": "{\"query\":\"mutation loginUser($username: String!, $password: String!) {\\n  login(username: $username, password: $password) {\\n    token\\n    status {\\n      success\\n    }\\n  }\\n}\\n\",\"variables\":\"{\\n    \\\"password\\\": \\\"{{password}}\\\",\\n    \\\"username\\\": \\\"{{username}}\\\"\\n}\"}"
+      },
+      "parameters": [],
+      "headers": [],
+      "authentication": {}
     }
   ]
 }

--- a/packages/insomnia-importers/src/importers/fixtures/postman/complex-v2_1-input.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/complex-v2_1-input.json
@@ -152,6 +152,26 @@
         "description": "Request with empty raw body"
       },
       "response": []
+    },
+    {
+      "name": "Test Request GraphQL Body",
+      "request": {
+        "method": "POST",
+        "body": {
+          "mode": "graphql",
+          "graphql": {
+            "query": "mutation loginUser($username: String!, $password: String!) {\n  login(username: $username, password: $password) {\n    token\n    status {\n      success\n    }\n  }\n}\n",
+            "variables": "{\n    \"password\": \"{{password}}\",\n    \"username\": \"{{username}}\"\n}"
+          }
+        },
+        "url": {
+          "raw": "{{base_url}}/graphql/",
+          "host": ["{{base_url}}"],
+          "path": ["api"]
+        },
+        "description": "Request with graphql body"
+      },
+      "response": []
     }
   ]
 }

--- a/packages/insomnia-importers/src/importers/fixtures/postman/complex-v2_1-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/complex-v2_1-output.json
@@ -128,6 +128,22 @@
       "parameters": [],
       "headers": [],
       "authentication": {}
+    },
+    {
+      "_id": "__REQ_6__",
+      "_type": "request",
+      "parentId": "__GRP_1__",
+      "url": "{{base_url}}/graphql/",
+      "name": "Test Request GraphQL Body",
+      "description": "Request with graphql body",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/graphql",
+        "text": "{\"query\":\"mutation loginUser($username: String!, $password: String!) {\\n  login(username: $username, password: $password) {\\n    token\\n    status {\\n      success\\n    }\\n  }\\n}\\n\",\"variables\":\"{\\n    \\\"password\\\": \\\"{{password}}\\\",\\n    \\\"username\\\": \\\"{{username}}\\\"\\n}\"}"
+      },
+      "parameters": [],
+      "headers": [],
+      "authentication": {}
     }
   ]
 }

--- a/packages/insomnia-importers/src/importers/postman.ts
+++ b/packages/insomnia-importers/src/importers/postman.ts
@@ -186,6 +186,9 @@ class ImportCollection {
         // TODO: Handle this as properly as multipart/form-data
         return this.importBodyFormdata(body.formdata);
 
+      case 'graphql':
+        return this.importBodyGraphQL(body.graphql);
+
       default:
         return {};
     }
@@ -257,6 +260,17 @@ class ImportCollection {
     return {
       mimeType: '',
       text: raw,
+    };
+  };
+
+  importBodyGraphQL = (graphql?: Record<string, unknown>) => {
+    if (!graphql) {
+      return {};
+    }
+
+    return {
+      mimeType: 'application/graphql',
+      text: JSON.stringify(graphql),
     };
   };
 


### PR DESCRIPTION
Postman introduced one more `body.mode` named `graphql` for GraphQL queries.

This PR implements support for graphql postman import.

Closes #2751 