### PR TITLE
Fix sizing in vertical layout while design preview is hidden

### DIFF
--- a/packages/insomnia-app/app/ui/components/page-layout.js
+++ b/packages/insomnia-app/app/ui/components/page-layout.js
@@ -74,7 +74,9 @@ class PageLayout extends React.PureComponent<Props, State> {
 
     const paneTwo = renderPaneTwo && renderPaneTwo();
 
-    const gridRows = `auto minmax(0, ${paneHeight}fr) 0 minmax(0, ${1 - paneHeight}fr)`;
+    const gridRows = paneTwo
+      ? `auto minmax(0, ${paneHeight}fr) 0 minmax(0, ${1 - paneHeight}fr)`
+      : `auto 1fr`;
     const gridColumns =
       `auto ${realSidebarWidth}rem 0 ` +
       `${paneTwo ? `minmax(0, ${paneWidth}fr) 0 minmax(0, ${1 - paneWidth}fr)` : '1fr'}`;


### PR DESCRIPTION
As part of #2712, some work was done to consolidate the pane sizing logic into one location for all views of Insomnia Core and Designer, so that the pane resizing and vertical/horizontal layout functionality was available to _all_ views (design, debug, test).

On the Design tab, the right pane (preview) can be hidden. When forced to be a vertical pane layout, the preview pane is the bottom pane.

The particular case in which the layout is forced to be vertical (through settings or resizing the application window) _and_ the design preview is _hidden_, the editor pane would fail to resize and fill the space.

Develop:
![2021-01-18 17 51 25](https://user-images.githubusercontent.com/4312346/104873629-db695c80-59b5-11eb-86fa-83934bfc1179.gif)

This PR:
![2021-01-18 17 46 33](https://user-images.githubusercontent.com/4312346/104873597-c42a6f00-59b5-11eb-98c7-cbe382e636cd.gif)
