### PR TITLE
Autobind replacement and react-hot-reload update

### DIFF
--- a/packages/insomnia-app/app/common/constants.js
+++ b/packages/insomnia-app/app/common/constants.js
@@ -111,6 +111,13 @@ export const HUGE_RESPONSE_MB = 100;
 export const FLEXIBLE_URL_REGEX = /^(http|https):\/\/[\wàâäèéêëîïôóœùûüÿçÀÂÄÈÉÊËÎÏÔŒÙÛÜŸÇ\-_.]+[/\wàâäèéêëîïôóœùûüÿçÀÂÄÈÉÊËÎÏÔŒÙÛÜŸÇ.\-+=:\][@%^*&!#?;$]*/;
 export const CHECK_FOR_UPDATES_INTERVAL = 1000 * 60 * 60 * 3; // 3 hours
 export const PLUGIN_PATH = path.join(getDataDirectory(), 'plugins');
+export const AUTOBIND_CFG = {
+  methodsToIgnore: [
+    'UNSAFE_componentWillMount',
+    'UNSAFE_componentWillReceiveProps',
+    'UNSAFE_componentWillUpdate',
+  ],
+};
 
 // Available editor key maps
 export const EDITOR_KEY_MAP_DEFAULT = 'default';

--- a/packages/insomnia-app/app/ui/components/base/button.js
+++ b/packages/insomnia-app/app/ui/components/base/button.js
@@ -1,8 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Button extends PureComponent {
   _handleClick(e) {
     const { onClick, onDisabledClick, disabled } = this.props;

--- a/packages/insomnia-app/app/ui/components/base/button.js
+++ b/packages/insomnia-app/app/ui/components/base/button.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 
-@autobind
+@autoBindMethodsForReact
 class Button extends PureComponent {
   _handleClick(e) {
     const { onClick, onDisabledClick, disabled } = this.props;

--- a/packages/insomnia-app/app/ui/components/base/copy-button.js
+++ b/packages/insomnia-app/app/ui/components/base/copy-button.js
@@ -1,10 +1,10 @@
 import React, { PureComponent } from 'react';
 import { clipboard } from 'electron';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Button } from 'insomnia-components';
 
-@autobind
+@autoBindMethodsForReact
 class CopyButton extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/copy-button.js
+++ b/packages/insomnia-app/app/ui/components/base/copy-button.js
@@ -2,9 +2,10 @@ import React, { PureComponent } from 'react';
 import { clipboard } from 'electron';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { Button } from 'insomnia-components';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class CopyButton extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/debounced-input.js
+++ b/packages/insomnia-app/app/ui/components/base/debounced-input.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { debounce } from '../../../common/misc';
 
-@autobind
+@autoBindMethodsForReact
 class DebouncedInput extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/debounced-input.js
+++ b/packages/insomnia-app/app/ui/components/base/debounced-input.js
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { debounce } from '../../../common/misc';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class DebouncedInput extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/dropdown/dropdown-item.js
+++ b/packages/insomnia-app/app/ui/components/base/dropdown/dropdown-item.js
@@ -2,8 +2,9 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class DropdownItem extends PureComponent {
   _handleClick(e) {
     const { stayOpenAfterClick, onClick, disabled } = this.props;

--- a/packages/insomnia-app/app/ui/components/base/dropdown/dropdown-item.js
+++ b/packages/insomnia-app/app/ui/components/base/dropdown/dropdown-item.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 
-@autobind
+@autoBindMethodsForReact
 class DropdownItem extends PureComponent {
   _handleClick(e) {
     const { stayOpenAfterClick, onClick, disabled } = this.props;

--- a/packages/insomnia-app/app/ui/components/base/dropdown/dropdown.js
+++ b/packages/insomnia-app/app/ui/components/base/dropdown/dropdown.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import DropdownButton from './dropdown-button';
 import DropdownItem from './dropdown-item';
@@ -13,7 +13,7 @@ import { hotKeyRefs } from '../../../../common/hotkeys';
 
 const dropdownsContainer = document.querySelector('#dropdowns-container');
 
-@autobind
+@autoBindMethodsForReact
 class Dropdown extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/dropdown/dropdown.js
+++ b/packages/insomnia-app/app/ui/components/base/dropdown/dropdown.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 import classnames from 'classnames';
 import DropdownButton from './dropdown-button';
 import DropdownItem from './dropdown-item';
@@ -13,7 +14,7 @@ import { hotKeyRefs } from '../../../../common/hotkeys';
 
 const dropdownsContainer = document.querySelector('#dropdowns-container');
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Dropdown extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/editable.js
+++ b/packages/insomnia-app/app/ui/components/base/editable.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import KeydownBinder from '../keydown-binder';
 
 export const shouldSave = (oldValue, newValue, preventBlank) => {
@@ -18,7 +19,7 @@ export const shouldSave = (oldValue, newValue, preventBlank) => {
   return true;
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Editable extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/editable.js
+++ b/packages/insomnia-app/app/ui/components/base/editable.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import KeydownBinder from '../keydown-binder';
 
 export const shouldSave = (oldValue, newValue, preventBlank) => {
@@ -18,7 +18,7 @@ export const shouldSave = (oldValue, newValue, preventBlank) => {
   return true;
 };
 
-@autobind
+@autoBindMethodsForReact
 class Editable extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/file-input-button.js
+++ b/packages/insomnia-app/app/ui/components/base/file-input-button.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { basename as pathBasename } from 'path';
 import selectFileOrFolder from '../../../common/select-file-or-folder';
 
@@ -17,7 +18,7 @@ type Props = {
   name?: string,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class FileInputButton extends React.PureComponent<Props> {
   _button: ?HTMLButtonElement;
 

--- a/packages/insomnia-app/app/ui/components/base/file-input-button.js
+++ b/packages/insomnia-app/app/ui/components/base/file-input-button.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { basename as pathBasename } from 'path';
 import selectFileOrFolder from '../../../common/select-file-or-folder';
 
@@ -17,7 +17,7 @@ type Props = {
   name?: string,
 };
 
-@autobind
+@autoBindMethodsForReact
 class FileInputButton extends React.PureComponent<Props> {
   _button: ?HTMLButtonElement;
 

--- a/packages/insomnia-app/app/ui/components/base/highlight.js
+++ b/packages/insomnia-app/app/ui/components/base/highlight.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import fuzzySort from 'fuzzysort';
 import { fuzzyMatch } from '../../../common/misc';
 
@@ -10,7 +11,7 @@ type Props = {|
   blankValue?: String,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Highlight extends React.PureComponent<Props> {
   render() {
     const { search, text, blankValue, ...otherProps } = this.props;

--- a/packages/insomnia-app/app/ui/components/base/highlight.js
+++ b/packages/insomnia-app/app/ui/components/base/highlight.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import fuzzySort from 'fuzzysort';
 import { fuzzyMatch } from '../../../common/misc';
 
@@ -10,7 +10,7 @@ type Props = {|
   blankValue?: String,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class Highlight extends React.PureComponent<Props> {
   render() {
     const { search, text, blankValue, ...otherProps } = this.props;

--- a/packages/insomnia-app/app/ui/components/base/indeterminate-checkbox.js
+++ b/packages/insomnia-app/app/ui/components/base/indeterminate-checkbox.js
@@ -1,13 +1,14 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 
 type Props = {
   indeterminate: boolean,
   checked: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class IndeterminateCheckbox extends React.PureComponent<Props> {
   input: ?HTMLInputElement;
 

--- a/packages/insomnia-app/app/ui/components/base/indeterminate-checkbox.js
+++ b/packages/insomnia-app/app/ui/components/base/indeterminate-checkbox.js
@@ -1,13 +1,13 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 
 type Props = {
   indeterminate: boolean,
   checked: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class IndeterminateCheckbox extends React.PureComponent<Props> {
   input: ?HTMLInputElement;
 

--- a/packages/insomnia-app/app/ui/components/base/lazy.js
+++ b/packages/insomnia-app/app/ui/components/base/lazy.js
@@ -1,8 +1,10 @@
 import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillMount'],
+})
 class Lazy extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/lazy.js
+++ b/packages/insomnia-app/app/ui/components/base/lazy.js
@@ -1,10 +1,9 @@
 import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillMount'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Lazy extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/link.js
+++ b/packages/insomnia-app/app/ui/components/base/link.js
@@ -2,6 +2,7 @@
 import classnames from 'classnames';
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import * as misc from '../../../common/misc';
 
 type Props = {|
@@ -15,7 +16,7 @@ type Props = {|
   noTheme?: boolean,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Link extends React.PureComponent<Props> {
   _handleClick(e: SyntheticEvent<HTMLAnchorElement>) {
     e && e.preventDefault();

--- a/packages/insomnia-app/app/ui/components/base/link.js
+++ b/packages/insomnia-app/app/ui/components/base/link.js
@@ -1,7 +1,7 @@
 // @flow
 import classnames from 'classnames';
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as misc from '../../../common/misc';
 
 type Props = {|
@@ -15,7 +15,7 @@ type Props = {|
   noTheme?: boolean,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class Link extends React.PureComponent<Props> {
   _handleClick(e: SyntheticEvent<HTMLAnchorElement>) {
     e && e.preventDefault();

--- a/packages/insomnia-app/app/ui/components/base/mailto.js
+++ b/packages/insomnia-app/app/ui/components/base/mailto.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
 import Link from './link';
 
@@ -11,7 +12,7 @@ type Props = {|
   body?: string,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Mailto extends React.PureComponent<Props> {
   render() {
     const { email, body, subject, children } = this.props;

--- a/packages/insomnia-app/app/ui/components/base/mailto.js
+++ b/packages/insomnia-app/app/ui/components/base/mailto.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
 import Link from './link';
 
@@ -11,7 +11,7 @@ type Props = {|
   body?: string,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class Mailto extends React.PureComponent<Props> {
   render() {
     const { email, body, subject, children } = this.props;

--- a/packages/insomnia-app/app/ui/components/base/modal.js
+++ b/packages/insomnia-app/app/ui/components/base/modal.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import KeydownBinder from '../keydown-binder';
 import { hotKeyRefs } from '../../../common/hotkeys';
@@ -10,7 +10,7 @@ import { pressedHotKey } from '../../../common/hotkeys-listener';
 // appear over top of an existing one.
 let globalZIndex = 1000;
 
-@autobind
+@autoBindMethodsForReact
 class Modal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/modal.js
+++ b/packages/insomnia-app/app/ui/components/base/modal.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import classnames from 'classnames';
 import KeydownBinder from '../keydown-binder';
 import { hotKeyRefs } from '../../../common/hotkeys';
@@ -10,7 +11,7 @@ import { pressedHotKey } from '../../../common/hotkeys-listener';
 // appear over top of an existing one.
 let globalZIndex = 1000;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Modal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/prompt-button.js
+++ b/packages/insomnia-app/app/ui/components/base/prompt-button.js
@@ -1,13 +1,14 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Button from './button';
 
 const STATE_DEFAULT = 'default';
 const STATE_ASK = 'ask';
 const STATE_DONE = 'done';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class PromptButton extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/base/prompt-button.js
+++ b/packages/insomnia-app/app/ui/components/base/prompt-button.js
@@ -1,13 +1,13 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Button from './button';
 
 const STATE_DEFAULT = 'default';
 const STATE_ASK = 'ask';
 const STATE_DONE = 'done';
 
-@autobind
+@autoBindMethodsForReact
 class PromptButton extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/check-for-updates-button.js
+++ b/packages/insomnia-app/app/ui/components/check-for-updates-button.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as electron from 'electron';
 
 type Props = {
@@ -14,7 +14,7 @@ type State = {
   updateAvailable: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class CheckForUpdatesButton extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/check-for-updates-button.js
+++ b/packages/insomnia-app/app/ui/components/check-for-updates-button.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as electron from 'electron';
+import { AUTOBIND_CFG } from '../../common/constants';
 
 type Props = {
   children: React.Node,
@@ -14,7 +15,7 @@ type State = {
   updateAvailable: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class CheckForUpdatesButton extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import {
+  AUTOBIND_CFG,
+  DEBOUNCE_MILLIS,
+  EDITOR_KEY_MAP_VIM,
+  isMac,
+} from '../../../common/constants';
 import CodeMirror from 'codemirror';
 import classnames from 'classnames';
 import clone from 'clone';
@@ -10,7 +16,7 @@ import { showModal } from '../modals/index';
 import FilterHelpModal from '../modals/filter-help-modal';
 import * as misc from '../../../common/misc';
 import prettify from 'insomnia-prettify';
-import { DEBOUNCE_MILLIS, EDITOR_KEY_MAP_VIM, isMac } from '../../../common/constants';
+
 import { keyboardKeys as keyCodes } from '../../../common/keyboard-keys';
 import './base-imports';
 import { getTagDefinitions } from '../../../templating/index';
@@ -78,9 +84,7 @@ const BASE_CODEMIRROR_OPTIONS = {
   gutters: ['CodeMirror-lint-markers'],
 };
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class CodeEditor extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import CodeMirror from 'codemirror';
 import classnames from 'classnames';
 import clone from 'clone';
@@ -78,7 +78,9 @@ const BASE_CODEMIRROR_OPTIONS = {
   gutters: ['CodeMirror-lint-markers'],
 };
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
+})
 class CodeEditor extends React.Component {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import CodeEditor from './code-editor';
 import Input from '../base/debounced-input';
 
@@ -11,7 +12,7 @@ const MODE_EDITOR = 'editor';
 const TYPE_TEXT = 'text';
 const NUNJUCKS_REGEX = /({%|%}|{{|}})/;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class OneLineEditor extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.js
+++ b/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import CodeEditor from './code-editor';
 import Input from '../base/debounced-input';
 
@@ -11,7 +11,7 @@ const MODE_EDITOR = 'editor';
 const TYPE_TEXT = 'text';
 const NUNJUCKS_REGEX = /({%|%}|{{|}})/;
 
-@autobind
+@autoBindMethodsForReact
 class OneLineEditor extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/cookie-list.js
+++ b/packages/insomnia-app/app/ui/components/cookie-list.js
@@ -8,6 +8,7 @@ import PromptButton from './base/prompt-button';
 import RenderedText from './rendered-text';
 import type { Cookie } from '../../models/cookie-jar';
 import { Dropdown, DropdownButton, DropdownItem } from './base/dropdown/index';
+import { AUTOBIND_CFG } from '../../common/constants';
 
 type Props = {
   handleCookieAdd: Function,
@@ -23,7 +24,7 @@ type Props = {
 // https://github.com/salesforce/tough-cookie/blob/5ae97c6a28122f3fb309adcd8428274d9b2bd795/lib/cookie.js#L77
 const MAX_TIME = 2147483647000;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class CookieList extends React.PureComponent<Props> {
   _handleCookieAdd() {
     const newCookie: Cookie = {

--- a/packages/insomnia-app/app/ui/components/cookie-list.js
+++ b/packages/insomnia-app/app/ui/components/cookie-list.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import * as uuid from 'uuid';
 import * as toughCookie from 'tough-cookie';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { cookieToString } from 'insomnia-cookies';
 import PromptButton from './base/prompt-button';
 import RenderedText from './rendered-text';
@@ -23,7 +23,7 @@ type Props = {
 // https://github.com/salesforce/tough-cookie/blob/5ae97c6a28122f3fb309adcd8428274d9b2bd795/lib/cookie.js#L77
 const MAX_TIME = 2147483647000;
 
-@autobind
+@autoBindMethodsForReact
 class CookieList extends React.PureComponent<Props> {
   _handleCookieAdd() {
     const newCookie: Cookie = {

--- a/packages/insomnia-app/app/ui/components/dropdowns/auth-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/auth-dropdown.js
@@ -2,12 +2,8 @@
 
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
-import { showModal } from '../modals';
-import AlertModal from '../modals/alert-modal';
-import * as models from '../../../models';
-import type { Request, RequestAuthentication } from '../../../models/request';
 import {
+  AUTOBIND_CFG,
   AUTH_BASIC,
   AUTH_DIGEST,
   AUTH_BEARER,
@@ -21,6 +17,11 @@ import {
   AUTH_ASAP,
   getAuthTypeName,
 } from '../../../common/constants';
+import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
+import { showModal } from '../modals';
+import AlertModal from '../modals/alert-modal';
+import * as models from '../../../models';
+import type { Request, RequestAuthentication } from '../../../models/request';
 
 type Props = {
   onChange: (r: Request, RequestAuthentication) => Promise<Request>,
@@ -31,7 +32,7 @@ type Props = {
   children: React.Node,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class AuthDropdown extends React.PureComponent<Props> {
   async _handleTypeChange(type: string) {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/dropdowns/auth-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/auth-dropdown.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import { showModal } from '../modals';
 import AlertModal from '../modals/alert-modal';
@@ -31,7 +31,7 @@ type Props = {
   children: React.Node,
 };
 
-@autobind
+@autoBindMethodsForReact
 class AuthDropdown extends React.PureComponent<Props> {
   async _handleTypeChange(type: string) {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/dropdowns/content-type-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/content-type-dropdown.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import {
   CONTENT_TYPE_FILE,
@@ -31,7 +31,7 @@ type Props = {
 
 const EMPTY_MIME_TYPE = null;
 
-@autobind
+@autoBindMethodsForReact
 class ContentTypeDropdown extends React.PureComponent<Props> {
   async _checkMimeTypeChange(body: RequestBody, mimeType: string | null) {
     // Nothing to do

--- a/packages/insomnia-app/app/ui/components/dropdowns/content-type-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/content-type-dropdown.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import {
+  AUTOBIND_CFG,
   CONTENT_TYPE_FILE,
   CONTENT_TYPE_FORM_DATA,
   CONTENT_TYPE_FORM_URLENCODED,
@@ -14,6 +14,8 @@ import {
   CONTENT_TYPE_EDN,
   getContentTypeName,
 } from '../../../common/constants';
+import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
+
 import { showModal } from '../modals/index';
 import AlertModal from '../modals/alert-modal';
 import type { Request, RequestBody } from '../../../models/request';
@@ -31,7 +33,7 @@ type Props = {
 
 const EMPTY_MIME_TYPE = null;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ContentTypeDropdown extends React.PureComponent<Props> {
   async _checkMimeTypeChange(body: RequestBody, mimeType: string | null) {
     // Nothing to do

--- a/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import { showError, showModal, showPrompt } from '../modals';
 import type { DocumentAction } from '../../../plugins';
@@ -30,7 +30,7 @@ type State = {
   loadingActions: { [string]: boolean },
 };
 
-@autobind
+@autoBindMethodsForReact
 class DocumentCardDropdown extends React.PureComponent<Props, State> {
   state = {
     actionPlugins: [],

--- a/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG, getAppName } from '../../../common/constants';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import { showError, showModal, showPrompt } from '../modals';
 import type { DocumentAction } from '../../../plugins';
@@ -14,7 +15,6 @@ import * as db from '../../../common/database';
 import * as models from '../../../models';
 import AskModal from '../modals/ask-modal';
 import type { Workspace } from '../../../models/workspace';
-import { getAppName } from '../../../common/constants';
 
 type Props = {
   apiSpec: ?ApiSpec,
@@ -30,7 +30,7 @@ type State = {
   loadingActions: { [string]: boolean },
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class DocumentCardDropdown extends React.PureComponent<Props, State> {
   state = {
     actionPlugins: [],

--- a/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import EnvironmentsModal from '../modals/workspace-environments-edit-modal';
 import {
   Dropdown,
@@ -30,7 +31,7 @@ type Props = {
   activeEnvironment: Environment | null,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class EnvironmentsDropdown extends React.PureComponent<Props> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import EnvironmentsModal from '../modals/workspace-environments-edit-modal';
 import {
   Dropdown,
@@ -30,7 +30,7 @@ type Props = {
   activeEnvironment: Environment | null,
 };
 
-@autobind
+@autoBindMethodsForReact
 class EnvironmentsDropdown extends React.PureComponent<Props> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import classnames from 'classnames';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import type { Workspace } from '../../../models/workspace';
@@ -40,7 +41,7 @@ type State = {|
   branches: Array<string>,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GitSyncDropdown extends React.PureComponent<Props, State> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import type { Workspace } from '../../../models/workspace';
@@ -40,7 +40,7 @@ type State = {|
   branches: Array<string>,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class GitSyncDropdown extends React.PureComponent<Props, State> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/method-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/method-dropdown.js
@@ -4,12 +4,12 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import * as constants from '../../../common/constants';
 import { showPrompt } from '../modals/index';
-import { METHOD_GRPC } from '../../../common/constants';
+import { METHOD_GRPC, AUTOBIND_CFG } from '../../../common/constants';
 
 const LOCALSTORAGE_KEY = 'insomnia.httpMethods';
 const GRPC_LABEL = 'gRPC';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class MethodDropdown extends PureComponent {
   _setDropdownRef(n) {
     this._dropdown = n;

--- a/packages/insomnia-app/app/ui/components/dropdowns/method-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/method-dropdown.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import * as constants from '../../../common/constants';
 import { showPrompt } from '../modals/index';
@@ -9,7 +9,7 @@ import { METHOD_GRPC } from '../../../common/constants';
 const LOCALSTORAGE_KEY = 'insomnia.httpMethods';
 const GRPC_LABEL = 'gRPC';
 
-@autobind
+@autoBindMethodsForReact
 class MethodDropdown extends PureComponent {
   _setDropdownRef(n) {
     this._dropdown = n;

--- a/packages/insomnia-app/app/ui/components/dropdowns/preview-mode-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/preview-mode-dropdown.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG, getPreviewModeName, PREVIEW_MODES } from '../../../common/constants';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
-import { getPreviewModeName, PREVIEW_MODES } from '../../../common/constants';
 
 type Props = {|
   download: (pretty: boolean) => any,
@@ -12,7 +12,7 @@ type Props = {|
   showPrettifyOption?: boolean,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class PreviewModeDropdown extends React.PureComponent<Props> {
   async _handleClick(previewMode: string) {
     const { updatePreviewMode } = this.props;

--- a/packages/insomnia-app/app/ui/components/dropdowns/preview-mode-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/preview-mode-dropdown.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import { getPreviewModeName, PREVIEW_MODES } from '../../../common/constants';
 
@@ -12,7 +12,7 @@ type Props = {|
   showPrettifyOption?: boolean,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class PreviewModeDropdown extends React.PureComponent<Props> {
   async _handleClick(previewMode: string) {
     const { updatePreviewMode } = this.props;

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import PromptButton from '../base/prompt-button';
 import {
   Dropdown,
@@ -47,7 +47,7 @@ type State = {
   loadingActions: { [string]: boolean },
 };
 
-@autobind
+@autoBindMethodsForReact
 class RequestActionsDropdown extends React.PureComponent<Props, State> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import PromptButton from '../base/prompt-button';
 import {
   Dropdown,
@@ -47,7 +48,7 @@ type State = {
   loadingActions: { [string]: boolean },
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestActionsDropdown extends React.PureComponent<Props, State> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import PromptButton from '../base/prompt-button';
 import {
@@ -39,7 +39,7 @@ type State = {
   loadingActions: { [string]: boolean },
 };
 
-@autobind
+@autoBindMethodsForReact
 class RequestGroupActionsDropdown extends React.PureComponent<Props, State> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import classnames from 'classnames';
 import PromptButton from '../base/prompt-button';
 import {
@@ -39,7 +40,7 @@ type State = {
   loadingActions: { [string]: boolean },
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestGroupActionsDropdown extends React.PureComponent<Props, State> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import moment from 'moment';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import StatusTag from '../tags/status-tag';
@@ -28,7 +29,7 @@ type Props = {
   activeEnvironment: ?Environment,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ResponseHistoryDropdown extends React.PureComponent<Props> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import moment from 'moment';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import StatusTag from '../tags/status-tag';
@@ -28,7 +28,7 @@ type Props = {
   activeEnvironment: ?Environment,
 };
 
-@autobind
+@autoBindMethodsForReact
 class ResponseHistoryDropdown extends React.PureComponent<Props> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import classnames from 'classnames';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import type { Workspace } from '../../../models/workspace';
@@ -55,7 +56,7 @@ type State = {
   remoteProjects: Array<Project>,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SyncDropdown extends React.PureComponent<Props, State> {
   checkInterval: IntervalID;
   refreshOnNextSyncItems = false;

--- a/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import type { Workspace } from '../../../models/workspace';
@@ -55,7 +55,7 @@ type State = {
   remoteProjects: Array<Project>,
 };
 
-@autobind
+@autoBindMethodsForReact
 class SyncDropdown extends React.PureComponent<Props, State> {
   checkInterval: IntervalID;
   refreshOnNextSyncItems = false;

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import Dropdown from '../base/dropdown/dropdown';
 import DropdownDivider from '../base/dropdown/dropdown-divider';
@@ -55,7 +55,7 @@ type State = {
   remoteProjects: Array<Project>,
 };
 
-@autobind
+@autoBindMethodsForReact
 class WorkspaceDropdown extends React.PureComponent<Props, State> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG, getAppName, getAppVersion } from '../../../common/constants';
 import classnames from 'classnames';
 import Dropdown from '../base/dropdown/dropdown';
 import DropdownDivider from '../base/dropdown/dropdown-divider';
@@ -9,7 +10,7 @@ import DropdownItem from '../base/dropdown/dropdown-item';
 import DropdownHint from '../base/dropdown/dropdown-hint';
 import SettingsModal, { TAB_INDEX_EXPORT } from '../modals/settings-modal';
 import * as models from '../../../models';
-import { getAppName, getAppVersion } from '../../../common/constants';
+
 import { showAlert, showError, showModal, showPrompt } from '../modals';
 import Link from '../base/link';
 import WorkspaceSettingsModal from '../modals/workspace-settings-modal';
@@ -55,7 +56,7 @@ type State = {
   remoteProjects: Array<Project>,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class WorkspaceDropdown extends React.PureComponent<Props, State> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.js
@@ -9,6 +9,7 @@ import { showModal } from '../../modals';
 import CodePromptModal from '../../modals/code-prompt-modal';
 import Button from '../../base/button';
 import type { Request, RequestAuthentication } from '../../../../models/request';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 
 type Props = {
   request: Request,
@@ -32,7 +33,7 @@ cJV+wRTs/Szp6LXAgMmTkKMJ+9XXErUIUgwbl27Y3Rv/9ox1p5VRg+A=
 -----END RSA PRIVATE KEY-----
 `.trim();
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class AsapAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.js
@@ -2,7 +2,7 @@
 
 import classnames from 'classnames';
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import HelpTooltip from '../../help-tooltip';
 import { showModal } from '../../modals';
@@ -32,7 +32,7 @@ cJV+wRTs/Szp6LXAgMmTkKMJ+9XXErUIUgwbl27Y3Rv/9ox1p5VRg+A=
 -----END RSA PRIVATE KEY-----
 `.trim();
 
-@autobind
+@autoBindMethodsForReact
 class AsapAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/auth-wrapper.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/auth-wrapper.js
@@ -12,6 +12,7 @@ import {
   AUTH_HAWK,
   AUTH_NETRC,
   AUTH_ASAP,
+  AUTOBIND_CFG,
 } from '../../../../common/constants';
 import BasicAuth from './basic-auth';
 import DigestAuth from './digest-auth';
@@ -42,7 +43,7 @@ type Props = {
   oAuth2Token: ?OAuth2Token,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class AuthWrapper extends React.PureComponent<Props> {
   renderEditor() {
     const {

--- a/packages/insomnia-app/app/ui/components/editors/auth/auth-wrapper.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/auth-wrapper.js
@@ -23,7 +23,7 @@ import HawkAuth from './hawk-auth';
 import AWSAuth from './aws-auth';
 import NetrcAuth from './netrc-auth';
 import AsapAuth from './asap-auth';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import type { Request, RequestAuthentication } from '../../../../models/request';
 import type { OAuth2Token } from '../../../../models/o-auth-2-token';
 import type { Settings } from '../../../../models/settings';
@@ -42,7 +42,7 @@ type Props = {
   oAuth2Token: ?OAuth2Token,
 };
 
-@autobind
+@autoBindMethodsForReact
 class AuthWrapper extends React.PureComponent<Props> {
   renderEditor() {
     const {

--- a/packages/insomnia-app/app/ui/components/editors/auth/aws-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/aws-auth.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import Button from '../../base/button';
@@ -19,7 +19,7 @@ type Props = {
   handleUpdateSettingsShowPasswords: boolean => Promise<Settings>,
 };
 
-@autobind
+@autoBindMethodsForReact
 class AWSAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/aws-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/aws-auth.js
@@ -7,6 +7,7 @@ import Button from '../../base/button';
 import HelpTooltip from '../../help-tooltip';
 import type { Request, RequestAuthentication } from '../../../../models/request';
 import type { Settings } from '../../../../models/settings';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 
 type Props = {
   request: Request,
@@ -19,7 +20,7 @@ type Props = {
   handleUpdateSettingsShowPasswords: boolean => Promise<Settings>,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class AWSAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/basic-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/basic-auth.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import Button from '../../base/button';
 import type { Settings } from '../../../../models/settings';
@@ -19,7 +20,7 @@ type Props = {
   isVariableUncovered: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class BasicAuth extends React.PureComponent<Props> {
   _handleUseISO88591() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/basic-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/basic-auth.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import classnames from 'classnames';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import Button from '../../base/button';
 import type { Settings } from '../../../../models/settings';
@@ -19,7 +19,7 @@ type Props = {
   isVariableUncovered: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class BasicAuth extends React.PureComponent<Props> {
   _handleUseISO88591() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/bearer-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/bearer-auth.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import classnames from 'classnames';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import Button from '../../base/button';
 import HelpTooltip from '../../help-tooltip';
@@ -16,7 +16,7 @@ type Props = {
   isVariableUncovered: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class BearerAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/bearer-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/bearer-auth.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import Button from '../../base/button';
 import HelpTooltip from '../../help-tooltip';
@@ -16,7 +17,7 @@ type Props = {
   isVariableUncovered: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class BearerAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/digest-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/digest-auth.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import classnames from 'classnames';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import Button from '../../base/button';
 import type { Settings } from '../../../../models/settings';
@@ -19,7 +19,7 @@ type Props = {
   isVariableUncovered: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class DigestAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/digest-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/digest-auth.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import Button from '../../base/button';
 import type { Settings } from '../../../../models/settings';
@@ -19,7 +20,7 @@ type Props = {
   isVariableUncovered: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class DigestAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/hawk-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/hawk-auth.js
@@ -3,8 +3,13 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import {
+  AUTOBIND_CFG,
+  HAWK_ALGORITHM_SHA1,
+  HAWK_ALGORITHM_SHA256,
+} from '../../../../common/constants';
 import OneLineEditor from '../../codemirror/one-line-editor';
-import { HAWK_ALGORITHM_SHA1, HAWK_ALGORITHM_SHA256 } from '../../../../common/constants';
+
 import HelpTooltip from '../../help-tooltip';
 import Button from '../../base/button';
 import type { Request, RequestAuthentication } from '../../../../models/request';
@@ -18,7 +23,7 @@ type Props = {
   onChange: (Request, RequestAuthentication) => Promise<Request>,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class HawkAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/hawk-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/hawk-auth.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import classnames from 'classnames';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import { HAWK_ALGORITHM_SHA1, HAWK_ALGORITHM_SHA256 } from '../../../../common/constants';
 import HelpTooltip from '../../help-tooltip';
@@ -18,7 +18,7 @@ type Props = {
   onChange: (Request, RequestAuthentication) => Promise<Request>,
 };
 
-@autobind
+@autoBindMethodsForReact
 class HawkAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/ntlm-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/ntlm-auth.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import classnames from 'classnames';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import Button from '../../base/button';
 import type { Request, RequestAuthentication } from '../../../../models/request';
@@ -18,7 +18,7 @@ type Props = {
   isVariableUncovered: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class NTLMAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/ntlm-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/ntlm-auth.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import Button from '../../base/button';
 import type { Request, RequestAuthentication } from '../../../../models/request';
@@ -18,7 +19,7 @@ type Props = {
   isVariableUncovered: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class NTLMAuth extends React.PureComponent<Props> {
   _handleDisable() {
     const { request, onChange } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.js
@@ -2,7 +2,7 @@
 import type { Request, RequestAuthentication } from '../../../../models/request';
 import * as React from 'react';
 import classnames from 'classnames';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import HelpTooltip from '../../help-tooltip';
 import {
@@ -38,7 +38,7 @@ cJV+wRTs/Szp6LXAgMmTkKMJ+9XXErUIUgwbl27Y3Rv/9ox1p5VRg+A=
 -----END RSA PRIVATE KEY-----
 `.trim();
 
-@autobind
+@autoBindMethodsForReact
 class OAuth1Auth extends React.PureComponent<Props> {
   _handleEditPrivateKey() {
     const { handleRender, handleGetRenderContext, request } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.js
@@ -3,6 +3,7 @@ import type { Request, RequestAuthentication } from '../../../../models/request'
 import * as React from 'react';
 import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import HelpTooltip from '../../help-tooltip';
 import {
@@ -38,7 +39,7 @@ cJV+wRTs/Szp6LXAgMmTkKMJ+9XXErUIUgwbl27Y3Rv/9ox1p5VRg+A=
 -----END RSA PRIVATE KEY-----
 `.trim();
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class OAuth1Auth extends React.PureComponent<Props> {
   _handleEditPrivateKey() {
     const { handleRender, handleGetRenderContext, request } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
@@ -4,7 +4,7 @@ import type { OAuth2Token } from '../../../../models/o-auth-2-token';
 
 import * as React from 'react';
 import classnames from 'classnames';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import {
   GRANT_TYPE_AUTHORIZATION_CODE,
@@ -54,7 +54,7 @@ const getAccessTokenUrls = () => accessTokenUrls;
 
 let showAdvanced = false;
 
-@autobind
+@autoBindMethodsForReact
 class OAuth2Auth extends React.PureComponent<Props, State> {
   constructor(props: any) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.js
@@ -5,6 +5,7 @@ import type { OAuth2Token } from '../../../../models/o-auth-2-token';
 import * as React from 'react';
 import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 import OneLineEditor from '../../codemirror/one-line-editor';
 import {
   GRANT_TYPE_AUTHORIZATION_CODE,
@@ -54,7 +55,7 @@ const getAccessTokenUrls = () => accessTokenUrls;
 
 let showAdvanced = false;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class OAuth2Auth extends React.PureComponent<Props, State> {
   constructor(props: any) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/editors/body/body-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/body-editor.js
@@ -12,6 +12,7 @@ import {
   CONTENT_TYPE_FORM_DATA,
   CONTENT_TYPE_FORM_URLENCODED,
   CONTENT_TYPE_GRAPHQL,
+  AUTOBIND_CFG,
   getContentTypeFromHeaders,
 } from '../../../../common/constants';
 import type {
@@ -47,7 +48,7 @@ type Props = {
   isVariableUncovered: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class BodyEditor extends React.PureComponent<Props> {
   _handleRawChange(rawValue: string) {
     const { onChange, request } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/body/body-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/body-editor.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import * as mimes from 'mime-types';
 import clone from 'clone';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import RawEditor from './raw-editor';
 import UrlEncodedEditor from './url-encoded-editor';
 import FormEditor from './form-editor';
@@ -47,7 +47,7 @@ type Props = {
   isVariableUncovered: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class BodyEditor extends React.PureComponent<Props> {
   _handleRawChange(rawValue: string) {
     const { onChange, request } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/body/file-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/file-editor.js
@@ -1,13 +1,13 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import fs from 'fs';
 import electron from 'electron';
 import FileInputButton from '../../base/file-input-button';
 import PromptButton from '../../base/prompt-button';
 import * as misc from '../../../../common/misc';
 
-@autobind
+@autoBindMethodsForReact
 class FileEditor extends PureComponent {
   _handleResetFile() {
     this.props.onChange('');

--- a/packages/insomnia-app/app/ui/components/editors/body/file-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/file-editor.js
@@ -1,13 +1,14 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 import fs from 'fs';
 import electron from 'electron';
 import FileInputButton from '../../base/file-input-button';
 import PromptButton from '../../base/prompt-button';
 import * as misc from '../../../../common/misc';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class FileEditor extends PureComponent {
   _handleResetFile() {
     this.props.onChange('');

--- a/packages/insomnia-app/app/ui/components/editors/body/form-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/form-editor.js
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 import KeyValueEditor from '../../key-value-editor/editor';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class FormEditor extends PureComponent {
   render() {
     const {

--- a/packages/insomnia-app/app/ui/components/editors/body/form-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/form-editor.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import KeyValueEditor from '../../key-value-editor/editor';
 
-@autobind
+@autoBindMethodsForReact
 class FormEditor extends PureComponent {
   render() {
     const {

--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
@@ -12,7 +12,7 @@ import type { CodeMirror, TextMarker } from 'codemirror';
 import CodeEditor from '../../codemirror/code-editor';
 import { jsonParseOr } from '../../../../common/misc';
 import HelpTooltip from '../../help-tooltip';
-import { CONTENT_TYPE_JSON, DEBOUNCE_MILLIS } from '../../../../common/constants';
+import { CONTENT_TYPE_JSON, DEBOUNCE_MILLIS, AUTOBIND_CFG } from '../../../../common/constants';
 import prettify from 'insomnia-prettify';
 import type { ResponsePatch } from '../../../../network/network';
 import * as network from '../../../../network/network';
@@ -75,9 +75,7 @@ type State = {
   },
 };
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GraphQLEditor extends React.PureComponent<Props, State> {
   _disabledOperationMarkers: Array<TextMarker>;
   _documentAST: null | Object;

--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.js
@@ -2,7 +2,7 @@
 import classnames from 'classnames';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { markdownToHTML } from '../../../../common/markdown-to-html';
 import type { GraphQLArgument, GraphQLField, GraphQLSchema, GraphQLType } from 'graphql';
 import { parse, print, typeFromAST } from 'graphql';
@@ -75,7 +75,9 @@ type State = {
   },
 };
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
+})
 class GraphQLEditor extends React.PureComponent<Props, State> {
   _disabledOperationMarkers: Array<TextMarker>;
   _documentAST: null | Object;

--- a/packages/insomnia-app/app/ui/components/editors/body/raw-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/raw-editor.js
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 import CodeEditor from '../../codemirror/code-editor';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RawEditor extends PureComponent {
   render() {
     const {

--- a/packages/insomnia-app/app/ui/components/editors/body/raw-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/raw-editor.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import CodeEditor from '../../codemirror/code-editor';
 
-@autobind
+@autoBindMethodsForReact
 class RawEditor extends PureComponent {
   render() {
     const {

--- a/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.js
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../../common/constants';
 import KeyValueEditor from '../../key-value-editor/editor';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class UrlEncodedEditor extends PureComponent {
   render() {
     const {

--- a/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import KeyValueEditor from '../../key-value-editor/editor';
 
-@autobind
+@autoBindMethodsForReact
 class UrlEncodedEditor extends PureComponent {
   render() {
     const {

--- a/packages/insomnia-app/app/ui/components/editors/environment-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/environment-editor.js
@@ -1,9 +1,10 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG, JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from '../../../common/constants';
 import CodeEditor from '../codemirror/code-editor';
 import orderedJSON from 'json-order';
-import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from '../../../common/constants';
+
 import { NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME } from '../../../templating';
 
 // NeDB field names cannot begin with '$' or contain a period '.'
@@ -46,7 +47,7 @@ type State = {
   error: string | null,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class EnvironmentEditor extends React.PureComponent<Props, State> {
   _editor: CodeEditor | null;
 

--- a/packages/insomnia-app/app/ui/components/editors/environment-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/environment-editor.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import CodeEditor from '../codemirror/code-editor';
 import orderedJSON from 'json-order';
 import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from '../../../common/constants';
@@ -46,7 +46,7 @@ type State = {
   error: string | null,
 };
 
-@autobind
+@autoBindMethodsForReact
 class EnvironmentEditor extends React.PureComponent<Props, State> {
   _editor: CodeEditor | null;
 

--- a/packages/insomnia-app/app/ui/components/editors/request-headers-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/request-headers-editor.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import KeyValueEditor from '../key-value-editor/editor';
 import CodeEditor from '../codemirror/code-editor';
 import allHeaderNames from '../../../datasets/header-names';
@@ -23,7 +24,7 @@ type Props = {
   request: Request,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestHeadersEditor extends React.PureComponent<Props> {
   _handleBulkUpdate(headersString: string) {
     const { onChange, request } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/request-headers-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/request-headers-editor.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import KeyValueEditor from '../key-value-editor/editor';
 import CodeEditor from '../codemirror/code-editor';
 import allHeaderNames from '../../../datasets/header-names';
@@ -23,7 +23,7 @@ type Props = {
   request: Request,
 };
 
-@autobind
+@autoBindMethodsForReact
 class RequestHeadersEditor extends React.PureComponent<Props> {
   _handleBulkUpdate(headersString: string) {
     const { onChange, request } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/request-parameters-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/request-parameters-editor.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import KeyValueEditor from '../key-value-editor/editor';
 import CodeEditor from '../codemirror/code-editor';
 import type { Request, RequestParameter } from '../../../models/request';
@@ -19,7 +19,7 @@ type Props = {
   request: Request,
 };
 
-@autobind
+@autoBindMethodsForReact
 class RequestParametersEditor extends React.PureComponent<Props> {
   _handleBulkUpdate(paramsString: string) {
     const { onChange, request } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/request-parameters-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/request-parameters-editor.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import KeyValueEditor from '../key-value-editor/editor';
 import CodeEditor from '../codemirror/code-editor';
 import type { Request, RequestParameter } from '../../../models/request';
@@ -19,7 +20,7 @@ type Props = {
   request: Request,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestParametersEditor extends React.PureComponent<Props> {
   _handleBulkUpdate(paramsString: string) {
     const { onChange, request } = this.props;

--- a/packages/insomnia-app/app/ui/components/export-requests/request-group-row.js
+++ b/packages/insomnia-app/app/ui/components/export-requests/request-group-row.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import type { RequestGroup } from '../../../models/request-group';
 
@@ -17,7 +17,7 @@ type Props = {
   children?: React.Node,
 };
 
-@autobind
+@autoBindMethodsForReact
 class RequestGroupRow extends React.PureComponent<Props> {
   checkbox: HTMLInputElement;
 

--- a/packages/insomnia-app/app/ui/components/export-requests/request-group-row.js
+++ b/packages/insomnia-app/app/ui/components/export-requests/request-group-row.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import classnames from 'classnames';
 import type { RequestGroup } from '../../../models/request-group';
 
@@ -17,7 +18,7 @@ type Props = {
   children?: React.Node,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestGroupRow extends React.PureComponent<Props> {
   checkbox: HTMLInputElement;
 

--- a/packages/insomnia-app/app/ui/components/export-requests/request-row.js
+++ b/packages/insomnia-app/app/ui/components/export-requests/request-row.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import MethodTag from '../tags/method-tag';
 import type { Request } from '../../../models/request';
 import type { GrpcRequest } from '../../../models/grpc-request';
@@ -13,7 +13,7 @@ type Props = {
   request: Request | GrpcRequest,
 };
 
-@autobind
+@autoBindMethodsForReact
 class RequestRow extends PureComponent<Props> {
   handleSelect(e: SyntheticEvent<HTMLInputElement>) {
     const el = e.currentTarget;

--- a/packages/insomnia-app/app/ui/components/export-requests/request-row.js
+++ b/packages/insomnia-app/app/ui/components/export-requests/request-row.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import MethodTag from '../tags/method-tag';
 import type { Request } from '../../../models/request';
 import type { GrpcRequest } from '../../../models/grpc-request';
@@ -13,7 +14,7 @@ type Props = {
   request: Request | GrpcRequest,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestRow extends PureComponent<Props> {
   handleSelect(e: SyntheticEvent<HTMLInputElement>) {
     const el = e.currentTarget;

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-enum.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-enum.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import MarkdownPreview from '../markdown-preview';
 import type { GraphQLEnumValue } from 'graphql';
 import { GraphQLEnumType } from 'graphql';
@@ -9,7 +9,7 @@ type Props = {|
   type: GraphQLEnumType,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class GraphQLExplorerEnum extends React.PureComponent<Props> {
   renderDescription() {
     const { type } = this.props;

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-enum.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-enum.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import MarkdownPreview from '../markdown-preview';
 import type { GraphQLEnumValue } from 'graphql';
 import { GraphQLEnumType } from 'graphql';
@@ -9,7 +10,7 @@ type Props = {|
   type: GraphQLEnumType,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GraphQLExplorerEnum extends React.PureComponent<Props> {
   renderDescription() {
     const { type } = this.props;

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-field-link.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-field-link.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import type { GraphQLField } from 'graphql';
 
 type Props = {
@@ -8,7 +8,7 @@ type Props = {
   field: GraphQLField<any, any>,
 };
 
-@autobind
+@autoBindMethodsForReact
 class GraphQLExplorerFieldLink extends React.PureComponent<Props> {
   _handleClick(e: MouseEvent) {
     e.preventDefault();

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-field-link.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-field-link.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import type { GraphQLField } from 'graphql';
 
 type Props = {
@@ -8,7 +9,7 @@ type Props = {
   field: GraphQLField<any, any>,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GraphQLExplorerFieldLink extends React.PureComponent<Props> {
   _handleClick(e: MouseEvent) {
     e.preventDefault();

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type-link.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type-link.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { GraphQLList, GraphQLNonNull } from 'graphql';
 import type { GraphQLType } from 'graphql';
 
@@ -9,7 +10,7 @@ type Props = {
   type: GraphQLType,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GraphQLExplorerTypeLink extends React.PureComponent<Props> {
   _handleClick(e: MouseEvent) {
     e.preventDefault();

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type-link.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type-link.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { GraphQLList, GraphQLNonNull } from 'graphql';
 import type { GraphQLType } from 'graphql';
 
@@ -9,7 +9,7 @@ type Props = {
   type: GraphQLType,
 };
 
-@autobind
+@autoBindMethodsForReact
 class GraphQLExplorerTypeLink extends React.PureComponent<Props> {
   _handleClick(e: MouseEvent) {
     e.preventDefault();

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { SvgIcon } from 'insomnia-components';
 import GraphQLExplorerTypeLink from './graph-ql-explorer-type-link';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import MarkdownPreview from '../markdown-preview';
 import GraphQLExplorerFieldLink from './graph-ql-explorer-field-link';
 import type { GraphQLField, GraphQLSchema, GraphQLType } from 'graphql';
@@ -17,7 +17,7 @@ type Props = {
   schema: GraphQLSchema | null,
 };
 
-@autobind
+@autoBindMethodsForReact
 class GraphQLExplorerType extends React.PureComponent<Props> {
   _handleNavigateType(type: Object) {
     const { onNavigateType } = this.props;

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { SvgIcon } from 'insomnia-components';
 import GraphQLExplorerTypeLink from './graph-ql-explorer-type-link';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import MarkdownPreview from '../markdown-preview';
 import GraphQLExplorerFieldLink from './graph-ql-explorer-field-link';
 import type { GraphQLField, GraphQLSchema, GraphQLType } from 'graphql';
@@ -17,7 +18,7 @@ type Props = {
   schema: GraphQLSchema | null,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GraphQLExplorerType extends React.PureComponent<Props> {
   _handleNavigateType(type: Object) {
     const { onNavigateType } = this.props;

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import GraphQLExplorerField from './graph-ql-explorer-field';
 import GraphQLExplorerType from './graph-ql-explorer-type';
 import type { GraphQLArgument, GraphQLField, GraphQLSchema, GraphQLType } from 'graphql';
@@ -28,7 +28,9 @@ type State = HistoryItem & {
   history: Array<HistoryItem>,
 };
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
+})
 class GraphQLExplorer extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer.js
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import GraphQLExplorerField from './graph-ql-explorer-field';
 import GraphQLExplorerType from './graph-ql-explorer-type';
 import type { GraphQLArgument, GraphQLField, GraphQLSchema, GraphQLType } from 'graphql';
@@ -28,9 +29,7 @@ type State = HistoryItem & {
   history: Array<HistoryItem>,
 };
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GraphQLExplorer extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/help-tooltip.js
+++ b/packages/insomnia-app/app/ui/components/help-tooltip.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Tooltip from './tooltip';
+import { AUTOBIND_CFG } from '../../common/constants';
 
 type Props = {
   children: React.Node,
@@ -13,7 +14,7 @@ type Props = {
   info?: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class HelpTooltip extends React.PureComponent<Props> {
   render() {
     const { children, className, style, info } = this.props;

--- a/packages/insomnia-app/app/ui/components/help-tooltip.js
+++ b/packages/insomnia-app/app/ui/components/help-tooltip.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Tooltip from './tooltip';
 
 type Props = {
@@ -13,7 +13,7 @@ type Props = {
   info?: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class HelpTooltip extends React.PureComponent<Props> {
   render() {
     const { children, className, style, info } = this.props;

--- a/packages/insomnia-app/app/ui/components/html-element-wrapper.js
+++ b/packages/insomnia-app/app/ui/components/html-element-wrapper.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../common/constants';
 
 type Props = {|
   el: HTMLElement,
@@ -12,7 +13,7 @@ type Props = {|
  * application. This was created to facilitate the layer between UI plugins
  * and the Insomnia application.
  */
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class HtmlElementWrapper extends React.Component<Props> {
   _setRef(n: ?HTMLDivElement) {
     if (!n) {

--- a/packages/insomnia-app/app/ui/components/html-element-wrapper.js
+++ b/packages/insomnia-app/app/ui/components/html-element-wrapper.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 
 type Props = {|
   el: HTMLElement,
@@ -12,7 +12,7 @@ type Props = {|
  * application. This was created to facilitate the layer between UI plugins
  * and the Insomnia application.
  */
-@autobind
+@autoBindMethodsForReact
 class HtmlElementWrapper extends React.Component<Props> {
   _setRef(n: ?HTMLDivElement) {
     if (!n) {

--- a/packages/insomnia-app/app/ui/components/key-value-editor/editor.js
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/editor.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import { DEBOUNCE_MILLIS } from '../../../common/constants';
 import Lazy from '../base/lazy';
@@ -19,7 +19,7 @@ const DOWN = 40;
 const LEFT = 37;
 const RIGHT = 39;
 
-@autobind
+@autoBindMethodsForReact
 class Editor extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/key-value-editor/editor.js
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/editor.js
@@ -1,8 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG, DEBOUNCE_MILLIS } from '../../../common/constants';
 import classnames from 'classnames';
-import { DEBOUNCE_MILLIS } from '../../../common/constants';
+
 import Lazy from '../base/lazy';
 import KeyValueEditorRow from './row';
 import { generateId, nullFn } from '../../../common/misc';
@@ -19,7 +20,7 @@ const DOWN = 40;
 const LEFT = 37;
 const RIGHT = 39;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Editor extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/key-value-editor/row.js
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/row.js
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { DragSource, DropTarget } from 'react-dnd';
 import classnames from 'classnames';
 import FileInputButton from '../base/file-input-button';
@@ -14,7 +15,7 @@ import OneLineEditor from '../codemirror/one-line-editor';
 import { showModal } from '../modals/index';
 import { describeByteSize } from '../../../common/misc';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class KeyValueEditorRow extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/key-value-editor/row.js
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/row.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { DragSource, DropTarget } from 'react-dnd';
 import classnames from 'classnames';
 import FileInputButton from '../base/file-input-button';
@@ -14,7 +14,7 @@ import OneLineEditor from '../codemirror/one-line-editor';
 import { showModal } from '../modals/index';
 import { describeByteSize } from '../../../common/misc';
 
-@autobind
+@autoBindMethodsForReact
 class KeyValueEditorRow extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/keydown-binder.js
+++ b/packages/insomnia-app/app/ui/components/keydown-binder.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { isMac } from '../../common/constants';
+import { isMac, AUTOBIND_CFG } from '../../common/constants';
 
 type Props = {
   children: React.Node,
@@ -13,7 +13,7 @@ type Props = {
   stopMetaPropagation?: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class KeydownBinder extends React.PureComponent<Props> {
   _handleKeydown(e: KeyboardEvent) {
     const { stopMetaPropagation, onKeydown, disabled } = this.props;

--- a/packages/insomnia-app/app/ui/components/keydown-binder.js
+++ b/packages/insomnia-app/app/ui/components/keydown-binder.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { isMac } from '../../common/constants';
 
 type Props = {
@@ -13,7 +13,7 @@ type Props = {
   stopMetaPropagation?: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class KeydownBinder extends React.PureComponent<Props> {
   _handleKeydown(e: KeyboardEvent) {
     const { stopMetaPropagation, onKeydown, disabled } = this.props;

--- a/packages/insomnia-app/app/ui/components/markdown-editor.js
+++ b/packages/insomnia-app/app/ui/components/markdown-editor.js
@@ -1,13 +1,14 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import classnames from 'classnames';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import Button from './base/button';
 import CodeEditor from './codemirror/code-editor';
 import MarkdownPreview from './markdown-preview';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class MarkdownEditor extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/markdown-editor.js
+++ b/packages/insomnia-app/app/ui/components/markdown-editor.js
@@ -1,13 +1,13 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import Button from './base/button';
 import CodeEditor from './codemirror/code-editor';
 import MarkdownPreview from './markdown-preview';
 
-@autobind
+@autoBindMethodsForReact
 class MarkdownEditor extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/markdown-editor.js
+++ b/packages/insomnia-app/app/ui/components/markdown-editor.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { AUTOBIND_CFG } from '../../../common/constants';
+import { AUTOBIND_CFG } from '../../common/constants';
 import classnames from 'classnames';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import Button from './base/button';

--- a/packages/insomnia-app/app/ui/components/markdown-preview.js
+++ b/packages/insomnia-app/app/ui/components/markdown-preview.js
@@ -3,13 +3,12 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../common/constants';
 import highlight from 'highlight.js';
 import * as misc from '../../common/misc';
 import { markdownToHTML } from '../../common/markdown-to-html';
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillMount', 'UNSAFE_componentWillReceiveProps'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class MarkdownPreview extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/markdown-preview.js
+++ b/packages/insomnia-app/app/ui/components/markdown-preview.js
@@ -2,12 +2,14 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import highlight from 'highlight.js';
 import * as misc from '../../common/misc';
 import { markdownToHTML } from '../../common/markdown-to-html';
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillMount', 'UNSAFE_componentWillReceiveProps'],
+})
 class MarkdownPreview extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/add-key-combination-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/add-key-combination-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import Modal from '../base/modal';
 import ModalHeader from '../base/modal-header';
@@ -19,7 +19,7 @@ type State = {
   pressedKeyCombination: KeyCombination | null,
 };
 
-@autobind
+@autoBindMethodsForReact
 class AddKeyCombinationModal extends PureComponent<Props, State> {
   _modal: Modal | null;
 

--- a/packages/insomnia-app/app/ui/components/modals/add-key-combination-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/add-key-combination-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import classnames from 'classnames';
 import Modal from '../base/modal';
 import ModalHeader from '../base/modal-header';
@@ -19,7 +20,7 @@ type State = {
   pressedKeyCombination: KeyCombination | null,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class AddKeyCombinationModal extends PureComponent<Props, State> {
   _modal: Modal | null;
 

--- a/packages/insomnia-app/app/ui/components/modals/alert-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/alert-modal.js
@@ -1,11 +1,12 @@
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class AlertModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/alert-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/alert-modal.js
@@ -1,11 +1,11 @@
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
 
-@autobind
+@autoBindMethodsForReact
 class AlertModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/ask-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/ask-modal.js
@@ -1,11 +1,11 @@
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
 
-@autobind
+@autoBindMethodsForReact
 class AskModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/ask-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/ask-modal.js
@@ -1,11 +1,12 @@
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class AskModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/code-prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/code-prompt-modal.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -22,7 +23,7 @@ const MODES = {
   'text/html': 'HTML',
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class CodePromptModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/code-prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/code-prompt-modal.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -22,7 +22,7 @@ const MODES = {
   'text/html': 'HTML',
 };
 
-@autobind
+@autoBindMethodsForReact
 class CodePromptModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as toughCookie from 'tough-cookie';
 import * as models from '../../../models';
 import clone from 'clone';
@@ -29,7 +29,7 @@ type State = {
   rawValue: string,
 };
 
-@autobind
+@autoBindMethodsForReact
 class CookieModifyModal extends React.PureComponent<Props, State> {
   modal: Modal | null;
   _rawTimeout: TimeoutID;

--- a/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.js
@@ -2,10 +2,11 @@
 import * as React from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG, DEBOUNCE_MILLIS } from '../../../common/constants';
 import * as toughCookie from 'tough-cookie';
 import * as models from '../../../models';
 import clone from 'clone';
-import { DEBOUNCE_MILLIS } from '../../../common/constants';
+
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -29,7 +30,7 @@ type State = {
   rawValue: string,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class CookieModifyModal extends React.PureComponent<Props, State> {
   modal: Modal | null;
   _rawTimeout: TimeoutID;

--- a/packages/insomnia-app/app/ui/components/modals/cookies-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/cookies-modal.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { PureComponent } from 'react';
 import deepEqual from 'deep-equal';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -24,7 +24,9 @@ type State = {
   visibleCookieIndexes: Array<number> | null,
 };
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
+})
 class CookiesModal extends PureComponent<Props, State> {
   modal: Modal | null;
   filterInput: HTMLInputElement | null;

--- a/packages/insomnia-app/app/ui/components/modals/cookies-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/cookies-modal.js
@@ -2,6 +2,7 @@
 import React, { PureComponent } from 'react';
 import deepEqual from 'deep-equal';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -24,9 +25,7 @@ type State = {
   visibleCookieIndexes: Array<number> | null,
 };
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class CookiesModal extends PureComponent<Props, State> {
   modal: Modal | null;
   filterInput: HTMLInputElement | null;

--- a/packages/insomnia-app/app/ui/components/modals/environment-edit-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/environment-edit-modal.js
@@ -1,13 +1,14 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import EnvironmentEditor from '../editors/environment-editor';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class EnvironmentEditModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/environment-edit-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/environment-edit-modal.js
@@ -1,13 +1,13 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import EnvironmentEditor from '../editors/environment-editor';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
 
-@autobind
+@autoBindMethodsForReact
 class EnvironmentEditModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/error-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/error-modal.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -14,7 +14,7 @@ export type ErrorModalOptions = {|
   message?: string,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class ErrorModal extends PureComponent<{}, ErrorModalOptions> {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/error-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/error-modal.js
@@ -2,6 +2,7 @@
 
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -14,7 +15,7 @@ export type ErrorModalOptions = {|
   message?: string,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ErrorModal extends PureComponent<{}, ErrorModalOptions> {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -29,7 +30,7 @@ type State = {
   treeRoot: ?Node,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ExportRequestsModal extends PureComponent<Props, State> {
   modal: Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/export-requests-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -29,7 +29,7 @@ type State = {
   treeRoot: ?Node,
 };
 
-@autobind
+@autoBindMethodsForReact
 class ExportRequestsModal extends PureComponent<Props, State> {
   modal: Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/filter-help-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/filter-help-modal.js
@@ -1,11 +1,12 @@
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Link from '../base/link';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class FilterHelpModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/filter-help-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/filter-help-modal.js
@@ -1,11 +1,11 @@
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Link from '../base/link';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 
-@autobind
+@autoBindMethodsForReact
 class FilterHelpModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/generate-code-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/generate-code-modal.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import HTTPSnippet, { availableTargets } from 'httpsnippet';
 import CopyButton from '../base/copy-button';
 import { Dropdown, DropdownButton, DropdownItem } from '../base/dropdown';
@@ -27,7 +28,7 @@ const TO_ADD_CONTENT_LENGTH = {
   node: ['native'],
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GenerateCodeModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/generate-code-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/generate-code-modal.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import HTTPSnippet, { availableTargets } from 'httpsnippet';
 import CopyButton from '../base/copy-button';
 import { Dropdown, DropdownButton, DropdownItem } from '../base/dropdown';
@@ -27,7 +27,7 @@ const TO_ADD_CONTENT_LENGTH = {
   node: ['native'],
 };
 
-@autobind
+@autoBindMethodsForReact
 class GenerateCodeModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -31,7 +32,7 @@ type State = {|
   activeTab: number,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GenerateConfigModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -31,7 +31,7 @@ type State = {|
   activeTab: number,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class GenerateConfigModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/git-branches-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-branches-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -26,7 +27,7 @@ type State = {|
   newBranchName: string,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GitBranchesModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   input: ?HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/git-branches-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-branches-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -26,7 +26,7 @@ type State = {|
   newBranchName: string,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class GitBranchesModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   input: ?HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/git-log-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-log-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -19,7 +20,7 @@ type State = {|
   branch: string,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GitLogModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/git-log-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-log-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -19,7 +19,7 @@ type State = {|
   branch: string,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class GitLogModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -24,7 +24,7 @@ type State = {|
   },
 |};
 
-@autobind
+@autoBindMethodsForReact
 class GitRepositorySettingsModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   input: ?HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -24,7 +25,7 @@ type State = {|
   },
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GitRepositorySettingsModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   input: ?HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/git-staging-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-staging-modal.js
@@ -1,7 +1,7 @@
 // @flow
 import YAML from 'yaml';
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import path from 'path';
 import * as models from '../../../models';
 import Modal from '../base/modal';
@@ -48,7 +48,7 @@ const INITIAL_STATE: State = {
   items: {},
 };
 
-@autobind
+@autoBindMethodsForReact
 class GitStagingModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   statusNames: { [string]: string };

--- a/packages/insomnia-app/app/ui/components/modals/git-staging-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/git-staging-modal.js
@@ -2,6 +2,7 @@
 import YAML from 'yaml';
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import path from 'path';
 import * as models from '../../../models';
 import Modal from '../base/modal';
@@ -48,7 +49,7 @@ const INITIAL_STATE: State = {
   items: {},
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class GitStagingModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   statusNames: { [string]: string };

--- a/packages/insomnia-app/app/ui/components/modals/login-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/login-modal.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Link from '../base/link';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
@@ -7,7 +7,7 @@ import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
 import * as session from '../../../account/session';
 
-@autobind
+@autoBindMethodsForReact
 class LoginModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/login-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/login-modal.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Link from '../base/link';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
@@ -7,7 +8,7 @@ import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
 import * as session from '../../../account/session';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class LoginModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -20,7 +20,7 @@ type State = {
   selectedWorkspaceId: string | null,
 };
 
-@autobind
+@autoBindMethodsForReact
 class MoveRequestGroupModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -20,7 +21,7 @@ type State = {
   selectedWorkspaceId: string | null,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class MoveRequestGroupModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/nunjucks-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/nunjucks-modal.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import VariableEditor from '../templating/variable-editor';
 import TagEditor from '../templating/tag-editor';
 import Modal from '../base/modal';
@@ -8,7 +8,7 @@ import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
 
-@autobind
+@autoBindMethodsForReact
 class NunjucksModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/nunjucks-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/nunjucks-modal.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import VariableEditor from '../templating/variable-editor';
 import TagEditor from '../templating/tag-editor';
 import Modal from '../base/modal';
@@ -8,7 +9,7 @@ import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class NunjucksModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/payment-notification-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/payment-notification-modal.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import PromptButton from '../base/prompt-button';
 import Link from '../base/link';
 import Modal from '../base/modal';
@@ -9,7 +10,7 @@ import { getFirstName, endTrial, logout } from '../../../account/session';
 
 let hidePaymentNotificationUntilNextLaunch = false;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class PaymentNotificationModal extends PureComponent {
   async _handleCancel() {
     try {

--- a/packages/insomnia-app/app/ui/components/modals/payment-notification-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/payment-notification-modal.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import PromptButton from '../base/prompt-button';
 import Link from '../base/link';
 import Modal from '../base/modal';
@@ -9,7 +9,7 @@ import { getFirstName, endTrial, logout } from '../../../account/session';
 
 let hidePaymentNotificationUntilNextLaunch = false;
 
-@autobind
+@autoBindMethodsForReact
 class PaymentNotificationModal extends PureComponent {
   async _handleCancel() {
     try {

--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
@@ -30,7 +30,7 @@ type State = {
   currentValue: string,
 };
 
-@autobind
+@autoBindMethodsForReact
 class PromptModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   _input: ?HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import classnames from 'classnames';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
@@ -30,7 +31,7 @@ type State = {
   currentValue: string,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class PromptModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   _input: ?HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -4,7 +4,7 @@ import type { ProtoFile } from '../../../models/proto-file';
 import ModalHeader from '../base/modal-header';
 import ModalBody from '../base/modal-body';
 import ModalFooter from '../base/modal-footer';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import type { Workspace } from '../../../models/workspace';
 import Modal from '../base/modal';
 import ProtoFileList from '../proto-file/proto-file-list';
@@ -39,7 +39,7 @@ const INITIAL_STATE: State = {
 
 const spinner = <i className="fa fa-spin fa-refresh" />;
 
-@autobind
+@autoBindMethodsForReact
 class ProtoFilesModal extends React.PureComponent<Props, State> {
   modal: Modal | null;
   onSave: (string => Promise<void>) | null;

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.js
@@ -5,6 +5,7 @@ import ModalHeader from '../base/modal-header';
 import ModalBody from '../base/modal-body';
 import ModalFooter from '../base/modal-footer';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import type { Workspace } from '../../../models/workspace';
 import Modal from '../base/modal';
 import ProtoFileList from '../proto-file/proto-file-list';
@@ -39,7 +40,7 @@ const INITIAL_STATE: State = {
 
 const spinner = <i className="fa fa-spin fa-refresh" />;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ProtoFilesModal extends React.PureComponent<Props, State> {
   modal: Modal | null;
   onSave: (string => Promise<void>) | null;

--- a/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import ContentTypeDropdown from '../dropdowns/content-type-dropdown';
 import MethodDropdown from '../dropdowns/method-dropdown';
 import Modal from '../base/modal';
@@ -25,7 +25,7 @@ type RequestCreateModalOptions = {
   onComplete: string => void,
 };
 
-@autobind
+@autoBindMethodsForReact
 class RequestCreateModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-create-modal.js
@@ -1,13 +1,8 @@
 // @flow
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import ContentTypeDropdown from '../dropdowns/content-type-dropdown';
-import MethodDropdown from '../dropdowns/method-dropdown';
-import Modal from '../base/modal';
-import ModalBody from '../base/modal-body';
-import ModalHeader from '../base/modal-header';
-import ModalFooter from '../base/modal-footer';
 import {
+  AUTOBIND_CFG,
   getContentTypeName,
   METHOD_GET,
   METHOD_HEAD,
@@ -15,6 +10,13 @@ import {
   METHOD_DELETE,
   METHOD_GRPC,
 } from '../../../common/constants';
+import ContentTypeDropdown from '../dropdowns/content-type-dropdown';
+import MethodDropdown from '../dropdowns/method-dropdown';
+import Modal from '../base/modal';
+import ModalBody from '../base/modal-body';
+import ModalHeader from '../base/modal-header';
+import ModalFooter from '../base/modal-footer';
+
 import * as models from '../../../models/index';
 import { trackEvent } from '../../../common/analytics';
 import { showModal } from './index';
@@ -25,7 +27,7 @@ type RequestCreateModalOptions = {
   onComplete: string => void,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestCreateModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/request-render-error-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-render-error-modal.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import jq from 'jsonpath';
 import RequestSettingsModal from '../modals/request-settings-modal';
 import Modal from '../base/modal';
@@ -8,7 +8,7 @@ import ModalHeader from '../base/modal-header';
 import { showModal } from './index';
 import Link from '../base/link';
 
-@autobind
+@autoBindMethodsForReact
 class RequestRenderErrorModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/request-render-error-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-render-error-modal.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import jq from 'jsonpath';
 import RequestSettingsModal from '../modals/request-settings-modal';
 import Modal from '../base/modal';
@@ -8,7 +9,7 @@ import ModalHeader from '../base/modal-header';
 import { showModal } from './index';
 import Link from '../base/link';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestRenderErrorModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -42,7 +43,7 @@ type RequestSettingsModalOptions = {
   forceEditMode: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestSettingsModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   _editor: ?MarkdownEditor;

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -42,7 +42,7 @@ type RequestSettingsModalOptions = {
   forceEditMode: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class RequestSettingsModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   _editor: ?MarkdownEditor;

--- a/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
 import Button from '../base/button';
@@ -46,7 +46,7 @@ type State = {
   title: string | null,
 };
 
-@autobind
+@autoBindMethodsForReact
 class RequestSwitcherModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   _input: ?HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import classnames from 'classnames';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
 import Button from '../base/button';
@@ -46,7 +47,7 @@ type State = {
   title: string | null,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestSwitcherModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   _input: ?HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/response-debug-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/response-debug-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import ResponseTimelineViewer from '../../components/viewers/response-timeline-viewer';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
@@ -18,7 +18,7 @@ type State = {|
   title: string | null,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class ResponseDebugModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/response-debug-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/response-debug-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import ResponseTimelineViewer from '../../components/viewers/response-timeline-viewer';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
@@ -18,7 +19,7 @@ type State = {|
   title: string | null,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ResponseDebugModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/select-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/select-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -16,7 +17,7 @@ type State = {
   onCancel?: Function,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SelectModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   doneButton: ?HTMLButtonElement;

--- a/packages/insomnia-app/app/ui/components/modals/select-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/select-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -16,7 +16,7 @@ type State = {
   onCancel?: Function,
 };
 
-@autobind
+@autoBindMethodsForReact
 class SelectModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   doneButton: ?HTMLButtonElement;

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG, getAppName, getAppVersion, isInsomnia } from '../../../common/constants';
 import Modal from '../base/modal';
 import Button from '../base/button';
 import ModalBody from '../base/modal-body';
@@ -13,7 +14,7 @@ import Plugins from '../settings/plugins';
 import Theme from '../settings/theme';
 import * as models from '../../../models/index';
 import { Curl } from 'node-libcurl';
-import { getAppName, getAppVersion, isInsomnia } from '../../../common/constants';
+
 import Tooltip from '../tooltip';
 import { setTheme } from '../../../plugins/misc';
 import * as session from '../../../account/session';
@@ -24,7 +25,7 @@ export const TAB_INDEX_SHORTCUTS = 3;
 export const TAB_INDEX_THEMES = 2;
 export const TAB_INDEX_PLUGINS = 5;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SettingsModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import Button from '../base/button';
 import ModalBody from '../base/modal-body';
@@ -24,7 +24,7 @@ export const TAB_INDEX_SHORTCUTS = 3;
 export const TAB_INDEX_THEMES = 2;
 export const TAB_INDEX_PLUGINS = 5;
 
-@autobind
+@autoBindMethodsForReact
 class SettingsModal extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/modals/sync-branches-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-branches-modal.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import classnames from 'classnames';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -26,7 +26,7 @@ type State = {
   remoteBranches: Array<string>,
 };
 
-@autobind
+@autoBindMethodsForReact
 class SyncBranchesModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/sync-branches-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-branches-modal.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -26,7 +27,7 @@ type State = {
   remoteBranches: Array<string>,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SyncBranchesModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -24,7 +25,7 @@ const INITIAL_STATE: State = {
   workspaceName: '',
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SyncDeleteModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   input: ?HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -24,7 +24,7 @@ const INITIAL_STATE: State = {
   workspaceName: '',
 };
 
-@autobind
+@autoBindMethodsForReact
 class SyncDeleteModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   input: ?HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/sync-history-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-history-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -23,7 +23,7 @@ type State = {
   history: Array<Snapshot>,
 };
 
-@autobind
+@autoBindMethodsForReact
 class SyncHistoryModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   handleRollback: Snapshot => Promise<void>;

--- a/packages/insomnia-app/app/ui/components/modals/sync-history-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-history-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -23,7 +24,7 @@ type State = {
   history: Array<Snapshot>,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SyncHistoryModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   handleRollback: Snapshot => Promise<void>;

--- a/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -20,7 +20,7 @@ type State = {
   conflicts: Array<MergeConflict>,
 };
 
-@autobind
+@autoBindMethodsForReact
 class SyncMergeModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   _handleDone: (Array<MergeConflict>) => void;

--- a/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -20,7 +21,7 @@ type State = {
   conflicts: Array<MergeConflict>,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SyncMergeModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   _handleDone: (Array<MergeConflict>) => void;

--- a/packages/insomnia-app/app/ui/components/modals/sync-share-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-share-modal.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import Link from '../base/link';
 import Modal from '../base/modal';
@@ -25,7 +26,7 @@ type State = {
   error: string,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SyncShareModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/sync-share-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-share-modal.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import Link from '../base/link';
 import Modal from '../base/modal';
@@ -25,7 +25,7 @@ type State = {
   error: string,
 };
 
-@autobind
+@autoBindMethodsForReact
 class SyncShareModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/sync-staging-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-staging-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -46,7 +46,7 @@ const _initialState: State = {
   lookupMap: {},
 };
 
-@autobind
+@autoBindMethodsForReact
 class SyncStagingModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   _onSnapshot: ?() => void;

--- a/packages/insomnia-app/app/ui/components/modals/sync-staging-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/sync-staging-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -46,7 +47,7 @@ const _initialState: State = {
   lookupMap: {},
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SyncStagingModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
   _onSnapshot: ?() => void;

--- a/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG, DEBOUNCE_MILLIS } from '../../../common/constants';
 import classnames from 'classnames';
 import { SortableContainer, SortableElement, arrayMove } from 'react-sortable-hoc/dist/es6';
 import { Dropdown, DropdownButton, DropdownItem } from '../base/dropdown';
@@ -14,7 +15,7 @@ import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 import ModalFooter from '../base/modal-footer';
 import * as models from '../../../models';
-import { DEBOUNCE_MILLIS } from '../../../common/constants';
+
 import type { Workspace } from '../../../models/workspace';
 import type { Environment } from '../../../models/environment';
 import * as db from '../../../common/database';
@@ -98,7 +99,7 @@ const SidebarList = SortableContainer(
   ),
 );
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
   environmentEditorRef: ?EnvironmentEditor;
   environmentColorInputRef: HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import { SortableContainer, SortableElement, arrayMove } from 'react-sortable-hoc/dist/es6';
 import { Dropdown, DropdownButton, DropdownItem } from '../base/dropdown';
@@ -98,7 +98,7 @@ const SidebarList = SortableContainer(
   ),
 );
 
-@autobind
+@autoBindMethodsForReact
 class WorkspaceEnvironmentsEditModal extends React.PureComponent<Props, State> {
   environmentEditorRef: ?EnvironmentEditor;
   environmentColorInputRef: HTMLInputElement;

--- a/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import DebouncedInput from '../base/debounced-input';
 import FileInputButton from '../base/file-input-button';
@@ -42,7 +43,7 @@ type State = {
   defaultPreviewMode: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class WorkspaceSettingsModal extends React.PureComponent<Props, State> {
   modal: Modal | null;
 

--- a/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import DebouncedInput from '../base/debounced-input';
 import FileInputButton from '../base/file-input-button';
@@ -42,7 +42,7 @@ type State = {
   defaultPreviewMode: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class WorkspaceSettingsModal extends React.PureComponent<Props, State> {
   modal: Modal | null;
 

--- a/packages/insomnia-app/app/ui/components/modals/wrapper-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/wrapper-modal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -15,7 +15,7 @@ type State = {
   wide: ?boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class WrapperModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/modals/wrapper-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/wrapper-modal.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
@@ -15,7 +16,7 @@ type State = {
   wide: ?boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class WrapperModal extends React.PureComponent<Props, State> {
   modal: ?Modal;
 

--- a/packages/insomnia-app/app/ui/components/notice.js
+++ b/packages/insomnia-app/app/ui/components/notice.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 
 const DISMISSED_VALUE = 'dismissed';
@@ -17,7 +17,7 @@ type State = {
   localStorageKey: string | null,
 };
 
-@autobind
+@autoBindMethodsForReact
 class Notice extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/notice.js
+++ b/packages/insomnia-app/app/ui/components/notice.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../common/constants';
 import classnames from 'classnames';
 
 const DISMISSED_VALUE = 'dismissed';
@@ -17,7 +18,7 @@ type State = {
   localStorageKey: string | null,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Notice extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/page-layout.js
+++ b/packages/insomnia-app/app/ui/components/page-layout.js
@@ -5,7 +5,7 @@ import type { WrapperProps } from './wrapper';
 import classnames from 'classnames';
 import ErrorBoundary from './error-boundary';
 import Sidebar from './sidebar/sidebar';
-import { isInsomnia } from '../../common/constants';
+import { isInsomnia, AUTOBIND_CFG } from '../../common/constants';
 
 type Props = {
   wrapperProps: WrapperProps,
@@ -20,7 +20,7 @@ type Props = {
 
 type State = {};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class PageLayout extends React.PureComponent<Props, State> {
   // Special request updaters
   _handleStartDragSidebar(e: Event): void {

--- a/packages/insomnia-app/app/ui/components/page-layout.js
+++ b/packages/insomnia-app/app/ui/components/page-layout.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import type { WrapperProps } from './wrapper';
 import classnames from 'classnames';
 import ErrorBoundary from './error-boundary';
@@ -20,7 +20,7 @@ type Props = {
 
 type State = {};
 
-@autobind
+@autoBindMethodsForReact
 class PageLayout extends React.PureComponent<Props, State> {
   // Special request updaters
   _handleStartDragSidebar(e: Event): void {

--- a/packages/insomnia-app/app/ui/components/panes/request-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/request-pane.js
@@ -9,10 +9,11 @@ import type {
 import type { Workspace } from '../../../models/workspace';
 import type { OAuth2Token } from '../../../models/o-auth-2-token';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG, getAuthTypeName, getContentTypeName } from '../../../common/constants';
 import { deconstructQueryStringToParams, extractQueryStringFromUrl } from 'insomnia-url';
 import * as React from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
-import { getAuthTypeName, getContentTypeName } from '../../../common/constants';
+
 import * as models from '../../../models';
 import AuthDropdown from '../dropdowns/auth-dropdown';
 import ContentTypeDropdown from '../dropdowns/content-type-dropdown';
@@ -71,7 +72,7 @@ type Props = {
   oAuth2Token: ?OAuth2Token,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestPane extends React.PureComponent<Props> {
   _handleEditDescriptionAdd() {
     this._handleEditDescription(true);

--- a/packages/insomnia-app/app/ui/components/panes/request-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/request-pane.js
@@ -8,7 +8,7 @@ import type {
 } from '../../../models/request';
 import type { Workspace } from '../../../models/workspace';
 import type { OAuth2Token } from '../../../models/o-auth-2-token';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { deconstructQueryStringToParams, extractQueryStringFromUrl } from 'insomnia-url';
 import * as React from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
@@ -71,7 +71,7 @@ type Props = {
   oAuth2Token: ?OAuth2Token,
 };
 
-@autobind
+@autoBindMethodsForReact
 class RequestPane extends React.PureComponent<Props> {
   _handleEditDescriptionAdd() {
     this._handleEditDescription(true);

--- a/packages/insomnia-app/app/ui/components/panes/response-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/response-pane.js
@@ -4,6 +4,7 @@ import type { Response } from '../../../models/response';
 
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG, PREVIEW_MODE_SOURCE } from '../../../common/constants';
 import fs from 'fs';
 import mime from 'mime-types';
 import { remote } from 'electron';
@@ -20,7 +21,7 @@ import ResponseTimelineViewer from '../viewers/response-timeline-viewer';
 import ResponseHeadersViewer from '../viewers/response-headers-viewer';
 import ResponseCookiesViewer from '../viewers/response-cookies-viewer';
 import * as models from '../../../models';
-import { PREVIEW_MODE_SOURCE } from '../../../common/constants';
+
 import { getSetCookieHeaders } from '../../../common/misc';
 import { cancelRequestById } from '../../../network/network';
 import ErrorBoundary from '../error-boundary';
@@ -67,7 +68,7 @@ type Props = {
   unitTestResult: ?UnitTestResult,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ResponsePane extends React.PureComponent<Props> {
   _responseViewer: any;
 

--- a/packages/insomnia-app/app/ui/components/panes/response-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/response-pane.js
@@ -3,7 +3,7 @@ import type { Request } from '../../../models/request';
 import type { Response } from '../../../models/response';
 
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import fs from 'fs';
 import mime from 'mime-types';
 import { remote } from 'electron';
@@ -67,7 +67,7 @@ type Props = {
   unitTestResult: ?UnitTestResult,
 };
 
-@autobind
+@autoBindMethodsForReact
 class ResponsePane extends React.PureComponent<Props> {
   _responseViewer: any;
 

--- a/packages/insomnia-app/app/ui/components/rendered-query-string.js
+++ b/packages/insomnia-app/app/ui/components/rendered-query-string.js
@@ -1,10 +1,12 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { buildQueryStringFromParams, joinUrlAndQueryString, smartEncodeUrl } from 'insomnia-url';
 import CopyButton from './base/copy-button';
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
+})
 class RenderedQueryString extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/rendered-query-string.js
+++ b/packages/insomnia-app/app/ui/components/rendered-query-string.js
@@ -1,12 +1,11 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../common/constants';
 import { buildQueryStringFromParams, joinUrlAndQueryString, smartEncodeUrl } from 'insomnia-url';
 import CopyButton from './base/copy-button';
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RenderedQueryString extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/request-url-bar.js
+++ b/packages/insomnia-app/app/ui/components/request-url-bar.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { remote } from 'electron';
-import { DEBOUNCE_MILLIS, isMac } from '../../common/constants';
+import { DEBOUNCE_MILLIS, AUTOBIND_CFG, isMac } from '../../common/constants';
 import {
   Dropdown,
   DropdownButton,
@@ -44,9 +44,7 @@ type State = {
   currentTimeout: number | null,
 };
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestUrlBar extends React.PureComponent<Props, State> {
   _urlChangeDebounceTimeout: TimeoutID;
   _sendTimeout: TimeoutID;

--- a/packages/insomnia-app/app/ui/components/request-url-bar.js
+++ b/packages/insomnia-app/app/ui/components/request-url-bar.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { remote } from 'electron';
 import { DEBOUNCE_MILLIS, isMac } from '../../common/constants';
 import {
@@ -44,7 +44,9 @@ type State = {
   currentTimeout: number | null,
 };
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
+})
 class RequestUrlBar extends React.PureComponent<Props, State> {
   _urlChangeDebounceTimeout: TimeoutID;
   _sendTimeout: TimeoutID;

--- a/packages/insomnia-app/app/ui/components/response-timer.js
+++ b/packages/insomnia-app/app/ui/components/response-timer.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { REQUEST_TIME_TO_SHOW_COUNTER } from '../../common/constants';
 
-@autobind
+@autoBindMethodsForReact
 class ResponseTimer extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/response-timer.js
+++ b/packages/insomnia-app/app/ui/components/response-timer.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { REQUEST_TIME_TO_SHOW_COUNTER } from '../../common/constants';
+import { REQUEST_TIME_TO_SHOW_COUNTER, AUTOBIND_CFG } from '../../common/constants';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ResponseTimer extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/settings/account.js
+++ b/packages/insomnia-app/app/ui/components/settings/account.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Link from '../base/link';
 import LoginModal from '../modals/login-modal';
 import { hideAllModals, showModal } from '../modals/index';
@@ -20,7 +20,7 @@ type State = {
   finishedResetting: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class Account extends React.PureComponent<Props, State> {
   state = {
     code: '',

--- a/packages/insomnia-app/app/ui/components/settings/account.js
+++ b/packages/insomnia-app/app/ui/components/settings/account.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Link from '../base/link';
 import LoginModal from '../modals/login-modal';
 import { hideAllModals, showModal } from '../modals/index';
@@ -20,7 +21,7 @@ type State = {
   finishedResetting: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Account extends React.PureComponent<Props, State> {
   state = {
     code: '',

--- a/packages/insomnia-app/app/ui/components/settings/general.js
+++ b/packages/insomnia-app/app/ui/components/settings/general.js
@@ -3,9 +3,8 @@ import * as React from 'react';
 import * as fontScanner from 'font-scanner';
 import * as electron from 'electron';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import HelpTooltip from '../help-tooltip';
-import type { HttpVersion } from '../../../common/constants';
 import {
+  AUTOBIND_CFG,
   EDITOR_KEY_MAP_DEFAULT,
   EDITOR_KEY_MAP_EMACS,
   EDITOR_KEY_MAP_SUBLIME,
@@ -17,6 +16,9 @@ import {
   UPDATE_CHANNEL_BETA,
   UPDATE_CHANNEL_STABLE,
 } from '../../../common/constants';
+import HelpTooltip from '../help-tooltip';
+import type { HttpVersion } from '../../../common/constants';
+
 import type { Settings } from '../../../models/settings';
 import { setFont } from '../../../plugins/misc';
 import Tooltip from '../tooltip';
@@ -39,7 +41,7 @@ type State = {
   fontsMono: Array<{ family: string, monospace: boolean }> | null,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class General extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/settings/general.js
+++ b/packages/insomnia-app/app/ui/components/settings/general.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import * as fontScanner from 'font-scanner';
 import * as electron from 'electron';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import HelpTooltip from '../help-tooltip';
 import type { HttpVersion } from '../../../common/constants';
 import {
@@ -39,7 +39,7 @@ type State = {
   fontsMono: Array<{ family: string, monospace: boolean }> | null,
 };
 
-@autobind
+@autoBindMethodsForReact
 class General extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/settings/import-export.js
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.js
@@ -1,12 +1,13 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import Link from '../base/link';
 import { showPrompt } from '../modals/index';
 import Strings from '../../../common/strings';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ImportExport extends PureComponent {
   _handleImportUri() {
     const promptOptions = {

--- a/packages/insomnia-app/app/ui/components/settings/import-export.js
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.js
@@ -1,12 +1,12 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import Link from '../base/link';
 import { showPrompt } from '../modals/index';
 import Strings from '../../../common/strings';
 
-@autobind
+@autoBindMethodsForReact
 class ImportExport extends PureComponent {
   _handleImportUri() {
     const promptOptions = {

--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -3,7 +3,7 @@ import * as path from 'path';
 import type { Plugin } from '../../../plugins/index';
 import { getPlugins } from '../../../plugins/index';
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as electron from 'electron';
 import CopyButton from '../base/copy-button';
 import { reload } from '../../../templating/index';
@@ -31,7 +31,7 @@ type Props = {
   updateSetting: Function,
 };
 
-@autobind
+@autoBindMethodsForReact
 class Plugins extends React.PureComponent<Props, State> {
   _isMounted: boolean;
 

--- a/packages/insomnia-app/app/ui/components/settings/plugins.js
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.js
@@ -4,6 +4,12 @@ import type { Plugin } from '../../../plugins/index';
 import { getPlugins } from '../../../plugins/index';
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import {
+  AUTOBIND_CFG,
+  NPM_PACKAGE_BASE,
+  PLUGIN_HUB_BASE,
+  PLUGIN_PATH,
+} from '../../../common/constants';
 import * as electron from 'electron';
 import CopyButton from '../base/copy-button';
 import { reload } from '../../../templating/index';
@@ -11,7 +17,7 @@ import installPlugin from '../../../plugins/install';
 import HelpTooltip from '../help-tooltip';
 import Link from '../base/link';
 import { delay } from '../../../common/misc';
-import { NPM_PACKAGE_BASE, PLUGIN_HUB_BASE, PLUGIN_PATH } from '../../../common/constants';
+
 import type { PluginConfig, Settings } from '../../../models/settings';
 import { Button, ToggleSwitch } from 'insomnia-components';
 import { createPlugin } from '../../../plugins/create';
@@ -31,7 +37,7 @@ type Props = {
   updateSetting: Function,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Plugins extends React.PureComponent<Props, State> {
   _isMounted: boolean;
 

--- a/packages/insomnia-app/app/ui/components/settings/shortcuts.js
+++ b/packages/insomnia-app/app/ui/components/settings/shortcuts.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Hotkey from '../hotkey';
 import type { HotKeyDefinition, HotKeyRegistry, KeyCombination } from '../../../common/hotkeys';
 import {
@@ -24,7 +25,7 @@ type Props = {
 
 const HOT_KEY_DEFS: Array<HotKeyDefinition> = Object.keys(hotKeyRefs).map(k => hotKeyRefs[k]);
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Shortcuts extends PureComponent<Props> {
   /**
    * Checks whether the given key combination already existed.

--- a/packages/insomnia-app/app/ui/components/settings/shortcuts.js
+++ b/packages/insomnia-app/app/ui/components/settings/shortcuts.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { PureComponent } from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Hotkey from '../hotkey';
 import type { HotKeyDefinition, HotKeyRegistry, KeyCombination } from '../../../common/hotkeys';
 import {
@@ -24,7 +24,7 @@ type Props = {
 
 const HOT_KEY_DEFS: Array<HotKeyDefinition> = Object.keys(hotKeyRefs).map(k => hotKeyRefs[k]);
 
-@autobind
+@autoBindMethodsForReact
 class Shortcuts extends PureComponent<Props> {
   /**
    * Checks whether the given key combination already existed.

--- a/packages/insomnia-app/app/ui/components/settings/theme.js
+++ b/packages/insomnia-app/app/ui/components/settings/theme.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import Button from '../base/button';
 import type { Theme as ThemeType } from '../../../plugins';
 import { getThemes } from '../../../plugins';
@@ -16,7 +17,7 @@ type State = {
   themes: Array<ThemeType>,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Theme extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/settings/theme.js
+++ b/packages/insomnia-app/app/ui/components/settings/theme.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Button from '../base/button';
 import type { Theme as ThemeType } from '../../../plugins';
 import { getThemes } from '../../../plugins';
@@ -16,7 +16,7 @@ type State = {
   themes: Array<ThemeType>,
 };
 
-@autobind
+@autoBindMethodsForReact
 class Theme extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import SidebarRequestRow from './sidebar-request-row';
 import SidebarRequestGroupRow from './sidebar-request-group-row';
 import * as models from '../../../models/index';
@@ -50,7 +50,7 @@ type Props = {
   activeRequest: ?Request,
 };
 
-@autobind
+@autoBindMethodsForReact
 class SidebarChildren extends React.PureComponent<Props> {
   _contextMenu: ?SidebarCreateDropdown;
 

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import SidebarRequestRow from './sidebar-request-row';
 import SidebarRequestGroupRow from './sidebar-request-group-row';
 import * as models from '../../../models/index';
@@ -50,7 +51,7 @@ type Props = {
   activeRequest: ?Request,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SidebarChildren extends React.PureComponent<Props> {
   _contextMenu: ?SidebarCreateDropdown;
 

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-create-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-create-dropdown.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { Dropdown, DropdownHint, DropdownButton, DropdownItem } from '../base/dropdown';
 import type { HotKeyRegistry } from '../../../common/hotkeys';
 import { hotKeyRefs } from '../../../common/hotkeys';
@@ -12,7 +13,7 @@ type Props = {
   right?: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SidebarCreateDropdown extends React.PureComponent<Props> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-create-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-create-dropdown.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Dropdown, DropdownHint, DropdownButton, DropdownItem } from '../base/dropdown';
 import type { HotKeyRegistry } from '../../../common/hotkeys';
 import { hotKeyRefs } from '../../../common/hotkeys';
@@ -12,7 +12,7 @@ type Props = {
   right?: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class SidebarCreateDropdown extends React.PureComponent<Props> {
   _dropdown: ?Dropdown;
 

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-filter.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-filter.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { DEBOUNCE_MILLIS, SortOrder } from '../../../common/constants';
 import KeydownBinder from '../keydown-binder';
 import type { HotKeyRegistry } from '../../../common/hotkeys';
@@ -18,7 +18,7 @@ type Props = {
   hotKeyRegistry: HotKeyRegistry,
 };
 
-@autobind
+@autoBindMethodsForReact
 class SidebarFilter extends React.PureComponent<Props> {
   _input: ?HTMLInputElement;
   _triggerTimeout: TimeoutID;

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-filter.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-filter.js
@@ -1,7 +1,8 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { DEBOUNCE_MILLIS, SortOrder } from '../../../common/constants';
+import { AUTOBIND_CFG, DEBOUNCE_MILLIS, SortOrder } from '../../../common/constants';
+
 import KeydownBinder from '../keydown-binder';
 import type { HotKeyRegistry } from '../../../common/hotkeys';
 import { hotKeyRefs } from '../../../common/hotkeys';
@@ -18,7 +19,7 @@ type Props = {
   hotKeyRegistry: HotKeyRegistry,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SidebarFilter extends React.PureComponent<Props> {
   _input: ?HTMLInputElement;
   _triggerTimeout: TimeoutID;

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import ReactDOM from 'react-dom';
 import { DragSource, DropTarget } from 'react-dnd';
 import classnames from 'classnames';
@@ -9,7 +9,7 @@ import RequestGroupActionsDropdown from '../dropdowns/request-group-actions-drop
 import SidebarRequestRow from './sidebar-request-row';
 import * as misc from '../../../common/misc';
 
-@autobind
+@autoBindMethodsForReact
 class SidebarRequestGroupRow extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import ReactDOM from 'react-dom';
 import { DragSource, DropTarget } from 'react-dnd';
 import classnames from 'classnames';
@@ -9,7 +10,7 @@ import RequestGroupActionsDropdown from '../dropdowns/request-group-actions-drop
 import SidebarRequestRow from './sidebar-request-row';
 import * as misc from '../../../common/misc';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SidebarRequestGroupRow extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
@@ -11,15 +11,13 @@ import MethodTag from '../tags/method-tag';
 import * as models from '../../../models';
 import { showModal } from '../modals/index';
 import RequestSettingsModal from '../modals/request-settings-modal';
-import { CONTENT_TYPE_GRAPHQL } from '../../../common/constants';
+import { CONTENT_TYPE_GRAPHQL, AUTOBIND_CFG } from '../../../common/constants';
 import { getMethodOverrideHeader } from '../../../common/misc';
 import GrpcTag from '../tags/grpc-tag';
 import * as requestOperations from '../../../models/helpers/request-operations';
 import GrpcSpinner from '../grpc-spinner';
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillUpdate'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SidebarRequestRow extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-row.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import ReactDOM from 'react-dom';
 import { DragSource, DropTarget } from 'react-dnd';
 import classnames from 'classnames';
@@ -17,7 +17,9 @@ import GrpcTag from '../tags/grpc-tag';
 import * as requestOperations from '../../../models/helpers/request-operations';
 import GrpcSpinner from '../grpc-spinner';
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillUpdate'],
+})
 class SidebarRequestRow extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar.js
@@ -5,7 +5,11 @@ import type { HotKeyRegistry } from '../../../common/hotkeys';
 import type { Workspace } from '../../../models/workspace';
 import type { Environment } from '../../../models/environment';
 import classnames from 'classnames';
-import { COLLAPSE_SIDEBAR_REMS, SIDEBAR_SKINNY_REMS } from '../../../common/constants';
+import {
+  COLLAPSE_SIDEBAR_REMS,
+  SIDEBAR_SKINNY_REMS,
+  AUTOBIND_CFG,
+} from '../../../common/constants';
 import SyncDropdown from '../dropdowns/sync-dropdown';
 import type { StatusCandidate } from '../../../sync/types';
 import { isLoggedIn } from '../../../account/session';
@@ -27,7 +31,7 @@ type Props = {|
   workspaces: Array<Workspace>,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Sidebar extends React.PureComponent<Props> {
   render() {
     const {

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar.js
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import type { HotKeyRegistry } from '../../../common/hotkeys';
 import type { Workspace } from '../../../models/workspace';
 import type { Environment } from '../../../models/environment';
@@ -27,7 +27,7 @@ type Props = {|
   workspaces: Array<Workspace>,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class Sidebar extends React.PureComponent<Props> {
   render() {
     const {

--- a/packages/insomnia-app/app/ui/components/spec-editor/spec-editor-sidebar.js
+++ b/packages/insomnia-app/app/ui/components/spec-editor/spec-editor-sidebar.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import YAML from 'yaml';
 import YAMLSourceMap from 'yaml-source-map';
 import { Sidebar } from 'insomnia-components';
@@ -22,7 +23,7 @@ const StyledSpecEditorSidebar: React.ComponentType<{}> = styled.div`
   overflow-y: auto;
 `;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SpecEditorSidebar extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/spec-editor/spec-editor-sidebar.js
+++ b/packages/insomnia-app/app/ui/components/spec-editor/spec-editor-sidebar.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import styled from 'styled-components';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import YAML from 'yaml';
 import YAMLSourceMap from 'yaml-source-map';
 import { Sidebar } from 'insomnia-components';
@@ -22,7 +22,7 @@ const StyledSpecEditorSidebar: React.ComponentType<{}> = styled.div`
   overflow-y: auto;
 `;
 
-@autobind
+@autoBindMethodsForReact
 class SpecEditorSidebar extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/sync-pull-button.js
+++ b/packages/insomnia-app/app/ui/components/sync-pull-button.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../common/constants';
 import VCS from '../../sync/vcs';
 import { showError } from './modals';
 
@@ -17,7 +18,7 @@ type State = {
   loading: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class SyncPullButton extends React.PureComponent<Props, State> {
   _timeout: TimeoutID;
   state = {

--- a/packages/insomnia-app/app/ui/components/sync-pull-button.js
+++ b/packages/insomnia-app/app/ui/components/sync-pull-button.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import VCS from '../../sync/vcs';
 import { showError } from './modals';
 
@@ -17,7 +17,7 @@ type State = {
   loading: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class SyncPullButton extends React.PureComponent<Props, State> {
   _timeout: TimeoutID;
   state = {

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import clone from 'clone';
 import * as templating from '../../../templating';
@@ -46,7 +46,9 @@ type State = {
   variables: Array<{ name: string, value: string }>,
 };
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
+})
 class TagEditor extends React.PureComponent<Props, State> {
   _select: ?HTMLSelectElement;
 

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import classnames from 'classnames';
 import clone from 'clone';
 import * as templating from '../../../templating';
@@ -46,9 +47,7 @@ type State = {
   variables: Array<{ name: string, value: string }>,
 };
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillReceiveProps'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class TagEditor extends React.PureComponent<Props, State> {
   _select: ?HTMLSelectElement;
 

--- a/packages/insomnia-app/app/ui/components/templating/variable-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/variable-editor.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 
-@autobind
+@autoBindMethodsForReact
 class VariableEditor extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/templating/variable-editor.js
+++ b/packages/insomnia-app/app/ui/components/templating/variable-editor.js
@@ -1,8 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class VariableEditor extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/time-from-now.js
+++ b/packages/insomnia-app/app/ui/components/time-from-now.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import moment from 'moment';
 
 type Props = {
@@ -14,7 +14,7 @@ type State = {
   text: string,
 };
 
-@autobind
+@autoBindMethodsForReact
 class TimeFromNow extends React.PureComponent<Props, State> {
   _interval: any;
 

--- a/packages/insomnia-app/app/ui/components/time-from-now.js
+++ b/packages/insomnia-app/app/ui/components/time-from-now.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../common/constants';
 import moment from 'moment';
 
 type Props = {
@@ -14,7 +15,7 @@ type State = {
   text: string,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class TimeFromNow extends React.PureComponent<Props, State> {
   _interval: any;
 

--- a/packages/insomnia-app/app/ui/components/toast.js
+++ b/packages/insomnia-app/app/ui/components/toast.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import Link from './base/link';
 import * as models from '../../models/index';
 import {
+  AUTOBIND_CFG,
   getAppName,
   getAppPlatform,
   getAppId,
@@ -65,7 +66,7 @@ const StyledFooter: React.ComponentType<{}> = styled.footer`
   width: 100%;
 `;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Toast extends React.PureComponent<Props, State> {
   _interval: any;
 

--- a/packages/insomnia-app/app/ui/components/toast.js
+++ b/packages/insomnia-app/app/ui/components/toast.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import * as electron from 'electron';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import styled from 'styled-components';
 import classnames from 'classnames';
 import Link from './base/link';
@@ -65,7 +65,7 @@ const StyledFooter: React.ComponentType<{}> = styled.footer`
   width: 100%;
 `;
 
-@autobind
+@autoBindMethodsForReact
 class Toast extends React.PureComponent<Props, State> {
   _interval: any;
 

--- a/packages/insomnia-app/app/ui/components/tooltip.js
+++ b/packages/insomnia-app/app/ui/components/tooltip.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import ReactDOM from 'react-dom';
 
@@ -20,7 +20,7 @@ type State = {
   visible: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class Tooltip extends React.PureComponent<Props, State> {
   _showTimeout: TimeoutID;
   _hideTimeout: TimeoutID;

--- a/packages/insomnia-app/app/ui/components/tooltip.js
+++ b/packages/insomnia-app/app/ui/components/tooltip.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../common/constants';
 import classnames from 'classnames';
 import ReactDOM from 'react-dom';
 
@@ -20,7 +21,7 @@ type State = {
   visible: boolean,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Tooltip extends React.PureComponent<Props, State> {
   _showTimeout: TimeoutID;
   _hideTimeout: TimeoutID;

--- a/packages/insomnia-app/app/ui/components/viewers/response-cookies-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-cookies-viewer.js
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { Cookie } from 'tough-cookie';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ResponseCookiesViewer extends PureComponent {
   renderRow(h, i) {
     let cookie = null;

--- a/packages/insomnia-app/app/ui/components/viewers/response-cookies-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-cookies-viewer.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Cookie } from 'tough-cookie';
 
-@autobind
+@autoBindMethodsForReact
 class ResponseCookiesViewer extends PureComponent {
   renderRow(h, i) {
     let cookie = null;

--- a/packages/insomnia-app/app/ui/components/viewers/response-csv-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-csv-viewer.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import Papa from 'papaparse';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 
 type Props = {
   body: Buffer,
@@ -11,9 +12,7 @@ type State = {
   result: null | { data: Array<Array<string>> },
 };
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillUpdate'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ResponseCSVViewer extends React.PureComponent<Props, State> {
   currentHash: string;
 

--- a/packages/insomnia-app/app/ui/components/viewers/response-csv-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-csv-viewer.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import Papa from 'papaparse';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 
 type Props = {
   body: Buffer,
@@ -11,7 +11,9 @@ type State = {
   result: null | { data: Array<Array<string>> },
 };
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillUpdate'],
+})
 class ResponseCSVViewer extends React.PureComponent<Props, State> {
   currentHash: string;
 

--- a/packages/insomnia-app/app/ui/components/viewers/response-multipart.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-multipart.js
@@ -7,7 +7,7 @@ import moment from 'moment';
 import path from 'path';
 import { PassThrough } from 'stream';
 import multiparty from 'multiparty';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import ResponseViewer from './response-viewer';
 import { getContentTypeFromHeaders, PREVIEW_MODE_FRIENDLY } from '../../../common/constants';
 import type { ResponseHeader } from '../../../models/response';
@@ -46,7 +46,7 @@ type State = {
   error: string | null,
 };
 
-@autobind
+@autoBindMethodsForReact
 class ResponseMultipart extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/viewers/response-multipart.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-multipart.js
@@ -9,7 +9,11 @@ import { PassThrough } from 'stream';
 import multiparty from 'multiparty';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import ResponseViewer from './response-viewer';
-import { getContentTypeFromHeaders, PREVIEW_MODE_FRIENDLY } from '../../../common/constants';
+import {
+  getContentTypeFromHeaders,
+  PREVIEW_MODE_FRIENDLY,
+  AUTOBIND_CFG,
+} from '../../../common/constants';
 import type { ResponseHeader } from '../../../models/response';
 import { Dropdown, DropdownButton, DropdownItem } from '../base/dropdown/index';
 import WrapperModal from '../modals/wrapper-modal';
@@ -46,7 +50,7 @@ type State = {
   error: string | null,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ResponseMultipart extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/viewers/response-pdf-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-pdf-viewer.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as PDF from 'pdfjs-dist/webpack';
 
 type Props = {
@@ -12,7 +12,7 @@ type State = {
   numPages: number | null,
 };
 
-@autobind
+@autoBindMethodsForReact
 class ResponsePDFViewer extends React.PureComponent<Props, State> {
   container: ?HTMLDivElement;
   debounceTimeout: any;

--- a/packages/insomnia-app/app/ui/components/viewers/response-pdf-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-pdf-viewer.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import * as PDF from 'pdfjs-dist/webpack';
 
 type Props = {
@@ -12,7 +13,7 @@ type State = {
   numPages: number | null,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ResponsePDFViewer extends React.PureComponent<Props, State> {
   container: ?HTMLDivElement;
   debounceTimeout: any;

--- a/packages/insomnia-app/app/ui/components/viewers/response-raw.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-raw.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import CodeEditor from '../codemirror/code-editor';
 
-@autobind
+@autoBindMethodsForReact
 class ResponseRaw extends PureComponent {
   _setCodeEditorRef(n) {
     this._codeEditor = n;

--- a/packages/insomnia-app/app/ui/components/viewers/response-raw.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-raw.js
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import CodeEditor from '../codemirror/code-editor';
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ResponseRaw extends PureComponent {
   _setCodeEditorRef(n) {
     this._codeEditor = n;

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
@@ -2,6 +2,13 @@
 import * as React from 'react';
 import iconv from 'iconv-lite';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import {
+  AUTOBIND_CFG,
+  HUGE_RESPONSE_MB,
+  LARGE_RESPONSE_MB,
+  PREVIEW_MODE_FRIENDLY,
+  PREVIEW_MODE_RAW,
+} from '../../../common/constants';
 import { shell } from 'electron';
 import PDFViewer from './response-pdf-viewer';
 import CSVViewer from './response-csv-viewer';
@@ -10,12 +17,7 @@ import ResponseWebView from './response-web-view';
 import MultipartViewer from './response-multipart';
 import ResponseRaw from './response-raw';
 import ResponseError from './response-error';
-import {
-  HUGE_RESPONSE_MB,
-  LARGE_RESPONSE_MB,
-  PREVIEW_MODE_FRIENDLY,
-  PREVIEW_MODE_RAW,
-} from '../../../common/constants';
+
 import KeydownBinder from '../keydown-binder';
 import { executeHotKey } from '../../../common/hotkeys-listener';
 import { hotKeyRefs } from '../../../common/hotkeys';
@@ -50,9 +52,7 @@ type State = {
   error: string,
 };
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillMount', 'UNSAFE_componentWillReceiveProps'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ResponseViewer extends React.Component<Props, State> {
   _selectableView: any;
 

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import iconv from 'iconv-lite';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { shell } from 'electron';
 import PDFViewer from './response-pdf-viewer';
 import CSVViewer from './response-csv-viewer';
@@ -50,7 +50,9 @@ type State = {
   error: string,
 };
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillMount', 'UNSAFE_componentWillReceiveProps'],
+})
 class ResponseViewer extends React.Component<Props, State> {
   _selectableView: any;
 

--- a/packages/insomnia-app/app/ui/components/viewers/response-web-view.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-web-view.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import { EventEmitter } from 'events';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import contextMenu from 'electron-context-menu';
 
 type Props = {
@@ -11,7 +11,7 @@ type Props = {
   webpreferences: string,
 };
 
-@autobind
+@autoBindMethodsForReact
 class ResponseWebView extends React.PureComponent<Props> {
   _webview: ?HTMLElement;
 

--- a/packages/insomnia-app/app/ui/components/viewers/response-web-view.js
+++ b/packages/insomnia-app/app/ui/components/viewers/response-web-view.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { EventEmitter } from 'events';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import contextMenu from 'electron-context-menu';
 
 type Props = {
@@ -11,7 +12,7 @@ type Props = {
   webpreferences: string,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class ResponseWebView extends React.PureComponent<Props> {
   _webview: ?HTMLElement;
 

--- a/packages/insomnia-app/app/ui/components/wrapper-debug.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-debug.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Breadcrumb, Header } from 'insomnia-components';
 import PageLayout from './page-layout';
 import type { WrapperProps } from './wrapper';
@@ -51,7 +51,7 @@ type Props = {
   wrapperProps: WrapperProps,
 };
 
-@autobind
+@autoBindMethodsForReact
 class WrapperDebug extends React.PureComponent<Props> {
   _handleBreadcrumb() {
     this.props.wrapperProps.handleSetActiveActivity(ACTIVITY_HOME);

--- a/packages/insomnia-app/app/ui/components/wrapper-debug.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-debug.js
@@ -12,7 +12,7 @@ import SidebarFilter from './sidebar/sidebar-filter';
 import EnvironmentsDropdown from './dropdowns/environments-dropdown';
 import designerLogo from '../images/insomnia-designer-logo.svg';
 import WorkspaceDropdown from './dropdowns/workspace-dropdown';
-import { ACTIVITY_HOME, isInsomnia } from '../../common/constants';
+import { ACTIVITY_HOME, AUTOBIND_CFG, isInsomnia } from '../../common/constants';
 import ActivityToggle from './activity-toggle';
 import { isGrpcRequest } from '../../models/helpers/is-model';
 import type { ForceToWorkspace } from '../redux/modules/helpers';
@@ -51,7 +51,7 @@ type Props = {
   wrapperProps: WrapperProps,
 };
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class WrapperDebug extends React.PureComponent<Props> {
   _handleBreadcrumb() {
     this.props.wrapperProps.handleSetActiveActivity(ACTIVITY_HOME);

--- a/packages/insomnia-app/app/ui/components/wrapper-design.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.js
@@ -19,7 +19,7 @@ import * as models from '../../models/index';
 import { parseApiSpec } from '../../common/api-specs';
 import { getConfigGenerators } from '../../plugins';
 import type { GlobalActivity } from '../../common/constants';
-import { ACTIVITY_HOME } from '../../common/constants';
+import { ACTIVITY_HOME, AUTOBIND_CFG } from '../../common/constants';
 import ActivityToggle from './activity-toggle';
 
 const spectral = new Spectral();
@@ -41,7 +41,7 @@ type State = {|
   }>,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class WrapperDesign extends React.PureComponent<Props, State> {
   editor: ?CodeEditor;
   debounceTimeout: IntervalID;

--- a/packages/insomnia-app/app/ui/components/wrapper-design.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import type { WrapperProps } from './wrapper';
 import PageLayout from './page-layout';
 import { Breadcrumb, Button, Header, NoticeTable } from 'insomnia-components';
@@ -41,7 +41,7 @@ type State = {|
   }>,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class WrapperDesign extends React.PureComponent<Props, State> {
   editor: ?CodeEditor;
   debounceTimeout: IntervalID;

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -4,7 +4,7 @@ import * as git from 'isomorphic-git';
 import path from 'path';
 import * as db from '../../common/database';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { AUTOBIND_CFG } from '../../../common/constants';
+import { AUTOBIND_CFG, ACTIVITY_DEBUG, ACTIVITY_HOME, ACTIVITY_SPEC } from '../../common/constants';
 import type { Workspace } from '../../models/workspace';
 import 'swagger-ui-react/swagger-ui.css';
 import {
@@ -29,7 +29,7 @@ import YAML from 'yaml';
 import TimeFromNow from './time-from-now';
 import Highlight from './base/highlight';
 import type { GlobalActivity } from '../../common/constants';
-import { ACTIVITY_DEBUG, ACTIVITY_HOME, ACTIVITY_SPEC } from '../../common/constants';
+
 import { fuzzyMatchAll } from '../../common/misc';
 import type { WrapperProps } from './wrapper';
 import Notice from './notice';

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as git from 'isomorphic-git';
 import path from 'path';
 import * as db from '../../common/database';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import type { Workspace } from '../../models/workspace';
 import 'swagger-ui-react/swagger-ui.css';
 import {
@@ -57,7 +57,7 @@ type State = {|
   filter: string,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class WrapperHome extends React.PureComponent<Props, State> {
   state = {
     filter: '',

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -4,6 +4,7 @@ import * as git from 'isomorphic-git';
 import path from 'path';
 import * as db from '../../common/database';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import type { Workspace } from '../../models/workspace';
 import 'swagger-ui-react/swagger-ui.css';
 import {
@@ -57,7 +58,7 @@ type State = {|
   filter: string,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class WrapperHome extends React.PureComponent<Props, State> {
   state = {
     filter: '',

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import 'swagger-ui-react/swagger-ui.css';
 import { showPrompt } from './modals';
 import type { BaseModel } from '../../models';
@@ -24,7 +24,7 @@ type State = {|
   step: number,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class WrapperOnboarding extends React.PureComponent<Props, State> {
   state = {
     step: 1,

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
@@ -5,7 +5,13 @@ import 'swagger-ui-react/swagger-ui.css';
 import { showPrompt } from './modals';
 import type { BaseModel } from '../../models';
 import * as models from '../../models';
-import { ACTIVITY_HOME, getAppLongName, getAppName, getAppSynopsis } from '../../common/constants';
+import {
+  AUTOBIND_CFG,
+  ACTIVITY_HOME,
+  getAppLongName,
+  getAppName,
+  getAppSynopsis,
+} from '../../common/constants';
 import type { WrapperProps } from './wrapper';
 import PageLayout from './page-layout';
 import * as db from '../../common/database';
@@ -24,7 +30,7 @@ type State = {|
   step: number,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class WrapperOnboarding extends React.PureComponent<Props, State> {
   state = {
     step: 1,

--- a/packages/insomnia-app/app/ui/components/wrapper-unit-test.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-unit-test.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { AUTOBIND_CFG } from '../../../common/constants';
+import { AUTOBIND_CFG, ACTIVITY_HOME } from '../../common/constants';
 import classnames from 'classnames';
 import PageLayout from './page-layout';
 import {
@@ -30,7 +30,6 @@ import type { UnitTestSuite } from '../../models/unit-test-suite';
 import ActivityToggle from './activity-toggle';
 import { getSendRequestCallback } from '../../common/send-request';
 import type { GlobalActivity } from '../../common/constants';
-import { ACTIVITY_HOME } from '../../common/constants';
 
 type Props = {|
   children: SidebarChildObjects,

--- a/packages/insomnia-app/app/ui/components/wrapper-unit-test.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-unit-test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import PageLayout from './page-layout';
 import {
@@ -43,7 +43,7 @@ type State = {|
   resultsError: string | null,
 |};
 
-@autobind
+@autoBindMethodsForReact
 class WrapperUnitTest extends React.PureComponent<Props, State> {
   state = {
     testsRunning: null,

--- a/packages/insomnia-app/app/ui/components/wrapper-unit-test.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-unit-test.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import classnames from 'classnames';
 import PageLayout from './page-layout';
 import {
@@ -43,7 +44,7 @@ type State = {|
   resultsError: string | null,
 |};
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class WrapperUnitTest extends React.PureComponent<Props, State> {
   state = {
     testsRunning: null,

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -14,6 +14,7 @@ import type {
 import type { SidebarChildObjects } from './sidebar/sidebar-children';
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { registerModal, showModal } from './modals/index';
 import AlertModal from './modals/alert-modal';
 import WrapperModal from './modals/wrapper-modal';
@@ -216,7 +217,7 @@ const rUpdate = (request, ...args) => {
 
 const sUpdate = models.settings.update;
 
-@autoBindMethodsForReact
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class Wrapper extends React.PureComponent<WrapperProps, State> {
   constructor(props: any) {
     super(props);

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -14,7 +14,16 @@ import type {
 import type { SidebarChildObjects } from './sidebar/sidebar-children';
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { AUTOBIND_CFG } from '../../../common/constants';
+import {
+  AUTOBIND_CFG,
+  ACTIVITY_DEBUG,
+  ACTIVITY_HOME,
+  ACTIVITY_INSOMNIA,
+  ACTIVITY_SPEC,
+  ACTIVITY_UNIT_TEST,
+  getAppName,
+  SortOrder,
+} from '../../common/constants';
 import { registerModal, showModal } from './modals/index';
 import AlertModal from './modals/alert-modal';
 import WrapperModal from './modals/wrapper-modal';
@@ -81,15 +90,7 @@ import type { UnitTest } from '../../models/unit-test';
 import type { UnitTestResult } from '../../models/unit-test-result';
 import type { UnitTestSuite } from '../../models/unit-test-suite';
 import type { GlobalActivity } from '../../common/constants';
-import {
-  ACTIVITY_DEBUG,
-  ACTIVITY_HOME,
-  ACTIVITY_INSOMNIA,
-  ACTIVITY_SPEC,
-  ACTIVITY_UNIT_TEST,
-  getAppName,
-  SortOrder,
-} from '../../common/constants';
+
 import { Spectral } from '@stoplight/spectral';
 import ProtoFilesModal from './modals/proto-files-modal';
 import { GrpcDispatchModalWrapper } from '../context/grpc';

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -13,7 +13,7 @@ import type {
 } from '../../models/request';
 import type { SidebarChildObjects } from './sidebar/sidebar-children';
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { registerModal, showModal } from './modals/index';
 import AlertModal from './modals/alert-modal';
 import WrapperModal from './modals/wrapper-modal';
@@ -216,7 +216,7 @@ const rUpdate = (request, ...args) => {
 
 const sUpdate = models.settings.update;
 
-@autobind
+@autoBindMethodsForReact
 class Wrapper extends React.PureComponent<WrapperProps, State> {
   constructor(props: any) {
     super(props);

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import fs from 'fs';
 import { clipboard, ipcRenderer, remote } from 'electron';
 import { parse as urlParse } from 'url';
@@ -99,8 +99,11 @@ import { isGrpcRequest, isGrpcRequestId, isRequestGroup } from '../../models/hel
 import * as requestOperations from '../../models/helpers/request-operations';
 import { GrpcProvider } from '../context/grpc';
 import { sortMethodMap } from '../../common/sorting';
+import withDragDropContext from '../context/app/drag-drop-context';
 
-@autobind
+@autoBindMethodsForReact({
+  methodsToIgnore: ['UNSAFE_componentWillMount', 'UNSAFE_componentWillReceiveProps'],
+})
 class App extends PureComponent {
   constructor(props) {
     super(props);
@@ -1626,4 +1629,4 @@ async function _moveDoc(docToMove, parentId, targetId, targetOffset) {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(App);
+export default connect(mapStateToProps, mapDispatchToProps)(withDragDropContext(App));

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import fs from 'fs';
 import { clipboard, ipcRenderer, remote } from 'electron';
 import { parse as urlParse } from 'url';
@@ -101,9 +102,7 @@ import { GrpcProvider } from '../context/grpc';
 import { sortMethodMap } from '../../common/sorting';
 import withDragDropContext from '../context/app/drag-drop-context';
 
-@autoBindMethodsForReact({
-  methodsToIgnore: ['UNSAFE_componentWillMount', 'UNSAFE_componentWillReceiveProps'],
-})
+@autoBindMethodsForReact(AUTOBIND_CFG)
 class App extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -1,21 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { AUTOBIND_CFG } from '../../../common/constants';
-import fs from 'fs';
-import { clipboard, ipcRenderer, remote } from 'electron';
-import { parse as urlParse } from 'url';
-import HTTPSnippet from 'httpsnippet';
-import ReactDOM from 'react-dom';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import Wrapper from '../components/wrapper';
-import WorkspaceEnvironmentsEditModal from '../components/modals/workspace-environments-edit-modal';
-import Toast from '../components/toast';
-import CookiesModal from '../components/modals/cookies-modal';
-import RequestSwitcherModal from '../components/modals/request-switcher-modal';
-import SettingsModal, { TAB_INDEX_SHORTCUTS } from '../components/modals/settings-modal';
 import {
+  AUTOBIND_CFG,
   ACTIVITY_HOME,
   ACTIVITY_INSOMNIA,
   COLLAPSE_SIDEBAR_REMS,
@@ -32,6 +19,20 @@ import {
   getAppId,
   getAppName,
 } from '../../common/constants';
+import fs from 'fs';
+import { clipboard, ipcRenderer, remote } from 'electron';
+import { parse as urlParse } from 'url';
+import HTTPSnippet from 'httpsnippet';
+import ReactDOM from 'react-dom';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import Wrapper from '../components/wrapper';
+import WorkspaceEnvironmentsEditModal from '../components/modals/workspace-environments-edit-modal';
+import Toast from '../components/toast';
+import CookiesModal from '../components/modals/cookies-modal';
+import RequestSwitcherModal from '../components/modals/request-switcher-modal';
+import SettingsModal, { TAB_INDEX_SHORTCUTS } from '../components/modals/settings-modal';
+
 import * as globalActions from '../redux/modules/global';
 import * as entitiesActions from '../redux/modules/entities';
 import * as db from '../../common/database';

--- a/packages/insomnia-app/app/ui/context/app/drag-drop-context.js
+++ b/packages/insomnia-app/app/ui/context/app/drag-drop-context.js
@@ -1,0 +1,4 @@
+import { DragDropContext } from 'react-dnd';
+import DNDBackend from '../../dnd-backend';
+
+export default DragDropContext(DNDBackend);

--- a/packages/insomnia-app/app/ui/index.js
+++ b/packages/insomnia-app/app/ui/index.js
@@ -1,3 +1,4 @@
+import { hot } from 'react-hot-loader';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
@@ -9,9 +10,6 @@ import { init as initPlugins } from '../plugins';
 import './css/index.less';
 import { getAppLongName, isDevelopment } from '../common/constants';
 import { setFont, setTheme } from '../plugins/misc';
-import { AppContainer } from 'react-hot-loader';
-import { DragDropContext } from 'react-dnd';
-import DNDBackend from './dnd-backend';
 import { trackEvent } from '../common/analytics';
 import * as styledComponents from 'styled-components';
 import { initNewOAuthSession } from '../network/o-auth-2/misc';
@@ -37,27 +35,17 @@ document.title = getAppLongName();
   // Create Redux store
   const store = await initStore();
 
-  const context = DragDropContext(DNDBackend);
-  const render = Component => {
-    const DnDComponent = context(Component);
+  const render = App => {
+    const TheHottestApp = hot(module)(App);
     ReactDOM.render(
-      <AppContainer>
-        <Provider store={store}>
-          <DnDComponent />
-        </Provider>
-      </AppContainer>,
+      <Provider store={store}>
+        <TheHottestApp />
+      </Provider>,
       document.getElementById('root'),
     );
   };
 
   render(App);
-
-  // Hot Module Replacement API
-  if (module.hot) {
-    // module.hot.accept('./containers/app', () => {
-    //   render(App);
-    // });
-  }
 })();
 
 // Export some useful things for dev

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -4119,20 +4119,6 @@
 				"yauzl": "^2.10.0"
 			},
 			"dependencies": {
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-				},
-				"js-yaml": {
-					"version": "3.14.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
 				"swagger-parser": {
 					"version": "8.0.3",
 					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
@@ -6049,9 +6035,9 @@
 					}
 				},
 				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -6180,9 +6166,9 @@
 					}
 				},
 				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -6302,6 +6288,11 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"class-autobind-decorator": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/class-autobind-decorator/-/class-autobind-decorator-3.0.1.tgz",
+			"integrity": "sha512-/5QCUe6KYGIMDDFEI/UrVc3egWVTVhuK00ppY/8sS/9f0KapY5Y2TirBbM1qICRq0p0WafuTaMfEGL2GKHcN0Q=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -6885,9 +6876,9 @@
 					}
 				},
 				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -11783,9 +11774,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -13508,20 +13499,6 @@
 				"ono": "^6.0.0"
 			},
 			"dependencies": {
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-				},
-				"js-yaml": {
-					"version": "3.14.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
 				"ono": {
 					"version": "6.0.1",
 					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
@@ -16433,9 +16410,9 @@
 					}
 				},
 				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -18008,9 +17985,9 @@
 			}
 		},
 		"react-hot-loader": {
-			"version": "4.12.21",
-			"resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.21.tgz",
-			"integrity": "sha512-Ynxa6ROfWUeKWsTHxsrL2KMzujxJVPjs385lmB2t5cHUxdoRPGind9F00tOkdc1l5WBleOF4XEAMILY1KPIIDA==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz",
+			"integrity": "sha512-JrLlvUPqh6wIkrK2hZDfOyq/Uh/WeVEr8nc7hkn2/3Ul0sx1Kr5y4kOGNacNRoj7RhwLNcQ3Udf1KJXrqc0ZtA==",
 			"dev": true,
 			"requires": {
 				"fast-levenshtein": "^2.0.6",
@@ -19222,9 +19199,9 @@
 					}
 				},
 				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -19629,9 +19606,9 @@
 					}
 				},
 				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -20610,11 +20587,6 @@
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
 					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
 				},
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-				},
 				"json-schema-ref-parser": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
@@ -20623,17 +20595,6 @@
 						"call-me-maybe": "^1.0.1",
 						"js-yaml": "^3.12.1",
 						"ono": "^4.0.11"
-					},
-					"dependencies": {
-						"js-yaml": {
-							"version": "3.14.1",
-							"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-							"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-							"requires": {
-								"argparse": "^1.0.7",
-								"esprima": "^4.0.0"
-							}
-						}
 					}
 				},
 				"ono": {
@@ -21673,9 +21634,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},
@@ -21688,9 +21649,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+					"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 				}
 			}
 		},

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -60,7 +60,7 @@
     ]
   },
   "packedDependencies": [
-    "autobind-decorator",
+    "class-autobind-decorator",
     "classnames",
     "codemirror",
     "codemirror-graphql",
@@ -98,9 +98,9 @@
   "dependencies": {
     "@hot-loader/react-dom": "^16.8.6",
     "@stoplight/spectral": "^4.1.1",
-    "autobind-decorator": "^2.4.0",
     "aws4": "^1.9.0",
     "axios": "^0.19.0",
+    "class-autobind-decorator": "^3.0.1",
     "classnames": "^2.2.5",
     "clone": "^2.1.0",
     "codemirror": "^5.50.0",
@@ -211,7 +211,7 @@
     "license-checker": "^25.0.1",
     "ncp": "^2.0.0",
     "prompt-run": "^1.4.5",
-    "react-hot-loader": "^4.8.3",
+    "react-hot-loader": "^4.13.0",
     "react-test-renderer": "^16.14.0",
     "source-map-loader": "^1.0.0",
     "spectron": "^11.1.0",

--- a/packages/insomnia-components/components/dropdown/dropdown-item.js
+++ b/packages/insomnia-components/components/dropdown/dropdown-item.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import styled, { css } from 'styled-components';
 
 const StyledButton = styled.button`
@@ -74,7 +74,7 @@ const StyledIconContainer = styled.div`
   padding-right: var(--padding-md);
 `;
 
-@autobind
+@autoBindMethodsForReact
 class DropdownItem extends PureComponent {
   _handleClick(e) {
     const { stayOpenAfterClick, onClick, disabled } = this.props;

--- a/packages/insomnia-components/components/dropdown/dropdown.js
+++ b/packages/insomnia-components/components/dropdown/dropdown.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import fuzzySort from 'fuzzysort';
 import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import DropdownItem from './dropdown-item';
 import DropdownDivider from './dropdown-divider';
@@ -109,7 +109,7 @@ const StyledMenu = styled.div`
   }
 `;
 
-@autobind
+@autoBindMethodsForReact
 class Dropdown extends PureComponent {
   constructor(props) {
     super(props);

--- a/packages/insomnia-components/components/help-tooltip.js
+++ b/packages/insomnia-components/components/help-tooltip.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Tooltip from './tooltip';
 import SvgIcon from './svg-icon';
 
@@ -15,7 +15,7 @@ type Props = {
   info?: boolean,
 };
 
-@autobind
+@autoBindMethodsForReact
 class HelpTooltip extends React.PureComponent<Props> {
   render() {
     const { children, className, style, info, position, delay } = this.props;

--- a/packages/insomnia-components/components/tooltip.js
+++ b/packages/insomnia-components/components/tooltip.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import autobind from 'autobind-decorator';
+import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
@@ -60,7 +60,7 @@ const StyledTooltipBubble: React.ComponentType<{}> = styled.div`
   }
 `;
 
-@autobind
+@autoBindMethodsForReact
 class Tooltip extends React.PureComponent<Props, State> {
   _showTimeout: TimeoutID;
   _hideTimeout: TimeoutID;

--- a/packages/insomnia-components/flow-typed/class-autobind-decorator.js
+++ b/packages/insomnia-components/flow-typed/class-autobind-decorator.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare module 'class-autobind-decorator' {
+  declare module.exports: *;
+}

--- a/packages/insomnia-components/package-lock.json
+++ b/packages/insomnia-components/package-lock.json
@@ -6625,11 +6625,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
-    "autobind-decorator": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/autobind-decorator/-/autobind-decorator-2.4.0.tgz",
-      "integrity": "sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw=="
-    },
     "autoprefixer": {
       "version": "9.8.6",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
@@ -8039,6 +8034,11 @@
           "dev": true
         }
       }
+    },
+    "class-autobind-decorator": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/class-autobind-decorator/-/class-autobind-decorator-3.0.1.tgz",
+      "integrity": "sha512-/5QCUe6KYGIMDDFEI/UrVc3egWVTVhuK00ppY/8sS/9f0KapY5Y2TirBbM1qICRq0p0WafuTaMfEGL2GKHcN0Q=="
     },
     "class-utils": {
       "version": "0.3.6",

--- a/packages/insomnia-components/package.json
+++ b/packages/insomnia-components/package.json
@@ -59,7 +59,7 @@
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
-    "autobind-decorator": "^2.4.0",
+    "class-autobind-decorator": "^3.0.1",
     "classnames": "^2.2.6",
     "framer-motion": "^1.10.3",
     "fuzzysort": "^1.1.4",

--- a/packages/insomnia-inso/package-lock.json
+++ b/packages/insomnia-inso/package-lock.json
@@ -1060,60 +1060,6 @@
 				"minimist": "^1.2.0"
 			}
 		},
-		"@hapi/b64": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
-			"integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
-			"requires": {
-				"@hapi/hoek": "8.x.x"
-			}
-		},
-		"@hapi/boom": {
-			"version": "7.4.11",
-			"resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-			"integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
-			"requires": {
-				"@hapi/hoek": "8.x.x"
-			}
-		},
-		"@hapi/bounce": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.2.tgz",
-			"integrity": "sha512-3bnb1AlcEByFZnpDIidxQyw1Gds81z/1rSqlx4bIEE+wUN0ATj0D49B5cE1wGocy90Rp/de4tv7GjsKd5RQeew==",
-			"requires": {
-				"@hapi/boom": "7.x.x",
-				"@hapi/hoek": "^8.3.1"
-			}
-		},
-		"@hapi/cryptiles": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
-			"integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
-			"requires": {
-				"@hapi/boom": "7.x.x"
-			}
-		},
-		"@hapi/hoek": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-			"integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
-		},
-		"@hapi/sntp": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@hapi/sntp/-/sntp-3.1.2.tgz",
-			"integrity": "sha512-i2UehKbFPKtKVXhp4v7wV3qJxkGV2TAPlZ5YSpmsqv/2eygXYYI+etBJ5r4T8kbyslhxgqQyHNS6xstL92Vmrg==",
-			"requires": {
-				"@hapi/boom": "7.x.x",
-				"@hapi/bounce": "1.x.x",
-				"@hapi/hoek": "8.x.x",
-				"@hapi/teamwork": "3.x.x"
-			}
-		},
-		"@hapi/teamwork": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
-			"integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ=="
-		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1632,11 +1578,6 @@
 			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
 			"dev": true
 		},
-		"@ungap/promise-all-settled": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
-		},
 		"@webassemblyjs/ast": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -1824,26 +1765,11 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
-		"JSV": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-			"integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
-		},
-		"a-sync-waterfall": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-			"integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
-		},
 		"abab": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
 			"integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
 			"dev": true
-		},
-		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 		},
 		"abort-controller": {
 			"version": "3.0.0",
@@ -2073,56 +1999,17 @@
 				}
 			}
 		},
-		"apiconnect-wsdl": {
-			"version": "1.8.31",
-			"resolved": "https://registry.npmjs.org/apiconnect-wsdl/-/apiconnect-wsdl-1.8.31.tgz",
-			"integrity": "sha512-kNs26If9xCJnGolVTAt0VWIA8KrqwodQLqDRTrfc7txD54LJ+hFx638sPYEdG9jw78eifWyy+FBlS5befYSa8Q==",
-			"requires": {
-				"iconv-lite": "^0.4.24",
-				"js-yaml": "^3.13.1",
-				"jszip": "^3.2.2",
-				"lodash": "^4.17.15",
-				"q": "^1.5.1",
-				"swagger-parser": "8.0.3",
-				"xml2js": "^0.4.22",
-				"xmldom": "^0.1.27",
-				"yauzl": "^2.10.0"
-			},
-			"dependencies": {
-				"swagger-parser": {
-					"version": "8.0.3",
-					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
-					"integrity": "sha512-y2gw+rTjn7Z9J+J1qwbBm0UL93k/VREDCveKBK6iGjf7KXC6QGshbnpEmeHL0ZkCgmIghsXzpNzPSbBH91BAEQ==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"json-schema-ref-parser": "^7.1.1",
-						"ono": "^5.1.0",
-						"openapi-schemas": "^1.0.2",
-						"openapi-types": "^1.3.5",
-						"swagger-methods": "^2.0.1",
-						"z-schema": "^4.1.1"
-					}
-				}
-			}
-		},
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-		},
-		"are-we-there-yet": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			}
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -2145,26 +2032,17 @@
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
 		},
-		"array-filter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-			"integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
-		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
 		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -2218,12 +2096,8 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-		},
-		"assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -2248,20 +2122,11 @@
 			"dev": true,
 			"optional": true
 		},
-		"async-lock": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.2.6.tgz",
-			"integrity": "sha512-gobUp/bRWL/uJsxi4ZK7NM770s5d2Tx5Hl7uxFIcN6yTz1Kvy2RCSKEvzhLsjAAnYaNa8lDvcjy9ybM6lXFjIg=="
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"atob": {
 			"version": "2.1.2",
@@ -2269,31 +2134,17 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
 		},
-		"available-typed-arrays": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
-			"integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
-			"requires": {
-				"array-filter": "^1.0.0"
-			}
-		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
-		},
-		"axios": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-			"requires": {
-				"follow-redirects": "1.5.10"
-			}
+			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+			"dev": true
 		},
 		"babel-jest": {
 			"version": "26.1.0",
@@ -2385,7 +2236,8 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
@@ -2452,6 +2304,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -2492,6 +2345,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
 			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+			"dev": true,
 			"optional": true
 		},
 		"binary-search-tree": {
@@ -2533,6 +2387,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2557,11 +2412,6 @@
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
 			"dev": true
-		},
-		"browser-stdout": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
@@ -2712,11 +2562,6 @@
 				}
 			}
 		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2800,40 +2645,10 @@
 				"unset-value": "^1.0.0"
 			}
 		},
-		"call-bind": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
-			"requires": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.0"
-			}
-		},
-		"call-me-maybe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
-		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
-		},
-		"camel-case": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-			"requires": {
-				"pascal-case": "^3.1.2",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"camelcase": {
 			"version": "5.3.1",
@@ -2845,23 +2660,6 @@
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001090.tgz",
 			"integrity": "sha512-QzPRKDCyp7RhjczTPZaqK3CjPA5Ht2UnXhZhCI4f7QiB5JK6KEuZBxIzyWnB3wO4hgAj4GMRxAhuiacfw0Psjg==",
 			"dev": true
-		},
-		"capital-case": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -2875,20 +2673,8 @@
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
-		"chai": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-			"requires": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
-				"type-detect": "^4.0.5"
-			}
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"chalk": {
 			"version": "4.0.0",
@@ -2936,47 +2722,17 @@
 				}
 			}
 		},
-		"change-case": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-			"requires": {
-				"camel-case": "^4.1.2",
-				"capital-case": "^1.0.4",
-				"constant-case": "^3.0.4",
-				"dot-case": "^3.0.4",
-				"header-case": "^2.0.4",
-				"no-case": "^3.0.4",
-				"param-case": "^3.0.4",
-				"pascal-case": "^3.1.2",
-				"path-case": "^3.0.4",
-				"sentence-case": "^3.0.4",
-				"snake-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"char-regex": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
 			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
 			"dev": true
 		},
-		"check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
-		},
 		"chokidar": {
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
 			"integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "~3.1.1",
@@ -2993,6 +2749,7 @@
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"normalize-path": "^3.0.0",
@@ -3004,7 +2761,8 @@
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -3054,20 +2812,6 @@
 				}
 			}
 		},
-		"clean-git-ref": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="
-		},
-		"cli": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
-			"integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
-			"requires": {
-				"exit": "0.1.2",
-				"glob": "^7.1.1"
-			}
-		},
 		"cliui": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -3077,11 +2821,6 @@
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^6.2.0"
 			}
-		},
-		"clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 		},
 		"clone-deep": {
 			"version": "4.0.1",
@@ -3104,11 +2843,6 @@
 			"resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
 			"integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw=="
 		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-		},
 		"collect-v8-coverage": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -3125,15 +2859,6 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"color": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-			"integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
-			"requires": {
-				"color-convert": "^1.9.1",
-				"color-string": "^1.5.4"
-			}
-		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3147,19 +2872,11 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
-		"color-string": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-			"integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
-			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
-		},
 		"combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -3184,7 +2901,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -3208,28 +2926,6 @@
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
 			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
 			"dev": true
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-		},
-		"constant-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -3324,15 +3020,6 @@
 				"parse-json": "^5.0.0",
 				"path-type": "^4.0.0",
 				"yaml": "^1.7.2"
-			}
-		},
-		"crc-32": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
-			"integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
-			"requires": {
-				"exit-on-epipe": "~1.0.1",
-				"printj": "~1.1.0"
 			}
 		},
 		"create-ecdh": {
@@ -3443,6 +3130,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -3462,11 +3150,6 @@
 				"whatwg-mimetype": "^2.3.0",
 				"whatwg-url": "^8.0.0"
 			}
-		},
-		"date-now": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
 		},
 		"debug": {
 			"version": "4.1.1",
@@ -3492,67 +3175,6 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
-		"decompress-response": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-			"requires": {
-				"mimic-response": "^2.0.0"
-			}
-		},
-		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-			"requires": {
-				"type-detect": "^4.0.0"
-			}
-		},
-		"deep-equal": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
-			"integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
-			"requires": {
-				"call-bind": "^1.0.0",
-				"es-get-iterator": "^1.1.1",
-				"get-intrinsic": "^1.0.1",
-				"is-arguments": "^1.0.4",
-				"is-date-object": "^1.0.2",
-				"is-regex": "^1.1.1",
-				"isarray": "^2.0.5",
-				"object-is": "^1.1.4",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.2",
-				"regexp.prototype.flags": "^1.3.0",
-				"side-channel": "^1.0.3",
-				"which-boxed-primitive": "^1.0.1",
-				"which-collection": "^1.0.1",
-				"which-typed-array": "^1.1.2"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
-			}
-		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -3568,6 +3190,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -3626,12 +3249,8 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -3659,32 +3278,17 @@
 			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
 			"dev": true
 		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-		},
 		"detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
 		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-		},
 		"diff-sequences": {
 			"version": "26.0.0",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
 			"integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
 			"dev": true
-		},
-		"diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha1-1OXDpM305f4SEatC5pP8tDIVgPw="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -3705,37 +3309,11 @@
 				}
 			}
 		},
-		"dom-serializer": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-			"requires": {
-				"domelementtype": "^2.0.1",
-				"entities": "^2.0.0"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-					"integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
-				},
-				"entities": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-					"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
-				}
-			}
-		},
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
 			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
 			"dev": true
-		},
-		"domelementtype": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
 		},
 		"domexception": {
 			"version": "2.0.1",
@@ -3754,44 +3332,6 @@
 				}
 			}
 		},
-		"domhandler": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-			"integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-			"requires": {
-				"domelementtype": "1"
-			}
-		},
-		"domutils": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-			"requires": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
-			}
-		},
-		"dot-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"duplexer": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-		},
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -3808,6 +3348,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -3893,11 +3434,6 @@
 				"ansi-colors": "^3.2.1"
 			}
 		},
-		"entities": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-			"integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
-		},
 		"env-paths": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
@@ -3923,69 +3459,6 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"requires": {
 				"is-arrayish": "^0.2.1"
-			}
-		},
-		"es-abstract": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-			"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
-			"requires": {
-				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1",
-				"is-callable": "^1.2.2",
-				"is-regex": "^1.1.1",
-				"object-inspect": "^1.8.0",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.1",
-				"string.prototype.trimend": "^1.0.1",
-				"string.prototype.trimstart": "^1.0.1"
-			},
-			"dependencies": {
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
-			}
-		},
-		"es-get-iterator": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.1.tgz",
-			"integrity": "sha512-qorBw8Y7B15DVLaJWy6WdEV/ZkieBcu6QCq/xzWzGOKJqgG1j754vXRfZ3NY7HSShneqU43mPB4OkQBTkvHhFw==",
-			"requires": {
-				"call-bind": "^1.0.0",
-				"get-intrinsic": "^1.0.1",
-				"has-symbols": "^1.0.1",
-				"is-arguments": "^1.0.4",
-				"is-map": "^2.0.1",
-				"is-set": "^2.0.1",
-				"is-string": "^1.0.5",
-				"isarray": "^2.0.5"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-				}
-			}
-		},
-		"es-to-primitive": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"requires": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
 			}
 		},
 		"es6-promise": {
@@ -4065,20 +3538,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
-		"event-stream": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-			"requires": {
-				"duplexer": "~0.1.1",
-				"from": "~0",
-				"map-stream": "~0.1.0",
-				"pause-stream": "0.0.11",
-				"split": "0.3",
-				"stream-combiner": "~0.0.4",
-				"through": "~2.3.1"
-			}
-		},
 		"event-target-shim": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -4126,12 +3585,8 @@
 		"exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
-		},
-		"exit-on-epipe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-			"integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "2.1.4",
@@ -4327,7 +3782,8 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -4376,14 +3832,6 @@
 			"dev": true,
 			"requires": {
 				"bser": "2.1.1"
-			}
-		},
-		"fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-			"requires": {
-				"pend": "~1.2.0"
 			}
 		},
 		"figgy-pudding": {
@@ -4587,11 +4035,6 @@
 				}
 			}
 		},
-		"flat": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
-		},
 		"flow-bin": {
 			"version": "0.126.1",
 			"resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.126.1.tgz",
@@ -4608,59 +4051,28 @@
 				"readable-stream": "^2.3.6"
 			}
 		},
-		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
-			}
-		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
 		},
-		"foreach": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"format-util": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-			"integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -4671,11 +4083,6 @@
 				"map-cache": "^0.2.2"
 			}
 		},
-		"from": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
-		},
 		"from2": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -4684,33 +4091,6 @@
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
-			}
-		},
-		"fs-extra": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-			"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-			"requires": {
-				"at-least-node": "^1.0.0",
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^1.0.0"
-			}
-		},
-		"fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"requires": {
-				"minipass": "^3.0.0"
-			}
-		},
-		"fs-readfile-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fs-readfile-promise/-/fs-readfile-promise-2.0.1.tgz",
-			"integrity": "sha1-gAI4I5gfn//+AWCei+Zo9prknnA=",
-			"requires": {
-				"graceful-fs": "^4.1.2"
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -4725,34 +4105,17 @@
 				"readable-stream": "1 || 2"
 			}
 		},
-		"fs-writefile-promise": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/fs-writefile-promise/-/fs-writefile-promise-1.0.3.tgz",
-			"integrity": "sha1-4C+bWP/CVe2CKtx6ARFPRF1I0GM=",
-			"requires": {
-				"mkdirp-promise": "^1.0.0",
-				"pinkie-promise": "^1.0.0"
-			},
-			"dependencies": {
-				"pinkie-promise": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-					"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-					"requires": {
-						"pinkie": "^1.0.0"
-					}
-				}
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
 			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+			"dev": true,
 			"optional": true
 		},
 		"ftp": {
@@ -4780,60 +4143,8 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-		},
-		"fuzzysort": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.1.4.tgz",
-			"integrity": "sha512-JzK/lHjVZ6joAg3OnCjylwYXYVjRiwTY6Yb25LvfpJHK8bjisfnZJ5bY8aVWwTwCXgxPNgLAtmHL+Hs5q1ddLQ=="
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"gensync": {
 			"version": "1.0.0-beta.1",
@@ -4855,26 +4166,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-		},
-		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
-		},
-		"get-intrinsic": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-			"integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
-			"requires": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1"
-			}
-		},
-		"get-own-enumerable-property-symbols": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
-			"integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
 		},
 		"get-package-type": {
 			"version": "0.1.0",
@@ -4929,6 +4220,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -4937,6 +4229,7 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -5018,17 +4311,13 @@
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+			"dev": true
 		},
 		"grapheme-splitter": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
-		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -5040,44 +4329,18 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"dev": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
 			}
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				}
-			}
-		},
-		"has-color": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -5087,12 +4350,8 @@
 		"has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
-		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -5195,44 +4454,6 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
-		"hawk": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-7.1.2.tgz",
-			"integrity": "sha512-Pa8cMp2f/pFUF9B7cJuBHrF8PYPQmVXe2CfxyrgUmmfRNHMHuQOBpIFHk/eCFrHLVqLlAf2kU7BRxks7814TmA==",
-			"requires": {
-				"@hapi/b64": "4.x.x",
-				"@hapi/boom": "7.x.x",
-				"@hapi/cryptiles": "4.x.x",
-				"@hapi/hoek": "8.x.x",
-				"@hapi/sntp": "3.x.x"
-			}
-		},
-		"he": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
-		},
-		"header-case": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-			"requires": {
-				"capital-case": "^1.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"hkdf": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz",
-			"integrity": "sha1-L422Ff3vhwIB+C0rYZym00fQZH4="
-		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5268,41 +4489,11 @@
 				"whatwg-encoding": "^1.0.5"
 			}
 		},
-		"html-entities": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.3.tgz",
-			"integrity": "sha512-/VulV3SYni1taM7a4RMdceqzJWR39gpZHjBwUnsCFKWV/GJkD14CJ5F7eWcZozmHJK0/f/H5U3b3SiPkuvxMgg=="
-		},
 		"html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
-		},
-		"htmlparser2": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-			"integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-			"requires": {
-				"domelementtype": "1",
-				"domhandler": "2.3",
-				"domutils": "1.5",
-				"entities": "1.0",
-				"readable-stream": "1.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				}
-			}
 		},
 		"http-errors": {
 			"version": "1.7.3",
@@ -5344,6 +4535,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -5375,88 +4567,6 @@
 				}
 			}
 		},
-		"httpsnippet": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-1.24.0.tgz",
-			"integrity": "sha512-W2GRlKXPm+alFdkYvts7zS54Y8sjOGN1H4dMfLCcNZZrG2Rg9jY57aN/Fyiov4/Z0paFxCS1vKDbugNYfAhUBg==",
-			"requires": {
-				"chalk": "^1.1.1",
-				"commander": "^2.9.0",
-				"debug": "^2.2.0",
-				"event-stream": "3.3.4",
-				"form-data": "3.0.0",
-				"fs-readfile-promise": "^2.0.1",
-				"fs-writefile-promise": "^1.0.3",
-				"har-validator": "^5.0.0",
-				"pinkie-promise": "^2.0.0",
-				"stringify-object": "^3.3.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"form-data": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-					"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.8",
-						"mime-types": "^2.1.12"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
 		"human-signals": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -5482,19 +4592,6 @@
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
 			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 			"dev": true
-		},
-		"ignore": {
-			"version": "5.1.8",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-			"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
-		},
-		"ignore-walk": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-			"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-			"requires": {
-				"minimatch": "^3.0.4"
-			}
 		},
 		"immediate": {
 			"version": "3.0.6",
@@ -5548,6 +4645,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -5561,226 +4659,8 @@
 		"ini": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-		},
-		"insomnia-cookies": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-cookies/-/insomnia-cookies-2.2.24.tgz",
-			"integrity": "sha512-WOipBrUbNhIav0OsBEboT/itCCmrrqiapLAG2/OylMsmutTyAS/7YABK2BS1O9HymTRSCmasWN31GZ87vvsykg==",
-			"requires": {
-				"tough-cookie": "^2.3.3"
-			},
-			"dependencies": {
-				"tough-cookie": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-					"requires": {
-						"psl": "^1.1.28",
-						"punycode": "^2.1.1"
-					}
-				}
-			}
-		},
-		"insomnia-importers": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-importers/-/insomnia-importers-2.2.24.tgz",
-			"integrity": "sha512-9Y88b0PnOfHnY2fWxLWLIKBZR8FQ4edVJYffmtrM8E7qtKObQq513IFnOEhGUQVSIjc2b39vSRXUq1myNrL/Qg==",
-			"requires": {
-				"apiconnect-wsdl": "^1.8.29",
-				"change-case": "^4.1.1",
-				"commander": "^2.20.0",
-				"lodash": "^4.17.15",
-				"shell-quote": "^1.6.1",
-				"swagger-parser": "^6.0.5",
-				"yaml": "^1.5.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				}
-			}
-		},
-		"insomnia-plugin-base64": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-base64/-/insomnia-plugin-base64-2.2.24.tgz",
-			"integrity": "sha512-uQXLrs4EiuGbM0Roet1kO3jNecIk5Ua87uBQFOuEE+9xpzxtHG78PgQ8LD1red6kyYby0cT6dLV624gS6WMa+A=="
-		},
-		"insomnia-plugin-cookie-jar": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-cookie-jar/-/insomnia-plugin-cookie-jar-2.2.24.tgz",
-			"integrity": "sha512-y58VLiO7xnqu5PFRre+wuklWmEdJC/S923w0H/bEqtEYzGQd6nm8nILgN+fJZF95e4k0ia9wGXwLRaBfXGzXOw==",
-			"requires": {
-				"insomnia-cookies": "^2.2.24"
-			}
-		},
-		"insomnia-plugin-core-themes": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-core-themes/-/insomnia-plugin-core-themes-2.2.24.tgz",
-			"integrity": "sha512-ZVcT2xhhEhH92PZIUJLM3BKK4ScV1et9GsxHMYWhN62m62NSkauUuJxI0FVueU3Rr1St7xmLxAZnEj/hBQ146Q=="
-		},
-		"insomnia-plugin-file": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-file/-/insomnia-plugin-file-2.2.24.tgz",
-			"integrity": "sha512-47j4hp7JToXnvGlomo4qgUEEJni8irFD+NgR0XH3n9ZV5b9ZaDtqrwbWYSwAXgTiuSLQibype4Zlq6Co9TiO+g=="
-		},
-		"insomnia-plugin-hash": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-hash/-/insomnia-plugin-hash-2.2.24.tgz",
-			"integrity": "sha512-CBSRtw3G+keBzey3KFiJz1T0jknvElYnaJh4whVO3EOb2E/a8N2/VNjiHrPBuFPPMMa+vvpJN8QFJ7LlNsnkbw=="
-		},
-		"insomnia-plugin-jsonpath": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-jsonpath/-/insomnia-plugin-jsonpath-2.2.24.tgz",
-			"integrity": "sha512-nt2kUvS1B1bLjRkg4YpjWBQ3b8pSiC15Ffx8hDxPJX86PS0fUeIvbLbXaKkMZi/AJ49G9G797UFJcQWzB/n0cw==",
-			"requires": {
-				"jsonpath": "^1.0.2"
-			}
-		},
-		"insomnia-plugin-now": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-now/-/insomnia-plugin-now-2.2.24.tgz",
-			"integrity": "sha512-UfOhMTrslvHWyRgbkG08MREezKP6CtidFoUHblIbWEclDlyEk7YhJsiNz0sw1hpfHIbpDgj0CZKYaEAKtRxtSQ==",
-			"requires": {
-				"moment": "^2.21.0"
-			}
-		},
-		"insomnia-plugin-os": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-os/-/insomnia-plugin-os-2.2.24.tgz",
-			"integrity": "sha512-iMf8hsbEidq0hFSE0rHevn8P6hWZUB/gJWKx5cX66B6fr8P4TfRFD8xShwrLDFPjYKU3maQpY12cNTh+Vuu/jw==",
-			"requires": {
-				"jsonpath": "^1.0.2"
-			}
-		},
-		"insomnia-plugin-prompt": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-prompt/-/insomnia-plugin-prompt-2.2.24.tgz",
-			"integrity": "sha512-nDytwD77v1xV+L+icz/f7xLwWvr6BRFjLHxFHy7dGsaPwD5Q5KluhQr1pAcs85e4Pn4bOdqWzLWjAtYwbHB68g=="
-		},
-		"insomnia-plugin-request": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-request/-/insomnia-plugin-request-2.2.24.tgz",
-			"integrity": "sha512-i6tV8qLjWNA88sMdjzg2t/PqoV3XfBRg9I3zA/tG1It33P12Sr7NUkqxmjpHk/7Pg3AY7YkSlOjd4Yh1YryXYg==",
-			"requires": {
-				"insomnia-cookies": "^2.2.24",
-				"insomnia-url": "^2.2.24"
-			}
-		},
-		"insomnia-plugin-response": {
-			"version": "2.2.25",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-response/-/insomnia-plugin-response-2.2.25.tgz",
-			"integrity": "sha512-JWD9lOA8Oe1cuGFOWmEpUaJi+xXTjpvU+T/BXVtrOgZkony3mLtPyaPi7uzDYg9Un/zDePH+wm54i6Vzxn0TFQ==",
-			"requires": {
-				"iconv-lite": "^0.4.19",
-				"insomnia-xpath": "^2.2.24",
-				"jsonpath": "^1.0.2"
-			}
-		},
-		"insomnia-plugin-uuid": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-plugin-uuid/-/insomnia-plugin-uuid-2.2.24.tgz",
-			"integrity": "sha512-In7RW5mw0XD+/yhWcjlSNaaFZ5bTcPj8sxnzzswaglS2YDk2Pq5TNVGn52kOyijUmGje6nQdubwmIB9iuLcfEg==",
-			"requires": {
-				"uuid": "^3.1.0"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-				}
-			}
-		},
-		"insomnia-send-request": {
-			"version": "2.2.28",
-			"resolved": "https://registry.npmjs.org/insomnia-send-request/-/insomnia-send-request-2.2.28.tgz",
-			"integrity": "sha512-xFP/zfjg4l5IzcQIo3ONmUeKFgAMJe+IGNSs97cMEYocPs/1lleGxd7+wCHJKNp8IGQCpd0tx4McvvGN9w43rQ==",
-			"requires": {
-				"@stoplight/spectral": "^5.4.0",
-				"aws4": "^1.10.0",
-				"axios": "^0.19.2",
-				"clone": "^2.1.2",
-				"color": "^3.1.2",
-				"deep-equal": "^2.0.3",
-				"fs-extra": "^9.0.1",
-				"fuzzysort": "^1.1.4",
-				"hawk": "^7.0.10",
-				"hkdf": "0.0.2",
-				"html-entities": "^1.3.1",
-				"httpsnippet": "^1.22.0",
-				"insomnia-importers": "^2.2.24",
-				"insomnia-testing": "^2.2.26",
-				"isomorphic-git": "^1.5.0",
-				"jshint": "^2.11.1",
-				"jsonlint": "^1.6.3",
-				"jsonpath": "^1.0.2",
-				"marked": "^1.1.0",
-				"mime-types": "^2.1.27",
-				"mkdirp": "^1.0.4",
-				"multiparty": "^4.2.1",
-				"nedb": "^1.8.0",
-				"node-forge": "^0.9.1",
-				"node-libcurl": "2.2.0",
-				"nunjucks": "^3.2.1",
-				"oauth-1.0a": "^2.2.6",
-				"openapi-2-kong": "^2.2.26",
-				"tough-cookie": "^4.0.0",
-				"url-join": "^4.0.1",
-				"uuid": "^8.2.0",
-				"whatwg-fetch": "^3.1.0",
-				"yaml": "^1.10.0"
-			},
-			"dependencies": {
-				"tough-cookie": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-					"integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-					"requires": {
-						"psl": "^1.1.33",
-						"punycode": "^2.1.1",
-						"universalify": "^0.1.2"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-				},
-				"uuid": {
-					"version": "8.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-				}
-			}
-		},
-		"insomnia-testing": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/insomnia-testing/-/insomnia-testing-2.2.26.tgz",
-			"integrity": "sha512-fmyXdwr/qoKCMbYK/nkenPhmC+o+zZb9QfP2g/Wy1sDzGF4++WNLH+XEHaeIHAh5SbRMYAR4x1nsgXL1bfqWAQ==",
-			"requires": {
-				"axios": "^0.19.2",
-				"chai": "^4.2.0",
-				"mkdirp": "^1.0.4",
-				"mocha": "^8.0.1"
-			}
-		},
-		"insomnia-url": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-url/-/insomnia-url-2.2.24.tgz",
-			"integrity": "sha512-KfyEBtrgvli5+gmlX7xWR/N3AzetqI43JECRDUVHxluJFKXvSlxoOOcOCIvE4rB+2ogOf2fdIqZF2MA9G3kFXA=="
-		},
-		"insomnia-xpath": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-xpath/-/insomnia-xpath-2.2.24.tgz",
-			"integrity": "sha512-oUIbm5f2xZ9t/+6i3ZspTEx2YPHk5kqejOU3eabThCsjcoGKY1lEdv5BJH8SiR1/gsVlRAbhYQzVWxK0bV0Xug==",
-			"requires": {
-				"insomnia-cookies": "^2.2.24",
-				"xmldom": "^0.1.27",
-				"xpath": "0.0.27"
-			}
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
 		},
 		"interpret": {
 			"version": "1.4.0",
@@ -5828,38 +4708,19 @@
 				}
 			}
 		},
-		"is-arguments": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
-			"integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
-			"requires": {
-				"call-bind": "^1.0.0"
-			}
-		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
-		"is-bigint": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
-		},
 		"is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
 			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-boolean-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
-			"requires": {
-				"call-bind": "^1.0.0"
 			}
 		},
 		"is-buffer": {
@@ -5867,11 +4728,6 @@
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
-		},
-		"is-callable": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-			"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -5901,11 +4757,6 @@
 					}
 				}
 			}
-		},
-		"is-date-object": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -5963,35 +4814,16 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
-		"is-map": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
-		},
-		"is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
-		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 		},
-		"is-number-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
-		},
-		"is-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-		},
 		"is-plain-obj": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"dev": true
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -6008,101 +4840,17 @@
 			"integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
 			"dev": true
 		},
-		"is-regex": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-			"requires": {
-				"has-symbols": "^1.0.1"
-			}
-		},
-		"is-regexp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
-		},
-		"is-set": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
-		},
 		"is-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
 			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 			"dev": true
 		},
-		"is-string": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
-		},
-		"is-symbol": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-			"requires": {
-				"has-symbols": "^1.0.1"
-			}
-		},
-		"is-typed-array": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.4.tgz",
-			"integrity": "sha512-ILaRgn4zaSrVNXNGtON6iFNotXW3hAPF3+0fB1usg2jFlWqo5fEDdmJkz0zBfoi7Dgskr8Khi2xZ8cXqZEfXNA==",
-			"requires": {
-				"available-typed-arrays": "^1.0.2",
-				"call-bind": "^1.0.0",
-				"es-abstract": "^1.18.0-next.1",
-				"foreach": "^2.0.5",
-				"has-symbols": "^1.0.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
-			}
-		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-		},
-		"is-weakmap": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-			"integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
-		},
-		"is-weakset": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
-			"integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -6128,7 +4876,8 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -6136,53 +4885,11 @@
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
-		"isomorphic-git": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.8.0.tgz",
-			"integrity": "sha512-TWJvQh+++eFrEG0IFS/jLhMwsBoCOX1/Dsw9q8no59Mp1K0jEjSHXFWv2P04PwkxcIpePkXVBI5YFcFT2nkuQg==",
-			"requires": {
-				"async-lock": "^1.1.0",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"minimisted": "^2.0.0",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^3.0.2"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					}
-				}
-			}
-		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
@@ -6773,6 +5480,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
 			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -6781,14 +5489,16 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				}
 			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
 		},
 		"jsdom": {
 			"version": "16.2.2",
@@ -6830,41 +5540,6 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
-		"jshint": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.12.0.tgz",
-			"integrity": "sha512-TwuuaUDmra0JMkuqvqy+WGo2xGHSNjv1BA1nTIgtH2K5z1jHuAEeAgp7laaR+hLRmajRjcrM71+vByBDanCyYA==",
-			"requires": {
-				"cli": "~1.0.0",
-				"console-browserify": "1.1.x",
-				"exit": "0.1.x",
-				"htmlparser2": "3.8.x",
-				"lodash": "~4.17.19",
-				"minimatch": "~3.0.2",
-				"shelljs": "0.3.x",
-				"strip-json-comments": "1.0.x"
-			},
-			"dependencies": {
-				"console-browserify": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-					"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-					"requires": {
-						"date-now": "^0.1.4"
-					}
-				},
-				"lodash": {
-					"version": "4.17.20",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-				},
-				"strip-json-comments": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-					"integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
-				}
-			}
-		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -6873,24 +5548,8 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-		},
-		"json-schema-ref-parser": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.4.tgz",
-			"integrity": "sha512-AD7bvav0vak1/63w3jH8F7eHId/4E4EPdMAEZhGxtjktteUv9dnNB/cJy6nVnMyoTPBJnLwFK6tiQPSTeleCtQ==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"js-yaml": "^3.13.1",
-				"ono": "^6.0.0"
-			},
-			"dependencies": {
-				"ono": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
-					"integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
-				}
-			}
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -6900,7 +5559,8 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"json-to-ast": {
 			"version": "2.1.0",
@@ -6925,53 +5585,6 @@
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
 			"integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
 		},
-		"jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"requires": {
-				"graceful-fs": "^4.1.6",
-				"universalify": "^2.0.0"
-			},
-			"dependencies": {
-				"universalify": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-				}
-			}
-		},
-		"jsonlint": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.3.tgz",
-			"integrity": "sha512-jMVTMzP+7gU/IyC6hvKyWpUU8tmTkK5b3BPNuMI9U8Sit+YAWLlZwB6Y6YrdCxfg2kNz05p3XY3Bmm4m26Nv3A==",
-			"requires": {
-				"JSV": "^4.0.x",
-				"nomnom": "^1.5.x"
-			}
-		},
-		"jsonpath": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.0.2.tgz",
-			"integrity": "sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==",
-			"requires": {
-				"esprima": "1.2.2",
-				"static-eval": "2.0.2",
-				"underscore": "1.7.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-					"integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
-				},
-				"underscore": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-					"integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-				}
-			}
-		},
 		"jsonpath-plus": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz",
@@ -6982,46 +5595,16 @@
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
 			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
 		},
-		"jsonschema": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
-		},
-		"jsonschema-draft4": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
-			"integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU="
-		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
-			}
-		},
-		"jszip": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-			"integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
-			"requires": {
-				"lie": "~3.3.0",
-				"pako": "~1.0.2",
-				"readable-stream": "~2.3.6",
-				"set-immediate-shim": "~1.0.1"
-			},
-			"dependencies": {
-				"lie": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-					"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-					"requires": {
-						"immediate": "~3.0.5"
-					}
-				}
 			}
 		},
 		"kind-of": {
@@ -7126,29 +5709,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
 		},
-		"lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
-		},
-		"log-symbols": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-			"requires": {
-				"chalk": "^4.0.0"
-			}
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -7157,21 +5722,6 @@
 			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
-		},
-		"lower-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
 			}
 		},
 		"lru-cache": {
@@ -7207,11 +5757,6 @@
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
 			"dev": true
 		},
-		"map-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
-		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -7220,11 +5765,6 @@
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
-		},
-		"marked": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-1.2.6.tgz",
-			"integrity": "sha512-7vVuSEZ8g/HH3hK/BH/+7u/NJj7x9VY4EHzujLDcqAQLiOUeFJYAsfSAyoWtR17lKrx7b08qyIno4lffwrzTaA=="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -7288,12 +5828,14 @@
 		"mime-db": {
 			"version": "1.44.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.27",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
 			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"dev": true,
 			"requires": {
 				"mime-db": "1.44.0"
 			}
@@ -7303,11 +5845,6 @@
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true
-		},
-		"mimic-response": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
@@ -7325,6 +5862,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -7333,45 +5871,6 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-		},
-		"minimisted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-			"requires": {
-				"minimist": "^1.2.5"
-			}
-		},
-		"minipass": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-			"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-			"requires": {
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
-		"minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"requires": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
 		},
 		"mississippi": {
 			"version": "3.0.0",
@@ -7417,278 +5916,6 @@
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 		},
-		"mkdirp-promise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-1.1.0.tgz",
-			"integrity": "sha1-LISJPtZ24NmPsY+5piEv0bK5qBk="
-		},
-		"mocha": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
-			"integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
-			"requires": {
-				"@ungap/promise-all-settled": "1.1.2",
-				"ansi-colors": "4.1.1",
-				"browser-stdout": "1.3.1",
-				"chokidar": "3.4.3",
-				"debug": "4.2.0",
-				"diff": "4.0.2",
-				"escape-string-regexp": "4.0.0",
-				"find-up": "5.0.0",
-				"glob": "7.1.6",
-				"growl": "1.10.5",
-				"he": "1.2.0",
-				"js-yaml": "3.14.0",
-				"log-symbols": "4.0.0",
-				"minimatch": "3.0.4",
-				"ms": "2.1.2",
-				"nanoid": "3.1.12",
-				"serialize-javascript": "5.0.1",
-				"strip-json-comments": "3.1.1",
-				"supports-color": "7.2.0",
-				"which": "2.0.2",
-				"wide-align": "1.1.3",
-				"workerpool": "6.0.2",
-				"yargs": "13.3.2",
-				"yargs-parser": "13.1.2",
-				"yargs-unparser": "2.0.0"
-			},
-			"dependencies": {
-				"ansi-colors": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-					"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-				},
-				"anymatch": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-					"requires": {
-						"normalize-path": "^3.0.0",
-						"picomatch": "^2.0.4"
-					}
-				},
-				"chokidar": {
-					"version": "3.4.3",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-					"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
-					"requires": {
-						"anymatch": "~3.1.1",
-						"braces": "~3.0.2",
-						"fsevents": "~2.1.2",
-						"glob-parent": "~5.1.0",
-						"is-binary-path": "~2.1.0",
-						"is-glob": "~4.0.1",
-						"normalize-path": "~3.0.0",
-						"readdirp": "~3.5.0"
-					}
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					}
-				},
-				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"emoji-regex": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-				},
-				"escape-string-regexp": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-				},
-				"find-up": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-					"requires": {
-						"locate-path": "^6.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"locate-path": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-					"requires": {
-						"p-locate": "^5.0.0"
-					}
-				},
-				"nanoid": {
-					"version": "3.1.12",
-					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-					"integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
-				},
-				"p-limit": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-					"requires": {
-						"yocto-queue": "^0.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-					"requires": {
-						"p-limit": "^3.0.2"
-					}
-				},
-				"readdirp": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-					"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-					"requires": {
-						"picomatch": "^2.2.1"
-					}
-				},
-				"serialize-javascript": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-					"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
-					"requires": {
-						"randombytes": "^2.1.0"
-					}
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					}
-				},
-				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-							"requires": {
-								"locate-path": "^3.0.0"
-							}
-						},
-						"locate-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-							"requires": {
-								"p-locate": "^3.0.0",
-								"path-exists": "^3.0.0"
-							}
-						},
-						"p-limit": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-							"requires": {
-								"p-try": "^2.0.0"
-							}
-						},
-						"p-locate": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-							"requires": {
-								"p-limit": "^2.0.0"
-							}
-						},
-						"path-exists": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-						}
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
-		"moment": {
-			"version": "2.29.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-		},
 		"move-concurrently": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -7728,44 +5955,12 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
-		"multiparty": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.2.2.tgz",
-			"integrity": "sha512-NtZLjlvsjcoGrzojtwQwn/Tm90aWJ6XXtPppYF4WmOk/6ncdwMMKggFY2NlRRN9yiCEIVxpOfPWahVEG2HAG8Q==",
-			"requires": {
-				"http-errors": "~1.8.0",
-				"safe-buffer": "5.2.1",
-				"uid-safe": "2.1.5"
-			},
-			"dependencies": {
-				"http-errors": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-					"integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.4",
-						"setprototypeof": "1.2.0",
-						"statuses": ">= 1.5.0 < 2",
-						"toidentifier": "1.0.0"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-				},
-				"setprototypeof": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-					"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-				}
-			}
-		},
 		"nan": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+			"dev": true,
+			"optional": true
 		},
 		"nanoid": {
 			"version": "2.1.11",
@@ -7819,26 +6014,6 @@
 				}
 			}
 		},
-		"needle": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
-			"integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
-			"requires": {
-				"debug": "^3.2.6",
-				"iconv-lite": "^0.4.4",
-				"sax": "^1.2.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
-		},
 		"neo-async": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -7856,105 +6031,16 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"no-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"requires": {
-				"lower-case": "^2.0.2",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"node-fetch": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
 			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-		},
-		"node-forge": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.2.tgz",
-			"integrity": "sha512-naKSScof4Wn+aoHU6HBsifh92Zeicm1GDQKd1vp3Y/kOi8ub0DozCa9KpvYNCXslFHYRmLNiqRopGdTGwNLpNw=="
-		},
-		"node-gyp": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.0.0.tgz",
-			"integrity": "sha512-ZW34qA3CJSPKDz2SJBHKRvyNQN0yWO5EGKKksJc+jElu9VA468gwJTyTArC1iOXU7rN3Wtfg/CMt/dBAOFIjvg==",
-			"requires": {
-				"env-paths": "^2.2.0",
-				"glob": "^7.1.4",
-				"graceful-fs": "^4.2.3",
-				"nopt": "^4.0.3",
-				"npmlog": "^4.1.2",
-				"request": "^2.88.2",
-				"rimraf": "^2.6.3",
-				"semver": "^7.3.2",
-				"tar": "^6.0.1",
-				"which": "^2.0.2"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
 		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
 			"dev": true
-		},
-		"node-libcurl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/node-libcurl/-/node-libcurl-2.2.0.tgz",
-			"integrity": "sha512-dyv3IuQBqO4KK5ojtM4k6FuBA3RxZjTqO4c+MUirwvlTY7qIH2oNSws8Xte1pp2aso9TuXyAwxS/g3ZqmAk8aA==",
-			"requires": {
-				"env-paths": "2.2.0",
-				"nan": "2.14.1",
-				"node-gyp": "7.0.0",
-				"node-pre-gyp": "0.15.0",
-				"npmlog": "4.1.2",
-				"tslib": "2.0.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
-					"integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g=="
-				}
-			}
 		},
 		"node-libs-browser": {
 			"version": "2.2.1",
@@ -8040,130 +6126,11 @@
 				}
 			}
 		},
-		"node-pre-gyp": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
-			"integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
-			"requires": {
-				"detect-libc": "^1.0.2",
-				"mkdirp": "^0.5.3",
-				"needle": "^2.5.0",
-				"nopt": "^4.0.1",
-				"npm-packlist": "^1.1.6",
-				"npmlog": "^4.0.2",
-				"rc": "^1.2.7",
-				"rimraf": "^2.6.1",
-				"semver": "^5.3.0",
-				"tar": "^4.4.2"
-			},
-			"dependencies": {
-				"fs-minipass": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-					"requires": {
-						"minipass": "^2.6.0"
-					}
-				},
-				"minipass": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-					"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-					"requires": {
-						"minipass": "^2.9.0"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"tar": {
-					"version": "4.4.13",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.8.6",
-						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.3"
-					}
-				}
-			}
-		},
 		"node-releases": {
 			"version": "1.1.58",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
 			"integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==",
 			"dev": true
-		},
-		"nomnom": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-			"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-			"requires": {
-				"chalk": "~0.4.0",
-				"underscore": "~1.6.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-				},
-				"chalk": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-					"requires": {
-						"ansi-styles": "~1.0.0",
-						"has-color": "~0.1.0",
-						"strip-ansi": "~0.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-				},
-				"underscore": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
-				}
-			}
-		},
-		"nopt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-			"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-			"requires": {
-				"abbrev": "1",
-				"osenv": "^0.1.4"
-			}
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -8180,30 +6147,8 @@
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-		},
-		"npm-bundled": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-			"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
-			"requires": {
-				"npm-normalize-package-bin": "^1.0.1"
-			}
-		},
-		"npm-normalize-package-bin": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-			"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
-		},
-		"npm-packlist": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-			"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-			"requires": {
-				"ignore-walk": "^3.0.1",
-				"npm-bundled": "^1.0.1",
-				"npm-normalize-package-bin": "^1.0.1"
-			}
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
 		},
 		"npm-run-path": {
 			"version": "4.0.1",
@@ -8214,53 +6159,23 @@
 				"path-key": "^3.0.0"
 			}
 		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-		},
-		"nunjucks": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.2.tgz",
-			"integrity": "sha512-KUi85OoF2NMygwODAy28Lh9qHmq5hO3rBlbkYoC8v377h4l8Pt5qFjILl0LWpMbOrZ18CzfVVUvIHUIrtED3sA==",
-			"requires": {
-				"a-sync-waterfall": "^1.0.0",
-				"asap": "^2.0.3",
-				"chokidar": "^3.3.0",
-				"commander": "^5.1.0"
-			}
-		},
 		"nwsapi": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
 			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
 			"dev": true
 		},
-		"oauth-1.0a": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
-			"integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ=="
-		},
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -8293,24 +6208,11 @@
 				}
 			}
 		},
-		"object-inspect": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-			"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
-		},
-		"object-is": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
-			"integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
-			"requires": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			}
-		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -8346,6 +6248,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -8358,63 +6261,6 @@
 			"requires": {
 				"mimic-fn": "^2.1.0"
 			}
-		},
-		"ono": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
-			"integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
-		},
-		"openapi-2-kong": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/openapi-2-kong/-/openapi-2-kong-2.2.26.tgz",
-			"integrity": "sha512-J9OzU8HcEVOl5yLksYYnzNkUb7OC768mCFQsdlfHWGmP5bAJVQbrZ3NubsdbiYVrbguJTqBL6Atzt3r3Y8i5Gw==",
-			"requires": {
-				"slugify": "^1.3.6",
-				"swagger-parser": "^8.0.3",
-				"url-join": "^4.0.1",
-				"yaml": "^1.7.2"
-			},
-			"dependencies": {
-				"ono": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
-					"integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
-				},
-				"swagger-parser": {
-					"version": "8.0.4",
-					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.4.tgz",
-					"integrity": "sha512-KGRdAaMJogSEB7sPKI31ptKIWX8lydEDAwWgB4pBMU7zys5cd54XNhoPSVlTxG/A3LphjX47EBn9j0dOGyzWbA==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"json-schema-ref-parser": "^7.1.3",
-						"ono": "^6.0.0",
-						"openapi-schemas": "^1.0.2",
-						"openapi-types": "^1.3.5",
-						"swagger-methods": "^2.0.1",
-						"z-schema": "^4.2.2"
-					}
-				}
-			}
-		},
-		"openapi-schema-validation": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
-			"integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
-			"requires": {
-				"jsonschema": "1.2.4",
-				"jsonschema-draft4": "^1.0.0",
-				"swagger-schema-official": "2.0.0-bab6bed"
-			}
-		},
-		"openapi-schemas": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.3.tgz",
-			"integrity": "sha512-KtMWcK2VtOS+nD8RKSIyScJsj8JrmVWcIX7Kjx4xEHijFYuvMTDON8WfeKOgeSb4uNG6UsqLj5Na7nKbSav9RQ=="
-		},
-		"openapi-types": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
-			"integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
 		},
 		"optionator": {
 			"version": "0.8.3",
@@ -8434,25 +6280,6 @@
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
 			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
 			"dev": true
-		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-		},
-		"os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-		},
-		"osenv": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
-			}
 		},
 		"p-each-series": {
 			"version": "2.1.0",
@@ -8517,7 +6344,8 @@
 		"pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true
 		},
 		"parallel-transform": {
 			"version": "1.2.0",
@@ -8528,22 +6356,6 @@
 				"cyclist": "^1.0.1",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.1.5"
-			}
-		},
-		"param-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
 			}
 		},
 		"parent-module": {
@@ -8591,22 +6403,6 @@
 			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
 			"dev": true
 		},
-		"pascal-case": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -8618,22 +6414,6 @@
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
 			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
 			"dev": true
-		},
-		"path-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"path-dirname": {
 			"version": "1.0.2",
@@ -8650,7 +6430,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-key": {
 			"version": "3.1.1",
@@ -8669,19 +6450,6 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 		},
-		"pathval": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
-		},
-		"pause-stream": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-			"requires": {
-				"through": "~2.3"
-			}
-		},
 		"pbkdf2": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
@@ -8695,15 +6463,11 @@
 				"sha.js": "^2.4.8"
 			}
 		},
-		"pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
-		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
 		},
 		"picomatch": {
 			"version": "2.2.2",
@@ -8713,27 +6477,8 @@
 		"pify": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-		},
-		"pinkie": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
-		},
-		"pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"requires": {
-				"pinkie": "^2.0.0"
-			},
-			"dependencies": {
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-				}
-			}
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true
 		},
 		"pirates": {
 			"version": "4.0.1",
@@ -8803,11 +6548,6 @@
 				}
 			}
 		},
-		"printj": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-			"integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
-		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -8870,7 +6610,8 @@
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+			"dev": true
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -8932,15 +6673,11 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
-		"q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -8954,15 +6691,11 @@
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
 			"dev": true
 		},
-		"random-bytes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-			"integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
-		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -8986,24 +6719,6 @@
 				"http-errors": "1.7.3",
 				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
-			}
-		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-				}
 			}
 		},
 		"react-is": {
@@ -9076,6 +6791,7 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
 			"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"picomatch": "^2.2.1"
@@ -9119,15 +6835,6 @@
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
-			}
-		},
-		"regexp.prototype.flags": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-			"integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
 			}
 		},
 		"regexpu-core": {
@@ -9189,6 +6896,7 @@
 			"version": "2.88.2",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -9216,6 +6924,7 @@
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+					"dev": true,
 					"requires": {
 						"psl": "^1.1.28",
 						"punycode": "^2.1.1"
@@ -9224,7 +6933,8 @@
 				"uuid": {
 					"version": "3.4.0",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				}
 			}
 		},
@@ -9601,11 +7311,6 @@
 				}
 			}
 		},
-		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-		},
 		"saxes": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -9629,24 +7334,8 @@
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-		},
-		"sentence-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true
 		},
 		"serialize-javascript": {
 			"version": "3.1.0",
@@ -9661,11 +7350,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -9705,6 +7389,7 @@
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -9734,16 +7419,6 @@
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true
 		},
-		"shell-quote": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
-		},
-		"shelljs": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-			"integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
-		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -9751,81 +7426,11 @@
 			"dev": true,
 			"optional": true
 		},
-		"side-channel": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
-			"integrity": "sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==",
-			"requires": {
-				"es-abstract": "^1.18.0-next.0",
-				"object-inspect": "^1.8.0"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
-			}
-		},
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-		},
-		"simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
-		},
-		"simple-get": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-			"requires": {
-				"decompress-response": "^4.2.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
-		"simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-			"requires": {
-				"is-arrayish": "^0.3.1"
-			},
-			"dependencies": {
-				"is-arrayish": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-				}
-			}
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
 		},
 		"sisteransi": {
 			"version": "1.0.5",
@@ -9833,31 +7438,10 @@
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
 			"dev": true
 		},
-		"slugify": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.6.tgz",
-			"integrity": "sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ=="
-		},
 		"smart-buffer": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
 			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
-		},
-		"snake-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -10087,14 +7671,6 @@
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
 			"dev": true
 		},
-		"split": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-			"requires": {
-				"through": "2"
-			}
-		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -10107,12 +7683,14 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -10149,14 +7727,6 @@
 					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
 					"dev": true
 				}
-			}
-		},
-		"static-eval": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-			"integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-			"requires": {
-				"escodegen": "^1.8.1"
 			}
 		},
 		"static-extend": {
@@ -10199,14 +7769,6 @@
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
-			}
-		},
-		"stream-combiner": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-			"requires": {
-				"duplexer": "~0.1.1"
 			}
 		},
 		"stream-each": {
@@ -10268,38 +7830,10 @@
 				"strip-ansi": "^6.0.0"
 			}
 		},
-		"string.prototype.trimend": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-			"integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
-			"requires": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			}
-		},
-		"string.prototype.trimstart": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-			"integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
-			"requires": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			}
-		},
 		"string_decoder": {
 			"version": "0.10.31",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-		},
-		"stringify-object": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-			"requires": {
-				"get-own-enumerable-property-symbols": "^3.0.0",
-				"is-obj": "^1.0.1",
-				"is-regexp": "^1.0.0"
-			}
 		},
 		"strip-ansi": {
 			"version": "6.0.0",
@@ -10326,11 +7860,6 @@
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
 			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"dev": true
-		},
-		"strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -10367,83 +7896,6 @@
 				}
 			}
 		},
-		"swagger-methods": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.2.tgz",
-			"integrity": "sha512-/RNqvBZkH8+3S/FqBPejHxJxZenaYq3MrpeXnzi06aDIS39Mqf5YCUNb/ZBjsvFFt8h9FxfKs8EXPtcYdfLiRg=="
-		},
-		"swagger-parser": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-6.0.5.tgz",
-			"integrity": "sha512-UL47eu4+GRm5y+N7J+W6QQiqAJn2lojyqgMwS0EZgA55dXd5xmpQCsjUmH/Rf0eKDiG1kULc9VS515PxAyTDVw==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"json-schema-ref-parser": "^6.0.3",
-				"ono": "^4.0.11",
-				"openapi-schema-validation": "^0.4.2",
-				"swagger-methods": "^1.0.8",
-				"swagger-schema-official": "2.0.0-bab6bed",
-				"z-schema": "^3.24.2"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"optional": true
-				},
-				"core-js": {
-					"version": "2.6.12",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-				},
-				"json-schema-ref-parser": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-					"integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"js-yaml": "^3.12.1",
-						"ono": "^4.0.11"
-					}
-				},
-				"ono": {
-					"version": "4.0.11",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-					"integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-					"requires": {
-						"format-util": "^1.0.3"
-					}
-				},
-				"swagger-methods": {
-					"version": "1.0.8",
-					"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.8.tgz",
-					"integrity": "sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA=="
-				},
-				"validator": {
-					"version": "10.11.0",
-					"resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-					"integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
-				},
-				"z-schema": {
-					"version": "3.25.1",
-					"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
-					"integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
-					"requires": {
-						"commander": "^2.7.1",
-						"core-js": "^2.5.7",
-						"lodash.get": "^4.0.0",
-						"lodash.isequal": "^4.0.0",
-						"validator": "^10.0.0"
-					}
-				}
-			}
-		},
-		"swagger-schema-official": {
-			"version": "2.0.0-bab6bed",
-			"resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
-			"integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
-		},
 		"symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -10455,31 +7907,6 @@
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
 			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
 			"dev": true
-		},
-		"tar": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
-			"integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
-			"requires": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^3.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"chownr": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
 		},
 		"terminal-link": {
 			"version": "2.1.1",
@@ -10556,11 +7983,6 @@
 			"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
 			"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
 			"dev": true
-		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -10684,6 +8106,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -10691,7 +8114,8 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -10704,7 +8128,8 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"type-fest": {
 			"version": "0.8.1",
@@ -10725,14 +8150,6 @@
 			"dev": true,
 			"requires": {
 				"is-typedarray": "^1.0.0"
-			}
-		},
-		"uid-safe": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-			"integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-			"requires": {
-				"random-bytes": "~1.0.0"
 			}
 		},
 		"underscore": {
@@ -10798,11 +8215,6 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
-		"universalify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
-		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -10861,36 +8273,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"upper-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"upper-case-first": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -10927,11 +8309,6 @@
 					"dev": true
 				}
 			}
-		},
-		"url-join": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
 		},
 		"use": {
 			"version": "3.1.1",
@@ -11008,15 +8385,11 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"validator": {
-			"version": "12.2.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
-			"integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
-		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -11755,11 +9128,6 @@
 				"iconv-lite": "0.4.24"
 			}
 		},
-		"whatwg-fetch": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
-			"integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
-		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -11789,120 +9157,15 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
-			}
-		},
-		"which-boxed-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.1.tgz",
-			"integrity": "sha512-7BT4TwISdDGBgaemWU0N0OU7FeAEJ9Oo2P1PHRm/FCWoEi2VLWC9b6xvxAA3C/NMpxg3HXVgi0sMmGbNUbNepQ==",
-			"requires": {
-				"is-bigint": "^1.0.0",
-				"is-boolean-object": "^1.0.0",
-				"is-number-object": "^1.0.3",
-				"is-string": "^1.0.4",
-				"is-symbol": "^1.0.2"
-			}
-		},
-		"which-collection": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-			"integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-			"requires": {
-				"is-map": "^2.0.1",
-				"is-set": "^2.0.1",
-				"is-weakmap": "^2.0.1",
-				"is-weakset": "^2.0.1"
 			}
 		},
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-		},
-		"which-typed-array": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
-			"integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
-			"requires": {
-				"available-typed-arrays": "^1.0.2",
-				"call-bind": "^1.0.0",
-				"es-abstract": "^1.18.0-next.1",
-				"foreach": "^2.0.5",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.1",
-				"is-typed-array": "^1.1.3"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
-			}
-		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
 		},
 		"wildcard": {
 			"version": "2.0.0",
@@ -11928,11 +9191,6 @@
 			"requires": {
 				"errno": "~0.1.7"
 			}
-		},
-		"workerpool": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
-			"integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q=="
 		},
 		"wrap-ansi": {
 			"version": "6.2.0",
@@ -11971,7 +9229,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "3.0.3",
@@ -11997,35 +9256,11 @@
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
 		},
-		"xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-			"requires": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~11.0.0"
-			}
-		},
-		"xmlbuilder": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-		},
 		"xmlchars": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
-		},
-		"xmldom": {
-			"version": "0.1.31",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
-		},
-		"xpath": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-			"integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
 		},
 		"xregexp": {
 			"version": "2.0.0",
@@ -12078,62 +9313,6 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
-			}
-		},
-		"yargs-unparser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-			"requires": {
-				"camelcase": "^6.0.0",
-				"decamelize": "^4.0.0",
-				"flat": "^5.0.2",
-				"is-plain-obj": "^2.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
-				},
-				"decamelize": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-					"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
-				}
-			}
-		},
-		"yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-			"requires": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
-			}
-		},
-		"yocto-queue": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-		},
-		"z-schema": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
-			"integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
-			"requires": {
-				"commander": "^2.7.1",
-				"lodash.get": "^4.4.2",
-				"lodash.isequal": "^4.5.0",
-				"validator": "^12.0.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"optional": true
-				}
 			}
 		}
 	}

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -190,11 +190,6 @@
 			"resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.9.tgz",
 			"integrity": "sha512-/tiJyrc0GPcsReHzgC0SXwOmoPjLqYe01W7dLYB0yasQXMbcRee+ZIk+g8MIQhoBS8fPoBQO3Y93+aeBrI93Ug=="
 		},
-		"@ungap/promise-all-settled": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
-		},
 		"JSV": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
@@ -245,11 +240,6 @@
 				"decimal.js": "^10.2.0"
 			}
 		},
-		"ansi-colors": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
-		},
 		"ansi-regex": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -267,41 +257,10 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+			"optional": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
-			}
-		},
-		"apiconnect-wsdl": {
-			"version": "1.8.31",
-			"resolved": "https://registry.npmjs.org/apiconnect-wsdl/-/apiconnect-wsdl-1.8.31.tgz",
-			"integrity": "sha512-kNs26If9xCJnGolVTAt0VWIA8KrqwodQLqDRTrfc7txD54LJ+hFx638sPYEdG9jw78eifWyy+FBlS5befYSa8Q==",
-			"requires": {
-				"iconv-lite": "^0.4.24",
-				"js-yaml": "^3.13.1",
-				"jszip": "^3.2.2",
-				"lodash": "^4.17.15",
-				"q": "^1.5.1",
-				"swagger-parser": "8.0.3",
-				"xml2js": "^0.4.22",
-				"xmldom": "^0.1.27",
-				"yauzl": "^2.10.0"
-			},
-			"dependencies": {
-				"swagger-parser": {
-					"version": "8.0.3",
-					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
-					"integrity": "sha512-y2gw+rTjn7Z9J+J1qwbBm0UL93k/VREDCveKBK6iGjf7KXC6QGshbnpEmeHL0ZkCgmIghsXzpNzPSbBH91BAEQ==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"json-schema-ref-parser": "^7.1.1",
-						"ono": "^5.1.0",
-						"openapi-schemas": "^1.0.2",
-						"openapi-types": "^1.3.5",
-						"swagger-methods": "^2.0.1",
-						"z-schema": "^4.1.1"
-					}
-				}
 			}
 		},
 		"aproba": {
@@ -316,14 +275,6 @@
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
-			}
-		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"requires": {
-				"sprintf-js": "~1.0.2"
 			}
 		},
 		"array-filter": {
@@ -348,11 +299,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-		},
-		"assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 		},
 		"ast-types": {
 			"version": "0.13.3",
@@ -512,81 +458,20 @@
 				"fill-range": "^7.0.1"
 			}
 		},
-		"browser-stdout": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
-		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-		},
 		"bytes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
 			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-		},
-		"call-me-maybe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
-		},
-		"camel-case": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-			"requires": {
-				"pascal-case": "^3.1.2",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
-		"capital-case": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
-		"chai": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-			"requires": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
-				"type-detect": "^4.0.5"
-			}
 		},
 		"chalk": {
 			"version": "4.0.0",
@@ -633,37 +518,6 @@
 					}
 				}
 			}
-		},
-		"change-case": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-			"requires": {
-				"camel-case": "^4.1.2",
-				"capital-case": "^1.0.4",
-				"constant-case": "^3.0.4",
-				"dot-case": "^3.0.4",
-				"header-case": "^2.0.4",
-				"no-case": "^3.0.4",
-				"param-case": "^3.0.4",
-				"pascal-case": "^3.1.2",
-				"path-case": "^3.0.4",
-				"sentence-case": "^3.0.4",
-				"snake-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
 		},
 		"chokidar": {
 			"version": "3.4.1",
@@ -792,23 +646,6 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
-		"constant-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"core-js": {
 			"version": "3.6.5",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
@@ -878,14 +715,6 @@
 			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
 			"requires": {
 				"mimic-response": "^2.0.0"
-			}
-		},
-		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-			"requires": {
-				"type-detect": "^4.0.0"
 			}
 		},
 		"deep-equal": {
@@ -969,11 +798,6 @@
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-		},
 		"diff3": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
@@ -1020,22 +844,6 @@
 			"requires": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
-			}
-		},
-		"dot-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
 			}
 		},
 		"duplexer": {
@@ -1282,11 +1090,6 @@
 				"path-exists": "^4.0.0"
 			}
 		},
-		"flat": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
-		},
 		"follow-redirects": {
 			"version": "1.5.10",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
@@ -1329,11 +1132,6 @@
 				"combined-stream": "^1.0.8",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"format-util": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-			"integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
 		},
 		"from": {
 			"version": "0.1.7",
@@ -1482,11 +1280,6 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
 		},
-		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
-		},
 		"get-own-enumerable-property-symbols": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -1559,11 +1352,6 @@
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
 		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
-		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -1631,27 +1419,6 @@
 				"cryptiles": "4.x.x",
 				"hoek": "6.x.x",
 				"sntp": "3.x.x"
-			}
-		},
-		"he": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
-		},
-		"header-case": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-			"requires": {
-				"capital-case": "^1.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
 			}
 		},
 		"hkdf": {
@@ -1876,31 +1643,6 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
-		"insomnia-importers": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/insomnia-importers/-/insomnia-importers-2.2.24.tgz",
-			"integrity": "sha512-9Y88b0PnOfHnY2fWxLWLIKBZR8FQ4edVJYffmtrM8E7qtKObQq513IFnOEhGUQVSIjc2b39vSRXUq1myNrL/Qg==",
-			"requires": {
-				"apiconnect-wsdl": "^1.8.29",
-				"change-case": "^4.1.1",
-				"commander": "^2.20.0",
-				"lodash": "^4.17.15",
-				"shell-quote": "^1.6.1",
-				"swagger-parser": "^6.0.5",
-				"yaml": "^1.5.0"
-			}
-		},
-		"insomnia-testing": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/insomnia-testing/-/insomnia-testing-2.2.26.tgz",
-			"integrity": "sha512-fmyXdwr/qoKCMbYK/nkenPhmC+o+zZb9QfP2g/Wy1sDzGF4++WNLH+XEHaeIHAh5SbRMYAR4x1nsgXL1bfqWAQ==",
-			"requires": {
-				"axios": "^0.19.2",
-				"chai": "^4.2.0",
-				"mkdirp": "^1.0.4",
-				"mocha": "^8.0.1"
-			}
-		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -1925,6 +1667,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
 			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"optional": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
 			}
@@ -1981,11 +1724,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-		},
-		"is-plain-obj": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
 		},
 		"is-regex": {
 			"version": "1.1.0",
@@ -2107,22 +1845,6 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
-		"js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-				}
-			}
-		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -2147,23 +1869,6 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-		},
-		"json-schema-ref-parser": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.4.tgz",
-			"integrity": "sha512-AD7bvav0vak1/63w3jH8F7eHId/4E4EPdMAEZhGxtjktteUv9dnNB/cJy6nVnMyoTPBJnLwFK6tiQPSTeleCtQ==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"js-yaml": "^3.13.1",
-				"ono": "^6.0.0"
-			},
-			"dependencies": {
-				"ono": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
-					"integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
-				}
-			}
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -2239,16 +1944,6 @@
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
 			"integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
 		},
-		"jsonschema": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
-		},
-		"jsonschema-draft4": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
-			"integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU="
-		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -2258,27 +1953,6 @@
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
-			}
-		},
-		"jszip": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-			"integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
-			"requires": {
-				"lie": "~3.3.0",
-				"pako": "~1.0.2",
-				"readable-stream": "~2.3.6",
-				"set-immediate-shim": "~1.0.1"
-			},
-			"dependencies": {
-				"lie": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-					"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-					"requires": {
-						"immediate": "~3.0.5"
-					}
-				}
 			}
 		},
 		"leven": {
@@ -2323,39 +1997,6 @@
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-		},
-		"lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-		},
-		"log-symbols": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-			"requires": {
-				"chalk": "^4.0.0"
-			}
-		},
-		"lower-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"lru-cache": {
 			"version": "5.1.1",
@@ -2469,265 +2110,6 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-1.1.0.tgz",
 			"integrity": "sha1-LISJPtZ24NmPsY+5piEv0bK5qBk="
 		},
-		"mocha": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
-			"integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
-			"requires": {
-				"@ungap/promise-all-settled": "1.1.2",
-				"ansi-colors": "4.1.1",
-				"browser-stdout": "1.3.1",
-				"chokidar": "3.4.3",
-				"debug": "4.2.0",
-				"diff": "4.0.2",
-				"escape-string-regexp": "4.0.0",
-				"find-up": "5.0.0",
-				"glob": "7.1.6",
-				"growl": "1.10.5",
-				"he": "1.2.0",
-				"js-yaml": "3.14.0",
-				"log-symbols": "4.0.0",
-				"minimatch": "3.0.4",
-				"ms": "2.1.2",
-				"nanoid": "3.1.12",
-				"serialize-javascript": "5.0.1",
-				"strip-json-comments": "3.1.1",
-				"supports-color": "7.2.0",
-				"which": "2.0.2",
-				"wide-align": "1.1.3",
-				"workerpool": "6.0.2",
-				"yargs": "13.3.2",
-				"yargs-parser": "13.1.2",
-				"yargs-unparser": "2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-				},
-				"chokidar": {
-					"version": "3.4.3",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-					"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
-					"requires": {
-						"anymatch": "~3.1.1",
-						"braces": "~3.0.2",
-						"fsevents": "~2.1.2",
-						"glob-parent": "~5.1.0",
-						"is-binary-path": "~2.1.0",
-						"is-glob": "~4.0.1",
-						"normalize-path": "~3.0.0",
-						"readdirp": "~3.5.0"
-					}
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					}
-				},
-				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"emoji-regex": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-				},
-				"escape-string-regexp": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-				},
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-				},
-				"find-up": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-					"requires": {
-						"locate-path": "^6.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"js-yaml": {
-					"version": "3.14.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-					"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-					"requires": {
-						"p-locate": "^5.0.0"
-					}
-				},
-				"nanoid": {
-					"version": "3.1.12",
-					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-					"integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
-				},
-				"p-limit": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-					"requires": {
-						"yocto-queue": "^0.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-					"requires": {
-						"p-limit": "^3.0.2"
-					}
-				},
-				"readdirp": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-					"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-					"requires": {
-						"picomatch": "^2.2.1"
-					}
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					}
-				},
-				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-							"requires": {
-								"locate-path": "^3.0.0"
-							}
-						},
-						"locate-path": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-							"requires": {
-								"p-locate": "^3.0.0",
-								"path-exists": "^3.0.0"
-							}
-						},
-						"p-limit": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-							"requires": {
-								"p-try": "^2.0.0"
-							}
-						},
-						"p-locate": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-							"requires": {
-								"p-limit": "^2.0.0"
-							}
-						},
-						"path-exists": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-						}
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2805,22 +2187,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
 			"integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
-		},
-		"no-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"requires": {
-				"lower-case": "^2.0.2",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"node-fetch": {
 			"version": "2.6.0",
@@ -2988,7 +2354,8 @@
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"optional": true
 		},
 		"npm-bundled": {
 			"version": "1.1.1",
@@ -3100,63 +2467,6 @@
 				"wrappy": "1"
 			}
 		},
-		"ono": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
-			"integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
-		},
-		"openapi-2-kong": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/openapi-2-kong/-/openapi-2-kong-2.2.26.tgz",
-			"integrity": "sha512-J9OzU8HcEVOl5yLksYYnzNkUb7OC768mCFQsdlfHWGmP5bAJVQbrZ3NubsdbiYVrbguJTqBL6Atzt3r3Y8i5Gw==",
-			"requires": {
-				"slugify": "^1.3.6",
-				"swagger-parser": "^8.0.3",
-				"url-join": "^4.0.1",
-				"yaml": "^1.7.2"
-			},
-			"dependencies": {
-				"ono": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
-					"integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
-				},
-				"swagger-parser": {
-					"version": "8.0.4",
-					"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.4.tgz",
-					"integrity": "sha512-KGRdAaMJogSEB7sPKI31ptKIWX8lydEDAwWgB4pBMU7zys5cd54XNhoPSVlTxG/A3LphjX47EBn9j0dOGyzWbA==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"json-schema-ref-parser": "^7.1.3",
-						"ono": "^6.0.0",
-						"openapi-schemas": "^1.0.2",
-						"openapi-types": "^1.3.5",
-						"swagger-methods": "^2.0.1",
-						"z-schema": "^4.2.2"
-					}
-				}
-			}
-		},
-		"openapi-schema-validation": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
-			"integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
-			"requires": {
-				"jsonschema": "1.2.4",
-				"jsonschema-draft4": "^1.0.0",
-				"swagger-schema-official": "2.0.0-bab6bed"
-			}
-		},
-		"openapi-schemas": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.3.tgz",
-			"integrity": "sha512-KtMWcK2VtOS+nD8RKSIyScJsj8JrmVWcIX7Kjx4xEHijFYuvMTDON8WfeKOgeSb4uNG6UsqLj5Na7nKbSav9RQ=="
-		},
-		"openapi-types": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
-			"integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
-		},
 		"optionator": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -3242,54 +2552,6 @@
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
 			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 		},
-		"param-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"pascal-case": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"path-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
 		"path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3299,11 +2561,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"pathval": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
 		},
 		"pause-stream": {
 			"version": "0.0.11",
@@ -3398,11 +2655,6 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
-		"q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -3412,14 +2664,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
 			"integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
-		},
-		"randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"requires": {
-				"safe-buffer": "^5.1.0"
-			}
 		},
 		"raw-body": {
 			"version": "2.4.1",
@@ -3608,40 +2852,10 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
 			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 		},
-		"sentence-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-			"requires": {
-				"no-case": "^3.0.4",
-				"tslib": "^2.0.3",
-				"upper-case-first": "^2.0.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"serialize-javascript": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-			"integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
-			"requires": {
-				"randombytes": "^2.1.0"
-			}
-		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"setprototypeof": {
 			"version": "1.1.1",
@@ -3656,11 +2870,6 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"shell-quote": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
 		},
 		"shelljs": {
 			"version": "0.3.0",
@@ -3704,31 +2913,10 @@
 				"is-arrayish": "^0.3.1"
 			}
 		},
-		"slugify": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.6.tgz",
-			"integrity": "sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ=="
-		},
 		"smart-buffer": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
 			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
-		},
-		"snake-case": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-			"requires": {
-				"dot-case": "^3.0.4",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"sntp": {
 			"version": "3.0.2",
@@ -3782,11 +2970,6 @@
 			"requires": {
 				"through": "2"
 			}
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.16.1",
@@ -3894,77 +3077,6 @@
 				"has-flag": "^3.0.0"
 			}
 		},
-		"swagger-methods": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.2.tgz",
-			"integrity": "sha512-/RNqvBZkH8+3S/FqBPejHxJxZenaYq3MrpeXnzi06aDIS39Mqf5YCUNb/ZBjsvFFt8h9FxfKs8EXPtcYdfLiRg=="
-		},
-		"swagger-parser": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-6.0.5.tgz",
-			"integrity": "sha512-UL47eu4+GRm5y+N7J+W6QQiqAJn2lojyqgMwS0EZgA55dXd5xmpQCsjUmH/Rf0eKDiG1kULc9VS515PxAyTDVw==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"json-schema-ref-parser": "^6.0.3",
-				"ono": "^4.0.11",
-				"openapi-schema-validation": "^0.4.2",
-				"swagger-methods": "^1.0.8",
-				"swagger-schema-official": "2.0.0-bab6bed",
-				"z-schema": "^3.24.2"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.12",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-				},
-				"json-schema-ref-parser": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-					"integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-					"requires": {
-						"call-me-maybe": "^1.0.1",
-						"js-yaml": "^3.12.1",
-						"ono": "^4.0.11"
-					}
-				},
-				"ono": {
-					"version": "4.0.11",
-					"resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-					"integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-					"requires": {
-						"format-util": "^1.0.3"
-					}
-				},
-				"swagger-methods": {
-					"version": "1.0.8",
-					"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.8.tgz",
-					"integrity": "sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA=="
-				},
-				"validator": {
-					"version": "10.11.0",
-					"resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-					"integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
-				},
-				"z-schema": {
-					"version": "3.25.1",
-					"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
-					"integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
-					"requires": {
-						"commander": "^2.7.1",
-						"core-js": "^2.5.7",
-						"lodash.get": "^4.0.0",
-						"lodash.isequal": "^4.0.0",
-						"validator": "^10.0.0"
-					}
-				}
-			}
-		},
-		"swagger-schema-official": {
-			"version": "2.0.0-bab6bed",
-			"resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
-			"integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
-		},
 		"tar": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.2.tgz",
@@ -4061,11 +3173,6 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
-		"type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
-		},
 		"uid-safe": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -4088,36 +3195,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
-		"upper-case": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
-		},
-		"upper-case-first": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-			"requires": {
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-				}
-			}
 		},
 		"uri-js": {
 			"version": "4.2.2",
@@ -4151,11 +3228,6 @@
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
 			"integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
-		},
-		"validator": {
-			"version": "12.2.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
-			"integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -4268,11 +3340,6 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
 		},
-		"workerpool": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
-			"integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q=="
-		},
 		"wrap-ansi": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -4311,25 +3378,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-			"requires": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~11.0.0"
-			}
-		},
-		"xmlbuilder": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-		},
-		"xmldom": {
-			"version": "0.1.31",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
 		},
 		"xregexp": {
 			"version": "2.0.0",
@@ -4376,54 +3424,6 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
-			}
-		},
-		"yargs-unparser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-			"requires": {
-				"camelcase": "^6.0.0",
-				"decamelize": "^4.0.0",
-				"flat": "^5.0.2",
-				"is-plain-obj": "^2.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
-				},
-				"decamelize": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-					"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
-				}
-			}
-		},
-		"yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-			"requires": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
-			}
-		},
-		"yocto-queue": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-		},
-		"z-schema": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
-			"integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
-			"requires": {
-				"commander": "^2.7.1",
-				"lodash.get": "^4.4.2",
-				"lodash.isequal": "^4.5.0",
-				"validator": "^12.0.0"
 			}
 		}
 	}

--- a/plugins/insomnia-plugin-kong-portal/package-lock.json
+++ b/plugins/insomnia-plugin-kong-portal/package-lock.json
@@ -1077,42 +1077,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@emotion/is-prop-valid": {
-			"version": "0.8.8",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-			"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"@emotion/memoize": "0.7.4"
-			}
-		},
-		"@emotion/memoize": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-			"dev": true,
-			"optional": true
-		},
-		"@popmotion/easing": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.2.tgz",
-			"integrity": "sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==",
-			"dev": true
-		},
-		"@popmotion/popcorn": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.4.4.tgz",
-			"integrity": "sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==",
-			"dev": true,
-			"requires": {
-				"@popmotion/easing": "^1.0.1",
-				"framesync": "^4.0.1",
-				"hey-listen": "^1.0.8",
-				"style-value-types": "^3.1.7",
-				"tslib": "^1.10.0"
-			}
-		},
 		"@webassemblyjs/ast": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -1788,12 +1752,6 @@
 				"supports-color": "^5.3.0"
 			}
 		},
-		"charenc": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
-			"dev": true
-		},
 		"chokidar": {
 			"version": "2.1.8",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -1861,12 +1819,6 @@
 					}
 				}
 			}
-		},
-		"classnames": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
-			"dev": true
 		},
 		"cliui": {
 			"version": "5.0.0",
@@ -2054,12 +2006,6 @@
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
-		},
-		"crypt": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
-			"dev": true
 		},
 		"crypto-browserify": {
 			"version": "3.12.0",
@@ -2592,32 +2538,6 @@
 			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
-			}
-		},
-		"framer-motion": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.11.1.tgz",
-			"integrity": "sha512-CP6aYLPSivAWkq9UoSurefHBggxG85IT8ObYyWYkcZppgtjHzpwRzhaA8P0ljMGRqtcpeQAIybiGgPioBPlOSw==",
-			"dev": true,
-			"requires": {
-				"@emotion/is-prop-valid": "^0.8.2",
-				"@popmotion/easing": "^1.0.2",
-				"@popmotion/popcorn": "^0.4.2",
-				"framesync": "^4.0.4",
-				"hey-listen": "^1.0.8",
-				"popmotion": "9.0.0-beta-8",
-				"style-value-types": "^3.1.6",
-				"stylefire": "^7.0.2",
-				"tslib": "^1.10.0"
-			}
-		},
-		"framesync": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/framesync/-/framesync-4.1.0.tgz",
-			"integrity": "sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==",
-			"dev": true,
-			"requires": {
-				"hey-listen": "^1.0.5"
 			}
 		},
 		"from2": {
@@ -3199,12 +3119,6 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
-		"fuzzysort": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.1.4.tgz",
-			"integrity": "sha512-JzK/lHjVZ6joAg3OnCjylwYXYVjRiwTY6Yb25LvfpJHK8bjisfnZJ5bY8aVWwTwCXgxPNgLAtmHL+Hs5q1ddLQ==",
-			"dev": true
-		},
 		"gensync": {
 			"version": "1.0.0-beta.1",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -3378,12 +3292,6 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
-		"hey-listen": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-			"integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-			"dev": true
-		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -3465,21 +3373,6 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true
-		},
-		"insomnia-components": {
-			"version": "2.2.26",
-			"resolved": "https://registry.npmjs.org/insomnia-components/-/insomnia-components-2.2.26.tgz",
-			"integrity": "sha512-IkTAi2BDX8l23+G822vm5op512d/UoK3zX6R46K6hoZr5KRu44QIcVp0Kk89MxgFRNt/OhnYAPWx1LEXucHBlg==",
-			"dev": true,
-			"requires": {
-				"autobind-decorator": "^2.4.0",
-				"classnames": "^2.2.6",
-				"framer-motion": "^1.10.3",
-				"fuzzysort": "^1.1.4",
-				"md5": "^2.2.1",
-				"prop-types": "^15.7.2",
-				"react-switch": "^5.0.1"
-			}
 		},
 		"interpret": {
 			"version": "1.2.0",
@@ -3825,17 +3718,6 @@
 			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
-			}
-		},
-		"md5": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-			"dev": true,
-			"requires": {
-				"charenc": "0.0.2",
-				"crypt": "0.0.2",
-				"is-buffer": "~1.1.6"
 			}
 		},
 		"md5.js": {
@@ -4402,20 +4284,6 @@
 				"find-up": "^2.1.0"
 			}
 		},
-		"popmotion": {
-			"version": "9.0.0-beta-8",
-			"resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-beta-8.tgz",
-			"integrity": "sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==",
-			"dev": true,
-			"requires": {
-				"@popmotion/easing": "^1.0.1",
-				"@popmotion/popcorn": "^0.4.2",
-				"framesync": "^4.0.4",
-				"hey-listen": "^1.0.8",
-				"style-value-types": "^3.1.6",
-				"tslib": "^1.10.0"
-			}
-		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -4575,15 +4443,6 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true
-		},
-		"react-switch": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/react-switch/-/react-switch-5.0.1.tgz",
-			"integrity": "sha512-Pa5kvqRfX85QUCK1Jv0rxyeElbC3aNpCP5hV0LoJpU/Y6kydf0t4kRriQ6ZYA4kxWwAYk/cH51T4/sPzV9mCgQ==",
-			"dev": true,
-			"requires": {
-				"prop-types": "^15.6.2"
-			}
 		},
 		"readable-stream": {
 			"version": "2.3.7",
@@ -5203,29 +5062,6 @@
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
-		},
-		"style-value-types": {
-			"version": "3.1.9",
-			"resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.9.tgz",
-			"integrity": "sha512-050uqgB7WdvtgacoQKm+4EgKzJExVq0sieKBQQtJiU3Muh6MYcCp4T3M8+dfl6VOF2LR0NNwXBP1QYEed8DfIw==",
-			"dev": true,
-			"requires": {
-				"hey-listen": "^1.0.8",
-				"tslib": "^1.10.0"
-			}
-		},
-		"stylefire": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/stylefire/-/stylefire-7.0.3.tgz",
-			"integrity": "sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==",
-			"dev": true,
-			"requires": {
-				"@popmotion/popcorn": "^0.4.4",
-				"framesync": "^4.0.0",
-				"hey-listen": "^1.0.8",
-				"style-value-types": "^3.1.7",
-				"tslib": "^1.10.0"
-			}
 		},
 		"supports-color": {
 			"version": "5.5.0",


### PR DESCRIPTION
As requested by @develohpanda, I'm opening this PR as a proposal about issue #2468.
This PR is an improved version from the previous one #2963 which has been closed in favor of this one.

**Context**
The auto-bind decorator is preventing react-hot-reload from working properly due to binding not only the class functions but even the React lifecycles functions (which is unnecessary and should be avoided) causing the following error:
![image](https://user-images.githubusercontent.com/20780192/105536787-31f5d400-5cf1-11eb-8cb2-a364a075094c.png)

**The current idea**
We aim to replace [autobind-decorator](https://www.npmjs.com/package/autobind-decorator) with [class-autobind-decorator](https://www.npmjs.com/package/class-autobind-decorator) that introduces `@autoBindMethodsForReact` a convenience decorator that skips auto binding methods from the React Component Spec that do not require binding.

Here is a gif that shows react-hot-reloading working again

![Test](https://user-images.githubusercontent.com/20780192/105537713-9d8c7100-5cf2-11eb-9e10-00384199267c.gif)

As always I'm glad to hear feedback.
Thanks

Closes #2468