### PR TITLE
Add reveal password text hint in auth tab

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/auth/auth-wrapper.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/auth-wrapper.js
@@ -27,6 +27,8 @@ import autobind from 'autobind-decorator';
 import type { Request, RequestAuthentication } from '../../../../models/request';
 import type { OAuth2Token } from '../../../../models/o-auth-2-token';
 import type { Settings } from '../../../../models/settings';
+import { showModal } from '../../modals';
+import SettingsModal from '../../modals/settings-modal';
 
 type Props = {
   handleRender: Function,
@@ -44,6 +46,10 @@ type Props = {
 
 @autobind
 class AuthWrapper extends React.PureComponent<Props> {
+  static _handleShowSettings() {
+    showModal(SettingsModal);
+  }
+
   renderEditor() {
     const {
       oAuth2Token,
@@ -180,6 +186,15 @@ class AuthWrapper extends React.PureComponent<Props> {
             <br />
             <br />
             Select an auth type from above
+            <br />
+            <br />
+            Use Reveal passwords in{' '}
+            <button
+              onClick={AuthWrapper._handleShowSettings}
+              className="btn btn--outlined btn--super-duper-compact">
+              Preferences
+            </button>{' '}
+            to toggle password visibility
           </p>
         </div>
       );

--- a/packages/insomnia-smoke-test/modules/debug.js
+++ b/packages/insomnia-smoke-test/modules/debug.js
@@ -152,7 +152,7 @@ export const clickBasicAuth = async app => {
 export const expectNoAuthSelected = async app => {
   const wrapper = await app.client.react$('RequestPane').then(e => e.react$('AuthWrapper'));
   await wrapper.waitForDisplayed();
-  await expectText(wrapper, 'Select an auth type from above');
+  await expectContainsText(wrapper, 'Select an auth type from above');
 };
 
 export const typeBasicAuthUsernameAndPassword = async (app, username, password, clear = false) => {


### PR DESCRIPTION
Added text hint for reveal password in auth tab

<img width="492" alt="Screen Shot 2020-12-30 at 1 24 26 PM" src="https://user-images.githubusercontent.com/14926492/103337785-671c5700-4aa2-11eb-8293-429bd5cc3091.png">

Closes #2929