### PR TITLE
Feat: SVG are themable now

### DIFF
--- a/packages/insomnia-components/components/svg-icon.js
+++ b/packages/insomnia-components/components/svg-icon.js
@@ -115,6 +115,7 @@ type IconKeys = $Values<typeof IconEnum>;
 type Props = {
   icon: IconKeys,
   label?: React.Node,
+  theme?: string,
 };
 
 const SvgIconStyled: React.ComponentType<{ theme: ThemeKeys, hasLabel: boolean }> = styled.div`
@@ -199,7 +200,7 @@ class SvgIcon extends React.Component<Props> {
   };
 
   render() {
-    const { icon, label } = this.props;
+    const { icon, label, theme } = this.props;
 
     if (!SvgIcon.icons[icon]) {
       throw new Error(
@@ -207,10 +208,16 @@ class SvgIcon extends React.Component<Props> {
       );
     }
 
-    const [theme, Svg] = SvgIcon.icons[icon];
+    if (!!theme && !ThemeEnum[theme]) {
+      throw new Error(
+        `Invalid theme "${theme}" used. Must be one of ${Object.values(ThemeEnum).join('|')}`,
+      );
+    }
+
+    const [defaultTheme, Svg] = SvgIcon.icons[icon];
 
     return (
-      <SvgIconStyled theme={theme} hasLabel={!!label}>
+      <SvgIconStyled theme={theme || defaultTheme} hasLabel={!!label}>
         <Svg />
         {label}
       </SvgIconStyled>


### PR DESCRIPTION
**TLDR;** This PR allows one to mention `theme` prop SVG icons.

```js
import { SvgIcon } from 'insomnia-components';

// ...
const warning = true;
<SvgIcon theme={warning ? 'danger' : 'default'} icon="warning-circle" />
```
---

**Background**:

I realised [Core SVG Icons](https://storybook.insomnia.rest/?path=/story/iconography-core-icons--default) does not support passing in custom theme, while, it can easily support one of following themes:

```js
export const ThemeEnum = {
  default: 'default',
  highlight: 'highlight',

  // Colors
  danger: 'danger',
  info: 'info',
  notice: 'notice',
  success: 'success',
  surprise: 'surprise',
  warning: 'warning',
};
```

Though one can argue if it will go along with all the icons, I suggest we leave that choice to the user to use which color fits what.

