### PR TITLE
Fix designer linting notice table visibility

### DIFF
--- a/packages/insomnia-app/app/ui/components/wrapper-design.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.js
@@ -159,20 +159,22 @@ class WrapperDesign extends React.PureComponent<Props, State> {
     const { lintMessages } = this.state;
 
     return (
-      <div className="tall theme--pane__body">
-        <CodeEditor
-          manualPrettify
-          ref={this._setEditorRef}
-          fontSize={settings.editorFontSize}
-          indentSize={settings.editorIndentSize}
-          lineWrapping={settings.lineWrapping}
-          keyMap={settings.editorKeyMap}
-          lintOptions={WrapperDesign.lintOptions}
-          mode="openapi"
-          defaultValue={activeApiSpec.contents}
-          onChange={this._handleOnChange}
-          uniquenessKey={activeApiSpec._id}
-        />
+      <div className="column tall theme--pane__body">
+        <div className="tall">
+          <CodeEditor
+            manualPrettify
+            ref={this._setEditorRef}
+            fontSize={settings.editorFontSize}
+            indentSize={settings.editorIndentSize}
+            lineWrapping={settings.lineWrapping}
+            keyMap={settings.editorKeyMap}
+            lintOptions={WrapperDesign.lintOptions}
+            mode="openapi"
+            defaultValue={activeApiSpec.contents}
+            onChange={this._handleOnChange}
+            uniquenessKey={activeApiSpec._id}
+          />
+        </div>
         {lintMessages.length > 0 && (
           <NoticeTable notices={lintMessages} onClick={this._handleLintClick} />
         )}

--- a/packages/insomnia-app/app/ui/css/layout/base.less
+++ b/packages/insomnia-app/app/ui/css/layout/base.less
@@ -400,6 +400,11 @@ blockquote {
   height: 100%;
 }
 
+.column {
+  display: flex;
+  flex-direction: column;
+}
+
 .row {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
As part of #2712, redundant CSS was removed, however that resulted in the notice table no longer showing because the grid definition was deleted. This PR fixes it (using flexbox instead of CSS grid) so that the notice table shows again.

Develop:
![2021-01-18 17 43 04](https://user-images.githubusercontent.com/4312346/104873153-ba543c00-59b4-11eb-8ca2-6ca2924d82b5.gif)

This PR:
![2021-01-18 17 42 26](https://user-images.githubusercontent.com/4312346/104873132-ad374d00-59b4-11eb-9fb5-731ddf76151d.gif)
