### PR TITLE
Remove dropdown button nesting

### DIFF
--- a/packages/insomnia-app/app/ui/components/base/dropdown/dropdown-button.js
+++ b/packages/insomnia-app/app/ui/components/base/dropdown/dropdown-button.js
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 
 class DropdownButton extends PureComponent {
   render() {
-    const { children, ...props } = this.props;
+    const { children, noWrap, ...props } = this.props;
+    if (noWrap) {
+      return <>{children}</>;
+    }
     return (
       <button type="button" {...props}>
         {children}
@@ -14,6 +17,7 @@ class DropdownButton extends PureComponent {
 
 DropdownButton.propTypes = {
   children: PropTypes.node,
+  noWrap: PropTypes.bool,
 };
 
 export default DropdownButton;

--- a/packages/insomnia-app/app/ui/components/dropdowns/account-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/account-dropdown.js
@@ -27,7 +27,7 @@ const StyledIconContainer = styled.div`
 const AccountDropdown = ({ className }: Props) => (
   <div className={className}>
     <Dropdown>
-      <DropdownButton>
+      <DropdownButton noWrap>
         <Tooltip delay={1000} position="bottom" message="Account">
           <CircleButton>
             <SvgIcon icon="user" />


### PR DESCRIPTION
`button` cannot be nested inside another `button`

<img width="672" alt="Screen Shot 2021-02-22 at 10 08 11 AM" src="https://user-images.githubusercontent.com/4312346/108638852-2d8e2800-74f6-11eb-8b3a-edf71cce2156.png">

`DropdownButton` as a component cannot be removed from `Dropdown` children because one is _required_ for the dropdown to work properly. Therefore, this PR just introduces a prop for the `DropdownButton` to not wrap it's children in a `button`.