### PR TITLE
Support OpenAPI 3.0.3 in Inso/O2K

### DIFF
--- a/packages/openapi-2-kong/flow-typed/swagger-parser.js
+++ b/packages/openapi-2-kong/flow-typed/swagger-parser.js
@@ -1,11 +1,23 @@
 // @flow
 
 declare module 'swagger-parser' {
-  declare module.exports: {
-    dereference: any => Promise<any>,
-    YAML: {
-      parse: any => any,
-      dereference: string => any,
-    },
-  };
+  declare class SwaggerParser {
+    validate(api: string): Promise;
+    validate(api: string, options: Object): Promise;
+    validate(baseUrl: string, api: string, options: Object): Promise;
+
+    dereference(api: string): Promise;
+    dereference(api: string, options: Object): Promise;
+    dereference(baseUrl: string, api: string, options: Object): Promise;
+
+    static validate(api: string): Promise;
+    static validate(api: string, options: Object): Promise;
+    static validate(baseUrl: string, api: string, options: Object): Promise;
+  
+    static dereference(api: string): Promise;
+    static dereference(api: string, options: Object): Promise;
+    static dereference(baseUrl: string, api: string, options: Object): Promise;
+  }
+
+  declare export default typeof SwaggerParser
 }

--- a/packages/openapi-2-kong/flow-typed/yaml.js
+++ b/packages/openapi-2-kong/flow-typed/yaml.js
@@ -1,0 +1,8 @@
+// @flow
+
+declare module 'yaml' {
+  declare module.exports: {
+    parse: any => any,
+  }
+}
+  

--- a/packages/openapi-2-kong/package-lock.json
+++ b/packages/openapi-2-kong/package-lock.json
@@ -4,6 +4,39 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1"
+      }
+    },
+    "@apidevtools/openapi-schemas": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.0.4.tgz",
+      "integrity": "sha512-ob5c4UiaMYkb24pNhvfSABShAwpREvUGCkqjiz/BX9gKZ32y/S22M+ALIHftTAuv9KsFVSpVdIDzi9ZzFh5TCA=="
+    },
+    "@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "@apidevtools/swagger-parser": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
+      "integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^4.2.3"
+      }
+    },
     "@babel/core": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
@@ -322,6 +355,11 @@
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -2753,9 +2791,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2772,16 +2810,6 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
-    },
-    "json-schema-ref-parser": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.2.tgz",
-      "integrity": "sha512-bi2Nns2UqdX7wThX5qSHd+lOxlu9oeJvlCnWGuR3qS4Ex4UZtuwygkyq/43J31GuNGX8xBHeV6zjQztYk/G5VA==",
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1",
-        "ono": "^5.1.0"
-      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -3228,21 +3256,6 @@
       "requires": {
         "wrappy": "1"
       }
-    },
-    "ono": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
-      "integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
-    },
-    "openapi-schemas": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.3.tgz",
-      "integrity": "sha512-KtMWcK2VtOS+nD8RKSIyScJsj8JrmVWcIX7Kjx4xEHijFYuvMTDON8WfeKOgeSb4uNG6UsqLj5Na7nKbSav9RQ=="
-    },
-    "openapi-types": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
-      "integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
     },
     "os-browserify": {
       "version": "0.3.0",
@@ -4080,23 +4093,12 @@
         "has-flag": "^3.0.0"
       }
     },
-    "swagger-methods": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.2.tgz",
-      "integrity": "sha512-/RNqvBZkH8+3S/FqBPejHxJxZenaYq3MrpeXnzi06aDIS39Mqf5YCUNb/ZBjsvFFt8h9FxfKs8EXPtcYdfLiRg=="
-    },
     "swagger-parser": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
-      "integrity": "sha512-y2gw+rTjn7Z9J+J1qwbBm0UL93k/VREDCveKBK6iGjf7KXC6QGshbnpEmeHL0ZkCgmIghsXzpNzPSbBH91BAEQ==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.2.tgz",
+      "integrity": "sha512-9jHkHM+QXyLGFLk1DkXBwV+4HyNm0Za3b8/zk/+mjr8jgOSiqm3FOTHBSDsBjtn9scdL+8eWcHdupp2NLM8tDw==",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "json-schema-ref-parser": "^7.1.1",
-        "ono": "^5.1.0",
-        "openapi-schemas": "^1.0.2",
-        "openapi-types": "^1.3.5",
-        "swagger-methods": "^2.0.1",
-        "z-schema": "^4.1.1"
+        "@apidevtools/swagger-parser": "10.0.2"
       }
     },
     "tapable": {
@@ -4370,9 +4372,9 @@
       "dev": true
     },
     "validator": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
-      "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
+      "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
     },
     "vm-browserify": {
       "version": "1.1.2",
@@ -4633,14 +4635,14 @@
       }
     },
     "z-schema": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.2.tgz",
-      "integrity": "sha512-7bGR7LohxSdlK1EOdvA/OHksvKGE4jTLSjd8dBj9YKT0S43N9pdMZ0Z7GZt9mHrBFhbNTRh3Ky6Eu2MHsPJe8g==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
+      "integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
       "requires": {
         "commander": "^2.7.1",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
-        "validator": "^11.0.0"
+        "validator": "^12.0.0"
       }
     }
   }

--- a/packages/openapi-2-kong/package.json
+++ b/packages/openapi-2-kong/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "slugify": "^1.3.6",
-    "swagger-parser": "^8.0.3",
+    "swagger-parser": "^10.0.0",
     "url-join": "^4.0.1",
     "yaml": "^1.7.2"
   },

--- a/packages/openapi-2-kong/src/__fixtures__/openapi-303.yaml
+++ b/packages/openapi-2-kong/src/__fixtures__/openapi-303.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: Greeting API
+  termsOfService: 'https://example.com/terms/'
+  contact:
+    email: contact@example.com
+    url: 'http://example.com/contact'
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+servers: 
+  - url: http://example.org
+paths: {}

--- a/packages/openapi-2-kong/src/__fixtures__/openapi-303.yaml.expected
+++ b/packages/openapi-2-kong/src/__fixtures__/openapi-303.yaml.expected
@@ -1,0 +1,29 @@
+{
+   "_format_version": "1.1",
+   "services": [
+      {
+         "name": "Greeting_API",
+         "url": "http://example.org",
+         "plugins": [],
+         "routes": [],
+         "tags": [
+            "OAS3_import",
+            "OAS3file_openapi-303.yaml"
+         ]
+      }
+   ],
+   "upstreams": [
+      {
+         "name": "Greeting_API",
+         "targets": [
+            {
+               "target": "example.org:80"
+            }
+         ],
+         "tags": [
+            "OAS3_import",
+            "OAS3file_openapi-303.yaml"
+         ]
+      }
+   ]
+}

--- a/packages/openapi-2-kong/src/index.js
+++ b/packages/openapi-2-kong/src/index.js
@@ -51,7 +51,6 @@ export function generateFromSpec(
 
 export async function parseSpec(spec: string | Object): Promise<OpenApi3Spec> {
   let api: OpenApi3Spec;
-  const parser: any = new SwaggerParser();
 
   if (typeof spec === 'string') {
     try {
@@ -74,5 +73,5 @@ export async function parseSpec(spec: string | Object): Promise<OpenApi3Spec> {
     api.openapi = '3.0.0';
   }
 
-  return parser.dereference(api);
+  return SwaggerParser.dereference(api);
 }

--- a/packages/openapi-2-kong/src/index.js
+++ b/packages/openapi-2-kong/src/index.js
@@ -4,6 +4,7 @@ import path from 'path';
 import { generateDeclarativeConfigFromSpec } from './declarative-config';
 import { generateKongForKubernetesConfigFromSpec } from './kubernetes';
 import SwaggerParser from 'swagger-parser';
+import YAML from 'yaml';
 
 export async function generate(
   specPath: string,
@@ -50,12 +51,13 @@ export function generateFromSpec(
 
 export async function parseSpec(spec: string | Object): Promise<OpenApi3Spec> {
   let api: OpenApi3Spec;
+  const parser: any = new SwaggerParser();
 
   if (typeof spec === 'string') {
     try {
       api = JSON.parse(spec);
     } catch (err) {
-      api = SwaggerParser.YAML.parse(spec);
+      api = YAML.parse(spec);
     }
   } else {
     api = JSON.parse(JSON.stringify(spec));
@@ -72,5 +74,5 @@ export async function parseSpec(spec: string | Object): Promise<OpenApi3Spec> {
     api.openapi = '3.0.0';
   }
 
-  return SwaggerParser.dereference(api);
+  return parser.dereference(api);
 }


### PR DESCRIPTION
- Replaced `SwaggerParser.YAML` with `yaml` module as per [breaking change](https://github.com/APIDevTools/swagger-parser/blob/master/CHANGELOG.md#v1000-2020-07-10) in `10x`.
- Replaced direct `SwaggerParser` usage with class instance as per `10x` [documentation](https://apitools.dev/swagger-parser/docs/).
- Added test case for `OpenAPI 3.0.3`

fixes #2977
