### PR TITLE
Add shim for window in insomnia-send-request

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "tagVersionPrefix": "lib@",
-  "version": "2.2.26",
+  "version": "2.2.27",
   "includeMergedTags": true,
   "packages": [
     "packages/*",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "tagVersionPrefix": "lib@",
-  "version": "2.2.27",
+  "version": "2.2.28",
   "includeMergedTags": true,
   "packages": [
     "packages/*",

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "insomnia-app",
-	"version": "2.2.26",
+	"version": "2.2.27",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "2.2.26",
+  "version": "2.2.27",
   "name": "insomnia-app",
   "homepage": "https://konghq.com",
   "description": "The Collaborative API Design Tool",

--- a/packages/insomnia-app/send-request/webpack.config.babel.js
+++ b/packages/insomnia-app/send-request/webpack.config.babel.js
@@ -46,5 +46,6 @@ module.exports = {
   plugins: [
     // Set the APP_ID environment variable because it's required to access the app config
     new webpack.DefinePlugin({ 'process.env.APP_ID': JSON.stringify('com.insomnia.designer') }),
+    new webpack.ProvidePlugin({ window: path.resolve(path.join(__dirname, './window-shim')) }),
   ],
 };

--- a/packages/insomnia-app/send-request/window-shim/index.js
+++ b/packages/insomnia-app/send-request/window-shim/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  localStorage: {
+    getItem: () => undefined,
+    setItem: () => {},
+  },
+};

--- a/packages/insomnia-app/send-request/window-shim/package.json
+++ b/packages/insomnia-app/send-request/window-shim/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "window-shim",
+  "main": "index.js"
+}

--- a/packages/insomnia-inso/package-lock.json
+++ b/packages/insomnia-inso/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "insomnia-inso",
-	"version": "2.2.27",
+	"version": "2.2.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/insomnia-inso/package-lock.json
+++ b/packages/insomnia-inso/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "insomnia-inso",
-	"version": "2.2.26",
+	"version": "2.2.27",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-inso",
-  "version": "2.2.26",
+  "version": "2.2.27",
   "homepage": "https://insomnia.rest",
   "description": "A CLI for Insomnia Designer - the collaborative API design tool.",
   "author": "Kong <office@konghq.com>",
@@ -80,7 +80,7 @@
     "insomnia-plugin-request": "^2.2.24",
     "insomnia-plugin-response": "^2.2.25",
     "insomnia-plugin-uuid": "^2.2.24",
-    "insomnia-send-request": "^2.2.26",
+    "insomnia-send-request": "^2.2.27",
     "insomnia-testing": "^2.2.26",
     "lodash.flattendeep": "^4.4.0",
     "mkdirp": "^1.0.4",

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-inso",
-  "version": "2.2.27",
+  "version": "2.2.28",
   "homepage": "https://insomnia.rest",
   "description": "A CLI for Insomnia Designer - the collaborative API design tool.",
   "author": "Kong <office@konghq.com>",
@@ -80,7 +80,7 @@
     "insomnia-plugin-request": "^2.2.24",
     "insomnia-plugin-response": "^2.2.25",
     "insomnia-plugin-uuid": "^2.2.24",
-    "insomnia-send-request": "^2.2.27",
+    "insomnia-send-request": "^2.2.28",
     "insomnia-testing": "^2.2.26",
     "lodash.flattendeep": "^4.4.0",
     "mkdirp": "^1.0.4",

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "insomnia-send-request",
-	"version": "2.2.26",
+	"version": "2.2.27",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "insomnia-send-request",
-	"version": "2.2.27",
+	"version": "2.2.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -27,7 +27,7 @@
     "multiparty": "^4.2.1",
     "nedb": "^1.8.0",
     "node-forge": "^0.9.1",
-    "node-libcurl": "^2.2.0",
+    "node-libcurl": "2.2.0",
     "nunjucks": "^3.2.1",
     "oauth-1.0a": "^2.2.6",
     "openapi-2-kong": "^2.2.26",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-send-request",
-  "version": "2.2.27",
+  "version": "2.2.28",
   "main": "dist/index.js",
   "dependencies": {
     "@stoplight/spectral": "^5.4.0",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-send-request",
-  "version": "2.2.26",
+  "version": "2.2.27",
   "main": "dist/index.js",
   "dependencies": {
     "@stoplight/spectral": "^5.4.0",

--- a/packages/insomnia-smoke-test/package-lock.json
+++ b/packages/insomnia-smoke-test/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-smoke-test",
-  "version": "2.2.26",
+  "version": "2.2.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "insomnia-smoke-test",
-  "version": "2.2.26",
+  "version": "2.2.27",
   "scripts": {
     "spectron:core:build": "cross-env BUNDLE=build xvfb-maybe jest --detectOpenHandles --testPathPattern core",
     "spectron:designer:build": "cross-env BUNDLE=build xvfb-maybe jest --detectOpenHandles --testPathPattern designer",


### PR DESCRIPTION
The following lines run while importing files in the insomnia networking layer:
https://github.com/Kong/insomnia/blob/aeafe4a7c92b1d5e93f4dfe7ac9a699b0804bf45/packages/insomnia-app/app/network/o-auth-2/misc.js#L5-L18

This is exposed to inso through `insomnia-send-request`, but `window` does not exist in a CLI environment and as such errors are thrown while trying to run unit tests through inso.

I explored various options: adding an explicit check in the code itself to ensure window exists, but that felt to brittle. I like the approach of using a shim, similar to the electron shim, as it is well defined when changes need to be made in future.

Fixes #2916 

This branch is based on 2020.5.1 and contains the minimal bug fix, while the branch in #2917 is based on develop and contains the smoke test. The two had to be split as many conflicts arise with the smoke tests because of recent changes in develop.

Tests:
- [x] Does this work? 😆 