### PR TITLE
feat: add loading state to git sync staging modal

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/git-staging-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-staging-modal.js
@@ -417,7 +417,7 @@ class GitStagingModal extends React.PureComponent<Props, State> {
             <button className="btn" onClick={this._hideModal}>
               Close
             </button>
-            <button className="btn" onClick={this._handleCommit} disabled={!hasChanges}>
+            <button className="btn" onClick={this._handleCommit} disabled={loading || !hasChanges}>
               Commit
             </button>
           </div>


### PR DESCRIPTION
There are two slightly different cases where a spinner needs to be shown but the UI is different. These are:
1. if loading diff for the first time, show spinner and loading text
2. if loading diff _not_ for the first time (eg after rollback), continue to show existing data with a spinner

Both states are visible in the gif below. This also contains an artificial 2 second wait during refresh in order to show the loading state. 

![2020-11-30 14 38 53](https://user-images.githubusercontent.com/4312346/100560293-3e296a80-331a-11eb-80c3-08aedcb491a2.gif)

Fixes #2457, Fixes INS-160