### PR TITLE
fix: only change environment on fresh import

### DIFF
--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -265,11 +265,13 @@ export async function importRaw(
       importedDocs[spec.type].push(spec);
     }
 
-    // Set default environment if there is one
+    // Set active environment when none is currently selected and one exists
     const meta = await models.workspaceMeta.getOrCreateByParentId(workspace._id);
     const envs = importedDocs[models.environment.type];
-    meta.activeEnvironmentId = envs.length > 0 ? envs[0]._id : null;
-    await models.workspaceMeta.update(meta);
+    if (!meta.activeEnvironmentId && envs.length > 0) {
+      meta.activeEnvironmentId = envs[0]._id;
+      await models.workspaceMeta.update(meta);
+    }
   }
 
   await db.flushChanges();


### PR DESCRIPTION
This change makes it so that when switching between debug and design tabs, it only selects the default environment *the first time*. Subsequent switches will test whether an active environment id has already been set and ignore.

I've updated the comments as well. Since there were no tests around this area, I did not add or edit any - and will not do so since I am not familiar with the tests infrastructure yet.

Impacts #2228
Impacts #2680
