### PR TITLE
Added indication after successful export

### DIFF
--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -523,6 +523,10 @@ export function exportWorkspacesToFile(workspaceId = null) {
             console.warn('Export failed', err);
           }
           dispatch(loadStop());
+          showModal(AlertModal, {
+            title: 'Success',
+            message: 'requests under all workspaces was exported successfully',
+          });
         });
       },
     );
@@ -612,6 +616,10 @@ export function exportRequestsToFile(requestIds) {
             console.warn('Export failed', err);
           }
           dispatch(loadStop());
+          showModal(AlertModal, {
+            title: 'Success',
+            message: 'requests under current workspace was exported successfully',
+          });
         });
       },
     );


### PR DESCRIPTION
Currently, after a successful export, there is no indication to the user. he needs to manually see in the filesystem. This pr introduces notification after successful export using modal.

Note: Initially, planned to use the `Toast` component for this, but is tightly coupled with the new `version` check functionality. So, used `Modal` for now

Closes #2055
