### PR TITLE
fix: remove request id validation 

### DIFF
--- a/packages/insomnia-app/app/models/__tests__/request-meta.test.js
+++ b/packages/insomnia-app/app/models/__tests__/request-meta.test.js
@@ -10,9 +10,9 @@ describe('create()', () => {
     );
   });
 
-  it('fails when parentId prefix is not that of a Request', async () => {
-    expect(() => models.requestMeta.create({ parentId: 'greq_123' })).toThrow(
-      'Expected the parent of RequestMeta to be a Request',
-    );
-  });
+  // it('fails when parentId prefix is not that of a Request', async () => {
+  //   expect(() => models.requestMeta.create({ parentId: 'greq_123' })).toThrow(
+  //     'Expected the parent of RequestMeta to be a Request',
+  //   );
+  // });
 });

--- a/packages/insomnia-app/app/models/helpers/__tests__/is-model.test.js
+++ b/packages/insomnia-app/app/models/helpers/__tests__/is-model.test.js
@@ -6,7 +6,6 @@ import {
   isProtoFile,
   isRequest,
   isRequestGroup,
-  isRequestId,
 } from '../is-model';
 import { generateId } from '../../../common/misc';
 
@@ -52,18 +51,18 @@ describe('isRequest', () => {
   });
 });
 
-describe('isRequestId', () => {
-  const supported = [models.request.prefix];
-  const unsupported = difference(allPrefixes, supported);
-
-  it.each(supported)('should return true if id is prefixed by "%s_"', prefix => {
-    expect(isRequestId(generateId(prefix))).toBe(true);
-  });
-
-  it.each(unsupported)('should return false if id is prefixed by "%s_"', prefix => {
-    expect(isRequestId(generateId(prefix))).toBe(false);
-  });
-});
+// describe('isRequestId', () => {
+//   const supported = [models.request.prefix];
+//   const unsupported = difference(allPrefixes, supported);
+//
+//   it.each(supported)('should return true if id is prefixed by "%s_"', prefix => {
+//     expect(isRequestId(generateId(prefix))).toBe(true);
+//   });
+//
+//   it.each(unsupported)('should return false if id is prefixed by "%s_"', prefix => {
+//     expect(isRequestId(generateId(prefix))).toBe(false);
+//   });
+// });
 
 describe('isRequestGroup', () => {
   const supported = [models.requestGroup.type];

--- a/packages/insomnia-app/app/models/helpers/is-model.js
+++ b/packages/insomnia-app/app/models/helpers/is-model.js
@@ -14,9 +14,10 @@ export function isRequest(obj: BaseModel): boolean {
   return obj.type === request.type;
 }
 
-export function isRequestId(id: string): boolean {
-  return id.startsWith(`${request.prefix}_`);
-}
+// TODO: Invalid until we can ensure all requests are prefixed by the id correctly INS-341
+// export function isRequestId(id: string): boolean {
+//   return id.startsWith(`${request.prefix}_`);
+// }
 
 export function isRequestGroup(obj: BaseModel): boolean {
   return obj.type === requestGroup.type;

--- a/packages/insomnia-app/app/models/request-meta.js
+++ b/packages/insomnia-app/app/models/request-meta.js
@@ -2,7 +2,6 @@
 import * as db from '../common/database';
 import { PREVIEW_MODE_FRIENDLY } from '../common/constants';
 import type { BaseModel } from './index';
-import { isRequestId } from './helpers/is-model';
 
 export const name = 'Request Meta';
 export const type = 'RequestMeta';
@@ -47,18 +46,18 @@ export function create(patch: $Shape<RequestMeta> = {}) {
     throw new Error('New RequestMeta missing `parentId` ' + JSON.stringify(patch));
   }
 
-  expectParentToBeRequest(patch.parentId);
+  // expectParentToBeRequest(patch.parentId);
 
   return db.docCreate(type, patch);
 }
 
 export function update(requestMeta: RequestMeta, patch: $Shape<RequestMeta>) {
-  expectParentToBeRequest(patch.parentId || requestMeta.parentId);
+  // expectParentToBeRequest(patch.parentId || requestMeta.parentId);
   return db.docUpdate(requestMeta, patch);
 }
 
 export function getByParentId(parentId: string) {
-  expectParentToBeRequest(parentId);
+  // expectParentToBeRequest(parentId);
   return db.getWhere(type, { parentId });
 }
 
@@ -87,8 +86,9 @@ export function all(): Promise<Array<RequestMeta>> {
   return db.all(type);
 }
 
-function expectParentToBeRequest(parentId: string) {
-  if (!isRequestId(parentId)) {
-    throw new Error('Expected the parent of RequestMeta to be a Request');
-  }
-}
+// TODO: Ensure the parent of RequestMeta can only be a Request - INS-341
+// function expectParentToBeRequest(parentId: string) {
+//   if (!isRequestId(parentId)) {
+//     throw new Error('Expected the parent of RequestMeta to be a Request');
+//   }
+// }

--- a/packages/insomnia-smoke-test/prism/swagger2.yaml
+++ b/packages/insomnia-smoke-test/prism/swagger2.yaml
@@ -1,0 +1,77 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: E2E testing specification
+  description: This is a specification used for E2E testing of Insomnia, and is served via prism
+servers:
+  - url: http://127.0.0.1:4010
+paths:
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /csv:
+    get:
+      description: Returns CSV content
+      responses:
+        200:
+          description: Get Todo Items
+          content:
+            text/csv:
+              schema: {}
+              example: |
+                a,b,c
+                1,2,3
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+          - id
+          properties:
+            id:
+              type: integer
+              format: int64
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
In the 2020.5 release we use heuristics to ensure a model (request and grpc-request) is a particular type (because it should genuinely fail if there is a mismatch) using its id. For example, a requestId is always prefixed by `req_*` and folder by `fld_*`. It has been like this since the start of time.

The problem is that not all of the importers follow that heuristic... evident through the swagger2 importer when importing and running `https://petstore.swagger.io/v2/swagger.json` in 2020.5.

Note that the above specification automatically enables OAuth on a request so it will still fail, but there should be no errors in the console. Additionally, if you remove the authentication on a request (for example on `/pet/findByStatus` the request should run correctly, whereas it exhibits adverse behavior in `2020.5.0-beta.2`.

The OpenAPI3 importer applies the id correctly, though.

Related to INS-341