### PR TITLE
GraphQL Explorer - Make text selectable

### DIFF
--- a/packages/insomnia-app/app/ui/css/components/graph-ql-explorer.less
+++ b/packages/insomnia-app/app/ui/css/components/graph-ql-explorer.less
@@ -12,6 +12,9 @@
   background: var(--color-bg);
   box-shadow: 0 0 1rem 0 rgba(0, 0, 0, 0.4);
   color: var(--color-font);
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  user-select: text;
 
   .markdown-preview__content *:first-child {
     margin-top: var(--padding-sm);

--- a/packages/insomnia-app/app/ui/css/components/graph-ql-explorer.less
+++ b/packages/insomnia-app/app/ui/css/components/graph-ql-explorer.less
@@ -12,8 +12,6 @@
   background: var(--color-bg);
   box-shadow: 0 0 1rem 0 rgba(0, 0, 0, 0.4);
   color: var(--color-font);
-  -webkit-user-select: text;
-  -moz-user-select: text;
   user-select: text;
 
   .markdown-preview__content *:first-child {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Closes #2899

By inspecting elements, the `user-select` with `none` seems to come from the [body](https://github.com/Kong/insomnia/blob/develop/packages/insomnia-app/app/ui/css/lib/chrome/platform_app.css#L3).

However, I don't think it cannot be removed or modified because all texts would be selected.
![insomnia_body_select](https://user-images.githubusercontent.com/1557482/102452539-7dd59f00-4008-11eb-955d-ff2ee3c6ac1f.png)

The next level for CSS change would be for the [GraphQL Explorer](https://github.com/Kong/insomnia/blob/develop/packages/insomnia-app/app/renderer.html#L16).
![insomnia_graphql_explorer_select](https://user-images.githubusercontent.com/1557482/102452673-ba08ff80-4008-11eb-8921-5a71501d4b71.png)