### PR TITLE
Add folder and file icons to proto files list

### DIFF
--- a/packages/insomnia-app/app/ui/components/proto-file/proto-directory-list-item.js
+++ b/packages/insomnia-app/app/ui/components/proto-file/proto-directory-list-item.js
@@ -22,7 +22,10 @@ const ProtoDirectoryListItem = ({ dir, indentLevel, handleDeleteDirectory }: Pro
 
   return (
     <ProtoListItem indentLevel={indentLevel}>
-      {dir.name}
+      <span className="wide">
+        <i className="fa fa-folder-open-o pad-right-sm" />
+        {dir.name}
+      </span>
       {indentLevel === 0 && (
         <div className="row">
           <Button

--- a/packages/insomnia-app/app/ui/components/proto-file/proto-file-list-item.js
+++ b/packages/insomnia-app/app/ui/components/proto-file/proto-file-list-item.js
@@ -66,10 +66,18 @@ const ProtoFileListItem = ({
       isSelected={isSelected}
       onClick={handleSelectCallback}
       indentLevel={indentLevel}>
-      {isReadOnly && <span className="wide">{name}</span>}
+      {isReadOnly && (
+        <span className="wide">
+          <i className="fa fa-file-o pad-right-sm" />
+          {name}
+        </span>
+      )}
       {!isReadOnly && (
         <>
-          <Editable className="wide" onSubmit={handleRenameCallback} value={name} preventBlank />
+          <span className="wide">
+            <i className="fa fa-file-o pad-right-sm" />
+            <Editable className="wide" onSubmit={handleRenameCallback} value={name} preventBlank />
+          </span>
           <div className="row">
             <AsyncButton
               variant="text"

--- a/packages/insomnia-app/app/ui/components/proto-file/proto-list-item.js
+++ b/packages/insomnia-app/app/ui/components/proto-file/proto-list-item.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { ListGroupItem } from 'insomnia-components';
 
 const ProtoListItem = styled(ListGroupItem).attrs(() => ({ className: 'row-spaced' }))`
-  i.fa {
+  button i.fa {
     font-size: var(--font-size-lg);
   }
 

--- a/packages/insomnia-app/app/ui/css/layout/base.less
+++ b/packages/insomnia-app/app/ui/css/layout/base.less
@@ -579,7 +579,7 @@ i.fa.fa--fixed-width {
 }
 
 .pad-left-sm {
-  padding-left: calc(var(--padding-md) / 2);
+  padding-left: var(--padding-md);
 }
 
 .pad-right {
@@ -588,7 +588,7 @@ i.fa.fa--fixed-width {
 }
 
 .pad-right-sm {
-  padding-right: calc(var(--padding-md) / 2);
+  padding-right: var(--padding-sm);
 }
 
 .pad-top {


### PR DESCRIPTION
This PR updates styling of the proto files list to better show folders and nesting

<img width="1077" alt="image" src="https://user-images.githubusercontent.com/4312346/105649031-592beb80-5f13-11eb-9b20-b25ade6b3ffe.png">
