### PR TITLE
Add option to disable migrating workspaces

### DIFF
--- a/packages/insomnia-app/app/common/migrate-from-designer.js
+++ b/packages/insomnia-app/app/common/migrate-from-designer.js
@@ -202,7 +202,6 @@ export default async function migrateFromDesigner({
         (entries[0]: Settings)[s] = coreSettings[s];
             }
           });
-        // TODO: need to set hasPromptedOnboarding
       }
 
       // For each workspace coming from Designer, mark workspace.scope as 'designer'

--- a/packages/insomnia-app/app/common/migrate-from-designer.js
+++ b/packages/insomnia-app/app/common/migrate-from-designer.js
@@ -58,7 +58,7 @@ type DBType = { [string]: Array<BaseModel> };
 export type MigrationOptions = {
   useDesignerSettings: boolean,
   copyPlugins: boolean,
-  copyResponses: boolean,
+  copyWorkspaces: boolean,
   designerDataDir: string,
   coreDataDir: string,
 };
@@ -149,7 +149,7 @@ export default async function migrateFromDesigner({
   designerDataDir,
   coreDataDir,
   copyPlugins,
-  copyResponses,
+  copyWorkspaces,
 }: MigrationOptions): Promise<MigrationResult> {
   const modelTypesToIgnore = [
     models.stats.type, // TODO: investigate further any implications that may invalidate collected stats
@@ -215,7 +215,7 @@ export default async function migrateFromDesigner({
     console.log(`[db-merge] migrating version control data from designer to core`);
     await copyDirs(['version-control'], designerDataDir, coreDataDir);
 
-    if (copyResponses) {
+    if (copyWorkspaces) {
       console.log(`[db-merge] migrating response cache from designer to core`);
       await copyDirs(['responses'], designerDataDir, coreDataDir);
     } else {

--- a/packages/insomnia-app/app/common/migrate-from-designer.js
+++ b/packages/insomnia-app/app/common/migrate-from-designer.js
@@ -189,19 +189,19 @@ export default async function migrateFromDesigner({
     for (const modelType of modelTypesToMerge) {
       const entries = designerDb[modelType];
 
-      // Decide how to merge settings
+      // Persist some settings from core
       if (modelType === models.settings.type) {
         const coreSettings = await models.settings.getOrCreate();
         const propertiesToPersist = [
-            '_id',
-            'hasPromptedOnboarding',
-            'hasPromptedToMigrateFromDesigner',
-          ];
-          propertiesToPersist.forEach(s => {
-            if (coreSettings.hasOwnProperty(s)) {
-        (entries[0]: Settings)[s] = coreSettings[s];
-            }
-          });
+          '_id',
+          'hasPromptedOnboarding',
+          'hasPromptedToMigrateFromDesigner',
+        ];
+        propertiesToPersist.forEach(s => {
+          if (coreSettings.hasOwnProperty(s)) {
+            (entries[0]: Settings)[s] = coreSettings[s];
+          }
+        });
       }
 
       // For each workspace coming from Designer, mark workspace.scope as 'designer'

--- a/packages/insomnia-app/app/common/migrate-from-designer.js
+++ b/packages/insomnia-app/app/common/migrate-from-designer.js
@@ -155,7 +155,21 @@ export default async function migrateFromDesigner({
     models.stats.type, // TODO: investigate further any implications that may invalidate collected stats
   ];
 
-  const modelTypesToMerge = difference(models.types(), modelTypesToIgnore);
+  // Every model except those to ignore and settings is a "workspace" model
+  const workspaceModels = difference(models.types(), ...modelTypesToIgnore, models.settings.type);
+
+  const modelTypesToMerge = [];
+
+  if (useDesignerSettings) {
+    modelTypesToMerge.push(models.settings.type);
+    console.log(`[db-merge] keeping settings from Insomnia Designer`);
+  } else {
+    console.log(`[db-merge] keeping settings from Insomnia Core`);
+  }
+
+  if (copyWorkspaces) {
+    modelTypesToMerge.push(workspaceModels);
+  }
 
   let backupDir = '';
 
@@ -167,6 +181,7 @@ export default async function migrateFromDesigner({
     const designerDb: DBType = await loadDesignerDb(modelTypesToMerge, designerDataDir);
 
     // Ensure user is not migrating an existing Insomnia Core repo
+    // Hmmm we probably don't need this check
     const designerSettings: Settings = designerDb[models.settings.type][0];
     if (designerSettings.hasOwnProperty('hasPromptedToMigrateFromDesigner')) {
       console.log('[db-merge] cannot merge database');
@@ -179,23 +194,18 @@ export default async function migrateFromDesigner({
 
       // Decide how to merge settings
       if (modelType === models.settings.type) {
-        if (useDesignerSettings) {
-          console.log(`[db-merge] keeping settings from Insomnia Designer`);
-          const coreSettings = await models.settings.getOrCreate();
-          const propertiesToPersist = [
+        const coreSettings = await models.settings.getOrCreate();
+        const propertiesToPersist = [
             '_id',
             'hasPromptedOnboarding',
             'hasPromptedToMigrateFromDesigner',
           ];
           propertiesToPersist.forEach(s => {
             if (coreSettings.hasOwnProperty(s)) {
-              (entries[0]: Settings)[s] = coreSettings[s];
+        (entries[0]: Settings)[s] = coreSettings[s];
             }
           });
-        } else {
-          console.log(`[db-merge] keeping settings from Insomnia Core`);
-          continue;
-        }
+        // TODO: need to set hasPromptedOnboarding
       }
 
       // For each workspace coming from Designer, mark workspace.scope as 'designer'
@@ -212,14 +222,12 @@ export default async function migrateFromDesigner({
       await db.batchModifyDocs({ upsert: entries, remove: [] });
     }
 
-    console.log(`[db-merge] migrating version control data from designer to core`);
-    await copyDirs(['version-control'], designerDataDir, coreDataDir);
-
     if (copyWorkspaces) {
+      console.log(`[db-merge] migrating version control data from designer to core`);
+      await copyDirs(['version-control'], designerDataDir, coreDataDir);
+
       console.log(`[db-merge] migrating response cache from designer to core`);
       await copyDirs(['responses'], designerDataDir, coreDataDir);
-    } else {
-      console.log(`[db-merge] not migrating response cache`);
     }
 
     if (copyPlugins) {

--- a/packages/insomnia-app/app/ui/components/wrapper-migration.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-migration.js
@@ -38,7 +38,7 @@ const TextSetting = ({ handleChange, label, name, options }: TextSettingProps) =
 type BooleanSettingProps = SettingProps & {
   handleChange: (boolean, Object, string) => void,
 };
-const BooleanSetting = ({ handleChange, label, name, options }: BooleanSettingProps) => {
+const BooleanSetting = ({ handleChange, label, name, options, hint }: BooleanSettingProps) => {
   if (!options.hasOwnProperty(name)) {
     throw new Error(`Invalid text setting name ${name}`);
   }
@@ -58,8 +58,8 @@ type OptionsProps = { start: MigrationOptions => void, cancel: () => void };
 const Options = ({ start, cancel }: OptionsProps) => {
   const [options, setOptions] = React.useState<MigrationOptions>(() => ({
     useDesignerSettings: false,
-    copyResponses: true,
-    copyPlugins: true,
+    copyWorkspaces: false,
+    copyPlugins: false,
     designerDataDir: getDesignerDataDir(),
     coreDataDir: getDataDirectory(),
   }));
@@ -71,6 +71,8 @@ const Options = ({ start, cancel }: OptionsProps) => {
   const handleSwitchChange = React.useCallback((checked: boolean, event: Object, id: string) => {
     setOptions(prevOpts => ({ ...prevOpts, [id]: checked }));
   }, []);
+
+  const canStart = options.useDesignerSettings || options.copyWorkspaces || options.copyPlugins;
 
   return (
     <>
@@ -95,8 +97,8 @@ const Options = ({ start, cancel }: OptionsProps) => {
           handleChange={handleSwitchChange}
         />
         <BooleanSetting
-          label="Copy Responses"
-          name="copyResponses"
+          label="Copy Workspaces"
+          name="copyWorkspaces"
           options={options}
           handleChange={handleSwitchChange}
         />
@@ -118,7 +120,11 @@ const Options = ({ start, cancel }: OptionsProps) => {
       </div>
 
       <div className="margin-top">
-        <button key="start" className="btn btn--clicky" onClick={() => start(options)}>
+        <button
+          key="start"
+          className="btn btn--clicky"
+          onClick={() => start(options)}
+          disabled={!canStart}>
           Start Migration
         </button>
         <button key="cancel" className="btn btn--super-compact" onClick={cancel}>

--- a/packages/insomnia-app/app/ui/components/wrapper-migration.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-migration.js
@@ -85,20 +85,20 @@ const Options = ({ start, cancel }: OptionsProps) => {
       </p>
       <div className="text-left margin-top">
         <BooleanSetting
-          label="Copy Designer Application Settings"
-          name="useDesignerSettings"
+          label="Copy all workspaces"
+          name="copyWorkspaces"
           options={options}
           handleChange={handleSwitchChange}
         />
         <BooleanSetting
-          label="Copy Plugins"
+          label="Copy all plugins"
           name="copyPlugins"
           options={options}
           handleChange={handleSwitchChange}
         />
         <BooleanSetting
-          label="Copy Workspaces"
-          name="copyWorkspaces"
+          label="Copy Designer application settings"
+          name="useDesignerSettings"
           options={options}
           handleChange={handleSwitchChange}
         />

--- a/packages/insomnia-app/app/ui/components/wrapper-migration.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-migration.js
@@ -9,6 +9,7 @@ import { getDataDirectory, getDesignerDataDir } from '../../common/misc';
 import { useDispatch } from 'react-redux';
 import OnboardingContainer from './onboarding-container';
 import { goToNextActivity } from '../redux/modules/global';
+import HelpTooltip from './help-tooltip';
 
 type Step = 'options' | 'migrating' | 'results';
 
@@ -16,7 +17,9 @@ type SettingProps = {
   label: string,
   name: $Keys<MigrationOptions>,
   options: MigrationOptions,
+  help?: string,
 };
+
 type TextSettingProps = SettingProps & {
   handleChange: (SyntheticEvent<HTMLInputElement>) => void,
 };
@@ -38,17 +41,27 @@ const TextSetting = ({ handleChange, label, name, options }: TextSettingProps) =
 type BooleanSettingProps = SettingProps & {
   handleChange: (boolean, Object, string) => void,
 };
-const BooleanSetting = ({ handleChange, label, name, options, hint }: BooleanSettingProps) => {
+const BooleanSetting = ({ handleChange, label, name, options, help }: BooleanSettingProps) => {
   if (!options.hasOwnProperty(name)) {
     throw new Error(`Invalid text setting name ${name}`);
   }
+
+  const labelNode = React.useMemo(
+    () => (
+      <>
+        {label}
+        {help && <HelpTooltip className="space-left">{help}</HelpTooltip>}
+      </>
+    ),
+    [help, label],
+  );
 
   return (
     <ToggleSwitch
       labelClassName="row margin-bottom wide"
       checked={options[name]}
       id={name}
-      label={label}
+      label={labelNode}
       onChange={handleChange}
     />
   );
@@ -85,22 +98,29 @@ const Options = ({ start, cancel }: OptionsProps) => {
       </p>
       <div className="text-left margin-top">
         <BooleanSetting
-          label="Copy all workspaces"
+          label="Copy Workspaces"
           name="copyWorkspaces"
           options={options}
           handleChange={handleSwitchChange}
+          help={
+            'This includes all resources linked to a workspace (eg. requests, proto files, environments, etc)'
+          }
         />
         <BooleanSetting
-          label="Copy all plugins"
+          label="Copy Plugins"
           name="copyPlugins"
           options={options}
           handleChange={handleSwitchChange}
+          help={
+            'Merge plugins between Designer and Insomnia, keeping the Designer version where a duplicate exists'
+          }
         />
         <BooleanSetting
-          label="Copy Designer application settings"
+          label="Copy Designer Application Settings"
           name="useDesignerSettings"
           options={options}
           handleChange={handleSwitchChange}
+          help={'Keep user preferences from Designer'}
         />
         <details>
           <summary className="margin-bottom">Advanced options</summary>

--- a/packages/insomnia-components/components/toggle-switch.js
+++ b/packages/insomnia-components/components/toggle-switch.js
@@ -9,7 +9,7 @@ type Props = {
   checked?: boolean,
   disabled?: boolean,
   onChange(checked: boolean, Event, string): void | Promise<void>,
-  label?: string,
+  label?: React.Node,
 };
 
 const ThemedSwitch: React.ComponentType<{ checked: boolean }> = styled(Switch)`

--- a/packages/insomnia-smoke-test/core/migration.test.js
+++ b/packages/insomnia-smoke-test/core/migration.test.js
@@ -41,7 +41,13 @@ describe('Migration', function() {
     await client.correctlyLaunched(app);
 
     await migration.migrationMessageShown(app);
+    await migration.ensureStartNotClickable(app);
+
+    await migration.toggleOption(app, 'Copy Workspaces');
+    await migration.toggleOption(app, 'Copy Plugins');
+    await migration.toggleOption(app, 'Copy Designer Application Settings');
     await migration.clickStart(app);
+
     await migration.successMessageShown(app);
     await migration.clickRestart(app);
 

--- a/packages/insomnia-smoke-test/modules/migration.js
+++ b/packages/insomnia-smoke-test/modules/migration.js
@@ -6,19 +6,32 @@ export const migrationMessageShown = async app => {
 };
 
 export const clickSkip = async app => {
-  const button = await app.client
-    .$('.onboarding__content__body')
-    .then(e => e.$(`button=Skip for now`));
+  const button = await app.client.react$('MigrationBody').then(e => e.$(`button=Skip for now`));
   await button.waitForClickable();
   await button.click();
 };
 
-export const clickStart = async app => {
-  const button = await app.client
+export const toggleOption = async (app, label) => {
+  const toggle = await app.client
     .$('.onboarding__content__body')
-    .then(e => e.$(`button=Start Migration`));
+    .then(e => e.react$(`BooleanSetting`, { props: { label } }));
+  await toggle.waitForClickable();
+  await toggle.click();
+};
+
+const _getStartButton = async app => {
+  return await app.client.react$('MigrationBody').then(e => e.$(`button=Start Migration`));
+};
+
+export const clickStart = async app => {
+  const button = await _getStartButton(app);
   await button.waitForClickable();
   await button.click();
+};
+
+export const ensureStartNotClickable = async app => {
+  const button = await _getStartButton(app);
+  await button.waitForClickable({ reverse: true });
 };
 
 export const successMessageShown = async app => {
@@ -31,7 +44,7 @@ export const successMessageShown = async app => {
 
 export const clickRestart = async app => {
   await app.client
-    .$('.onboarding__content__body')
+    .react$('MigrationBody')
     .then(e => e.$(`button=Restart Now`))
     .then(e => e.click());
 };


### PR DESCRIPTION
As per the description in INS-469

This PR slightly changes the option order and sets all migration options to false by default

<img width="897" alt="Screen Shot 2021-02-24 at 4 50 29 PM" src="https://user-images.githubusercontent.com/4312346/108944853-7691d800-76c0-11eb-9f98-b25735f15386.png">
<img width="897" alt="Screen Shot 2021-02-24 at 4 50 32 PM" src="https://user-images.githubusercontent.com/4312346/108944862-77c30500-76c0-11eb-822f-7cce7bf424c3.png">
<img width="897" alt="Screen Shot 2021-02-24 at 4 50 34 PM" src="https://user-images.githubusercontent.com/4312346/108944869-798cc880-76c0-11eb-8e2b-09d026d1b319.png">
<img width="897" alt="Screen Shot 2021-02-24 at 4 50 37 PM" src="https://user-images.githubusercontent.com/4312346/108944873-7b568c00-76c0-11eb-848d-677185188699.png">

