### PR TITLE
Add YAML linting and extend accepted yaml content types

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/base-imports.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/base-imports.js
@@ -39,6 +39,7 @@ import 'codemirror/addon/selection/selection-pointer';
 import 'codemirror/addon/display/placeholder';
 import 'codemirror/addon/lint/lint';
 import 'codemirror/addon/lint/json-lint';
+import 'codemirror/addon/lint/yaml-lint';
 import 'codemirror/addon/lint/lint.css';
 import 'codemirror/keymap/vim';
 import 'codemirror/keymap/emacs';
@@ -63,6 +64,11 @@ import './extensions/nunjucks-tags';
 import 'codemirror/lib/codemirror.css';
 import '../../css/editor/index.less';
 
-// Make jsonlint available to the jsonlint addon
+// Make jsonlint available to the json-lint addon
 import { parser as jsonlint } from 'jsonlint';
+
+// Make js-yaml available to the yaml-lint addon
+import * as jsYaml from 'js-yaml';
+
 global.jsonlint = jsonlint;
+global.jsyaml = jsYaml;

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -724,6 +724,10 @@ class CodeEditor extends React.Component {
       return 'application/xml';
     } else if (mimeType.includes('kotlin')) {
       return 'text/x-kotlin';
+    } else if (CodeEditor._isYAML(mimeType)) {
+      // code-mirror doesn't recognize text/yaml or application/yaml
+      // as a valid mime-type
+      return 'yaml';
     } else {
       return mimeType;
     }

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -2865,7 +2865,25 @@
 						"is-directory": "^0.3.1",
 						"js-yaml": "^3.13.1",
 						"parse-json": "^4.0.0"
+					},
+					"dependencies": {
+						"js-yaml": {
+							"version": "3.14.1",
+							"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+							"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+							"dev": true,
+							"requires": {
+								"argparse": "^1.0.7",
+								"esprima": "^4.0.0"
+							}
+						}
 					}
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				},
 				"import-fresh": {
 					"version": "2.0.0",
@@ -2937,7 +2955,25 @@
 						"is-directory": "^0.3.1",
 						"js-yaml": "^3.13.1",
 						"parse-json": "^4.0.0"
+					},
+					"dependencies": {
+						"js-yaml": {
+							"version": "3.14.1",
+							"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+							"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+							"dev": true,
+							"requires": {
+								"argparse": "^1.0.7",
+								"esprima": "^4.0.0"
+							}
+						}
 					}
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				},
 				"import-fresh": {
 					"version": "2.0.0",
@@ -4083,6 +4119,20 @@
 				"yauzl": "^2.10.0"
 			},
 			"dependencies": {
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
 				"swagger-parser": {
 					"version": "8.0.3",
 					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
@@ -4163,6 +4213,12 @@
 						"jake": "^10.6.1"
 					}
 				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				},
 				"fs-extra": {
 					"version": "9.0.1",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
@@ -4182,6 +4238,16 @@
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
+					}
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
 					}
 				},
 				"lru-cache": {
@@ -5702,6 +5768,12 @@
 						"ms": "2.1.2"
 					}
 				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				},
 				"fs-extra": {
 					"version": "9.0.1",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
@@ -5719,6 +5791,16 @@
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
 				},
 				"supports-color": {
 					"version": "7.1.0",
@@ -7862,6 +7944,12 @@
 				"sanitize-filename": "^1.6.3"
 			},
 			"dependencies": {
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				},
 				"fs-extra": {
 					"version": "9.0.1",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
@@ -7881,6 +7969,16 @@
 					"dev": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
 					}
 				}
 			}
@@ -8418,6 +8516,18 @@
 						"sanitize-filename": "^1.6.3",
 						"semver": "^7.3.2",
 						"temp-file": "^3.3.7"
+					},
+					"dependencies": {
+						"js-yaml": {
+							"version": "3.14.1",
+							"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+							"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+							"dev": true,
+							"requires": {
+								"argparse": "^1.0.7",
+								"esprima": "^4.0.0"
+							}
+						}
 					}
 				},
 				"builder-util": {
@@ -8440,6 +8550,18 @@
 						"source-map-support": "^0.5.19",
 						"stat-mode": "^1.0.0",
 						"temp-file": "^3.3.7"
+					},
+					"dependencies": {
+						"js-yaml": {
+							"version": "3.14.1",
+							"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+							"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+							"dev": true,
+							"requires": {
+								"argparse": "^1.0.7",
+								"esprima": "^4.0.0"
+							}
+						}
 					}
 				},
 				"builder-util-runtime": {
@@ -8501,6 +8623,12 @@
 						"lazy-val": "^1.0.4",
 						"mime": "^2.4.6"
 					}
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				},
 				"fs-extra": {
 					"version": "9.0.1",
@@ -8787,6 +8915,11 @@
 				"semver": "^7.1.3"
 			},
 			"dependencies": {
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+				},
 				"fs-extra": {
 					"version": "9.0.1",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
@@ -8796,6 +8929,15 @@
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
 						"universalify": "^1.0.0"
+					}
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
 					}
 				}
 			}
@@ -13226,9 +13368,9 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -13366,6 +13508,20 @@
 				"ono": "^6.0.0"
 			},
 			"dependencies": {
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
 				"ono": {
 					"version": "6.0.1",
 					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
@@ -14878,6 +15034,11 @@
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
 				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+				},
 				"find-up": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -14891,6 +15052,15 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"js-yaml": {
+					"version": "3.14.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+					"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
 				},
 				"locate-path": {
 					"version": "6.0.0",
@@ -16580,7 +16750,25 @@
 						"is-directory": "^0.3.1",
 						"js-yaml": "^3.13.1",
 						"parse-json": "^4.0.0"
+					},
+					"dependencies": {
+						"js-yaml": {
+							"version": "3.14.1",
+							"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+							"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+							"dev": true,
+							"requires": {
+								"argparse": "^1.0.7",
+								"esprima": "^4.0.0"
+							}
+						}
 					}
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				},
 				"import-fresh": {
 					"version": "2.0.0",
@@ -18056,6 +18244,22 @@
 					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
 					"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
 					"dev": true
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
 				}
 			}
 		},
@@ -20321,6 +20525,22 @@
 						"dom-serializer": "0",
 						"domelementtype": "1"
 					}
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
 				}
 			}
 		},
@@ -20345,6 +20565,20 @@
 				"url": "~0.11.0"
 			},
 			"dependencies": {
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
 				"qs": {
 					"version": "6.9.4",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
@@ -20376,6 +20610,11 @@
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
 					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
 				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+				},
 				"json-schema-ref-parser": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
@@ -20384,6 +20623,17 @@
 						"call-me-maybe": "^1.0.1",
 						"js-yaml": "^3.12.1",
 						"ono": "^4.0.11"
+					},
+					"dependencies": {
+						"js-yaml": {
+							"version": "3.14.1",
+							"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+							"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+							"requires": {
+								"argparse": "^1.0.7",
+								"esprima": "^4.0.0"
+							}
+						}
 					}
 				},
 				"ono": {
@@ -20475,6 +20725,20 @@
 					"version": "2.6.11",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
 					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
 				},
 				"react-redux": {
 					"version": "5.1.2",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -139,6 +139,7 @@
     "insomnia-url": "^2.2.24",
     "insomnia-xpath": "^2.2.24",
     "isomorphic-git": "^0.70.3",
+    "js-yaml": "^3.14.1",
     "jshint": "^2.11.1",
     "json-order": "^1.1.0",
     "jsonlint": "^1.6.3",


### PR DESCRIPTION
Closes #2999, closes INS-396

The language mode required by CodeMirror in order to configure it as yaml is `yaml`. We need to normalize `text/yaml`, `application/yaml` to `yaml`, the same way some of the other content types are normalized/translated to something CodeMirror can understand.

Additionally, CodeMirror includes JSON lint and YAML lint addons, however Insomnia was only configured with JSON lint. This PR configures the YAML lint plugin to show syntax errors etc.

## Screenshots
With the default `content-type: text/yaml`
<img width="864" alt="image" src="https://user-images.githubusercontent.com/4312346/104546490-2f600280-5691-11eb-8ff1-0be68a3708c0.png">

With `content-type: application/yaml`
<img width="864" alt="image" src="https://user-images.githubusercontent.com/4312346/104546514-3edf4b80-5691-11eb-8c6d-c4f02cd0fe34.png">

<img width="864" alt="image" src="https://user-images.githubusercontent.com/4312346/104546528-443c9600-5691-11eb-951e-61481548f047.png">

With a lint error:
<img width="864" alt="image" src="https://user-images.githubusercontent.com/4312346/104546572-58809300-5691-11eb-9228-4d9ddb21500f.png">

<img width="864" alt="image" src="https://user-images.githubusercontent.com/4312346/104546557-51f21b80-5691-11eb-973d-9fa4f84c8e44.png">

Nunjucks tag - variable:
<img width="864" alt="image" src="https://user-images.githubusercontent.com/4312346/104546685-9978a780-5691-11eb-9aa1-33d80aadaa4e.png">

Nunjucks tag - complex variable or action:
Shows an error if using the default tag syntax because of unexpected characters. **This is only a UI error**, it does not prevent the app from continuing or tag from resolving

<img width="864" alt="image" src="https://user-images.githubusercontent.com/4312346/104546921-228fde80-5692-11eb-986d-9cd01609996b.png">

<img width="864" alt="image" src="https://user-images.githubusercontent.com/4312346/104546736-bf05b100-5691-11eb-8bd4-700fdba73597.png">

<img width="864" alt="image" src="https://user-images.githubusercontent.com/4312346/104546782-d3e24480-5691-11eb-908e-78a345ddd6c7.png">

Works if you encapsulate with speech marks
<img width="864" alt="image" src="https://user-images.githubusercontent.com/4312346/104554404-034c7d80-56a1-11eb-98e9-b31164049ec3.png">


<img width="864" alt="image" src="https://user-images.githubusercontent.com/4312346/104546962-38050880-5692-11eb-958b-358aca23d41a.png">


## QA:
- [x] Tested Design tab in Designer
- [x] Tested both content types
- [x] Tested template tags