### PR TITLE
add tags to generated entities

### DIFF
--- a/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
@@ -17,7 +17,7 @@ module.exports = {
     let result;
 
     try {
-      result = await o2k.generateFromString(contents, 'kong-declarative-config');
+      result = await o2k.generateFromString(contents, 'kong-declarative-config', contents['x-kong-tags']);
     } catch (err) {
       return {
         document: null,

--- a/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
@@ -17,7 +17,7 @@ module.exports = {
     let result;
 
     try {
-      result = await o2k.generateFromString(contents, 'kong-for-kubernetes');
+      result = await o2k.generateFromString(contents, 'kong-for-kubernetes', contents['x-kong-tags']);
     } catch (err) {
       return {
         document: null,


### PR DESCRIPTION
The CLI doesn't allow to specify tags. This changes allows to specify tags on the top level, passed on to generated enities.
