### PR TITLE
Close hint dropdown when a code editor field unmounts

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -95,6 +95,7 @@ class CodeEditor extends React.Component {
   componentWillUnmount() {
     if (this.codeMirror) {
       this.codeMirror.toTextArea();
+      this.codeMirror.closeHintDropdown();
     }
   }
 

--- a/packages/insomnia-app/app/ui/components/codemirror/extensions/autocomplete.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/extensions/autocomplete.js
@@ -37,6 +37,10 @@ CodeMirror.defineExtension('isHintDropdownActive', function() {
   );
 });
 
+CodeMirror.defineExtension('closeHintDropdown', function() {
+  this.state.completionActive?.close();
+});
+
 CodeMirror.defineOption('environmentAutocomplete', null, (cm, options) => {
   if (!options) {
     return;


### PR DESCRIPTION
The bug described in the linked issue is a little tricky to reproduce but before reviewing try to get the hang of it by pressing `ctrl + space` and at the same time switch to a new request in the live application.

If you get the timing right, the request actions dropdown and autocomplete dropdown will open together, and then the application is in the state described in the issue, where the autocomplete dropdown doesn't close on switching requests.

![2020-12-18 09 18 03](https://user-images.githubusercontent.com/4312346/102539185-389d9400-4112-11eb-98d1-197e87cdb0ad.gif)

Following the same process, the dropdown will correctly close with this PR (as shown in the gif below)

![2020-12-18 09 10 13](https://user-images.githubusercontent.com/4312346/102538824-aeedc680-4111-11eb-9a12-7603745ff7ad.gif)

Closes #2591 