### PR TITLE
Insomnia CLI - Reporter integration

### DIFF
--- a/packages/insomnia-inso/README.md
+++ b/packages/insomnia-inso/README.md
@@ -190,7 +190,7 @@ Scope by document name or id using an external reporter
 
 ``` sh
 inso run test spc_ff27a1 --reporter my-custom-reporter
-inso run test spc_ff27a1 --reporter my-custom-reporter --reporter-options key1=value1 key2=value2
+inso run test spc_ff27a1 --reporter my-custom-reporter --reporterOptions key1=value1 key2=value2
 ```
 **Important**:
 Mocha and the external reporter must be installed as global in order to work

--- a/packages/insomnia-inso/README.md
+++ b/packages/insomnia-inso/README.md
@@ -147,7 +147,8 @@ The test runner is built on top of Mocha, thus many of the options behave as the
 |Option|Alias|Description|
 |- |- |- |
 | `--env <identifier>` | `-e` |the environment to use - an environment name or id |
-| `--reporter <value>` | `-r` |reporter to use, options are `dot, list, min, progress, spec` (default: `spec` )|
+| `--reporter <value>` | `-r` |specify reporter to use (default: `spec` )|
+| `--reporter-options <option> [options...]` | `-ro` |reporter-specific options|
 | `--testNamePattern <regex>` | `-t` | run tests that match the regex|
 | `--bail` | `-b` | abort ("bail") after the first test failure|
 | `--keepFile` | | do not delete the generated test file (useful for debugging)|
@@ -169,7 +170,7 @@ inso run test "Sample Specification" --env "OpenAPI env"
 inso run test spc_46c5a4 --env env_env_ca046a
 ```
 
-Scope by the a test suite name or id
+Scope by test suite name or id
 
 ``` sh
 inso run test "Math Suite" --env "OpenAPI env"
@@ -184,6 +185,15 @@ inso run test spc_46c5a4 --reporter progress --bail --keepFile
 ```
 
 More examples: [#2338](https://github.com/Kong/insomnia/pull/2338).
+
+Scope by document name or id using an external reporter
+
+``` sh
+inso run test spc_ff27a1 --reporter my-custom-reporter
+inso run test spc_ff27a1 --reporter my-custom-reporter --reporter-options key1=value1 key2=value2
+```
+**Important**:
+Mocha and the external reporter must be installed as global in order to work
 
 ## `$ inso export spec [identifier]`
 

--- a/packages/insomnia-inso/package-lock.json
+++ b/packages/insomnia-inso/package-lock.json
@@ -2444,9 +2444,9 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"commander": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
 		},
 		"commondir": {
 			"version": "1.0.1",

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@stoplight/spectral": "^5.4.0",
-    "commander": "^5.1.0",
+    "commander": "^6.1.0",
     "consola": "^2.15.0",
     "cosmiconfig": "^6.0.0",
     "enquirer": "^2.3.6",

--- a/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
+++ b/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
@@ -164,8 +164,8 @@ Run Insomnia unit test suites
 Options:
   -e, --env <identifier>         environment to use
   -t, --testNamePattern <regex>  run tests that match the regex
-  -r, --reporter <reporter>      reporter to use, options are [dot, list, min,
-                                 progress, spec] (default: spec)
+  -r, --reporter <reporter>      standard reporters options are [dot, list,
+                                  min, progress, spec] (default: spec)
   -b, --bail                     abort (\\"bail\\") after first test failure
   --keepFile                     do not delete the generated test file
   -h, --help                     display help for command"

--- a/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
+++ b/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
@@ -162,11 +162,11 @@ exports[`Snapshot for "inso run test -h" 1`] = `
 Run Insomnia unit test suites
 
 Options:
-  -e, --env <identifier>         environment to use
-  -t, --testNamePattern <regex>  run tests that match the regex
-  -r, --reporter <reporter>      standard reporters options are [dot, list,
-                                  min, progress, spec] (default: spec)
-  -b, --bail                     abort (\\"bail\\") after first test failure
-  --keepFile                     do not delete the generated test file
-  -h, --help                     display help for command"
+  -e, --env <identifier>                         environment to use
+  -t, --testNamePattern <regex>                  run tests that match the regex
+  -r, --reporter <reporter>                      standard reporters options are [dot, list,  min, progress, spec] (default: spec)
+  -ro, --reporter-options <option> [options...]  reporter-specific options
+  -b, --bail                                     abort (\\"bail\\") after first test failure
+  --keepFile                                     do not delete the generated test file
+  -h, --help                                     display help for command"
 `;

--- a/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
+++ b/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
@@ -162,11 +162,11 @@ exports[`Snapshot for "inso run test -h" 1`] = `
 Run Insomnia unit test suites
 
 Options:
-  -e, --env <identifier>                         environment to use
-  -t, --testNamePattern <regex>                  run tests that match the regex
-  -r, --reporter <reporter>                      specify report to use (default: spec)
-  -ro, --reporter-options <option> [options...]  reporter-specific options
-  -b, --bail                                     abort (\\"bail\\") after first test failure
-  --keepFile                                     do not delete the generated test file
-  -h, --help                                     display help for command"
+  -e, --env <identifier>                        environment to use
+  -t, --testNamePattern <regex>                 run tests that match the regex
+  -r, --reporter <reporter>                     specify report to use (default: spec)
+  -ro, --reporterOptions <option> [options...]  reporter-specific options
+  -b, --bail                                    abort (\\"bail\\") after first test failure
+  --keepFile                                    do not delete the generated test file
+  -h, --help                                    display help for command"
 `;

--- a/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
+++ b/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
@@ -164,7 +164,7 @@ Run Insomnia unit test suites
 Options:
   -e, --env <identifier>                         environment to use
   -t, --testNamePattern <regex>                  run tests that match the regex
-  -r, --reporter <reporter>                      standard reporters options are [dot, list,  min, progress, spec] (default: spec)
+  -r, --reporter <reporter>                      specify report to use (default: spec)
   -ro, --reporter-options <option> [options...]  reporter-specific options
   -b, --bail                                     abort (\\"bail\\") after first test failure
   --keepFile                                     do not delete the generated test file

--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -179,6 +179,10 @@ describe('cli', () => {
       expect(() => inso('run test -r')).toThrowError();
     });
 
+    it('should throw error if reporterOptions argument is missing', () => {
+      expect(() => inso('run test -ro')).toThrowError();
+    });
+
     it('should call runInsomniaTests with expected options', () => {
       inso('run test uts_123 -e env_123 -t name -r min -b --keepFile');
       expect(runInsomniaTests).toHaveBeenCalledWith('uts_123', {

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -59,7 +59,7 @@ const makeTestCommand = (commandCreator: CreateCommand) => {
     .option('-t, --testNamePattern <regex>', 'run tests that match the regex')
     .option(
       '-r, --reporter <reporter>',
-      `reporter to use, options are [${reporterTypes.join(', ')}] (default: ${defaultReporter})`,
+      `standard reporters options are [${reporterTypes.join(', ')}] (default: ${defaultReporter})`,
     )
     .option('-b, --bail', 'abort ("bail") after first test failure')
     .option('--keepFile', 'do not delete the generated test file')

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -57,10 +57,7 @@ const makeTestCommand = (commandCreator: CreateCommand) => {
     .description('Run Insomnia unit test suites')
     .option('-e, --env <identifier>', 'environment to use')
     .option('-t, --testNamePattern <regex>', 'run tests that match the regex')
-    .option(
-      '-r, --reporter <reporter>',
-      `standard reporters options are [${reporterTypes.join(', ')}] (default: ${defaultReporter})`,
-    )
+    .option('-r, --reporter <reporter>', `specify report to use (default: ${defaultReporter})`)
     .option('-ro, --reporter-options <option> [options...]', 'reporter-specific options')
     .option('-b, --bail', 'abort ("bail") after first test failure')
     .option('--keepFile', 'do not delete the generated test file')

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -1,6 +1,6 @@
 import { ConversionOption, conversionOptions, generateConfig } from './commands/generate-config';
 import { getVersion, logErrorExit1, exit } from './util';
-import { reporterTypes, runInsomniaTests, TestReporter } from './commands/run-tests';
+import { runInsomniaTests, TestReporter } from './commands/run-tests';
 import { lintSpecification } from './commands/lint-specification';
 import { exportSpecification } from './commands/export-specification';
 import { parseArgsStringToArgv } from 'string-argv';

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -58,7 +58,7 @@ const makeTestCommand = (commandCreator: CreateCommand) => {
     .option('-e, --env <identifier>', 'environment to use')
     .option('-t, --testNamePattern <regex>', 'run tests that match the regex')
     .option('-r, --reporter <reporter>', `specify report to use (default: ${defaultReporter})`)
-    .option('-ro, --reporter-options <option> [options...]', 'reporter-specific options')
+    .option('-ro, --reporterOptions <option> [options...]', 'reporter-specific options')
     .option('-b, --bail', 'abort ("bail") after first test failure')
     .option('--keepFile', 'do not delete the generated test file')
     .action((identifier, cmd) => {

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -61,6 +61,7 @@ const makeTestCommand = (commandCreator: CreateCommand) => {
       '-r, --reporter <reporter>',
       `standard reporters options are [${reporterTypes.join(', ')}] (default: ${defaultReporter})`,
     )
+    .option('-ro, --reporter-options <option> [options...]', 'reporter-specific options')
     .option('-b, --bail', 'abort ("bail") after first test failure')
     .option('--keepFile', 'do not delete the generated test file')
     .action((identifier, cmd) => {

--- a/packages/insomnia-inso/src/commands/run-tests.test.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.test.ts
@@ -103,7 +103,16 @@ describe('runInsomniaTests()', () => {
       bail: false,
       keepFile: false,
       reporter: 'custom-reporter',
-      reporterOptions: ['key1=value1', 'key2=value2'],
+      reporterOptions: [
+        'key1=value1',
+        'key2=value2',
+        'path=/tmp/9047ue.txt',
+        'delimiter="="',
+        'delimiter2==',
+        'someBoolStuff=true',
+        'someNumber=5',
+        'someNumber2=10.52',
+      ],
       env: 'env_env_ca046a738f001eb3090261a537b1b78f86c2094c_sub',
     };
 
@@ -116,6 +125,12 @@ describe('runInsomniaTests()', () => {
       reporterOptions: {
         key1: 'value1',
         key2: 'value2',
+        path: '/tmp/9047ue.txt',
+        delimiter: '"="',
+        delimiter2: '=',
+        someBoolStuff: true,
+        someNumber: 5,
+        someNumber2: 10.52,
       },
       sendRequest: expect.any(Function),
       testFilter: undefined,

--- a/packages/insomnia-inso/src/commands/run-tests.test.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.test.ts
@@ -1,5 +1,5 @@
 import { generate as _generate, runTestsCli as _runTestsCli } from 'insomnia-testing';
-import { runInsomniaTests, RunTestsOptions } from './run-tests';
+import { runInsomniaTests, RunTestsOptions, TestReporterEnum, isReporterFailure } from './run-tests';
 import { globalBeforeAll, globalBeforeEach } from '../jest/before';
 import { logger } from '../logger';
 import { GenerateConfigOptions } from './generate-config';
@@ -126,5 +126,25 @@ describe('runInsomniaTests()', () => {
     });
 
     await expect(result).toBeFalsy();
+  });
+
+  it('should prompt cli for test suites', async () => {
+    const result = await runInsomniaTests(undefined, {
+      ...base,
+      env: 'env_env_ca046a738f001eb3090261a537b1b78f86c2094c_sub',
+    });
+    await expect(result).toBe(false);
+  });
+
+  it('should report failure with logger name', async () => {
+    isReporterFailure('unknown-reporter', 'An invalid reporter has been provided');
+    expect(logger.__getLogs().fatal).toEqual([
+      'The following reporter `unknown-reporter` was not found!',
+    ]);
+  });
+
+  it('should report an unknown failure', async () => {
+    isReporterFailure('unknown-reporter', 'Javascript crashed');
+    expect(logger.__getLogs().fatal).toEqual(['An unknown error occurred: Javascript crashed']);
   });
 });

--- a/packages/insomnia-inso/src/commands/run-tests.test.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.test.ts
@@ -101,4 +101,17 @@ describe('runInsomniaTests()', () => {
     });
     expect(result).toBe(true);
   });
+
+  it('should return false if environment is undefined', async () => {
+    const result = await runInsomniaTests('spc_46c5a4a40e83445a9bd9d9758b86c16c', {
+      ...base,
+      workingDir: 'src/db/__fixtures__/git-repo',
+      env: undefined,
+    });
+
+    await expect(result).toBe(false);
+    expect(logger.__getLogs().fatal).toEqual([
+      'No environment identified; cannot run tests without a valid environment.',
+    ]);
+  });
 });

--- a/packages/insomnia-inso/src/commands/run-tests.test.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.test.ts
@@ -60,6 +60,7 @@ describe('runInsomniaTests()', () => {
       bail: true,
       keepFile: false,
       sendRequest: expect.any(Function),
+      reporterOptions: {},
       testFilter: 'Math',
     });
   });
@@ -139,12 +140,12 @@ describe('runInsomniaTests()', () => {
   it('should report failure with logger name', async () => {
     isReporterFailure('unknown-reporter', 'An invalid reporter has been provided');
     expect(logger.__getLogs().fatal).toEqual([
-      'The following reporter `unknown-reporter` was not found!',
+      'Reporter "unknown-reporter" not found: An invalid reporter has been provided',
     ]);
   });
 
   it('should report an unknown failure', async () => {
     isReporterFailure('unknown-reporter', 'Javascript crashed');
-    expect(logger.__getLogs().fatal).toEqual(['An unknown error occurred: Javascript crashed']);
+    expect(logger.__getLogs().fatal).toEqual(['Javascript crashed']);
   });
 });

--- a/packages/insomnia-inso/src/commands/run-tests.test.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.test.ts
@@ -1,5 +1,5 @@
 import { generate as _generate, runTestsCli as _runTestsCli } from 'insomnia-testing';
-import { runInsomniaTests, RunTestsOptions, TestReporterEnum, isReporterFailure } from './run-tests';
+import { runInsomniaTests, RunTestsOptions, isReporterFailure } from './run-tests';
 import { globalBeforeAll, globalBeforeEach } from '../jest/before';
 import { logger } from '../logger';
 import { GenerateConfigOptions } from './generate-config';
@@ -28,17 +28,6 @@ describe('runInsomniaTests()', () => {
     appDataDir: 'src/db/fixtures/nedb',
     ci: true,
   };
-
-  it('should should not  as _generate if type arg is invalid', async () => {
-    await runInsomniaTests(null, {
-      // @ts-expect-error this is intentionally passing in a bad value
-      reporter: 'invalid',
-    });
-    expect(runTestsCli).not.toHaveBeenCalled();
-    expect(logger.__getLogs().fatal).toEqual([
-      'Reporter "invalid" not unrecognized. Options are [dot, list, min, progress, spec].',
-    ]);
-  });
 
   it('should forward options to insomnia-testing', async () => {
     const contents = 'generated test contents';
@@ -96,7 +85,7 @@ describe('runInsomniaTests()', () => {
 
   it('should return true if reporter options are decoded properly', async () => {
     const contents = 'generated test contents';
-    mock(insomniaTesting.generate).mockResolvedValue(contents);
+    generate.mockReturnValue(contents);
 
     const options = {
       ...base,
@@ -118,7 +107,7 @@ describe('runInsomniaTests()', () => {
 
     await runInsomniaTests('spc_46c5a4a40e83445a9bd9d9758b86c16c', options);
 
-    expect(insomniaTesting.runTestsCli).toHaveBeenCalledWith(contents, {
+    expect(runTestsCli).toHaveBeenCalledWith(contents, {
       bail: false,
       keepFile: false,
       reporter: 'custom-reporter',
@@ -133,7 +122,6 @@ describe('runInsomniaTests()', () => {
         someNumber2: 10.52,
       },
       sendRequest: expect.any(Function),
-      testFilter: undefined,
     });
   });
 
@@ -161,7 +149,7 @@ describe('runInsomniaTests()', () => {
 
   it('should return falsy value if reporter is not found', async () => {
     const contents = 'generated test contents';
-    mock(insomniaTesting.generate).mockResolvedValue(contents);
+    generate.mockReturnValue(contents);
 
     const result = await runInsomniaTests('spc_46c5a4a40e83445a9bd9d9758b86c16c', {
       ...base,

--- a/packages/insomnia-inso/src/commands/run-tests.test.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.test.ts
@@ -94,6 +94,34 @@ describe('runInsomniaTests()', () => {
     );
   });
 
+  it('should return true if reporter options are decoded properly', async () => {
+    const contents = 'generated test contents';
+    mock(insomniaTesting.generate).mockResolvedValue(contents);
+
+    const options = {
+      ...base,
+      bail: false,
+      keepFile: false,
+      reporter: 'custom-reporter',
+      reporterOptions: ['key1=value1', 'key2=value2'],
+      env: 'env_env_ca046a738f001eb3090261a537b1b78f86c2094c_sub',
+    };
+
+    await runInsomniaTests('spc_46c5a4a40e83445a9bd9d9758b86c16c', options);
+
+    expect(insomniaTesting.runTestsCli).toHaveBeenCalledWith(contents, {
+      bail: false,
+      keepFile: false,
+      reporter: 'custom-reporter',
+      reporterOptions: {
+        key1: 'value1',
+        key2: 'value2',
+      },
+      sendRequest: expect.any(Function),
+      testFilter: undefined,
+    });
+  });
+
   it('should return true if test results have no failures', async function() {
     runTestsCli.mockResolvedValue(true);
     const result = await runInsomniaTests('spc_46c5a4a40e83445a9bd9d9758b86c16c', {

--- a/packages/insomnia-inso/src/commands/run-tests.test.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.test.ts
@@ -114,4 +114,17 @@ describe('runInsomniaTests()', () => {
       'No environment identified; cannot run tests without a valid environment.',
     ]);
   });
+
+  it('should return falsy value if reporter is not found', async () => {
+    const contents = 'generated test contents';
+    mock(insomniaTesting.generate).mockResolvedValue(contents);
+
+    const result = await runInsomniaTests('spc_46c5a4a40e83445a9bd9d9758b86c16c', {
+      ...base,
+      env: 'env_env_ca046a738f001eb3090261a537b1b78f86c2094c_sub',
+      reporter: 'does-not-exists',
+    });
+
+    await expect(result).toBeFalsy();
+  });
 });

--- a/packages/insomnia-inso/src/commands/run-tests.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.ts
@@ -1,32 +1,50 @@
-// @flow
 import { generate, runTestsCli } from 'insomnia-testing';
 import type { GlobalOptions } from '../get-options';
-import { loadDb } from '../db';
+import { Database, loadDb } from '../db';
 import type { UnitTest, UnitTestSuite } from '../db/models/types';
-import logger, { noConsoleLog } from '../logger';
+import { logger, noConsoleLog } from '../logger';
 import { loadTestSuites, promptTestSuites } from '../db/models/unit-test-suite';
 import { loadEnvironment, promptEnvironment } from '../db/models/environment';
+import { parseObjFromKeyValuePair } from '../util';
 
-export const TestReporterEnum = {
-  dot: 'dot',
-  doc: 'doc',
-  tap: 'tap',
-  json: 'json',
-  list: 'list',
-  min: 'min',
-  spec: 'spec',
-  nyan: 'nyan',
-  xunit: 'xunit',
-  markdown: 'markdown',
-  progress: 'progress',
-  landing: 'landing',
-  'json-stream': 'json-stream',
-};
+export type TestReporter =
+  'dot'
+  | 'doc'
+  | 'tap'
+  | 'json'
+  | 'list'
+  | 'min'
+  | 'spec'
+  | 'nyan'
+  | 'xunit'
+  | 'markdown'
+  | 'progress'
+  | 'landing'
+  | 'json-stream'
+  | string;
+
+export const reporterTypes: TestReporter[] = [
+  'dot',
+  'doc',
+  'tap',
+  'json',
+  'list',
+  'min',
+  'spec',
+  'nyan',
+  'xunit',
+  'markdown',
+  'progress',
+  'landing',
+  'json-stream',
+];
+
+export const reporterTypesSet = new Set(reporterTypes);
 
 export type RunTestsOptions = GlobalOptions & {
   env?: string,
-  reporter: string,
-  reporterOptions?: Array<string>,
+  reporter: typeof reporterTypes[number] | string,
+  reporterOptions?: string[],
   bail?: boolean,
   keepFile?: boolean,
   testNamePattern?: string,
@@ -40,13 +58,14 @@ export function isReporterFailure(reporter: string, err: string): void {
   }
 }
 
-function isExternalReporter({ reporter }: RunTestsOptions): boolean {
-  return reporter && !TestReporterEnum[reporter];
+function isExternalReporter(reporter = ''): boolean {
+  return !reporterTypesSet.has(reporter);
 }
 
-function getTestSuite(dbSuite: UnitTestSuite, dbTests: Array<UnitTest>) {
+function getTestSuite(dbSuite: UnitTestSuite, dbTests: UnitTest[]) {
   return {
     name: dbSuite.name,
+    suites: [],
     tests: dbTests.map(({ name, code, requestId }) => ({
       name,
       code,
@@ -55,63 +74,39 @@ function getTestSuite(dbSuite: UnitTestSuite, dbTests: Array<UnitTest>) {
   };
 }
 
-async function getEnvironments(db, ci, suites, env) {
+async function getEnvironments(db: Database, suites: UnitTestSuite[], ci: boolean, env?: string) {
   const workspaceId = suites[0].parentId;
   return env
     ? loadEnvironment(db, workspaceId, env)
-    : await promptEnvironment(db, !!ci, workspaceId);
+    : await promptEnvironment(db, ci, workspaceId);
 }
 
-async function getTestFileContent(db, suites) {
-  return await generate(
-    suites.map(suite =>
-      getTestSuite(
-        suite,
-        db.UnitTest.filter(t => t.parentId === suite._id),
-      ),
+async function getTestFileContent(db: Database, suites: UnitTestSuite[]) {
+  return generate(
+    suites.map((suite: UnitTestSuite) => getTestSuite(
+      suite,
+      db.UnitTest.filter((t: UnitTest) => t.parentId === suite._id),
+    ),
     ),
   );
 }
 
-/**
- * Extract an object from string given a key=value format
- * @param data An array of 'equal'(=) separated key value pairs
- */
-function getReporterOptions(data: Array<string> = []): Object {
-  const obj = {};
-  data.forEach(arg => {
-    // Extract option key-value
-    const key = arg.substring(0, arg.indexOf('='));
-    let value = arg.substring(arg.indexOf('=') + 1);
-
-    // Everything is treated as a string, except:
-    if (value === 'true' || value === 'false') value = value === 'true';
-    else if (value === 'null') value = null;
-    else if (value === 'undefined') value = undefined;
-    else if (!isNaN(value)) value = Number(value);
-
-    // Assign
-    obj[key] = value;
-  });
-  return obj;
-}
-
 // Identifier can be the id or name of a workspace, apiSpec, or unit test suite
 export async function runInsomniaTests(
-  identifier?: string,
-  options: RunTestsOptions,
+  identifier: string | null | undefined,
+  options: Partial<RunTestsOptions>,
 ): Promise<boolean> {
-  const { reporter, reporterOptions, ci, bail, keepFile, testNamePattern, env } = options;
+  const { reporter, reporterOptions, ci = false, bail, keepFile, testNamePattern, env } = options;
   // Loading database instance
   const db = await loadDb(options);
 
   // Check if any provider has been provided (Yeah, comedy king)
-  const isExternal = isExternalReporter(options);
+  const isExternal = isExternalReporter(reporter);
   // Extracting data key=value as an object
-  const reporterOptionsObj = getReporterOptions(reporterOptions);
+  const reporterOptionsObj = parseObjFromKeyValuePair(reporterOptions);
 
   // Find suites
-  const suites = identifier ? loadTestSuites(db, identifier) : await promptTestSuites(db, !!ci);
+  const suites = identifier ? loadTestSuites(db, identifier) : await promptTestSuites(db, ci);
 
   if (!suites.length) {
     logger.fatal('No test suites found; cannot run tests.');
@@ -119,7 +114,7 @@ export async function runInsomniaTests(
   }
 
   // Find env
-  const environment = await getEnvironments(db, ci, suites, env);
+  const environment = await getEnvironments(db, suites, ci, env);
 
   if (!environment) {
     logger.fatal('No environment identified; cannot run tests without a valid environment.');
@@ -129,12 +124,18 @@ export async function runInsomniaTests(
   // Generate test file
   const testFiles = await getTestFileContent(db, suites);
 
-  // Load lazily when needed, otherwise this require slows down the entire CLI.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- Load lazily when needed, otherwise this require slows down the entire CLI.
   const { getSendRequestCallbackMemDb } = require('insomnia-send-request');
   const sendRequest = await getSendRequestCallbackMemDb(environment._id, db);
 
   const config = {
-    reporter,
+    /*
+    * Q: Why type assertion as never?
+    * A: The problem comes from runTestsCli using the internal mocha.js interface representation called <ReporterContributions>.
+    * Due to being stated that this module should be independent from insomnia-testing implementation
+    * the only way I can remove the type-assertion error is forcing it as never
+    * */
+    reporter: reporter as never,
     reporterOptions: reporterOptionsObj,
     bail,
     keepFile,
@@ -142,13 +143,15 @@ export async function runInsomniaTests(
     testFilter: testNamePattern,
   };
 
-  let result;
+  let result = false;
 
   if (isExternal) {
     try {
       result = await runTestsCli(testFiles, config);
     } catch (e) {
-      isReporterFailure(reporter, e.toString());
+      /* Due to 'option' var expressed as Partial, even if 'reporter' it's not optional, I must use a type assertion here
+      /* I prefer to do not initialize it with anything else but using an assertion because it may be misleading when bug-reporting */
+      isReporterFailure(reporter as string, e.toString());
     }
   } else {
     result = await noConsoleLog(() => runTestsCli(testFiles, config));

--- a/packages/insomnia-inso/src/commands/run-tests.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.ts
@@ -9,15 +9,24 @@ import { loadEnvironment, promptEnvironment } from '../db/models/environment';
 
 export const TestReporterEnum = {
   dot: 'dot',
+  doc: 'doc',
+  tap: 'tap',
+  json: 'json',
+  html: 'html',
   list: 'list',
-  spec: 'spec',
   min: 'min',
+  spec: 'spec',
+  nyan: 'nyan',
+  xunit: 'xunit',
+  markdown: 'markdown',
   progress: 'progress',
+  landing: 'landing',
+  'json-stream': 'json-stream',
 };
 
 export type RunTestsOptions = GlobalOptions & {
   env?: string,
-  reporter: $Keys<typeof TestReporterEnum>,
+  reporter: string,
   reporterOptions?: Array<string>,
   bail?: boolean,
   keepFile?: boolean,
@@ -26,11 +35,10 @@ export type RunTestsOptions = GlobalOptions & {
 
 export function isReporterFailure(reporter: string, err: string): void {
   if (err.includes('invalid reporter')) {
-    logger.fatal(`The following reporter \`${reporter}\` was not found!`);
+    logger.fatal(`Reporter "${reporter}" not found: ${err}`);
   } else {
-    logger.fatal(`An unknown error occurred: ${err}`);
+    logger.fatal(err);
   }
-  return false;
 }
 
 function isExternalReporter({ reporter }: RunTestsOptions): boolean {

--- a/packages/insomnia-inso/src/commands/run-tests.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.ts
@@ -24,6 +24,15 @@ export type RunTestsOptions = GlobalOptions & {
   testNamePattern?: string,
 };
 
+export function isReporterFailure(reporter: string, err: string): void {
+  if (err.includes('invalid reporter')) {
+    logger.fatal(`The following reporter \`${reporter}\` was not found!`);
+  } else {
+    logger.fatal(`An unknown error occurred: ${err}`);
+  }
+  return false;
+}
+
 function isExternalReporter({ reporter }: RunTestsOptions): boolean {
   return reporter && !TestReporterEnum[reporter];
 }
@@ -102,12 +111,6 @@ export async function runInsomniaTests(
   };
 
   return isExternal
-    ? runTestsCli(testFiles, config)?.catch(e => {
-        if (e.toString().includes('invalid reporter')) {
-          logger.fatal(`The following reporter \`${reporter}\` was not found!`);
-        } else {
-          logger.fatal(`An unknown error occurred: ${e}`);
-        }
-      })
+    ? await runTestsCli(testFiles, config)?.catch(e => isReporterFailure(reporter, e.toString()))
     : await noConsoleLog(() => runTestsCli(testFiles, config));
 }

--- a/packages/insomnia-inso/src/commands/run-tests.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.ts
@@ -142,13 +142,17 @@ export async function runInsomniaTests(
     testFilter: testNamePattern,
   };
 
+  let result;
+
   if (isExternal) {
     try {
-      await runTestsCli(testFiles, config);
+      result = await runTestsCli(testFiles, config);
     } catch (e) {
       isReporterFailure(reporter, e.toString());
     }
   } else {
-    await noConsoleLog(() => runTestsCli(testFiles, config));
+    result = await noConsoleLog(() => runTestsCli(testFiles, config));
   }
+
+  return result;
 }

--- a/packages/insomnia-inso/src/commands/run-tests.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.ts
@@ -80,7 +80,17 @@ async function getTestFileContent(db, suites) {
 function getReporterOptions(data: Array<string> = []): Object {
   const obj = {};
   data.forEach(arg => {
-    const [key, value] = arg.split('=', 2);
+    // Extract option key-value
+    const key = arg.substring(0, arg.indexOf('='));
+    let value = arg.substring(arg.indexOf('=') + 1);
+
+    // Everything is treated as a string, except:
+    if (value === 'true' || value === 'false') value = value === 'true';
+    else if (value === 'null') value = null;
+    else if (value === 'undefined') value = undefined;
+    else if (!isNaN(value)) value = Number(value);
+
+    // Assign
     obj[key] = value;
   });
   return obj;

--- a/packages/insomnia-inso/src/commands/run-tests.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.ts
@@ -18,6 +18,7 @@ export const TestReporterEnum = {
 export type RunTestsOptions = GlobalOptions & {
   env?: string,
   reporter: $Keys<typeof TestReporterEnum>,
+  reporterOptions?: Array<string>,
   bail?: boolean,
   keepFile?: boolean,
   testNamePattern?: string,
@@ -61,7 +62,7 @@ export async function runInsomniaTests(
   identifier?: string,
   options: RunTestsOptions,
 ): Promise<boolean> {
-  const { reporter, ci, bail, keepFile, testNamePattern, env } = options;
+  const { reporter, reporterOptions, ci, bail, keepFile, testNamePattern, env } = options;
   // Loading database instance
   const db = await loadDb(options);
 
@@ -93,6 +94,7 @@ export async function runInsomniaTests(
 
   const config = {
     reporter,
+    reporterOptions,
     bail,
     keepFile,
     sendRequest,

--- a/packages/insomnia-inso/src/commands/run-tests.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.ts
@@ -12,7 +12,6 @@ export const TestReporterEnum = {
   doc: 'doc',
   tap: 'tap',
   json: 'json',
-  html: 'html',
   list: 'list',
   min: 'min',
   spec: 'spec',
@@ -118,7 +117,13 @@ export async function runInsomniaTests(
     testFilter: testNamePattern,
   };
 
-  return isExternal
-    ? await runTestsCli(testFiles, config)?.catch(e => isReporterFailure(reporter, e.toString()))
-    : await noConsoleLog(() => runTestsCli(testFiles, config));
+  if (isExternal) {
+    try {
+      await runTestsCli(testFiles, config);
+    } catch (e) {
+      isReporterFailure(reporter, e.toString());
+    }
+  } else {
+    await noConsoleLog(() => runTestsCli(testFiles, config));
+  }
 }

--- a/packages/insomnia-inso/src/commands/run-tests.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.ts
@@ -125,7 +125,7 @@ export async function runInsomniaTests(
 
   const config = {
     reporter,
-    reporterOptionsObj,
+    reporterOptions: reporterOptionsObj,
     bail,
     keepFile,
     sendRequest,

--- a/packages/insomnia-inso/src/commands/run-tests.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.ts
@@ -73,6 +73,19 @@ async function getTestFileContent(db, suites) {
   );
 }
 
+/**
+ * Extract an object from string given a key=value format
+ * @param data An array of 'equal'(=) separated key value pairs
+ */
+function getReporterOptions(data: Array<string> = []): Object {
+  const obj = {};
+  data.forEach(arg => {
+    const [key, value] = arg.split('=', 2);
+    obj[key] = value;
+  });
+  return obj;
+}
+
 // Identifier can be the id or name of a workspace, apiSpec, or unit test suite
 export async function runInsomniaTests(
   identifier?: string,
@@ -84,6 +97,8 @@ export async function runInsomniaTests(
 
   // Check if any provider has been provided (Yeah, comedy king)
   const isExternal = isExternalReporter(options);
+  // Extracting data key=value as an object
+  const reporterOptionsObj = getReporterOptions(reporterOptions);
 
   // Find suites
   const suites = identifier ? loadTestSuites(db, identifier) : await promptTestSuites(db, !!ci);
@@ -110,7 +125,7 @@ export async function runInsomniaTests(
 
   const config = {
     reporter,
-    reporterOptions,
+    reporterOptionsObj,
     bail,
     keepFile,
     sendRequest,

--- a/packages/insomnia-inso/src/util.test.ts
+++ b/packages/insomnia-inso/src/util.test.ts
@@ -1,4 +1,4 @@
-import { exit, logErrorExit1, getDefaultAppName, getVersion, isDevelopment, noop } from './util';
+import { exit, logErrorExit1, getDefaultAppName, getVersion, isDevelopment, noop, parseObjFromKeyValuePair } from './util';
 import * as packageJson from '../package.json';
 import { globalBeforeAll, globalBeforeEach } from './jest/before';
 import { logger } from './logger';
@@ -147,6 +147,34 @@ describe('isDevelopment()', () => {
     process.env.NODE_ENV = 'production';
     expect(isDevelopment()).toBe(false);
     process.env.NODE_ENV = oldNodeEnv;
+  });
+});
+
+describe('parseObjFromKeyValuePair()', function() {
+  it('should return true if key-value pairs are decoded properly', async () => {
+    const arr = [
+      'key1=value1',
+      'key2=value2',
+      'path=/tmp/9047ue.txt',
+      'delimiter="="',
+      'delimiter2==',
+      'someBoolStuff=true',
+      'someNumber=5',
+      'someNumber2=10.52',
+    ];
+
+    const expected = {
+      key1: 'value1',
+      key2: 'value2',
+      path: '/tmp/9047ue.txt',
+      delimiter: '"="',
+      delimiter2: '=',
+      someBoolStuff: true,
+      someNumber: 5,
+      someNumber2: 10.52,
+    };
+
+    expect(parseObjFromKeyValuePair(arr)).toBe(expected);
   });
 });
 

--- a/packages/insomnia-inso/src/util.ts
+++ b/packages/insomnia-inso/src/util.ts
@@ -28,5 +28,29 @@ export const getDefaultAppName = (): string => {
   return name;
 };
 
+/**
+ * Extract an object from a string array with a key=value format
+ * (e.g var arr = ["prop1=value", "prop2=value" ...])
+ * @param data An array of 'equal'(=) separated key value pairs
+ */
+export const parseObjFromKeyValuePair = (data: string[] = []): Record<string, unknown> => {
+  // Placeholder data
+  const obj: Record<string, unknown> = {};
+  // Cycling for extraction each pair key-value
+  data.forEach(arg => {
+    // Extract option key-value
+    const key = arg.substring(0, arg.indexOf('='));
+    let value: unknown = arg.substring(arg.indexOf('=') + 1);
+    // Everything is treated as a string, except:
+    if (value === 'true' || value === 'false') value = value === 'true';
+    else if (value === 'null') value = null;
+    else if (value === 'undefined') value = undefined;
+    else if (!isNaN(<number>value)) value = Number(value);
+    // Assign
+    obj[key] = value;
+  });
+  return obj;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const noop = () => {};

--- a/packages/insomnia-testing/src/run/insomnia.ts
+++ b/packages/insomnia-testing/src/run/insomnia.ts
@@ -34,6 +34,7 @@ export type SendRequestCallback = (requestId: string) => Promise<Response>;
 export interface InsomniaOptions {
   requests?: Request[];
   sendRequest?: SendRequestCallback;
+  reporterOptions?: Record<string, unknown>;
   bail?: boolean;
   keepFile?: boolean;
   testFilter?: string;

--- a/packages/insomnia-testing/src/run/run.ts
+++ b/packages/insomnia-testing/src/run/run.ts
@@ -23,7 +23,7 @@ const runInternal = async <T>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- type not available, and postponing anyway until the impending move to all jest (and no mocha)
   extractResult: (runner: { [key: string]: any }) => T,
 ): Promise<T> => new Promise((resolve, reject) => {
-  const { bail, keepFile, testFilter } = options;
+  const { bail, keepFile, testFilter, reporterOptions } = options;
 
   // Add global `insomnia` helper.
   // This is the only way to add new globals to the Mocha environment as far as I can tell
@@ -35,6 +35,7 @@ const runInternal = async <T>(
     globals: ['insomnia', 'chai'],
     bail,
     reporter,
+    reporterOptions,
     // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51770
     fgrep: testFilter,
   });
@@ -67,6 +68,7 @@ const runInternal = async <T>(
       });
     });
   } catch (err) {
+    console.log(err);
     reject(err);
   }
 });


### PR DESCRIPTION
The following PR contains these changes:
- Removed blocking-code for external reporters
- ~When using an external reporter (installed with npm) an info message is printed to say "be careful, we try our best but it may fail...if you can use our internal reporters".~
- If the reporter is external, now it is able to print on console (because of some Insomnia code preventing it), so the result can be eventually piped
- If the external reporter is not found, it is now caught from Mocha and displayed to the user in a nice way

To-Do:
- ~Handle arguments given to the reporter~

Closes #3059 