### PR TITLE
Update layout of the homepage

### DIFF
--- a/packages/insomnia-app/app/ui/components/workspace-page-header.js
+++ b/packages/insomnia-app/app/ui/components/workspace-page-header.js
@@ -58,7 +58,7 @@ const WorkspacePageHeader = ({
       className="app-header"
       gridLeft={
         <React.Fragment>
-          <img src={coreLogo} alt="Insomnia" width="32" height="32" />
+          <img src={coreLogo} alt="Insomnia" width="24" height="24" />
           <Breadcrumb
             className="breadcrumb"
             crumbs={[strings.home, <React.Fragment key="workspace-dd">{workspace}</React.Fragment>]}

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -22,6 +22,7 @@ import {
   DropdownDivider,
   DropdownItem,
   Header,
+  CircleButton,
   SvgIcon,
 } from 'insomnia-components';
 import DocumentCardDropdown from './dropdowns/document-card-dropdown';
@@ -460,6 +461,13 @@ class WrapperHome extends React.PureComponent<Props, State> {
                 <img src={coreLogo} alt="Insomnia" width="32" height="32" />
                 <Breadcrumb className="breadcrumb" crumbs={[getAppName()]} />
               </React.Fragment>
+            }
+            gridRight={
+              <>
+                <CircleButton>
+                  <SvgIcon icon="gear" />
+                </CircleButton>
+              </>
             }
           />
         )}

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -4,7 +4,13 @@ import * as git from 'isomorphic-git';
 import path from 'path';
 import * as db from '../../common/database';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { AUTOBIND_CFG, ACTIVITY_HOME, ACTIVITY_SPEC, ACTIVITY_DEBUG } from '../../common/constants';
+import {
+  AUTOBIND_CFG,
+  ACTIVITY_HOME,
+  ACTIVITY_SPEC,
+  ACTIVITY_DEBUG,
+  getAppName,
+} from '../../common/constants';
 import type { Workspace } from '../../models/workspace';
 import 'swagger-ui-react/swagger-ui.css';
 import {
@@ -46,7 +52,6 @@ import {
   GIT_INTERNAL_DIR,
 } from '../../sync/git/git-vcs';
 import { parseApiSpec } from '../../common/api-specs';
-import strings from '../../common/strings';
 
 type Props = {|
   wrapperProps: WrapperProps,
@@ -442,29 +447,32 @@ class WrapperHome extends React.PureComponent<Props, State> {
             gridLeft={
               <React.Fragment>
                 <img src={coreLogo} alt="Insomnia" width="32" height="32" />
-                <Breadcrumb className="breadcrumb" crumbs={[strings.home]} />
+                <Breadcrumb className="breadcrumb" crumbs={[getAppName()]} />
               </React.Fragment>
             }
-            gridCenter={
-              <div className="form-control form-control--outlined no-margin">
-                <KeydownBinder onKeydown={this._handleKeyDown}>
-                  <input
-                    ref={this._setFilterInputRef}
-                    type="text"
-                    placeholder="Filter..."
-                    onChange={this._handleFilterChange}
-                    className="no-margin"
-                  />
-                  <span className="fa fa-search filter-icon" />
-                </KeydownBinder>
-              </div>
-            }
-            gridRight={this.renderMenu()}
           />
         )}
         renderPageBody={() => (
-          <div className="document-listing theme--pane layout-body pad-top">
-            <div className="document-listing__body">
+          <div className="document-listing theme--pane layout-body">
+            <div className="document-listing__body pad-bottom">
+              <div className="row-spaced margin-top margin-bottom-sm">
+                <h2 className="no-margin">Dashboard</h2>
+                <span className="row-spaced pad-left" style={{ maxWidth: '400px' }}>
+                  <div className="form-control form-control--outlined no-margin">
+                    <KeydownBinder onKeydown={this._handleKeyDown}>
+                      <input
+                        ref={this._setFilterInputRef}
+                        type="text"
+                        placeholder="Filter..."
+                        onChange={this._handleFilterChange}
+                        className="no-margin"
+                      />
+                      <span className="fa fa-search filter-icon" />
+                    </KeydownBinder>
+                  </div>
+                  {this.renderMenu()}
+                </span>
+              </div>
               <CardContainer>{cards}</CardContainer>
               {filter && cards.length === 0 && (
                 <Notice color="subtle">

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -358,17 +358,20 @@ class WrapperHome extends React.PureComponent<Props, State> {
       </DocumentCardDropdown>
     );
     const version = spec?.info?.version || '';
-    let label: string = 'Insomnia';
+    let label: string = 'Collection';
+    let format: string = '';
+    let labelIcon = <i className="fa fa-bars" />;
     let defaultActivity = ACTIVITY_DEBUG;
     let title = w.name;
 
     if (w.scope === 'designer') {
-      label = '';
+      label = 'Document';
+      labelIcon = <i className="fa fa-file-o" />;
       if (specFormat === 'openapi') {
-        label = `OpenAPI ${specFormatVersion}`;
+        format = `OpenAPI ${specFormatVersion}`;
       } else if (specFormat === 'swagger') {
         // NOTE: This is not a typo, we're labeling Swagger as OpenAPI also
-        label = `OpenAPI ${specFormatVersion}`;
+        format = `OpenAPI ${specFormatVersion}`;
       }
 
       defaultActivity = ACTIVITY_SPEC;
@@ -391,10 +394,18 @@ class WrapperHome extends React.PureComponent<Props, State> {
         key={apiSpec._id}
         docBranch={branch && <Highlight search={filter} text={branch} />}
         docTitle={title && <Highlight search={filter} text={title} />}
-        docVersion={version && <Highlight search={filter} text={version} />}
-        tagLabel={label && <Highlight search={filter} text={label} />}
+        docVersion={version && <Highlight search={filter} text={`v${version}`} />}
+        tagLabel={
+          label && (
+            <>
+              <span className="margin-right-xs">{labelIcon}</span>
+              <Highlight search={filter} text={label} />
+            </>
+          )
+        }
         docLog={log}
         docMenu={docMenu}
+        docFormat={format}
         onClick={() => this._handleClickCard(w._id, defaultActivity)}
       />
     );

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -53,6 +53,7 @@ import {
   GIT_INTERNAL_DIR,
 } from '../../sync/git/git-vcs';
 import { parseApiSpec } from '../../common/api-specs';
+import SettingsModal from './modals/settings-modal';
 
 type Props = {|
   wrapperProps: WrapperProps,
@@ -116,6 +117,10 @@ class WrapperHome extends React.PureComponent<Props, State> {
         this.props.handleImportUri(uri, ForceToWorkspaceKeys.new);
       },
     });
+  }
+
+  static _handleShowSettings() {
+    showModal(SettingsModal);
   }
 
   async _handleWorkspaceClone() {
@@ -417,7 +422,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
       <Dropdown
         renderButton={() => (
           <Button variant="contained" bg="surprise" className="margin-left">
-            Create <i className="fa fa-caret-down" />
+            Create <i className="fa fa-caret-down pad-left-sm" />
           </Button>
         )}>
         <DropdownDivider>New</DropdownDivider>
@@ -463,11 +468,9 @@ class WrapperHome extends React.PureComponent<Props, State> {
               </React.Fragment>
             }
             gridRight={
-              <>
-                <CircleButton>
-                  <SvgIcon icon="gear" />
-                </CircleButton>
-              </>
+              <CircleButton onClick={WrapperHome._handleShowSettings}>
+                <SvgIcon icon="gear" />
+              </CircleButton>
             }
           />
         )}
@@ -498,6 +501,9 @@ class WrapperHome extends React.PureComponent<Props, State> {
                   No documents found for <strong>{filter}</strong>
                 </Notice>
               )}
+            </div>
+            <div className="document-listing__footer vertically-center">
+              <span>{cards.length} Documents</span>
             </div>
           </div>
         )}

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -463,7 +463,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
             className="app-header"
             gridLeft={
               <React.Fragment>
-                <img src={coreLogo} alt="Insomnia" width="32" height="32" />
+                <img src={coreLogo} alt="Insomnia" width="24" height="24" />
                 <Breadcrumb className="breadcrumb" crumbs={[getAppName()]} />
               </React.Fragment>
             }

--- a/packages/insomnia-app/app/ui/css/components/document-listing.less
+++ b/packages/insomnia-app/app/ui/css/components/document-listing.less
@@ -3,7 +3,8 @@
   width: 100%;
   box-sizing: border-box;
   background: var(--color-bg);
-  grid-template-rows: auto auto minmax(0, 1fr);
+  display: flex;
+  flex-direction: column;
 
   &__body {
     padding: var(--padding-md);
@@ -12,6 +13,12 @@
     box-sizing: border-box;
     width: 100%;
     height: 100%;
+  }
+
+  &__footer {
+    height: var(--line-height-xs);
+    border-top: 1px solid var(--hl-md);
+    width: 100%;
   }
 
   &__header {

--- a/packages/insomnia-app/app/ui/css/layout/base.less
+++ b/packages/insomnia-app/app/ui/css/layout/base.less
@@ -649,6 +649,14 @@ i.fa.fa--fixed-width {
   margin-right: var(--padding-sm);
 }
 
+.margin-left-xs {
+  margin-left: var(--padding-xs);
+}
+
+.margin-right-xs {
+  margin-right: var(--padding-xs);
+}
+
 .margin-bottom {
   margin-bottom: var(--padding-md);
 }

--- a/packages/insomnia-components/components/breadcrumb.js
+++ b/packages/insomnia-components/components/breadcrumb.js
@@ -8,7 +8,7 @@ type Props = {|
 |};
 
 const StyledBreadcrumb: React.ComponentType<{}> = styled.ul`
-  font-size: var(--font-size-md);
+  font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--color-font);
   grid-area: breadcrumbs;

--- a/packages/insomnia-components/components/button/button.js
+++ b/packages/insomnia-components/components/button/button.js
@@ -6,6 +6,7 @@ export const ButtonSizeEnum = {
   Default: 'default',
   Small: 'small',
   Medium: 'medium',
+  Circle: 'circle',
 };
 
 export const ButtonVariantEnum = {
@@ -38,6 +39,7 @@ const StyledButton: React.ComponentType<ButtonProps> = styled.button`
   display: inline-flex !important;
   flex-direction: row !important;
   align-items: center !important;
+  justify-content: center !important;
   border: 1px solid transparent;
 
   ${({ radius }) => css`
@@ -57,6 +59,12 @@ const StyledButton: React.ComponentType<ButtonProps> = styled.button`
           padding: 0 var(--padding-md);
           height: calc(var(--line-height-md) * 0.8);
           font-size: var(--font-size-md);
+        `;
+      case 'circle':
+        return css`
+          padding: 0.6rem;
+          font-size: var(--font-size-xxl);
+          border-radius: 50%;
         `;
       default:
         return css`

--- a/packages/insomnia-components/components/button/button.js
+++ b/packages/insomnia-components/components/button/button.js
@@ -6,7 +6,6 @@ export const ButtonSizeEnum = {
   Default: 'default',
   Small: 'small',
   Medium: 'medium',
-  Circle: 'circle',
 };
 
 export const ButtonVariantEnum = {

--- a/packages/insomnia-components/components/button/button.js
+++ b/packages/insomnia-components/components/button/button.js
@@ -60,12 +60,6 @@ const StyledButton: React.ComponentType<ButtonProps> = styled.button`
           height: calc(var(--line-height-md) * 0.8);
           font-size: var(--font-size-md);
         `;
-      case 'circle':
-        return css`
-          padding: 0.6rem;
-          font-size: var(--font-size-xxl);
-          border-radius: 50%;
-        `;
       default:
         return css`
           padding: 0 var(--padding-md);

--- a/packages/insomnia-components/components/button/circle-button.js
+++ b/packages/insomnia-components/components/button/circle-button.js
@@ -1,0 +1,31 @@
+// @flow
+
+import * as React from 'react';
+import styled, { css } from 'styled-components';
+import { Button } from './button';
+import type { ButtonProps } from './button';
+
+type Props = {
+  height?: string,
+  width?: string,
+} & ButtonProps;
+
+const StyledCircleButton: React.ComponentType<Props> = styled(Button)`
+  padding: unset;
+  font-size: var(--font-size-xxxl);
+  border-radius: 50%;
+
+  ${({ height }) => css`
+    height: ${height || 'unset'};
+  `};
+
+  ${({ width }) => css`
+    width: ${width || 'unset'};
+  `};
+
+  svg {
+    padding: var(--padding-xs);
+  }
+`;
+
+export const CircleButton = (props: Props) => <StyledCircleButton {...props} />;

--- a/packages/insomnia-components/components/button/circle-button.js
+++ b/packages/insomnia-components/components/button/circle-button.js
@@ -12,7 +12,7 @@ type Props = {
 
 const StyledCircleButton: React.ComponentType<Props> = styled(Button)`
   padding: unset;
-  font-size: var(--font-size-xxxl);
+  font-size: var(--font-size-xl);
   border-radius: 50%;
 
   ${({ height }) => css`

--- a/packages/insomnia-components/components/button/circle-button.stories.js
+++ b/packages/insomnia-components/components/button/circle-button.stories.js
@@ -1,8 +1,9 @@
 // @flow
 import * as React from 'react';
-import { number, withKnobs } from '@storybook/addon-knobs';
+import { number, select, withKnobs } from '@storybook/addon-knobs';
 import SvgIcon, { IconEnum } from '../svg-icon';
 import { CircleButton } from './circle-button';
+import { ButtonThemeEnum, ButtonVariantEnum } from './button';
 
 export default {
   title: 'Buttons | Circle Button',
@@ -31,8 +32,10 @@ export const dimensions = () => {
     <CircleButton
       onClick={() => window.alert('Clicked!')}
       width={selectWidth()}
-      height={selectHeight()}>
-      <SvgIcon icon={IconEnum.gear} />
+      height={selectHeight()}
+      variant={select('Variant', ButtonVariantEnum)}
+      bg={select('Background', ButtonThemeEnum)}>
+      <SvgIcon icon={select('Icon', IconEnum, IconEnum.gear)} />
     </CircleButton>
   );
 };

--- a/packages/insomnia-components/components/button/circle-button.stories.js
+++ b/packages/insomnia-components/components/button/circle-button.stories.js
@@ -1,0 +1,38 @@
+// @flow
+import * as React from 'react';
+import { number, withKnobs } from '@storybook/addon-knobs';
+import SvgIcon, { IconEnum } from '../svg-icon';
+import { CircleButton } from './circle-button';
+
+export default {
+  title: 'Buttons | Circle Button',
+  decorators: [withKnobs],
+};
+
+const selectWidth = () => `${number('Width (px)', 32)}px`;
+const selectHeight = () => `${number('Height (px)', 32)}px`;
+
+export const disabled = () => (
+  <CircleButton onClick={() => window.alert('Clicked!')} disabled>
+    <SvgIcon icon={IconEnum.gear} />
+  </CircleButton>
+);
+
+export const _default = () => {
+  return (
+    <CircleButton onClick={() => window.alert('Clicked!')}>
+      <SvgIcon icon={IconEnum.gear} />
+    </CircleButton>
+  );
+};
+
+export const dimensions = () => {
+  return (
+    <CircleButton
+      onClick={() => window.alert('Clicked!')}
+      width={selectWidth()}
+      height={selectHeight()}>
+      <SvgIcon icon={IconEnum.gear} />
+    </CircleButton>
+  );
+};

--- a/packages/insomnia-components/components/button/index.js
+++ b/packages/insomnia-components/components/button/index.js
@@ -1,2 +1,3 @@
 export { Button } from './button';
 export { AsyncButton } from './async-button';
+export { CircleButton } from './circle-button';

--- a/packages/insomnia-components/components/card.js
+++ b/packages/insomnia-components/components/card.js
@@ -9,7 +9,7 @@ type Props = {
   docMenu: React.Node,
   docTitle: string,
   docVersion: string,
-  docType: string,
+  docFormat: string,
   tagLabel: string,
 
   onChange?: (e: SyntheticEvent<HTMLInputElement>) => any,
@@ -203,10 +203,10 @@ const CardFooter: React.ComponentType<{}> = styled.div`
     display: flex;
     justify-content: left;
     flex-direction: row;
+    margin-bottom: var(--padding-xs);
   }
 
   .icoLabel {
-    margin-bottom: var(--padding-xxs);
     padding-left: var(--padding-xs);
     font-size: var(--font-size-sm);
     * {
@@ -243,8 +243,8 @@ class Card extends React.PureComponent<Props, State> {
       docBranch,
       docLog,
       docMenu,
+      docFormat,
       selectable,
-      docType,
       onClick,
     } = this.props;
 
@@ -264,14 +264,18 @@ class Card extends React.PureComponent<Props, State> {
           )}
         </CardHeader>
         <CardBody>
-          {docTitle && <div className="title">{docTitle}</div>}
+          {docTitle && (
+            <div className="title">
+              <strong>{docTitle}</strong>
+            </div>
+          )}
           {docVersion && <div className="version">{docVersion}</div>}
         </CardBody>
         <CardFooter>
-          {docType && (
+          {docFormat && (
             <span>
               <SvgIcon icon={IconEnum.file} />
-              <div className="icoLabel">{docType}</div>
+              <div className="icoLabel">{docFormat}</div>
             </span>
           )}
           {docBranch && (

--- a/packages/insomnia-components/components/card.js
+++ b/packages/insomnia-components/components/card.js
@@ -9,6 +9,7 @@ type Props = {
   docMenu: React.Node,
   docTitle: string,
   docVersion: string,
+  docType: string,
   tagLabel: string,
 
   onChange?: (e: SyntheticEvent<HTMLInputElement>) => any,
@@ -243,8 +244,10 @@ class Card extends React.PureComponent<Props, State> {
       docLog,
       docMenu,
       selectable,
+      docType,
       onClick,
     } = this.props;
+
     return (
       <StyledCard className={this.state.selected ? 'selected' : 'deselected'} onClick={onClick}>
         <CardHeader>
@@ -265,6 +268,12 @@ class Card extends React.PureComponent<Props, State> {
           {docVersion && <div className="version">{docVersion}</div>}
         </CardBody>
         <CardFooter>
+          {docType && (
+            <span>
+              <SvgIcon icon={IconEnum.file} />
+              <div className="icoLabel">{docType}</div>
+            </span>
+          )}
           {docBranch && (
             <span>
               <SvgIcon icon={IconEnum.gitBranch} />

--- a/packages/insomnia-components/index.js
+++ b/packages/insomnia-components/index.js
@@ -19,7 +19,7 @@ import _ToggleSwitch from './components/toggle-switch';
 import * as table from './components/table';
 import _Tooltip from './components/tooltip';
 
-export { Button, AsyncButton } from './components/button';
+export { Button, AsyncButton, CircleButton } from './components/button';
 
 export const Breadcrumb = _Breadcrumb;
 export const Card = _Card;


### PR DESCRIPTION
Updated homepage, as per Figma designs.

![image](https://user-images.githubusercontent.com/4312346/107573270-2e030500-6c52-11eb-9515-9f338c24cb8c.png)


- The only thing missing right now is the "Account" image.
- ~The "Insomnia" text could probably be bigger.~

Where styled-components are used, I stayed with styled-components. And where CSS stylesheets are used, I stayed with CSS stylesheets. Mainly for consistency, and ease of understanding.