### PR TITLE
Enable always using parens for arrow functions

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
     "singleQuote": true,
     "tabWidth": 2,
     "trailingComma": "all",
-    "printWidth": 100
+    "printWidth": 100,
+    "arrowParens": "always",
 }

--- a/packages/insomnia-app/app/__jest__/setup.js
+++ b/packages/insomnia-app/app/__jest__/setup.js
@@ -19,7 +19,7 @@ const localStorageMock = (function() {
 
 global.__DEV__ = false;
 global.localStorage = localStorageMock;
-global.requestAnimationFrame = cb => process.nextTick(cb);
+global.requestAnimationFrame = (cb) => process.nextTick(cb);
 global.require = require;
 
 // Set APP_ID for tests so the user doesn't have to worry

--- a/packages/insomnia-app/app/__mocks__/node-libcurl.js
+++ b/packages/insomnia-app/app/__mocks__/node-libcurl.js
@@ -167,7 +167,7 @@ Curl.option = {
 //  converted to an object with format:
 // { EnumKey: 0, 0: EnumKey }
 // We only want the named members (non-number ones)
-const getTsEnumOnlyWithNamedMembers = enumObj => {
+const getTsEnumOnlyWithNamedMembers = (enumObj) => {
   let obj = {};
   for (const member in enumObj) {
     if (typeof enumObj[member] === 'number') {

--- a/packages/insomnia-app/app/account/crypt.js
+++ b/packages/insomnia-app/app/account/crypt.js
@@ -29,7 +29,7 @@ export function encryptRSAWithJWK(publicKeyJWK, plaintext) {
     throw new Error('Public key algorithm was not RSA-OAEP-256');
   } else if (publicKeyJWK.kty !== 'RSA') {
     throw new Error('Public key type was not RSA');
-  } else if (!publicKeyJWK.key_ops.find(o => o === 'encrypt')) {
+  } else if (!publicKeyJWK.key_ops.find((o) => o === 'encrypt')) {
     throw new Error('Public key does not have "encrypt" op');
   }
 
@@ -302,9 +302,9 @@ export async function generateKeyPairJWK() {
  * @returns {Promise}
  */
 async function _hkdfSalt(rawSalt, rawEmail) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     const hkdf = new HKDF('sha256', rawSalt, rawEmail);
-    hkdf.derive('', DEFAULT_BYTE_LENGTH, buffer => resolve(buffer.toString('hex')));
+    hkdf.derive('', DEFAULT_BYTE_LENGTH, (buffer) => resolve(buffer.toString('hex')));
   });
 }
 

--- a/packages/insomnia-app/app/account/fetch.js
+++ b/packages/insomnia-app/app/account/fetch.js
@@ -100,5 +100,5 @@ function _notifyCommandListeners(uri) {
   const command = `${parsed.hostname}${parsed.pathname}`;
   const args = JSON.parse(JSON.stringify(parsed.query));
 
-  _commandListeners.map(fn => fn(command, args));
+  _commandListeners.map((fn) => fn(command, args));
 }

--- a/packages/insomnia-app/app/common/__tests__/analytics.test.js
+++ b/packages/insomnia-app/app/common/__tests__/analytics.test.js
@@ -16,7 +16,7 @@ import {
 describe('init()', () => {
   beforeEach(async () => {
     await globalBeforeEach();
-    electron.net.request = jest.fn(url => {
+    electron.net.request = jest.fn((url) => {
       const req = new EventEmitter();
       req.end = function() {};
       return req;

--- a/packages/insomnia-app/app/common/__tests__/database.test.js
+++ b/packages/insomnia-app/app/common/__tests__/database.test.js
@@ -33,7 +33,7 @@ describe('onChange()', () => {
     };
 
     const changesSeen = [];
-    const callback = change => {
+    const callback = (change) => {
       changesSeen.push(change);
     };
     db.onChange(callback);
@@ -63,7 +63,7 @@ describe('bufferChanges()', () => {
     };
 
     const changesSeen = [];
-    const callback = change => {
+    const callback = (change) => {
       changesSeen.push(change);
     };
     db.onChange(callback);
@@ -208,7 +208,7 @@ describe('_repairDatabase()', () => {
 
     // Make sure we have everything
     expect((await db.withDescendants(workspace)).length).toBe(8);
-    const descendants = (await db.withDescendants(workspace)).map(d => ({
+    const descendants = (await db.withDescendants(workspace)).map((d) => ({
       _id: d._id,
       parentId: d.parentId,
       data: d.data || null,
@@ -228,7 +228,7 @@ describe('_repairDatabase()', () => {
     await db._repairDatabase();
 
     // Make sure things get adjusted
-    const descendants2 = (await db.withDescendants(workspace)).map(d => ({
+    const descendants2 = (await db.withDescendants(workspace)).map((d) => ({
       _id: d._id,
       parentId: d.parentId,
       data: d.data || null,
@@ -277,7 +277,7 @@ describe('_repairDatabase()', () => {
 
     // Make sure we have everything
     expect((await db.withDescendants(workspace)).length).toBe(4);
-    const descendants = (await db.withDescendants(workspace)).map(d => ({
+    const descendants = (await db.withDescendants(workspace)).map((d) => ({
       _id: d._id,
       cookies: d.cookies || null,
       parentId: d.parentId,
@@ -307,7 +307,7 @@ describe('_repairDatabase()', () => {
     await db._repairDatabase();
 
     // Make sure things get adjusted
-    const descendants2 = (await db.withDescendants(workspace)).map(d => ({
+    const descendants2 = (await db.withDescendants(workspace)).map((d) => ({
       _id: d._id,
       cookies: d.cookies || null,
       parentId: d.parentId,

--- a/packages/insomnia-app/app/common/__tests__/misc.test.js
+++ b/packages/insomnia-app/app/common/__tests__/misc.test.js
@@ -61,7 +61,7 @@ describe('keyedDebounce()', () => {
 
   it('debounces correctly', () => {
     const resultsList = [];
-    const fn = misc.keyedDebounce(results => {
+    const fn = misc.keyedDebounce((results) => {
       resultsList.push(results);
     }, 100);
 

--- a/packages/insomnia-app/app/common/analytics.js
+++ b/packages/insomnia-app/app/common/analytics.js
@@ -182,7 +182,7 @@ async function _getDefaultParams(): Promise<Array<RequestParameter>> {
 
 // Monitor database changes to see if analytics gets enabled. If analytics
 // become enabled, flush any queued events.
-db.onChange(async changes => {
+db.onChange(async (changes) => {
   for (const change of changes) {
     const [event, doc] = change;
     if (doc.type === models.settings.type && event === 'update') {
@@ -214,11 +214,11 @@ async function _sendToGoogle(params: Array<RequestParameter>, queueable: boolean
   const net = (electron.remote || electron).net;
   const request = net.request(url);
 
-  request.once('error', err => {
+  request.once('error', (err) => {
     console.warn('[ga] Network error', err);
   });
 
-  request.once('response', response => {
+  request.once('response', (response) => {
     const { statusCode } = response;
     if (statusCode < 200 && statusCode >= 300) {
       console.warn('[ga] Bad status code ' + statusCode);
@@ -251,7 +251,7 @@ async function _sendToGoogle(params: Array<RequestParameter>, queueable: boolean
       }
     });
 
-    response.on('data', chunk => {
+    response.on('data', (chunk) => {
       chunks.push(chunk);
     });
   });

--- a/packages/insomnia-app/app/common/database.js
+++ b/packages/insomnia-app/app/common/database.js
@@ -106,7 +106,7 @@ export async function init(
 
   // This isn't the best place for this but w/e
   // Listen for response deletions and delete corresponding response body files
-  onChange(async changes => {
+  onChange(async (changes) => {
     for (const [type, doc] of changes) {
       const m: Object | null = models.getModel(doc.type);
 
@@ -161,7 +161,7 @@ export function onChange(callback: Function): void {
 }
 
 export function offChange(callback: Function): void {
-  changeListeners = changeListeners.filter(l => l !== callback);
+  changeListeners = changeListeners.filter((l) => l !== callback);
 }
 
 /** buffers database changes and returns false if was already buffering */
@@ -251,7 +251,7 @@ export const findMostRecentlyModified = (database.findMostRecentlyModified = asy
 ): Promise<Array<T>> {
   if (db._empty) return _send('findMostRecentlyModified', ...arguments);
 
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     db[type]
       .find(query)
       .sort({ modified: -1 })
@@ -406,7 +406,7 @@ export const update = (database.update = async function<T: BaseModel>(
       return reject(err);
     }
 
-    db[doc.type].update({ _id: docWithDefaults._id }, docWithDefaults, err => {
+    db[doc.type].update({ _id: docWithDefaults._id }, docWithDefaults, (err) => {
       if (err) {
         return reject(err);
       }
@@ -428,13 +428,13 @@ export const remove = (database.remove = async function<T: BaseModel>(
   const flushId = await database.bufferChanges();
 
   const docs = await database.withDescendants(doc);
-  const docIds = docs.map(d => d._id);
-  const types = [...new Set(docs.map(d => d.type))];
+  const docIds = docs.map((d) => d._id);
+  const types = [...new Set(docs.map((d) => d.type))];
 
   // Don't really need to wait for this to be over;
-  types.map(t => db[t].remove({ _id: { $in: docIds } }, { multi: true }));
+  types.map((t) => db[t].remove({ _id: { $in: docIds } }, { multi: true }));
 
-  docs.map(d => notifyOfChange(CHANGE_REMOVE, d, fromSync));
+  docs.map((d) => notifyOfChange(CHANGE_REMOVE, d, fromSync));
 
   await database.flushChanges(flushId);
 });
@@ -460,13 +460,13 @@ export const removeWhere = (database.removeWhere = async function(
 
   for (const doc of await database.find(type, query)) {
     const docs = await database.withDescendants(doc);
-    const docIds = docs.map(d => d._id);
-    const types = [...new Set(docs.map(d => d.type))];
+    const docIds = docs.map((d) => d._id);
+    const types = [...new Set(docs.map((d) => d.type))];
 
     // Don't really need to wait for this to be over;
-    types.map(t => db[t].remove({ _id: { $in: docIds } }, { multi: true }));
+    types.map((t) => db[t].remove({ _id: { $in: docIds } }, { multi: true }));
 
-    docs.map(d => notifyOfChange(CHANGE_REMOVE, d, false));
+    docs.map((d) => notifyOfChange(CHANGE_REMOVE, d, false));
   }
 
   await database.flushChanges(flushId);
@@ -764,7 +764,7 @@ async function _fixMultipleCookieJars(workspace) {
     }
 
     for (const cookie of cookieJar.cookies) {
-      if (chosenJar.cookies.find(c => c.id === cookie.id)) {
+      if (chosenJar.cookies.find((c) => c.id === cookie.id)) {
         continue;
       }
 

--- a/packages/insomnia-app/app/common/grpc-paths.js
+++ b/packages/insomnia-app/app/common/grpc-paths.js
@@ -52,4 +52,4 @@ const getMethodInfo = (method: GrpcMethodDefinition): GrpcMethodInfo => ({
 export const groupGrpcMethodsByPackage = (
   methods: Array<GrpcMethodDefinition>,
 ): GroupedGrpcMethodInfo =>
-  groupBy(methods.map(getMethodInfo), m => m.segments.packageName || NO_PACKAGE_KEY);
+  groupBy(methods.map(getMethodInfo), (m) => m.segments.packageName || NO_PACKAGE_KEY);

--- a/packages/insomnia-app/app/common/har.js
+++ b/packages/insomnia-app/app/common/har.js
@@ -372,7 +372,7 @@ function getRequestCookies(renderedRequest: RenderedRequest): Array<HarCookie> {
 function getReponseCookies(response: ResponseModel): Array<HarCookie> {
   return misc
     .getSetCookieHeaders(response.headers)
-    .map(h => {
+    .map((h) => {
       let cookie;
       try {
         cookie = toughCookie.parse(h.value || '');
@@ -443,8 +443,8 @@ function getResponseContent(response: ResponseModel): HarContent {
 
 function getResponseHeaders(response: ResponseModel): Array<HarHeader> {
   return response.headers
-    .filter(header => header.name)
-    .map(h => {
+    .filter((header) => header.name)
+    .map((h) => {
       return {
         name: h.name,
         value: h.value,
@@ -454,8 +454,8 @@ function getResponseHeaders(response: ResponseModel): Array<HarHeader> {
 
 function getRequestHeaders(renderedRequest: RenderedRequest): Array<HarHeader> {
   return renderedRequest.headers
-    .filter(header => header.name)
-    .map(header => {
+    .filter((header) => header.name)
+    .map((header) => {
       return {
         name: header.name,
         value: header.value,
@@ -464,7 +464,7 @@ function getRequestHeaders(renderedRequest: RenderedRequest): Array<HarHeader> {
 }
 
 function getRequestQueryString(renderedRequest: RenderedRequest): Array<HarQueryString> {
-  return renderedRequest.parameters.map(parameter => {
+  return renderedRequest.parameters.map((parameter) => {
     return {
       name: parameter.name,
       value: parameter.value,
@@ -488,7 +488,7 @@ function getRequestPostData(renderedRequest: RenderedRequest): HarPostData | voi
 
   let params = [];
   if (body.params) {
-    params = body.params.map(param => {
+    params = body.params.map((param) => {
       if (param.type === 'file') {
         return {
           name: param.name,

--- a/packages/insomnia-app/app/common/hotkeys.js
+++ b/packages/insomnia-app/app/common/hotkeys.js
@@ -366,7 +366,7 @@ const defaultRegistry: HotKeyRegistry = {
 
 function copyKeyCombs(sources: Array<KeyCombination>): Array<KeyCombination> {
   const targets: Array<KeyCombination> = [];
-  sources.forEach(keyComb => {
+  sources.forEach((keyComb) => {
     targets.push(Object.assign({}, keyComb));
   });
   return targets;
@@ -445,7 +445,7 @@ export function areKeyBindingsSameAsDefault(hotKeyRefId: string, keyBinds: KeyBi
     return false;
   }
   for (const keyComb of keyCombs) {
-    const found = defaultKeyCombs.find(defKeyComb => {
+    const found = defaultKeyCombs.find((defKeyComb) => {
       if (areSameKeyCombinations(keyComb, defKeyComb)) {
         return true;
       }
@@ -464,7 +464,7 @@ export function areKeyBindingsSameAsDefault(hotKeyRefId: string, keyBinds: KeyBi
  */
 export function getChar(keyCode: number): string {
   let char;
-  const key = Object.keys(keyboardKeys).find(k => keyboardKeys[k].keyCode === keyCode);
+  const key = Object.keys(keyboardKeys).find((k) => keyboardKeys[k].keyCode === keyCode);
 
   if (!key) {
     console.error('Invalid key code', keyCode);

--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -90,12 +90,12 @@ export async function importUri(
   }
 
   const statements = Object.keys(summary)
-    .map(type => {
+    .map((type) => {
       const count = summary[type].length;
       const name = models.getModelName(type, count);
       return count === 0 ? null : `${count} ${name}`;
     })
-    .filter(s => s !== null);
+    .filter((s) => s !== null);
 
   let message;
   if (statements.length === 0) {
@@ -218,7 +218,7 @@ export async function importRaw(
       resource.body &&
       typeof resource.body.text === 'string' &&
       Array.isArray(resource.headers) &&
-      !resource.headers.find(h => h.name.toLowerCase() === 'content-type')
+      !resource.headers.find((h) => h.name.toLowerCase() === 'content-type')
     ) {
       try {
         JSON.parse(resource.body.text);
@@ -299,7 +299,7 @@ export async function exportRequestsHAR(
       models.workspace.type,
       models.requestGroup.type,
     ]);
-    const workspace = ancestors.find(ancestor => ancestor.type === models.workspace.type);
+    const workspace = ancestors.find((ancestor) => ancestor.type === models.workspace.type);
     mapRequestIdToWorkspace[request._id] = workspace;
     if (workspace == null || workspaceLookup.hasOwnProperty(workspace._id)) {
       continue;
@@ -347,7 +347,7 @@ export async function exportWorkspacesData(
   format: 'json' | 'yaml',
 ): Promise<string> {
   const docs: Array<BaseModel> = await getDocWithDescendants(parentDoc, includePrivateDocs);
-  const requests: Array<BaseModel> = docs.filter(doc => isRequest(doc) || isGrpcRequest(doc));
+  const requests: Array<BaseModel> = docs.filter((doc) => isRequest(doc) || isGrpcRequest(doc));
   return exportRequestsData(requests, includePrivateDocs, format);
 }
 
@@ -383,7 +383,7 @@ export async function exportRequestsData(
   }
 
   for (const workspace of workspaces) {
-    const descendants: Array<BaseModel> = (await db.withDescendants(workspace)).filter(d => {
+    const descendants: Array<BaseModel> = (await db.withDescendants(workspace)).filter((d) => {
       // Only interested in these additional model types.
       return (
         d.type === models.cookieJar.type ||
@@ -398,7 +398,7 @@ export async function exportRequestsData(
   }
 
   data.resources = docs
-    .filter(d => {
+    .filter((d) => {
       // Only export these model types.
       if (
         !(
@@ -463,7 +463,7 @@ async function getDocWithDescendants(
 ): Promise<Array<BaseModel>> {
   const docs = await db.withDescendants(parentDoc);
   return docs.filter(
-    d =>
+    (d) =>
       // Don't include if private, except if we want to
       !(d: any).isPrivate || includePrivateDocs,
   );

--- a/packages/insomnia-app/app/common/misc.js
+++ b/packages/insomnia-app/app/common/misc.js
@@ -25,7 +25,7 @@ export function filterParameters<T: Parameter>(parameters: Array<T>, name: strin
     return [];
   }
 
-  return parameters.filter(h => (!h || !h.name ? false : h.name === name));
+  return parameters.filter((h) => (!h || !h.name ? false : h.name === name));
 }
 
 export function filterHeaders<T: Header>(headers: Array<T>, name: string): Array<T> {
@@ -33,7 +33,7 @@ export function filterHeaders<T: Header>(headers: Array<T>, name: string): Array
     return [];
   }
 
-  return headers.filter(h => {
+  return headers.filter((h) => {
     // Never match against invalid headers
     if (!h || !h.name || typeof h.name !== 'string') {
       return false;
@@ -117,7 +117,7 @@ export function generateId(prefix: string): string {
 }
 
 export function delay(milliseconds: number = DEBOUNCE_MILLIS): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, milliseconds));
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 export function removeVowels(str: string): string {
@@ -155,7 +155,7 @@ export function keyedDebounce(callback: Function, millis: number = DEBOUNCE_MILL
 
 export function debounce(callback: Function, millis: number = DEBOUNCE_MILLIS): Function {
   // For regular debounce, just use a keyed debounce with a fixed key
-  return keyedDebounce(results => {
+  return keyedDebounce((results) => {
     callback.apply(null, results.__key__);
   }, millis).bind(null, '__key__');
 }
@@ -268,7 +268,7 @@ export function fuzzyMatchAll(
     return null;
   }
 
-  const words = searchString.split(' ').filter(w => w.trim());
+  const words = searchString.split(' ').filter((w) => w.trim());
   const terms = options.splitSpace ? [...words, searchString] : [searchString];
 
   let maxScore = null;
@@ -276,7 +276,7 @@ export function fuzzyMatchAll(
   let termsMatched = 0;
   for (const term of terms) {
     let matchedTerm = false;
-    for (const text of allText.filter(t => !t || t.trim())) {
+    for (const text of allText.filter((t) => !t || t.trim())) {
       const result = fuzzysort.single(term, text);
       if (!result) {
         continue;
@@ -341,7 +341,7 @@ export function getUserLanguage(): string {
 }
 
 export async function waitForStreamToFinish(s: Readable | Writable): Promise<void> {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     if ((s: any)._readableState && (s: any)._readableState.finished) {
       return resolve();
     }

--- a/packages/insomnia-app/app/common/render.js
+++ b/packages/insomnia-app/app/common/render.js
@@ -262,7 +262,7 @@ export async function getRenderContext(
     ancestors = await _getRequestAncestors(request);
   }
 
-  const workspace = ancestors.find(doc => doc.type === models.workspace.type);
+  const workspace = ancestors.find((doc) => doc.type === models.workspace.type);
   if (!workspace) {
     throw new Error('Failed to render. Could not find workspace');
   }
@@ -335,7 +335,7 @@ export async function getRenderContext(
       return null;
     }
 
-    const p = extraInfo.find(v => v.name === key);
+    const p = extraInfo.find((v) => v.name === key);
     return p ? p.value : null;
   };
 
@@ -407,7 +407,7 @@ export async function getRenderedRequestAndContext(
   extraInfo?: ExtraRenderInfo,
 ): Promise<{ request: RenderedRequest, context: Object }> {
   const ancestors = await _getRequestAncestors(request);
-  const workspace = ancestors.find(doc => doc.type === models.workspace.type);
+  const workspace = ancestors.find((doc) => doc.type === models.workspace.type);
   const parentId = workspace ? workspace._id : 'n/a';
   const cookieJar = await models.cookieJar.getOrCreateForParentId(parentId);
 
@@ -445,14 +445,14 @@ export async function getRenderedRequestAndContext(
   renderedRequest.description = await render(description, renderContext, null, KEEP_ON_ERROR);
 
   // Remove disabled params
-  renderedRequest.parameters = renderedRequest.parameters.filter(p => !p.disabled);
+  renderedRequest.parameters = renderedRequest.parameters.filter((p) => !p.disabled);
 
   // Remove disabled headers
-  renderedRequest.headers = renderedRequest.headers.filter(p => !p.disabled);
+  renderedRequest.headers = renderedRequest.headers.filter((p) => !p.disabled);
 
   // Remove disabled body params
   if (renderedRequest.body && Array.isArray(renderedRequest.body.params)) {
-    renderedRequest.body.params = renderedRequest.body.params.filter(p => !p.disabled);
+    renderedRequest.body.params = renderedRequest.body.params.filter((p) => !p.disabled);
   }
 
   // Remove disabled authentication

--- a/packages/insomnia-app/app/common/select-file-or-folder.js
+++ b/packages/insomnia-app/app/common/select-file-or-folder.js
@@ -28,7 +28,7 @@ const selectFileOrFolder = async ({ itemTypes, extensions }: Options): Promise<F
   const options = {
     title: title,
     buttonLabel: 'Select',
-    properties: types.map(type => {
+    properties: types.map((type) => {
       if (type === 'file') {
         return 'openFile';
       }

--- a/packages/insomnia-app/app/main/__tests__/grpc-ipc-main.test.js
+++ b/packages/insomnia-app/app/main/__tests__/grpc-ipc-main.test.js
@@ -14,7 +14,7 @@ describe('grpcIpcMain', () => {
     grpcIpcMain.init(); // ipcMain is mocked
   });
 
-  it.each(Object.values(GrpcRequestEventEnum))('should add listener for channel: %s', channel => {
+  it.each(Object.values(GrpcRequestEventEnum))('should add listener for channel: %s', (channel) => {
     expect(ipcMain.on).toHaveBeenCalledWith(channel, expect.anything());
   });
 

--- a/packages/insomnia-app/app/main/error-handling.js
+++ b/packages/insomnia-app/app/main/error-handling.js
@@ -1,9 +1,9 @@
 export function init() {
-  process.on('uncaughtException', err => {
+  process.on('uncaughtException', (err) => {
     console.error('[catcher] Uncaught exception:', err.stack);
   });
 
-  process.on('unhandledRejection', err => {
+  process.on('unhandledRejection', (err) => {
     console.error('[catcher] Unhandled rejection:', err.stack);
   });
 }

--- a/packages/insomnia-app/app/main/updates.js
+++ b/packages/insomnia-app/app/main/updates.js
@@ -70,7 +70,7 @@ function _sendUpdateComplete(success: boolean, msg: string) {
 let hasPromptedForUpdates = false;
 
 export async function init() {
-  autoUpdater.on('error', e => {
+  autoUpdater.on('error', (e) => {
     console.warn(`[updater] Error: ${e.message}`);
   });
 
@@ -90,7 +90,7 @@ export async function init() {
     _showUpdateNotification();
   });
 
-  ipcMain.on('updater.check', async e => {
+  ipcMain.on('updater.check', async (e) => {
     await _checkForUpdates(true);
   });
 

--- a/packages/insomnia-app/app/main/window-utils.js
+++ b/packages/insomnia-app/app/main/window-utils.js
@@ -91,15 +91,15 @@ export function createWindow() {
     mainWindow.maximize();
   }
 
-  mainWindow.on('resize', e => saveBounds());
+  mainWindow.on('resize', (e) => saveBounds());
 
-  mainWindow.on('maximize', e => saveBounds());
+  mainWindow.on('maximize', (e) => saveBounds());
 
-  mainWindow.on('unmaximize', e => saveBounds());
+  mainWindow.on('unmaximize', (e) => saveBounds());
 
-  mainWindow.on('move', e => saveBounds());
+  mainWindow.on('move', (e) => saveBounds());
 
-  mainWindow.on('unresponsive', e => {
+  mainWindow.on('unresponsive', (e) => {
     showUnresponsiveModal();
   });
 
@@ -371,7 +371,7 @@ export function createWindow() {
       {
         label: `Take ${MNEMONIC_SYM}Screenshot`,
         click: function() {
-          mainWindow.capturePage(image => {
+          mainWindow.capturePage((image) => {
             const buffer = image.toPNG();
             const dir = app.getPath('desktop');
             fs.writeFileSync(path.join(dir, `Screenshot-${new Date()}.png`), buffer);

--- a/packages/insomnia-app/app/models/__tests__/response.test.js
+++ b/packages/insomnia-app/app/models/__tests__/response.test.js
@@ -179,7 +179,7 @@ describe('cleanDeletedResponses()', function() {
     await models.response.cleanDeletedResponses();
 
     expect(fs.unlinkSync.mock.calls.length).toBe(notDbResponseIds.length);
-    Object.keys(notDbResponseIds).map(index => {
+    Object.keys(notDbResponseIds).map((index) => {
       const resId = notDbResponseIds[index];
       const bodyPath = path.join(responsesDir, resId);
       expect(fs.unlinkSync.mock.calls[index][0]).toBe(bodyPath);

--- a/packages/insomnia-app/app/models/helpers/__tests__/is-model.test.js
+++ b/packages/insomnia-app/app/models/helpers/__tests__/is-model.test.js
@@ -10,17 +10,17 @@ import {
 import { generateId } from '../../../common/misc';
 
 const allTypes = models.types();
-const allPrefixes = models.all().map(model => model.prefix);
+const allPrefixes = models.all().map((model) => model.prefix);
 
 describe('isGrpcRequest', () => {
   const supported = [models.grpcRequest.type];
   const unsupported = difference(allTypes, supported);
 
-  it.each(supported)('should return true: "%s"', type => {
+  it.each(supported)('should return true: "%s"', (type) => {
     expect(isGrpcRequest({ type })).toBe(true);
   });
 
-  it.each(unsupported)('should return false: "%s"', type => {
+  it.each(unsupported)('should return false: "%s"', (type) => {
     expect(isGrpcRequest({ type })).toBe(false);
   });
 });
@@ -29,11 +29,11 @@ describe('isGrpcRequestId', () => {
   const supported = [models.grpcRequest.prefix];
   const unsupported = difference(allPrefixes, supported);
 
-  it.each(supported)('should return true if id is prefixed by "%s_"', prefix => {
+  it.each(supported)('should return true if id is prefixed by "%s_"', (prefix) => {
     expect(isGrpcRequestId(generateId(prefix))).toBe(true);
   });
 
-  it.each(unsupported)('should return false if id is prefixed by "%s_"', prefix => {
+  it.each(unsupported)('should return false if id is prefixed by "%s_"', (prefix) => {
     expect(isGrpcRequestId(generateId(prefix))).toBe(false);
   });
 });
@@ -42,11 +42,11 @@ describe('isRequest', () => {
   const supported = [models.request.type];
   const unsupported = difference(allTypes, supported);
 
-  it.each(supported)('should return true: "%s"', type => {
+  it.each(supported)('should return true: "%s"', (type) => {
     expect(isRequest({ type })).toBe(true);
   });
 
-  it.each(unsupported)('should return false: "%s"', type => {
+  it.each(unsupported)('should return false: "%s"', (type) => {
     expect(isRequest({ type })).toBe(false);
   });
 });
@@ -68,11 +68,11 @@ describe('isRequestGroup', () => {
   const supported = [models.requestGroup.type];
   const unsupported = difference(allTypes, supported);
 
-  it.each(supported)('should return true: "%s"', type => {
+  it.each(supported)('should return true: "%s"', (type) => {
     expect(isRequestGroup({ type })).toBe(true);
   });
 
-  it.each(unsupported)('should return false: "%s"', type => {
+  it.each(unsupported)('should return false: "%s"', (type) => {
     expect(isRequestGroup({ type })).toBe(false);
   });
 });
@@ -81,11 +81,11 @@ describe('isProtoFile', () => {
   const supported = [models.protoFile.type];
   const unsupported = difference(allTypes, supported);
 
-  it.each(supported)('should return true: "%s"', type => {
+  it.each(supported)('should return true: "%s"', (type) => {
     expect(isProtoFile({ type })).toBe(true);
   });
 
-  it.each(unsupported)('should return false: "%s"', type => {
+  it.each(unsupported)('should return false: "%s"', (type) => {
     expect(isProtoFile({ type })).toBe(false);
   });
 });

--- a/packages/insomnia-app/app/models/index.js
+++ b/packages/insomnia-app/app/models/index.js
@@ -86,7 +86,7 @@ export function all() {
 }
 
 export function types(): Array<any> {
-  return all().map(model => model.type);
+  return all().map((model) => model.type);
 }
 
 export function canSync(d: BaseModel): boolean {
@@ -103,7 +103,7 @@ export function canSync(d: BaseModel): boolean {
 }
 
 export function getModel(type: string): Object | null {
-  return all().find(m => m.type === type) || null;
+  return all().find((m) => m.type === type) || null;
 }
 
 export function mustGetModel(type: string): Object {
@@ -140,7 +140,7 @@ export async function initModel<T: BaseModel>(type: string, ...sources: Array<Ob
 
   if (!model) {
     const choices = all()
-      .map(m => m.type)
+      .map((m) => m.type)
       .join(', ');
     throw new Error(`Tried to init invalid model "${type}". Choices are ${choices}`);
   }

--- a/packages/insomnia-app/app/models/request.js
+++ b/packages/insomnia-app/app/models/request.js
@@ -294,7 +294,7 @@ export function updateMimeType(
 
   const hasBody = typeof mimeType === 'string';
   if (!hasBody) {
-    headers = headers.filter(h => h !== contentTypeHeader);
+    headers = headers.filter((h) => h !== contentTypeHeader);
   } else if (mimeType === CONTENT_TYPE_OTHER) {
     // Leave headers alone
   } else if (mimeType && contentTypeHeader && !leaveContentTypeAlone) {

--- a/packages/insomnia-app/app/models/response.js
+++ b/packages/insomnia-app/app/models/response.js
@@ -180,7 +180,7 @@ export async function create(patch: Object = {}, maxResponses: number = 20) {
 
   // Delete all other responses before creating the new one
   const allResponses = await db.findMostRecentlyModified(type, query, Math.max(1, maxResponses));
-  const recentIds = allResponses.map(r => r._id);
+  const recentIds = allResponses.map((r) => r._id);
 
   // Remove all that were in the last query, except the first `maxResponses` IDs
   await db.removeWhere(type, { ...query, _id: { $nin: recentIds } });

--- a/packages/insomnia-app/app/models/stats.js
+++ b/packages/insomnia-app/app/models/stats.js
@@ -86,12 +86,12 @@ export async function incrementExecutedRequests() {
 
 export async function incrementCreatedRequestsForDescendents(doc: Workspace | RequestGroup) {
   const docs = await db.withDescendants(doc);
-  const requests = docs.filter(doc => isRequest(doc) || isGrpcRequest(doc));
+  const requests = docs.filter((doc) => isRequest(doc) || isGrpcRequest(doc));
   await incrementRequestStats({ createdRequests: requests.length });
 }
 
 export async function incrementDeletedRequestsForDescendents(doc: Workspace | RequestGroup) {
   const docs = await db.withDescendants(doc);
-  const requests = docs.filter(doc => isRequest(doc) || isGrpcRequest(doc));
+  const requests = docs.filter((doc) => isRequest(doc) || isGrpcRequest(doc));
   await incrementRequestStats({ deletedRequests: requests.length });
 }

--- a/packages/insomnia-app/app/network/grpc/__tests__/parse-grpc-url.test.js
+++ b/packages/insomnia-app/app/network/grpc/__tests__/parse-grpc-url.test.js
@@ -34,7 +34,7 @@ describe('parseGrpcUrl', () => {
     });
   });
 
-  it.each([null, undefined, ''])('can handle falsey urls', input => {
+  it.each([null, undefined, ''])('can handle falsey urls', (input) => {
     expect(parseGrpcUrl(input)).toStrictEqual({
       url: '',
       enableTls: false,

--- a/packages/insomnia-app/app/network/grpc/__tests__/prepare.test.js
+++ b/packages/insomnia-app/app/network/grpc/__tests__/prepare.test.js
@@ -15,7 +15,7 @@ describe('prepareGrpcRequest', () => {
 
   it.each([GrpcMethodTypeEnum.unary, GrpcMethodTypeEnum.server])(
     'should prepare grpc request with all properties: %s',
-    async methodType => {
+    async (methodType) => {
       const w = await models.workspace.create();
       const env = await models.environment.create({ parentId: w._id });
       const gr = await models.grpcRequest.create({ parentId: w._id });
@@ -37,7 +37,7 @@ describe('prepareGrpcRequest', () => {
 
   it.each([GrpcMethodTypeEnum.client, GrpcMethodTypeEnum.bidi])(
     'should prepare grpc request and ignore body: %s',
-    async methodType => {
+    async (methodType) => {
       const w = await models.workspace.create();
       const env = await models.environment.create({ parentId: w._id });
       const gr = await models.grpcRequest.create({ parentId: w._id });

--- a/packages/insomnia-app/app/network/grpc/__tests__/proto-loader.test.js
+++ b/packages/insomnia-app/app/network/grpc/__tests__/proto-loader.test.js
@@ -27,7 +27,7 @@ describe('loadMethods', () => {
     expect(writeProtoFile).toHaveBeenCalledWith(protoFile.protoText);
 
     expect(methods).toHaveLength(4);
-    expect(methods.map(c => c.path)).toStrictEqual(
+    expect(methods.map((c) => c.path)).toStrictEqual(
       expect.arrayContaining([
         '/hello.HelloService/SayHello',
         '/hello.HelloService/LotsOfReplies',

--- a/packages/insomnia-app/app/network/grpc/index.js
+++ b/packages/insomnia-app/app/network/grpc/index.js
@@ -202,11 +202,11 @@ export const cancel = (requestId: string) => callCache.get(requestId)?.cancel();
 export const cancelMultiple = (requestIds: Array<string>) => requestIds.forEach(cancel);
 
 const _setupStatusListener = (call: Call, requestId: string, respond: ResponseCallbacks) => {
-  call.on('status', s => respond.sendStatus(requestId, s));
+  call.on('status', (s) => respond.sendStatus(requestId, s));
 };
 
 const _setupServerStreamListeners = (call: Call, requestId: string, respond: ResponseCallbacks) => {
-  call.on('data', data => respond.sendData(requestId, data));
+  call.on('data', (data) => respond.sendData(requestId, data));
 
   call.on('error', (error: ServiceError) => {
     if (error && error.code !== GrpcStatusEnum.CANCELLED) {
@@ -245,7 +245,7 @@ const _createUnaryCallback = (requestId: string, respond: ResponseCallbacks) => 
 
 type WriteCallback = (error: Error | null | undefined) => void;
 
-const _streamWriteCallback: WriteCallback = err => {
+const _streamWriteCallback: WriteCallback = (err) => {
   if (err) {
     console.error('[gRPC] Error when writing to stream', err);
   }

--- a/packages/insomnia-app/app/network/grpc/proto-loader.js
+++ b/packages/insomnia-app/app/network/grpc/proto-loader.js
@@ -49,5 +49,5 @@ export const getSelectedMethod = async (request: GrpcRequest): GrpcMethodDefinit
 
   const methods = await loadMethods(protoFile);
 
-  return methods.find(c => c.path === request.protoMethodName);
+  return methods.find((c) => c.path === request.protoMethodName);
 };

--- a/packages/insomnia-app/app/network/multipart.js
+++ b/packages/insomnia-app/app/network/multipart.js
@@ -28,7 +28,7 @@ export async function buildMultipart(params: Array<RequestBodyParameter>) {
           resolve();
         });
 
-        stream.once('error', err => {
+        stream.once('error', (err) => {
           reject(err);
         });
 
@@ -92,7 +92,7 @@ export async function buildMultipart(params: Array<RequestBodyParameter>) {
     addString(`--${DEFAULT_BOUNDARY}--`);
     addString(lineBreak);
 
-    writeStream.once('error', err => {
+    writeStream.once('error', (err) => {
       reject(err);
     });
 

--- a/packages/insomnia-app/app/network/network.js
+++ b/packages/insomnia-app/app/network/network.js
@@ -139,7 +139,7 @@ export async function _actuallySend(
   settings: Settings,
   environment: Environment | null,
 ): Promise<ResponsePatch> {
-  return new Promise(async resolve => {
+  return new Promise(async (resolve) => {
     const timeline: Array<ResponseTimelineEntry> = [];
 
     function addTimeline(name, value) {
@@ -223,7 +223,7 @@ export async function _actuallySend(
 
     /** Helper function to set Curl options */
     function setOpt(opt: number, val: any, optional: boolean = false) {
-      const name = Object.keys(Curl.option).find(name => Curl.option[name] === opt);
+      const name = Object.keys(Curl.option).find((name) => Curl.option[name] === opt);
       try {
         curl.setOpt(opt, val);
       } catch (err) {
@@ -309,7 +309,7 @@ export async function _actuallySend(
       // Setup debug handler
       setOpt(Curl.option.DEBUGFUNCTION, (infoType: string, contentBuffer: Buffer) => {
         const content = contentBuffer.toString('utf8');
-        const rawName = Object.keys(CurlInfoDebug).find(k => CurlInfoDebug[k] === infoType) || '';
+        const rawName = Object.keys(CurlInfoDebug).find((k) => CurlInfoDebug[k] === infoType) || '';
         const name = LIBCURL_DEBUG_MIGRATION_MAP[rawName] || rawName;
 
         if (infoType === CurlInfoDebug.SslDataIn || infoType === CurlInfoDebug.SslDataOut) {
@@ -504,7 +504,7 @@ export async function _actuallySend(
         const cHostWithProtocol = setDefaultProtocol(certificate.host, 'https:');
 
         if (urlMatchesCertHost(cHostWithProtocol, renderedRequest.url)) {
-          const ensureFile = blobOrFilename => {
+          const ensureFile = (blobOrFilename) => {
             try {
               fs.statSync(blobOrFilename);
             } catch (err) {
@@ -711,8 +711,8 @@ export async function _actuallySend(
 
       // NOTE: This is last because headers might be modified multiple times
       const headerStrings = headers
-        .filter(h => h.name)
-        .map(h => {
+        .filter((h) => h.name)
+        .map((h) => {
           const value = h.value || '';
           if (value === '') {
             // Curl needs a semicolon suffix to send empty header values
@@ -766,7 +766,7 @@ export async function _actuallySend(
         for (const { headers } of allCurlHeadersObjects) {
           // Collect Set-Cookie headers
           const setCookieHeaders = getSetCookieHeaders(headers);
-          setCookieStrings = [...setCookieStrings, ...setCookieHeaders.map(h => h.value)];
+          setCookieStrings = [...setCookieStrings, ...setCookieHeaders.map((h) => h.value)];
 
           // Pull out new URL if there is a redirect
           const newLocation = getLocationHeader(headers);
@@ -866,7 +866,7 @@ export async function sendWithSettings(
     models.workspace.type,
   ]);
 
-  const workspaceDoc = ancestors.find(doc => doc.type === models.workspace.type);
+  const workspaceDoc = ancestors.find((doc) => doc.type === models.workspace.type);
   const workspaceId = workspaceDoc ? workspaceDoc._id : 'n/a';
   const workspace = await models.workspace.getById(workspaceId);
   if (!workspace) {
@@ -945,7 +945,7 @@ export async function send(
   const renderedRequestBeforePlugins = renderResult.request;
   const renderedContextBeforePlugins = renderResult.context;
 
-  const workspaceDoc = ancestors.find(doc => doc.type === models.workspace.type);
+  const workspaceDoc = ancestors.find((doc) => doc.type === models.workspace.type);
   const workspace = await models.workspace.getById(workspaceDoc ? workspaceDoc._id : 'n/a');
   if (!workspace) {
     throw new Error(`Failed to find workspace for request: ${requestId}`);
@@ -1119,8 +1119,8 @@ export function _getAwsAuthHeaders(
   const signature = aws4.sign(awsSignOptions, credentials);
 
   return Object.keys(signature.headers)
-    .filter(name => name !== 'content-type') // Don't add this because we already have it
-    .map(name => ({
+    .filter((name) => name !== 'content-type') // Don't add this because we already have it
+    .map((name) => ({
       name,
       value: signature.headers[name],
     }));
@@ -1136,7 +1136,7 @@ function storeTimeline(timeline: Array<ResponseTimelineEntry>): Promise<string> 
     const responsesDir = pathJoin(getDataDirectory(), 'responses');
     mkdirp.sync(responsesDir);
     const timelinePath = pathJoin(responsesDir, timelineHash + '.timeline');
-    fs.writeFile(timelinePath, timelineStr, err => {
+    fs.writeFile(timelinePath, timelineStr, (err) => {
       if (err != null) {
         reject(err);
       } else {

--- a/packages/insomnia-app/app/plugins/context/request.js
+++ b/packages/insomnia-app/app/plugins/context/request.js
@@ -32,7 +32,7 @@ export function init(
       renderedRequest.url = url;
     },
     setCookie(name: string, value: string): void {
-      const cookie = renderedRequest.cookies.find(c => c.name === name);
+      const cookie = renderedRequest.cookies.find((c) => c.name === name);
       if (cookie) {
         cookie.value = value;
       } else {
@@ -71,7 +71,7 @@ export function init(
       }
     },
     getHeaders(): Array<{ name: string, value: string }> {
-      return renderedRequest.headers.map(h => ({
+      return renderedRequest.headers.map((h) => ({
         name: h.name,
         value: h.value,
       }));
@@ -81,7 +81,7 @@ export function init(
     },
     removeHeader(name: string): void {
       const headers = misc.filterHeaders(renderedRequest.headers, name);
-      renderedRequest.headers = renderedRequest.headers.filter(h => !headers.includes(h));
+      renderedRequest.headers = renderedRequest.headers.filter((h) => !headers.includes(h));
     },
     setHeader(name: string, value: string): void {
       const header = misc.filterHeaders(renderedRequest.headers, name)[0];
@@ -108,7 +108,7 @@ export function init(
       }
     },
     getParameters(): Array<{ name: string, value: string }> {
-      return renderedRequest.parameters.map(p => ({
+      return renderedRequest.parameters.map((p) => ({
         name: p.name,
         value: p.value,
       }));
@@ -118,7 +118,9 @@ export function init(
     },
     removeParameter(name: string): void {
       const parameters = misc.filterParameters(renderedRequest.parameters, name);
-      renderedRequest.parameters = renderedRequest.parameters.filter(p => !parameters.includes(p));
+      renderedRequest.parameters = renderedRequest.parameters.filter(
+        (p) => !parameters.includes(p),
+      );
     },
     setParameter(name: string, value: string): void {
       const parameter = misc.filterParameters(renderedRequest.parameters, name)[0];

--- a/packages/insomnia-app/app/plugins/context/response.js
+++ b/packages/insomnia-app/app/plugins/context/response.js
@@ -59,9 +59,9 @@ export function init(response: MaybeResponse): { response: Object } {
       },
       getHeader(name: string): string | Array<string> | null {
         const headers = response.headers || [];
-        const matchedHeaders = headers.filter(h => h.name.toLowerCase() === name.toLowerCase());
+        const matchedHeaders = headers.filter((h) => h.name.toLowerCase() === name.toLowerCase());
         if (matchedHeaders.length > 1) {
-          return matchedHeaders.map(h => h.value);
+          return matchedHeaders.map((h) => h.value);
         } else if (matchedHeaders.length === 1) {
           return matchedHeaders[0].value;
         } else {

--- a/packages/insomnia-app/app/plugins/context/store.js
+++ b/packages/insomnia-app/app/plugins/context/store.js
@@ -33,7 +33,7 @@ export function init(plugin: Plugin): { store: PluginStore } {
       },
       async all(): Promise<Array<{ key: string, value: string }>> {
         const docs = await models.pluginData.all(plugin.name);
-        return docs.map(d => ({
+        return docs.map((d) => ({
           value: d.value,
           key: d.key,
         }));

--- a/packages/insomnia-app/app/plugins/index.js
+++ b/packages/insomnia-app/app/plugins/index.js
@@ -168,7 +168,7 @@ export async function getPlugins(force: boolean = false): Promise<Array<Plugin>>
     const allConfigs: PluginConfigMap = settings.pluginConfig;
     const extraPaths = settings.pluginPath
       .split(':')
-      .filter(p => p)
+      .filter((p) => p)
       .map(resolveHomePath);
 
     // Make sure the default directories exist
@@ -176,7 +176,7 @@ export async function getPlugins(force: boolean = false): Promise<Array<Plugin>>
 
     // Also look in node_modules folder in each directory
     const basePaths = [PLUGIN_PATH, ...extraPaths];
-    const extendedPaths = basePaths.map(p => path.join(p, 'node_modules'));
+    const extendedPaths = basePaths.map((p) => path.join(p, 'node_modules'));
     const allPaths = [...basePaths, ...extendedPaths];
 
     // Store plugins in a map so that plugins with the same
@@ -194,7 +194,7 @@ export async function getPlugins(force: boolean = false): Promise<Array<Plugin>>
 
     await _traversePluginPath(pluginMap, allPaths, allConfigs);
 
-    plugins = Object.keys(pluginMap).map(name => pluginMap[name]);
+    plugins = Object.keys(pluginMap).map((name) => pluginMap[name]);
   }
 
   return plugins;
@@ -205,14 +205,14 @@ export async function reloadPlugins(): Promise<void> {
 }
 
 async function getActivePlugins(): Promise<Array<Plugin>> {
-  return (await getPlugins()).filter(p => !p.config.disabled);
+  return (await getPlugins()).filter((p) => !p.config.disabled);
 }
 
 export async function getRequestGroupActions(): Promise<Array<RequestGroupAction>> {
   let extensions = [];
   for (const plugin of await getActivePlugins()) {
     const actions = plugin.module.requestGroupActions || [];
-    extensions = [...extensions, ...actions.map(p => ({ plugin, ...p }))];
+    extensions = [...extensions, ...actions.map((p) => ({ plugin, ...p }))];
   }
 
   return extensions;
@@ -222,7 +222,7 @@ export async function getWorkspaceActions(): Promise<Array<WorkspaceAction>> {
   let extensions = [];
   for (const plugin of await getActivePlugins()) {
     const actions = plugin.module.workspaceActions || [];
-    extensions = [...extensions, ...actions.map(p => ({ plugin, ...p }))];
+    extensions = [...extensions, ...actions.map((p) => ({ plugin, ...p }))];
   }
 
   return extensions;
@@ -232,7 +232,7 @@ export async function getDocumentActions(): Promise<Array<DocumentAction>> {
   let extensions = [];
   for (const plugin of await getActivePlugins()) {
     const actions = plugin.module.documentActions || [];
-    extensions = [...extensions, ...actions.map(p => ({ plugin, ...p }))];
+    extensions = [...extensions, ...actions.map((p) => ({ plugin, ...p }))];
   }
 
   return extensions;
@@ -242,7 +242,7 @@ export async function getTemplateTags(): Promise<Array<TemplateTag>> {
   let extensions = [];
   for (const plugin of await getActivePlugins()) {
     const templateTags = plugin.module.templateTags || [];
-    extensions = [...extensions, ...templateTags.map(tt => ({ plugin, templateTag: tt }))];
+    extensions = [...extensions, ...templateTags.map((tt) => ({ plugin, templateTag: tt }))];
   }
 
   return extensions;
@@ -252,7 +252,7 @@ export async function getRequestHooks(): Promise<Array<RequestHook>> {
   let functions = [];
   for (const plugin of await getActivePlugins()) {
     const moreFunctions = plugin.module.requestHooks || [];
-    functions = [...functions, ...moreFunctions.map(hook => ({ plugin, hook }))];
+    functions = [...functions, ...moreFunctions.map((hook) => ({ plugin, hook }))];
   }
 
   return functions;
@@ -262,7 +262,7 @@ export async function getResponseHooks(): Promise<Array<ResponseHook>> {
   let functions = [];
   for (const plugin of await getActivePlugins()) {
     const moreFunctions = plugin.module.responseHooks || [];
-    functions = [...functions, ...moreFunctions.map(hook => ({ plugin, hook }))];
+    functions = [...functions, ...moreFunctions.map((hook) => ({ plugin, hook }))];
   }
 
   return functions;
@@ -272,7 +272,7 @@ export async function getThemes(): Promise<Array<Theme>> {
   let extensions = [];
   for (const plugin of await getActivePlugins()) {
     const themes = plugin.module.themes || [];
-    extensions = [...extensions, ...themes.map(theme => ({ plugin, theme }))];
+    extensions = [...extensions, ...themes.map((theme) => ({ plugin, theme }))];
   }
 
   return extensions;
@@ -282,7 +282,7 @@ export async function getConfigGenerators(): Promise<Array<ConfigGenerator>> {
   let functions = [];
   for (const plugin of await getActivePlugins()) {
     const moreFunctions = plugin.module.configGenerators || [];
-    functions = [...functions, ...moreFunctions.map(p => ({ plugin, ...p }))];
+    functions = [...functions, ...moreFunctions.map((p) => ({ plugin, ...p }))];
   }
 
   return functions;

--- a/packages/insomnia-app/app/plugins/install.js
+++ b/packages/insomnia-app/app/plugins/install.js
@@ -25,7 +25,7 @@ export default async function(lookupName: string): Promise<void> {
 
       // Download the module
       const request = electron.remote.net.request(info.dist.tarball);
-      request.on('error', err => {
+      request.on('error', (err) => {
         reject(new Error(`Failed to make plugin request ${info.dist.tarball}: ${err.message}`));
       });
 
@@ -174,11 +174,11 @@ async function _installPluginToTmpDir(lookupName: string): Promise<{ tmpDir: str
 
 export function containsOnlyDeprecationWarnings(stderr) {
   // Split on line breaks and remove falsy values (null, undefined, 0, -0, NaN, "", false)
-  const arr = stderr.split(/\r?\n/).filter(e => e);
+  const arr = stderr.split(/\r?\n/).filter((e) => e);
   // Retrieve all matching deprecated dependency warning
-  const warnings = arr.filter(e => isDeprecatedDependencies(e));
+  const warnings = arr.filter((e) => isDeprecatedDependencies(e));
   // Print each deprecation warnings to the console, so we don't hide them.
-  warnings.forEach(e => console.warn('[plugins] deprecation warning during installation: ', e));
+  warnings.forEach((e) => console.warn('[plugins] deprecation warning during installation: ', e));
   // If they mismatch, it means there are warnings and errors
   return warnings.length === arr.length;
 }

--- a/packages/insomnia-app/app/plugins/misc.js
+++ b/packages/insomnia-app/app/plugins/misc.js
@@ -165,7 +165,7 @@ function getThemeBlockCSS(block?: ThemeBlock): string {
     css += `${indent}--${variable}: ${value};\n`;
   };
 
-  const addComment = comment => {
+  const addComment = (comment) => {
     css += `${indent}/* ${comment} */\n`;
   };
 
@@ -245,7 +245,7 @@ export async function setTheme(themeName: string) {
   const themes: Array<Theme> = await getThemes();
 
   // If theme isn't installed for some reason, set to the default
-  if (!themes.find(t => t.theme.name === themeName)) {
+  if (!themes.find((t) => t.theme.name === themeName)) {
     console.log(`[theme] Theme not found ${themeName}`);
     themeName = getAppDefaultTheme();
   }

--- a/packages/insomnia-app/app/sync-legacy/__tests__/sync.test.js
+++ b/packages/insomnia-app/app/sync-legacy/__tests__/sync.test.js
@@ -531,7 +531,7 @@ async function _setupSessionMocks() {
     return resourceGroups[id];
   });
 
-  network.syncGetResourceGroup = jest.fn(id => {
+  network.syncGetResourceGroup = jest.fn((id) => {
     if (resourceGroups[id]) {
       return resourceGroups[id];
     }
@@ -541,14 +541,14 @@ async function _setupSessionMocks() {
     throw err;
   });
 
-  network.syncPull = jest.fn(body => ({
+  network.syncPull = jest.fn((body) => ({
     updatedResources: [],
     createdResources: [],
     idsToPush: [],
     idsToRemove: [],
   }));
 
-  network.syncPush = jest.fn(body => ({
+  network.syncPush = jest.fn((body) => ({
     conflicts: [],
     updated: [],
     created: [],

--- a/packages/insomnia-app/app/sync-legacy/index.js
+++ b/packages/insomnia-app/app/sync-legacy/index.js
@@ -62,7 +62,7 @@ export async function init() {
 
   // NOTE: This is at the top to prevent race conditions
   _isInitialized = true;
-  db.onChange(async changes => {
+  db.onChange(async (changes) => {
     // To help prevent bugs, put Workspaces first
     const sortedChanges = changes.sort(([event, doc, fromSync]) =>
       doc.type === models.workspace.type ? 1 : -1,
@@ -175,7 +175,7 @@ export async function fixDuplicateResourceGroups() {
     }
 
     // Fix duplicates
-    const ids = resources.map(r => r.resourceGroupId);
+    const ids = resources.map((r) => r.resourceGroupId);
     const { deleteResourceGroupIds } = await syncFixDupes(ids);
 
     for (const idToDelete of deleteResourceGroupIds) {
@@ -349,20 +349,20 @@ export async function pull(resourceGroupId = null, createMissingResources = true
   if (resourceGroupId) {
     // When doing specific sync, blacklist all configs except the one we're trying to sync.
     const allConfigs = await store.allConfigs();
-    blacklistedConfigs = allConfigs.filter(c => c.resourceGroupId !== resourceGroupId);
+    blacklistedConfigs = allConfigs.filter((c) => c.resourceGroupId !== resourceGroupId);
   } else {
     // When doing a full sync, blacklist the inactive configs
     blacklistedConfigs = await store.findInactiveConfigs(resourceGroupId);
   }
 
-  const resources = allResources.map(r => ({
+  const resources = allResources.map((r) => ({
     id: r.id,
     resourceGroupId: r.resourceGroupId,
     version: r.version,
     removed: r.removed,
   }));
 
-  const blacklistedResourceGroupIds = blacklistedConfigs.map(c => c.resourceGroupId);
+  const blacklistedResourceGroupIds = blacklistedConfigs.map((c) => c.resourceGroupId);
 
   const body = {
     resources,
@@ -735,7 +735,7 @@ export async function decryptDoc(resourceGroupId, messageJSON) {
 
 async function _getWorkspaceForDoc(doc) {
   const ancestors = await db.withAncestors(doc);
-  return ancestors.find(d => d.type === models.workspace.type);
+  return ancestors.find((d) => d.type === models.workspace.type);
 }
 
 export async function createResourceGroup(parentId, name) {
@@ -860,7 +860,7 @@ export async function getOrCreateAllActiveResources(resourceGroupId = null) {
     }
   }
 
-  const resources = Object.keys(activeResourceMap).map(k => activeResourceMap[k]);
+  const resources = Object.keys(activeResourceMap).map((k) => activeResourceMap[k]);
 
   const time = (Date.now() - startTime) / 1000;
   if (created > 0) {

--- a/packages/insomnia-app/app/sync-legacy/storage.js
+++ b/packages/insomnia-app/app/sync-legacy/storage.js
@@ -18,7 +18,7 @@ export function onChange(callback) {
 }
 
 export function offChange(callback) {
-  changeListeners = changeListeners.filter(l => l !== callback);
+  changeListeners = changeListeners.filter((l) => l !== callback);
 }
 
 let _changeTimeout = null;
@@ -53,7 +53,7 @@ export async function findResources(query = {}) {
 
 export async function findActiveResources(query) {
   const configs = await findActiveConfigs();
-  const resourceGroupIds = configs.map(c => c.resourceGroupId);
+  const resourceGroupIds = configs.map((c) => c.resourceGroupId);
   return findResources(Object.assign({ resourceGroupId: { $in: resourceGroupIds } }, query));
 }
 

--- a/packages/insomnia-app/app/sync/git/__mocks__/path.js
+++ b/packages/insomnia-app/app/sync/git/__mocks__/path.js
@@ -6,7 +6,7 @@ const exportObj = { __mockPath, ...path };
 function __mockPath(type) {
   const mock = type === 'win32' ? path.win32 : path.posix;
 
-  Object.keys(mock).forEach(k => (exportObj[k] = mock[k]));
+  Object.keys(mock).forEach((k) => (exportObj[k] = mock[k]));
 }
 
 module.exports = exportObj;

--- a/packages/insomnia-app/app/sync/git/__tests__/git-vcs.test.js
+++ b/packages/insomnia-app/app/sync/git/__tests__/git-vcs.test.js
@@ -211,16 +211,16 @@ describe('Git-VCS', () => {
       await vcs.init(GIT_CLONE_DIR, fs);
 
       // Write to all files
-      await Promise.all(files.map(f => fs.promises.writeFile(f, originalContent)));
+      await Promise.all(files.map((f) => fs.promises.writeFile(f, originalContent)));
 
       // Commit all files
       await vcs.setAuthor('Karen Brown', 'karen@example.com');
-      await Promise.all(files.map(f => vcs.add(f, originalContent)));
+      await Promise.all(files.map((f) => vcs.add(f, originalContent)));
       await vcs.commit('First commit!');
 
       // Change all files
-      await Promise.all(files.map(f => fs.promises.writeFile(f, changedContent)));
-      await Promise.all(files.map(f => expect(vcs.status(foo1Txt)).resolves.toBe('*modified')));
+      await Promise.all(files.map((f) => fs.promises.writeFile(f, changedContent)));
+      await Promise.all(files.map((f) => expect(vcs.status(foo1Txt)).resolves.toBe('*modified')));
 
       // Undo foo1 and foo2, but not foo3
       await vcs.undoPendingChanges([foo1Txt, foo2Txt]);

--- a/packages/insomnia-app/app/sync/git/__tests__/parse-git-path.test.js
+++ b/packages/insomnia-app/app/sync/git/__tests__/parse-git-path.test.js
@@ -34,7 +34,7 @@ describe('parseGitPath', () => {
     expect(result.id).toBe('wrk_1');
   });
 
-  it.each(['json', 'yml'])('should omit the %s extension', ext => {
+  it.each(['json', 'yml'])('should omit the %s extension', (ext) => {
     const gitPath = `${GIT_INSOMNIA_DIR}/${models.workspace.type}/wrk_1.${ext}`;
 
     const result = parseGitPath(gitPath);

--- a/packages/insomnia-app/app/sync/git/__tests__/path-sep.test.js
+++ b/packages/insomnia-app/app/sync/git/__tests__/path-sep.test.js
@@ -8,7 +8,7 @@ describe('convertToPosixSep()', () => {
     expect(convertToPosixSep('')).toBe('');
   });
 
-  it.each(['win32', 'posix'])('should convert separator from %s to posix', type => {
+  it.each(['win32', 'posix'])('should convert separator from %s to posix', (type) => {
     const input = path[type].join('a', 'b', 'c');
     const posix = path.posix.join('a', 'b', 'c');
 
@@ -16,11 +16,11 @@ describe('convertToPosixSep()', () => {
   });
 });
 
-describe.each(['win32', 'posix'])('convertToOsSep() where os is %s', osType => {
+describe.each(['win32', 'posix'])('convertToOsSep() where os is %s', (osType) => {
   beforeAll(() => path.__mockPath(osType));
   afterAll(() => jest.restoreAllMocks());
 
-  it.each(['win32', 'posix'])(`should convert separators from %s to ${osType}`, inputType => {
+  it.each(['win32', 'posix'])(`should convert separators from %s to ${osType}`, (inputType) => {
     const input = path[inputType].join('a', 'b', 'c');
     const output = path[osType].join('a', 'b', 'c');
 

--- a/packages/insomnia-app/app/sync/git/fs-plugin.js
+++ b/packages/insomnia-app/app/sync/git/fs-plugin.js
@@ -61,8 +61,8 @@ export default class FSPlugin {
   _callbackAsPromise<T>(fn: Function, filePath: string, ...args: Array<any>): Promise<T> {
     return new Promise((resolve, reject) => {
       filePath = path.join(this._basePath, path.normalize(filePath));
-      const callback = args.find(arg => typeof arg === 'function');
-      const newArgs = args.filter(arg => arg !== callback);
+      const callback = args.find((arg) => typeof arg === 'function');
+      const newArgs = args.filter((arg) => arg !== callback);
 
       fn(filePath, ...newArgs, (err, result) => {
         if (err) reject(err);

--- a/packages/insomnia-app/app/sync/git/git-rollback.js
+++ b/packages/insomnia-app/app/sync/git/git-rollback.js
@@ -17,7 +17,7 @@ export const gitRollback = async (vcs: GitVCS, files: Array<FileWithStatus>): Pr
   });
 
   // Rollback existing (versioned) files
-  const existingFiles = files.filter(isNotAdded).map(f => f.filePath);
+  const existingFiles = files.filter(isNotAdded).map((f) => f.filePath);
   if (existingFiles.length) {
     promises.push(vcs.undoPendingChanges(existingFiles));
   }

--- a/packages/insomnia-app/app/sync/git/git-vcs.js
+++ b/packages/insomnia-app/app/sync/git/git-vcs.js
@@ -70,7 +70,7 @@ export default class GitVCS {
     const emitter = new EventEmitter();
     git.plugins.set('emitter', emitter);
 
-    emitter.on('message', message => {
+    emitter.on('message', (message) => {
       console.log(`[git-event] ${message}`);
     });
 
@@ -140,7 +140,7 @@ export default class GitVCS {
     const branches = await git.listBranches({ ...this._baseOpts, remote: 'origin' });
 
     // Don't care about returning remote HEAD
-    return GitVCS._sortBranches(branches.filter(b => b !== 'HEAD'));
+    return GitVCS._sortBranches(branches.filter((b) => b !== 'HEAD'));
   }
 
   async status(filepath: string) {
@@ -198,7 +198,7 @@ export default class GitVCS {
 
   async getRemote(name: string): Promise<GitRemoteConfig | null> {
     const remotes = await this.listRemotes();
-    return remotes.find(r => r.remote === name) || null;
+    return remotes.find((r) => r.remote === name) || null;
   }
 
   async commit(message: string): Promise<string> {

--- a/packages/insomnia-app/app/sync/git/mem-plugin.js
+++ b/packages/insomnia-app/app/sync/git/mem-plugin.js
@@ -171,7 +171,7 @@ export class MemPlugin {
     basePath = path.normalize(basePath);
     const entry = this._assertDir(basePath);
 
-    const names = entry.children.map(c => c.name);
+    const names = entry.children.map((c) => c.name);
     names.sort();
     return names;
   }
@@ -186,7 +186,7 @@ export class MemPlugin {
       this._assertDir(path.dirname(dirPath));
     }
 
-    const pathSegments = dirPath.split(path.sep).filter(s => s !== '');
+    const pathSegments = dirPath.split(path.sep).filter((s) => s !== '');
 
     // Recurse over all sub paths, ensure they are all directories,
     // create them if they don't exist
@@ -196,7 +196,7 @@ export class MemPlugin {
       const nextPath = path.join(currentPath, pathSegment);
 
       // Create dir if it doesn't exist yet
-      if (!dirEntry.children.find(e => e.name === pathSegment)) {
+      if (!dirEntry.children.find((e) => e.name === pathSegment)) {
         dirEntry.children.push({
           type: 'dir',
           ino: this.__ino++,
@@ -280,9 +280,9 @@ export class MemPlugin {
     let current = this.__fs;
 
     // Ignore empty and current directory '.' segments
-    const pathSegments = filePath.split(path.sep).filter(s => s !== '' && s !== '.');
+    const pathSegments = filePath.split(path.sep).filter((s) => s !== '' && s !== '.');
     for (const expectedName of pathSegments) {
-      const e = (current.children || []).find(c => c.name === expectedName);
+      const e = (current.children || []).find((c) => c.name === expectedName);
 
       if (!e) {
         return null;
@@ -395,7 +395,7 @@ export class MemPlugin {
 
   _remove(entry: FSEntry) {
     const parentEntry = this._assertDir(path.dirname(entry.path));
-    const index = parentEntry.children.findIndex(c => c === entry);
+    const index = parentEntry.children.findIndex((c) => c === entry);
     if (index < 0) {
       // Should never happen so w/e
       return;

--- a/packages/insomnia-app/app/sync/git/ne-db-plugin.js
+++ b/packages/insomnia-app/app/sync/git/ne-db-plugin.js
@@ -129,12 +129,12 @@ export default class NeDBPlugin {
     } else if (type !== null && id === null) {
       const workspace = await db.get(models.workspace.type, this._workspaceId);
       const children = await db.withDescendants(workspace);
-      docs = children.filter(d => d.type === type && !(d: any).isPrivate);
+      docs = children.filter((d) => d.type === type && !(d: any).isPrivate);
     } else {
       throw this._errMissing(filePath);
     }
 
-    const ids = docs.map(d => `${d._id}.yml`);
+    const ids = docs.map((d) => `${d._id}.yml`);
 
     return [...ids, ...otherFolders].sort();
   }

--- a/packages/insomnia-app/app/sync/git/parse-git-path.js
+++ b/packages/insomnia-app/app/sync/git/parse-git-path.js
@@ -21,7 +21,7 @@ const parseGitPath = (filePath: string): GitPathSegments => {
   filePath = filePath.replace(_cloneDirRegExp, '');
 
   // Ignore empty and current directory '.' segments
-  const [root, type, idRaw] = filePath.split(path.sep).filter(s => s !== '' && s !== '.');
+  const [root, type, idRaw] = filePath.split(path.sep).filter((s) => s !== '' && s !== '.');
 
   const id = typeof idRaw === 'string' ? idRaw.replace(/\.(json|yml)$/, '') : idRaw;
 

--- a/packages/insomnia-app/app/sync/store/drivers/file-system-driver.js
+++ b/packages/insomnia-app/app/sync/store/drivers/file-system-driver.js
@@ -36,11 +36,11 @@ export default class FileSystemDriver implements BaseDriver {
 
       // This method implements atomic writes by first writing to a temporary
       // file (non-atomic) then renaming the file to the final value (atomic)
-      fs.writeFile(tmpPath, value, 'utf8', err => {
+      fs.writeFile(tmpPath, value, 'utf8', (err) => {
         if (err) {
           return reject(err);
         }
-        fs.rename(tmpPath, finalPath, err => {
+        fs.rename(tmpPath, finalPath, (err) => {
           if (err) {
             return reject(err);
           }
@@ -66,7 +66,7 @@ export default class FileSystemDriver implements BaseDriver {
 
   removeItem(key: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      fs.unlink(this._getKeyPath(key), err => {
+      fs.unlink(this._getKeyPath(key), (err) => {
         if (err && err.code === 'ENOENT') {
           resolve();
         } else if (err) {
@@ -95,7 +95,7 @@ export default class FileSystemDriver implements BaseDriver {
   }
 
   async keys(prefix: string, recursive: boolean): Promise<Array<string>> {
-    const next = dir => {
+    const next = (dir) => {
       return new Promise(async (resolve, reject) => {
         let keys: Array<string> = [];
         let names = [];

--- a/packages/insomnia-app/app/sync/vcs/index.js
+++ b/packages/insomnia-app/app/sync/vcs/index.js
@@ -79,7 +79,7 @@ export default class VCS {
 
   async removeProjectsForRoot(rootDocumentId: string): Promise<void> {
     const all = await this._allProjects();
-    const toRemove = all.filter(p => p.rootDocumentId === rootDocumentId);
+    const toRemove = all.filter((p) => p.rootDocumentId === rootDocumentId);
     for (const project of toRemove) {
       await this._removeProject(project);
     }
@@ -129,7 +129,7 @@ export default class VCS {
       return null;
     }
 
-    const entry = snapshot.state.find(e => e.key === key);
+    const entry = snapshot.state.find((e) => e.key === key);
     if (!entry) {
       return null;
     }
@@ -172,7 +172,7 @@ export default class VCS {
     }
 
     await this._storeBlobs(blobsToStore);
-    console.log(`[sync] Staged ${stageEntries.map(e => e.name).join(', ')}`);
+    console.log(`[sync] Staged ${stageEntries.map((e) => e.name).join(', ')}`);
 
     return stage;
   }
@@ -182,7 +182,7 @@ export default class VCS {
       delete stage[entry.key];
     }
 
-    console.log(`[sync] Unstaged ${stageEntries.map(e => e.name).join(', ')}`);
+    console.log(`[sync] Unstaged ${stageEntries.map((e) => e.name).join(', ')}`);
     return stage;
   }
 
@@ -280,16 +280,16 @@ export default class VCS {
     const delta = stateDelta(latestStateCurrent, latestStateNext);
 
     // Filter out things that should stay dirty
-    const add = delta.add.filter(e => !dirtyMap[e.key]);
-    const update = delta.update.filter(e => !dirtyMap[e.key]);
-    const remove = delta.remove.filter(e => !dirtyMap[e.key]);
+    const add = delta.add.filter((e) => !dirtyMap[e.key]);
+    const update = delta.update.filter((e) => !dirtyMap[e.key]);
+    const remove = delta.remove.filter((e) => !dirtyMap[e.key]);
     const upsert = [...add, ...update];
     console.log(`[sync] Switched to branch ${branchName}`);
 
     // Remove all dirty items from the delta so we keep them around
     return {
-      upsert: await this._getBlobs(upsert.map(e => e.blob)),
-      remove: await this._getBlobs(remove.map(e => e.blob)),
+      upsert: await this._getBlobs(upsert.map((e) => e.blob)),
+      remove: await this._getBlobs(remove.map((e) => e.blob)),
     };
   }
 
@@ -315,7 +315,7 @@ export default class VCS {
       throw new Error('Failed to get latest snapshot for all documents');
     }
 
-    return this._getBlobs(snapshot.state.map(s => s.blob));
+    return this._getBlobs(snapshot.state.map((s) => s.blob));
   }
 
   async rollbackToLatest(
@@ -345,7 +345,7 @@ export default class VCS {
       throw new Error(`Failed to find snapshot by id ${snapshotId}`);
     }
 
-    const potentialNewState: SnapshotState = candidates.map(c => ({
+    const potentialNewState: SnapshotState = candidates.map((c) => ({
       key: c.key,
       blob: hashDocument(c.document).hash,
       name: c.name,
@@ -357,7 +357,7 @@ export default class VCS {
     // yet have been stored as blobs.
     const remove = [];
     for (const e of delta.remove) {
-      const c = candidates.find(c => c.key === e.key);
+      const c = candidates.find((c) => c.key === e.key);
       if (!c) {
         // Should never happen
         throw new Error('Failed to find removal in candidates');
@@ -369,7 +369,7 @@ export default class VCS {
 
     const upsert = [...delta.update, ...delta.add];
     return {
-      upsert: await this._getBlobs(upsert.map(e => e.blob)),
+      upsert: await this._getBlobs(upsert.map((e) => e.blob)),
       remove,
     };
   }
@@ -401,12 +401,12 @@ export default class VCS {
 
   async getRemoteBranches(): Promise<Array<string>> {
     const branches = await this._queryBranches();
-    return branches.map(b => b.name);
+    return branches.map((b) => b.name);
   }
 
   async getBranches(): Promise<Array<string>> {
     const branches = await this._getBranches();
-    return branches.map(b => b.name);
+    return branches.map((b) => b.name);
   }
 
   async merge(
@@ -681,8 +681,8 @@ export default class VCS {
     // Remove all dirty items from the delta so we keep them around
     const dirtyMap = generateCandidateMap(dirty);
     return {
-      upsert: await this._getBlobs(upsert.filter(e => !dirtyMap[e.key]).map(e => e.blob)),
-      remove: await this._getBlobs(remove.filter(e => !dirtyMap[e.key]).map(e => e.blob)),
+      upsert: await this._getBlobs(upsert.filter((e) => !dirtyMap[e.key]).map((e) => e.blob)),
+      remove: await this._getBlobs(remove.filter((e) => !dirtyMap[e.key]).map((e) => e.blob)),
     };
   }
 
@@ -881,7 +881,7 @@ export default class VCS {
         {
           branchName: branch.name,
           projectId: this._projectId(),
-          snapshots: snapshots.map(s => ({
+          snapshots: snapshots.map((s) => ({
             created: s.created,
             name: s.name,
             description: s.description,
@@ -897,7 +897,7 @@ export default class VCS {
       // Store them in case something has changed
       await this._storeSnapshots(snapshotsCreate);
 
-      console.log('[sync] Pushed snapshots', snapshotsCreate.map(s => s.id).join(', '));
+      console.log('[sync] Pushed snapshots', snapshotsCreate.map((s) => s.id).join(', '));
     }
   }
 
@@ -934,7 +934,7 @@ export default class VCS {
     const symmetricKey = await this._getProjectSymmetricKey();
 
     const next = async (items: Array<{ id: string, content: string }>) => {
-      const encodedBlobs = items.map(i => ({
+      const encodedBlobs = items.map((i) => ({
         id: i.id,
         content: i.content,
       }));
@@ -1322,13 +1322,13 @@ export default class VCS {
 
     // First, try finding the project
     const projects = await this._allProjects();
-    let matchedProjects = projects.filter(p => p.rootDocumentId === rootDocumentId);
+    let matchedProjects = projects.filter((p) => p.rootDocumentId === rootDocumentId);
 
     // If there is more than one project for root, try pruning unused ones by branch activity
     if (matchedProjects.length > 1) {
       for (const p of matchedProjects) {
         const branches = await this._getBranches(p.id);
-        if (!branches.find(b => b.snapshots.length > 0)) {
+        if (!branches.find((b) => b.snapshots.length > 0)) {
           await this._removeProject(p);
           matchedProjects = matchedProjects.filter(({ id }) => id !== p.id);
           console.log(`[sync] Remove inactive project for root ${rootDocumentId}`);

--- a/packages/insomnia-app/app/sync/vcs/util.js
+++ b/packages/insomnia-app/app/sync/vcs/util.js
@@ -461,7 +461,7 @@ export function updateStateWithConflictResolutions(
 ): SnapshotState {
   const newStateMap = generateStateMap(state);
   for (const { choose, key, name } of conflicts) {
-    const stateEntry = state.find(e => e.key === key);
+    const stateEntry = state.find((e) => e.key === key);
 
     // Not in the state, but we choose the conflict
     if (!stateEntry && choose !== null) {
@@ -479,7 +479,7 @@ export function updateStateWithConflictResolutions(
     delete newStateMap[key];
   }
 
-  return Object.keys(newStateMap).map(k => newStateMap[k]);
+  return Object.keys(newStateMap).map((k) => newStateMap[k]);
 }
 
 export function describeChanges(a: any, b: any): Array<string> {

--- a/packages/insomnia-app/app/templating/base-extension.js
+++ b/packages/insomnia-app/app/templating/base-extension.js
@@ -90,7 +90,7 @@ export default class BaseExtension {
     // Extract the rest of the args
     const args = runArgs
       .slice(0, runArgs.length - 1)
-      .filter(a => a !== EMPTY_ARG)
+      .filter((a) => a !== EMPTY_ARG)
       .map(decodeEncoding);
 
     // Define a helper context with utils
@@ -102,22 +102,22 @@ export default class BaseExtension {
       meta: renderMeta,
       renderPurpose,
       util: {
-        render: str => templating.render(str, { context: renderContext }),
+        render: (str) => templating.render(str, { context: renderContext }),
         models: {
           request: {
             getById: models.request.getById,
-            getAncestors: async request => {
+            getAncestors: async (request) => {
               const ancestors = await db.withAncestors(request, [
                 models.requestGroup.type,
                 models.workspace.type,
               ]);
-              return ancestors.filter(doc => doc._id !== request._id);
+              return ancestors.filter((doc) => doc._id !== request._id);
             },
           },
           workspace: { getById: models.workspace.getById },
           oAuth2Token: { getByRequestId: models.oAuth2Token.getByParentId },
           cookieJar: {
-            getOrCreateForWorkspace: workspace => {
+            getOrCreateForWorkspace: (workspace) => {
               return models.cookieJar.getOrCreateForParentId(workspace._id);
             },
           },
@@ -141,10 +141,10 @@ export default class BaseExtension {
     // If the result is a promise, resolve it async
     if (result instanceof Promise) {
       result
-        .then(r => {
+        .then((r) => {
           callback(null, r);
         })
-        .catch(err => {
+        .catch((err) => {
           callback(err);
         });
       return;

--- a/packages/insomnia-app/app/templating/index.js
+++ b/packages/insomnia-app/app/templating/index.js
@@ -90,10 +90,10 @@ export async function getTagDefinitions(): Promise<Array<NunjucksParsedTag>> {
   const env = await getNunjucks(RENDER_ALL);
 
   return Object.keys(env.extensions)
-    .map(k => env.extensions[k])
-    .filter(ext => !ext.isDeprecated())
+    .map((k) => env.extensions[k])
+    .filter((ext) => !ext.isDeprecated())
     .sort((a, b) => (a.getPriority() > b.getPriority() ? 1 : -1))
-    .map(ext => ({
+    .map((ext) => ({
       name: ext.getTag(),
       displayName: ext.getName(),
       liveDisplayName: ext.getLiveDisplayName(),
@@ -162,7 +162,7 @@ async function getNunjucks(renderMode: string) {
 
     // Hidden helper filter to debug complicated things
     // eg. `{{ foo | urlencode | debug | upper }}`
-    nj.addFilter('debug', o => o);
+    nj.addFilter('debug', (o) => o);
   }
 
   // ~~~~~~~~~~~~~~~~~~~~ //

--- a/packages/insomnia-app/app/templating/utils.js
+++ b/packages/insomnia-app/app/templating/utils.js
@@ -195,7 +195,7 @@ export function unTokenizeTag(tagData: NunjucksParsedTag): string {
 
 /** Get the default Nunjucks string for an extension */
 export function getDefaultFill(name: string, args: Array<NunjucksParsedTagArg>): string {
-  const stringArgs: Array<string> = (args || []).map(argDefinition => {
+  const stringArgs: Array<string> = (args || []).map((argDefinition) => {
     switch (argDefinition.type) {
       case 'enum':
         const { defaultValue, options } = argDefinition;

--- a/packages/insomnia-app/app/ui/components/activity-toggle.js
+++ b/packages/insomnia-app/app/ui/components/activity-toggle.js
@@ -22,7 +22,7 @@ export default function ActivityToggle({ activity, handleActivityChange, workspa
   return (
     <MultiSwitch
       name="activity-toggle"
-      onChange={a => handleActivityChange(workspace._id, a)}
+      onChange={(a) => handleActivityChange(workspace._id, a)}
       choices={choices}
       selectedValue={activity}
     />

--- a/packages/insomnia-app/app/ui/components/base/editable.stories.js
+++ b/packages/insomnia-app/app/ui/components/base/editable.stories.js
@@ -5,5 +5,5 @@ import Editable from './editable';
 export default { title: 'Editable' };
 
 export const input = () => (
-  <Editable value="Double-click to edit me" onSubmit={v => console.log('New value', v)} />
+  <Editable value="Double-click to edit me" onSubmit={(v) => console.log('New value', v)} />
 );

--- a/packages/insomnia-app/app/ui/components/base/modal.js
+++ b/packages/insomnia-app/app/ui/components/base/modal.js
@@ -36,7 +36,7 @@ class Modal extends PureComponent {
 
     const closeOnKeyCodes = this.props.closeOnKeyCodes || [];
     const pressedEscape = await pressedHotKey(e, hotKeyRefs.CLOSE_MODAL);
-    const pressedCloseButton = closeOnKeyCodes.find(c => c === e.keyCode);
+    const pressedCloseButton = closeOnKeyCodes.find((c) => c === e.keyCode);
 
     // Pressed escape
     if (pressedEscape || pressedCloseButton) {

--- a/packages/insomnia-app/app/ui/components/buttons/__tests__/grpc-send-button.test.js
+++ b/packages/insomnia-app/app/ui/components/buttons/__tests__/grpc-send-button.test.js
@@ -64,7 +64,7 @@ describe('<GrpcSendButton />', () => {
 
   it.each([GrpcMethodTypeEnum.bidi, GrpcMethodTypeEnum.server, GrpcMethodTypeEnum.client])(
     'should render start button if streaming RPC: %s',
-    type => {
+    (type) => {
       const handleSend = jest.fn();
       const { getByRole } = render(
         <GrpcSendButton

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -254,8 +254,8 @@ class CodeEditor extends React.Component {
     }
     const marks = this.codeMirror
       .getAllMarks()
-      .filter(c => c.__isFold)
-      .map(mark => {
+      .filter((c) => c.__isFold)
+      .map((mark) => {
         const { from, to } = mark.find();
 
         return { from, to };
@@ -368,7 +368,7 @@ class CodeEditor extends React.Component {
 
     this.codeMirror.setOption('extraKeys', {
       ...BASE_CODEMIRROR_OPTIONS.extraKeys,
-      Tab: cm => {
+      Tab: (cm) => {
         // Indent with tabs or spaces
         // From https://github.com/codemirror/CodeMirror/issues/988#issuecomment-14921785
         if (cm.somethingSelected()) {
@@ -509,7 +509,7 @@ class CodeEditor extends React.Component {
     if (this.props.updateFilter && this.state.filter) {
       try {
         const results = queryXPath(code, this.state.filter);
-        code = `<result>${results.map(r => r.outer).join('\n')}</result>`;
+        code = `<result>${results.map((r) => r.outer).join('\n')}</result>`;
       } catch (err) {
         // Failed to parse filter (that's ok)
         code = `<error>${err.message}</error>`;
@@ -673,7 +673,7 @@ class CodeEditor extends React.Component {
     }
 
     // Strip of charset if there is one
-    Object.keys(options).map(key => {
+    Object.keys(options).map((key) => {
       this._codemirrorSmartSetOption(key, options[key]);
     });
   }
@@ -818,7 +818,7 @@ class CodeEditor extends React.Component {
 
       // Don't allow non-breaking spaces because they break the GraphQL syntax
       if (doc.options.mode === 'graphql' && change.text && change.text.length > 1) {
-        change.text = change.text.map(text => text.replace(/\u00A0/g, ' '));
+        change.text = change.text.map((text) => text.replace(/\u00A0/g, ' '));
       }
     }
   }
@@ -970,7 +970,7 @@ class CodeEditor extends React.Component {
             <DropdownButton className="btn btn--compact">
               <i className="fa fa-clock-o" />
             </DropdownButton>
-            {filterHistory.reverse().map(filter => (
+            {filterHistory.reverse().map((filter) => (
               <DropdownItem key={filter} value={filter} onClick={this._handleFilterHistorySelect}>
                 {filter}
               </DropdownItem>

--- a/packages/insomnia-app/app/ui/components/codemirror/extensions/autocomplete.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/extensions/autocomplete.js
@@ -185,10 +185,10 @@ CodeMirror.defineOption('environmentAutocomplete', null, (cm, options) => {
  */
 function hint(cm, options) {
   // Add type to all things (except constants, which need to convert to an object)
-  const variablesToMatch = (options.variables || []).map(v => ({ ...v, type: TYPE_VARIABLE }));
-  const snippetsToMatch = (options.snippets || []).map(v => ({ ...v, type: TYPE_SNIPPET }));
-  const tagsToMatch = (options.tags || []).map(v => ({ ...v, type: TYPE_TAG }));
-  const constantsToMatch = (options.constants || []).map(s => ({
+  const variablesToMatch = (options.variables || []).map((v) => ({ ...v, type: TYPE_VARIABLE }));
+  const snippetsToMatch = (options.snippets || []).map((v) => ({ ...v, type: TYPE_SNIPPET }));
+  const tagsToMatch = (options.tags || []).map((v) => ({ ...v, type: TYPE_TAG }));
+  const constantsToMatch = (options.constants || []).map((s) => ({
     name: s,
     value: s,
     displayValue: '', // No display since name === value
@@ -231,10 +231,10 @@ function hint(cm, options) {
 
   // Match variables
   if (allowMatchingVariables) {
-    matchSegments(variablesToMatch, nameSegment, TYPE_VARIABLE, MAX_VARIABLES).forEach(m =>
+    matchSegments(variablesToMatch, nameSegment, TYPE_VARIABLE, MAX_VARIABLES).forEach((m) =>
       lowPriorityMatches.push(m),
     );
-    matchSegments(variablesToMatch, nameSegmentLong, TYPE_VARIABLE, MAX_VARIABLES).forEach(m =>
+    matchSegments(variablesToMatch, nameSegmentLong, TYPE_VARIABLE, MAX_VARIABLES).forEach((m) =>
       highPriorityMatches.push(m),
     );
   }
@@ -252,7 +252,7 @@ function hint(cm, options) {
 
       if (token.type === 'variable') {
         // We're inside a JSON key
-        matchSegments(constantsToMatch, segment, TYPE_CONSTANT, MAX_CONSTANTS).forEach(m =>
+        matchSegments(constantsToMatch, segment, TYPE_CONSTANT, MAX_CONSTANTS).forEach((m) =>
           highPriorityMatches.push(m),
         );
       } else if (
@@ -261,13 +261,13 @@ function hint(cm, options) {
         (token.type === 'punctuation' && token.string === '{')
       ) {
         // We're outside of a JSON key
-        matchSegments(constantsToMatch, segment, TYPE_CONSTANT, MAX_CONSTANTS).forEach(m =>
+        matchSegments(constantsToMatch, segment, TYPE_CONSTANT, MAX_CONSTANTS).forEach((m) =>
           highPriorityMatches.push({ ...m, text: '"' + m.text + '": ' }),
         );
       }
     } else {
       // Otherwise match full segments
-      matchSegments(constantsToMatch, nameSegmentFull, TYPE_CONSTANT, MAX_CONSTANTS).forEach(m =>
+      matchSegments(constantsToMatch, nameSegmentFull, TYPE_CONSTANT, MAX_CONSTANTS).forEach((m) =>
         highPriorityMatches.push(m),
       );
     }
@@ -275,15 +275,15 @@ function hint(cm, options) {
 
   // Match tags
   if (allowMatchingTags) {
-    matchSegments(tagsToMatch, nameSegment, TYPE_TAG, MAX_TAGS).forEach(m =>
+    matchSegments(tagsToMatch, nameSegment, TYPE_TAG, MAX_TAGS).forEach((m) =>
       lowPriorityMatches.push(m),
     );
-    matchSegments(tagsToMatch, nameSegmentLong, TYPE_TAG, MAX_TAGS).forEach(m =>
+    matchSegments(tagsToMatch, nameSegmentLong, TYPE_TAG, MAX_TAGS).forEach((m) =>
       highPriorityMatches.push(m),
     );
   }
 
-  matchSegments(snippetsToMatch, nameSegment, TYPE_SNIPPET, MAX_SNIPPETS).forEach(m =>
+  matchSegments(snippetsToMatch, nameSegment, TYPE_SNIPPET, MAX_SNIPPETS).forEach((m) =>
     highPriorityMatches.push(m),
   );
 
@@ -293,7 +293,7 @@ function hint(cm, options) {
   const segment = highPriorityMatches.length ? nameSegmentLong : nameSegment;
 
   const uniqueMatches = matches.reduce(
-    (arr, v) => (arr.find(a => a.text === v.text) ? arr : [...arr, v]),
+    (arr, v) => (arr.find((a) => a.text === v.text) ? arr : [...arr, v]),
     [], // Default value
   );
 
@@ -440,7 +440,7 @@ function matchSegments(listOfThings, segment, type, limit = -1) {
 function replaceWithSurround(text, find, prefix, suffix) {
   const escapedString = escapeRegex(find);
   const re = new RegExp(escapedString, 'gi');
-  return text.replace(re, matched => prefix + matched + suffix);
+  return text.replace(re, (matched) => prefix + matched + suffix);
 }
 
 /**

--- a/packages/insomnia-app/app/ui/components/codemirror/extensions/clickable.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/extensions/clickable.js
@@ -24,15 +24,15 @@ CodeMirror.defineExtension('makeLinksClickable', function(handleClick) {
   const el = this.getWrapperElement();
   let movedDuringClick = false;
 
-  el.addEventListener('mousemove', e => {
+  el.addEventListener('mousemove', (e) => {
     movedDuringClick = true;
   });
 
-  el.addEventListener('mousedown', e => {
+  el.addEventListener('mousedown', (e) => {
     movedDuringClick = false;
   });
 
-  el.addEventListener('mouseup', e => {
+  el.addEventListener('mouseup', (e) => {
     if (movedDuringClick) {
       return;
     }

--- a/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.js
@@ -43,7 +43,7 @@ CodeMirror.defineExtension('enableNunjucksTags', function(
 
 async function _highlightNunjucksTags(render, renderContext, isVariableUncovered) {
   const renderCacheKey = Math.random() + '';
-  const renderString = text => render(text, renderCacheKey);
+  const renderString = (text) => render(text, renderCacheKey);
   const activeMarks = [];
   const doc = this.getDoc();
 
@@ -146,7 +146,7 @@ async function _highlightNunjucksTags(render, renderContext, isVariableUncovered
         // Define the dialog HTML
         showModal(NunjucksVariableModal, {
           template: mark.__template,
-          onDone: template => {
+          onDone: (template) => {
             const pos = mark.find();
             if (pos) {
               const { from, to } = pos;
@@ -176,7 +176,7 @@ async function _highlightNunjucksTags(render, renderContext, isVariableUncovered
       };
 
       // Set up the drag
-      el.addEventListener('dragstart', e => {
+      el.addEventListener('dragstart', (e) => {
         // Setup the drag contents
         const template = e.target.getAttribute('data-template');
         e.dataTransfer.setData('text/plain', template);
@@ -188,7 +188,7 @@ async function _highlightNunjucksTags(render, renderContext, isVariableUncovered
         this.on('drop', dropCb);
       });
 
-      el.addEventListener('dragend', e => {
+      el.addEventListener('dragend', (e) => {
         // If dragged within same editor, delete the old reference
         // TODO: Actually only use dropEffect for this logic. For some reason
         // changing it doesn't seem to take affect in Chromium 56 (maybe bug?)
@@ -203,7 +203,7 @@ async function _highlightNunjucksTags(render, renderContext, isVariableUncovered
       });
 
       // Don't allow dropping on itself
-      el.addEventListener('drop', e => {
+      el.addEventListener('drop', (e) => {
         e.stopPropagation();
       });
     }
@@ -252,7 +252,7 @@ async function _updateElementText(render, mark, text, renderContext, isVariableU
   try {
     if (tagMatch) {
       const tagData = tokenizeTag(str);
-      const tagDefinition = (await getTagDefinitions()).find(d => d.name === tagData.name);
+      const tagDefinition = (await getTagDefinitions()).find((d) => d.name === tagData.name);
 
       if (tagDefinition) {
         // Try rendering these so we can show errors if needed
@@ -262,7 +262,7 @@ async function _updateElementText(render, mark, text, renderContext, isVariableU
           innerHTML = liveDisplayName;
         } else if (firstArg && firstArg.type === 'enum') {
           const argData = tagData.args[0];
-          const foundOption = firstArg.options.find(d => d.value === argData.value);
+          const foundOption = firstArg.options.find((d) => d.value === argData.value);
           const option = foundOption || firstArg.options[0];
           innerHTML = `${tagDefinition.displayName} &rArr; ${option.displayName}`;
         } else {

--- a/packages/insomnia-app/app/ui/components/codemirror/lint/openapi.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/lint/openapi.js
@@ -6,7 +6,7 @@ const spectral = new Spectral();
 CodeMirror.registerHelper('lint', 'openapi', async function(text) {
   const results = await spectral.run(text);
 
-  return results.map(result => ({
+  return results.map((result) => ({
     from: CodeMirror.Pos(result.range.start.line, result.range.start.chracter),
     to: CodeMirror.Pos(result.range.end.line, result.range.end.chracter),
     message: result.message,

--- a/packages/insomnia-app/app/ui/components/cookie-list.js
+++ b/packages/insomnia-app/app/ui/components/cookie-list.js
@@ -85,7 +85,7 @@ class CookieList extends React.PureComponent<Props> {
                   <td onClick={null} className="text-right no-wrap">
                     <button
                       className="btn btn--super-compact btn--outlined"
-                      onClick={e => handleShowModifyCookieModal(cookie)}
+                      onClick={(e) => handleShowModifyCookieModal(cookie)}
                       title="Edit cookie properties">
                       Edit
                     </button>{' '}
@@ -93,7 +93,7 @@ class CookieList extends React.PureComponent<Props> {
                       className="btn btn--super-compact btn--outlined"
                       addIcon
                       confirmMessage=""
-                      onClick={e => this._handleDeleteCookie(cookie)}
+                      onClick={(e) => this._handleDeleteCookie(cookie)}
                       title="Delete cookie">
                       <i className="fa fa-trash-o" />
                     </PromptButton>
@@ -107,7 +107,7 @@ class CookieList extends React.PureComponent<Props> {
           <div className="pad faint italic text-center">
             <p>I couldn't find any cookies for you.</p>
             <p>
-              <button className="btn btn--clicky" onClick={e => this._handleCookieAdd()}>
+              <button className="btn btn--clicky" onClick={(e) => this._handleCookieAdd()}>
                 Add Cookie <i className="fa fa-plus-circle" />
               </button>
             </p>

--- a/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
@@ -47,7 +47,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
       submitName: 'Create',
       selectText: true,
       label: 'New Name',
-      onComplete: async newName => {
+      onComplete: async (newName) => {
         const newWorkspace = await db.duplicate(workspace, { name: newName });
         await models.apiSpec.updateOrCreateForParentId(newWorkspace._id, { fileName: newName });
 
@@ -67,7 +67,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
       submitName: 'Rename',
       selectText: true,
       label: 'Name',
-      onComplete: async fileName => {
+      onComplete: async (fileName) => {
         await models.apiSpec.update(apiSpec, { fileName });
       },
     });
@@ -88,7 +88,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
       message: messages.join(' '),
       yesText: 'Yes',
       noText: 'Cancel',
-      onDone: async isYes => {
+      onDone: async (isYes) => {
         if (!isYes) {
           return;
         }
@@ -110,7 +110,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
   }
 
   async _handlePluginClick(p: DocumentAction) {
-    this.setState(state => ({
+    this.setState((state) => ({
       loadingActions: {
         ...state.loadingActions,
         [p.label]: true,
@@ -134,7 +134,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
       });
     }
 
-    this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));
+    this.setState((state) => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));
     this._dropdown && this._dropdown.hide();
   }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
@@ -76,9 +76,9 @@ class EnvironmentsDropdown extends React.PureComponent<Props> {
     } = this.props;
 
     // NOTE: Base environment might not exist if the users hasn't managed environments yet.
-    const baseEnvironment = environments.find(e => e.parentId === workspace._id);
+    const baseEnvironment = environments.find((e) => e.parentId === workspace._id);
     const subEnvironments = environments
-      .filter(e => e.parentId === (baseEnvironment && baseEnvironment._id))
+      .filter((e) => e.parentId === (baseEnvironment && baseEnvironment._id))
       .sort((e1, e2) => e1.metaSortKey - e2.metaSortKey);
 
     let description;

--- a/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
@@ -177,7 +177,7 @@ class GitSyncDropdown extends React.PureComponent<Props, State> {
     const { gitRepository } = this.props;
     showModal(GitRepositorySettingsModal, {
       gitRepository,
-      onSubmitEdits: async patch => {
+      onSubmitEdits: async (patch) => {
         const { workspace } = this.props;
         const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(workspace._id);
 
@@ -228,7 +228,7 @@ class GitSyncDropdown extends React.PureComponent<Props, State> {
 
     const renderBtn =
       renderDropdownButton ||
-      (children => (
+      ((children) => (
         <DropdownButton className="btn btn--compact wide text-left overflow-hidden row-spaced">
           {children}
         </DropdownButton>

--- a/packages/insomnia-app/app/ui/components/dropdowns/grpc-method-dropdown/grpc-method-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/grpc-method-dropdown/grpc-method-dropdown.js
@@ -16,8 +16,8 @@ type Props = {
   disabled?: boolean,
   methods: Array<GrpcMethodDefinition>,
   selectedMethod?: GrpcMethodDefinition,
-  handleChange: string => Promise<void>,
-  handleChangeProtoFile: string => Promise<void>,
+  handleChange: (string) => Promise<void>,
+  handleChangeProtoFile: (string) => Promise<void>,
 };
 
 const NormalCase = styled.span`
@@ -49,7 +49,7 @@ const GrpcMethodDropdown = ({
           <DropdownItem disabled>No methods found</DropdownItem>
         </>
       )}
-      {Object.keys(groupedByPkg).map(pkgName => (
+      {Object.keys(groupedByPkg).map((pkgName) => (
         <React.Fragment key={pkgName}>
           <DropdownDivider
             children={pkgName !== NO_PACKAGE_KEY && <NormalCase>pkg: {pkgName}</NormalCase>}

--- a/packages/insomnia-app/app/ui/components/dropdowns/method-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/method-dropdown.js
@@ -35,11 +35,11 @@ class MethodDropdown extends PureComponent {
       label: 'Name',
       placeholder: 'CUSTOM',
       hints: recentMethods,
-      onDeleteHint: method => {
-        recentMethods = recentMethods.filter(m => m !== method);
+      onDeleteHint: (method) => {
+        recentMethods = recentMethods.filter((m) => m !== method);
         window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(recentMethods));
       },
-      onComplete: method => {
+      onComplete: (method) => {
         // Don't add empty methods
         if (!method) {
           return;
@@ -51,7 +51,7 @@ class MethodDropdown extends PureComponent {
         }
 
         // Save method as recent
-        recentMethods = recentMethods.filter(m => m !== method);
+        recentMethods = recentMethods.filter((m) => m !== method);
         recentMethods.unshift(method);
         window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(recentMethods));
 
@@ -84,7 +84,7 @@ class MethodDropdown extends PureComponent {
         <DropdownButton type="button" {...extraProps}>
           {buttonLabel} <i className="fa fa-caret-down" />
         </DropdownButton>
-        {constants.HTTP_METHODS.map(method => (
+        {constants.HTTP_METHODS.map((method) => (
           <DropdownItem
             key={method}
             className={`http-method-${method}`}

--- a/packages/insomnia-app/app/ui/components/dropdowns/preview-mode-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/preview-mode-dropdown.js
@@ -7,7 +7,7 @@ import { getPreviewModeName, PREVIEW_MODES } from '../../../common/constants';
 type Props = {|
   download: (pretty: boolean) => any,
   fullDownload: (pretty: boolean) => any,
-  updatePreviewMode: string => any,
+  updatePreviewMode: (string) => any,
   previewMode: string,
   showPrettifyOption?: boolean,
 |};

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.js
@@ -58,7 +58,7 @@ class RequestGroupActionsDropdown extends React.PureComponent<Props, State> {
     showPrompt({
       title: 'Rename Folder',
       defaultValue: requestGroup.name,
-      onComplete: name => {
+      onComplete: (name) => {
         models.requestGroup.update(requestGroup, { name });
       },
     });
@@ -100,7 +100,7 @@ class RequestGroupActionsDropdown extends React.PureComponent<Props, State> {
   }
 
   async _handlePluginClick(p: RequestGroupAction) {
-    this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: true } }));
+    this.setState((state) => ({ loadingActions: { ...state.loadingActions, [p.label]: true } }));
 
     try {
       const { activeEnvironment, requestGroup } = this.props;
@@ -123,7 +123,7 @@ class RequestGroupActionsDropdown extends React.PureComponent<Props, State> {
       });
     }
 
-    this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));
+    this.setState((state) => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));
     this._dropdown && this._dropdown.hide();
   }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.js
@@ -18,9 +18,9 @@ import { decompressObject } from '../../../common/misc';
 import type { Environment } from '../../../models/environment';
 
 type Props = {
-  handleSetActiveResponse: Response => Promise<void>,
+  handleSetActiveResponse: (Response) => Promise<void>,
   handleDeleteResponses: (requestId: string, environmentId: string | null) => Promise<void>,
-  handleDeleteResponse: Response => Promise<void>,
+  handleDeleteResponse: (Response) => Promise<void>,
   requestId: string,
   responses: Array<Response>,
   requestVersions: Array<RequestVersion>,
@@ -64,7 +64,7 @@ class ResponseHistoryDropdown extends React.PureComponent<Props> {
     const message =
       'Request will not be restored with this response because ' +
       'it was created before this ability was added';
-    const requestVersion = requestVersions.find(v => v._id === response.requestVersionId);
+    const requestVersion = requestVersions.find((v) => v._id === response.requestVersionId);
     const request = requestVersion ? decompressObject(requestVersion.compressedRequest) : null;
 
     return (
@@ -102,7 +102,7 @@ class ResponseHistoryDropdown extends React.PureComponent<Props> {
     const now = moment();
     // Four arrays for four time groups
     const categories = { minutes: [], hours: [], today: [], week: [], other: [] };
-    responses.forEach(r => {
+    responses.forEach((r) => {
       const resTime = moment(r.created);
       if (now.diff(resTime, 'minutes') < 5) {
         // Five minutes ago

--- a/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
@@ -89,7 +89,7 @@ class SyncDropdown extends React.PureComponent<Props, State> {
 
     if (!vcs.hasProject()) {
       const remoteProjects = await vcs.remoteProjects();
-      const matchedProjects = remoteProjects.filter(p => p.rootDocumentId === workspace._id);
+      const matchedProjects = remoteProjects.filter((p) => p.rootDocumentId === workspace._id);
       this.setState({ remoteProjects: matchedProjects });
       return;
     }
@@ -122,7 +122,7 @@ class SyncDropdown extends React.PureComponent<Props, State> {
   componentDidMount() {
     this.setState({ initializing: true });
     this.refreshMainAttributes()
-      .catch(err => console.log('[sync_menu] Error refreshing sync state', err))
+      .catch((err) => console.log('[sync_menu] Error refreshing sync state', err))
       .finally(() => this.setState({ initializing: false }));
 
     // Refresh but only if the user has been active in the last n minutes
@@ -146,7 +146,7 @@ class SyncDropdown extends React.PureComponent<Props, State> {
     // Update if new sync items
     if (syncItems !== prevProps.syncItems) {
       if (vcs.hasProject()) {
-        vcs.status(syncItems, {}).then(status => {
+        vcs.status(syncItems, {}).then((status) => {
           this.setState({ status });
         });
       }
@@ -307,7 +307,7 @@ class SyncDropdown extends React.PureComponent<Props, State> {
         // It will result in the workspace getting deleted
         // So we filter out the workspace from the delta to prevent this
         if (!defaultBranchHistoryCount && historyCount) {
-          delta.remove = delta.remove.filter(e => e.type !== models.workspace.type);
+          delta.remove = delta.remove.filter((e) => e.type !== models.workspace.type);
         }
       }
 
@@ -445,7 +445,7 @@ class SyncDropdown extends React.PureComponent<Props, State> {
     const canCreateSnapshot =
       Object.keys(status.stage).length > 0 || Object.keys(status.unstaged).length > 0;
 
-    const visibleBranches = localBranches.filter(b => !b.match(/\.hidden$/));
+    const visibleBranches = localBranches.filter((b) => !b.match(/\.hidden$/));
 
     const syncMenuHeader = (
       <DropdownDivider>
@@ -485,7 +485,7 @@ class SyncDropdown extends React.PureComponent<Props, State> {
                 <i className="fa fa-plus-circle" /> Create Local Project
               </DropdownItem>
             )}
-            {remoteProjects.map(p => (
+            {remoteProjects.map((p) => (
               <DropdownItem key={p.id} onClick={() => this._handleSetProject(p)}>
                 <i className="fa fa-cloud-download" /> Pull <strong>{p.name}</strong>
               </DropdownItem>

--- a/packages/insomnia-app/app/ui/components/dropdowns/sync-legacy-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/sync-legacy-dropdown.js
@@ -106,7 +106,7 @@ class SyncLegacyDropdown extends React.PureComponent<Props, State> {
 
   async _handleShowSyncModePrompt() {
     showModal(SetupSyncModal, {
-      onSelectSyncMode: async syncMode => {
+      onSelectSyncMode: async (syncMode) => {
         await this._reloadData();
       },
     });

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
@@ -71,7 +71,7 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
   };
 
   async _handlePluginClick(p: WorkspaceAction) {
-    this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: true } }));
+    this.setState((state) => ({ loadingActions: { ...state.loadingActions, [p.label]: true } }));
 
     const { activeEnvironment, activeWorkspace } = this.props;
 
@@ -86,8 +86,10 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
       };
 
       const docs = await db.withDescendants(activeWorkspace);
-      const requests: any = docs.filter(d => d.type === models.request.type && !(d: any).isPrivate);
-      const requestGroups: any = docs.filter(d => d.type === models.requestGroup.type);
+      const requests: any = docs.filter(
+        (d) => d.type === models.request.type && !(d: any).isPrivate,
+      );
+      const requestGroups: any = docs.filter((d) => d.type === models.requestGroup.type);
 
       await p.action(context, { requestGroups, requests, workspace: activeWorkspace });
     } catch (err) {
@@ -97,7 +99,7 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
       });
     }
 
-    this.setState(state => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));
+    this.setState((state) => ({ loadingActions: { ...state.loadingActions, [p.label]: false } }));
     this._dropdown && this._dropdown.hide();
   }
 
@@ -140,7 +142,7 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
       throw new Error('VCS is not defined');
     }
 
-    this.setState(state => ({
+    this.setState((state) => ({
       pullingProjects: { ...state.pullingProjects, [project.id]: true },
     }));
 
@@ -187,7 +189,7 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
       });
     }
 
-    this.setState(state => ({
+    this.setState((state) => ({
       pullingProjects: { ...state.pullingProjects, [project.id]: false },
     }));
   }
@@ -226,7 +228,7 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
       defaultValue: 'My Workspace',
       submitName: 'Create',
       selectText: true,
-      onComplete: async name => {
+      onComplete: async (name) => {
         const workspace = await models.workspace.create({ name });
         this.props.handleSetActiveWorkspace(workspace._id);
       },
@@ -266,8 +268,8 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
     const { remoteProjects, localProjects, pullingProjects } = this.state;
 
     const missingRemoteProjects = remoteProjects.filter(({ id, rootDocumentId }) => {
-      const localProjectExists = localProjects.find(p => p.id === id);
-      const workspaceExists = workspaces.find(w => w._id === rootDocumentId);
+      const localProjectExists = localProjects.find((p) => p.id === id);
+      const workspaceExists = workspaces.find((w) => w._id === rootDocumentId);
 
       // Mark as missing if:
       //   - the project doesn't yet exists locally
@@ -276,9 +278,9 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
     });
 
     const nonActiveWorkspaces = workspaces
-      .filter(w => w._id !== activeWorkspace._id)
+      .filter((w) => w._id !== activeWorkspace._id)
       .sort((w1, w2) => w1.name.localeCompare(w2.name));
-    const addedWorkspaceNames = unseenWorkspaces.map(w => `"${w.name}"`).join(', ');
+    const addedWorkspaceNames = unseenWorkspaces.map((w) => `"${w.name}"`).join(', ');
     const classes = classnames(className, 'wide', 'workspace-dropdown');
 
     const unseenWorkspacesMessage = (
@@ -326,8 +328,8 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
 
           <DropdownDivider>Switch Workspace</DropdownDivider>
 
-          {nonActiveWorkspaces.map(w => {
-            const isUnseen = !!unseenWorkspaces.find(v => v._id === w._id);
+          {nonActiveWorkspaces.map((w) => {
+            const isUnseen = !!unseenWorkspaces.find((v) => v._id === w._id);
             return (
               <DropdownItem key={w._id} onClick={handleSetActiveWorkspace} value={w._id}>
                 <i className="fa fa-random" /> To <strong>{w.name}</strong>
@@ -354,7 +356,7 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
             </DropdownDivider>
           )}
 
-          {missingRemoteProjects.map(p => (
+          {missingRemoteProjects.map((p) => (
             <DropdownItem
               key={p.id}
               stayOpenAfterClick

--- a/packages/insomnia-app/app/ui/components/editors/__tests__/environment-editor.test.js
+++ b/packages/insomnia-app/app/ui/components/editors/__tests__/environment-editor.test.js
@@ -3,15 +3,15 @@ import { ensureKeyIsValid } from '../environment-editor';
 import { NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME } from '../../../../templating';
 
 describe('ensureKeyIsValid', () => {
-  it.each(['$', '$a', '$ab'])('%s should be invalid when as key begins with $', key => {
+  it.each(['$', '$a', '$ab'])('%s should be invalid when as key begins with $', (key) => {
     expect(ensureKeyIsValid(key)).toBe(`"${key}" cannot begin with '$' or contain a '.'`);
   });
 
-  it.each(['.', 'a.', '.a', 'a.b'])('%s should be invalid when key contains .', key => {
+  it.each(['.', 'a.', '.a', 'a.b'])('%s should be invalid when key contains .', (key) => {
     expect(ensureKeyIsValid(key)).toBe(`"${key}" cannot begin with '$' or contain a '.'`);
   });
 
-  it.each(['$a.b', '$.'])('%s should be invalid when key starts with $ and contains .', key => {
+  it.each(['$a.b', '$.'])('%s should be invalid when key starts with $ and contains .', (key) => {
     expect(ensureKeyIsValid(key)).toBe(`"${key}" cannot begin with '$' or contain a '.'`);
   });
 
@@ -21,7 +21,10 @@ describe('ensureKeyIsValid', () => {
     expect(ensureKeyIsValid(name)).toBe(`"${name}" is a reserved key`);
   });
 
-  it.each(['a', 'ab', 'a$', 'a$b', 'a-b', `a${name}b`, `${name}ab`])('%s should be valid', key => {
-    expect(ensureKeyIsValid(key)).toBe(null);
-  });
+  it.each(['a', 'ab', 'a$', 'a$b', 'a-b', `a${name}b`, `${name}ab`])(
+    '%s should be valid',
+    (key) => {
+      expect(ensureKeyIsValid(key)).toBe(null);
+    },
+  );
 });

--- a/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.js
@@ -53,15 +53,15 @@ class AsapAuth extends React.PureComponent<Props> {
   }
 
   renderAsapAuthenticationFields(): React.Node {
-    const asapIssuer = this.renderTextInput('Issuer (iss)', 'issuer', 'text/plain', value =>
+    const asapIssuer = this.renderTextInput('Issuer (iss)', 'issuer', 'text/plain', (value) =>
       this._handleChangeProperty('issuer', value),
     );
 
-    const asapSubject = this.renderTextInput('Subject (sub)', 'subject', 'text/plain', value =>
+    const asapSubject = this.renderTextInput('Subject (sub)', 'subject', 'text/plain', (value) =>
       this._handleChangeProperty('subject', value),
     );
 
-    const asapAudience = this.renderTextInput('Audience (aud)', 'audience', 'text/plain', value =>
+    const asapAudience = this.renderTextInput('Audience (aud)', 'audience', 'text/plain', (value) =>
       this._handleChangeProperty('audience', value),
     );
 
@@ -69,10 +69,10 @@ class AsapAuth extends React.PureComponent<Props> {
       'Additional Claims',
       'additionalClaims',
       'application/json',
-      value => this._handleChangeProperty('additionalClaims', value),
+      (value) => this._handleChangeProperty('additionalClaims', value),
     );
 
-    const asapKeyId = this.renderTextInput('Key ID (kid)', 'keyId', 'text/plain', value =>
+    const asapKeyId = this.renderTextInput('Key ID (kid)', 'keyId', 'text/plain', (value) =>
       this._handleChangeProperty('keyId', value),
     );
 

--- a/packages/insomnia-app/app/ui/components/editors/auth/aws-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/aws-auth.js
@@ -14,9 +14,9 @@ type Props = {
   showPasswords: boolean,
   isVariableUncovered: boolean,
   onChange: (Request, RequestAuthentication) => Promise<Request>,
-  handleRender: string => Promise<string>,
+  handleRender: (string) => Promise<string>,
   handleGetRenderContext: () => Promise<Object>,
-  handleUpdateSettingsShowPasswords: boolean => Promise<Settings>,
+  handleUpdateSettingsShowPasswords: (boolean) => Promise<Settings>,
 };
 
 @autobind

--- a/packages/insomnia-app/app/ui/components/editors/auth/basic-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/basic-auth.js
@@ -11,7 +11,7 @@ import HelpTooltip from '../../help-tooltip';
 type Props = {
   handleRender: Function,
   handleGetRenderContext: Function,
-  handleUpdateSettingsShowPasswords: boolean => Promise<Settings>,
+  handleUpdateSettingsShowPasswords: (boolean) => Promise<Settings>,
   nunjucksPowerUserMode: boolean,
   onChange: (Request, RequestAuthentication) => Promise<Request>,
   request: Request,

--- a/packages/insomnia-app/app/ui/components/editors/auth/digest-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/digest-auth.js
@@ -11,7 +11,7 @@ import type { Request, RequestAuthentication } from '../../../../models/request'
 type Props = {
   handleRender: Function,
   handleGetRenderContext: Function,
-  handleUpdateSettingsShowPasswords: boolean => Promise<Settings>,
+  handleUpdateSettingsShowPasswords: (boolean) => Promise<Settings>,
   nunjucksPowerUserMode: boolean,
   onChange: (Request, RequestAuthentication) => Promise<Request>,
   request: Request,

--- a/packages/insomnia-app/app/ui/components/editors/auth/ntlm-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/ntlm-auth.js
@@ -10,7 +10,7 @@ import type { Settings } from '../../../../models/settings';
 type Props = {
   handleRender: Function,
   handleGetRenderContext: Function,
-  handleUpdateSettingsShowPasswords: boolean => Promise<Settings>,
+  handleUpdateSettingsShowPasswords: (boolean) => Promise<Settings>,
   nunjucksPowerUserMode: boolean,
   onChange: (Request, RequestAuthentication) => Promise<Request>,
   request: Request,

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.js
@@ -123,7 +123,7 @@ class OAuth1Auth extends React.PureComponent<Props> {
     label: string,
     property: string,
     help: string,
-    onChange: boolean => void,
+    onChange: (boolean) => void,
   ): React.Element<*> {
     const { request } = this.props;
     const { authentication } = request;
@@ -154,7 +154,7 @@ class OAuth1Auth extends React.PureComponent<Props> {
     );
   }
 
-  renderEnabledRow(onChange: boolean => void): React.Element<*> {
+  renderEnabledRow(onChange: (boolean) => void): React.Element<*> {
     const { request } = this.props;
     const { authentication } = request;
     return (

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
@@ -32,7 +32,7 @@ import { initNewOAuthSession } from '../../../../network/o-auth-2/misc';
 type Props = {
   handleRender: Function,
   handleGetRenderContext: Function,
-  handleUpdateSettingsShowPasswords: boolean => Promise<Settings>,
+  handleUpdateSettingsShowPasswords: (boolean) => Promise<Settings>,
   nunjucksPowerUserMode: boolean,
   onChange: (Request, RequestAuthentication) => Promise<Request>,
   request: Request,
@@ -210,7 +210,7 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
     this._handleChangeProperty('grantType', e.currentTarget.value);
   }
 
-  renderEnabledRow(onChange: boolean => void): React.Element<*> {
+  renderEnabledRow(onChange: (boolean) => void): React.Element<*> {
     const { request } = this.props;
     const { authentication } = request;
     return (
@@ -240,7 +240,7 @@ class OAuth2Auth extends React.PureComponent<Props, State> {
     );
   }
 
-  renderUsePkceRow(onChange: boolean => void): React.Element<*> {
+  renderUsePkceRow(onChange: (boolean) => void): React.Element<*> {
     const { request } = this.props;
     const { authentication } = request;
     return (

--- a/packages/insomnia-app/app/ui/components/editors/body/body-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/body-editor.js
@@ -103,7 +103,7 @@ class BodyEditor extends React.PureComponent<Props> {
             <span className="monospace">{newContentType}</span>?
           </p>
         ),
-        onDone: saidYes => {
+        onDone: (saidYes) => {
           if (saidYes) {
             onChangeHeaders(newRequest, headers);
           }

--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
@@ -188,7 +188,7 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
       return null;
     }
 
-    const disabledDefinitions = _documentAST.definitions.filter(d => {
+    const disabledDefinitions = _documentAST.definitions.filter((d) => {
       const name = d.name ? d.name.value : null;
       return d.kind === 'OperationDefinition' && name !== operationName;
     });
@@ -199,7 +199,7 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
     }
 
     // Add "Unhighlight" markers
-    this._disabledOperationMarkers = disabledDefinitions.map(definition => {
+    this._disabledOperationMarkers = disabledDefinitions.map((definition) => {
       const { startToken, endToken } = definition.loc;
 
       const from = {
@@ -378,7 +378,7 @@ class GraphQLEditor extends React.PureComponent<Props, State> {
       return [];
     }
 
-    return this._documentAST.definitions.filter(def => def.kind === 'OperationDefinition');
+    return this._documentAST.definitions.filter((def) => def.kind === 'OperationDefinition');
   }
 
   _setDocumentAST(query: string) {

--- a/packages/insomnia-app/app/ui/components/editors/grpc-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/grpc-editor.js
@@ -5,11 +5,11 @@ import type { Settings } from '../../../models/settings';
 
 type Props = {
   content: string,
-  handleChange: string => Promise<void>,
+  handleChange: (string) => Promise<void>,
   settings: Settings,
   readOnly: boolean,
 
-  handleRender?: string => Promise<string>,
+  handleRender?: (string) => Promise<string>,
   isVariableUncovered?: boolean,
   handleGetRenderContext?: Function,
 };

--- a/packages/insomnia-app/app/ui/components/export-requests/tree.js
+++ b/packages/insomnia-app/app/ui/components/export-requests/tree.js
@@ -38,7 +38,7 @@ class Tree extends React.PureComponent<Props> {
       return null;
     }
 
-    const children = node.children.map(child => this.renderChildren(child));
+    const children = node.children.map((child) => this.renderChildren(child));
 
     // Directly cast to RequestGroup will result in error, so cast it to any first.
     const requestGroup: RequestGroup = ((node.doc: any): RequestGroup);

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-field.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-field.js
@@ -37,7 +37,7 @@ class GraphQLExplorerField extends React.PureComponent<Props> {
       <React.Fragment>
         <h2 className="graphql-explorer__subheading">Arguments</h2>
         <ul className="graphql-explorer__defs">
-          {field.args.map(a => {
+          {field.args.map((a) => {
             return (
               <li key={a.name}>
                 <span className="info">{a.name}</span>:{' '}

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type.js
@@ -61,7 +61,7 @@ class GraphQLExplorerType extends React.PureComponent<Props> {
       <React.Fragment>
         <h2 className="graphql-explorer__subheading">{title}</h2>
         <ul className="graphql-explorer__defs">
-          {types.map(type => (
+          {types.map((type) => (
             <li key={type.name}>
               <GraphQLExplorerTypeLink onNavigate={onNavigateType} type={type} />
             </li>
@@ -85,7 +85,7 @@ class GraphQLExplorerType extends React.PureComponent<Props> {
       <React.Fragment>
         <h2 className="graphql-explorer__subheading">Fields</h2>
         <ul className="graphql-explorer__defs">
-          {fieldKeys.map(key => {
+          {fieldKeys.map((key) => {
             const field: GraphQLField<any, any> = (fields[key]: any);
 
             let argLinks = null;
@@ -94,7 +94,7 @@ class GraphQLExplorerType extends React.PureComponent<Props> {
               argLinks = (
                 <React.Fragment>
                   (
-                  {args.map(a => (
+                  {args.map((a) => (
                     <div key={a.name} className="graphql-explorer__defs__arg">
                       <span className="info">{a.name}</span>:{' '}
                       <GraphQLExplorerTypeLink onNavigate={onNavigateType} type={a.type} />

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer.js
@@ -113,7 +113,7 @@ class GraphQLExplorer extends React.PureComponent<Props, State> {
         <a
           href="#"
           className="graphql-explorer__header__back-btn"
-          onClick={e => {
+          onClick={(e) => {
             e.preventDefault();
             this._handlePopHistory();
           }}>
@@ -140,7 +140,7 @@ class GraphQLExplorer extends React.PureComponent<Props, State> {
       <a
         href="#"
         className="graphql-explorer__header__back-btn"
-        onClick={e => {
+        onClick={(e) => {
           e.preventDefault();
           this._handlePopHistory();
         }}>

--- a/packages/insomnia-app/app/ui/components/key-value-editor/editor.js
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/editor.js
@@ -40,7 +40,7 @@ class Editor extends PureComponent {
       pairs: pairs,
 
       // If any pair has a description, display description field
-      displayDescription: props.pairs.some(p => p.description),
+      displayDescription: props.pairs.some((p) => p.description),
     };
   }
 
@@ -72,8 +72,8 @@ class Editor extends PureComponent {
       return;
     }
 
-    const withoutPair = this.state.pairs.filter(p => p.id !== pairToMove.id);
-    let toIndex = withoutPair.findIndex(p => p.id === pairToTarget.id);
+    const withoutPair = this.state.pairs.filter((p) => p.id !== pairToMove.id);
+    let toIndex = withoutPair.findIndex((p) => p.id === pairToTarget.id);
 
     // If we're moving below, add 1 to the index
     if (targetOffset < 0) {
@@ -90,7 +90,7 @@ class Editor extends PureComponent {
   }
 
   _handlePairDelete(pair) {
-    const i = this.state.pairs.findIndex(p => p.id === pair.id);
+    const i = this.state.pairs.findIndex((p) => p.id === pair.id);
     this._deletePair(i, true);
   }
 
@@ -322,7 +322,7 @@ class Editor extends PureComponent {
 
   _getPairIndex(pair) {
     if (pair) {
-      return this.state.pairs.findIndex(p => p.id === pair.id);
+      return this.state.pairs.findIndex((p) => p.id === pair.id);
     } else {
       return -1;
     }
@@ -333,7 +333,7 @@ class Editor extends PureComponent {
   }
 
   _getFocusedPair() {
-    return this.state.pairs.find(p => p.id === this._focusedPairId) || null;
+    return this.state.pairs.find((p) => p.id === this._focusedPairId) || null;
   }
 
   _setFocusedPair(pair) {

--- a/packages/insomnia-app/app/ui/components/key-value-editor/row.js
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/row.js
@@ -186,7 +186,7 @@ class KeyValueEditorRow extends PureComponent {
       onChange: this._handleValueChange,
       enableRender: handleRender || handleGetRenderContext,
       mode: pair.multiline || 'text/plain',
-      onModeChange: mode => {
+      onModeChange: (mode) => {
         this._handleTypeChange(Object.assign({}, pair, { multiline: mode }));
       },
     });

--- a/packages/insomnia-app/app/ui/components/modals/alert-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/alert-modal.js
@@ -56,7 +56,7 @@ class AlertModal extends PureComponent {
 
     this._okCallback2 = onConfirm;
 
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       this._okCallback = resolve;
     });
   }

--- a/packages/insomnia-app/app/ui/components/modals/ask-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/ask-modal.js
@@ -69,7 +69,7 @@ class AskModal extends PureComponent {
       this.yesButton && this.yesButton.focus();
     }, 100);
 
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       this._promiseCallback = resolve;
     });
   }

--- a/packages/insomnia-app/app/ui/components/modals/code-prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/code-prompt-modal.js
@@ -185,7 +185,7 @@ class CodePromptModal extends PureComponent {
                 <i className="fa fa-caret-down space-left" />
               </DropdownButton>
               <DropdownDivider>Editor Syntax</DropdownDivider>
-              {Object.keys(MODES).map(mode => (
+              {Object.keys(MODES).map((mode) => (
                 <DropdownItem key={mode} value={mode} onClick={this._handleChangeMode}>
                   <i className="fa fa-code" />
                   {MODES[mode]}

--- a/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.js
@@ -53,7 +53,7 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
     cookie = cookie[0] || cookie;
 
     const { cookieJar } = this.props;
-    const oldCookie = cookieJar.cookies.find(c => c.id === cookie.id);
+    const oldCookie = cookieJar.cookies.find((c) => c.id === cookie.id);
 
     if (!oldCookie) {
       // Cookie not found in jar
@@ -120,7 +120,7 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
     const cookieJar = clone(this.props.cookieJar);
 
     const { cookies } = cookieJar;
-    const index = cookies.findIndex(c => c.id === cookie.id);
+    const index = cookies.findIndex((c) => c.id === cookie.id);
 
     if (index < 0) {
       console.warn(`Could not find cookie with id=${cookie.id} to edit`);
@@ -206,7 +206,7 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
             nunjucksPowerUserMode={nunjucksPowerUserMode}
             isVariableUncovered={isVariableUncovered}
             defaultValue={val || ''}
-            onChange={value => this._handleChange(field, value)}
+            onChange={(value) => this._handleChange(field, value)}
           />
         </label>
       </div>
@@ -259,7 +259,7 @@ class CookieModifyModal extends React.PureComponent<Props, State> {
                           type="checkbox"
                           name={field}
                           defaultChecked={checked || false}
-                          onChange={e => this._handleChange(field, e)}
+                          onChange={(e) => this._handleChange(field, e)}
                         />
                       </label>
                     );

--- a/packages/insomnia-app/app/ui/components/modals/cookies-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/cookies-modal.js
@@ -70,7 +70,7 @@ class CookiesModal extends PureComponent<Props, State> {
     const { cookies } = cookieJar;
 
     // NOTE: This is sketchy because it relies on the same reference
-    cookieJar.cookies = cookies.filter(c => c.id !== cookie.id);
+    cookieJar.cookies = cookies.filter((c) => c.id !== cookie.id);
 
     await this._saveChanges();
   }

--- a/packages/insomnia-app/app/ui/components/modals/error-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/error-modal.js
@@ -48,7 +48,7 @@ class ErrorModal extends PureComponent<{}, ErrorModalOptions> {
 
     console.log('[ErrorModal]', error);
 
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       this._okCallback = resolve;
     });
   }

--- a/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
@@ -80,9 +80,9 @@ class ExportRequestsModal extends PureComponent<Props, State> {
 
   createTree() {
     const { childObjects } = this.props;
-    const children: Array<Node> = childObjects.map(child => this.createNode(child));
+    const children: Array<Node> = childObjects.map((child) => this.createNode(child));
     const totalRequests = children
-      .map(child => child.totalRequests)
+      .map((child) => child.totalRequests)
       .reduce((acc, totalRequests) => acc + totalRequests, 0);
     const rootFolder: RequestGroup = Object.assign({}, models.requestGroup.init(), {
       _id: 'all',
@@ -104,9 +104,9 @@ class ExportRequestsModal extends PureComponent<Props, State> {
   }
 
   createNode(item: Object): Node {
-    const children: Array<Node> = item.children.map(child => this.createNode(child));
+    const children: Array<Node> = item.children.map((child) => this.createNode(child));
     let totalRequests = children
-      .map(child => child.totalRequests)
+      .map((child) => child.totalRequests)
       .reduce((acc, totalRequests) => acc + totalRequests, 0);
 
     const docIsRequest = isRequest(item.doc) || isGrpcRequest(item.doc);
@@ -181,7 +181,7 @@ class ExportRequestsModal extends PureComponent<Props, State> {
       const found = this.setItemSelected(child, isSelected, id);
       if (found) {
         node.selectedRequests = node.children
-          .map(ch => ch.selectedRequests)
+          .map((ch) => ch.selectedRequests)
           .reduce((acc, selected) => acc + selected, 0);
         return true;
       }

--- a/packages/insomnia-app/app/ui/components/modals/generate-code-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/generate-code-modal.js
@@ -12,8 +12,8 @@ import ModalFooter from '../base/modal-footer';
 import { exportHarRequest } from '../../../common/har';
 import Link from '../base/link';
 
-const DEFAULT_TARGET = availableTargets().find(t => t.key === 'shell');
-const DEFAULT_CLIENT = DEFAULT_TARGET.clients.find(t => t.key === 'curl');
+const DEFAULT_TARGET = availableTargets().find((t) => t.key === 'shell');
+const DEFAULT_CLIENT = DEFAULT_TARGET.clients.find((t) => t.key === 'curl');
 const MODE_MAP = {
   c: 'clike',
   java: 'clike',
@@ -76,13 +76,15 @@ class GenerateCodeModal extends PureComponent {
       return;
     }
 
-    const client = target.clients.find(c => c.key === target.default);
+    const client = target.clients.find((c) => c.key === target.default);
     this._generateCode(this.state.request, target, client);
   }
 
   async _generateCode(request, target, client) {
     // Some clients need a content-length for the request to succeed
-    const addContentLength = (TO_ADD_CONTENT_LENGTH[target.key] || []).find(c => c === client.key);
+    const addContentLength = (TO_ADD_CONTENT_LENGTH[target.key] || []).find(
+      (c) => c === client.key,
+    );
 
     const { environmentId } = this.props;
     const har = await exportHarRequest(request._id, environmentId, addContentLength);
@@ -130,7 +132,7 @@ class GenerateCodeModal extends PureComponent {
                 {target ? target.title : 'n/a'}
                 <i className="fa fa-caret-down" />
               </DropdownButton>
-              {targets.map(target => (
+              {targets.map((target) => (
                 <DropdownItem key={target.key} onClick={this._handleTargetChange} value={target}>
                   {target.title}
                 </DropdownItem>
@@ -142,7 +144,7 @@ class GenerateCodeModal extends PureComponent {
                 {client ? client.title : 'n/a'}
                 <i className="fa fa-caret-down" />
               </DropdownButton>
-              {clients.map(client => (
+              {clients.map((client) => (
                 <DropdownItem key={client.key} onClick={this._handleClientChange} value={client}>
                   {client.title}
                 </DropdownItem>

--- a/packages/insomnia-app/app/ui/components/modals/git-branches-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-branches-modal.js
@@ -173,7 +173,7 @@ class GitBranchesModal extends React.PureComponent<Props, State> {
   render() {
     const { branch: currentBranch, branches, remoteBranches, newBranchName, error } = this.state;
 
-    const remoteOnlyBranches = remoteBranches.filter(b => !branches.includes(b));
+    const remoteOnlyBranches = remoteBranches.filter((b) => !branches.includes(b));
 
     return (
       <Modal ref={this._setModalRef} onHide={this._handleHide}>
@@ -218,7 +218,7 @@ class GitBranchesModal extends React.PureComponent<Props, State> {
                 </tr>
               </thead>
               <tbody>
-                {branches.map(name => (
+                {branches.map((name) => (
                   <tr key={name} className="table--no-outline-row">
                     <td>
                       <span className={classnames({ bold: name === currentBranch })}>{name}</span>
@@ -264,7 +264,7 @@ class GitBranchesModal extends React.PureComponent<Props, State> {
                   </tr>
                 </thead>
                 <tbody>
-                  {remoteOnlyBranches.map(name => (
+                  {remoteOnlyBranches.map((name) => (
                     <tr key={name} className="table--no-outline-row">
                       <td>{name}</td>
                       <td className="text-right">

--- a/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
@@ -49,7 +49,7 @@ class GitRepositorySettingsModal extends React.PureComponent<Props, State> {
 
   async _handleInputChange(e: SyntheticEvent<HTMLInputElement>) {
     const { name, value } = e.currentTarget;
-    this.setState(state => ({
+    this.setState((state) => ({
       inputs: { ...state.inputs, [name]: value },
     }));
   }
@@ -105,7 +105,7 @@ class GitRepositorySettingsModal extends React.PureComponent<Props, State> {
     this.hide();
   }
 
-  show(options: { gitRepository: GitRepository | null, onSubmitEdits: GitRepository => any }) {
+  show(options: { gitRepository: GitRepository | null, onSubmitEdits: (GitRepository) => any }) {
     this._onSubmitEdits = options.onSubmitEdits;
 
     const { gitRepository } = options;

--- a/packages/insomnia-app/app/ui/components/modals/git-staging-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-staging-modal.js
@@ -106,7 +106,7 @@ class GitStagingModal extends React.PureComponent<Props, State> {
   }
 
   async _toggleAll(items: Array<Item>, forceAdd: boolean = false) {
-    const allStaged = items.every(i => i.staged);
+    const allStaged = items.every((i) => i.staged);
     const doStage = !allStaged;
 
     const newItems = { ...this.state.items };
@@ -277,7 +277,7 @@ class GitStagingModal extends React.PureComponent<Props, State> {
   async _handleRollback(items: Array<Item>) {
     const { vcs } = this.props;
 
-    const files = items.map(i => ({ filePath: i.path, status: i.status }));
+    const files = items.map((i) => ({ filePath: i.path, status: i.status }));
 
     await gitRollback(vcs, files);
     await this._refresh();
@@ -322,8 +322,8 @@ class GitStagingModal extends React.PureComponent<Props, State> {
       return null;
     }
 
-    const allStaged = items.every(i => i.staged);
-    const allUnstaged = items.every(i => !i.staged);
+    const allStaged = items.every((i) => i.staged);
+    const allUnstaged = items.every((i) => !i.staged);
 
     return (
       <div className="pad-top">
@@ -372,8 +372,8 @@ class GitStagingModal extends React.PureComponent<Props, State> {
   _renderItems(items: Array<Item>) {
     const { message } = this.state;
 
-    const newItems = items.filter(i => i.status.includes('added'));
-    const existingItems = items.filter(i => !i.status.includes('added'));
+    const newItems = items.filter((i) => i.status.includes('added'));
+    const existingItems = items.filter((i) => !i.status.includes('added'));
 
     return (
       <>
@@ -396,7 +396,7 @@ class GitStagingModal extends React.PureComponent<Props, State> {
   render() {
     const { items, branch, loading } = this.state;
 
-    const itemsList = Object.keys(items).map(k => items[k]);
+    const itemsList = Object.keys(items).map((k) => items[k]);
     const hasChanges = !!itemsList.length;
 
     return (

--- a/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
@@ -92,7 +92,7 @@ class MoveRequestGroupModal extends React.PureComponent<Props, State> {
                 <HelpTooltip>Folder will be moved to the root of the new workspace</HelpTooltip>
                 <select onChange={this._handleChangeSelectedWorkspace} value={selectedWorkspaceId}>
                   <option value="n/a">-- Select Workspace --</option>
-                  {workspaces.map(w =>
+                  {workspaces.map((w) =>
                     w._id === activeWorkspace._id ? null : (
                       <option key={w._id} value={w._id}>
                         {w.name}

--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
@@ -79,7 +79,7 @@ class PromptModal extends React.PureComponent<Props, State> {
   _handleDeleteHint(hint: string) {
     const { onDeleteHint } = this.state;
     onDeleteHint && onDeleteHint(hint);
-    const hints = this.state.hints.filter(h => h !== hint);
+    const hints = this.state.hints.filter((h) => h !== hint);
     this.setState({ hints });
   }
 
@@ -116,11 +116,11 @@ class PromptModal extends React.PureComponent<Props, State> {
     cancelable?: boolean,
     inputType?: string,
     placeholder?: string,
-    validate?: string => string,
+    validate?: (string) => string,
     label?: string,
     hints?: Array<string>,
-    onComplete?: string => void,
-    onDeleteHint?: string => void,
+    onComplete?: (string) => void,
+    onDeleteHint?: (string) => void,
     onCancel?: () => void,
   }) {
     const {

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -31,7 +31,7 @@ type State = {|
 
 type ProtoFilesModalOptions = {|
   preselectProtoFileId?: string,
-  onSave: string => Promise<void>,
+  onSave: (string) => Promise<void>,
 |};
 
 const INITIAL_STATE: State = {
@@ -43,7 +43,7 @@ const spinner = <i className="fa fa-spin fa-refresh" />;
 @autobind
 class ProtoFilesModal extends React.PureComponent<Props, State> {
   modal: Modal | null;
-  onSave: (string => Promise<void>) | null;
+  onSave: ((string) => Promise<void>) | null;
 
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
@@ -22,7 +22,7 @@ import ProtoFilesModal from './proto-files-modal';
 
 type RequestCreateModalOptions = {
   parentId: string,
-  onComplete: string => void,
+  onComplete: (string) => void,
 };
 
 @autobind

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
@@ -194,9 +194,9 @@ class RequestSettingsModal extends React.PureComponent<Props, State> {
 
     // Find workspaces for use with moving workspace
     const ancestors = await db.withAncestors(request);
-    const doc = ancestors.find(doc => doc.type === models.workspace.type);
+    const doc = ancestors.find((doc) => doc.type === models.workspace.type);
     const workspaceId = doc ? doc._id : 'should-never-happen';
-    const workspace = workspaces.find(w => w._id === workspaceId);
+    const workspace = workspaces.find((w) => w._id === workspaceId);
 
     this.setState(
       {
@@ -394,7 +394,7 @@ class RequestSettingsModal extends React.PureComponent<Props, State> {
               value={activeWorkspaceIdToCopyTo || '__NULL__'}
               onChange={this._handleUpdateMoveCopyWorkspace}>
               <option value="__NULL__">-- Select Workspace --</option>
-              {workspaces.map(w => {
+              {workspaces.map((w) => {
                 if (workspace && workspace._id === w._id) {
                   return null;
                 }

--- a/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.js
@@ -167,8 +167,8 @@ class RequestSwitcherModal extends React.PureComponent<Props, State> {
   /** Return array of path segments for given request or folder */
   _groupOf(requestOrRequestGroup: BaseModel): Array<string> {
     const { workspaceChildren } = this.props;
-    const requestGroups = workspaceChildren.filter(d => d.type === models.requestGroup.type);
-    const matchedGroups = requestGroups.filter(g => g._id === requestOrRequestGroup.parentId);
+    const requestGroups = workspaceChildren.filter((d) => d.type === models.requestGroup.type);
+    const matchedGroups = requestGroups.filter((g) => g._id === requestOrRequestGroup.parentId);
     const currentGroupName =
       requestOrRequestGroup.type === models.requestGroup.type
         ? `${(requestOrRequestGroup: any).name}`
@@ -226,7 +226,7 @@ class RequestSwitcherModal extends React.PureComponent<Props, State> {
 
     // OPTIMIZATION: This only filters if we have a filter
     let matchedRequests = workspaceChildren
-      .filter(d => d.type === models.request.type)
+      .filter((d) => d.type === models.request.type)
       .sort((a, b) => {
         const aLA = lastActiveMap[a._id] || 0;
         const bLA = lastActiveMap[b._id] || 0;
@@ -240,23 +240,23 @@ class RequestSwitcherModal extends React.PureComponent<Props, State> {
       });
 
     if (hideNeverActiveRequests) {
-      matchedRequests = matchedRequests.filter(r => lastActiveMap[r._id]);
+      matchedRequests = matchedRequests.filter((r) => lastActiveMap[r._id]);
     }
 
     if (searchString) {
       matchedRequests = matchedRequests
-        .map(r => ({
+        .map((r) => ({
           request: r,
           score: this._isMatch((r: any), searchString),
         }))
-        .filter(v => v.score !== null)
+        .filter((v) => v.score !== null)
         .sort((a, b) => (a.score || -Infinity) - (b.score || -Infinity))
-        .map(v => v.request);
+        .map((v) => v.request);
     }
 
     const matchedWorkspaces = workspaces
-      .filter(w => w._id !== workspace._id)
-      .filter(w => {
+      .filter((w) => w._id !== workspace._id)
+      .filter((w) => {
         const name = w.name.toLowerCase();
         const toMatch = searchString.toLowerCase();
         return name.indexOf(toMatch) !== -1;
@@ -265,7 +265,9 @@ class RequestSwitcherModal extends React.PureComponent<Props, State> {
     // Make sure we select the first item but we don't want to select the currently active
     // one because that wouldn't make any sense.
     const activeRequestId = activeRequest ? activeRequest._id : 'n/a';
-    const indexOfFirstNonActiveRequest = matchedRequests.findIndex(r => r._id !== activeRequestId);
+    const indexOfFirstNonActiveRequest = matchedRequests.findIndex(
+      (r) => r._id !== activeRequestId,
+    );
 
     this.setState({
       searchString,
@@ -381,7 +383,7 @@ class RequestSwitcherModal extends React.PureComponent<Props, State> {
     } = this.state;
 
     const { workspaceChildren } = this.props;
-    const requestGroups = workspaceChildren.filter(d => d.type === models.requestGroup.type);
+    const requestGroups = workspaceChildren.filter((d) => d.type === models.requestGroup.type);
 
     return (
       <KeydownBinder onKeydown={this._handleKeydown} onKeyup={this._handleKeyup}>
@@ -422,7 +424,7 @@ class RequestSwitcherModal extends React.PureComponent<Props, State> {
             )}
             <ul>
               {matchedRequests.map((r, i) => {
-                const requestGroup = requestGroups.find(rg => rg._id === r.parentId);
+                const requestGroup = requestGroups.find((rg) => rg._id === r.parentId);
                 const buttonClasses = classnames(
                   'btn btn--expandable-small wide text-left pad-bottom',
                   { focus: activeIndex === i },

--- a/packages/insomnia-app/app/ui/components/modals/sync-branches-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-branches-modal.js
@@ -134,7 +134,7 @@ class SyncBranchesModal extends React.PureComponent<Props, State> {
       });
 
       const remoteBranches = (await vcs.getRemoteBranches())
-        .filter(b => !branches.includes(b))
+        .filter((b) => !branches.includes(b))
         .sort();
       this.setState({ remoteBranches });
     } catch (err) {
@@ -198,7 +198,7 @@ class SyncBranchesModal extends React.PureComponent<Props, State> {
                 </tr>
               </thead>
               <tbody>
-                {branches.map(name => (
+                {branches.map((name) => (
                   <tr key={name} className="table--no-outline-row">
                     <td>
                       <span className={classnames({ bold: name === currentBranch })}>{name}</span>
@@ -245,7 +245,7 @@ class SyncBranchesModal extends React.PureComponent<Props, State> {
                   </tr>
                 </thead>
                 <tbody>
-                  {remoteBranches.map(name => (
+                  {remoteBranches.map((name) => (
                     <tr key={name} className="table--no-outline-row">
                       <td>
                         {name}

--- a/packages/insomnia-app/app/ui/components/modals/sync-history-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-history-modal.js
@@ -26,7 +26,7 @@ type State = {
 @autobind
 class SyncHistoryModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
-  handleRollback: Snapshot => Promise<void>;
+  handleRollback: (Snapshot) => Promise<void>;
 
   constructor(props: Props) {
     super(props);
@@ -61,7 +61,7 @@ class SyncHistoryModal extends React.PureComponent<Props, State> {
     this.modal && this.modal.hide();
   }
 
-  async show(options: { handleRollback: Snapshot => Promise<void> }) {
+  async show(options: { handleRollback: (Snapshot) => Promise<void> }) {
     this.modal && this.modal.show();
     this.handleRollback = options.handleRollback;
     await this.refreshState();
@@ -120,7 +120,7 @@ class SyncHistoryModal extends React.PureComponent<Props, State> {
               </tr>
             </thead>
             <tbody>
-              {history.map(snapshot => (
+              {history.map((snapshot) => (
                 <tr key={snapshot.id}>
                   <td>
                     <Tooltip message={snapshot.id} selectable wide delay={500}>

--- a/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.js
@@ -42,7 +42,7 @@ class SyncMergeModal extends React.PureComponent<Props, State> {
   }
 
   _handleToggleSelect(key: DocumentKey, e: SyntheticEvent<HTMLInputElement>) {
-    const conflicts = this.state.conflicts.map(c => {
+    const conflicts = this.state.conflicts.map((c) => {
       if (c.key !== key) {
         return c;
       }
@@ -84,7 +84,7 @@ class SyncMergeModal extends React.PureComponent<Props, State> {
               </tr>
             </thead>
             <tbody>
-              {conflicts.map(conflict => (
+              {conflicts.map((conflict) => (
                 <tr key={conflict.key}>
                   <td className="text-left">{conflict.name}</td>
                   <td className="text-left">{conflict.message}</td>
@@ -95,7 +95,7 @@ class SyncMergeModal extends React.PureComponent<Props, State> {
                         type="radio"
                         value={conflict.mineBlob || ''}
                         checked={conflict.choose === conflict.mineBlob}
-                        onChange={e => this._handleToggleSelect(conflict.key, e)}
+                        onChange={(e) => this._handleToggleSelect(conflict.key, e)}
                       />
                     </label>
                     <label className="no-pad margin-left">
@@ -104,7 +104,7 @@ class SyncMergeModal extends React.PureComponent<Props, State> {
                         type="radio"
                         value={conflict.theirsBlob || ''}
                         checked={conflict.choose === conflict.theirsBlob}
-                        onChange={e => this._handleToggleSelect(conflict.key, e)}
+                        onChange={(e) => this._handleToggleSelect(conflict.key, e)}
                       />
                     </label>
                   </td>

--- a/packages/insomnia-app/app/ui/components/modals/sync-share-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-share-modal.js
@@ -135,7 +135,7 @@ class SyncShareModal extends React.PureComponent<Props, State> {
                   Private <i className="fa fa-caret-down" />
                 </DropdownButton>
               )}
-              {teams.map(team => (
+              {teams.map((team) => (
                 <DropdownItem key={team.id} value={team} onClick={this._handleChangeTeam}>
                   <i className="fa fa-users" /> Share with <strong>{team.name}</strong>
                 </DropdownItem>

--- a/packages/insomnia-app/app/ui/components/modals/sync-staging-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-staging-modal.js
@@ -146,7 +146,7 @@ class SyncStagingModal extends React.PureComponent<Props, State> {
     const lookupMap = {};
     const allKeys = [...Object.keys(status.stage), ...Object.keys(status.unstaged)];
     for (const key of allKeys) {
-      const item = syncItems.find(si => si.key === key);
+      const item = syncItems.find((si) => si.key === key);
       const oldDoc: Object | null = await vcs.blobFromLastSnapshot(key);
       const doc = (item && item.document) || oldDoc;
       const entry = status.stage[key] || status.unstaged[key];
@@ -282,7 +282,7 @@ class SyncStagingModal extends React.PureComponent<Props, State> {
             </tr>
           </thead>
           <tbody>
-            {keys.map(key => {
+            {keys.map((key) => {
               if (!lookupMap[key]) {
                 return null;
               }

--- a/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
@@ -72,7 +72,7 @@ const SidebarListItem = SortableElement(
 
           <Editable
             className="inline-block"
-            onSubmit={name => changeEnvironmentName(environment, name)}
+            onSubmit={(name) => changeEnvironmentName(environment, name)}
             value={environment.name}
           />
         </Button>
@@ -281,7 +281,7 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
     if (rootEnvironment && rootEnvironment._id === selectedEnvironmentId) {
       return rootEnvironment;
     } else {
-      return subEnvironments.find(e => e._id === selectedEnvironmentId) || null;
+      return subEnvironments.find((e) => e._id === selectedEnvironmentId) || null;
     }
   }
 
@@ -290,7 +290,7 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    db.onChange(async changes => {
+    db.onChange(async (changes) => {
       const { selectedEnvironmentId } = this.state;
 
       for (const change of changes) {
@@ -453,7 +453,7 @@ class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
                   <Editable
                     singleClick
                     className="wide"
-                    onSubmit={name =>
+                    onSubmit={(name) =>
                       activeEnvironment &&
                       this._handleChangeEnvironmentName(activeEnvironment, name)
                     }

--- a/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.js
@@ -91,7 +91,7 @@ class WorkspaceSettingsModal extends React.PureComponent<Props, State> {
   }
 
   _handleToggleCertificateForm() {
-    this.setState(state => ({
+    this.setState((state) => ({
       showAddCertificateForm: !state.showAddCertificateForm,
       crtPath: '',
       keyPath: '',
@@ -262,8 +262,8 @@ class WorkspaceSettingsModal extends React.PureComponent<Props, State> {
       isVariableUncovered,
     } = this.props;
 
-    const publicCertificates = clientCertificates.filter(c => !c.isPrivate);
-    const privateCertificates = clientCertificates.filter(c => c.isPrivate);
+    const publicCertificates = clientCertificates.filter((c) => !c.isPrivate);
+    const privateCertificates = clientCertificates.filter((c) => c.isPrivate);
 
     const {
       pfxPath,

--- a/packages/insomnia-app/app/ui/components/modals/workspace-share-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-share-settings-modal.js
@@ -148,7 +148,7 @@ class WorkspaceShareSettingsModal extends PureComponent {
                     <i className="fa fa-caret-down" />
                   </DropdownButton>
                 )}
-                {teams.map(team => (
+                {teams.map((team) => (
                   <DropdownItem key={team.id} value={team} onClick={this._handleShareWithTeam}>
                     <i className="fa fa-users" /> Share with <strong>{team.name}</strong>
                   </DropdownItem>

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/__tests__/use-proto-file-reload.test.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/__tests__/use-proto-file-reload.test.js
@@ -44,7 +44,7 @@ describe('useProtoFileReload', () => {
     const dispatch = jest.fn();
     const r1 = { _id: 'rid', protoFileId: 'pfid' };
 
-    const { rerender } = renderHook(request => useProtoFileReload(state, dispatch, request), {
+    const { rerender } = renderHook((request) => useProtoFileReload(state, dispatch, request), {
       initialProps: r1,
     });
 

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.js
@@ -24,7 +24,7 @@ type Props = {
   settings: Settings,
 
   // For variables
-  handleRender: string => Promise<string>,
+  handleRender: (string) => Promise<string>,
   isVariableUncovered: boolean,
   handleGetRenderContext: Function,
 };

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-change-handlers.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-change-handlers.js
@@ -9,10 +9,10 @@ import { showModal } from '../../modals';
 import ProtoFilesModal from '../../modals/proto-files-modal';
 
 type ChangeHandlers = {
-  url: string => Promise<void>,
-  body: string => Promise<void>,
-  method: string => Promise<void>,
-  protoFile: string => Promise<void>,
+  url: (string) => Promise<void>,
+  body: (string) => Promise<void>,
+  method: (string) => Promise<void>,
+  protoFile: (string) => Promise<void>,
 };
 
 // This will create memoized change handlers for the url, body and method selection

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-selected-method.js
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-selected-method.js
@@ -30,7 +30,7 @@ const useSelectedMethod = (
       return;
     }
 
-    const selectedMethod = methods.find(c => c.path === protoMethodName);
+    const selectedMethod = methods.find((c) => c.path === protoMethodName);
 
     const methodType = selectedMethod && getMethodType(selectedMethod);
     const methodTypeLabel = GrpcMethodTypeName[methodType];

--- a/packages/insomnia-app/app/ui/components/panes/request-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/request-pane.js
@@ -170,11 +170,11 @@ class RequestPane extends React.PureComponent<Props> {
 
     let numBodyParams = 0;
     if (request.body && request.body.params) {
-      numBodyParams = request.body.params.filter(p => !p.disabled).length;
+      numBodyParams = request.body.params.filter((p) => !p.disabled).length;
     }
 
-    const numParameters = request.parameters.filter(p => !p.disabled).length;
-    const numHeaders = request.headers.filter(h => !h.disabled).length;
+    const numParameters = request.parameters.filter((p) => !p.disabled).length;
+    const numHeaders = request.headers.filter((h) => !h.disabled).length;
     const urlHasQueryParameters = request.url.indexOf('?') >= 0;
 
     const uniqueKey = `${forceRefreshCounter}::${request._id}`;

--- a/packages/insomnia-app/app/ui/components/panes/response-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/response-pane.js
@@ -108,14 +108,14 @@ class ResponsePane extends React.PureComponent<Props> {
     const readStream = models.response.getBodyStream(response);
     const dataBuffers = [];
     if (readStream) {
-      readStream.on('data', data => {
+      readStream.on('data', (data) => {
         dataBuffers.push(data);
       });
       readStream.on('end', () => {
         const to = fs.createWriteStream(outputPath);
         const finalBuffer = Buffer.concat(dataBuffers);
 
-        to.on('error', err => {
+        to.on('error', (err) => {
           showError({
             title: 'Save Failed',
             message: 'Failed to save response body',
@@ -143,8 +143,8 @@ class ResponsePane extends React.PureComponent<Props> {
 
     const timeline = await models.response.getTimeline(response);
     const headers = timeline
-      .filter(v => v.name === 'HEADER_IN')
-      .map(v => v.value)
+      .filter((v) => v.name === 'HEADER_IN')
+      .map((v) => v.value)
       .join('');
 
     const options = {
@@ -163,7 +163,7 @@ class ResponsePane extends React.PureComponent<Props> {
       const to = fs.createWriteStream(filePath);
       to.write(headers);
       readStream.pipe(to);
-      to.on('error', err => {
+      to.on('error', (err) => {
         console.warn('Failed to save full response', err);
       });
     }

--- a/packages/insomnia-app/app/ui/components/proto-file/proto-file-list.js
+++ b/packages/insomnia-app/app/ui/components/proto-file/proto-file-list.js
@@ -28,7 +28,7 @@ const ProtoFileList = ({
 }: Props) => (
   <ListGroup bordered>
     {!protoFiles.length && <ListGroupItem>No proto files exist for this workspace</ListGroupItem>}
-    {protoFiles.map(p => (
+    {protoFiles.map((p) => (
       <ProtoFileListItem
         key={p._id}
         protoFile={p}

--- a/packages/insomnia-app/app/ui/components/rendered-query-string.js
+++ b/packages/insomnia-app/app/ui/components/rendered-query-string.js
@@ -23,7 +23,7 @@ class RenderedQueryString extends PureComponent {
 
   async _update(props) {
     const { request } = props;
-    const enabledParameters = request.parameters.filter(p => !p.disabled);
+    const enabledParameters = request.parameters.filter((p) => !p.disabled);
 
     let result;
     try {

--- a/packages/insomnia-app/app/ui/components/request-url-bar.js
+++ b/packages/insomnia-app/app/ui/components/request-url-bar.js
@@ -25,7 +25,7 @@ type Props = {
   handleGenerateCode: Function,
   handleGetRenderContext: Function,
   handleImport: Function,
-  handleRender: string => Promise<string>,
+  handleRender: (string) => Promise<string>,
   handleSend: () => void,
   handleSendAndDownload: (filepath?: string) => Promise<void>,
   handleUpdateDownloadPath: Function,
@@ -192,7 +192,7 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
       label: 'Delay in seconds',
       defaultValue: 3,
       submitName: 'Start',
-      onComplete: seconds => {
+      onComplete: (seconds) => {
         this._handleStopTimeout();
         this._sendTimeout = setTimeout(this._handleSend, seconds * 1000);
         this.setState({ currentTimeout: seconds });
@@ -207,7 +207,7 @@ class RequestUrlBar extends React.PureComponent<Props, State> {
       label: 'Interval in seconds',
       defaultValue: 3,
       submitName: 'Start',
-      onComplete: seconds => {
+      onComplete: (seconds) => {
         this._handleStopInterval();
         this._sendInterval = setInterval(this._handleSend, seconds * 1000);
         this.setState({ currentInterval: seconds });

--- a/packages/insomnia-app/app/ui/components/settings/account.js
+++ b/packages/insomnia-app/app/ui/components/settings/account.js
@@ -34,7 +34,7 @@ class Account extends React.PureComponent<Props, State> {
   };
 
   async _handleShowChangePasswordForm(e: SyntheticEvent<HTMLInputElement>) {
-    this.setState(state => ({
+    this.setState((state) => ({
       showChangePassword: !state.showChangePassword,
       finishedResetting: false,
     }));

--- a/packages/insomnia-app/app/ui/components/settings/general.js
+++ b/packages/insomnia-app/app/ui/components/settings/general.js
@@ -55,13 +55,13 @@ class General extends React.PureComponent<Props, State> {
 
     // Find regular fonts
     const fonts = allFonts
-      .filter(i => ['regular', 'book'].includes(i.style.toLowerCase()) && !i.italic)
+      .filter((i) => ['regular', 'book'].includes(i.style.toLowerCase()) && !i.italic)
       .sort((a, b) => (a.family > b.family ? 1 : -1));
 
     // Find monospaced fonts
     // NOTE: Also include some others:
     //  - https://github.com/Kong/insomnia/issues/1835
-    const fontsMono = fonts.filter(i => i.monospace || i.family.match(FORCED_MONO_FONT_REGEX));
+    const fontsMono = fonts.filter((i) => i.monospace || i.family.match(FORCED_MONO_FONT_REGEX));
 
     this.setState({
       fonts,

--- a/packages/insomnia-app/app/ui/components/settings/import-export.js
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.js
@@ -14,7 +14,7 @@ class ImportExport extends PureComponent {
       submitName: 'Fetch and Import',
       label: 'URL',
       placeholder: 'https://website.com/insomnia-import.json',
-      onComplete: uri => {
+      onComplete: (uri) => {
         this.props.handleImportUri(uri);
       },
     });

--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -120,9 +120,9 @@ class Plugins extends React.PureComponent<Props, State> {
       submitName: 'Generate',
       label: 'Plugin Name',
       selectText: true,
-      validate: name =>
+      validate: (name) =>
         name.match(/^[a-z][a-z-]*[a-z]$/) ? '' : 'Plugin name must be of format my-plugin-name',
-      onComplete: async name => {
+      onComplete: async (name) => {
         // Remove insomnia-plugin- prefix if they accidentally typed it
         name = name.replace(/^insomnia-plugin-/, '');
         try {
@@ -185,7 +185,7 @@ class Plugins extends React.PureComponent<Props, State> {
         className="valign-middle"
         checked={!plugin.config.disabled}
         disabled={this.state.isRefreshingPlugins}
-        onChange={async checked => {
+        onChange={async (checked) => {
           await this._togglePluginEnabled(plugin.name, checked, plugin.config);
         }}
       />
@@ -235,7 +235,7 @@ class Plugins extends React.PureComponent<Props, State> {
               </tr>
             </thead>
             <tbody>
-              {plugins.map(plugin =>
+              {plugins.map((plugin) =>
                 !plugin.directory ? null : (
                   <tr key={plugin.name}>
                     <td style={{ width: '4rem' }}>{this.renderToggleSwitch(plugin)}</td>

--- a/packages/insomnia-app/app/ui/components/settings/shortcuts.js
+++ b/packages/insomnia-app/app/ui/components/settings/shortcuts.js
@@ -22,7 +22,7 @@ type Props = {
   handleUpdateKeyBindings: Function,
 };
 
-const HOT_KEY_DEFS: Array<HotKeyDefinition> = Object.keys(hotKeyRefs).map(k => hotKeyRefs[k]);
+const HOT_KEY_DEFS: Array<HotKeyDefinition> = Object.keys(hotKeyRefs).map((k) => hotKeyRefs[k]);
 
 @autobind
 class Shortcuts extends PureComponent<Props> {

--- a/packages/insomnia-app/app/ui/components/settings/theme.js
+++ b/packages/insomnia-app/app/ui/components/settings/theme.js
@@ -8,7 +8,7 @@ import { getThemes } from '../../../plugins';
 const THEMES_PER_ROW = 5;
 
 type Props = {
-  handleChangeTheme: string => void,
+  handleChangeTheme: (string) => void,
   activeTheme: string,
 };
 

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.js
@@ -98,7 +98,7 @@ class SidebarChildren extends React.PureComponent<Props> {
 
     const activeRequestId = activeRequest ? activeRequest._id : 'n/a';
 
-    return children.map(child => {
+    return children.map((child) => {
       if (!isInPinnedList && child.hidden) {
         return null;
       }

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-filter.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-filter.js
@@ -10,7 +10,7 @@ import SidebarCreateDropdown from './sidebar-create-dropdown';
 import SidebarSortDropdown from './sidebar-sort-dropdown';
 
 type Props = {
-  onChange: string => void,
+  onChange: (string) => void,
   requestCreate: () => void,
   requestGroupCreate: () => void,
   sidebarSort: (sortOrder: SortOrder) => void,

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-sort-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-sort-dropdown.js
@@ -15,7 +15,7 @@ const SidebarSortDropdown = (props: Props) => {
       <DropdownButton className="btn btn--compact">
         <i className="fa fa-sort" />
       </DropdownButton>
-      {SORT_ORDERS.map(order => (
+      {SORT_ORDERS.map((order) => (
         <DropdownItem onClick={() => handleSort(order)} key={order}>
           {sortOrderName[order]}
         </DropdownItem>

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -71,7 +71,7 @@ class TagEditor extends React.PureComponent<Props, State> {
 
     const tagDefinitions = await templating.getTagDefinitions();
     const activeTagDefinition: NunjucksParsedTag | null =
-      tagDefinitions.find(d => d.name === activeTagData.name) || null;
+      tagDefinitions.find((d) => d.name === activeTagData.name) || null;
 
     // Edit tags raw that we don't know about
     if (!activeTagDefinition) {
@@ -116,9 +116,9 @@ class TagEditor extends React.PureComponent<Props, State> {
   _sortRequests(_models: Array<Request | RequestGroup>, parentId: string) {
     let sortedModels = [];
     _models
-      .filter(model => model.parentId === parentId)
+      .filter((model) => model.parentId === parentId)
       .sort(metaSortKeySort)
-      .forEach(model => {
+      .forEach((model) => {
         if (isRequest(model)) sortedModels.push(model);
         if (isRequestGroup(model))
           sortedModels = sortedModels.concat(this._sortRequests(_models, model._id));
@@ -219,13 +219,13 @@ class TagEditor extends React.PureComponent<Props, State> {
     const existingValue = argData ? argData.value : '';
 
     if (variable) {
-      const variable = variables.find(v => v.value === existingValue);
+      const variable = variables.find((v) => v.value === existingValue);
       const firstVariable = variables.length ? variables[0].name : '';
       const value = variable ? variable.name : firstVariable;
       return this._updateArg(value || 'my_variable', argIndex, 'variable');
     } else {
       const initialType = argDef ? argDef.type : 'string';
-      const variable = variables.find(v => v.name === existingValue);
+      const variable = variables.find((v) => v.name === existingValue);
       const value = variable ? variable.value : '';
       return this._updateArg(value, argIndex, initialType, { quotedBy: "'" });
     }
@@ -276,7 +276,7 @@ class TagEditor extends React.PureComponent<Props, State> {
   async _handleChangeTag(e: SyntheticEvent<HTMLInputElement>) {
     const name = e.currentTarget.value;
     const tagDefinitions = await templating.getTagDefinitions();
-    const tagDefinition = tagDefinitions.find(d => d.name === name) || null;
+    const tagDefinition = tagDefinitions.find((d) => d.name === name) || null;
     this._update(this.state.tagDefinitions, tagDefinition, null, false);
   }
 
@@ -438,7 +438,7 @@ class TagEditor extends React.PureComponent<Props, State> {
         showFileIcon
         showFileName
         className="btn btn--clicky btn--super-compact"
-        onChange={path => this._handleChangeFile(path, argIndex)}
+        onChange={(path) => this._handleChangeFile(path, argIndex)}
         path={value}
         itemtypes={itemTypes}
         extensions={extensions}
@@ -450,14 +450,14 @@ class TagEditor extends React.PureComponent<Props, State> {
     const argDatas = this.state.activeTagData ? this.state.activeTagData.args : [];
 
     let unsetOption = null;
-    if (!options.find(o => o.value === value)) {
+    if (!options.find((o) => o.value === value)) {
       unsetOption = <option value="">-- Select Option --</option>;
     }
 
     return (
       <select value={value} onChange={this._handleChange}>
         {unsetOption}
-        {options.map(option => {
+        {options.map((option) => {
           let label: string;
           const { description } = option;
           if (description) {
@@ -482,7 +482,7 @@ class TagEditor extends React.PureComponent<Props, State> {
 
     do {
       // Get prefix from inner most request group.
-      reqGroup = allRequestGroups.find(rg => rg._id === requestGroupId);
+      reqGroup = allRequestGroups.find((rg) => rg._id === requestGroupId);
       if (reqGroup == null) {
         break;
       }
@@ -516,7 +516,7 @@ class TagEditor extends React.PureComponent<Props, State> {
           // Show paren't folder with name if it's a request
           if (doc.type === models.request.type) {
             const requests = allDocs[models.request.type] || [];
-            const request: any = requests.find(r => r._id === doc._id);
+            const request: any = requests.find((r) => r._id === doc._id);
             const method = request && typeof request.method === 'string' ? request.method : 'GET';
             const parentId = request ? request.parentId : 'n/a';
             const allRequestGroups = allDocs[models.requestGroup.type] || [];

--- a/packages/insomnia-app/app/ui/components/templating/variable-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/variable-editor.js
@@ -81,7 +81,7 @@ class VariableEditor extends PureComponent {
 
   render() {
     const { error, value, preview, variables, variableSource } = this.state;
-    const isOther = !variables.find(v => value === `{{ ${v.name} }}`);
+    const isOther = !variables.find((v) => value === `{{ ${v.name} }}`);
     return (
       <div>
         <div className="form-control form-control--outlined">

--- a/packages/insomnia-app/app/ui/components/tooltip.stories.js
+++ b/packages/insomnia-app/app/ui/components/tooltip.stories.js
@@ -40,7 +40,7 @@ export const withChildren = () => {
   const message = (
     <React.Fragment>
       This is a{' '}
-      <a href="#" onClick={e => e.preventDefault()}>
+      <a href="#" onClick={(e) => e.preventDefault()}>
         Link
       </a>
       .

--- a/packages/insomnia-app/app/ui/components/viewers/grpc-tabbed-messages.js
+++ b/packages/insomnia-app/app/ui/components/viewers/grpc-tabbed-messages.js
@@ -18,12 +18,12 @@ type Props = {
   bodyText: string,
   uniquenessKey: string,
 
-  handleBodyChange?: string => Promise<void>,
+  handleBodyChange?: (string) => Promise<void>,
   handleStream?: () => void,
   handleCommit?: () => void,
   showActions?: boolean,
 
-  handleRender: string => Promise<string>,
+  handleRender: (string) => Promise<string>,
   isVariableUncovered: boolean,
   handleGetRenderContext: Function,
 };
@@ -96,7 +96,7 @@ const GrpcTabbedMessages = ({
           />
         </TabPanel>
       )}
-      {orderedMessages.map(m => (
+      {orderedMessages.map((m) => (
         <TabPanel key={m.id} className="react-tabs__tab-panel editor-wrapper">
           <GRPCEditor content={m.text} settings={settings} readOnly />
         </TabPanel>

--- a/packages/insomnia-app/app/ui/components/viewers/response-cookies-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-cookies-viewer.js
@@ -56,7 +56,7 @@ class ResponseCookiesViewer extends PureComponent {
           <tbody>{!headers.length ? this.renderRow(null, -1) : headers.map(this.renderRow)}</tbody>
         </table>
         <p className="pad-top">
-          <button className="pull-right btn btn--clicky" onClick={e => showCookiesModal()}>
+          <button className="pull-right btn btn--clicky" onClick={(e) => showCookiesModal()}>
             Manage Cookies
           </button>
         </p>

--- a/packages/insomnia-app/app/ui/components/viewers/response-csv-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-csv-viewer.js
@@ -28,7 +28,7 @@ class ResponseCSVViewer extends React.PureComponent<Props, State> {
 
     Papa.parse(csv, {
       skipEmptyLines: true,
-      complete: result => {
+      complete: (result) => {
         this.setState({ result });
       },
     });
@@ -57,9 +57,9 @@ class ResponseCSVViewer extends React.PureComponent<Props, State> {
       <div className="pad-sm">
         <table className="table--fancy table--striped table--compact selectable">
           <tbody>
-            {result.data.map(row => (
+            {result.data.map((row) => (
               <tr>
-                {row.map(c => (
+                {row.map((c) => (
                   <td>{c}</td>
                 ))}
               </tr>

--- a/packages/insomnia-app/app/ui/components/viewers/response-headers-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-headers-viewer.js
@@ -24,7 +24,7 @@ class ResponseHeadersViewer extends React.PureComponent<Props> {
   render() {
     const { headers } = this.props;
 
-    const headersString = headers.map(h => `${h.name}: ${h.value}`).join('\n');
+    const headersString = headers.map((h) => `${h.name}: ${h.value}`).join('\n');
 
     return (
       <React.Fragment>

--- a/packages/insomnia-app/app/ui/components/viewers/response-multipart.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-multipart.js
@@ -170,13 +170,13 @@ class ResponseMultipart extends React.PureComponent<Props, State> {
       };
 
       const form = new multiparty.Form();
-      form.on('part', part => {
+      form.on('part', (part) => {
         const dataBuffers = [];
-        part.on('data', data => {
+        part.on('data', (data) => {
           dataBuffers.push(data);
         });
 
-        part.on('error', err => {
+        part.on('error', (err) => {
           reject(new Error(`Failed to parse part: ${err.message}`));
         });
 
@@ -186,7 +186,7 @@ class ResponseMultipart extends React.PureComponent<Props, State> {
             name: part.name,
             filename: part.filename || null,
             bytes: part.byteCount,
-            headers: Object.keys(part.headers).map(name => ({
+            headers: Object.keys(part.headers).map((name) => ({
               name,
               value: part.headers[name],
             })),
@@ -194,7 +194,7 @@ class ResponseMultipart extends React.PureComponent<Props, State> {
         });
       });
 
-      form.on('error', err => {
+      form.on('error', (err) => {
         reject(err);
       });
 

--- a/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.js
@@ -68,7 +68,7 @@ class ResponseTimelineViewer extends PureComponent {
     }
 
     const lines = (value + '').replace(/\n$/, '').split('\n');
-    const newLines = lines.filter(l => !l.match(/^\s*$/)).map(l => `${prefix}${l}`);
+    const newLines = lines.filter((l) => !l.match(/^\s*$/)).map((l) => `${prefix}${l}`);
 
     let leadingSpace = '';
 
@@ -86,7 +86,7 @@ class ResponseTimelineViewer extends PureComponent {
     const { timeline, timelineKey } = this.state;
     const rows = timeline
       .map(this.renderRow)
-      .filter(r => r !== null)
+      .filter((r) => r !== null)
       .join('\n')
       .trim();
 

--- a/packages/insomnia-app/app/ui/components/wrapper-design.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.js
@@ -73,7 +73,7 @@ class WrapperDesign extends React.PureComponent<Props, State> {
 
   async _handleTogglePreview() {
     await this.setState(
-      prevState => ({ previewHidden: !prevState.previewHidden }),
+      (prevState) => ({ previewHidden: !prevState.previewHidden }),
       async () => {
         const workspaceId = this.props.wrapperProps.activeWorkspace._id;
         const previewHidden = this.state.previewHidden;
@@ -118,7 +118,7 @@ class WrapperDesign extends React.PureComponent<Props, State> {
     if (activeApiSpec.contents.length !== 0) {
       const results = await spectral.run(activeApiSpec.contents);
       this.setState({
-        lintMessages: results.map(r => ({
+        lintMessages: results.map((r) => ({
           type: r.severity === 0 ? 'error' : 'warning',
           message: `${r.code} ${r.message}`,
           line: r.range.start.line,

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -79,7 +79,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
       submitName: 'Create',
       placeholder: 'spec-name.yaml',
       selectText: true,
-      onComplete: async name => {
+      onComplete: async (name) => {
         await models.workspace.create({
           name,
           scope: 'spec',
@@ -104,7 +104,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
       submitName: 'Fetch and Import',
       label: 'URL',
       placeholder: 'https://website.com/insomnia-import.json',
-      onComplete: uri => {
+      onComplete: (uri) => {
         this.props.handleImportUri(uri, ForceToWorkspaceKeys.new);
       },
     });
@@ -115,7 +115,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
     // it's fine here for now (?)
     showModal(GitRepositorySettingsModal, {
       gitRepository: null,
-      onSubmitEdits: async repoSettingsPatch => {
+      onSubmitEdits: async (repoSettingsPatch) => {
         trackEvent('Git', 'Clone');
 
         const core = Math.random() + '';
@@ -294,7 +294,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
 
     const { filter } = this.state;
 
-    const apiSpec = apiSpecs.find(s => s.parentId === w._id);
+    const apiSpec = apiSpecs.find((s) => s.parentId === w._id);
 
     let spec = null;
     let specFormat = null;
@@ -310,7 +310,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
     }
 
     // Get cached branch from WorkspaceMeta
-    const workspaceMeta = workspaceMetas.find(wm => wm.parentId === w._id);
+    const workspaceMeta = workspaceMetas.find((wm) => wm.parentId === w._id);
     const lastActiveBranch = workspaceMeta ? workspaceMeta.cachedGitRepositoryBranch : null;
     const lastCommitAuthor = workspaceMeta ? workspaceMeta.cachedGitLastAuthor : null;
     const lastCommitTime = workspaceMeta ? workspaceMeta.cachedGitLastCommitTime : null;
@@ -426,7 +426,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
     const { filter } = this.state;
 
     // Render each card, removing all the ones that don't match the filter
-    const cards = workspaces.map(this.renderCard).filter(c => c !== null);
+    const cards = workspaces.map(this.renderCard).filter((c) => c !== null);
 
     return (
       <PageLayout

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
@@ -56,7 +56,7 @@ class WrapperOnboarding extends React.PureComponent<Props, State> {
   _handleBackStep(e: SyntheticEvent<HTMLAnchorElement>) {
     e.preventDefault();
 
-    this.setState(state => ({ step: state.step - 1 }));
+    this.setState((state) => ({ step: state.step - 1 }));
   }
 
   async _handleCompleteAnalyticsStep(enableAnalytics: boolean) {
@@ -65,7 +65,7 @@ class WrapperOnboarding extends React.PureComponent<Props, State> {
     // Update settings with analytics preferences
     await models.settings.update(settings, { enableAnalytics });
 
-    this.setState(state => ({ step: state.step + 1 }));
+    this.setState((state) => ({ step: state.step + 1 }));
   }
 
   async _handleClickEnableAnalytics(e: SyntheticEvent<HTMLButtonElement>) {
@@ -89,7 +89,7 @@ class WrapperOnboarding extends React.PureComponent<Props, State> {
       defaultValue: typeof defaultValue === 'string' ? defaultValue : '',
       placeholder: 'https://example.com/openapi-spec.yaml',
       label: 'URI to Import',
-      onComplete: value => {
+      onComplete: (value) => {
         handleImportUri(value, ForceToWorkspaceKeys.current);
       },
     });

--- a/packages/insomnia-app/app/ui/components/wrapper-unit-test.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-unit-test.js
@@ -98,7 +98,7 @@ class WrapperUnitTest extends React.PureComponent<Props, State> {
         name: 'Send Request By ID',
         displayValue: '',
         value: async () => {
-          return new Promise(resolve => {
+          return new Promise((resolve) => {
             showModal(SelectModal, {
               title: 'Select Request',
               message: 'Select a request to fill',
@@ -111,7 +111,7 @@ class WrapperUnitTest extends React.PureComponent<Props, State> {
                   value: this.generateSendReqSnippet(unitTest.code, `'${request._id}'`),
                 })),
               ],
-              onDone: v => resolve(v),
+              onDone: (v) => resolve(v),
             });
           });
         },
@@ -127,7 +127,7 @@ class WrapperUnitTest extends React.PureComponent<Props, State> {
       submitName: 'Create Suite',
       label: 'Test Suite Name',
       selectText: true,
-      onComplete: async name => {
+      onComplete: async (name) => {
         const unitTestSuite = await models.unitTestSuite.create({
           parentId: activeWorkspace._id,
           name,
@@ -145,7 +145,7 @@ class WrapperUnitTest extends React.PureComponent<Props, State> {
       submitName: 'New Test',
       label: 'Test Name',
       selectText: true,
-      onComplete: async name => {
+      onComplete: async (name) => {
         await models.unitTest.create({
           parentId: activeUnitTestSuite._id,
           code: this.generateSendReqSnippet('', ''),
@@ -448,7 +448,7 @@ class WrapperUnitTest extends React.PureComponent<Props, State> {
             </Button>
           </div>
           <ul>
-            {activeUnitTestSuites.map(s => (
+            {activeUnitTestSuites.map((s) => (
               <li key={s._id} className={classnames({ active: s._id === activeId })}>
                 <button key={s._id} onClick={this._handleSetActiveUnitTestSuite.bind(this, s)}>
                   {s.name}

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -446,7 +446,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
 
   async _handleActiveWorkspaceClearAllResponses(): Promise<void> {
     const docs = await db.withDescendants(this.props.activeWorkspace, models.request.type);
-    const requests = docs.filter(doc => doc.type === models.request.type);
+    const requests = docs.filter((doc) => doc.type === models.request.type);
     for (const req of requests) {
       await models.response.removeForRequest(req._id);
     }
@@ -568,7 +568,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
           vcs={gitVCS}
           handleInitializeEntities={handleInitializeEntities}
           handleGitBranchChanged={this._handleGitBranchChanged}
-          renderDropdownButton={children => (
+          renderDropdownButton={(children) => (
             <DropdownButton className="btn--clicky-small btn-sync btn-utility">
               {children}
             </DropdownButton>
@@ -789,7 +789,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
             />
 
             <GrpcDispatchModalWrapper>
-              {dispatch => (
+              {(dispatch) => (
                 <ProtoFilesModal
                   ref={registerModal}
                   grpcDispatch={dispatch}

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -124,9 +124,11 @@ class App extends PureComponent {
 
     this._getRenderContextPromiseCache = {};
 
-    this._savePaneWidth = debounce(paneWidth => this._updateActiveWorkspaceMeta({ paneWidth }));
-    this._savePaneHeight = debounce(paneHeight => this._updateActiveWorkspaceMeta({ paneHeight }));
-    this._saveSidebarWidth = debounce(sidebarWidth =>
+    this._savePaneWidth = debounce((paneWidth) => this._updateActiveWorkspaceMeta({ paneWidth }));
+    this._savePaneHeight = debounce((paneHeight) =>
+      this._updateActiveWorkspaceMeta({ paneHeight }),
+    );
+    this._saveSidebarWidth = debounce((sidebarWidth) =>
       this._updateActiveWorkspaceMeta({ sidebarWidth }),
     );
 
@@ -233,7 +235,7 @@ class App extends PureComponent {
           showModal(AskModal, {
             title: 'Delete Request?',
             message: `Really delete ${activeRequest.name}?`,
-            onDone: async confirmed => {
+            onDone: async (confirmed) => {
               if (!confirmed) {
                 return;
               }
@@ -275,7 +277,7 @@ class App extends PureComponent {
             ? entities.grpcRequestMetas
             : entities.requestMetas;
 
-          const meta = Object.values(entitiesToCheck).find(m => m.parentId === activeRequest._id);
+          const meta = Object.values(entitiesToCheck).find((m) => m.parentId === activeRequest._id);
 
           await this._handleSetRequestPinned(this.props.activeRequest, !meta?.pinned);
         },
@@ -323,7 +325,7 @@ class App extends PureComponent {
       submitName: 'Create',
       label: 'Name',
       selectText: true,
-      onComplete: async name => {
+      onComplete: async (name) => {
         const requestGroup = await models.requestGroup.create({
           parentId,
           name,
@@ -339,7 +341,7 @@ class App extends PureComponent {
   _requestCreate(parentId) {
     showModal(RequestCreateModal, {
       parentId,
-      onComplete: requestId => {
+      onComplete: (requestId) => {
         this._handleSetActiveRequest(requestId);
         models.stats.incrementCreatedRequests();
       },
@@ -369,7 +371,7 @@ class App extends PureComponent {
     await this._recalculateMetaSortKey(docs);
 
     // sort RequestGroups recursively
-    await Promise.all(docs.filter(isRequestGroup).map(g => this._sortSidebar(order, g._id)));
+    await Promise.all(docs.filter(isRequestGroup).map((g) => this._sortSidebar(order, g._id)));
 
     if (flushId) {
       await db.flushChanges(flushId);
@@ -383,7 +385,7 @@ class App extends PureComponent {
       submitName: 'Create',
       label: 'New Name',
       selectText: true,
-      onComplete: async name => {
+      onComplete: async (name) => {
         const newRequestGroup = await models.requestGroup.duplicate(requestGroup, { name });
 
         models.stats.incrementCreatedRequestsForDescendents(newRequestGroup);
@@ -406,7 +408,7 @@ class App extends PureComponent {
       submitName: 'Create',
       label: 'New Name',
       selectText: true,
-      onComplete: async name => {
+      onComplete: async (name) => {
         const newRequest = await requestOperations.duplicate(request, { name });
         await this._handleSetActiveRequest(newRequest._id);
         models.stats.incrementCreatedRequests();
@@ -415,7 +417,7 @@ class App extends PureComponent {
   }
 
   _workspaceRename(callback, workspaceId) {
-    const workspace = this.props.workspaces.find(w => w._id === workspaceId);
+    const workspace = this.props.workspaces.find((w) => w._id === workspaceId);
     console.dir(AppContext);
     showPrompt({
       title: `Rename ${AppContext.workspace}`,
@@ -423,7 +425,7 @@ class App extends PureComponent {
       submitName: 'Rename',
       selectText: true,
       label: 'Name',
-      onComplete: async name => {
+      onComplete: async (name) => {
         await models.workspace.update(workspace, { name: name });
         callback();
       },
@@ -431,13 +433,13 @@ class App extends PureComponent {
   }
 
   _workspaceDeleteById(callback, workspaceId) {
-    const workspace = this.props.workspaces.find(w => w._id === workspaceId);
+    const workspace = this.props.workspaces.find((w) => w._id === workspaceId);
     showModal(AskModal, {
       title: `Delete ${AppContext.workspace}`,
       message: `Do you really want to delete ${workspace.name}?`,
       yesText: 'Yes',
       noText: 'Cancel',
-      onDone: async isYes => {
+      onDone: async (isYes) => {
         if (!isYes) {
           return;
         }
@@ -450,7 +452,7 @@ class App extends PureComponent {
   }
 
   _workspaceDuplicateById(callback, workspaceId) {
-    const workspace = this.props.workspaces.find(w => w._id === workspaceId);
+    const workspace = this.props.workspaces.find((w) => w._id === workspaceId);
 
     showPrompt({
       title: `Duplicate ${AppContext.workspace}`,
@@ -458,7 +460,7 @@ class App extends PureComponent {
       submitName: 'Create',
       selectText: true,
       label: 'New Name',
-      onComplete: async name => {
+      onComplete: async (name) => {
         const newWorkspace = await db.duplicate(workspace, { name });
         await this.props.handleSetActiveWorkspace(newWorkspace._id);
         callback();
@@ -738,7 +740,7 @@ class App extends PureComponent {
           await models.response.create(responsePatch, settings.maxHistoryResponses);
         });
 
-        readStream.on('error', async err => {
+        readStream.on('error', async (err) => {
           console.warn('Failed to download request after sending', responsePatch.bodyPath, err);
           await models.response.create(responsePatch, settings.maxHistoryResponses);
         });
@@ -1022,7 +1024,7 @@ class App extends PureComponent {
 
     // Force app refresh if login state changes
     if (prevProps.isLoggedIn !== this.props.isLoggedIn) {
-      this.setState(state => ({
+      this.setState((state) => ({
         forceRefreshCounter: state.forceRefreshCounter + 1,
       }));
     }
@@ -1114,11 +1116,11 @@ class App extends PureComponent {
     if (!vcs) {
       const directory = path.join(getDataDirectory(), 'version-control');
       const driver = new FileSystemDriver({ directory });
-      vcs = new VCS(driver, async conflicts => {
-        return new Promise(resolve => {
+      vcs = new VCS(driver, async (conflicts) => {
+        return new Promise((resolve) => {
           showModal(SyncMergeModal, {
             conflicts,
-            handleDone: conflicts => resolve(conflicts),
+            handleDone: (conflicts) => resolve(conflicts),
           });
         });
       });
@@ -1145,7 +1147,7 @@ class App extends PureComponent {
     await this._updateVCS();
     await this._updateGitVCS(this.props.activeWorkspace);
 
-    db.onChange(async changes => {
+    db.onChange(async (changes) => {
       let needsRefresh = false;
 
       for (const change of changes) {
@@ -1205,7 +1207,7 @@ class App extends PureComponent {
     // NOTE: This is required for "drop" event to trigger.
     document.addEventListener(
       'dragover',
-      e => {
+      (e) => {
         e.preventDefault();
       },
       false,
@@ -1213,7 +1215,7 @@ class App extends PureComponent {
 
     document.addEventListener(
       'drop',
-      async e => {
+      async (e) => {
         e.preventDefault();
         const { activeWorkspace, handleImportUriToWorkspace } = this.props;
         if (!activeWorkspace) {
@@ -1267,7 +1269,7 @@ class App extends PureComponent {
       environments,
       activeApiSpec,
     } = this.props;
-    const baseEnvironments = environments.filter(e => e.parentId === activeWorkspace._id);
+    const baseEnvironments = environments.filter((e) => e.parentId === activeWorkspace._id);
 
     // Nothing to do
     if (baseEnvironments.length && activeCookieJar && activeApiSpec && activeWorkspaceMeta) {
@@ -1483,7 +1485,7 @@ function mapStateToProps(state, props) {
   const syncItems = selectSyncItems(state, props);
 
   // Api spec stuff
-  const activeApiSpec = apiSpecs.find(s => s.parentId === activeWorkspace._id);
+  const activeApiSpec = apiSpecs.find((s) => s.parentId === activeWorkspace._id);
 
   // Test stuff
   const activeUnitTests = selectActiveUnitTests(state, props);

--- a/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-ipc-renderer.test.js
+++ b/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-ipc-renderer.test.js
@@ -26,9 +26,12 @@ describe('init', () => {
     grpcIpcRenderer.init(dispatch);
   });
 
-  it.each(Object.values(GrpcResponseEventEnum))('should add listener for channel: %s', channel => {
-    expect(ipcRenderer.on).toHaveBeenCalledWith(channel, expect.anything());
-  });
+  it.each(Object.values(GrpcResponseEventEnum))(
+    'should add listener for channel: %s',
+    (channel) => {
+      expect(ipcRenderer.on).toHaveBeenCalledWith(channel, expect.anything());
+    },
+  );
 
   it('should attach listener for start', () => {
     const [channel, listener] = ipcRenderer.on.mock.calls[0];
@@ -92,7 +95,7 @@ describe('init', () => {
 describe('destroy', () => {
   it.each(Object.values(GrpcResponseEventEnum))(
     'should remove listeners for channel: %s',
-    channel => {
+    (channel) => {
       grpcIpcRenderer.destroy();
       expect(ipcRenderer.removeAllListeners).toHaveBeenCalledWith(channel);
     },

--- a/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-reducer.test.js
+++ b/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-reducer.test.js
@@ -398,7 +398,7 @@ describe('grpcReducer actions', () => {
     );
   });
 
-  it.each([null, undefined])('should do nothing if action is falsey', action => {
+  it.each([null, undefined])('should do nothing if action is falsey', (action) => {
     expect(grpcReducer({}, action)).toStrictEqual({});
   });
 });

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-actions.js
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-actions.js
@@ -130,7 +130,7 @@ const invalidateMany = async (protoFileId: string): Promise<InvalidateManyAction
 
   return {
     type: GrpcActionTypeEnum.invalidateMany,
-    requestIds: impacted.map(g => g._id),
+    requestIds: impacted.map((g) => g._id),
   };
 };
 

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.js
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.js
@@ -59,7 +59,7 @@ const multiRequestReducer = (state: GrpcState, action: GrpcActionMany): GrpcStat
   switch (action.type) {
     case GrpcActionTypeEnum.invalidateMany: {
       const newStates = {};
-      requestIds.forEach(id => {
+      requestIds.forEach((id) => {
         const oldState = findGrpcRequestState(state, id);
         const newState: GrpcRequestState = { ...oldState, reloadMethods: true };
         newStates[id] = newState;

--- a/packages/insomnia-app/app/ui/index.js
+++ b/packages/insomnia-app/app/ui/index.js
@@ -40,7 +40,7 @@ document.title = getAppLongName();
   const store = await initStore();
 
   const context = DragDropContext(DNDBackend);
-  const render = Component => {
+  const render = (Component) => {
     const DnDComponent = context(Component);
     ReactDOM.render(
       <AppContainer>
@@ -92,12 +92,12 @@ window['styled-components'] = styledComponents;
 
 // Catch uncaught errors and report them
 if (window && !isDevelopment()) {
-  window.addEventListener('error', e => {
+  window.addEventListener('error', (e) => {
     console.error('Uncaught Error', e);
     trackEvent('Error', 'Uncaught Error');
   });
 
-  window.addEventListener('unhandledrejection', e => {
+  window.addEventListener('unhandledrejection', (e) => {
     console.error('Unhandled Promise', e);
     trackEvent('Error', 'Uncaught Promise');
   });

--- a/packages/insomnia-app/app/ui/redux/__tests__/sidebar-selectors.test.js
+++ b/packages/insomnia-app/app/ui/redux/__tests__/sidebar-selectors.test.js
@@ -11,21 +11,24 @@ describe('shouldShowInSidebar', () => {
   const supported = [models.request.type, models.requestGroup.type, models.grpcRequest.type];
   const unsupported = difference(allTypes, supported);
 
-  it.each(supported)('should show %s in sidebar', type => {
+  it.each(supported)('should show %s in sidebar', (type) => {
     expect(shouldShowInSidebar({ type })).toBe(true);
   });
 
-  it.each(unsupported)('should not show %s in sidebar', type => {
+  it.each(unsupported)('should not show %s in sidebar', (type) => {
     expect(shouldShowInSidebar({ type })).toBe(false);
   });
 });
 
 describe('shouldIgnoreChildrenOf', () => {
-  it.each([models.request.type, models.grpcRequest.type])('should ignore children of %s', type => {
-    expect(shouldIgnoreChildrenOf({ type })).toBe(true);
-  });
+  it.each([models.request.type, models.grpcRequest.type])(
+    'should ignore children of %s',
+    (type) => {
+      expect(shouldIgnoreChildrenOf({ type })).toBe(true);
+    },
+  );
 
-  it.each([models.requestGroup.type])('should not ignore children of', type => {
+  it.each([models.requestGroup.type])('should not ignore children of', (type) => {
     expect(shouldIgnoreChildrenOf({ type })).toBe(false);
   });
 });

--- a/packages/insomnia-app/app/ui/redux/modules/__tests__/helpers.test.js
+++ b/packages/insomnia-app/app/ui/redux/modules/__tests__/helpers.test.js
@@ -38,7 +38,7 @@ describe('ensureActivityIsForApp()', () => {
 
   it.each([...designerActivities, ...insomniaActivities])(
     'should return ACTIVITY_INSOMNIA if default app id is insomnia: %o',
-    activity => {
+    (activity) => {
       jest.spyOn(constants, 'getDefaultAppId').mockReturnValue(APP_ID_INSOMNIA);
       expect(ensureActivityIsForApp(activity)).toBe(ACTIVITY_INSOMNIA);
     },
@@ -46,7 +46,7 @@ describe('ensureActivityIsForApp()', () => {
 
   it.each(insomniaActivities)(
     'should return ACTIVITY_HOME if default app id is designer: %o',
-    activity => {
+    (activity) => {
       jest.spyOn(constants, 'getDefaultAppId').mockReturnValue(APP_ID_DESIGNER);
       expect(ensureActivityIsForApp(activity)).toBe(ACTIVITY_HOME);
     },
@@ -54,7 +54,7 @@ describe('ensureActivityIsForApp()', () => {
 
   it.each(designerActivities)(
     'should return source activity if default app id is designer: %o',
-    activity => {
+    (activity) => {
       jest.spyOn(constants, 'getDefaultAppId').mockReturnValue(APP_ID_DESIGNER);
       expect(ensureActivityIsForApp(activity)).toBe(activity);
     },

--- a/packages/insomnia-app/app/ui/redux/modules/entities.js
+++ b/packages/insomnia-app/app/ui/redux/modules/entities.js
@@ -87,7 +87,7 @@ export function addChanges(changes) {
 }
 
 export function initialize() {
-  return async dispatch => {
+  return async (dispatch) => {
     const docs = await allDocs();
     dispatch(initializeWith(docs));
   };

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -115,7 +115,7 @@ export const reducer = combineReducers({
 // ~~~~~~~ //
 
 export function newCommand(command, args) {
-  return async dispatch => {
+  return async (dispatch) => {
     switch (command) {
       case COMMAND_ALERT:
         showModal(AlertModal, { title: args.title, message: args.message });
@@ -148,7 +148,7 @@ export function newCommand(command, args) {
           ),
           yesText: 'Install',
           noText: 'Cancel',
-          onDone: async isYes => {
+          onDone: async (isYes) => {
             if (!isYes) {
               return;
             }
@@ -177,7 +177,7 @@ export function newCommand(command, args) {
           ),
           yesText: 'Install',
           noText: 'Cancel',
-          onDone: async isYes => {
+          onDone: async (isYes) => {
             if (!isYes) {
               return;
             }
@@ -245,7 +245,7 @@ export function setActiveWorkspace(workspaceId: string) {
 }
 
 export function importFile(workspaceId: string, forceToWorkspace?: ForceToWorkspace) {
-  return async dispatch => {
+  return async (dispatch) => {
     dispatch(loadStart());
 
     const options = {
@@ -321,7 +321,7 @@ function handleImportResult(result: ImportResult, errorMessage: string): Array<W
 }
 
 export function importClipBoard(workspaceId: string, forceToWorkspace?: ForceToWorkspace) {
-  return async dispatch => {
+  return async (dispatch) => {
     dispatch(loadStart());
     const schema = electron.clipboard.readText();
     if (!schema) {
@@ -357,7 +357,7 @@ export function importClipBoard(workspaceId: string, forceToWorkspace?: ForceToW
 }
 
 export function importUri(workspaceId: string, uri: string, forceToWorkspace?: ForceToWorkspace) {
-  return async dispatch => {
+  return async (dispatch) => {
     dispatch(loadStart());
 
     let importedWorkspaces = [];
@@ -405,7 +405,7 @@ function showSelectExportTypeModal(onCancel, onDone) {
     ],
     message: 'Which format would you like to export as?',
     onCancel: onCancel,
-    onDone: selectedFormat => {
+    onDone: (selectedFormat) => {
       window.localStorage.setItem('insomnia.lastExportFormat', selectedFormat);
       onDone(selectedFormat);
     },
@@ -456,12 +456,12 @@ function writeExportedFileToFileSystem(filename, jsonData, onDone) {
 }
 
 export function exportWorkspacesToFile(workspaceId = null) {
-  return async dispatch => {
+  return async (dispatch) => {
     dispatch(loadStart());
 
     showSelectExportTypeModal(
       () => dispatch(loadStop()),
-      async selectedFormat => {
+      async (selectedFormat) => {
         const workspace = await models.workspace.getById(workspaceId);
 
         // Check if we want to export private environments.
@@ -474,9 +474,9 @@ export function exportWorkspacesToFile(workspaceId = null) {
         }
 
         let exportPrivateEnvironments = false;
-        const privateEnvironments = environments.filter(e => e.isPrivate);
+        const privateEnvironments = environments.filter((e) => e.isPrivate);
         if (privateEnvironments.length) {
-          const names = privateEnvironments.map(e => e.name).join(', ');
+          const names = privateEnvironments.map((e) => e.name).join(', ');
           exportPrivateEnvironments = await showExportPrivateEnvironmentsModal(names);
         }
 
@@ -518,7 +518,7 @@ export function exportWorkspacesToFile(workspaceId = null) {
           return;
         }
 
-        writeExportedFileToFileSystem(fileName, stringifiedExport, err => {
+        writeExportedFileToFileSystem(fileName, stringifiedExport, (err) => {
           if (err) {
             console.warn('Export failed', err);
           }
@@ -530,12 +530,12 @@ export function exportWorkspacesToFile(workspaceId = null) {
 }
 
 export function exportRequestsToFile(requestIds) {
-  return async dispatch => {
+  return async (dispatch) => {
     dispatch(loadStart());
 
     showSelectExportTypeModal(
       () => dispatch(loadStop()),
-      async selectedFormat => {
+      async (selectedFormat) => {
         const requests = [];
         const privateEnvironments = [];
         const workspaceLookup = {};
@@ -550,7 +550,7 @@ export function exportRequestsToFile(requestIds) {
             models.workspace.type,
             models.requestGroup.type,
           ]);
-          const workspace = ancestors.find(ancestor => ancestor.type === models.workspace.type);
+          const workspace = ancestors.find((ancestor) => ancestor.type === models.workspace.type);
           if (workspace == null || workspaceLookup.hasOwnProperty(workspace._id)) {
             continue;
           }
@@ -558,14 +558,14 @@ export function exportRequestsToFile(requestIds) {
 
           const descendants = await db.withDescendants(workspace);
           const privateEnvs = descendants.filter(
-            descendant => descendant.type === models.environment.type && descendant.isPrivate,
+            (descendant) => descendant.type === models.environment.type && descendant.isPrivate,
           );
           privateEnvironments.push(...privateEnvs);
         }
 
         let exportPrivateEnvironments = false;
         if (privateEnvironments.length) {
-          const names = privateEnvironments.map(e => e.name).join(', ');
+          const names = privateEnvironments.map((e) => e.name).join(', ');
           exportPrivateEnvironments = await showExportPrivateEnvironmentsModal(names);
         }
 
@@ -607,7 +607,7 @@ export function exportRequestsToFile(requestIds) {
           return;
         }
 
-        writeExportedFileToFileSystem(fileName, stringifiedExport, err => {
+        writeExportedFileToFileSystem(fileName, stringifiedExport, (err) => {
           if (err) {
             console.warn('Export failed', err);
           }

--- a/packages/insomnia-app/app/ui/redux/modules/helpers.js
+++ b/packages/insomnia-app/app/ui/redux/modules/helpers.js
@@ -20,13 +20,13 @@ export function askToImportIntoWorkspace(workspaceId: string, forceToWorkspace?:
       case ForceToWorkspaceKeys.current:
         return workspaceId;
       default:
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
           showModal(AskModal, {
             title: 'Import',
             message: 'Do you want to import into the current workspace or a new one?',
             yesText: 'Current',
             noText: 'New Workspace',
-            onDone: yes => {
+            onDone: (yes) => {
               resolve(yes ? workspaceId : null);
             },
           });

--- a/packages/insomnia-app/app/ui/redux/modules/index.js
+++ b/packages/insomnia-app/app/ui/redux/modules/index.js
@@ -22,7 +22,7 @@ export async function init() {
 
   // Initialize login state
   loginStateChange(isLoggedIn());
-  onLoginLogout(loggedIn => {
+  onLoginLogout((loggedIn) => {
     loginStateChange(loggedIn);
   });
 

--- a/packages/insomnia-app/app/ui/redux/selectors.js
+++ b/packages/insomnia-app/app/ui/redux/selectors.js
@@ -6,20 +6,20 @@ import * as models from '../../models';
 // ~~~~~~~~~ //
 
 export const selectEntitiesLists = createSelector(
-  state => state.entities,
-  entities => {
+  (state) => state.entities,
+  (entities) => {
     const entitiesLists = {};
 
     for (const k of Object.keys(entities)) {
       const entityMap = entities[k];
-      entitiesLists[k] = Object.keys(entityMap).map(id => entityMap[id]);
+      entitiesLists[k] = Object.keys(entityMap).map((id) => entityMap[id]);
     }
 
     return entitiesLists;
   },
 );
 
-export const selectEntitiesChildrenMap = createSelector(selectEntitiesLists, entities => {
+export const selectEntitiesChildrenMap = createSelector(selectEntitiesLists, (entities) => {
   const parentLookupMap = {};
   for (const k of Object.keys(entities)) {
     for (const e of entities[k]) {
@@ -38,14 +38,14 @@ export const selectEntitiesChildrenMap = createSelector(selectEntitiesLists, ent
   return parentLookupMap;
 });
 
-export const selectSettings = createSelector(selectEntitiesLists, entities => {
+export const selectSettings = createSelector(selectEntitiesLists, (entities) => {
   return entities.settings[0] || models.settings.init();
 });
 
 export const selectActiveWorkspace = createSelector(
-  state => selectEntitiesLists(state).workspaces,
-  state => state.entities,
-  state => state.global.activeWorkspaceId,
+  (state) => selectEntitiesLists(state).workspaces,
+  (state) => state.entities,
+  (state) => state.global.activeWorkspaceId,
   (workspaces, entities, activeWorkspaceId) => {
     return entities.workspaces[activeWorkspaceId] || workspaces[0];
   },
@@ -56,7 +56,7 @@ export const selectActiveWorkspaceMeta = createSelector(
   selectEntitiesLists,
   (activeWorkspace, entities) => {
     const id = activeWorkspace ? activeWorkspace._id : 'n/a';
-    return entities.workspaceMetas.find(m => m.parentId === id);
+    return entities.workspaceMetas.find((m) => m.parentId === id);
   },
 );
 
@@ -68,7 +68,7 @@ export const selectActiveEnvironment = createSelector(
       return null;
     }
 
-    return entities.environments.find(e => e._id === meta.activeEnvironmentId) || null;
+    return entities.environments.find((e) => e._id === meta.activeEnvironmentId) || null;
   },
 );
 
@@ -76,7 +76,7 @@ export const selectActiveWorkspaceClientCertificates = createSelector(
   selectEntitiesLists,
   selectActiveWorkspace,
   (entities, activeWorkspace) => {
-    return entities.clientCertificates.filter(c => c.parentId === activeWorkspace._id);
+    return entities.clientCertificates.filter((c) => c.parentId === activeWorkspace._id);
   },
 );
 
@@ -89,12 +89,12 @@ export const selectActiveGitRepository = createSelector(
     }
 
     const id = activeWorkspaceMeta ? activeWorkspaceMeta.gitRepositoryId : 'n/a';
-    const repo = entities.gitRepositories.find(r => r._id === id);
+    const repo = entities.gitRepositories.find((r) => r._id === id);
     return repo || null;
   },
 );
 
-export const selectCollapsedRequestGroups = createSelector(selectEntitiesLists, entities => {
+export const selectCollapsedRequestGroups = createSelector(selectEntitiesLists, (entities) => {
   const collapsed = {};
 
   // Default all to collapsed
@@ -115,7 +115,7 @@ export const selectActiveWorkspaceEntities = createSelector(
   selectEntitiesChildrenMap,
   (activeWorkspace, childrenMap) => {
     const descendants = [activeWorkspace];
-    const addChildrenOf = parent => {
+    const addChildrenOf = (parent) => {
       // Don't add children of requests (eg. auth requests)
       if (parent.type === models.request.type) {
         return [];
@@ -135,7 +135,7 @@ export const selectActiveWorkspaceEntities = createSelector(
   },
 );
 
-export const selectPinnedRequests = createSelector(selectEntitiesLists, entities => {
+export const selectPinnedRequests = createSelector(selectEntitiesLists, (entities) => {
   const pinned = {};
 
   const requests = [...entities.requests, ...entities.grpcRequests];
@@ -156,15 +156,15 @@ export const selectPinnedRequests = createSelector(selectEntitiesLists, entities
 
 export const selectWorkspaceRequestsAndRequestGroups = createSelector(
   selectActiveWorkspaceEntities,
-  entities => {
+  (entities) => {
     return entities.filter(
-      e => e.type === models.request.type || e.type === models.requestGroup.type,
+      (e) => e.type === models.request.type || e.type === models.requestGroup.type,
     );
   },
 );
 
 export const selectActiveRequest = createSelector(
-  state => state.entities,
+  (state) => state.entities,
   selectActiveWorkspaceMeta,
   (entities, workspaceMeta) => {
     const id = workspaceMeta ? workspaceMeta.activeRequestId : 'n/a';
@@ -176,7 +176,7 @@ export const selectActiveProtoFiles = createSelector(
   selectEntitiesLists,
   selectActiveWorkspace,
   (entities, workspace) => {
-    return entities.protoFiles.filter(pf => pf.parentId === workspace._id);
+    return entities.protoFiles.filter((pf) => pf.parentId === workspace._id);
   },
 );
 
@@ -184,7 +184,7 @@ export const selectActiveCookieJar = createSelector(
   selectEntitiesLists,
   selectActiveWorkspace,
   (entities, workspace) => {
-    const cookieJar = entities.cookieJars.find(cj => cj.parentId === workspace._id);
+    const cookieJar = entities.cookieJars.find((cj) => cj.parentId === workspace._id);
     return cookieJar || null;
   },
 );
@@ -194,14 +194,14 @@ export const selectActiveOAuth2Token = createSelector(
   selectActiveWorkspaceMeta,
   (entities, workspaceMeta) => {
     const id = workspaceMeta ? workspaceMeta.activeRequestId : 'n/a';
-    return entities.oAuth2Tokens.find(t => t.parentId === id);
+    return entities.oAuth2Tokens.find((t) => t.parentId === id);
   },
 );
 
-export const selectUnseenWorkspaces = createSelector(selectEntitiesLists, entities => {
+export const selectUnseenWorkspaces = createSelector(selectEntitiesLists, (entities) => {
   const { workspaces, workspaceMetas } = entities;
-  return workspaces.filter(workspace => {
-    const meta = workspaceMetas.find(m => m.parentId === workspace._id);
+  return workspaces.filter((workspace) => {
+    const meta = workspaceMetas.find((m) => m.parentId === workspace._id);
     return !!(meta && !meta.hasSeen);
   });
 });
@@ -211,7 +211,7 @@ export const selectActiveRequestMeta = createSelector(
   selectEntitiesLists,
   (activeRequest, entities) => {
     const id = activeRequest ? activeRequest._id : 'n/a';
-    return entities.requestMetas.find(m => m.parentId === id);
+    return entities.requestMetas.find((m) => m.parentId === id);
   },
 );
 
@@ -225,7 +225,7 @@ export const selectActiveRequestResponses = createSelector(
 
     // Filter responses down if the setting is enabled
     return entities.responses
-      .filter(response => {
+      .filter((response) => {
         const requestMatches = requestId === response.parentId;
 
         if (settings.filterResponsesByEnv) {
@@ -245,7 +245,7 @@ export const selectActiveResponse = createSelector(
   selectActiveRequestResponses,
   (activeRequestMeta, responses) => {
     const activeResponseId = activeRequestMeta ? activeRequestMeta.activeResponseId : 'n/a';
-    const activeResponse = responses.find(response => response._id === activeResponseId);
+    const activeResponse = responses.find((response) => response._id === activeResponseId);
 
     if (activeResponse) {
       return activeResponse;
@@ -288,7 +288,7 @@ export const selectActiveUnitTestSuite = createSelector(
     }
 
     const id = activeWorkspaceMeta.activeUnitTestSuiteId;
-    return entities.unitTestSuites.find(s => s._id === id) || null;
+    return entities.unitTestSuites.find((s) => s._id === id) || null;
   },
 );
 
@@ -300,7 +300,7 @@ export const selectActiveUnitTests = createSelector(
       return [];
     }
 
-    return entities.unitTests.filter(s => s.parentId === activeUnitTestSuite._id);
+    return entities.unitTests.filter((s) => s.parentId === activeUnitTestSuite._id);
   },
 );
 
@@ -308,12 +308,12 @@ export const selectActiveUnitTestSuites = createSelector(
   selectEntitiesLists,
   selectActiveWorkspace,
   (entities, activeWorkspace) => {
-    return entities.unitTestSuites.filter(s => s.parentId === activeWorkspace._id);
+    return entities.unitTestSuites.filter((s) => s.parentId === activeWorkspace._id);
   },
 );
 
-export const selectSyncItems = createSelector(selectActiveWorkspaceEntities, workspaceEntities =>
-  workspaceEntities.filter(models.canSync).map(doc => ({
+export const selectSyncItems = createSelector(selectActiveWorkspaceEntities, (workspaceEntities) =>
+  workspaceEntities.filter(models.canSync).map((doc) => ({
     key: doc._id,
     name: doc.name || '',
     document: doc,

--- a/packages/insomnia-app/app/ui/redux/sidebar-selectors.js
+++ b/packages/insomnia-app/app/ui/redux/sidebar-selectors.js
@@ -45,7 +45,7 @@ export const selectSidebarChildren = createSelector(
         .sort(sortByMetaKeyOrId);
 
       if (children.length > 0) {
-        return children.map(c => {
+        return children.map((c) => {
           const child = {
             doc: c,
             hidden: false,
@@ -77,7 +77,7 @@ export const selectSidebarChildren = createSelector(
         // Gather all parents so we can match them too
         matchChildren(child.children, [...parentNames, child.doc.name]);
 
-        const hasMatchedChildren = child.children.find(c => c.hidden === false);
+        const hasMatchedChildren = child.children.find((c) => c.hidden === false);
 
         // Try to match request attributes
         const name = child.doc.name;

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -3531,11 +3531,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@ungap/promise-all-settled": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
-		},
 		"@wdio/config": {
 			"version": "6.1.14",
 			"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.1.14.tgz",
@@ -4062,41 +4057,10 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+			"optional": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
-			}
-		},
-		"apiconnect-wsdl": {
-			"version": "1.8.31",
-			"resolved": "https://registry.npmjs.org/apiconnect-wsdl/-/apiconnect-wsdl-1.8.31.tgz",
-			"integrity": "sha512-kNs26If9xCJnGolVTAt0VWIA8KrqwodQLqDRTrfc7txD54LJ+hFx638sPYEdG9jw78eifWyy+FBlS5befYSa8Q==",
-			"requires": {
-				"iconv-lite": "^0.4.24",
-				"js-yaml": "^3.13.1",
-				"jszip": "^3.2.2",
-				"lodash": "^4.17.15",
-				"q": "^1.5.1",
-				"swagger-parser": "8.0.3",
-				"xml2js": "^0.4.22",
-				"xmldom": "^0.1.27",
-				"yauzl": "^2.10.0"
-			},
-			"dependencies": {
-				"swagger-parser": {
-					"version": "8.0.3",
-					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
-					"integrity": "sha512-y2gw+rTjn7Z9J+J1qwbBm0UL93k/VREDCveKBK6iGjf7KXC6QGshbnpEmeHL0ZkCgmIghsXzpNzPSbBH91BAEQ==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"json-schema-ref-parser": "^7.1.1",
-						"ono": "^5.1.0",
-						"openapi-schemas": "^1.0.2",
-						"openapi-types": "^1.3.5",
-						"swagger-methods": "^2.0.1",
-						"z-schema": "^4.1.1"
-					}
-				}
 			}
 		},
 		"app-builder-bin": {
@@ -4470,11 +4434,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-		},
-		"assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -5112,7 +5071,8 @@
 		"binary-extensions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+			"optional": true
 		},
 		"binary-search-tree": {
 			"version": "0.2.5",
@@ -5451,11 +5411,6 @@
 			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
 			"dev": true
 		},
-		"browser-stdout": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
-		},
 		"browserify-aes": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -5601,7 +5556,8 @@
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+			"dev": true
 		},
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
@@ -5854,7 +5810,8 @@
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+			"dev": true
 		},
 		"caller-callsite": {
 			"version": "2.0.0",
@@ -5939,40 +5896,6 @@
 			"integrity": "sha512-JupOe6+dGMr7E20siZHIZQwYqrllxotAhiaej96y6x00b/48rPt42o+SzOSCPbrpsDWvRja40Hwrj0g0q6LZJg==",
 			"dev": true
 		},
-		"capital-case": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
-			},
-			"dependencies": {
-				"lower-case": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-					"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-					"requires": {
-						"tslib": "^2.0.3"
-					}
-				},
-				"no-case": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-					"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-					"requires": {
-						"lower-case": "^2.0.2",
-						"tslib": "^2.0.3"
-					}
-				},
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"case-sensitive-paths-webpack-plugin": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
@@ -6002,19 +5925,6 @@
 				"lazy-cache": "^1.0.3"
 			}
 		},
-		"chai": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-			"requires": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
-				"type-detect": "^4.0.5"
-			}
-		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -6023,85 +5933,6 @@
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
-			}
-		},
-		"change-case": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-			"requires": {
-				"camel-case": "^4.1.2",
-				"capital-case": "^1.0.4",
-				"constant-case": "^3.0.4",
-				"dot-case": "^3.0.4",
-				"header-case": "^2.0.4",
-				"no-case": "^3.0.4",
-				"param-case": "^3.0.4",
-				"pascal-case": "^3.1.2",
-				"path-case": "^3.0.4",
-				"sentence-case": "^3.0.4",
-				"snake-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"camel-case": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-					"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-					"requires": {
-						"pascal-case": "^3.1.2",
-						"tslib": "^2.0.3"
-					}
-				},
-				"dot-case": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-					"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-					"requires": {
-						"no-case": "^3.0.4",
-						"tslib": "^2.0.3"
-					}
-				},
-				"lower-case": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-					"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-					"requires": {
-						"tslib": "^2.0.3"
-					}
-				},
-				"no-case": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-					"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-					"requires": {
-						"lower-case": "^2.0.2",
-						"tslib": "^2.0.3"
-					}
-				},
-				"param-case": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-					"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-					"requires": {
-						"dot-case": "^3.0.4",
-						"tslib": "^2.0.3"
-					}
-				},
-				"pascal-case": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-					"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-					"requires": {
-						"no-case": "^3.0.4",
-						"tslib": "^2.0.3"
-					}
-				},
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
 			}
 		},
 		"character-entities": {
@@ -6124,16 +5955,6 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
-		},
-		"charenc": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-		},
-		"check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
 		},
 		"chokidar": {
 			"version": "3.4.1",
@@ -6775,40 +6596,6 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
-		"constant-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case": "^2.0.2"
-			},
-			"dependencies": {
-				"lower-case": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-					"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-					"requires": {
-						"tslib": "^2.0.3"
-					}
-				},
-				"no-case": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-					"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-					"requires": {
-						"lower-case": "^2.0.2",
-						"tslib": "^2.0.3"
-					}
-				},
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -7130,11 +6917,6 @@
 					}
 				}
 			}
-		},
-		"crypt": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
 		},
 		"cryptiles": {
 			"version": "3.1.4",
@@ -7475,14 +7257,6 @@
 				"mimic-response": "^2.0.0"
 			}
 		},
-		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-			"requires": {
-				"type-detect": "^4.0.0"
-			}
-		},
 		"deep-equal": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -7785,11 +7559,6 @@
 				"asap": "^2.0.0",
 				"wrappy": "1"
 			}
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
 		},
 		"diff-sequences": {
 			"version": "26.6.2",
@@ -10073,11 +9842,6 @@
 				}
 			}
 		},
-		"flat": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
-		},
 		"flush-write-stream": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -10391,11 +10155,6 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
 			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
-		},
-		"format-util": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-			"integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -10750,11 +10509,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-		},
-		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
 		},
 		"get-own-enumerable-property-symbols": {
 			"version": "3.0.2",
@@ -11359,11 +11113,6 @@
 				"graphql-language-service-types": "^1.6.0"
 			}
 		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
-		},
 		"gtoken": {
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.5.tgz",
@@ -11629,23 +11378,8 @@
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
-		},
-		"header-case": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-			"requires": {
-				"capital-case": "^1.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true
 		},
 		"hey-listen": {
 			"version": "1.0.8",
@@ -12380,164 +12114,6 @@
 				}
 			}
 		},
-		"insomnia-components": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/insomnia-components/-/insomnia-components-2.2.26.tgz",
-			"integrity": "sha512-IkTAi2BDX8l23+G822vm5op512d/UoK3zX6R46K6hoZr5KRu44QIcVp0Kk89MxgFRNt/OhnYAPWx1LEXucHBlg==",
-			"requires": {
-				"autobind-decorator": "^2.4.0",
-				"classnames": "^2.2.6",
-				"framer-motion": "^1.10.3",
-				"fuzzysort": "^1.1.4",
-				"md5": "^2.2.1",
-				"prop-types": "^15.7.2",
-				"react-switch": "^5.0.1"
-			}
-		},
-		"insomnia-cookies": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-cookies/-/insomnia-cookies-2.2.24.tgz",
-			"integrity": "sha512-WOipBrUbNhIav0OsBEboT/itCCmrrqiapLAG2/OylMsmutTyAS/7YABK2BS1O9HymTRSCmasWN31GZ87vvsykg==",
-			"requires": {
-				"tough-cookie": "^2.3.3"
-			}
-		},
-		"insomnia-importers": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-importers/-/insomnia-importers-2.2.24.tgz",
-			"integrity": "sha512-9Y88b0PnOfHnY2fWxLWLIKBZR8FQ4edVJYffmtrM8E7qtKObQq513IFnOEhGUQVSIjc2b39vSRXUq1myNrL/Qg==",
-			"requires": {
-				"apiconnect-wsdl": "^1.8.29",
-				"change-case": "^4.1.1",
-				"commander": "^2.20.0",
-				"lodash": "^4.17.15",
-				"shell-quote": "^1.6.1",
-				"swagger-parser": "^6.0.5",
-				"yaml": "^1.5.0"
-			}
-		},
-		"insomnia-plugin-base64": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-base64/-/insomnia-plugin-base64-2.2.24.tgz",
-			"integrity": "sha512-uQXLrs4EiuGbM0Roet1kO3jNecIk5Ua87uBQFOuEE+9xpzxtHG78PgQ8LD1red6kyYby0cT6dLV624gS6WMa+A=="
-		},
-		"insomnia-plugin-cookie-jar": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-cookie-jar/-/insomnia-plugin-cookie-jar-2.2.24.tgz",
-			"integrity": "sha512-y58VLiO7xnqu5PFRre+wuklWmEdJC/S923w0H/bEqtEYzGQd6nm8nILgN+fJZF95e4k0ia9wGXwLRaBfXGzXOw==",
-			"requires": {
-				"insomnia-cookies": "^2.2.24"
-			}
-		},
-		"insomnia-plugin-core-themes": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-core-themes/-/insomnia-plugin-core-themes-2.2.24.tgz",
-			"integrity": "sha512-ZVcT2xhhEhH92PZIUJLM3BKK4ScV1et9GsxHMYWhN62m62NSkauUuJxI0FVueU3Rr1St7xmLxAZnEj/hBQ146Q=="
-		},
-		"insomnia-plugin-file": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-file/-/insomnia-plugin-file-2.2.24.tgz",
-			"integrity": "sha512-47j4hp7JToXnvGlomo4qgUEEJni8irFD+NgR0XH3n9ZV5b9ZaDtqrwbWYSwAXgTiuSLQibype4Zlq6Co9TiO+g=="
-		},
-		"insomnia-plugin-hash": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-hash/-/insomnia-plugin-hash-2.2.24.tgz",
-			"integrity": "sha512-CBSRtw3G+keBzey3KFiJz1T0jknvElYnaJh4whVO3EOb2E/a8N2/VNjiHrPBuFPPMMa+vvpJN8QFJ7LlNsnkbw=="
-		},
-		"insomnia-plugin-jsonpath": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-jsonpath/-/insomnia-plugin-jsonpath-2.2.24.tgz",
-			"integrity": "sha512-nt2kUvS1B1bLjRkg4YpjWBQ3b8pSiC15Ffx8hDxPJX86PS0fUeIvbLbXaKkMZi/AJ49G9G797UFJcQWzB/n0cw==",
-			"requires": {
-				"jsonpath": "^1.0.2"
-			}
-		},
-		"insomnia-plugin-now": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-now/-/insomnia-plugin-now-2.2.24.tgz",
-			"integrity": "sha512-UfOhMTrslvHWyRgbkG08MREezKP6CtidFoUHblIbWEclDlyEk7YhJsiNz0sw1hpfHIbpDgj0CZKYaEAKtRxtSQ==",
-			"requires": {
-				"moment": "^2.21.0"
-			}
-		},
-		"insomnia-plugin-os": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-os/-/insomnia-plugin-os-2.2.24.tgz",
-			"integrity": "sha512-iMf8hsbEidq0hFSE0rHevn8P6hWZUB/gJWKx5cX66B6fr8P4TfRFD8xShwrLDFPjYKU3maQpY12cNTh+Vuu/jw==",
-			"requires": {
-				"jsonpath": "^1.0.2"
-			}
-		},
-		"insomnia-plugin-prompt": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-prompt/-/insomnia-plugin-prompt-2.2.24.tgz",
-			"integrity": "sha512-nDytwD77v1xV+L+icz/f7xLwWvr6BRFjLHxFHy7dGsaPwD5Q5KluhQr1pAcs85e4Pn4bOdqWzLWjAtYwbHB68g=="
-		},
-		"insomnia-plugin-request": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-request/-/insomnia-plugin-request-2.2.24.tgz",
-			"integrity": "sha512-i6tV8qLjWNA88sMdjzg2t/PqoV3XfBRg9I3zA/tG1It33P12Sr7NUkqxmjpHk/7Pg3AY7YkSlOjd4Yh1YryXYg==",
-			"requires": {
-				"insomnia-cookies": "^2.2.24",
-				"insomnia-url": "^2.2.24"
-			}
-		},
-		"insomnia-plugin-response": {
-			"version": "2.2.25",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-response/-/insomnia-plugin-response-2.2.25.tgz",
-			"integrity": "sha512-JWD9lOA8Oe1cuGFOWmEpUaJi+xXTjpvU+T/BXVtrOgZkony3mLtPyaPi7uzDYg9Un/zDePH+wm54i6Vzxn0TFQ==",
-			"requires": {
-				"iconv-lite": "^0.4.19",
-				"insomnia-xpath": "^2.2.24",
-				"jsonpath": "^1.0.2"
-			}
-		},
-		"insomnia-plugin-uuid": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-uuid/-/insomnia-plugin-uuid-2.2.24.tgz",
-			"integrity": "sha512-In7RW5mw0XD+/yhWcjlSNaaFZ5bTcPj8sxnzzswaglS2YDk2Pq5TNVGn52kOyijUmGje6nQdubwmIB9iuLcfEg==",
-			"requires": {
-				"uuid": "^3.1.0"
-			}
-		},
-		"insomnia-prettify": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-prettify/-/insomnia-prettify-2.2.24.tgz",
-			"integrity": "sha512-q+IvS2wWcS7Orx7x4hLGGpiaQL04IBbdCl7L+AnmK3yaXyL9NbJ1gESRqLcZ6INDLO8biSdlq9bRu58yKsHDrQ=="
-		},
-		"insomnia-testing": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/insomnia-testing/-/insomnia-testing-2.2.26.tgz",
-			"integrity": "sha512-fmyXdwr/qoKCMbYK/nkenPhmC+o+zZb9QfP2g/Wy1sDzGF4++WNLH+XEHaeIHAh5SbRMYAR4x1nsgXL1bfqWAQ==",
-			"requires": {
-				"axios": "^0.19.2",
-				"chai": "^4.2.0",
-				"mkdirp": "^1.0.4",
-				"mocha": "^8.0.1"
-			},
-			"dependencies": {
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-				}
-			}
-		},
-		"insomnia-url": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-url/-/insomnia-url-2.2.24.tgz",
-			"integrity": "sha512-KfyEBtrgvli5+gmlX7xWR/N3AzetqI43JECRDUVHxluJFKXvSlxoOOcOCIvE4rB+2ogOf2fdIqZF2MA9G3kFXA=="
-		},
-		"insomnia-xpath": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-xpath/-/insomnia-xpath-2.2.24.tgz",
-			"integrity": "sha512-oUIbm5f2xZ9t/+6i3ZspTEx2YPHk5kqejOU3eabThCsjcoGKY1lEdv5BJH8SiR1/gsVlRAbhYQzVWxK0bV0Xug==",
-			"requires": {
-				"insomnia-cookies": "^2.2.24",
-				"xmldom": "^0.1.27",
-				"xpath": "0.0.27"
-			}
-		},
 		"internal-ip": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -12644,6 +12220,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
 			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"optional": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
 			}
@@ -12651,7 +12228,8 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.2.0",
@@ -13356,23 +12934,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
-		"json-schema-ref-parser": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.4.tgz",
-			"integrity": "sha512-AD7bvav0vak1/63w3jH8F7eHId/4E4EPdMAEZhGxtjktteUv9dnNB/cJy6nVnMyoTPBJnLwFK6tiQPSTeleCtQ==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"js-yaml": "^3.13.1",
-				"ono": "^6.0.0"
-			},
-			"dependencies": {
-				"ono": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
-					"integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
-				}
-			}
-		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -13475,16 +13036,6 @@
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
 			"integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
 		},
-		"jsonschema": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
-		},
-		"jsonschema-draft4": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
-			"integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU="
-		},
 		"jsonwebtoken": {
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
@@ -13511,27 +13062,6 @@
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
-			}
-		},
-		"jszip": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-			"integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
-			"requires": {
-				"lie": "~3.3.0",
-				"pako": "~1.0.2",
-				"readable-stream": "~2.3.6",
-				"set-immediate-shim": "~1.0.1"
-			},
-			"dependencies": {
-				"lie": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-					"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-					"requires": {
-						"immediate": "~3.0.5"
-					}
-				}
 			}
 		},
 		"jwa": {
@@ -13996,11 +13526,6 @@
 			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
 			"dev": true
 		},
-		"lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -14082,59 +13607,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
 			"integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
 			"dev": true
-		},
-		"log-symbols": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-			"requires": {
-				"chalk": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
 		},
 		"loglevel": {
 			"version": "1.6.8",
@@ -14366,16 +13838,6 @@
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
 			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
 			"dev": true
-		},
-		"md5": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-			"requires": {
-				"charenc": "0.0.2",
-				"crypt": "0.0.2",
-				"is-buffer": "~1.1.6"
-			}
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -14812,216 +14274,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-1.1.0.tgz",
 			"integrity": "sha1-LISJPtZ24NmPsY+5piEv0bK5qBk="
-		},
-		"mocha": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
-			"integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
-			"requires": {
-				"@ungap/promise-all-settled": "1.1.2",
-				"ansi-colors": "4.1.1",
-				"browser-stdout": "1.3.1",
-				"chokidar": "3.4.3",
-				"debug": "4.2.0",
-				"diff": "4.0.2",
-				"escape-string-regexp": "4.0.0",
-				"find-up": "5.0.0",
-				"glob": "7.1.6",
-				"growl": "1.10.5",
-				"he": "1.2.0",
-				"js-yaml": "3.14.0",
-				"log-symbols": "4.0.0",
-				"minimatch": "3.0.4",
-				"ms": "2.1.2",
-				"nanoid": "3.1.12",
-				"serialize-javascript": "5.0.1",
-				"strip-json-comments": "3.1.1",
-				"supports-color": "7.2.0",
-				"which": "2.0.2",
-				"wide-align": "1.1.3",
-				"workerpool": "6.0.2",
-				"yargs": "13.3.2",
-				"yargs-parser": "13.1.2",
-				"yargs-unparser": "2.0.0"
-			},
-			"dependencies": {
-				"ansi-colors": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-					"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
-				},
-				"chokidar": {
-					"version": "3.4.3",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-					"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
-					"requires": {
-						"anymatch": "~3.1.1",
-						"braces": "~3.0.2",
-						"fsevents": "~2.1.2",
-						"glob-parent": "~5.1.0",
-						"is-binary-path": "~2.1.0",
-						"is-glob": "~4.0.1",
-						"normalize-path": "~3.0.0",
-						"readdirp": "~3.5.0"
-					}
-				},
-				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"escape-string-regexp": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-				},
-				"find-up": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-					"requires": {
-						"locate-path": "^6.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"locate-path": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-					"requires": {
-						"p-locate": "^5.0.0"
-					}
-				},
-				"nanoid": {
-					"version": "3.1.12",
-					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-					"integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
-				},
-				"p-limit": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-					"requires": {
-						"yocto-queue": "^0.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-					"requires": {
-						"p-limit": "^3.0.2"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-				},
-				"readdirp": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-					"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-					"requires": {
-						"picomatch": "^2.2.1"
-					}
-				},
-				"serialize-javascript": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-					"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
-					"requires": {
-						"randombytes": "^2.1.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-							"requires": {
-								"locate-path": "^3.0.0"
-							}
-						},
-						"locate-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-							"requires": {
-								"p-locate": "^3.0.0",
-								"path-exists": "^3.0.0"
-							}
-						},
-						"p-limit": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-							"requires": {
-								"p-try": "^2.0.0"
-							}
-						},
-						"p-locate": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-							"requires": {
-								"p-limit": "^2.0.0"
-							}
-						},
-						"path-exists": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-						}
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
 		},
 		"modify-filename": {
 			"version": "1.1.0",
@@ -15825,11 +15077,6 @@
 				"mimic-fn": "^2.1.0"
 			}
 		},
-		"ono": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
-			"integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
-		},
 		"open": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/open/-/open-7.1.0.tgz",
@@ -15850,58 +15097,6 @@
 					}
 				}
 			}
-		},
-		"openapi-2-kong": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/openapi-2-kong/-/openapi-2-kong-2.2.26.tgz",
-			"integrity": "sha512-J9OzU8HcEVOl5yLksYYnzNkUb7OC768mCFQsdlfHWGmP5bAJVQbrZ3NubsdbiYVrbguJTqBL6Atzt3r3Y8i5Gw==",
-			"requires": {
-				"slugify": "^1.3.6",
-				"swagger-parser": "^8.0.3",
-				"url-join": "^4.0.1",
-				"yaml": "^1.7.2"
-			},
-			"dependencies": {
-				"ono": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
-					"integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
-				},
-				"swagger-parser": {
-					"version": "8.0.4",
-					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.4.tgz",
-					"integrity": "sha512-KGRdAaMJogSEB7sPKI31ptKIWX8lydEDAwWgB4pBMU7zys5cd54XNhoPSVlTxG/A3LphjX47EBn9j0dOGyzWbA==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"json-schema-ref-parser": "^7.1.3",
-						"ono": "^6.0.0",
-						"openapi-schemas": "^1.0.2",
-						"openapi-types": "^1.3.5",
-						"swagger-methods": "^2.0.1",
-						"z-schema": "^4.2.2"
-					}
-				}
-			}
-		},
-		"openapi-schema-validation": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
-			"integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
-			"requires": {
-				"jsonschema": "1.2.4",
-				"jsonschema-draft4": "^1.0.0",
-				"swagger-schema-official": "2.0.0-bab6bed"
-			}
-		},
-		"openapi-schemas": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.3.tgz",
-			"integrity": "sha512-KtMWcK2VtOS+nD8RKSIyScJsj8JrmVWcIX7Kjx4xEHijFYuvMTDON8WfeKOgeSb4uNG6UsqLj5Na7nKbSav9RQ=="
-		},
-		"openapi-types": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
-			"integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
 		},
 		"opn": {
 			"version": "5.5.0",
@@ -16227,48 +15422,6 @@
 			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
 			"dev": true
 		},
-		"path-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"dot-case": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-					"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-					"requires": {
-						"no-case": "^3.0.4",
-						"tslib": "^2.0.3"
-					}
-				},
-				"lower-case": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-					"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-					"requires": {
-						"tslib": "^2.0.3"
-					}
-				},
-				"no-case": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-					"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-					"requires": {
-						"lower-case": "^2.0.2",
-						"tslib": "^2.0.3"
-					}
-				},
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -16314,11 +15467,6 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"dev": true
-		},
-		"pathval": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
 		},
 		"pause-stream": {
 			"version": "0.0.11",
@@ -17980,14 +17128,6 @@
 				"@babel/runtime": "^7.0.0"
 			}
 		},
-		"react-switch": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.1.tgz",
-			"integrity": "sha512-Pa5kvqRfX85QUCK1Jv0rxyeElbC3aNpCP5hV0LoJpU/Y6kydf0t4kRriQ6ZYA4kxWwAYk/cH51T4/sPzV9mCgQ==",
-			"requires": {
-				"prop-types": "^15.6.2"
-			}
-		},
 		"react-syntax-highlighter": {
 			"version": "12.2.1",
 			"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz",
@@ -18990,40 +18130,6 @@
 				}
 			}
 		},
-		"sentence-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
-			},
-			"dependencies": {
-				"lower-case": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-					"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-					"requires": {
-						"tslib": "^2.0.3"
-					}
-				},
-				"no-case": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-					"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-					"requires": {
-						"lower-case": "^2.0.2",
-						"tslib": "^2.0.3"
-					}
-				},
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"serialize-error": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
@@ -19137,11 +18243,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -19259,7 +18360,8 @@
 		"shell-quote": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
+			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+			"dev": true
 		},
 		"shelljs": {
 			"version": "0.3.0",
@@ -19379,57 +18481,10 @@
 			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
 			"dev": true
 		},
-		"slugify": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.6.tgz",
-			"integrity": "sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ=="
-		},
 		"smart-buffer": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
 			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
-		},
-		"snake-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"dot-case": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-					"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-					"requires": {
-						"no-case": "^3.0.4",
-						"tslib": "^2.0.3"
-					}
-				},
-				"lower-case": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-					"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-					"requires": {
-						"tslib": "^2.0.3"
-					}
-				},
-				"no-case": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-					"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-					"requires": {
-						"lower-case": "^2.0.2",
-						"tslib": "^2.0.3"
-					}
-				},
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -20352,77 +19407,6 @@
 				}
 			}
 		},
-		"swagger-methods": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.2.tgz",
-			"integrity": "sha512-/RNqvBZkH8+3S/FqBPejHxJxZenaYq3MrpeXnzi06aDIS39Mqf5YCUNb/ZBjsvFFt8h9FxfKs8EXPtcYdfLiRg=="
-		},
-		"swagger-parser": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-6.0.5.tgz",
-			"integrity": "sha512-UL47eu4+GRm5y+N7J+W6QQiqAJn2lojyqgMwS0EZgA55dXd5xmpQCsjUmH/Rf0eKDiG1kULc9VS515PxAyTDVw==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"json-schema-ref-parser": "^6.0.3",
-				"ono": "^4.0.11",
-				"openapi-schema-validation": "^0.4.2",
-				"swagger-methods": "^1.0.8",
-				"swagger-schema-official": "2.0.0-bab6bed",
-				"z-schema": "^3.24.2"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.12",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-				},
-				"json-schema-ref-parser": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-					"integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"js-yaml": "^3.12.1",
-						"ono": "^4.0.11"
-					}
-				},
-				"ono": {
-					"version": "4.0.11",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-					"integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-					"requires": {
-						"format-util": "^1.0.3"
-					}
-				},
-				"swagger-methods": {
-					"version": "1.0.8",
-					"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.8.tgz",
-					"integrity": "sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA=="
-				},
-				"validator": {
-					"version": "10.11.0",
-					"resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-					"integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
-				},
-				"z-schema": {
-					"version": "3.25.1",
-					"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
-					"integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
-					"requires": {
-						"commander": "^2.7.1",
-						"core-js": "^2.5.7",
-						"lodash.get": "^4.0.0",
-						"lodash.isequal": "^4.0.0",
-						"validator": "^10.0.0"
-					}
-				}
-			}
-		},
-		"swagger-schema-official": {
-			"version": "2.0.0-bab6bed",
-			"resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
-			"integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
-		},
 		"swagger-ui-react": {
 			"version": "3.30.2",
 			"resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-3.30.2.tgz",
@@ -20995,11 +19979,6 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
-		"type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
-		},
 		"type-fest": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -21400,36 +20379,6 @@
 				}
 			}
 		},
-		"upper-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"upper-case-first": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -21618,11 +20567,6 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
-		},
-		"validator": {
-			"version": "12.2.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
-			"integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
 		},
 		"varint": {
 			"version": "0.0.3",
@@ -23856,11 +22800,6 @@
 				"microevent.ts": "~0.1.1"
 			}
 		},
-		"workerpool": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
-			"integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q=="
-		},
 		"wrap-ansi": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -23911,34 +22850,10 @@
 				"repeat-string": "^1.5.2"
 			}
 		},
-		"xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-			"requires": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~11.0.0"
-			}
-		},
-		"xmlbuilder": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-		},
 		"xmlcreate": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
 			"integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ=="
-		},
-		"xmldom": {
-			"version": "0.1.31",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
-		},
-		"xpath": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-			"integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
 		},
 		"xregexp": {
 			"version": "2.0.0",
@@ -23997,57 +22912,14 @@
 				"decamelize": "^1.2.0"
 			}
 		},
-		"yargs-unparser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-			"requires": {
-				"camelcase": "^6.0.0",
-				"decamelize": "^4.0.0",
-				"flat": "^5.0.2",
-				"is-plain-obj": "^2.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
-				},
-				"decamelize": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-					"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
-				},
-				"is-plain-obj": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-				}
-			}
-		},
 		"yauzl": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
 			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+			"dev": true,
 			"requires": {
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
-			}
-		},
-		"yocto-queue": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-		},
-		"z-schema": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
-			"integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
-			"requires": {
-				"commander": "^2.7.1",
-				"lodash.get": "^4.4.2",
-				"lodash.isequal": "^4.5.0",
-				"validator": "^12.0.0"
 			}
 		},
 		"zenscroll": {

--- a/packages/insomnia-app/scripts/build.js
+++ b/packages/insomnia-app/scripts/build.js
@@ -109,7 +109,7 @@ async function buildWebpack(config) {
 async function emptyDir(relPath) {
   return new Promise((resolve, reject) => {
     const dir = path.resolve(__dirname, relPath);
-    rimraf(dir, err => {
+    rimraf(dir, (err) => {
       if (err) {
         reject(err);
       } else {
@@ -125,7 +125,7 @@ async function copyFiles(relSource, relDest) {
     const source = path.resolve(__dirname, relSource);
     const dest = path.resolve(__dirname, relDest);
     console.log(`[build] copy "${relSource}" to "${relDest}"`);
-    ncp(source, dest, err => {
+    ncp(source, dest, (err) => {
       if (err) {
         reject(err);
       } else {
@@ -166,7 +166,7 @@ async function buildLicenseList(relSource, relDest) {
             email ? `EMAIL: ${email}` : null,
             '\n' + txt,
           ]
-            .filter(v => v !== null)
+            .filter((v) => v !== null)
             .join('\n');
 
           out.push(`${body}\n\n`);
@@ -188,7 +188,7 @@ async function buildLicenseList(relSource, relDest) {
 }
 
 async function install(relDir) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     const prefix = path.resolve(__dirname, relDir);
 
     const p = childProcess.spawn('npm', ['install', '--production', '--no-optional'], {
@@ -196,15 +196,15 @@ async function install(relDir) {
       shell: true,
     });
 
-    p.stdout.on('data', data => {
+    p.stdout.on('data', (data) => {
       console.log(data.toString());
     });
 
-    p.stderr.on('data', data => {
+    p.stderr.on('data', (data) => {
       console.log(data.toString());
     });
 
-    p.on('exit', code => {
+    p.on('exit', (code) => {
       console.log('child process exited with code ' + code.toString());
       resolve();
     });
@@ -244,7 +244,7 @@ function generatePackageJson(relBasePkg, relOutPkg) {
   // Figure out which dependencies to pack
   const allDependencies = Object.keys(basePkg.dependencies);
   const packedDependencies = basePkg.packedDependencies;
-  const unpackedDependencies = allDependencies.filter(name => !packedDependencies.includes(name));
+  const unpackedDependencies = allDependencies.filter((name) => !packedDependencies.includes(name));
 
   // Add dependencies
   console.log(`[build] Adding ${unpackedDependencies.length} node dependencies`);

--- a/packages/insomnia-app/scripts/getBuildContext.js
+++ b/packages/insomnia-app/scripts/getBuildContext.js
@@ -1,4 +1,4 @@
-module.exports.getBuildContext = forceFromGitRef => {
+module.exports.getBuildContext = (forceFromGitRef) => {
   if (forceFromGitRef) {
     return fromGitRef();
   }

--- a/packages/insomnia-app/scripts/package.js
+++ b/packages/insomnia-app/scripts/package.js
@@ -66,7 +66,7 @@ async function pkg(electronBuilderConfig) {
 async function emptyDir(relPath) {
   return new Promise((resolve, reject) => {
     const dir = path.resolve(__dirname, relPath);
-    rimraf(dir, err => {
+    rimraf(dir, (err) => {
       if (err) {
         reject(err);
       } else {

--- a/packages/insomnia-app/scripts/release.js
+++ b/packages/insomnia-app/scripts/release.js
@@ -30,7 +30,7 @@ async function start(app, version) {
   const appId = appConfig().appId;
 
   // globs should only use forward slash, so force use of path.posix
-  const distGlob = ext => path.posix.join('dist', appId, '**', `*${ext}`);
+  const distGlob = (ext) => path.posix.join('dist', appId, '**', `*${ext}`);
   const assetGlobs = {
     darwin: [distGlob('.zip'), distGlob('.dmg')],
     win32: [path.posix.join('dist', appId, 'squirrel-windows', '*')],

--- a/packages/insomnia-app/scripts/start.js
+++ b/packages/insomnia-app/scripts/start.js
@@ -13,4 +13,4 @@ promptRun({
       },
     ],
   },
-}).then(childProcess => {});
+}).then((childProcess) => {});

--- a/packages/insomnia-app/send-request/webpack.config.babel.js
+++ b/packages/insomnia-app/send-request/webpack.config.babel.js
@@ -34,7 +34,7 @@ module.exports = {
   },
   externals: [
     // Omit all dependencies in app/package.json (we want them loaded at runtime via NodeJS)
-    ...Object.keys(pkg.dependencies).filter(name => !pkg.packedDependencies.includes(name)),
+    ...Object.keys(pkg.dependencies).filter((name) => !pkg.packedDependencies.includes(name)),
   ],
   resolve: {
     alias: {

--- a/packages/insomnia-components/components/__tests__/tooltip.test.js
+++ b/packages/insomnia-components/components/__tests__/tooltip.test.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import Tooltip from '../tooltip';
 
-const pause = time => new Promise(resolve => setTimeout(resolve, time));
+const pause = (time) => new Promise((resolve) => setTimeout(resolve, time));
 
-const expectNoTooltip = queryByRole => {
+const expectNoTooltip = (queryByRole) => {
   expect(queryByRole('tooltip', { hidden: true })).toBeNull();
   expect(queryByRole('tooltip')).toBeNull();
 };

--- a/packages/insomnia-components/components/button/async-button.js
+++ b/packages/insomnia-components/components/button/async-button.js
@@ -27,7 +27,7 @@ export const AsyncButton = ({
   const [loading, setLoading] = React.useState(false);
 
   const asyncHandler = React.useCallback(
-    async e => {
+    async (e) => {
       const result = onClick(e);
       if (isPromise(result)) {
         try {

--- a/packages/insomnia-components/components/button/async-button.stories.js
+++ b/packages/insomnia-components/components/button/async-button.stories.js
@@ -11,7 +11,7 @@ export default {
 
 export const _default = () => (
   <AsyncButton
-    onClick={() => new Promise(resolve => setTimeout(resolve, 3000))}
+    onClick={() => new Promise((resolve) => setTimeout(resolve, 3000))}
     variant={select('Variant', ButtonVariantEnum)}
     size={select('Size', ButtonSizeEnum)}
     bg={select('Background', ButtonThemeEnum)}>
@@ -21,7 +21,7 @@ export const _default = () => (
 
 export const customLoader = () => (
   <AsyncButton
-    onClick={() => new Promise(resolve => setTimeout(resolve, 3000))}
+    onClick={() => new Promise((resolve) => setTimeout(resolve, 3000))}
     variant={select('Variant', ButtonVariantEnum)}
     size={select('Size', ButtonSizeEnum)}
     bg={select('Background', ButtonThemeEnum)}

--- a/packages/insomnia-components/components/button/button.stories.js
+++ b/packages/insomnia-components/components/button/button.stories.js
@@ -82,14 +82,14 @@ export const reference = () => {
 
   return (
     <React.Fragment>
-      {Object.values(ButtonSizeEnum).map(s => (
+      {Object.values(ButtonSizeEnum).map((s) => (
         <Padded>
           <h2>
             <code>size={(s: any)}</code>
           </h2>
-          {Object.values(ButtonVariantEnum).map(v => (
+          {Object.values(ButtonVariantEnum).map((v) => (
             <Wrapper>
-              {Object.values(ButtonThemeEnum).map(b => (
+              {Object.values(ButtonThemeEnum).map((b) => (
                 <Button bg={b} variant={v} size={s} radius={radius}>
                   {b || 'Default'}
                 </Button>

--- a/packages/insomnia-components/components/list-group/unit-test-item.js
+++ b/packages/insomnia-components/components/list-group/unit-test-item.js
@@ -89,7 +89,7 @@ const UnitTestItem = ({
         <Button
           variant="text"
           onClick={onRunTest}
-          disabled={testsRunning && testsRunning.find(t => t._id === item._id)}>
+          disabled={testsRunning && testsRunning.find((t) => t._id === item._id)}>
           <SvgIcon icon="play" />
         </Button>
       </div>

--- a/packages/insomnia-components/components/notice-table.js
+++ b/packages/insomnia-components/components/notice-table.js
@@ -104,7 +104,7 @@ class NoticeTable extends React.PureComponent<Props, State> {
   collapse(e: SyntheticEvent<HTMLButtonElement>) {
     const { onVisibilityToggle } = this.props;
     this.setState(
-      state => ({ collapsed: !state.collapsed }),
+      (state) => ({ collapsed: !state.collapsed }),
       () => {
         if (onVisibilityToggle) {
           onVisibilityToggle(!this.state.collapsed);
@@ -132,8 +132,8 @@ class NoticeTable extends React.PureComponent<Props, State> {
       <SvgIcon icon={IconEnum.chevronDown} />
     );
 
-    const errors = notices.filter(n => n.type === 'error');
-    const warnings = notices.filter(n => n.type === 'warning');
+    const errors = notices.filter((n) => n.type === 'error');
+    const warnings = notices.filter((n) => n.type === 'warning');
 
     return (
       <Wrapper>

--- a/packages/insomnia-components/components/notice-table.stories.js
+++ b/packages/insomnia-components/components/notice-table.stories.js
@@ -25,8 +25,8 @@ const notices = [
 export const _default = () => (
   <NoticeTable
     notices={notices}
-    onClick={n => window.alert(n.message)}
-    onVisibilityToggle={v => console.log('Visible?', v)}
+    onClick={(n) => window.alert(n.message)}
+    onVisibilityToggle={(v) => console.log('Visible?', v)}
   />
 );
 
@@ -38,8 +38,8 @@ export const manyItems = () => {
   return (
     <NoticeTable
       notices={notices}
-      onClick={n => window.alert(n.message)}
-      onVisibilityToggle={v => console.log('Visible?', v)}
+      onClick={(n) => window.alert(n.message)}
+      onVisibilityToggle={(v) => console.log('Visible?', v)}
     />
   );
 };

--- a/packages/insomnia-components/components/radio-button-group.js
+++ b/packages/insomnia-components/components/radio-button-group.js
@@ -55,7 +55,7 @@ export default function RadioButtonGroup({
   selectedValue,
 }: Props) {
   const handleChange = React.useCallback(
-    e => {
+    (e) => {
       if (typeof onChange !== 'function') {
         return;
       }

--- a/packages/insomnia-components/components/sidebar/sidebar-header.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-header.js
@@ -65,7 +65,7 @@ const SidebarHeader = ({
 }: Props) => {
   const handleFilterClick =
     sectionVisible && toggleFilter // only handle a click if the section is open
-      ? e => {
+      ? (e) => {
           e.stopPropagation(); // Prevent a parent from also handling the click
           toggleFilter();
         }

--- a/packages/insomnia-components/components/sidebar/sidebar-headers.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-headers.js
@@ -21,7 +21,7 @@ export default class SidebarHeaders extends React.Component<Props> {
       return <StyledInvalidSection name={'header'} />;
     }
 
-    const filteredValues = Object.keys(headers).filter(header =>
+    const filteredValues = Object.keys(headers).filter((header) =>
       header.toLowerCase().includes(filter.toLocaleLowerCase()),
     );
 
@@ -31,7 +31,7 @@ export default class SidebarHeaders extends React.Component<Props> {
 
     return (
       <div>
-        {filteredValues.map(header => (
+        {filteredValues.map((header) => (
           <React.Fragment key={header}>
             <SidebarItem onClick={() => onClick('components', 'headers', header)}>
               <div>

--- a/packages/insomnia-components/components/sidebar/sidebar-parameters.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-parameters.js
@@ -21,7 +21,7 @@ export default class SidebarParameters extends React.Component<Props> {
       return <StyledInvalidSection name={'parameter'} />;
     }
 
-    const filteredValues = Object.keys(parameters).filter(parameter =>
+    const filteredValues = Object.keys(parameters).filter((parameter) =>
       parameter.toLowerCase().includes(filter.toLocaleLowerCase()),
     );
 
@@ -31,7 +31,7 @@ export default class SidebarParameters extends React.Component<Props> {
 
     return (
       <div>
-        {filteredValues.map(parameter => (
+        {filteredValues.map((parameter) => (
           <React.Fragment key={parameter}>
             <SidebarItem onClick={() => onClick('components', 'parameters', parameter)}>
               <div>

--- a/packages/insomnia-components/components/sidebar/sidebar-paths.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-paths.js
@@ -11,7 +11,7 @@ type Props = {
   onClick: (section: string, ...args: any) => void,
 };
 
-const isNotXDashKey = key => key.indexOf('x-') !== 0;
+const isNotXDashKey = (key) => key.indexOf('x-') !== 0;
 
 // Implemented as a class component because of a caveat with render props
 // https://reactjs.org/docs/render-props.html#be-careful-when-using-render-props-with-reactpurecomponent
@@ -25,7 +25,7 @@ export default class SidebarPaths extends React.Component<Props> {
     if (Object.prototype.toString.call(pathItems) !== '[object Array]') {
       return <StyledInvalidSection name={'path'} />;
     }
-    const filteredValues = pathItems.filter(pathDetail =>
+    const filteredValues = pathItems.filter((pathDetail) =>
       pathDetail[0].toLowerCase().includes(filter.toLocaleLowerCase()),
     );
 
@@ -46,7 +46,7 @@ export default class SidebarPaths extends React.Component<Props> {
             <SidebarItem>
               {Object.keys((routeBody: any))
                 .filter(isNotXDashKey)
-                .map(method => (
+                .map((method) => (
                   <SidebarBadge
                     key={method}
                     method={method}

--- a/packages/insomnia-components/components/sidebar/sidebar-requests.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-requests.js
@@ -27,7 +27,7 @@ export default class SidebarRequests extends React.Component<Props> {
       return <StyledInvalidSection name={'request'} />;
     }
 
-    const filteredValues = Object.keys(requests).filter(requestName =>
+    const filteredValues = Object.keys(requests).filter((requestName) =>
       requestName.toLowerCase().includes(filter.toLocaleLowerCase()),
     );
 
@@ -37,7 +37,7 @@ export default class SidebarRequests extends React.Component<Props> {
 
     return (
       <div>
-        {filteredValues.map(requestName => {
+        {filteredValues.map((requestName) => {
           const { description, content } = requests[requestName];
           return (
             <React.Fragment key={requestName}>
@@ -53,7 +53,7 @@ export default class SidebarRequests extends React.Component<Props> {
                   </Tooltip>
                 </span>
               </SidebarItem>
-              {Object.keys(content).map(requestFormat => (
+              {Object.keys(content).map((requestFormat) => (
                 <React.Fragment key={requestFormat}>
                   <SidebarItem>
                     <StyledRequestFormat>
@@ -74,7 +74,7 @@ export default class SidebarRequests extends React.Component<Props> {
                   </SidebarItem>
                   {content[requestFormat].examples && (
                     <SidebarItem>
-                      {Object.keys(content[requestFormat].examples).map(requestExample => (
+                      {Object.keys(content[requestFormat].examples).map((requestExample) => (
                         <SidebarBadge
                           key={requestExample}
                           label={requestExample}

--- a/packages/insomnia-components/components/sidebar/sidebar-responses.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-responses.js
@@ -21,7 +21,7 @@ export default class SidebarResponses extends React.Component<Props> {
       return <StyledInvalidSection name={'response'} />;
     }
 
-    const filteredValues = Object.keys(responses).filter(response =>
+    const filteredValues = Object.keys(responses).filter((response) =>
       response.toLowerCase().includes(filter.toLocaleLowerCase()),
     );
 
@@ -31,7 +31,7 @@ export default class SidebarResponses extends React.Component<Props> {
 
     return (
       <div>
-        {filteredValues.map(response => (
+        {filteredValues.map((response) => (
           <SidebarItem key={response} onClick={() => onClick('components', 'responses', response)}>
             <div>
               <SvgIcon icon={IconEnum.indentation} />

--- a/packages/insomnia-components/components/sidebar/sidebar-schemas.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-schemas.js
@@ -20,7 +20,7 @@ export default class SidebarSchemas extends React.Component<Props> {
       return <StyledInvalidSection name={'schema'} />;
     }
 
-    const filteredValues = Object.keys(schemas).filter(schema =>
+    const filteredValues = Object.keys(schemas).filter((schema) =>
       schema.toLowerCase().includes(filter.toLocaleLowerCase()),
     );
 
@@ -30,7 +30,7 @@ export default class SidebarSchemas extends React.Component<Props> {
 
     return (
       <div>
-        {filteredValues.map(schema => (
+        {filteredValues.map((schema) => (
           <SidebarItem key={schema} onClick={() => onClick('components', 'schemas', schema)}>
             <div>
               <SvgIcon icon={IconEnum.brackets} />

--- a/packages/insomnia-components/components/sidebar/sidebar-security.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-security.js
@@ -20,7 +20,7 @@ export default class SidebarSecurity extends React.Component<Props> {
       return <StyledInvalidSection name={'security'} />;
     }
 
-    const filteredValues = Object.keys(security).filter(scheme =>
+    const filteredValues = Object.keys(security).filter((scheme) =>
       scheme.toLowerCase().includes(filter.toLocaleLowerCase()),
     );
 
@@ -30,7 +30,7 @@ export default class SidebarSecurity extends React.Component<Props> {
 
     return (
       <div>
-        {filteredValues.map(scheme => (
+        {filteredValues.map((scheme) => (
           <React.Fragment key={scheme}>
             <SidebarItem onClick={() => onClick('components', 'securitySchemes', scheme)}>
               <div>

--- a/packages/insomnia-components/components/sidebar/sidebar-servers.js
+++ b/packages/insomnia-components/components/sidebar/sidebar-servers.js
@@ -18,7 +18,7 @@ export default class SidebarServers extends React.Component<Props> {
     if (!Array.isArray(servers)) {
       return <StyledInvalidSection name={'server'} />;
     }
-    const filteredValues = servers.filter(server =>
+    const filteredValues = servers.filter((server) =>
       server.url.includes(filter.toLocaleLowerCase()),
     );
 

--- a/packages/insomnia-components/components/svg-icon.stories.js
+++ b/packages/insomnia-components/components/svg-icon.stories.js
@@ -37,7 +37,7 @@ export const reference = () => (
       <TableBody>
         {Object.keys(SvgIcon.icons)
           .sort()
-          .map(name => (
+          .map((name) => (
             <TableRow>
               <TableData>
                 <code>{name}</code>

--- a/packages/insomnia-components/components/table.stories.js
+++ b/packages/insomnia-components/components/table.stories.js
@@ -14,7 +14,7 @@ export const _default = () => (
       </TableRow>
     </TableHead>
     <TableBody>
-      {[1, 2, 3].map(i => (
+      {[1, 2, 3].map((i) => (
         <TableRow key={i}>
           <TableData>Column 1</TableData>
           <TableData>Column 2</TableData>
@@ -35,7 +35,7 @@ export const striped = () => (
       </TableRow>
     </TableHead>
     <TableBody>
-      {[1, 2, 3].map(i => (
+      {[1, 2, 3].map((i) => (
         <TableRow key={i}>
           <TableData>Column 1</TableData>
           <TableData>Column 2</TableData>
@@ -56,7 +56,7 @@ export const stripedAndOutlined = () => (
       </TableRow>
     </TableHead>
     <TableBody>
-      {[1, 2, 3].map(i => (
+      {[1, 2, 3].map((i) => (
         <TableRow key={i}>
           <TableData>Column 1</TableData>
           <TableData>Column 2</TableData>
@@ -77,7 +77,7 @@ export const compactAndOutlined = () => (
       </TableRow>
     </TableHead>
     <TableBody>
-      {[1, 2, 3].map(i => (
+      {[1, 2, 3].map((i) => (
         <TableRow key={i}>
           <TableData>Column 1</TableData>
           <TableData>Column 2</TableData>

--- a/packages/insomnia-components/components/toggle-switch.js
+++ b/packages/insomnia-components/components/toggle-switch.js
@@ -30,7 +30,7 @@ const ToggleSwitch: React.StatelessFunctionalComponent<Props> = ({
   }, [checkedProp]);
 
   const callback = React.useCallback(
-    c => {
+    (c) => {
       setChecked(c);
       onChange(c);
     },

--- a/packages/insomnia-components/components/tooltip.stories.js
+++ b/packages/insomnia-components/components/tooltip.stories.js
@@ -39,7 +39,7 @@ export const withChildren = () => {
   const message = (
     <React.Fragment>
       This is a{' '}
-      <a href="#" onClick={e => e.preventDefault()}>
+      <a href="#" onClick={(e) => e.preventDefault()}>
         Link
       </a>
       .

--- a/packages/insomnia-cookies/__tests__/index.test.js
+++ b/packages/insomnia-cookies/__tests__/index.test.js
@@ -2,7 +2,7 @@ const { CookieJar } = require('tough-cookie');
 const { jarFromCookies, cookiesFromJar } = require('..');
 
 describe('jarFromCookies()', () => {
-  it('returns valid cookies', done => {
+  it('returns valid cookies', (done) => {
     const jar = jarFromCookies([
       {
         key: 'foo',
@@ -60,7 +60,7 @@ describe('cookiesFromJar()', () => {
 
     // MemoryStore never actually throws errors, so lets mock the
     // function to force it to this time.
-    jar.store.getAllCookies = cb => cb(new Error('Dummy Error'));
+    jar.store.getAllCookies = (cb) => cb(new Error('Dummy Error'));
     const cookies = await cookiesFromJar(jar);
 
     // Cookies failed to p

--- a/packages/insomnia-cookies/index.js
+++ b/packages/insomnia-cookies/index.js
@@ -6,14 +6,14 @@ const { CookieJar, Cookie } = require('tough-cookie');
  * @param jar
  */
 module.exports.cookiesFromJar = function(jar) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     jar.store.getAllCookies((err, cookies) => {
       if (err) {
         console.warn('Failed to get cookies form jar', err);
         resolve([]);
       } else {
         // NOTE: Perform toJSON so we have a plain JS object instead of Cookie instance
-        resolve(cookies.map(c => c.toJSON()));
+        resolve(cookies.map((c) => c.toJSON()));
       }
     });
   });

--- a/packages/insomnia-importers/src/__tests__/fixtures.test.js
+++ b/packages/insomnia-importers/src/__tests__/fixtures.test.js
@@ -8,9 +8,9 @@ const fixturesPath = path.join(__dirname, './fixtures');
 const fixtures = fs.readdirSync(fixturesPath);
 
 describe('Fixtures', () => {
-  describe.each(fixtures)('Import %s', name => {
+  describe.each(fixtures)('Import %s', (name) => {
     const dir = path.join(fixturesPath, `./${name}`);
-    const inputs = fs.readdirSync(dir).filter(name => !!name.match(/^(.+)-?input\.[^.]+$/));
+    const inputs = fs.readdirSync(dir).filter((name) => !!name.match(/^(.+)-?input\.[^.]+$/));
 
     for (const input of inputs) {
       const prefix = input.replace(/-input\.[^.]+/, '');

--- a/packages/insomnia-importers/src/importers/curl.js
+++ b/packages/insomnia-importers/src/importers/curl.js
@@ -148,14 +148,14 @@ function importArgs(args) {
   const authentication = username ? { username: username.trim(), password: password.trim() } : {};
 
   // Headers
-  const headers = [...(pairs.header || []), ...(pairs.H || [])].map(str => {
+  const headers = [...(pairs.header || []), ...(pairs.H || [])].map((str) => {
     const [name, value] = str.split(/:(.*)$/);
     return { name: name.trim(), value: value.trim() };
   });
 
   // Cookies
   const cookieHeaderValue = [...(pairs.cookie || []), ...(pairs.b || [])]
-    .map(str => {
+    .map((str) => {
       const name = str.split('=', 1)[0];
       const value = str.replace(`${name}=`, '');
       return `${name}=${value}`;
@@ -163,7 +163,7 @@ function importArgs(args) {
     .join('; ');
 
   // Convert cookie value to header
-  const existingCookieHeader = headers.find(h => h.name.toLowerCase() === 'cookie');
+  const existingCookieHeader = headers.find((h) => h.name.toLowerCase() === 'cookie');
   if (cookieHeaderValue && existingCookieHeader) {
     // Has existing cookie header, so let's update it
     existingCookieHeader.value += `; ${cookieHeaderValue}`;
@@ -187,11 +187,11 @@ function importArgs(args) {
   // join params to make body
   const textBody = textBodyParams.join('&');
 
-  const contentTypeHeader = headers.find(h => h.name.toLowerCase() === 'content-type');
+  const contentTypeHeader = headers.find((h) => h.name.toLowerCase() === 'content-type');
   const mimeType = contentTypeHeader ? contentTypeHeader.value.split(';')[0] : null;
 
   // Body (Multipart Form Data)
-  const formDataParams = [...(pairs.form || []), ...(pairs.F || [])].map(str => {
+  const formDataParams = [...(pairs.form || []), ...(pairs.F || [])].map((str) => {
     const [name, value] = str.split('=');
     const item = { name };
 
@@ -208,14 +208,14 @@ function importArgs(args) {
   // Body
   const body = mimeType ? { mimeType: mimeType } : {};
   if (textBody && bodyAsGET) {
-    const bodyParams = textBody.split('&').map(v => {
+    const bodyParams = textBody.split('&').map((v) => {
       const [name, value] = v.split('=');
       return { name: name || '', value: value || '' };
     });
 
     parameters.push(...bodyParams);
   } else if (textBody && mimeType === 'application/x-www-form-urlencoded') {
-    body.params = textBody.split('&').map(v => {
+    body.params = textBody.split('&').map((v) => {
       const [name, value] = v.split('=');
       return { name: name || '', value: value || '' };
     });

--- a/packages/insomnia-importers/src/importers/har.js
+++ b/packages/insomnia-importers/src/importers/har.js
@@ -24,7 +24,7 @@ function importRequest(request) {
   const headers = mapImporter(request.headers, importHeader);
 
   // Convert cookie value to header
-  const existingCookieHeader = headers.find(h => h.name.toLowerCase() === 'cookie');
+  const existingCookieHeader = headers.find((h) => h.name.toLowerCase() === 'cookie');
   if (cookieHeaderValue && existingCookieHeader) {
     // Has existing cookie header, so let's update it
     existingCookieHeader.value += `; ${cookieHeaderValue}`;
@@ -80,7 +80,7 @@ function importPostData(obj) {
 
   if (obj.params && obj.params.length) {
     const mimeType = obj.mimeType || 'application/x-www-form-urlencoded';
-    const params = obj.params.map(p => {
+    const params = obj.params.map((p) => {
       const item = { name: p.name };
       if (p.fileName) {
         item.fileName = p.fileName;

--- a/packages/insomnia-importers/src/importers/insomnia-1.js
+++ b/packages/insomnia-importers/src/importers/insomnia-1.js
@@ -41,7 +41,7 @@ function importItems(items, parentId) {
     resources = [
       ...resources,
       requestGroup,
-      ...item.requests.map(item => importRequestItem(item, requestGroup._id)),
+      ...item.requests.map((item) => importRequestItem(item, requestGroup._id)),
     ];
   }
 
@@ -72,7 +72,7 @@ function importRequestItem(item, parentId) {
   }
 
   const headers = item.headers || [];
-  let contentTypeHeader = headers.find(h => h.name.toLowerCase() === 'content-type');
+  let contentTypeHeader = headers.find((h) => h.name.toLowerCase() === 'content-type');
   if (item.__insomnia && item.__insomnia.format) {
     const contentType = FORMAT_MAP[item.__insomnia.format];
     if (!contentTypeHeader) {
@@ -88,7 +88,7 @@ function importRequestItem(item, parentId) {
       contentTypeHeader.value.match(/^multipart\/form-encoded/i))
   ) {
     body.mimeType = contentTypeHeader.value.split(';')[0];
-    body.params = (item.body || '').split('&').map(v => {
+    body.params = (item.body || '').split('&').map((v) => {
       const [name, value] = v.split('=');
       return {
         name: decodeURIComponent(name),

--- a/packages/insomnia-importers/src/importers/insomnia-2.js
+++ b/packages/insomnia-importers/src/importers/insomnia-2.js
@@ -25,7 +25,7 @@ module.exports.convert = function(rawData) {
 
     // Convert old String request bodies to new (HAR) schema
     const headers = resource.headers || [];
-    const contentTypeHeader = headers.find(h => h.name.toLowerCase() === 'content-type');
+    const contentTypeHeader = headers.find((h) => h.name.toLowerCase() === 'content-type');
     const mimeType = contentTypeHeader ? contentTypeHeader.value.split(';')[0] : null;
     resource.body = {
       mimeType: mimeType || '',

--- a/packages/insomnia-importers/src/importers/openapi3.js
+++ b/packages/insomnia-importers/src/importers/openapi3.js
@@ -184,13 +184,13 @@ function parseEndpoints(document) {
 
   const paths = Object.keys(document.paths);
   const endpointsSchemas = paths
-    .map(path => {
+    .map((path) => {
       const schemasPerMethod = document.paths[path];
       const methods = Object.keys(schemasPerMethod);
 
       return methods
-        .filter(method => method !== 'parameters' && method.indexOf('x-') !== 0)
-        .map(method => Object.assign({}, schemasPerMethod[method], { path, method }));
+        .filter((method) => method !== 'parameters' && method.indexOf('x-') !== 0)
+        .map((method) => Object.assign({}, schemasPerMethod[method], { path, method }));
     })
     .reduce(
       // flat single array
@@ -199,7 +199,7 @@ function parseEndpoints(document) {
     );
 
   const tags = document.tags || [];
-  const folders = tags.map(tag => {
+  const folders = tags.map((tag) => {
     return importFolderItem(tag, defaultParent);
   });
   const folderLookup = {};
@@ -209,7 +209,7 @@ function parseEndpoints(document) {
   }
 
   const requests = [];
-  endpointsSchemas.map(endpointSchema => {
+  endpointsSchemas.map((endpointSchema) => {
     let { tags } = endpointSchema;
 
     if (!tags || tags.length === 0) {
@@ -303,7 +303,7 @@ function pathWithParamsAsVariables(path) {
  * @returns {Object[]} array of parameters definitions
  */
 function prepareQueryParams(endpointSchema) {
-  const isSendInQuery = p => p.in === 'query';
+  const isSendInQuery = (p) => p.in === 'query';
   const parameters = endpointSchema.parameters || [];
   const queryParameters = parameters.filter(isSendInQuery);
   return convertParameters(queryParameters);
@@ -316,7 +316,7 @@ function prepareQueryParams(endpointSchema) {
  * @returns {Object[]} array of parameters definitions
  */
 function prepareHeaders(endpointSchema) {
-  const isSendInHeader = p => p.in === 'header';
+  const isSendInHeader = (p) => p.in === 'header';
   const parameters = endpointSchema.parameters || [];
   const headerParameters = parameters.filter(isSendInHeader);
   return convertParameters(headerParameters);
@@ -339,18 +339,18 @@ function parseSecurity(security, securitySchemes) {
   }
 
   const supportedSchemes = security
-    .map(securityPolicy => {
+    .map((securityPolicy) => {
       const securityName = Object.keys(securityPolicy)[0];
       return securitySchemes[securityName];
     })
     .filter(
-      schemeDetails => schemeDetails && SUPPORTED_SECURITY_TYPES.includes(schemeDetails.type),
+      (schemeDetails) => schemeDetails && SUPPORTED_SECURITY_TYPES.includes(schemeDetails.type),
     );
 
-  const apiKeySchemes = supportedSchemes.filter(scheme => scheme.type === SECURITY_TYPE.API_KEY);
+  const apiKeySchemes = supportedSchemes.filter((scheme) => scheme.type === SECURITY_TYPE.API_KEY);
   const apiKeyHeaders = apiKeySchemes
-    .filter(scheme => scheme.in === 'header')
-    .map(scheme => {
+    .filter((scheme) => scheme.in === 'header')
+    .map((scheme) => {
       const variableName = changeCase.camelCase(scheme.name);
       return {
         name: scheme.name,
@@ -359,15 +359,15 @@ function parseSecurity(security, securitySchemes) {
       };
     });
   const apiKeyCookies = apiKeySchemes
-    .filter(scheme => scheme.in === 'cookie')
-    .map(scheme => {
+    .filter((scheme) => scheme.in === 'cookie')
+    .map((scheme) => {
       const variableName = changeCase.camelCase(scheme.name);
       return `${scheme.name}={{ ${variableName} }}`;
     });
   const apiKeyCookieHeader = { name: 'Cookie', disabled: false, value: apiKeyCookies.join('; ') };
   const apiKeyParams = apiKeySchemes
-    .filter(scheme => scheme.in === 'query')
-    .map(scheme => {
+    .filter((scheme) => scheme.in === 'query')
+    .map((scheme) => {
       const variableName = changeCase.camelCase(scheme.name);
       return {
         name: scheme.name,
@@ -382,7 +382,7 @@ function parseSecurity(security, securitySchemes) {
 
   const authentication = (() => {
     const authScheme = supportedSchemes.find(
-      scheme =>
+      (scheme) =>
         [SECURITY_TYPE.HTTP, SECURITY_TYPE.OAUTH].includes(scheme.type) &&
         SUPPORTED_HTTP_AUTH_SCHEMES.includes(scheme.scheme),
     );
@@ -422,13 +422,13 @@ function getSecurityEnvVariables(securitySchemes) {
   const variables = {};
   const securitySchemesArray = Object.values(securitySchemes);
   const apiKeyVariableNames = securitySchemesArray
-    .filter(scheme => scheme.type === SECURITY_TYPE.API_KEY)
-    .map(scheme => changeCase.camelCase(scheme.name));
+    .filter((scheme) => scheme.type === SECURITY_TYPE.API_KEY)
+    .map((scheme) => changeCase.camelCase(scheme.name));
   const hasHttpBasicScheme = securitySchemesArray.some(
-    scheme => scheme.type === SECURITY_TYPE.HTTP && scheme.scheme === 'basic',
+    (scheme) => scheme.type === SECURITY_TYPE.HTTP && scheme.scheme === 'basic',
   );
   const hasHttpBearerScheme = securitySchemesArray.some(
-    scheme => scheme.type === SECURITY_TYPE.HTTP && scheme.scheme === 'bearer',
+    (scheme) => scheme.type === SECURITY_TYPE.HTTP && scheme.scheme === 'bearer',
   );
   const oauth2Variables = securitySchemesArray.reduce((acc, scheme) => {
     if (scheme.type === SECURITY_TYPE.OAUTH && scheme.scheme === 'bearer') {
@@ -445,7 +445,7 @@ function getSecurityEnvVariables(securitySchemes) {
     return acc;
   }, {});
 
-  Array.from(new Set(apiKeyVariableNames)).forEach(name => {
+  Array.from(new Set(apiKeyVariableNames)).forEach((name) => {
     variables[name] = name;
   });
 
@@ -476,7 +476,7 @@ function prepareBody(endpointSchema) {
   const content = requestBody.content || {};
   const mimeTypes = Object.keys(content);
 
-  const isAvailable = m => mimeTypes.includes(m);
+  const isAvailable = (m) => mimeTypes.includes(m);
   const supportedMimeType = SUPPORTED_MIME_TYPES.find(isAvailable);
 
   if (supportedMimeType === MIMETYPE_JSON) {
@@ -512,7 +512,7 @@ function prepareBody(endpointSchema) {
  * @returns {Object[]} array of insomnia parameters definitions
  */
 function convertParameters(parameters) {
-  return parameters.map(parameter => {
+  return parameters.map((parameter) => {
     const { required, name, schema } = parameter;
     return {
       name,
@@ -542,7 +542,7 @@ function generateParameterExample(schema) {
     number_double: () => 0.0,
     integer: () => 0,
     boolean: () => true,
-    object: schema => {
+    object: (schema) => {
       const example = {};
       const { properties } = schema;
 
@@ -554,7 +554,7 @@ function generateParameterExample(schema) {
 
       return example;
     },
-    array: schema => {
+    array: (schema) => {
       const value = generateParameterExample(schema.items);
       if (schema.collectionFormat === 'csv') {
         return value;

--- a/packages/insomnia-importers/src/importers/postman.js
+++ b/packages/insomnia-importers/src/importers/postman.js
@@ -402,7 +402,7 @@ function findValueByKey(array, key) {
     return '';
   }
 
-  const obj = array.find(o => o.key === key);
+  const obj = array.find((o) => o.key === key);
   if (obj) {
     return obj.value || '';
   }

--- a/packages/insomnia-importers/src/importers/swagger2.js
+++ b/packages/insomnia-importers/src/importers/swagger2.js
@@ -98,20 +98,20 @@ function parseEndpoints(document) {
 
   const paths = Object.keys(document.paths);
   const endpointsSchemas = paths
-    .map(path => {
+    .map((path) => {
       const schemasPerMethod = document.paths[path];
       const methods = Object.keys(schemasPerMethod);
 
       return methods
-        .filter(method => method !== 'parameters')
-        .map(method => Object.assign({}, schemasPerMethod[method], { path, method }));
+        .filter((method) => method !== 'parameters')
+        .map((method) => Object.assign({}, schemasPerMethod[method], { path, method }));
     })
     .reduce((flat, arr) => flat.concat(arr), []); // flat single array
 
   const tags = document.tags || [];
 
   const implicitTags = endpointsSchemas
-    .map(endpointSchema => endpointSchema.tags)
+    .map((endpointSchema) => endpointSchema.tags)
     .reduce((flat, arr) => flat.concat(arr), []) // flat single array
     .reduce((distinct, value) => {
       if (!distinct.includes(value)) {
@@ -119,20 +119,20 @@ function parseEndpoints(document) {
       }
       return distinct;
     }, []) // remove duplicates
-    .filter(tag => !tags.map(tag => tag.name).includes(tag))
-    .map(tag => ({
+    .filter((tag) => !tags.map((tag) => tag.name).includes(tag))
+    .map((tag) => ({
       name: tag,
       desciption: '',
     }));
 
-  const folders = [...tags, ...implicitTags].map(tag => {
+  const folders = [...tags, ...implicitTags].map((tag) => {
     return importFolderItem(tag, defaultParent);
   });
   const folderLookup = {};
-  folders.forEach(folder => (folderLookup[folder.name] = folder._id));
+  folders.forEach((folder) => (folderLookup[folder.name] = folder._id));
 
   const requests = [];
-  endpointsSchemas.map(endpointSchema => {
+  endpointsSchemas.map((endpointSchema) => {
     let { tags } = endpointSchema;
     if (!tags || tags.length === 0) tags = [''];
     tags.forEach((tag, index) => {
@@ -196,7 +196,7 @@ function importRequest(schema, endpointSchema, globalMimeTypes, id, parentId) {
     parameters: prepareQueryParams(endpointSchema),
   };
 
-  if (request.body.mimeType && !request.headers.find(header => header.name === 'Content-Type')) {
+  if (request.body.mimeType && !request.headers.find((header) => header.name === 'Content-Type')) {
     request.headers = [
       {
         name: 'Content-Type',
@@ -333,7 +333,7 @@ function pathWithParamsAsVariables(path) {
  * @returns {Object[]} array of parameters definitions
  */
 function prepareQueryParams(endpointSchema) {
-  const isSendInQuery = p => p.in === 'query';
+  const isSendInQuery = (p) => p.in === 'query';
   const parameters = endpointSchema.parameters || [];
   const queryParameters = parameters.filter(isSendInQuery);
   return convertParameters(queryParameters);
@@ -346,7 +346,7 @@ function prepareQueryParams(endpointSchema) {
  * @returns {Object[]} array of parameters definitions
  */
 function prepareHeaders(endpointSchema) {
-  const isSendInHeader = p => p.in === 'header';
+  const isSendInHeader = (p) => p.in === 'header';
   const parameters = endpointSchema.parameters || [];
   const headerParameters = parameters.filter(isSendInHeader);
   return convertParameters(headerParameters);
@@ -371,10 +371,10 @@ function resolve$ref(schema, $ref) {
  */
 function prepareBody(schema, endpointSchema, globalMimeTypes) {
   const mimeTypes = endpointSchema.consumes || globalMimeTypes || [];
-  const isAvailable = m => mimeTypes.includes(m);
+  const isAvailable = (m) => mimeTypes.includes(m);
   const supportedMimeType = SUPPORTED_MIME_TYPES.find(isAvailable);
   if (supportedMimeType === MIMETYPE_JSON) {
-    const isSendInBody = p => p.in === 'body';
+    const isSendInBody = (p) => p.in === 'body';
     const parameters = endpointSchema.parameters || [];
     const bodyParameter = parameters.find(isSendInBody);
     if (!bodyParameter) {
@@ -402,7 +402,7 @@ function prepareBody(schema, endpointSchema, globalMimeTypes) {
   }
 
   if (supportedMimeType === MIMETYPE_URLENCODED || supportedMimeType === MIMETYPE_MULTIPART) {
-    const isSendInFormData = p => p.in === 'formData';
+    const isSendInFormData = (p) => p.in === 'formData';
     const parameters = endpointSchema.parameters || [];
     const formDataParameters = parameters.filter(isSendInFormData);
 
@@ -431,7 +431,7 @@ function prepareBody(schema, endpointSchema, globalMimeTypes) {
  * @returns {Object[]} array of insomnia parameters definitions
  */
 function convertParameters(parameters) {
-  return parameters.map(parameter => {
+  return parameters.map((parameter) => {
     const { required, name, type } = parameter;
     if (type === 'file') {
       return {
@@ -468,19 +468,19 @@ function generateParameterExample(schema) {
     number_double: () => 0.0,
     integer: () => 0,
     boolean: () => true,
-    object: schema => {
+    object: (schema) => {
       const example = {};
       const { properties } = schema;
 
       if (properties) {
-        Object.keys(properties).forEach(propertyName => {
+        Object.keys(properties).forEach((propertyName) => {
           example[propertyName] = generateParameterExample(properties[propertyName]);
         });
       }
 
       return example;
     },
-    array: schema => {
+    array: (schema) => {
       const value = generateParameterExample(schema.items);
       if (schema.collectionFormat === 'csv') {
         return value;

--- a/packages/insomnia-importers/src/importers/wsdl.js
+++ b/packages/insomnia-importers/src/importers/wsdl.js
@@ -32,7 +32,7 @@ function convertToPostman(items) {
     },
   };
 
-  out.item = items.map(i => {
+  out.item = items.map((i) => {
     const item = [];
     const url = get(i, 'x-ibm-configuration.assembly.execute.0.proxy.target-url');
     for (const k of Object.keys(i.paths)) {

--- a/packages/insomnia-inso/__jest__/before.js
+++ b/packages/insomnia-inso/__jest__/before.js
@@ -15,8 +15,8 @@ export function globalBeforeAll() {
       'debug',
       'trace',
       'verbose',
-    ].forEach(level => {
-      logs[level] = logger[level].mock.calls.map(c => (c.length === 1 ? c[0] : c));
+    ].forEach((level) => {
+      logs[level] = logger[level].mock.calls.map((c) => (c.length === 1 ? c[0] : c));
     });
     return logs;
   };

--- a/packages/insomnia-inso/__mocks__/enquirer.js
+++ b/packages/insomnia-inso/__mocks__/enquirer.js
@@ -13,7 +13,7 @@ class Prompt {
 
 module.exports = {
   __constructorMock,
-  __mockPromptRun: v => {
+  __mockPromptRun: (v) => {
     returnValue = v;
   },
   AutoComplete: Prompt,

--- a/packages/insomnia-inso/package-lock.json
+++ b/packages/insomnia-inso/package-lock.json
@@ -1060,60 +1060,6 @@
 				"minimist": "^1.2.0"
 			}
 		},
-		"@hapi/b64": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
-			"integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
-			"requires": {
-				"@hapi/hoek": "8.x.x"
-			}
-		},
-		"@hapi/boom": {
-			"version": "7.4.11",
-			"resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-			"integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
-			"requires": {
-				"@hapi/hoek": "8.x.x"
-			}
-		},
-		"@hapi/bounce": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.2.tgz",
-			"integrity": "sha512-3bnb1AlcEByFZnpDIidxQyw1Gds81z/1rSqlx4bIEE+wUN0ATj0D49B5cE1wGocy90Rp/de4tv7GjsKd5RQeew==",
-			"requires": {
-				"@hapi/boom": "7.x.x",
-				"@hapi/hoek": "^8.3.1"
-			}
-		},
-		"@hapi/cryptiles": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
-			"integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
-			"requires": {
-				"@hapi/boom": "7.x.x"
-			}
-		},
-		"@hapi/hoek": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-			"integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
-		},
-		"@hapi/sntp": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@hapi/sntp/-/sntp-3.1.2.tgz",
-			"integrity": "sha512-i2UehKbFPKtKVXhp4v7wV3qJxkGV2TAPlZ5YSpmsqv/2eygXYYI+etBJ5r4T8kbyslhxgqQyHNS6xstL92Vmrg==",
-			"requires": {
-				"@hapi/boom": "7.x.x",
-				"@hapi/bounce": "1.x.x",
-				"@hapi/hoek": "8.x.x",
-				"@hapi/teamwork": "3.x.x"
-			}
-		},
-		"@hapi/teamwork": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
-			"integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ=="
-		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1632,11 +1578,6 @@
 			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
 			"dev": true
 		},
-		"@ungap/promise-all-settled": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
-		},
 		"@webassemblyjs/ast": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -1824,26 +1765,11 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
-		"JSV": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-			"integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
-		},
-		"a-sync-waterfall": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-			"integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
-		},
 		"abab": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
 			"integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
 			"dev": true
-		},
-		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 		},
 		"abort-controller": {
 			"version": "3.0.0",
@@ -2073,56 +1999,17 @@
 				}
 			}
 		},
-		"apiconnect-wsdl": {
-			"version": "1.8.31",
-			"resolved": "https://registry.npmjs.org/apiconnect-wsdl/-/apiconnect-wsdl-1.8.31.tgz",
-			"integrity": "sha512-kNs26If9xCJnGolVTAt0VWIA8KrqwodQLqDRTrfc7txD54LJ+hFx638sPYEdG9jw78eifWyy+FBlS5befYSa8Q==",
-			"requires": {
-				"iconv-lite": "^0.4.24",
-				"js-yaml": "^3.13.1",
-				"jszip": "^3.2.2",
-				"lodash": "^4.17.15",
-				"q": "^1.5.1",
-				"swagger-parser": "8.0.3",
-				"xml2js": "^0.4.22",
-				"xmldom": "^0.1.27",
-				"yauzl": "^2.10.0"
-			},
-			"dependencies": {
-				"swagger-parser": {
-					"version": "8.0.3",
-					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
-					"integrity": "sha512-y2gw+rTjn7Z9J+J1qwbBm0UL93k/VREDCveKBK6iGjf7KXC6QGshbnpEmeHL0ZkCgmIghsXzpNzPSbBH91BAEQ==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"json-schema-ref-parser": "^7.1.1",
-						"ono": "^5.1.0",
-						"openapi-schemas": "^1.0.2",
-						"openapi-types": "^1.3.5",
-						"swagger-methods": "^2.0.1",
-						"z-schema": "^4.1.1"
-					}
-				}
-			}
-		},
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-		},
-		"are-we-there-yet": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			}
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -2145,26 +2032,17 @@
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
 		},
-		"array-filter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-			"integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
-		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
 		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -2218,12 +2096,8 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-		},
-		"assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -2248,20 +2122,11 @@
 			"dev": true,
 			"optional": true
 		},
-		"async-lock": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.2.6.tgz",
-			"integrity": "sha512-gobUp/bRWL/uJsxi4ZK7NM770s5d2Tx5Hl7uxFIcN6yTz1Kvy2RCSKEvzhLsjAAnYaNa8lDvcjy9ybM6lXFjIg=="
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"atob": {
 			"version": "2.1.2",
@@ -2269,31 +2134,17 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
 		},
-		"available-typed-arrays": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
-			"integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
-			"requires": {
-				"array-filter": "^1.0.0"
-			}
-		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
-		},
-		"axios": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-			"requires": {
-				"follow-redirects": "1.5.10"
-			}
+			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+			"dev": true
 		},
 		"babel-jest": {
 			"version": "26.1.0",
@@ -2385,7 +2236,8 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
@@ -2452,6 +2304,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -2492,6 +2345,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
 			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+			"dev": true,
 			"optional": true
 		},
 		"binary-search-tree": {
@@ -2533,6 +2387,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2557,11 +2412,6 @@
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
 			"dev": true
-		},
-		"browser-stdout": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
@@ -2712,11 +2562,6 @@
 				}
 			}
 		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2800,40 +2645,10 @@
 				"unset-value": "^1.0.0"
 			}
 		},
-		"call-bind": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
-			"requires": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.0"
-			}
-		},
-		"call-me-maybe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
-		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
-		},
-		"camel-case": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-			"requires": {
-				"pascal-case": "^3.1.2",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"camelcase": {
 			"version": "5.3.1",
@@ -2845,23 +2660,6 @@
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001090.tgz",
 			"integrity": "sha512-QzPRKDCyp7RhjczTPZaqK3CjPA5Ht2UnXhZhCI4f7QiB5JK6KEuZBxIzyWnB3wO4hgAj4GMRxAhuiacfw0Psjg==",
 			"dev": true
-		},
-		"capital-case": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -2875,20 +2673,8 @@
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
-		"chai": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-			"requires": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
-				"type-detect": "^4.0.5"
-			}
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"chalk": {
 			"version": "4.0.0",
@@ -2936,47 +2722,17 @@
 				}
 			}
 		},
-		"change-case": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-			"requires": {
-				"camel-case": "^4.1.2",
-				"capital-case": "^1.0.4",
-				"constant-case": "^3.0.4",
-				"dot-case": "^3.0.4",
-				"header-case": "^2.0.4",
-				"no-case": "^3.0.4",
-				"param-case": "^3.0.4",
-				"pascal-case": "^3.1.2",
-				"path-case": "^3.0.4",
-				"sentence-case": "^3.0.4",
-				"snake-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"char-regex": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
 			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
 			"dev": true
 		},
-		"check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
-		},
 		"chokidar": {
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
 			"integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "~3.1.1",
@@ -2993,6 +2749,7 @@
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
@@ -3004,7 +2761,8 @@
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -3054,20 +2812,6 @@
 				}
 			}
 		},
-		"clean-git-ref": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="
-		},
-		"cli": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
-			"integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
-			"requires": {
-				"exit": "0.1.2",
-				"glob": "^7.1.1"
-			}
-		},
 		"cliui": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -3077,11 +2821,6 @@
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^6.2.0"
 			}
-		},
-		"clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 		},
 		"clone-deep": {
 			"version": "4.0.1",
@@ -3104,11 +2843,6 @@
 			"resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
 			"integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw=="
 		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-		},
 		"collect-v8-coverage": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -3125,15 +2859,6 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"color": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-			"integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
-			"requires": {
-				"color-convert": "^1.9.1",
-				"color-string": "^1.5.4"
-			}
-		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3147,19 +2872,11 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
-		"color-string": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-			"integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
-			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
 		"combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -3184,7 +2901,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -3208,28 +2926,6 @@
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
 			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
 			"dev": true
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-		},
-		"constant-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -3324,15 +3020,6 @@
 				"parse-json": "^5.0.0",
 				"path-type": "^4.0.0",
 				"yaml": "^1.7.2"
-			}
-		},
-		"crc-32": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
-			"integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
-			"requires": {
-				"exit-on-epipe": "~1.0.1",
-				"printj": "~1.1.0"
 			}
 		},
 		"create-ecdh": {
@@ -3443,6 +3130,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -3462,11 +3150,6 @@
 				"whatwg-mimetype": "^2.3.0",
 				"whatwg-url": "^8.0.0"
 			}
-		},
-		"date-now": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
 		},
 		"debug": {
 			"version": "4.1.1",
@@ -3492,67 +3175,6 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
-		"decompress-response": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-			"requires": {
-				"mimic-response": "^2.0.0"
-			}
-		},
-		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-			"requires": {
-				"type-detect": "^4.0.0"
-			}
-		},
-		"deep-equal": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
-			"integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
-			"requires": {
-				"call-bind": "^1.0.0",
-				"es-get-iterator": "^1.1.1",
-				"get-intrinsic": "^1.0.1",
-				"is-arguments": "^1.0.4",
-				"is-date-object": "^1.0.2",
-				"is-regex": "^1.1.1",
-				"isarray": "^2.0.5",
-				"object-is": "^1.1.4",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.2",
-				"regexp.prototype.flags": "^1.3.0",
-				"side-channel": "^1.0.3",
-				"which-boxed-primitive": "^1.0.1",
-				"which-collection": "^1.0.1",
-				"which-typed-array": "^1.1.2"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
-			}
-		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -3568,6 +3190,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -3626,12 +3249,8 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -3659,32 +3278,17 @@
 			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
 			"dev": true
 		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-		},
 		"detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
 		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-		},
 		"diff-sequences": {
 			"version": "26.0.0",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
 			"integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
 			"dev": true
-		},
-		"diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha1-1OXDpM305f4SEatC5pP8tDIVgPw="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -3705,37 +3309,11 @@
 				}
 			}
 		},
-		"dom-serializer": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-			"requires": {
-				"domelementtype": "^2.0.1",
-				"entities": "^2.0.0"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-					"integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
-				},
-				"entities": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-					"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
-				}
-			}
-		},
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
 			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
 			"dev": true
-		},
-		"domelementtype": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
 		},
 		"domexception": {
 			"version": "2.0.1",
@@ -3754,44 +3332,6 @@
 				}
 			}
 		},
-		"domhandler": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-			"integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-			"requires": {
-				"domelementtype": "1"
-			}
-		},
-		"domutils": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-			"requires": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
-			}
-		},
-		"dot-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"duplexer": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-		},
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -3808,6 +3348,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -3893,11 +3434,6 @@
 				"ansi-colors": "^3.2.1"
 			}
 		},
-		"entities": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-			"integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
-		},
 		"env-paths": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
@@ -3923,69 +3459,6 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"requires": {
 				"is-arrayish": "^0.2.1"
-			}
-		},
-		"es-abstract": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-			"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
-			"requires": {
-				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1",
-				"is-callable": "^1.2.2",
-				"is-regex": "^1.1.1",
-				"object-inspect": "^1.8.0",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.1",
-				"string.prototype.trimend": "^1.0.1",
-				"string.prototype.trimstart": "^1.0.1"
-			},
-			"dependencies": {
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
-			}
-		},
-		"es-get-iterator": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.1.tgz",
-			"integrity": "sha512-qorBw8Y7B15DVLaJWy6WdEV/ZkieBcu6QCq/xzWzGOKJqgG1j754vXRfZ3NY7HSShneqU43mPB4OkQBTkvHhFw==",
-			"requires": {
-				"call-bind": "^1.0.0",
-				"get-intrinsic": "^1.0.1",
-				"has-symbols": "^1.0.1",
-				"is-arguments": "^1.0.4",
-				"is-map": "^2.0.1",
-				"is-set": "^2.0.1",
-				"is-string": "^1.0.5",
-				"isarray": "^2.0.5"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-				}
-			}
-		},
-		"es-to-primitive": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"requires": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
 			}
 		},
 		"es6-promise": {
@@ -4065,20 +3538,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
-		"event-stream": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-			"requires": {
-				"duplexer": "~0.1.1",
-				"from": "~0",
-				"map-stream": "~0.1.0",
-				"pause-stream": "0.0.11",
-				"split": "0.3",
-				"stream-combiner": "~0.0.4",
-				"through": "~2.3.1"
-			}
-		},
 		"event-target-shim": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -4126,12 +3585,8 @@
 		"exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
-		},
-		"exit-on-epipe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-			"integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "2.1.4",
@@ -4327,7 +3782,8 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -4376,14 +3832,6 @@
 			"dev": true,
 			"requires": {
 				"bser": "2.1.1"
-			}
-		},
-		"fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-			"requires": {
-				"pend": "~1.2.0"
 			}
 		},
 		"figgy-pudding": {
@@ -4587,11 +4035,6 @@
 				}
 			}
 		},
-		"flat": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
-		},
 		"flow-bin": {
 			"version": "0.126.1",
 			"resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.126.1.tgz",
@@ -4608,59 +4051,28 @@
 				"readable-stream": "^2.3.6"
 			}
 		},
-		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
-			}
-		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
 		},
-		"foreach": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"format-util": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-			"integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -4671,11 +4083,6 @@
 				"map-cache": "^0.2.2"
 			}
 		},
-		"from": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
-		},
 		"from2": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -4684,33 +4091,6 @@
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
-			}
-		},
-		"fs-extra": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-			"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-			"requires": {
-				"at-least-node": "^1.0.0",
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^1.0.0"
-			}
-		},
-		"fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"requires": {
-				"minipass": "^3.0.0"
-			}
-		},
-		"fs-readfile-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fs-readfile-promise/-/fs-readfile-promise-2.0.1.tgz",
-			"integrity": "sha1-gAI4I5gfn//+AWCei+Zo9prknnA=",
-			"requires": {
-				"graceful-fs": "^4.1.2"
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -4725,34 +4105,17 @@
 				"readable-stream": "1 || 2"
 			}
 		},
-		"fs-writefile-promise": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/fs-writefile-promise/-/fs-writefile-promise-1.0.3.tgz",
-			"integrity": "sha1-4C+bWP/CVe2CKtx6ARFPRF1I0GM=",
-			"requires": {
-				"mkdirp-promise": "^1.0.0",
-				"pinkie-promise": "^1.0.0"
-			},
-			"dependencies": {
-				"pinkie-promise": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-					"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-					"requires": {
-						"pinkie": "^1.0.0"
-					}
-				}
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
 			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+			"dev": true,
 			"optional": true
 		},
 		"ftp": {
@@ -4780,60 +4143,8 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-		},
-		"fuzzysort": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.1.4.tgz",
-			"integrity": "sha512-JzK/lHjVZ6joAg3OnCjylwYXYVjRiwTY6Yb25LvfpJHK8bjisfnZJ5bY8aVWwTwCXgxPNgLAtmHL+Hs5q1ddLQ=="
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"gensync": {
 			"version": "1.0.0-beta.1",
@@ -4855,26 +4166,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-		},
-		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
-		},
-		"get-intrinsic": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-			"integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
-			"requires": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1"
-			}
-		},
-		"get-own-enumerable-property-symbols": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
-			"integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
 		},
 		"get-package-type": {
 			"version": "0.1.0",
@@ -4929,6 +4220,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -4937,6 +4229,7 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -5018,17 +4311,13 @@
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+			"dev": true
 		},
 		"grapheme-splitter": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
-		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -5040,44 +4329,18 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"dev": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
 			}
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				}
-			}
-		},
-		"has-color": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -5087,12 +4350,8 @@
 		"has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
-		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -5195,44 +4454,6 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
-		"hawk": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-7.1.2.tgz",
-			"integrity": "sha512-Pa8cMp2f/pFUF9B7cJuBHrF8PYPQmVXe2CfxyrgUmmfRNHMHuQOBpIFHk/eCFrHLVqLlAf2kU7BRxks7814TmA==",
-			"requires": {
-				"@hapi/b64": "4.x.x",
-				"@hapi/boom": "7.x.x",
-				"@hapi/cryptiles": "4.x.x",
-				"@hapi/hoek": "8.x.x",
-				"@hapi/sntp": "3.x.x"
-			}
-		},
-		"he": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
-		},
-		"header-case": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-			"requires": {
-				"capital-case": "^1.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"hkdf": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz",
-			"integrity": "sha1-L422Ff3vhwIB+C0rYZym00fQZH4="
-		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5268,41 +4489,11 @@
 				"whatwg-encoding": "^1.0.5"
 			}
 		},
-		"html-entities": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.3.tgz",
-			"integrity": "sha512-/VulV3SYni1taM7a4RMdceqzJWR39gpZHjBwUnsCFKWV/GJkD14CJ5F7eWcZozmHJK0/f/H5U3b3SiPkuvxMgg=="
-		},
 		"html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
-		},
-		"htmlparser2": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-			"integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-			"requires": {
-				"domelementtype": "1",
-				"domhandler": "2.3",
-				"domutils": "1.5",
-				"entities": "1.0",
-				"readable-stream": "1.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				}
-			}
 		},
 		"http-errors": {
 			"version": "1.7.3",
@@ -5344,6 +4535,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -5375,88 +4567,6 @@
 				}
 			}
 		},
-		"httpsnippet": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-1.24.0.tgz",
-			"integrity": "sha512-W2GRlKXPm+alFdkYvts7zS54Y8sjOGN1H4dMfLCcNZZrG2Rg9jY57aN/Fyiov4/Z0paFxCS1vKDbugNYfAhUBg==",
-			"requires": {
-				"chalk": "^1.1.1",
-				"commander": "^2.9.0",
-				"debug": "^2.2.0",
-				"event-stream": "3.3.4",
-				"form-data": "3.0.0",
-				"fs-readfile-promise": "^2.0.1",
-				"fs-writefile-promise": "^1.0.3",
-				"har-validator": "^5.0.0",
-				"pinkie-promise": "^2.0.0",
-				"stringify-object": "^3.3.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"form-data": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-					"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.8",
-						"mime-types": "^2.1.12"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
 		"human-signals": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -5482,19 +4592,6 @@
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
 			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 			"dev": true
-		},
-		"ignore": {
-			"version": "5.1.8",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-			"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
-		},
-		"ignore-walk": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-			"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-			"requires": {
-				"minimatch": "^3.0.4"
-			}
 		},
 		"immediate": {
 			"version": "3.0.6",
@@ -5548,6 +4645,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -5561,226 +4659,8 @@
 		"ini": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-		},
-		"insomnia-cookies": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-cookies/-/insomnia-cookies-2.2.24.tgz",
-			"integrity": "sha512-WOipBrUbNhIav0OsBEboT/itCCmrrqiapLAG2/OylMsmutTyAS/7YABK2BS1O9HymTRSCmasWN31GZ87vvsykg==",
-			"requires": {
-				"tough-cookie": "^2.3.3"
-			},
-			"dependencies": {
-				"tough-cookie": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-					"requires": {
-						"psl": "^1.1.28",
-						"punycode": "^2.1.1"
-					}
-				}
-			}
-		},
-		"insomnia-importers": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-importers/-/insomnia-importers-2.2.24.tgz",
-			"integrity": "sha512-9Y88b0PnOfHnY2fWxLWLIKBZR8FQ4edVJYffmtrM8E7qtKObQq513IFnOEhGUQVSIjc2b39vSRXUq1myNrL/Qg==",
-			"requires": {
-				"apiconnect-wsdl": "^1.8.29",
-				"change-case": "^4.1.1",
-				"commander": "^2.20.0",
-				"lodash": "^4.17.15",
-				"shell-quote": "^1.6.1",
-				"swagger-parser": "^6.0.5",
-				"yaml": "^1.5.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				}
-			}
-		},
-		"insomnia-plugin-base64": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-base64/-/insomnia-plugin-base64-2.2.24.tgz",
-			"integrity": "sha512-uQXLrs4EiuGbM0Roet1kO3jNecIk5Ua87uBQFOuEE+9xpzxtHG78PgQ8LD1red6kyYby0cT6dLV624gS6WMa+A=="
-		},
-		"insomnia-plugin-cookie-jar": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-cookie-jar/-/insomnia-plugin-cookie-jar-2.2.24.tgz",
-			"integrity": "sha512-y58VLiO7xnqu5PFRre+wuklWmEdJC/S923w0H/bEqtEYzGQd6nm8nILgN+fJZF95e4k0ia9wGXwLRaBfXGzXOw==",
-			"requires": {
-				"insomnia-cookies": "^2.2.24"
-			}
-		},
-		"insomnia-plugin-core-themes": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-core-themes/-/insomnia-plugin-core-themes-2.2.24.tgz",
-			"integrity": "sha512-ZVcT2xhhEhH92PZIUJLM3BKK4ScV1et9GsxHMYWhN62m62NSkauUuJxI0FVueU3Rr1St7xmLxAZnEj/hBQ146Q=="
-		},
-		"insomnia-plugin-file": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-file/-/insomnia-plugin-file-2.2.24.tgz",
-			"integrity": "sha512-47j4hp7JToXnvGlomo4qgUEEJni8irFD+NgR0XH3n9ZV5b9ZaDtqrwbWYSwAXgTiuSLQibype4Zlq6Co9TiO+g=="
-		},
-		"insomnia-plugin-hash": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-hash/-/insomnia-plugin-hash-2.2.24.tgz",
-			"integrity": "sha512-CBSRtw3G+keBzey3KFiJz1T0jknvElYnaJh4whVO3EOb2E/a8N2/VNjiHrPBuFPPMMa+vvpJN8QFJ7LlNsnkbw=="
-		},
-		"insomnia-plugin-jsonpath": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-jsonpath/-/insomnia-plugin-jsonpath-2.2.24.tgz",
-			"integrity": "sha512-nt2kUvS1B1bLjRkg4YpjWBQ3b8pSiC15Ffx8hDxPJX86PS0fUeIvbLbXaKkMZi/AJ49G9G797UFJcQWzB/n0cw==",
-			"requires": {
-				"jsonpath": "^1.0.2"
-			}
-		},
-		"insomnia-plugin-now": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-now/-/insomnia-plugin-now-2.2.24.tgz",
-			"integrity": "sha512-UfOhMTrslvHWyRgbkG08MREezKP6CtidFoUHblIbWEclDlyEk7YhJsiNz0sw1hpfHIbpDgj0CZKYaEAKtRxtSQ==",
-			"requires": {
-				"moment": "^2.21.0"
-			}
-		},
-		"insomnia-plugin-os": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-os/-/insomnia-plugin-os-2.2.24.tgz",
-			"integrity": "sha512-iMf8hsbEidq0hFSE0rHevn8P6hWZUB/gJWKx5cX66B6fr8P4TfRFD8xShwrLDFPjYKU3maQpY12cNTh+Vuu/jw==",
-			"requires": {
-				"jsonpath": "^1.0.2"
-			}
-		},
-		"insomnia-plugin-prompt": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-prompt/-/insomnia-plugin-prompt-2.2.24.tgz",
-			"integrity": "sha512-nDytwD77v1xV+L+icz/f7xLwWvr6BRFjLHxFHy7dGsaPwD5Q5KluhQr1pAcs85e4Pn4bOdqWzLWjAtYwbHB68g=="
-		},
-		"insomnia-plugin-request": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-request/-/insomnia-plugin-request-2.2.24.tgz",
-			"integrity": "sha512-i6tV8qLjWNA88sMdjzg2t/PqoV3XfBRg9I3zA/tG1It33P12Sr7NUkqxmjpHk/7Pg3AY7YkSlOjd4Yh1YryXYg==",
-			"requires": {
-				"insomnia-cookies": "^2.2.24",
-				"insomnia-url": "^2.2.24"
-			}
-		},
-		"insomnia-plugin-response": {
-			"version": "2.2.25",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-response/-/insomnia-plugin-response-2.2.25.tgz",
-			"integrity": "sha512-JWD9lOA8Oe1cuGFOWmEpUaJi+xXTjpvU+T/BXVtrOgZkony3mLtPyaPi7uzDYg9Un/zDePH+wm54i6Vzxn0TFQ==",
-			"requires": {
-				"iconv-lite": "^0.4.19",
-				"insomnia-xpath": "^2.2.24",
-				"jsonpath": "^1.0.2"
-			}
-		},
-		"insomnia-plugin-uuid": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-uuid/-/insomnia-plugin-uuid-2.2.24.tgz",
-			"integrity": "sha512-In7RW5mw0XD+/yhWcjlSNaaFZ5bTcPj8sxnzzswaglS2YDk2Pq5TNVGn52kOyijUmGje6nQdubwmIB9iuLcfEg==",
-			"requires": {
-				"uuid": "^3.1.0"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-				}
-			}
-		},
-		"insomnia-send-request": {
-			"version": "2.2.28",
-			"resolved": "https://registry.npmjs.org/insomnia-send-request/-/insomnia-send-request-2.2.28.tgz",
-			"integrity": "sha512-xFP/zfjg4l5IzcQIo3ONmUeKFgAMJe+IGNSs97cMEYocPs/1lleGxd7+wCHJKNp8IGQCpd0tx4McvvGN9w43rQ==",
-			"requires": {
-				"@stoplight/spectral": "^5.4.0",
-				"aws4": "^1.10.0",
-				"axios": "^0.19.2",
-				"clone": "^2.1.2",
-				"color": "^3.1.2",
-				"deep-equal": "^2.0.3",
-				"fs-extra": "^9.0.1",
-				"fuzzysort": "^1.1.4",
-				"hawk": "^7.0.10",
-				"hkdf": "0.0.2",
-				"html-entities": "^1.3.1",
-				"httpsnippet": "^1.22.0",
-				"insomnia-importers": "^2.2.24",
-				"insomnia-testing": "^2.2.26",
-				"isomorphic-git": "^1.5.0",
-				"jshint": "^2.11.1",
-				"jsonlint": "^1.6.3",
-				"jsonpath": "^1.0.2",
-				"marked": "^1.1.0",
-				"mime-types": "^2.1.27",
-				"mkdirp": "^1.0.4",
-				"multiparty": "^4.2.1",
-				"nedb": "^1.8.0",
-				"node-forge": "^0.9.1",
-				"node-libcurl": "2.2.0",
-				"nunjucks": "^3.2.1",
-				"oauth-1.0a": "^2.2.6",
-				"openapi-2-kong": "^2.2.26",
-				"tough-cookie": "^4.0.0",
-				"url-join": "^4.0.1",
-				"uuid": "^8.2.0",
-				"whatwg-fetch": "^3.1.0",
-				"yaml": "^1.10.0"
-			},
-			"dependencies": {
-				"tough-cookie": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-					"integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-					"requires": {
-						"psl": "^1.1.33",
-						"punycode": "^2.1.1",
-						"universalify": "^0.1.2"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-				},
-				"uuid": {
-					"version": "8.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-				}
-			}
-		},
-		"insomnia-testing": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/insomnia-testing/-/insomnia-testing-2.2.26.tgz",
-			"integrity": "sha512-fmyXdwr/qoKCMbYK/nkenPhmC+o+zZb9QfP2g/Wy1sDzGF4++WNLH+XEHaeIHAh5SbRMYAR4x1nsgXL1bfqWAQ==",
-			"requires": {
-				"axios": "^0.19.2",
-				"chai": "^4.2.0",
-				"mkdirp": "^1.0.4",
-				"mocha": "^8.0.1"
-			}
-		},
-		"insomnia-url": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-url/-/insomnia-url-2.2.24.tgz",
-			"integrity": "sha512-KfyEBtrgvli5+gmlX7xWR/N3AzetqI43JECRDUVHxluJFKXvSlxoOOcOCIvE4rB+2ogOf2fdIqZF2MA9G3kFXA=="
-		},
-		"insomnia-xpath": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-xpath/-/insomnia-xpath-2.2.24.tgz",
-			"integrity": "sha512-oUIbm5f2xZ9t/+6i3ZspTEx2YPHk5kqejOU3eabThCsjcoGKY1lEdv5BJH8SiR1/gsVlRAbhYQzVWxK0bV0Xug==",
-			"requires": {
-				"insomnia-cookies": "^2.2.24",
-				"xmldom": "^0.1.27",
-				"xpath": "0.0.27"
-			}
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
 		},
 		"interpret": {
 			"version": "1.4.0",
@@ -5828,38 +4708,19 @@
 				}
 			}
 		},
-		"is-arguments": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
-			"integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
-			"requires": {
-				"call-bind": "^1.0.0"
-			}
-		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
-		"is-bigint": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
-		},
 		"is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
 			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-boolean-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
-			"requires": {
-				"call-bind": "^1.0.0"
 			}
 		},
 		"is-buffer": {
@@ -5867,11 +4728,6 @@
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
-		},
-		"is-callable": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-			"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -5901,11 +4757,6 @@
 					}
 				}
 			}
-		},
-		"is-date-object": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -5963,35 +4814,16 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
-		"is-map": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
-		},
-		"is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
-		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 		},
-		"is-number-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
-		},
-		"is-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-		},
 		"is-plain-obj": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"dev": true
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -6008,101 +4840,17 @@
 			"integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
 			"dev": true
 		},
-		"is-regex": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-			"requires": {
-				"has-symbols": "^1.0.1"
-			}
-		},
-		"is-regexp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
-		},
-		"is-set": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
-		},
 		"is-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
 			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 			"dev": true
 		},
-		"is-string": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
-		},
-		"is-symbol": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-			"requires": {
-				"has-symbols": "^1.0.1"
-			}
-		},
-		"is-typed-array": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.4.tgz",
-			"integrity": "sha512-ILaRgn4zaSrVNXNGtON6iFNotXW3hAPF3+0fB1usg2jFlWqo5fEDdmJkz0zBfoi7Dgskr8Khi2xZ8cXqZEfXNA==",
-			"requires": {
-				"available-typed-arrays": "^1.0.2",
-				"call-bind": "^1.0.0",
-				"es-abstract": "^1.18.0-next.1",
-				"foreach": "^2.0.5",
-				"has-symbols": "^1.0.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
-			}
-		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-		},
-		"is-weakmap": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-			"integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
-		},
-		"is-weakset": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
-			"integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -6128,7 +4876,8 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -6136,53 +4885,11 @@
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
-		"isomorphic-git": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.8.0.tgz",
-			"integrity": "sha512-TWJvQh+++eFrEG0IFS/jLhMwsBoCOX1/Dsw9q8no59Mp1K0jEjSHXFWv2P04PwkxcIpePkXVBI5YFcFT2nkuQg==",
-			"requires": {
-				"async-lock": "^1.1.0",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"minimisted": "^2.0.0",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^3.0.2"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					}
-				}
-			}
-		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
@@ -6773,6 +5480,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
 			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -6781,14 +5489,16 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				}
 			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
 		},
 		"jsdom": {
 			"version": "16.2.2",
@@ -6830,41 +5540,6 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
-		"jshint": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.12.0.tgz",
-			"integrity": "sha512-TwuuaUDmra0JMkuqvqy+WGo2xGHSNjv1BA1nTIgtH2K5z1jHuAEeAgp7laaR+hLRmajRjcrM71+vByBDanCyYA==",
-			"requires": {
-				"cli": "~1.0.0",
-				"console-browserify": "1.1.x",
-				"exit": "0.1.x",
-				"htmlparser2": "3.8.x",
-				"lodash": "~4.17.19",
-				"minimatch": "~3.0.2",
-				"shelljs": "0.3.x",
-				"strip-json-comments": "1.0.x"
-			},
-			"dependencies": {
-				"console-browserify": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-					"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-					"requires": {
-						"date-now": "^0.1.4"
-					}
-				},
-				"lodash": {
-					"version": "4.17.20",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-				},
-				"strip-json-comments": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-					"integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
-				}
-			}
-		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -6873,24 +5548,8 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-		},
-		"json-schema-ref-parser": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.4.tgz",
-			"integrity": "sha512-AD7bvav0vak1/63w3jH8F7eHId/4E4EPdMAEZhGxtjktteUv9dnNB/cJy6nVnMyoTPBJnLwFK6tiQPSTeleCtQ==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"js-yaml": "^3.13.1",
-				"ono": "^6.0.0"
-			},
-			"dependencies": {
-				"ono": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
-					"integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
-				}
-			}
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -6900,7 +5559,8 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"json-to-ast": {
 			"version": "2.1.0",
@@ -6925,53 +5585,6 @@
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
 			"integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
 		},
-		"jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"requires": {
-				"graceful-fs": "^4.1.6",
-				"universalify": "^2.0.0"
-			},
-			"dependencies": {
-				"universalify": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-				}
-			}
-		},
-		"jsonlint": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.3.tgz",
-			"integrity": "sha512-jMVTMzP+7gU/IyC6hvKyWpUU8tmTkK5b3BPNuMI9U8Sit+YAWLlZwB6Y6YrdCxfg2kNz05p3XY3Bmm4m26Nv3A==",
-			"requires": {
-				"JSV": "^4.0.x",
-				"nomnom": "^1.5.x"
-			}
-		},
-		"jsonpath": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.0.2.tgz",
-			"integrity": "sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==",
-			"requires": {
-				"esprima": "1.2.2",
-				"static-eval": "2.0.2",
-				"underscore": "1.7.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-					"integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
-				},
-				"underscore": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-					"integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-				}
-			}
-		},
 		"jsonpath-plus": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz",
@@ -6982,46 +5595,16 @@
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
 			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
 		},
-		"jsonschema": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
-		},
-		"jsonschema-draft4": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
-			"integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU="
-		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
-			}
-		},
-		"jszip": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-			"integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
-			"requires": {
-				"lie": "~3.3.0",
-				"pako": "~1.0.2",
-				"readable-stream": "~2.3.6",
-				"set-immediate-shim": "~1.0.1"
-			},
-			"dependencies": {
-				"lie": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-					"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-					"requires": {
-						"immediate": "~3.0.5"
-					}
-				}
 			}
 		},
 		"kind-of": {
@@ -7126,29 +5709,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
 		},
-		"lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
-		},
-		"log-symbols": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-			"requires": {
-				"chalk": "^4.0.0"
-			}
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -7157,21 +5722,6 @@
 			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
-		},
-		"lower-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
 			}
 		},
 		"lru-cache": {
@@ -7207,11 +5757,6 @@
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
 			"dev": true
 		},
-		"map-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
-		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -7220,11 +5765,6 @@
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
-		},
-		"marked": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-1.2.6.tgz",
-			"integrity": "sha512-7vVuSEZ8g/HH3hK/BH/+7u/NJj7x9VY4EHzujLDcqAQLiOUeFJYAsfSAyoWtR17lKrx7b08qyIno4lffwrzTaA=="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -7288,12 +5828,14 @@
 		"mime-db": {
 			"version": "1.44.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.27",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
 			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"dev": true,
 			"requires": {
 				"mime-db": "1.44.0"
 			}
@@ -7303,11 +5845,6 @@
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true
-		},
-		"mimic-response": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
@@ -7325,6 +5862,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -7333,45 +5871,6 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-		},
-		"minimisted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-			"requires": {
-				"minimist": "^1.2.5"
-			}
-		},
-		"minipass": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-			"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-			"requires": {
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
-		"minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"requires": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
 		},
 		"mississippi": {
 			"version": "3.0.0",
@@ -7417,278 +5916,6 @@
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 		},
-		"mkdirp-promise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-1.1.0.tgz",
-			"integrity": "sha1-LISJPtZ24NmPsY+5piEv0bK5qBk="
-		},
-		"mocha": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
-			"integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
-			"requires": {
-				"@ungap/promise-all-settled": "1.1.2",
-				"ansi-colors": "4.1.1",
-				"browser-stdout": "1.3.1",
-				"chokidar": "3.4.3",
-				"debug": "4.2.0",
-				"diff": "4.0.2",
-				"escape-string-regexp": "4.0.0",
-				"find-up": "5.0.0",
-				"glob": "7.1.6",
-				"growl": "1.10.5",
-				"he": "1.2.0",
-				"js-yaml": "3.14.0",
-				"log-symbols": "4.0.0",
-				"minimatch": "3.0.4",
-				"ms": "2.1.2",
-				"nanoid": "3.1.12",
-				"serialize-javascript": "5.0.1",
-				"strip-json-comments": "3.1.1",
-				"supports-color": "7.2.0",
-				"which": "2.0.2",
-				"wide-align": "1.1.3",
-				"workerpool": "6.0.2",
-				"yargs": "13.3.2",
-				"yargs-parser": "13.1.2",
-				"yargs-unparser": "2.0.0"
-			},
-			"dependencies": {
-				"ansi-colors": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-					"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-				},
-				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"requires": {
-						"normalize-path": "^3.0.0",
-						"picomatch": "^2.0.4"
-					}
-				},
-				"chokidar": {
-					"version": "3.4.3",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-					"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
-					"requires": {
-						"anymatch": "~3.1.1",
-						"braces": "~3.0.2",
-						"fsevents": "~2.1.2",
-						"glob-parent": "~5.1.0",
-						"is-binary-path": "~2.1.0",
-						"is-glob": "~4.0.1",
-						"normalize-path": "~3.0.0",
-						"readdirp": "~3.5.0"
-					}
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					}
-				},
-				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"emoji-regex": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-				},
-				"escape-string-regexp": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-				},
-				"find-up": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-					"requires": {
-						"locate-path": "^6.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"locate-path": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-					"requires": {
-						"p-locate": "^5.0.0"
-					}
-				},
-				"nanoid": {
-					"version": "3.1.12",
-					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-					"integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
-				},
-				"p-limit": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-					"requires": {
-						"yocto-queue": "^0.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-					"requires": {
-						"p-limit": "^3.0.2"
-					}
-				},
-				"readdirp": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-					"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-					"requires": {
-						"picomatch": "^2.2.1"
-					}
-				},
-				"serialize-javascript": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-					"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
-					"requires": {
-						"randombytes": "^2.1.0"
-					}
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					}
-				},
-				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-							"requires": {
-								"locate-path": "^3.0.0"
-							}
-						},
-						"locate-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-							"requires": {
-								"p-locate": "^3.0.0",
-								"path-exists": "^3.0.0"
-							}
-						},
-						"p-limit": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-							"requires": {
-								"p-try": "^2.0.0"
-							}
-						},
-						"p-locate": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-							"requires": {
-								"p-limit": "^2.0.0"
-							}
-						},
-						"path-exists": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-						}
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
-		"moment": {
-			"version": "2.29.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-		},
 		"move-concurrently": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -7728,44 +5955,12 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
-		"multiparty": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.2.2.tgz",
-			"integrity": "sha512-NtZLjlvsjcoGrzojtwQwn/Tm90aWJ6XXtPppYF4WmOk/6ncdwMMKggFY2NlRRN9yiCEIVxpOfPWahVEG2HAG8Q==",
-			"requires": {
-				"http-errors": "~1.8.0",
-				"safe-buffer": "5.2.1",
-				"uid-safe": "2.1.5"
-			},
-			"dependencies": {
-				"http-errors": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-					"integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.4",
-						"setprototypeof": "1.2.0",
-						"statuses": ">= 1.5.0 < 2",
-						"toidentifier": "1.0.0"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-				},
-				"setprototypeof": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-					"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-				}
-			}
-		},
 		"nan": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+			"dev": true,
+			"optional": true
 		},
 		"nanoid": {
 			"version": "2.1.11",
@@ -7819,26 +6014,6 @@
 				}
 			}
 		},
-		"needle": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
-			"integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
-			"requires": {
-				"debug": "^3.2.6",
-				"iconv-lite": "^0.4.4",
-				"sax": "^1.2.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
-		},
 		"neo-async": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -7856,105 +6031,16 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"no-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"requires": {
-				"lower-case": "^2.0.2",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"node-fetch": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
 			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-		},
-		"node-forge": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.2.tgz",
-			"integrity": "sha512-naKSScof4Wn+aoHU6HBsifh92Zeicm1GDQKd1vp3Y/kOi8ub0DozCa9KpvYNCXslFHYRmLNiqRopGdTGwNLpNw=="
-		},
-		"node-gyp": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.0.0.tgz",
-			"integrity": "sha512-ZW34qA3CJSPKDz2SJBHKRvyNQN0yWO5EGKKksJc+jElu9VA468gwJTyTArC1iOXU7rN3Wtfg/CMt/dBAOFIjvg==",
-			"requires": {
-				"env-paths": "^2.2.0",
-				"glob": "^7.1.4",
-				"graceful-fs": "^4.2.3",
-				"nopt": "^4.0.3",
-				"npmlog": "^4.1.2",
-				"request": "^2.88.2",
-				"rimraf": "^2.6.3",
-				"semver": "^7.3.2",
-				"tar": "^6.0.1",
-				"which": "^2.0.2"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
 		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
 			"dev": true
-		},
-		"node-libcurl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/node-libcurl/-/node-libcurl-2.2.0.tgz",
-			"integrity": "sha512-dyv3IuQBqO4KK5ojtM4k6FuBA3RxZjTqO4c+MUirwvlTY7qIH2oNSws8Xte1pp2aso9TuXyAwxS/g3ZqmAk8aA==",
-			"requires": {
-				"env-paths": "2.2.0",
-				"nan": "2.14.1",
-				"node-gyp": "7.0.0",
-				"node-pre-gyp": "0.15.0",
-				"npmlog": "4.1.2",
-				"tslib": "2.0.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
-					"integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g=="
-				}
-			}
 		},
 		"node-libs-browser": {
 			"version": "2.2.1",
@@ -8040,130 +6126,11 @@
 				}
 			}
 		},
-		"node-pre-gyp": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
-			"integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
-			"requires": {
-				"detect-libc": "^1.0.2",
-				"mkdirp": "^0.5.3",
-				"needle": "^2.5.0",
-				"nopt": "^4.0.1",
-				"npm-packlist": "^1.1.6",
-				"npmlog": "^4.0.2",
-				"rc": "^1.2.7",
-				"rimraf": "^2.6.1",
-				"semver": "^5.3.0",
-				"tar": "^4.4.2"
-			},
-			"dependencies": {
-				"fs-minipass": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-					"requires": {
-						"minipass": "^2.6.0"
-					}
-				},
-				"minipass": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-					"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-					"requires": {
-						"minipass": "^2.9.0"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"tar": {
-					"version": "4.4.13",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.8.6",
-						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.3"
-					}
-				}
-			}
-		},
 		"node-releases": {
 			"version": "1.1.58",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
 			"integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==",
 			"dev": true
-		},
-		"nomnom": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-			"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-			"requires": {
-				"chalk": "~0.4.0",
-				"underscore": "~1.6.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-				},
-				"chalk": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-					"requires": {
-						"ansi-styles": "~1.0.0",
-						"has-color": "~0.1.0",
-						"strip-ansi": "~0.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-				},
-				"underscore": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
-				}
-			}
-		},
-		"nopt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-			"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-			"requires": {
-				"abbrev": "1",
-				"osenv": "^0.1.4"
-			}
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -8180,30 +6147,8 @@
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-		},
-		"npm-bundled": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-			"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
-			"requires": {
-				"npm-normalize-package-bin": "^1.0.1"
-			}
-		},
-		"npm-normalize-package-bin": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-			"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
-		},
-		"npm-packlist": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-			"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-			"requires": {
-				"ignore-walk": "^3.0.1",
-				"npm-bundled": "^1.0.1",
-				"npm-normalize-package-bin": "^1.0.1"
-			}
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
 		},
 		"npm-run-path": {
 			"version": "4.0.1",
@@ -8214,53 +6159,23 @@
 				"path-key": "^3.0.0"
 			}
 		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-		},
-		"nunjucks": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.2.tgz",
-			"integrity": "sha512-KUi85OoF2NMygwODAy28Lh9qHmq5hO3rBlbkYoC8v377h4l8Pt5qFjILl0LWpMbOrZ18CzfVVUvIHUIrtED3sA==",
-			"requires": {
-				"a-sync-waterfall": "^1.0.0",
-				"asap": "^2.0.3",
-				"chokidar": "^3.3.0",
-				"commander": "^5.1.0"
-			}
-		},
 		"nwsapi": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
 			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
 			"dev": true
 		},
-		"oauth-1.0a": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
-			"integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ=="
-		},
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -8293,24 +6208,11 @@
 				}
 			}
 		},
-		"object-inspect": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-			"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
-		},
-		"object-is": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
-			"integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
-			"requires": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			}
-		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -8346,6 +6248,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -8358,63 +6261,6 @@
 			"requires": {
 				"mimic-fn": "^2.1.0"
 			}
-		},
-		"ono": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
-			"integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
-		},
-		"openapi-2-kong": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/openapi-2-kong/-/openapi-2-kong-2.2.26.tgz",
-			"integrity": "sha512-J9OzU8HcEVOl5yLksYYnzNkUb7OC768mCFQsdlfHWGmP5bAJVQbrZ3NubsdbiYVrbguJTqBL6Atzt3r3Y8i5Gw==",
-			"requires": {
-				"slugify": "^1.3.6",
-				"swagger-parser": "^8.0.3",
-				"url-join": "^4.0.1",
-				"yaml": "^1.7.2"
-			},
-			"dependencies": {
-				"ono": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
-					"integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
-				},
-				"swagger-parser": {
-					"version": "8.0.4",
-					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.4.tgz",
-					"integrity": "sha512-KGRdAaMJogSEB7sPKI31ptKIWX8lydEDAwWgB4pBMU7zys5cd54XNhoPSVlTxG/A3LphjX47EBn9j0dOGyzWbA==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"json-schema-ref-parser": "^7.1.3",
-						"ono": "^6.0.0",
-						"openapi-schemas": "^1.0.2",
-						"openapi-types": "^1.3.5",
-						"swagger-methods": "^2.0.1",
-						"z-schema": "^4.2.2"
-					}
-				}
-			}
-		},
-		"openapi-schema-validation": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
-			"integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
-			"requires": {
-				"jsonschema": "1.2.4",
-				"jsonschema-draft4": "^1.0.0",
-				"swagger-schema-official": "2.0.0-bab6bed"
-			}
-		},
-		"openapi-schemas": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.3.tgz",
-			"integrity": "sha512-KtMWcK2VtOS+nD8RKSIyScJsj8JrmVWcIX7Kjx4xEHijFYuvMTDON8WfeKOgeSb4uNG6UsqLj5Na7nKbSav9RQ=="
-		},
-		"openapi-types": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
-			"integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
 		},
 		"optionator": {
 			"version": "0.8.3",
@@ -8434,25 +6280,6 @@
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
 			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
 			"dev": true
-		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-		},
-		"os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-		},
-		"osenv": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
-			}
 		},
 		"p-each-series": {
 			"version": "2.1.0",
@@ -8517,7 +6344,8 @@
 		"pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true
 		},
 		"parallel-transform": {
 			"version": "1.2.0",
@@ -8528,22 +6356,6 @@
 				"cyclist": "^1.0.1",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.1.5"
-			}
-		},
-		"param-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
 			}
 		},
 		"parent-module": {
@@ -8591,22 +6403,6 @@
 			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
 			"dev": true
 		},
-		"pascal-case": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -8618,22 +6414,6 @@
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
 			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
 			"dev": true
-		},
-		"path-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"path-dirname": {
 			"version": "1.0.2",
@@ -8650,7 +6430,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-key": {
 			"version": "3.1.1",
@@ -8669,19 +6450,6 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 		},
-		"pathval": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
-		},
-		"pause-stream": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-			"requires": {
-				"through": "~2.3"
-			}
-		},
 		"pbkdf2": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
@@ -8695,15 +6463,11 @@
 				"sha.js": "^2.4.8"
 			}
 		},
-		"pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
-		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
 		},
 		"picomatch": {
 			"version": "2.2.2",
@@ -8713,27 +6477,8 @@
 		"pify": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-		},
-		"pinkie": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
-		},
-		"pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"requires": {
-				"pinkie": "^2.0.0"
-			},
-			"dependencies": {
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-				}
-			}
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true
 		},
 		"pirates": {
 			"version": "4.0.1",
@@ -8803,11 +6548,6 @@
 				}
 			}
 		},
-		"printj": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-			"integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
-		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -8870,7 +6610,8 @@
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+			"dev": true
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -8932,15 +6673,11 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
-		"q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -8954,15 +6691,11 @@
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
 			"dev": true
 		},
-		"random-bytes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-			"integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
-		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -8986,24 +6719,6 @@
 				"http-errors": "1.7.3",
 				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
-			}
-		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-				}
 			}
 		},
 		"react-is": {
@@ -9076,6 +6791,7 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
 			"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"picomatch": "^2.2.1"
@@ -9119,15 +6835,6 @@
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
-			}
-		},
-		"regexp.prototype.flags": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-			"integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
 			}
 		},
 		"regexpu-core": {
@@ -9189,6 +6896,7 @@
 			"version": "2.88.2",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -9216,6 +6924,7 @@
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+					"dev": true,
 					"requires": {
 						"psl": "^1.1.28",
 						"punycode": "^2.1.1"
@@ -9224,7 +6933,8 @@
 				"uuid": {
 					"version": "3.4.0",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				}
 			}
 		},
@@ -9601,11 +7311,6 @@
 				}
 			}
 		},
-		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-		},
 		"saxes": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -9629,24 +7334,8 @@
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-		},
-		"sentence-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true
 		},
 		"serialize-javascript": {
 			"version": "3.1.0",
@@ -9661,11 +7350,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -9705,6 +7389,7 @@
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -9734,16 +7419,6 @@
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true
 		},
-		"shell-quote": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
-		},
-		"shelljs": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-			"integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
-		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -9751,81 +7426,11 @@
 			"dev": true,
 			"optional": true
 		},
-		"side-channel": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
-			"integrity": "sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==",
-			"requires": {
-				"es-abstract": "^1.18.0-next.0",
-				"object-inspect": "^1.8.0"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
-			}
-		},
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-		},
-		"simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
-		},
-		"simple-get": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-			"requires": {
-				"decompress-response": "^4.2.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
-		"simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"requires": {
-				"is-arrayish": "^0.3.1"
-			},
-			"dependencies": {
-				"is-arrayish": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-				}
-			}
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
 		},
 		"sisteransi": {
 			"version": "1.0.5",
@@ -9833,31 +7438,10 @@
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
 			"dev": true
 		},
-		"slugify": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.6.tgz",
-			"integrity": "sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ=="
-		},
 		"smart-buffer": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
 			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
-		},
-		"snake-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -10087,14 +7671,6 @@
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
 			"dev": true
 		},
-		"split": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-			"requires": {
-				"through": "2"
-			}
-		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -10107,12 +7683,14 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -10149,14 +7727,6 @@
 					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
 					"dev": true
 				}
-			}
-		},
-		"static-eval": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-			"integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-			"requires": {
-				"escodegen": "^1.8.1"
 			}
 		},
 		"static-extend": {
@@ -10199,14 +7769,6 @@
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
-			}
-		},
-		"stream-combiner": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-			"requires": {
-				"duplexer": "~0.1.1"
 			}
 		},
 		"stream-each": {
@@ -10268,38 +7830,10 @@
 				"strip-ansi": "^6.0.0"
 			}
 		},
-		"string.prototype.trimend": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-			"integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
-			"requires": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			}
-		},
-		"string.prototype.trimstart": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-			"integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
-			"requires": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			}
-		},
 		"string_decoder": {
 			"version": "0.10.31",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-		},
-		"stringify-object": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-			"requires": {
-				"get-own-enumerable-property-symbols": "^3.0.0",
-				"is-obj": "^1.0.1",
-				"is-regexp": "^1.0.0"
-			}
 		},
 		"strip-ansi": {
 			"version": "6.0.0",
@@ -10326,11 +7860,6 @@
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
 			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"dev": true
-		},
-		"strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -10367,83 +7896,6 @@
 				}
 			}
 		},
-		"swagger-methods": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.2.tgz",
-			"integrity": "sha512-/RNqvBZkH8+3S/FqBPejHxJxZenaYq3MrpeXnzi06aDIS39Mqf5YCUNb/ZBjsvFFt8h9FxfKs8EXPtcYdfLiRg=="
-		},
-		"swagger-parser": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-6.0.5.tgz",
-			"integrity": "sha512-UL47eu4+GRm5y+N7J+W6QQiqAJn2lojyqgMwS0EZgA55dXd5xmpQCsjUmH/Rf0eKDiG1kULc9VS515PxAyTDVw==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"json-schema-ref-parser": "^6.0.3",
-				"ono": "^4.0.11",
-				"openapi-schema-validation": "^0.4.2",
-				"swagger-methods": "^1.0.8",
-				"swagger-schema-official": "2.0.0-bab6bed",
-				"z-schema": "^3.24.2"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"optional": true
-				},
-				"core-js": {
-					"version": "2.6.12",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-				},
-				"json-schema-ref-parser": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-					"integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"js-yaml": "^3.12.1",
-						"ono": "^4.0.11"
-					}
-				},
-				"ono": {
-					"version": "4.0.11",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-					"integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-					"requires": {
-						"format-util": "^1.0.3"
-					}
-				},
-				"swagger-methods": {
-					"version": "1.0.8",
-					"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.8.tgz",
-					"integrity": "sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA=="
-				},
-				"validator": {
-					"version": "10.11.0",
-					"resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-					"integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
-				},
-				"z-schema": {
-					"version": "3.25.1",
-					"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
-					"integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
-					"requires": {
-						"commander": "^2.7.1",
-						"core-js": "^2.5.7",
-						"lodash.get": "^4.0.0",
-						"lodash.isequal": "^4.0.0",
-						"validator": "^10.0.0"
-					}
-				}
-			}
-		},
-		"swagger-schema-official": {
-			"version": "2.0.0-bab6bed",
-			"resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
-			"integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
-		},
 		"symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -10455,31 +7907,6 @@
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
 			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
 			"dev": true
-		},
-		"tar": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
-			"integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
-			"requires": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^3.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"chownr": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
 		},
 		"terminal-link": {
 			"version": "2.1.1",
@@ -10556,11 +7983,6 @@
 			"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
 			"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
 			"dev": true
-		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -10684,6 +8106,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -10691,7 +8114,8 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -10704,7 +8128,8 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"type-fest": {
 			"version": "0.8.1",
@@ -10725,14 +8150,6 @@
 			"dev": true,
 			"requires": {
 				"is-typedarray": "^1.0.0"
-			}
-		},
-		"uid-safe": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-			"integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-			"requires": {
-				"random-bytes": "~1.0.0"
 			}
 		},
 		"underscore": {
@@ -10798,11 +8215,6 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
-		"universalify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
-		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -10861,36 +8273,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"upper-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"upper-case-first": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -10927,11 +8309,6 @@
 					"dev": true
 				}
 			}
-		},
-		"url-join": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
 		},
 		"use": {
 			"version": "3.1.1",
@@ -11008,15 +8385,11 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"validator": {
-			"version": "12.2.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
-			"integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
-		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -11755,11 +9128,6 @@
 				"iconv-lite": "0.4.24"
 			}
 		},
-		"whatwg-fetch": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
-			"integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
-		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -11789,120 +9157,15 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
-			}
-		},
-		"which-boxed-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.1.tgz",
-			"integrity": "sha512-7BT4TwISdDGBgaemWU0N0OU7FeAEJ9Oo2P1PHRm/FCWoEi2VLWC9b6xvxAA3C/NMpxg3HXVgi0sMmGbNUbNepQ==",
-			"requires": {
-				"is-bigint": "^1.0.0",
-				"is-boolean-object": "^1.0.0",
-				"is-number-object": "^1.0.3",
-				"is-string": "^1.0.4",
-				"is-symbol": "^1.0.2"
-			}
-		},
-		"which-collection": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-			"integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-			"requires": {
-				"is-map": "^2.0.1",
-				"is-set": "^2.0.1",
-				"is-weakmap": "^2.0.1",
-				"is-weakset": "^2.0.1"
 			}
 		},
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-		},
-		"which-typed-array": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
-			"integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
-			"requires": {
-				"available-typed-arrays": "^1.0.2",
-				"call-bind": "^1.0.0",
-				"es-abstract": "^1.18.0-next.1",
-				"foreach": "^2.0.5",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.1",
-				"is-typed-array": "^1.1.3"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
-			}
-		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
 		},
 		"wildcard": {
 			"version": "2.0.0",
@@ -11928,11 +9191,6 @@
 			"requires": {
 				"errno": "~0.1.7"
 			}
-		},
-		"workerpool": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
-			"integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q=="
 		},
 		"wrap-ansi": {
 			"version": "6.2.0",
@@ -11971,7 +9229,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "3.0.3",
@@ -11997,35 +9256,11 @@
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
 		},
-		"xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-			"requires": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~11.0.0"
-			}
-		},
-		"xmlbuilder": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-		},
 		"xmlchars": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
-		},
-		"xmldom": {
-			"version": "0.1.31",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
-		},
-		"xpath": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-			"integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
 		},
 		"xregexp": {
 			"version": "2.0.0",
@@ -12078,62 +9313,6 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
-			}
-		},
-		"yargs-unparser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-			"requires": {
-				"camelcase": "^6.0.0",
-				"decamelize": "^4.0.0",
-				"flat": "^5.0.2",
-				"is-plain-obj": "^2.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
-				},
-				"decamelize": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-					"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
-				}
-			}
-		},
-		"yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-			"requires": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
-			}
-		},
-		"yocto-queue": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-		},
-		"z-schema": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
-			"integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
-			"requires": {
-				"commander": "^2.7.1",
-				"lodash.get": "^4.4.2",
-				"lodash.isequal": "^4.5.0",
-				"validator": "^12.0.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"optional": true
-				}
 			}
 		}
 	}

--- a/packages/insomnia-inso/src/__tests__/cli.test.js
+++ b/packages/insomnia-inso/src/__tests__/cli.test.js
@@ -54,13 +54,13 @@ describe('cli', () => {
       expect(() => inso('-w')).toThrowError();
     });
 
-    it.each(['-v', '--version'])('inso %s should print version from package.json', args => {
+    it.each(['-v', '--version'])('inso %s should print version from package.json', (args) => {
       logger.wrapAll();
       expect(() => inso(args)).toThrowError(packageJson.version);
       logger.restoreAll();
     });
 
-    it.each(['-v', '--version'])('inso %s should print "dev" if running in development', args => {
+    it.each(['-v', '--version'])('inso %s should print "dev" if running in development', (args) => {
       const oldNodeEnv = process.env.NODE_ENV;
 
       process.env.NODE_ENV = 'development';

--- a/packages/insomnia-inso/src/__tests__/get-options.test.js
+++ b/packages/insomnia-inso/src/__tests__/get-options.test.js
@@ -14,7 +14,7 @@ describe('extractCommandOptions()', () => {
     command
       .command('subCommand')
       .option('-s, --subCmd')
-      .action(cmd => {
+      .action((cmd) => {
         expect(extractCommandOptions(cmd)).toEqual({
           global: true,
           subCmd: true,

--- a/packages/insomnia-inso/src/__tests__/inso-snapshot.test.js
+++ b/packages/insomnia-inso/src/__tests__/inso-snapshot.test.js
@@ -20,7 +20,7 @@ describe('Snapshot for', () => {
     'export spec -h',
   ])(
     '"inso %s"',
-    async args => {
+    async (args) => {
       const { stdout } = await execa(getBinPathSync(), args.split(' '));
       expect(stdout).toMatchSnapshot();
     },

--- a/packages/insomnia-inso/src/__tests__/util.test.js
+++ b/packages/insomnia-inso/src/__tests__/util.test.js
@@ -16,7 +16,7 @@ describe('exit()', () => {
   it('should exit 0 if successful result', async () => {
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
 
-    await exit(new Promise(resolve => resolve(true)));
+    await exit(new Promise((resolve) => resolve(true)));
 
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
@@ -24,7 +24,7 @@ describe('exit()', () => {
   it('should exit 1 if unsuccessful result', async () => {
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
 
-    await exit(new Promise(resolve => resolve(false)));
+    await exit(new Promise((resolve) => resolve(false)));
 
     expect(exitSpy).toHaveBeenCalledWith(1);
   });

--- a/packages/insomnia-inso/src/cli.js
+++ b/packages/insomnia-inso/src/cli.js
@@ -128,12 +128,12 @@ function addScriptCommand(originalCommand: Object) {
 
       if (!scriptTask) {
         logger.fatal(`Could not find inso script "${scriptName}" in the config file.`);
-        return exit(new Promise(resolve => resolve(false)));
+        return exit(new Promise((resolve) => resolve(false)));
       }
 
       if (!scriptTask.startsWith('inso')) {
         logger.fatal('Tasks in a script should start with `inso`.');
-        return exit(new Promise(resolve => resolve(false)));
+        return exit(new Promise((resolve) => resolve(false)));
       }
 
       // Collect args

--- a/packages/insomnia-inso/src/commands/generate-config.js
+++ b/packages/insomnia-inso/src/commands/generate-config.js
@@ -68,7 +68,7 @@ export async function generateConfig(
     return false;
   }
 
-  const yamlDocs = result.documents.map(d => YAML.stringify(d));
+  const yamlDocs = result.documents.map((d) => YAML.stringify(d));
 
   // Join the YAML docs with "---" and strip any extra newlines surrounding them
   const document = yamlDocs.join('\n---\n').replace(/\n+---\n+/g, '\n---\n');

--- a/packages/insomnia-inso/src/commands/lint-specification.js
+++ b/packages/insomnia-inso/src/commands/lint-specification.js
@@ -50,7 +50,7 @@ export async function lintSpecification(
   if (results.length) {
     logger.log(`${results.length} lint errors found. \n`);
 
-    results.forEach(r =>
+    results.forEach((r) =>
       logger.log(`${r.range.start.line}:${r.range.start.character} - ${r.message}`),
     );
     return false;

--- a/packages/insomnia-inso/src/commands/run-tests.js
+++ b/packages/insomnia-inso/src/commands/run-tests.js
@@ -73,10 +73,10 @@ export async function runInsomniaTests(
 
   // Generate test file
   const testFileContents = await generate(
-    suites.map(suite =>
+    suites.map((suite) =>
       createTestSuite(
         suite,
-        db.UnitTest.filter(t => t.parentId === suite._id),
+        db.UnitTest.filter((t) => t.parentId === suite._id),
       ),
     ),
   );

--- a/packages/insomnia-inso/src/db/adapters/git-adapter.js
+++ b/packages/insomnia-inso/src/db/adapters/git-adapter.js
@@ -27,7 +27,7 @@ const gitAdapter: DbAdapter = async (dir, filterTypes) => {
   const types = filterTypes?.length ? filterTypes : Object.keys(db);
 
   await Promise.all(
-    types.map(async type => {
+    types.map(async (type) => {
       // Get all files in type dir
       const typeDir = path.join(dir, type);
       if (!fs.existsSync(typeDir)) {
@@ -37,7 +37,7 @@ const gitAdapter: DbAdapter = async (dir, filterTypes) => {
       const files = await fs.promises.readdir(typeDir);
       return Promise.all(
         // Insert each file from each type
-        files.map(file => readAndInsertDoc(type, path.join(dir, type, file))),
+        files.map((file) => readAndInsertDoc(type, path.join(dir, type, file))),
       );
     }),
   );

--- a/packages/insomnia-inso/src/db/adapters/ne-db-adapter.js
+++ b/packages/insomnia-inso/src/db/adapters/ne-db-adapter.js
@@ -17,7 +17,7 @@ const neDbAdapter: DbAdapter = async (dir, filterTypes) => {
   const types = filterTypes?.length ? filterTypes : Object.keys(db);
 
   const promises = types.map(
-    type =>
+    (type) =>
       new Promise((resolve, reject) => {
         const filePath = path.join(dir, `insomnia.${type}.db`);
         const collection = new NeDB({

--- a/packages/insomnia-inso/src/db/models/__tests__/api-spec.test.js
+++ b/packages/insomnia-inso/src/db/models/__tests__/api-spec.test.js
@@ -68,7 +68,7 @@ describe('apiSpec', () => {
 
     it.each([generateIdIsh(spec), spec._id, spec.fileName])(
       'should return spec with identifier: %o',
-      identifier => {
+      (identifier) => {
         expect(loadApiSpec(db, identifier)).toBe(spec);
       },
     );

--- a/packages/insomnia-inso/src/db/models/__tests__/environment.test.js
+++ b/packages/insomnia-inso/src/db/models/__tests__/environment.test.js
@@ -104,7 +104,7 @@ describe('Environment', () => {
 
     it.each([generateIdIsh(subEnvironment), subEnvironment._id, subEnvironment.name])(
       'should return the sub environment if matched with id: %s',
-      identifier => {
+      (identifier) => {
         expect(loadEnvironment(db, workspace._id, subEnvironment._id)).toBe(subEnvironment);
       },
     );

--- a/packages/insomnia-inso/src/db/models/__tests__/unit-test-suite.test.js
+++ b/packages/insomnia-inso/src/db/models/__tests__/unit-test-suite.test.js
@@ -91,7 +91,7 @@ describe('Unit Test Suite', () => {
 
     it.each([generateIdIsh(workspace), workspace._id, workspace.name])(
       'should load all suites that match by workspace id: %o',
-      identifier => {
+      (identifier) => {
         const result = loadTestSuites(db, identifier);
         expect(result).toHaveLength(2);
         expect(result).toContain(suite1);
@@ -101,7 +101,7 @@ describe('Unit Test Suite', () => {
 
     it.each([generateIdIsh(spec), spec._id, spec.fileName])(
       'should load all suites that match by apiSpec id: %o',
-      identifier => {
+      (identifier) => {
         const result = loadTestSuites(db, identifier);
         expect(result).toHaveLength(2);
         expect(result).toContain(suite1);
@@ -111,7 +111,7 @@ describe('Unit Test Suite', () => {
 
     it.each([generateIdIsh(suite1), suite1._id, suite1.name])(
       'should load single suite that matches by id: %o',
-      identifier => {
+      (identifier) => {
         const result = loadTestSuites(db, identifier);
         expect(result).toHaveLength(1);
         expect(result).toContain(suite1);

--- a/packages/insomnia-inso/src/db/models/__tests__/workspace.test.js
+++ b/packages/insomnia-inso/src/db/models/__tests__/workspace.test.js
@@ -32,7 +32,7 @@ describe('workspace', () => {
 
     it.each([generateIdIsh(workspace), workspace._id, workspace.name])(
       'should return workspace with identifier: %o',
-      identifier => {
+      (identifier) => {
         expect(loadWorkspace(db, identifier)).toBe(workspace);
       },
     );

--- a/packages/insomnia-inso/src/db/models/api-spec.js
+++ b/packages/insomnia-inso/src/db/models/api-spec.js
@@ -9,7 +9,7 @@ const entity = 'api specification';
 
 export const loadApiSpec = (db: Database, identifier: string): ?ApiSpec => {
   logger.trace('Load %s with identifier `%s` from data store', entity, identifier);
-  const items = db.ApiSpec.filter(s => matchIdIsh(s, identifier) || s.fileName === identifier);
+  const items = db.ApiSpec.filter((s) => matchIdIsh(s, identifier) || s.fileName === identifier);
   logger.trace('Found %d.', items.length);
 
   return ensureSingleOrNone(items, entity);
@@ -23,7 +23,7 @@ export const promptApiSpec = async (db: Database, ci: boolean): Promise<?ApiSpec
   const prompt = new AutoComplete({
     name: 'apiSpec',
     message: 'Select an API Specification',
-    choices: db.ApiSpec.map(s => getDbChoice(generateIdIsh(s), s.fileName)),
+    choices: db.ApiSpec.map((s) => getDbChoice(generateIdIsh(s), s.fileName)),
   });
 
   logger.trace('Prompt for %s', entity);

--- a/packages/insomnia-inso/src/db/models/environment.js
+++ b/packages/insomnia-inso/src/db/models/environment.js
@@ -7,7 +7,7 @@ import logger from '../../logger';
 
 const loadBaseEnvironmentForWorkspace = (db: Database, workspaceId: string): Environment => {
   logger.trace('Load base environment for the workspace `%s` from data store', workspaceId);
-  const items = db.Environment.filter(e => e.parentId === workspaceId);
+  const items = db.Environment.filter((e) => e.parentId === workspaceId);
   logger.trace('Found %d.', items.length);
 
   return ensureSingle(items, 'base environment');
@@ -24,7 +24,7 @@ export const loadEnvironment = (
 
   // Get the sub environments
   const baseWorkspaceEnv = loadBaseEnvironmentForWorkspace(db, workspaceId);
-  const subEnvs = db.Environment.filter(e => e.parentId === baseWorkspaceEnv._id);
+  const subEnvs = db.Environment.filter((e) => e.parentId === baseWorkspaceEnv._id);
 
   // If no identifier, return base environmenmt
   if (!identifier) {
@@ -33,7 +33,7 @@ export const loadEnvironment = (
   }
 
   logger.trace('Load sub environment with identifier `%s` from data store', identifier);
-  const items = subEnvs.filter(e => matchIdIsh(e, identifier) || e.name === identifier);
+  const items = subEnvs.filter((e) => matchIdIsh(e, identifier) || e.name === identifier);
   logger.trace('Found %d', items.length);
 
   return ensureSingle(items, 'sub environment');
@@ -50,7 +50,7 @@ export const promptEnvironment = async (
 
   // Get the sub environments
   const baseWorkspaceEnv = loadBaseEnvironmentForWorkspace(db, workspaceId);
-  const subEnvs = db.Environment.filter(e => e.parentId === baseWorkspaceEnv._id);
+  const subEnvs = db.Environment.filter((e) => e.parentId === baseWorkspaceEnv._id);
 
   if (!subEnvs.length) {
     logger.trace('No sub environments found, using base environment');
@@ -60,7 +60,7 @@ export const promptEnvironment = async (
   const prompt = new AutoComplete({
     name: 'environment',
     message: `Select an environment`,
-    choices: subEnvs.map(e => getDbChoice(generateIdIsh(e, 14), e.name)),
+    choices: subEnvs.map((e) => getDbChoice(generateIdIsh(e, 14), e.name)),
   });
 
   logger.trace('Prompt for environment');

--- a/packages/insomnia-inso/src/db/models/unit-test-suite.js
+++ b/packages/insomnia-inso/src/db/models/unit-test-suite.js
@@ -11,7 +11,7 @@ import logger from '../../logger';
 export const loadUnitTestSuite = (db: Database, identifier: string): ?UnitTestSuite => {
   // Identifier is for one specific suite; find it
   logger.trace('Load unit test suite with identifier `%s` from data store', identifier);
-  const items = db.UnitTestSuite.filter(s => matchIdIsh(s, identifier) || s.name === identifier);
+  const items = db.UnitTestSuite.filter((s) => matchIdIsh(s, identifier) || s.name === identifier);
   logger.trace('Found %d.', items.length);
 
   return ensureSingleOrNone(items, 'unit test suite');
@@ -23,7 +23,7 @@ export const loadTestSuites = (db: Database, identifier: string): Array<UnitTest
 
   // if identifier is for an apiSpec or a workspace, return all suites for that workspace
   if (workspace) {
-    return db.UnitTestSuite.filter(s => s.parentId === workspace._id);
+    return db.UnitTestSuite.filter((s) => s.parentId === workspace._id);
   }
 
   // load particular suite
@@ -39,9 +39,9 @@ export const promptTestSuites = async (
     return [];
   }
 
-  const choices = db.ApiSpec.map(spec => [
+  const choices = db.ApiSpec.map((spec) => [
     getDbChoice(generateIdIsh(spec), spec.fileName),
-    ...db.UnitTestSuite.filter(suite => suite.parentId === spec.parentId).map(suite =>
+    ...db.UnitTestSuite.filter((suite) => suite.parentId === spec.parentId).map((suite) =>
       getDbChoice(generateIdIsh(suite), suite.name, { indent: 1 }),
     ),
   ]);

--- a/packages/insomnia-inso/src/db/models/workspace.js
+++ b/packages/insomnia-inso/src/db/models/workspace.js
@@ -6,7 +6,7 @@ import logger from '../../logger';
 
 export const loadWorkspace = (db: Database, identifier: string): ?Workspace => {
   logger.trace('Load workspace with identifier `%s` from data store', identifier);
-  const items = db.Workspace.filter(s => matchIdIsh(s, identifier) || s.name === identifier);
+  const items = db.Workspace.filter((s) => matchIdIsh(s, identifier) || s.name === identifier);
   logger.trace('Found %d.', items.length);
 
   return ensureSingleOrNone(items, 'workspace');

--- a/packages/insomnia-inso/src/get-options.js
+++ b/packages/insomnia-inso/src/get-options.js
@@ -35,7 +35,7 @@ export const loadCosmiConfig = (configFile?: string): ConfigFileOptions => {
     if (results && !results?.isEmpty) {
       const options = {};
 
-      OptionsSupportedInConfigFile.forEach(key => {
+      OptionsSupportedInConfigFile.forEach((key) => {
         const value = results.config?.options?.[key];
         if (value) {
           options[key] = value;

--- a/packages/insomnia-inso/src/util.js
+++ b/packages/insomnia-inso/src/util.js
@@ -16,7 +16,7 @@ export function logErrorExit1(err?: Error) {
 }
 
 export async function exit(result: Promise<boolean>): Promise<void> {
-  return result.then(r => process.exit(r ? 0 : 1)).catch(logErrorExit1);
+  return result.then((r) => process.exit(r ? 0 : 1)).catch(logErrorExit1);
 }
 
 export function getDefaultAppDataDir(): string {

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -190,11 +190,6 @@
 			"resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.9.tgz",
 			"integrity": "sha512-/tiJyrc0GPcsReHzgC0SXwOmoPjLqYe01W7dLYB0yasQXMbcRee+ZIk+g8MIQhoBS8fPoBQO3Y93+aeBrI93Ug=="
 		},
-		"@ungap/promise-all-settled": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
-		},
 		"JSV": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
@@ -245,11 +240,6 @@
 				"decimal.js": "^10.2.0"
 			}
 		},
-		"ansi-colors": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
-		},
 		"ansi-regex": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -267,41 +257,10 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+			"optional": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
-			}
-		},
-		"apiconnect-wsdl": {
-			"version": "1.8.31",
-			"resolved": "https://registry.npmjs.org/apiconnect-wsdl/-/apiconnect-wsdl-1.8.31.tgz",
-			"integrity": "sha512-kNs26If9xCJnGolVTAt0VWIA8KrqwodQLqDRTrfc7txD54LJ+hFx638sPYEdG9jw78eifWyy+FBlS5befYSa8Q==",
-			"requires": {
-				"iconv-lite": "^0.4.24",
-				"js-yaml": "^3.13.1",
-				"jszip": "^3.2.2",
-				"lodash": "^4.17.15",
-				"q": "^1.5.1",
-				"swagger-parser": "8.0.3",
-				"xml2js": "^0.4.22",
-				"xmldom": "^0.1.27",
-				"yauzl": "^2.10.0"
-			},
-			"dependencies": {
-				"swagger-parser": {
-					"version": "8.0.3",
-					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
-					"integrity": "sha512-y2gw+rTjn7Z9J+J1qwbBm0UL93k/VREDCveKBK6iGjf7KXC6QGshbnpEmeHL0ZkCgmIghsXzpNzPSbBH91BAEQ==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"json-schema-ref-parser": "^7.1.1",
-						"ono": "^5.1.0",
-						"openapi-schemas": "^1.0.2",
-						"openapi-types": "^1.3.5",
-						"swagger-methods": "^2.0.1",
-						"z-schema": "^4.1.1"
-					}
-				}
 			}
 		},
 		"aproba": {
@@ -316,14 +275,6 @@
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
-			}
-		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"requires": {
-				"sprintf-js": "~1.0.2"
 			}
 		},
 		"array-filter": {
@@ -348,11 +299,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-		},
-		"assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 		},
 		"ast-types": {
 			"version": "0.13.3",
@@ -512,81 +458,20 @@
 				"fill-range": "^7.0.1"
 			}
 		},
-		"browser-stdout": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
-		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-		},
 		"bytes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
 			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-		},
-		"call-me-maybe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
-		},
-		"camel-case": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-			"requires": {
-				"pascal-case": "^3.1.2",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
-		"capital-case": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
-		"chai": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-			"requires": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
-				"type-detect": "^4.0.5"
-			}
 		},
 		"chalk": {
 			"version": "4.0.0",
@@ -633,37 +518,6 @@
 					}
 				}
 			}
-		},
-		"change-case": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-			"requires": {
-				"camel-case": "^4.1.2",
-				"capital-case": "^1.0.4",
-				"constant-case": "^3.0.4",
-				"dot-case": "^3.0.4",
-				"header-case": "^2.0.4",
-				"no-case": "^3.0.4",
-				"param-case": "^3.0.4",
-				"pascal-case": "^3.1.2",
-				"path-case": "^3.0.4",
-				"sentence-case": "^3.0.4",
-				"snake-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
 		},
 		"chokidar": {
 			"version": "3.4.1",
@@ -792,23 +646,6 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
-		"constant-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"core-js": {
 			"version": "3.6.5",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
@@ -878,14 +715,6 @@
 			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
 			"requires": {
 				"mimic-response": "^2.0.0"
-			}
-		},
-		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-			"requires": {
-				"type-detect": "^4.0.0"
 			}
 		},
 		"deep-equal": {
@@ -969,11 +798,6 @@
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-		},
 		"diff3": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
@@ -1020,22 +844,6 @@
 			"requires": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
-			}
-		},
-		"dot-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
 			}
 		},
 		"duplexer": {
@@ -1282,11 +1090,6 @@
 				"path-exists": "^4.0.0"
 			}
 		},
-		"flat": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
-		},
 		"follow-redirects": {
 			"version": "1.5.10",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
@@ -1329,11 +1132,6 @@
 				"combined-stream": "^1.0.8",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"format-util": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-			"integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
 		},
 		"from": {
 			"version": "0.1.7",
@@ -1482,11 +1280,6 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
 		},
-		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
-		},
 		"get-own-enumerable-property-symbols": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -1559,11 +1352,6 @@
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
 		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
-		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -1631,27 +1419,6 @@
 				"cryptiles": "4.x.x",
 				"hoek": "6.x.x",
 				"sntp": "3.x.x"
-			}
-		},
-		"he": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
-		},
-		"header-case": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-			"requires": {
-				"capital-case": "^1.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
 			}
 		},
 		"hkdf": {
@@ -1876,31 +1643,6 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
-		"insomnia-importers": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-importers/-/insomnia-importers-2.2.24.tgz",
-			"integrity": "sha512-9Y88b0PnOfHnY2fWxLWLIKBZR8FQ4edVJYffmtrM8E7qtKObQq513IFnOEhGUQVSIjc2b39vSRXUq1myNrL/Qg==",
-			"requires": {
-				"apiconnect-wsdl": "^1.8.29",
-				"change-case": "^4.1.1",
-				"commander": "^2.20.0",
-				"lodash": "^4.17.15",
-				"shell-quote": "^1.6.1",
-				"swagger-parser": "^6.0.5",
-				"yaml": "^1.5.0"
-			}
-		},
-		"insomnia-testing": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/insomnia-testing/-/insomnia-testing-2.2.26.tgz",
-			"integrity": "sha512-fmyXdwr/qoKCMbYK/nkenPhmC+o+zZb9QfP2g/Wy1sDzGF4++WNLH+XEHaeIHAh5SbRMYAR4x1nsgXL1bfqWAQ==",
-			"requires": {
-				"axios": "^0.19.2",
-				"chai": "^4.2.0",
-				"mkdirp": "^1.0.4",
-				"mocha": "^8.0.1"
-			}
-		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -1925,6 +1667,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
 			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"optional": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
 			}
@@ -1981,11 +1724,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-		},
-		"is-plain-obj": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
 		},
 		"is-regex": {
 			"version": "1.1.0",
@@ -2107,22 +1845,6 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
-		"js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-				}
-			}
-		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -2147,23 +1869,6 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-		},
-		"json-schema-ref-parser": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.4.tgz",
-			"integrity": "sha512-AD7bvav0vak1/63w3jH8F7eHId/4E4EPdMAEZhGxtjktteUv9dnNB/cJy6nVnMyoTPBJnLwFK6tiQPSTeleCtQ==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"js-yaml": "^3.13.1",
-				"ono": "^6.0.0"
-			},
-			"dependencies": {
-				"ono": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
-					"integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
-				}
-			}
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -2239,16 +1944,6 @@
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
 			"integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
 		},
-		"jsonschema": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
-		},
-		"jsonschema-draft4": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
-			"integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU="
-		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -2258,27 +1953,6 @@
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
-			}
-		},
-		"jszip": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-			"integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
-			"requires": {
-				"lie": "~3.3.0",
-				"pako": "~1.0.2",
-				"readable-stream": "~2.3.6",
-				"set-immediate-shim": "~1.0.1"
-			},
-			"dependencies": {
-				"lie": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-					"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-					"requires": {
-						"immediate": "~3.0.5"
-					}
-				}
 			}
 		},
 		"leven": {
@@ -2323,39 +1997,6 @@
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-		},
-		"lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-		},
-		"log-symbols": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-			"requires": {
-				"chalk": "^4.0.0"
-			}
-		},
-		"lower-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"lru-cache": {
 			"version": "5.1.1",
@@ -2469,265 +2110,6 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-1.1.0.tgz",
 			"integrity": "sha1-LISJPtZ24NmPsY+5piEv0bK5qBk="
 		},
-		"mocha": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
-			"integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
-			"requires": {
-				"@ungap/promise-all-settled": "1.1.2",
-				"ansi-colors": "4.1.1",
-				"browser-stdout": "1.3.1",
-				"chokidar": "3.4.3",
-				"debug": "4.2.0",
-				"diff": "4.0.2",
-				"escape-string-regexp": "4.0.0",
-				"find-up": "5.0.0",
-				"glob": "7.1.6",
-				"growl": "1.10.5",
-				"he": "1.2.0",
-				"js-yaml": "3.14.0",
-				"log-symbols": "4.0.0",
-				"minimatch": "3.0.4",
-				"ms": "2.1.2",
-				"nanoid": "3.1.12",
-				"serialize-javascript": "5.0.1",
-				"strip-json-comments": "3.1.1",
-				"supports-color": "7.2.0",
-				"which": "2.0.2",
-				"wide-align": "1.1.3",
-				"workerpool": "6.0.2",
-				"yargs": "13.3.2",
-				"yargs-parser": "13.1.2",
-				"yargs-unparser": "2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-				},
-				"chokidar": {
-					"version": "3.4.3",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-					"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
-					"requires": {
-						"anymatch": "~3.1.1",
-						"braces": "~3.0.2",
-						"fsevents": "~2.1.2",
-						"glob-parent": "~5.1.0",
-						"is-binary-path": "~2.1.0",
-						"is-glob": "~4.0.1",
-						"normalize-path": "~3.0.0",
-						"readdirp": "~3.5.0"
-					}
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					}
-				},
-				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"emoji-regex": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-				},
-				"escape-string-regexp": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-				},
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-				},
-				"find-up": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-					"requires": {
-						"locate-path": "^6.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"js-yaml": {
-					"version": "3.14.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-					"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-					"requires": {
-						"p-locate": "^5.0.0"
-					}
-				},
-				"nanoid": {
-					"version": "3.1.12",
-					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-					"integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
-				},
-				"p-limit": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-					"requires": {
-						"yocto-queue": "^0.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-					"requires": {
-						"p-limit": "^3.0.2"
-					}
-				},
-				"readdirp": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-					"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-					"requires": {
-						"picomatch": "^2.2.1"
-					}
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					}
-				},
-				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-							"requires": {
-								"locate-path": "^3.0.0"
-							}
-						},
-						"locate-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-							"requires": {
-								"p-locate": "^3.0.0",
-								"path-exists": "^3.0.0"
-							}
-						},
-						"p-limit": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-							"requires": {
-								"p-try": "^2.0.0"
-							}
-						},
-						"p-locate": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-							"requires": {
-								"p-limit": "^2.0.0"
-							}
-						},
-						"path-exists": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-						}
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2805,22 +2187,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
 			"integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
-		},
-		"no-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"requires": {
-				"lower-case": "^2.0.2",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"node-fetch": {
 			"version": "2.6.0",
@@ -2988,7 +2354,8 @@
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"optional": true
 		},
 		"npm-bundled": {
 			"version": "1.1.1",
@@ -3100,63 +2467,6 @@
 				"wrappy": "1"
 			}
 		},
-		"ono": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
-			"integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
-		},
-		"openapi-2-kong": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/openapi-2-kong/-/openapi-2-kong-2.2.26.tgz",
-			"integrity": "sha512-J9OzU8HcEVOl5yLksYYnzNkUb7OC768mCFQsdlfHWGmP5bAJVQbrZ3NubsdbiYVrbguJTqBL6Atzt3r3Y8i5Gw==",
-			"requires": {
-				"slugify": "^1.3.6",
-				"swagger-parser": "^8.0.3",
-				"url-join": "^4.0.1",
-				"yaml": "^1.7.2"
-			},
-			"dependencies": {
-				"ono": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
-					"integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
-				},
-				"swagger-parser": {
-					"version": "8.0.4",
-					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.4.tgz",
-					"integrity": "sha512-KGRdAaMJogSEB7sPKI31ptKIWX8lydEDAwWgB4pBMU7zys5cd54XNhoPSVlTxG/A3LphjX47EBn9j0dOGyzWbA==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"json-schema-ref-parser": "^7.1.3",
-						"ono": "^6.0.0",
-						"openapi-schemas": "^1.0.2",
-						"openapi-types": "^1.3.5",
-						"swagger-methods": "^2.0.1",
-						"z-schema": "^4.2.2"
-					}
-				}
-			}
-		},
-		"openapi-schema-validation": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
-			"integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
-			"requires": {
-				"jsonschema": "1.2.4",
-				"jsonschema-draft4": "^1.0.0",
-				"swagger-schema-official": "2.0.0-bab6bed"
-			}
-		},
-		"openapi-schemas": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.3.tgz",
-			"integrity": "sha512-KtMWcK2VtOS+nD8RKSIyScJsj8JrmVWcIX7Kjx4xEHijFYuvMTDON8WfeKOgeSb4uNG6UsqLj5Na7nKbSav9RQ=="
-		},
-		"openapi-types": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
-			"integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
-		},
 		"optionator": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -3242,54 +2552,6 @@
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
 			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 		},
-		"param-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"pascal-case": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"path-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3299,11 +2561,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"pathval": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
 		},
 		"pause-stream": {
 			"version": "0.0.11",
@@ -3398,11 +2655,6 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
-		"q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -3412,14 +2664,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
 			"integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
-		},
-		"randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"requires": {
-				"safe-buffer": "^5.1.0"
-			}
 		},
 		"raw-body": {
 			"version": "2.4.1",
@@ -3608,40 +2852,10 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
 			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 		},
-		"sentence-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"serialize-javascript": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-			"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
-			"requires": {
-				"randombytes": "^2.1.0"
-			}
-		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"setprototypeof": {
 			"version": "1.1.1",
@@ -3656,11 +2870,6 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"shell-quote": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
 		},
 		"shelljs": {
 			"version": "0.3.0",
@@ -3704,31 +2913,10 @@
 				"is-arrayish": "^0.3.1"
 			}
 		},
-		"slugify": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.6.tgz",
-			"integrity": "sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ=="
-		},
 		"smart-buffer": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
 			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
-		},
-		"snake-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"sntp": {
 			"version": "3.0.2",
@@ -3782,11 +2970,6 @@
 			"requires": {
 				"through": "2"
 			}
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.16.1",
@@ -3894,77 +3077,6 @@
 				"has-flag": "^3.0.0"
 			}
 		},
-		"swagger-methods": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.2.tgz",
-			"integrity": "sha512-/RNqvBZkH8+3S/FqBPejHxJxZenaYq3MrpeXnzi06aDIS39Mqf5YCUNb/ZBjsvFFt8h9FxfKs8EXPtcYdfLiRg=="
-		},
-		"swagger-parser": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-6.0.5.tgz",
-			"integrity": "sha512-UL47eu4+GRm5y+N7J+W6QQiqAJn2lojyqgMwS0EZgA55dXd5xmpQCsjUmH/Rf0eKDiG1kULc9VS515PxAyTDVw==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"json-schema-ref-parser": "^6.0.3",
-				"ono": "^4.0.11",
-				"openapi-schema-validation": "^0.4.2",
-				"swagger-methods": "^1.0.8",
-				"swagger-schema-official": "2.0.0-bab6bed",
-				"z-schema": "^3.24.2"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.12",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-				},
-				"json-schema-ref-parser": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-					"integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"js-yaml": "^3.12.1",
-						"ono": "^4.0.11"
-					}
-				},
-				"ono": {
-					"version": "4.0.11",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-					"integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-					"requires": {
-						"format-util": "^1.0.3"
-					}
-				},
-				"swagger-methods": {
-					"version": "1.0.8",
-					"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.8.tgz",
-					"integrity": "sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA=="
-				},
-				"validator": {
-					"version": "10.11.0",
-					"resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-					"integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
-				},
-				"z-schema": {
-					"version": "3.25.1",
-					"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
-					"integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
-					"requires": {
-						"commander": "^2.7.1",
-						"core-js": "^2.5.7",
-						"lodash.get": "^4.0.0",
-						"lodash.isequal": "^4.0.0",
-						"validator": "^10.0.0"
-					}
-				}
-			}
-		},
-		"swagger-schema-official": {
-			"version": "2.0.0-bab6bed",
-			"resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
-			"integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
-		},
 		"tar": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.2.tgz",
@@ -4061,11 +3173,6 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
-		"type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
-		},
 		"uid-safe": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -4088,36 +3195,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
-		"upper-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"upper-case-first": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"uri-js": {
 			"version": "4.2.2",
@@ -4151,11 +3228,6 @@
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
 			"integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
-		},
-		"validator": {
-			"version": "12.2.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
-			"integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -4268,11 +3340,6 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
 		},
-		"workerpool": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
-			"integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q=="
-		},
 		"wrap-ansi": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -4311,25 +3378,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-			"requires": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~11.0.0"
-			}
-		},
-		"xmlbuilder": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-		},
-		"xmldom": {
-			"version": "0.1.31",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
 		},
 		"xregexp": {
 			"version": "2.0.0",
@@ -4376,54 +3424,6 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
-			}
-		},
-		"yargs-unparser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-			"requires": {
-				"camelcase": "^6.0.0",
-				"decamelize": "^4.0.0",
-				"flat": "^5.0.2",
-				"is-plain-obj": "^2.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
-				},
-				"decamelize": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-					"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
-				}
-			}
-		},
-		"yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-			"requires": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
-			}
-		},
-		"yocto-queue": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-		},
-		"z-schema": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
-			"integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
-			"requires": {
-				"commander": "^2.7.1",
-				"lodash.get": "^4.4.2",
-				"lodash.isequal": "^4.5.0",
-				"validator": "^12.0.0"
 			}
 		}
 	}

--- a/packages/insomnia-smoke-test/core/app.test.js
+++ b/packages/insomnia-smoke-test/core/app.test.js
@@ -36,7 +36,7 @@ describe('Application launch', function() {
 
   it.each([true, false])(
     'imports swagger 2 and sends request: new workspace=%s ',
-    async newWorkspace => {
+    async (newWorkspace) => {
       await debug.workspaceDropdownExists(app);
 
       // Copy text to clipboard

--- a/packages/insomnia-smoke-test/designer/app.test.js
+++ b/packages/insomnia-smoke-test/designer/app.test.js
@@ -7,7 +7,7 @@ import * as dropdown from '../modules/dropdown';
 
 import { isPackage, launchDesigner, stop } from '../modules/application';
 
-const itIf = condition => (condition ? it : it.skip);
+const itIf = (condition) => (condition ? it : it.skip);
 it.if = itIf;
 
 describe('Application launch', function() {

--- a/packages/insomnia-smoke-test/modules/application.js
+++ b/packages/insomnia-smoke-test/modules/application.js
@@ -39,7 +39,7 @@ export const launchDesigner = async () => {
   return await launch(config);
 };
 
-const getLaunchPath = config =>
+const getLaunchPath = (config) =>
   isPackage()
     ? { path: config.packagePath }
     : {
@@ -47,7 +47,7 @@ const getLaunchPath = config =>
         args: [config.buildPath],
       };
 
-const launch = async config => {
+const launch = async (config) => {
   if (!config) {
     throw new Error('Spectron config could not be loaded.');
   }
@@ -81,7 +81,7 @@ const launch = async config => {
   return app;
 };
 
-export const stop = async app => {
+export const stop = async (app) => {
   if (app && app.isRunning()) {
     await app.stop();
   }

--- a/packages/insomnia-smoke-test/modules/client.js
+++ b/packages/insomnia-smoke-test/modules/client.js
@@ -1,11 +1,11 @@
-export const correctlyLaunched = async app => {
+export const correctlyLaunched = async (app) => {
   await expect(app.browserWindow.isDevToolsOpened()).resolves.toBe(false);
   await expect(app.client.getWindowCount()).resolves.toBe(1);
   await expect(app.browserWindow.isMinimized()).resolves.toBe(false);
   await expect(app.browserWindow.isFocused()).resolves.toBe(true);
 };
 
-export const resetToOnboarding = async app => {
+export const resetToOnboarding = async (app) => {
   await app.webContents.executeJavaScript("localStorage['insomnia::meta::activity'] = null;");
   await app.browserWindow.reload(); // reload for local storage clearing to take effect
 };

--- a/packages/insomnia-smoke-test/modules/debug.js
+++ b/packages/insomnia-smoke-test/modules/debug.js
@@ -5,19 +5,19 @@ export const workspaceDropdownExists = async (app, workspaceName = 'Insomnia') =
   await app.client.waitUntilTextExists('.workspace-dropdown', workspaceName);
 };
 
-export const clickWorkspaceDropdown = async app => {
+export const clickWorkspaceDropdown = async (app) => {
   const dropdown = await app.client.react$('WorkspaceDropdown');
   await dropdown.click();
   return dropdown;
 };
 
 export const createNewRequest = async (app, name) => {
-  await app.client.$('.sidebar .dropdown .fa-plus-circle').then(e => e.click());
+  await app.client.$('.sidebar .dropdown .fa-plus-circle').then((e) => e.click());
 
   await app.client
     .$('[aria-hidden=false]')
-    .then(e => e.$('button*=New Request'))
-    .then(e => e.click());
+    .then((e) => e.$('button*=New Request'))
+    .then((e) => e.click());
 
   // Wait for modal to open
   await app.client.waitUntilTextExists('.modal__header', 'New Request');
@@ -31,8 +31,8 @@ export const createNewRequest = async (app, name) => {
 
   await app.client
     .$('.modal .modal__footer')
-    .then(e => e.$('button=Create'))
-    .then(e => e.click());
+    .then((e) => e.$('button=Create'))
+    .then((e) => e.click());
 
   await waitUntilRequestIsActive(app, requestName);
 };
@@ -70,11 +70,11 @@ export const typeInUrlBar = async (app, url) => {
   await urlEditor.keys(url);
 };
 
-export const clickSendRequest = async app => {
+export const clickSendRequest = async (app) => {
   await app.client
     .react$('RequestUrlBar')
-    .then(e => e.$('.urlbar__send-btn'))
-    .then(e => e.click());
+    .then((e) => e.$('.urlbar__send-btn'))
+    .then((e) => e.click());
 
   // Wait for spinner to show
   const spinner = await app.client.react$('ResponseTimer');
@@ -84,38 +84,38 @@ export const clickSendRequest = async app => {
   await spinner.waitForDisplayed({ reverse: true });
 };
 
-export const expect200 = async app => {
+export const expect200 = async (app) => {
   const tag = await app.client.$('.response-pane .pane__header .tag.bg-success');
   await tag.waitForDisplayed();
   await expectText(tag, '200 OK');
 };
 
-export const expect401 = async app => {
+export const expect401 = async (app) => {
   const tag = await app.client.$('.response-pane .pane__header .tag.bg-warning');
   await tag.waitForDisplayed();
   await expectText(tag, '401 Unauthorized');
 };
 
-export const getResponseViewer = async app => {
+export const getResponseViewer = async (app) => {
   // app.client.react$('ResponseViewer') doesn't seem to work because ResponseViewer is not a PureComponent
   const codeEditor = await app.client.$('.response-pane .editor');
   await codeEditor.waitForDisplayed();
   return codeEditor;
 };
 
-export const getTimelineViewer = async app => {
+export const getTimelineViewer = async (app) => {
   const codeEditor = await app.client.react$('ResponseTimelineViewer');
   await codeEditor.waitForDisplayed();
   return codeEditor;
 };
 
-export const getCsvViewer = async app => {
+export const getCsvViewer = async (app) => {
   const csvViewer = await app.client.react$('ResponseCSVViewer');
   await csvViewer.waitForDisplayed();
   return csvViewer;
 };
 
-export const getPdfCanvas = async app => {
+export const getPdfCanvas = async (app) => {
   const pdfViewer = await app.client.react$('ResponsePDFViewer');
   await pdfViewer.waitForDisplayed();
   const canvas = await pdfViewer.$('.S-PDF-ID canvas');
@@ -123,34 +123,34 @@ export const getPdfCanvas = async app => {
   return canvas;
 };
 
-export const clickRequestAuthDropdown = async app => {
+export const clickRequestAuthDropdown = async (app) => {
   await app.client
     .react$('AuthDropdown')
-    .then(e => e.react$('DropdownButton'))
-    .then(e => e.click());
+    .then((e) => e.react$('DropdownButton'))
+    .then((e) => e.click());
 };
 
-export const clickRequestAuthTab = async app => {
+export const clickRequestAuthTab = async (app) => {
   await app.client
     .react$('RequestPane')
-    .then(e => e.$('#react-tabs-2'))
-    .then(e => e.click());
+    .then((e) => e.$('#react-tabs-2'))
+    .then((e) => e.click());
 };
 
 const basicAuthPause = 300;
 
-export const clickBasicAuth = async app => {
+export const clickBasicAuth = async (app) => {
   await app.client
     .react$('AuthDropdown')
-    .then(e => e.react$('DropdownItem', { props: { value: 'basic' } }))
-    .then(e => e.click());
+    .then((e) => e.react$('DropdownItem', { props: { value: 'basic' } }))
+    .then((e) => e.click());
 
   // Wait for basic auth to be enabled on the request
   await app.client.pause(basicAuthPause);
 };
 
-export const expectNoAuthSelected = async app => {
-  const wrapper = await app.client.react$('RequestPane').then(e => e.react$('AuthWrapper'));
+export const expectNoAuthSelected = async (app) => {
+  const wrapper = await app.client.react$('RequestPane').then((e) => e.react$('AuthWrapper'));
   await wrapper.waitForDisplayed();
   await expectText(wrapper, 'Select an auth type from above');
 };
@@ -190,20 +190,20 @@ export const typeBasicAuthUsernameAndPassword = async (app, username, password, 
   await app.client.pause(basicAuthPause);
 };
 
-export const toggleBasicAuthEnabled = async app => {
+export const toggleBasicAuthEnabled = async (app) => {
   await app.client
     .react$('BasicAuth')
-    .then(e => e.$('button#enabled'))
-    .then(e => e.click());
+    .then((e) => e.$('button#enabled'))
+    .then((e) => e.click());
   // Allow toggle to persist
   await app.client.pause(basicAuthPause);
 };
 
-export const toggleBasicAuthEncoding = async app => {
+export const toggleBasicAuthEncoding = async (app) => {
   await app.client
     .react$('BasicAuth')
-    .then(e => e.$('button#use-iso-8859-1'))
-    .then(e => e.click());
+    .then((e) => e.$('button#use-iso-8859-1'))
+    .then((e) => e.click());
 
   // Allow toggle to persist
   await app.client.pause(basicAuthPause);
@@ -221,17 +221,17 @@ export const expectNotContainsText = async (element, text) => {
   await expect(element.getText()).resolves.not.toContain(text);
 };
 
-export const clickTimelineTab = async app => {
+export const clickTimelineTab = async (app) => {
   await app.client
     .$('.response-pane')
-    .then(e => e.$('#react-tabs-16'))
-    .then(e => e.click());
+    .then((e) => e.$('#react-tabs-16'))
+    .then((e) => e.click());
 
   // Wait until some text shows
   const codeEditor = await getTimelineViewer(app);
   await app.client.waitUntil(() => codeEditor.getText());
 };
 
-export const selectAll = async app => {
+export const selectAll = async (app) => {
   await app.client.keys(spectronKeys.mapAccelerator('CommandOrControl+A'));
 };

--- a/packages/insomnia-smoke-test/modules/dropdown.js
+++ b/packages/insomnia-smoke-test/modules/dropdown.js
@@ -4,7 +4,7 @@ export const clickDropdownItemByText = async (dropdown, text) => {
   let item;
   await dropdown.waitUntil(async () => {
     const items = await dropdown.react$$('DropdownItem');
-    item = await findAsync(items, async i => (await i.getText()) === text);
+    item = await findAsync(items, async (i) => (await i.getText()) === text);
     return !!item;
   });
   await item.waitForDisplayed();
@@ -14,7 +14,7 @@ export const clickDropdownItemByText = async (dropdown, text) => {
 export const clickOpenDropdownItemByText = async (app, text) => {
   const item = await app.client
     .$('.dropdown__menu[aria-hidden=false]')
-    .then(e => e.$(`button*=${text}`));
+    .then((e) => e.$(`button*=${text}`));
   await item.waitForDisplayed();
   await item.click();
 };

--- a/packages/insomnia-smoke-test/modules/find-async.js
+++ b/packages/insomnia-smoke-test/modules/find-async.js
@@ -1,6 +1,6 @@
 export default async function findAsync(arr, asyncCallback) {
   const promises = arr.map(asyncCallback);
   const results = await Promise.all(promises);
-  const index = results.findIndex(result => result);
+  const index = results.findIndex((result) => result);
   return arr[index];
 }

--- a/packages/insomnia-smoke-test/modules/home.js
+++ b/packages/insomnia-smoke-test/modules/home.js
@@ -1,9 +1,9 @@
-export const documentListingShown = async app => {
+export const documentListingShown = async (app) => {
   const item = await app.client.$('.document-listing');
   await item.waitForExist();
 };
 
-export const openDocumentMenuDropdown = async app => {
+export const openDocumentMenuDropdown = async (app) => {
   const dropdown = await app.client.react$('DocumentCardDropdown');
   await dropdown.click();
   return dropdown;

--- a/packages/insomnia-smoke-test/modules/modal.js
+++ b/packages/insomnia-smoke-test/modules/modal.js
@@ -15,16 +15,16 @@ export const close = async (app, modalName) => {
     modal = await app.client.react$(modalName);
   } else {
     const modals = await app.client.react$$('Modal');
-    modal = await findAsync(modals, m => m.isDisplayed());
+    modal = await findAsync(modals, (m) => m.isDisplayed());
   }
 
-  await modal.$('button.modal__close-btn').then(e => e.click());
+  await modal.$('button.modal__close-btn').then((e) => e.click());
 };
 
 export const clickModalFooterByText = async (app, modalName, text) => {
   const modal = await app.client.react$(modalName);
   await modal.waitForDisplayed();
-  const btn = await modal.$(`.modal__footer`).then(e => e.$(`button*=${text}`));
+  const btn = await modal.$(`.modal__footer`).then((e) => e.$(`button*=${text}`));
   await btn.waitForClickable();
   await btn.click();
 };

--- a/packages/insomnia-smoke-test/modules/onboarding.js
+++ b/packages/insomnia-smoke-test/modules/onboarding.js
@@ -1,20 +1,20 @@
-export const welcomeMessageShown = async app => {
+export const welcomeMessageShown = async (app) => {
   await app.client.waitUntilTextExists(
     '.onboarding__content__header h1',
     'Welcome to Insomnia Designer',
   );
 };
 
-export const clickDontShare = async app => {
+export const clickDontShare = async (app) => {
   await app.client
     .$('.onboarding__content__body')
-    .then(e => e.$(`button=Don't share usage analytics`))
-    .then(e => e.click());
+    .then((e) => e.$(`button=Don't share usage analytics`))
+    .then((e) => e.click());
 };
 
-export const clickSkipImport = async app => {
+export const clickSkipImport = async (app) => {
   await app.client
     .$('.onboarding__content__body')
-    .then(e => e.$(`button=Skip`))
-    .then(e => e.click());
+    .then((e) => e.$(`button=Skip`))
+    .then((e) => e.click());
 };

--- a/packages/insomnia-smoke-test/modules/settings.js
+++ b/packages/insomnia-smoke-test/modules/settings.js
@@ -3,29 +3,29 @@ import { mapAccelerator } from 'spectron-keys';
 import * as modal from './modal';
 import * as dropdown from './dropdown';
 
-export const openWithKeyboardShortcut = async app => {
+export const openWithKeyboardShortcut = async (app) => {
   await app.client.keys(mapAccelerator('CommandOrControl+,'));
 
   await modal.waitUntilOpened(app, { modalName: 'SettingsModal' });
 };
 
-export const closeModal = async app => {
+export const closeModal = async (app) => {
   await modal.close(app, 'SettingsModal');
 };
 
-export const goToPlugins = async app => {
+export const goToPlugins = async (app) => {
   // Click on the plugins tab
-  await app.client.react$('SettingsModal').then(e => clickTabByText(e, 'Plugins'));
+  await app.client.react$('SettingsModal').then((e) => clickTabByText(e, 'Plugins'));
 
   // Wait for the plugins component to show
-  await app.client.react$('Plugins').then(e => e.waitForDisplayed());
+  await app.client.react$('Plugins').then((e) => e.waitForDisplayed());
 };
 
 export const importFromClipboard = async (app, newWorkspace = false) => {
   const importExport = await app.client.react$('ImportExport');
   await importExport.waitForDisplayed();
 
-  await importExport.$('button*=Import Data').then(e => e.click());
+  await importExport.$('button*=Import Data').then((e) => e.click());
 
   await dropdown.clickOpenDropdownItemByText(app, 'From Clipboard');
 
@@ -33,7 +33,7 @@ export const importFromClipboard = async (app, newWorkspace = false) => {
 };
 
 export const installPlugin = async (app, pluginName) => {
-  const plugins = await app.client.react$('SettingsModal').then(e => e.react$('Plugins'));
+  const plugins = await app.client.react$('SettingsModal').then((e) => e.react$('Plugins'));
 
   // Find text input and install button
   const inputField = await plugins.$('form input[placeholder="npm-package-name"]');
@@ -59,7 +59,7 @@ export const installPlugin = async (app, pluginName) => {
   });
 
   // Spinner should show
-  await installButton.$('i.fa.fa-refresh.fa-spin').then(e => e.waitForDisplayed());
+  await installButton.$('i.fa.fa-refresh.fa-spin').then((e) => e.waitForDisplayed());
 
   // Button and field should re-enable
   await plugins.waitUntil(

--- a/packages/insomnia-smoke-test/modules/tabs.js
+++ b/packages/insomnia-smoke-test/modules/tabs.js
@@ -1,3 +1,3 @@
 export const clickTabByText = async (element, text) => {
-  await element.$(`.react-tabs__tab=${text}`).then(e => e.click());
+  await element.$(`.react-tabs__tab=${text}`).then((e) => e.click());
 };

--- a/packages/insomnia-testing/src/generate/index.js
+++ b/packages/insomnia-testing/src/generate/index.js
@@ -34,7 +34,7 @@ export function generate(suites: Array<TestSuite>): string {
 export async function generateToFile(filepath: string, suites: Array<TestSuite>): Promise<void> {
   return new Promise((resolve, reject) => {
     const js = generate(suites);
-    return fs.writeFile(filepath, js, err => {
+    return fs.writeFile(filepath, js, (err) => {
       if (err) {
         reject(err);
       } else {

--- a/packages/insomnia-testing/src/generate/util.js
+++ b/packages/insomnia-testing/src/generate/util.js
@@ -12,6 +12,6 @@ export function indent(level: number, code: string, tab: string = '  '): string 
   const prefix = new Array(level + 1).join('  ');
   return code
     .split('\n')
-    .map(line => prefix + line)
+    .map((line) => prefix + line)
     .join('\n');
 }

--- a/packages/insomnia-testing/src/run/index.js
+++ b/packages/insomnia-testing/src/run/index.js
@@ -94,7 +94,7 @@ async function runInternal<T>(
 
         // Clean up temp files
         for (const f of mocha.files) {
-          fs.unlink(f, err => {
+          fs.unlink(f, (err) => {
             if (err) {
               console.log('Failed to clean up test file', f, err);
             }
@@ -130,7 +130,7 @@ export async function runTestsCli(
   testSrc: string | Array<string>,
   { reporter, ...options }: CliOptions = {},
 ): Promise<boolean> {
-  return await runInternal(testSrc, options, reporter, runner => !runner.stats.failures);
+  return await runInternal(testSrc, options, reporter, (runner) => !runner.stats.failures);
 }
 
 /**
@@ -140,5 +140,5 @@ export async function runTests(
   testSrc: string | Array<string>,
   options: InsomniaOptions = {},
 ): Promise<TestResults> {
-  return await runInternal(testSrc, options, JavaScriptReporter, runner => runner.testResults);
+  return await runInternal(testSrc, options, JavaScriptReporter, (runner) => runner.testResults);
 }

--- a/packages/insomnia-testing/src/run/insomnia.js
+++ b/packages/insomnia-testing/src/run/insomnia.js
@@ -76,7 +76,7 @@ export default class Insomnia {
       return sendRequest(reqId);
     }
 
-    const req = this.requests.find(r => r._id === reqId);
+    const req = this.requests.find((r) => r._id === reqId);
 
     if (!req) {
       throw new Error('Request not provided to test');

--- a/packages/insomnia-url/src/querystring.js
+++ b/packages/insomnia-url/src/querystring.js
@@ -173,7 +173,7 @@ module.exports.smartEncodeUrl = function(url, encode) {
     if (parsedUrl.pathname) {
       const segments = parsedUrl.pathname.split('/');
       parsedUrl.pathname = segments
-        .map(s => module.exports.flexibleEncodeComponent(s, URL_PATH_CHARACTER_WHITELIST))
+        .map((s) => module.exports.flexibleEncodeComponent(s, URL_PATH_CHARACTER_WHITELIST))
         .join('/');
     }
 

--- a/packages/openapi-2-kong/src/__tests__/common.test.js
+++ b/packages/openapi-2-kong/src/__tests__/common.test.js
@@ -212,7 +212,7 @@ describe('common', () => {
 
   const methods = ['get', 'put', 'post', 'options', 'delete', 'head', 'patch', 'trace'];
   describe('isHttpMethodKey()', () => {
-    it.each(methods)('should be true for %o', method => {
+    it.each(methods)('should be true for %o', (method) => {
       expect(isHttpMethodKey(method)).toBe(true);
     });
     it('should be false for non http method key', () => {
@@ -221,7 +221,7 @@ describe('common', () => {
   });
 
   describe('getMethodAnnotationName', () => {
-    it.each(methods)('should suffix with -method and lowercase: %o', method => {
+    it.each(methods)('should suffix with -method and lowercase: %o', (method) => {
       expect(getMethodAnnotationName(method)).toBe(`${method}-method`.toLowerCase());
     });
   });

--- a/packages/openapi-2-kong/src/common.js
+++ b/packages/openapi-2-kong/src/common.js
@@ -97,7 +97,7 @@ export const HttpMethod = {
 
 export function isHttpMethodKey(key: string): boolean {
   const uppercaseKey = key.toUpperCase();
-  return Object.values(HttpMethod).some(m => m === uppercaseKey);
+  return Object.values(HttpMethod).some((m) => m === uppercaseKey);
 }
 
 export function getMethodAnnotationName(method: HttpMethodType): string {

--- a/packages/openapi-2-kong/src/kubernetes/__tests__/index.test.js
+++ b/packages/openapi-2-kong/src/kubernetes/__tests__/index.test.js
@@ -232,12 +232,12 @@ describe('index', () => {
   describe('generateServicePath()', () => {
     it.each(['', '/'])(
       'returns undefined if base path is [%o] and no specific path exists',
-      serverBasePath => {
+      (serverBasePath) => {
         expect(generateServicePath(serverBasePath)).toBe(undefined);
       },
     );
 
-    it.each(['/api/v1', '/api/v1/'])('adds closing wildcard if base path is [%o]', basePath => {
+    it.each(['/api/v1', '/api/v1/'])('adds closing wildcard if base path is [%o]', (basePath) => {
       expect(generateServicePath(basePath)).toBe('/api/v1/.*');
     });
 
@@ -248,7 +248,7 @@ describe('index', () => {
 
     it.each(['/', '/specificPath'])(
       'does not add closing wildcard if using specific path: [%o]',
-      specificPath => {
+      (specificPath) => {
         const serverBasePath = '/';
         const result = generateServicePath(serverBasePath, specificPath);
         expect(result).toBe(specificPath);

--- a/packages/openapi-2-kong/src/kubernetes/__tests__/plugins.test.js
+++ b/packages/openapi-2-kong/src/kubernetes/__tests__/plugins.test.js
@@ -246,7 +246,7 @@ describe('plugins', () => {
       const result = getServerPlugins(servers, increment);
 
       expect(result).toHaveLength(2);
-      result.forEach(s => expect(s.plugins).toHaveLength(0));
+      result.forEach((s) => expect(s.plugins).toHaveLength(0));
     });
     it('returns plugins from each server', () => {
       const servers = [
@@ -407,7 +407,7 @@ describe('plugins', () => {
     });
     it.each(Object.values(HttpMethod))(
       'should extract method plugins for %o from path item',
-      methodName => {
+      (methodName) => {
         const pathItem = {
           [methodName]: {
             ...pluginKeyAuth,
@@ -705,9 +705,9 @@ describe('plugins', () => {
 
   describe('distinctByProperty()', () => {
     it('returns empty array if no truthy items', () => {
-      expect(distinctByProperty([], i => i)).toHaveLength(0);
-      expect(distinctByProperty([undefined], i => i)).toHaveLength(0);
-      expect(distinctByProperty([null, undefined, ''], i => i)).toHaveLength(0);
+      expect(distinctByProperty([], (i) => i)).toHaveLength(0);
+      expect(distinctByProperty([undefined], (i) => i)).toHaveLength(0);
+      expect(distinctByProperty([null, undefined, ''], (i) => i)).toHaveLength(0);
     });
 
     it('should remove objects with the same property selector - removes 2/4', () => {
@@ -718,7 +718,7 @@ describe('plugins', () => {
       const items = [item1, item2, item3, item4];
 
       // distinct by the name property
-      const filtered = distinctByProperty(items, i => i.name);
+      const filtered = distinctByProperty(items, (i) => i.name);
 
       // Should remove item2 and item4
       expect(filtered).toEqual([item1, item3]);
@@ -732,7 +732,7 @@ describe('plugins', () => {
       const items = [item1, item2, item3, item4];
 
       // distinct by the value property
-      const filtered = distinctByProperty(items, i => i.value);
+      const filtered = distinctByProperty(items, (i) => i.value);
 
       // Should remove no items
       expect(filtered).toEqual(items);

--- a/packages/openapi-2-kong/src/kubernetes/index.js
+++ b/packages/openapi-2-kong/src/kubernetes/index.js
@@ -24,15 +24,15 @@ export function generateKongForKubernetesConfigFromSpec(
   // Iterate all global servers
   plugins.servers.forEach((sp, serverIndex) => {
     // Iterate all paths
-    plugins.paths.forEach(pp => {
+    plugins.paths.forEach((pp) => {
       // Iterate methods
-      pp.operations.forEach(o => {
+      pp.operations.forEach((o) => {
         // Prioritize plugins for doc
         const pluginsForDoc = prioritizePlugins(plugins.global, sp.plugins, pp.plugins, o.plugins);
 
         // Identify custom annotations
         const annotations: CustomAnnotations = {
-          pluginNames: pluginsForDoc.map(x => x.metadata.name),
+          pluginNames: pluginsForDoc.map((x) => x.metadata.name),
         };
 
         const method = o.method;
@@ -152,7 +152,7 @@ export function generateRulesForServer(
   const backend = { serviceName, servicePort };
 
   const pathsToUse: Array<string> = (paths?.length && paths) || ['']; // Make flow happy
-  const k8sPaths: Array<K8sPath> = pathsToUse.map(p => {
+  const k8sPaths: Array<K8sPath> = pathsToUse.map((p) => {
     const path = generateServicePath(pathname, p);
 
     return path ? { path, backend } : { backend };
@@ -208,7 +208,7 @@ export function generateServicePort(server: OA3Server): number {
 
   // Return 443
   if (generateTlsConfig(server)) {
-    if (ports.find(p => p.port === 443)) {
+    if (ports.find((p) => p.port === 443)) {
       return 443;
     }
 

--- a/packages/openapi-2-kong/src/kubernetes/plugins.js
+++ b/packages/openapi-2-kong/src/kubernetes/plugins.js
@@ -15,13 +15,13 @@ export function flattenPluginDocuments(plugins: Plugins): Array<KubernetesPlugin
   const { global, servers, paths } = plugins;
 
   all.push(...global);
-  servers.forEach(s => {
+  servers.forEach((s) => {
     all.push(...s.plugins);
   });
-  paths.forEach(s => {
+  paths.forEach((s) => {
     all.push(...s.plugins);
 
-    s.operations.forEach(o => {
+    s.operations.forEach((o) => {
       all.push(...o.plugins);
     });
   });
@@ -57,7 +57,7 @@ export function mapDcPluginsToK8Plugins(
   suffix: string,
   increment: IndexIncrement,
 ): Array<KubernetesPluginConfig> {
-  return dcPlugins.map(dcPlugin => {
+  return dcPlugins.map((dcPlugin) => {
     const k8sPlugin: KubernetesPluginConfig = {
       apiVersion: 'configuration.konghq.com/v1',
       kind: 'KongPlugin',
@@ -94,7 +94,7 @@ export function getServerPlugins(
   servers: Array<OA3Server>,
   increment: IndexIncrement,
 ): ServerPlugins {
-  return servers.map(server => ({
+  return servers.map((server) => ({
     server,
     plugins: generateK8PluginConfig(server, PluginNameSuffix.server, increment),
   }));
@@ -105,7 +105,7 @@ export function getPathPlugins(
   increment: IndexIncrement,
   api: OpenApi3Spec,
 ): PathPlugins {
-  const pathPlugins = Object.keys(paths).map(path => {
+  const pathPlugins = Object.keys(paths).map((path) => {
     const pathItem = paths[path];
 
     return {
@@ -125,7 +125,7 @@ export function getOperationPlugins(
 ): OperationPlugins {
   const operationPlugins = Object.keys(pathItem)
     .filter(isHttpMethodKey)
-    .map(key => {
+    .map((key) => {
       // We know this will always, only be OA3Operation (because of the filter above), but Flow doesn't know that...
       const operation: Object = pathItem[key];
 
@@ -191,13 +191,13 @@ const blankPath = { path: '', plugins: [], operations: [blankOperation] };
 
 export function normalizePathPlugins(pathPlugins: PathPlugins): PathPlugins {
   const pluginsExist = pathPlugins.some(
-    p => p.plugins.length || p.operations.some(o => o.plugins.length),
+    (p) => p.plugins.length || p.operations.some((o) => o.plugins.length),
   );
   return pluginsExist ? pathPlugins : [blankPath];
 }
 
 export function normalizeOperationPlugins(operationPlugins: OperationPlugins): OperationPlugins {
-  const pluginsExist = operationPlugins.some(o => o.plugins.length);
+  const pluginsExist = operationPlugins.some((o) => o.plugins.length);
   return pluginsExist ? operationPlugins : [blankOperation];
 }
 
@@ -211,14 +211,14 @@ export function prioritizePlugins(
   const plugins: Array<KubernetesPluginConfig> = [...operation, ...path, ...server, ...global];
 
   // Select first of each type of plugin
-  return distinctByProperty(plugins, p => p.plugin);
+  return distinctByProperty(plugins, (p) => p.plugin);
 }
 
 export function distinctByProperty<T>(arr: Array<T>, propertySelector: (item: T) => any): Array<T> {
   const result: Array<T> = [];
   const set = new Set();
 
-  for (const item of arr.filter(i => i)) {
+  for (const item of arr.filter((i) => i)) {
     const selector = propertySelector(item);
     if (set.has(selector)) {
       continue;

--- a/plugins/insomnia-plugin-cookie-jar/__tests__/index.js
+++ b/plugins/insomnia-plugin-cookie-jar/__tests__/index.js
@@ -91,18 +91,18 @@ function _getTestContext(workspaces, requests, jars) {
       models: {
         request: {
           getById(id) {
-            return requests.find(r => r._id === id);
+            return requests.find((r) => r._id === id);
           },
         },
         workspace: {
           getById(id) {
-            return workspaces.find(w => w._id === id);
+            return workspaces.find((w) => w._id === id);
           },
         },
         cookieJar: {
           getOrCreateForWorkspace(workspace) {
             return (
-              jars.find(j => j.parentId === workspace._id) || {
+              jars.find((j) => j.parentId === workspace._id) || {
                 parentId: workspace._id,
                 cookies: [],
               }

--- a/plugins/insomnia-plugin-cookie-jar/index.js
+++ b/plugins/insomnia-plugin-cookie-jar/index.js
@@ -50,9 +50,9 @@ function getCookieValue(cookieJar, url, name) {
         reject(new Error(`No cookies in store for url "${url}"`));
       }
 
-      const cookie = cookies.find(cookie => cookie.key === name);
+      const cookie = cookies.find((cookie) => cookie.key === name);
       if (!cookie) {
-        const names = cookies.map(c => `"${c.key}"`).join(',\n\t');
+        const names = cookies.map((c) => `"${c.key}"`).join(',\n\t');
         throw new Error(
           `No cookie with name "${name}".\nChoices are [\n\t${names}\n] for url "${url}"`,
         );

--- a/plugins/insomnia-plugin-kong-bundle/index.js
+++ b/plugins/insomnia-plugin-kong-bundle/index.js
@@ -4,8 +4,8 @@
  */
 const { dependencies } = require('./package.json');
 const bundledPlugins = Object.keys(dependencies)
-  .filter(name => name.indexOf('insomnia-plugin-') === 0)
-  .map(name => require(name));
+  .filter((name) => name.indexOf('insomnia-plugin-') === 0)
+  .map((name) => require(name));
 
 // Iterate over all plugins
 for (const plugin of bundledPlugins) {

--- a/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
@@ -25,7 +25,7 @@ module.exports = {
       };
     }
 
-    const yamlDocs = result.documents.map(d => YAML.stringify(d));
+    const yamlDocs = result.documents.map((d) => YAML.stringify(d));
 
     // Join the YAML docs with "---" and strip any extra newlines surrounding them
     const document = yamlDocs.join('\n---\n').replace(/\n+---\n+/g, '\n---\n');

--- a/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
@@ -25,7 +25,7 @@ module.exports = {
       };
     }
 
-    const yamlDocs = result.documents.map(d => YAML.stringify(d));
+    const yamlDocs = result.documents.map((d) => YAML.stringify(d));
 
     // Join the YAML docs with "---" and strip any extra newlines surrounding them
     const document = yamlDocs.join('\n---\n').replace(/\n+---\n+/g, '\n---\n');

--- a/plugins/insomnia-plugin-kong-portal/package-lock.json
+++ b/plugins/insomnia-plugin-kong-portal/package-lock.json
@@ -1077,42 +1077,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@emotion/is-prop-valid": {
-			"version": "0.8.8",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-			"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"@emotion/memoize": "0.7.4"
-			}
-		},
-		"@emotion/memoize": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-			"dev": true,
-			"optional": true
-		},
-		"@popmotion/easing": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.2.tgz",
-			"integrity": "sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==",
-			"dev": true
-		},
-		"@popmotion/popcorn": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.4.4.tgz",
-			"integrity": "sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==",
-			"dev": true,
-			"requires": {
-				"@popmotion/easing": "^1.0.1",
-				"framesync": "^4.0.1",
-				"hey-listen": "^1.0.8",
-				"style-value-types": "^3.1.7",
-				"tslib": "^1.10.0"
-			}
-		},
 		"@webassemblyjs/ast": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -1788,12 +1752,6 @@
 				"supports-color": "^5.3.0"
 			}
 		},
-		"charenc": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
-			"dev": true
-		},
 		"chokidar": {
 			"version": "2.1.8",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -1861,12 +1819,6 @@
 					}
 				}
 			}
-		},
-		"classnames": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
-			"dev": true
 		},
 		"cliui": {
 			"version": "5.0.0",
@@ -2054,12 +2006,6 @@
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
-		},
-		"crypt": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
-			"dev": true
 		},
 		"crypto-browserify": {
 			"version": "3.12.0",
@@ -2592,32 +2538,6 @@
 			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
-			}
-		},
-		"framer-motion": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.11.1.tgz",
-			"integrity": "sha512-CP6aYLPSivAWkq9UoSurefHBggxG85IT8ObYyWYkcZppgtjHzpwRzhaA8P0ljMGRqtcpeQAIybiGgPioBPlOSw==",
-			"dev": true,
-			"requires": {
-				"@emotion/is-prop-valid": "^0.8.2",
-				"@popmotion/easing": "^1.0.2",
-				"@popmotion/popcorn": "^0.4.2",
-				"framesync": "^4.0.4",
-				"hey-listen": "^1.0.8",
-				"popmotion": "9.0.0-beta-8",
-				"style-value-types": "^3.1.6",
-				"stylefire": "^7.0.2",
-				"tslib": "^1.10.0"
-			}
-		},
-		"framesync": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/framesync/-/framesync-4.1.0.tgz",
-			"integrity": "sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==",
-			"dev": true,
-			"requires": {
-				"hey-listen": "^1.0.5"
 			}
 		},
 		"from2": {
@@ -3199,12 +3119,6 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
-		"fuzzysort": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.1.4.tgz",
-			"integrity": "sha512-JzK/lHjVZ6joAg3OnCjylwYXYVjRiwTY6Yb25LvfpJHK8bjisfnZJ5bY8aVWwTwCXgxPNgLAtmHL+Hs5q1ddLQ==",
-			"dev": true
-		},
 		"gensync": {
 			"version": "1.0.0-beta.1",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -3378,12 +3292,6 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
-		"hey-listen": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-			"integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-			"dev": true
-		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -3465,21 +3373,6 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true
-		},
-		"insomnia-components": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/insomnia-components/-/insomnia-components-2.2.26.tgz",
-			"integrity": "sha512-IkTAi2BDX8l23+G822vm5op512d/UoK3zX6R46K6hoZr5KRu44QIcVp0Kk89MxgFRNt/OhnYAPWx1LEXucHBlg==",
-			"dev": true,
-			"requires": {
-				"autobind-decorator": "^2.4.0",
-				"classnames": "^2.2.6",
-				"framer-motion": "^1.10.3",
-				"fuzzysort": "^1.1.4",
-				"md5": "^2.2.1",
-				"prop-types": "^15.7.2",
-				"react-switch": "^5.0.1"
-			}
 		},
 		"interpret": {
 			"version": "1.2.0",
@@ -3825,17 +3718,6 @@
 			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
-			}
-		},
-		"md5": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-			"dev": true,
-			"requires": {
-				"charenc": "0.0.2",
-				"crypt": "0.0.2",
-				"is-buffer": "~1.1.6"
 			}
 		},
 		"md5.js": {
@@ -4402,20 +4284,6 @@
 				"find-up": "^2.1.0"
 			}
 		},
-		"popmotion": {
-			"version": "9.0.0-beta-8",
-			"resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-beta-8.tgz",
-			"integrity": "sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==",
-			"dev": true,
-			"requires": {
-				"@popmotion/easing": "^1.0.1",
-				"@popmotion/popcorn": "^0.4.2",
-				"framesync": "^4.0.4",
-				"hey-listen": "^1.0.8",
-				"style-value-types": "^3.1.6",
-				"tslib": "^1.10.0"
-			}
-		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -4575,15 +4443,6 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true
-		},
-		"react-switch": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.1.tgz",
-			"integrity": "sha512-Pa5kvqRfX85QUCK1Jv0rxyeElbC3aNpCP5hV0LoJpU/Y6kydf0t4kRriQ6ZYA4kxWwAYk/cH51T4/sPzV9mCgQ==",
-			"dev": true,
-			"requires": {
-				"prop-types": "^15.6.2"
-			}
 		},
 		"readable-stream": {
 			"version": "2.3.7",
@@ -5203,29 +5062,6 @@
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
-		},
-		"style-value-types": {
-			"version": "3.1.9",
-			"resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.9.tgz",
-			"integrity": "sha512-050uqgB7WdvtgacoQKm+4EgKzJExVq0sieKBQQtJiU3Muh6MYcCp4T3M8+dfl6VOF2LR0NNwXBP1QYEed8DfIw==",
-			"dev": true,
-			"requires": {
-				"hey-listen": "^1.0.8",
-				"tslib": "^1.10.0"
-			}
-		},
-		"stylefire": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/stylefire/-/stylefire-7.0.3.tgz",
-			"integrity": "sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==",
-			"dev": true,
-			"requires": {
-				"@popmotion/popcorn": "^0.4.4",
-				"framesync": "^4.0.0",
-				"hey-listen": "^1.0.8",
-				"style-value-types": "^3.1.7",
-				"tslib": "^1.10.0"
-			}
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/plugins/insomnia-plugin-kong-portal/src/deploy-to-portal.js
+++ b/plugins/insomnia-plugin-kong-portal/src/deploy-to-portal.js
@@ -335,7 +335,7 @@ class DeployToPortal extends React.Component<Props, State> {
                 type="text"
                 placeholder="Eg. unique-file-name.yaml"
                 defaultValue=""
-                onChange={evt => {
+                onChange={(evt) => {
                   this.setState({ kongSpecFileName: evt.target.value });
                 }}
               />

--- a/plugins/insomnia-plugin-now/index.js
+++ b/plugins/insomnia-plugin-now/index.js
@@ -21,7 +21,7 @@ module.exports.templateTags = [
         displayName: 'Custom Format Template',
         type: 'string',
         placeholder: 'MMMM Do YYYY, h:mm:ss a',
-        hide: args => args[0].value !== 'custom',
+        hide: (args) => args[0].value !== 'custom',
       },
     ],
     run(context, dateType = 'iso-8601', formatStr = '') {

--- a/plugins/insomnia-plugin-os/index.js
+++ b/plugins/insomnia-plugin-os/index.js
@@ -25,7 +25,7 @@ module.exports.templateTags = [
       {
         displayName: 'JSONPath Filter',
         help: 'Some OS functions return objects. Use JSONPath queries to extract desired values.',
-        hide: args => !FILTERABLE.includes(args[0].value),
+        hide: (args) => !FILTERABLE.includes(args[0].value),
         type: 'string',
       },
     ],

--- a/plugins/insomnia-plugin-prompt/index.js
+++ b/plugins/insomnia-plugin-prompt/index.js
@@ -5,13 +5,13 @@ module.exports.templateTags = [
     displayName: 'Prompt',
     name: 'prompt',
     description: 'prompt user for input',
-    disablePreview: args => args[4] && args[4].value === true,
+    disablePreview: (args) => args[4] && args[4].value === true,
     args: [
       {
         displayName: 'Title',
         type: 'string',
         help: 'Title is a unique string used to identify the prompt value',
-        validate: v => (v ? '' : 'Required'),
+        validate: (v) => (v ? '' : 'Required'),
       },
       {
         displayName: 'Label',
@@ -52,7 +52,7 @@ module.exports.templateTags = [
       {
         name: 'Clear',
         icon: 'fa fa-trash',
-        run: context => {
+        run: (context) => {
           console.log(`[prompt] Clear action`);
           return context.store.clear();
         },

--- a/plugins/insomnia-plugin-request/__tests__/index.test.js
+++ b/plugins/insomnia-plugin-request/__tests__/index.test.js
@@ -119,18 +119,18 @@ function _getTestContext(workspaces, requests, jars) {
       models: {
         request: {
           getById(id) {
-            return requests.find(r => r._id === id);
+            return requests.find((r) => r._id === id);
           },
         },
         workspace: {
           getById(id) {
-            return workspaces.find(w => w._id === id);
+            return workspaces.find((w) => w._id === id);
           },
         },
         cookieJar: {
           getOrCreateForWorkspace(workspace) {
             return (
-              jars.find(j => j.parentId === workspace._id) || {
+              jars.find((j) => j.parentId === workspace._id) || {
                 parentId: workspace._id,
                 cookies: [],
               }

--- a/plugins/insomnia-plugin-request/index.js
+++ b/plugins/insomnia-plugin-request/index.js
@@ -54,8 +54,8 @@ module.exports.templateTags = [
       },
       {
         type: 'string',
-        hide: args => ['url', 'oauth2', 'name', 'folder'].includes(args[0].value),
-        displayName: args => {
+        hide: (args) => ['url', 'oauth2', 'name', 'folder'].includes(args[0].value),
+        displayName: (args) => {
           switch (args[0].value) {
             case 'cookie':
               return 'Cookie Name';
@@ -69,7 +69,7 @@ module.exports.templateTags = [
         },
       },
       {
-        hide: args => args[0].value !== 'folder',
+        hide: (args) => args[0].value !== 'folder',
         displayName: 'Parent Index',
         help: 'Specify an index (Starting at 0) for how high up the folder tree to look',
         type: 'number',
@@ -124,7 +124,7 @@ module.exports.templateTags = [
             }
           }
 
-          const parameterNamesStr = parameterNames.map(n => `"${n}"`).join(',\n\t');
+          const parameterNamesStr = parameterNames.map((n) => `"${n}"`).join(',\n\t');
           throw new Error(
             `No query parameter with name "${name}".\nChoices are [\n\t${parameterNamesStr}\n]`,
           );
@@ -147,7 +147,7 @@ module.exports.templateTags = [
             }
           }
 
-          const headerNamesStr = headerNames.map(n => `"${n}"`).join(',\n\t');
+          const headerNamesStr = headerNames.map((n) => `"${n}"`).join(',\n\t');
           throw new Error(`No header with name "${name}".\nChoices are [\n\t${headerNamesStr}\n]`);
         case 'oauth2':
           const token = await context.util.models.oAuth2Token.getByRequestId(request._id);
@@ -203,9 +203,9 @@ function getCookieValue(cookieJar, url, name) {
         reject(new Error(`No cookies in store for url "${url}"`));
       }
 
-      const cookie = cookies.find(cookie => cookie.key === name);
+      const cookie = cookies.find((cookie) => cookie.key === name);
       if (!cookie) {
-        const names = cookies.map(c => `"${c.key}"`).join(',\n\t');
+        const names = cookies.map((c) => `"${c.key}"`).join(',\n\t');
         throw new Error(
           `No cookie with name "${name}".\nChoices are [\n\t${names}\n] for url "${url}"`,
         );

--- a/plugins/insomnia-plugin-response/__tests__/index.test.js
+++ b/plugins/insomnia-plugin-response/__tests__/index.test.js
@@ -560,7 +560,7 @@ describe('Response tag', () => {
 
   describe('Max Age', () => {
     const maxAgeArg = tag.args[4];
-    const toValueObj = value => ({ value });
+    const toValueObj = (value) => ({ value });
 
     it('should ensure fourth argument is maxAge', () => {
       expect(maxAgeArg.displayName).toBe('Max age (seconds)');
@@ -639,9 +639,9 @@ function _genTestContext(requests, responses, extraInfoRoot) {
       },
     },
     store: {
-      hasItem: key => Object.prototype.hasOwnProperty.call(store, key),
-      getItem: key => store[key],
-      removeItem: key => {
+      hasItem: (key) => Object.prototype.hasOwnProperty.call(store, key),
+      getItem: (key) => store[key],
+      removeItem: (key) => {
         delete store[key];
       },
       setItem: (key, value) => {
@@ -652,12 +652,12 @@ function _genTestContext(requests, responses, extraInfoRoot) {
       models: {
         request: {
           getById(requestId) {
-            return requests.find(r => r._id === requestId) || null;
+            return requests.find((r) => r._id === requestId) || null;
           },
         },
         response: {
           getLatestForRequestId(requestId, environmentId) {
-            return responses.find(r => r.parentId === requestId) || null;
+            return responses.find((r) => r.parentId === requestId) || null;
           },
           getBodyBuffer(response) {
             const strOrBuffer = bodies[response._id];

--- a/plugins/insomnia-plugin-response/index.js
+++ b/plugins/insomnia-plugin-response/index.js
@@ -48,8 +48,8 @@ module.exports.templateTags = [
       {
         type: 'string',
         encoding: 'base64',
-        hide: args => !isFilterableField(args[0].value),
-        displayName: args => {
+        hide: (args) => !isFilterableField(args[0].value),
+        displayName: (args) => {
           switch (args[0].value) {
             case 'body':
               return 'Filter (JSONPath or XPath)';
@@ -92,7 +92,7 @@ module.exports.templateTags = [
         displayName: 'Max age (seconds)',
         help: 'The maximum age of a response to use before it expires',
         type: 'number',
-        hide: args => {
+        hide: (args) => {
           const triggerBehavior = (args[3] && args[3].value) || defaultTriggerBehaviour;
           return triggerBehavior !== 'when-expired';
         },
@@ -261,10 +261,10 @@ function matchHeader(headers, name) {
     throw new Error('No headers available');
   }
 
-  const header = headers.find(h => h.name.toLowerCase() === name.toLowerCase());
+  const header = headers.find((h) => h.name.toLowerCase() === name.toLowerCase());
 
   if (!header) {
-    const names = headers.map(c => `"${c.name}"`).join(',\n\t');
+    const names = headers.map((c) => `"${c.name}"`).join(',\n\t');
     throw new Error(`No header with name "${name}".\nChoices are [\n\t${names}\n]`);
   }
 


### PR DESCRIPTION
From discussions on #2963 (apologies for the pings snix 😓)

This adds `"arrowParens": "always",` to the prettier config. 

I've also ran `npm run lint:fix` here. So all changes to files are from formatters.