### PR TITLE
Update workspace or api spec name as appropriate

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/database.test.js
+++ b/packages/insomnia-app/app/common/__tests__/database.test.js
@@ -432,7 +432,7 @@ describe('_repairDatabase()', () => {
 
     // Make sure we have everything
     expect((await models.apiSpec.getByParentId(w1._id)).fileName).toBe('');
-    expect((await models.apiSpec.getByParentId(w2._id)).fileName).toBe('Insomnia Designer');
+    expect((await models.apiSpec.getByParentId(w2._id)).fileName).toBe('New Document');
     expect((await models.apiSpec.getByParentId(w3._id)).fileName).toBe('Unique name');
 
     // Run the fix algorithm

--- a/packages/insomnia-app/app/common/__tests__/strings.test.js
+++ b/packages/insomnia-app/app/common/__tests__/strings.test.js
@@ -1,0 +1,17 @@
+// @flow
+import * as models from '../../models';
+import { getWorkspaceLabel, strings } from '../strings';
+
+describe('getWorkspaceLabel', () => {
+  it('should return document label', () => {
+    const w = models.workspace.init();
+    w.scope = 'designer';
+    expect(getWorkspaceLabel(w)).toBe(strings.document);
+  });
+
+  it('should return collection label', () => {
+    const w = models.workspace.init();
+    w.scope = 'collection';
+    expect(getWorkspaceLabel(w)).toBe(strings.collection);
+  });
+});

--- a/packages/insomnia-app/app/common/hotkeys.js
+++ b/packages/insomnia-app/app/common/hotkeys.js
@@ -1,7 +1,7 @@
 // @flow
 import { keyboardKeys } from './keyboard-keys';
 import { ALT_SYM, CTRL_SYM, isMac, META_SYM, SHIFT_SYM } from './constants';
-import AppContext from './strings';
+import { strings } from './strings';
 
 /**
  * The readable definition of a hotkey.
@@ -88,7 +88,7 @@ function keyBinds(
 export const hotKeyRefs: { [string]: HotKeyDefinition } = {
   WORKSPACE_SHOW_SETTINGS: defineHotKey(
     'workspace_showSettings',
-    `Show ${AppContext.workspace} Settings`,
+    `Show ${strings.workspace} Settings`,
   ),
 
   REQUEST_SHOW_SETTINGS: defineHotKey('request_showSettings', 'Show Request Settings'),

--- a/packages/insomnia-app/app/common/strings.js
+++ b/packages/insomnia-app/app/common/strings.js
@@ -1,6 +1,15 @@
+// @flow
+import type { Workspace } from '../models/workspace';
+import { isDocument } from '../models/helpers/is-model';
+
 export const strings = {
   workspace: 'Workspace',
   workspaces: 'Workspaces',
   document: 'Document',
+  collection: 'Collection',
   home: 'Dashboard',
 };
+
+// Some helpers
+export const getWorkspaceLabel = (w: Workspace) =>
+  isDocument(w) ? strings.document : strings.collection;

--- a/packages/insomnia-app/app/common/strings.js
+++ b/packages/insomnia-app/app/common/strings.js
@@ -1,6 +1,6 @@
 export const strings = {
   workspace: 'Workspace',
   workspaces: 'Workspaces',
-  apiSpec: 'Document',
+  document: 'Document',
   home: 'Dashboard',
 };

--- a/packages/insomnia-app/app/common/strings.js
+++ b/packages/insomnia-app/app/common/strings.js
@@ -1,4 +1,4 @@
-export default {
+export const strings = {
   workspace: 'Workspace',
   workspaces: 'Workspaces',
   apiSpec: 'Document',

--- a/packages/insomnia-app/app/common/strings.js
+++ b/packages/insomnia-app/app/common/strings.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Workspace } from '../models/workspace';
-import { isDocument } from '../models/helpers/is-model';
+import { isDesigner } from '../models/helpers/is-model';
 
 export const strings = {
   workspace: 'Workspace',
@@ -12,4 +12,4 @@ export const strings = {
 
 // Some helpers
 export const getWorkspaceLabel = (w: Workspace) =>
-  isDocument(w) ? strings.document : strings.collection;
+  isDesigner(w) ? strings.document : strings.collection;

--- a/packages/insomnia-app/app/models/api-spec.js
+++ b/packages/insomnia-app/app/models/api-spec.js
@@ -1,6 +1,7 @@
 // @flow
 import type { BaseModel } from './index';
 import * as db from '../common/database';
+import { strings } from '../common/strings';
 
 export const name = 'ApiSpec';
 export const type = 'ApiSpec';
@@ -18,7 +19,7 @@ export type ApiSpec = BaseModel & BaseApiSpec;
 
 export function init(): BaseApiSpec {
   return {
-    fileName: 'Insomnia Designer',
+    fileName: `New ${strings.document}`,
     contents: '',
     contentType: 'yaml',
   };

--- a/packages/insomnia-app/app/models/helpers/__tests__/get-workspace-name.test.js
+++ b/packages/insomnia-app/app/models/helpers/__tests__/get-workspace-name.test.js
@@ -1,0 +1,20 @@
+// @flow
+
+import * as models from '../../../models';
+import getWorkspaceName from '../get-workspace-name';
+
+describe('getWorkspaceName', () => {
+  it('returns workspace name', () => {
+    const w = models.workspace.init();
+    const s = models.apiSpec.init();
+    w.scope = 'collection';
+    expect(getWorkspaceName(w, s)).toBe(w.name);
+  });
+
+  it('returns api spec name', () => {
+    const w = models.workspace.init();
+    const s = models.apiSpec.init();
+    w.scope = 'designer';
+    expect(getWorkspaceName(w, s)).toBe(s.fileName);
+  });
+});

--- a/packages/insomnia-app/app/models/helpers/__tests__/is-model.test.js
+++ b/packages/insomnia-app/app/models/helpers/__tests__/is-model.test.js
@@ -1,6 +1,7 @@
 import * as models from '../../index';
 import { difference } from 'lodash';
 import {
+  isDesigner,
   isGrpcRequest,
   isGrpcRequestId,
   isProtoDirectory,
@@ -115,5 +116,19 @@ describe('isWorkspace', () => {
 
   it.each(unsupported)('should return false: "%s"', type => {
     expect(isWorkspace({ type })).toBe(false);
+  });
+});
+
+describe('isDesigner', () => {
+  it('should be true', () => {
+    const w = models.workspace.init();
+    w.scope = 'designer';
+    expect(isDesigner(w)).toBe(true);
+  });
+
+  it('should be false', () => {
+    const w = models.workspace.init();
+    w.scope = 'collection';
+    expect(isDesigner(w)).toBe(false);
   });
 });

--- a/packages/insomnia-app/app/models/helpers/get-workspace-name.js
+++ b/packages/insomnia-app/app/models/helpers/get-workspace-name.js
@@ -1,0 +1,9 @@
+// @flow
+
+import type { ApiSpec } from '../api-spec';
+import type { Workspace } from '../workspace';
+import { isDocument } from './is-model';
+
+export default function getWorkspaceName(w: Workspace, s: ApiSpec): string {
+  return isDocument(w) ? s.fileName : w.name;
+}

--- a/packages/insomnia-app/app/models/helpers/get-workspace-name.js
+++ b/packages/insomnia-app/app/models/helpers/get-workspace-name.js
@@ -2,8 +2,8 @@
 
 import type { ApiSpec } from '../api-spec';
 import type { Workspace } from '../workspace';
-import { isDocument } from './is-model';
+import { isDesigner } from './is-model';
 
 export default function getWorkspaceName(w: Workspace, s: ApiSpec): string {
-  return isDocument(w) ? s.fileName : w.name;
+  return isDesigner(w) ? s.fileName : w.name;
 }

--- a/packages/insomnia-app/app/models/helpers/is-model.js
+++ b/packages/insomnia-app/app/models/helpers/is-model.js
@@ -36,6 +36,6 @@ export function isWorkspace(obj: BaseModel): boolean {
   return obj.type === workspace.type;
 }
 
-export function isDocument({ scope }: Workspace): boolean {
+export function isDesigner({ scope }: Workspace): boolean {
   return scope === 'designer';
 }

--- a/packages/insomnia-app/app/models/helpers/is-model.js
+++ b/packages/insomnia-app/app/models/helpers/is-model.js
@@ -1,6 +1,7 @@
 // @flow
 import type { BaseModel } from '../index';
 import { grpcRequest, request, requestGroup, protoFile, protoDirectory, workspace } from '../index';
+import type { Workspace } from '../workspace';
 
 export function isGrpcRequest(obj: BaseModel): boolean {
   return obj.type === grpcRequest.type;
@@ -33,4 +34,8 @@ export function isProtoDirectory(obj: BaseModel): boolean {
 
 export function isWorkspace(obj: BaseModel): boolean {
   return obj.type === workspace.type;
+}
+
+export function isDocument({ scope }: Workspace): boolean {
+  return scope === 'designer';
 }

--- a/packages/insomnia-app/app/models/helpers/workspace-operations.js
+++ b/packages/insomnia-app/app/models/helpers/workspace-operations.js
@@ -1,0 +1,23 @@
+// @flow
+import * as models from '../index';
+import * as db from '../../common/database';
+
+import { isDesigner } from './is-model';
+import type { Workspace } from '../workspace';
+import type { ApiSpec } from '../api-spec';
+
+export async function rename(w: Workspace, s: ApiSpec, name: string): Promise<void> {
+  if (isDesigner(w)) {
+    await models.apiSpec.update(s, { fileName: name });
+  } else {
+    await models.workspace.update(w, { name });
+  }
+}
+
+export async function duplicate(w: Workspace, name: string): Promise<Workspace> {
+  const newWorkspace = await db.duplicate(w, { name });
+  await models.apiSpec.updateOrCreateForParentId(newWorkspace._id, { fileName: name });
+  models.stats.incrementCreatedRequestsForDescendents(newWorkspace);
+
+  return newWorkspace;
+}

--- a/packages/insomnia-app/app/models/workspace.js
+++ b/packages/insomnia-app/app/models/workspace.js
@@ -3,6 +3,7 @@ import type { BaseModel } from './index';
 import * as models from './index';
 import * as db from '../common/database';
 import { getAppName } from '../common/constants';
+import { strings } from '../common/strings';
 
 export const name = 'Workspace';
 export const type = 'Workspace';
@@ -20,7 +21,7 @@ export type Workspace = BaseModel & BaseWorkspace;
 
 export function init() {
   return {
-    name: 'New Workspace',
+    name: `New ${strings.collection}`,
     description: '',
     scope: 'collection',
   };

--- a/packages/insomnia-app/app/plugins/context/__tests__/data.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/data.test.js
@@ -180,7 +180,7 @@ describe('app.export.*', () => {
           created: 111,
           description: '',
           modified: 222,
-          name: 'New Workspace',
+          name: 'New Collection',
           parentId: null,
           scope: 'collection',
         },

--- a/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
@@ -42,7 +42,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
     const { fileName } = apiSpec;
 
     showPrompt({
-      title: `Duplicate ${strings.apiSpec}`,
+      title: `Duplicate ${strings.document}`,
       defaultValue: fileName,
       submitName: 'Create',
       selectText: true,
@@ -62,7 +62,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
     const { apiSpec } = this.props;
 
     showPrompt({
-      title: `Rename ${strings.apiSpec}`,
+      title: `Rename ${strings.document}`,
       defaultValue: apiSpec.fileName,
       submitName: 'Rename',
       selectText: true,
@@ -79,12 +79,12 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
     const messages = [
       `Do you really want to delete "${apiSpec.fileName}"?`,
       isLastWorkspace
-        ? ` This is the only ${strings.apiSpec.toLowerCase()} so a new one will be created for you.`
+        ? ` This is the only ${strings.document.toLowerCase()} so a new one will be created for you.`
         : null,
     ];
 
     showModal(AskModal, {
-      title: `Delete ${strings.apiSpec}`,
+      title: `Delete ${strings.document}`,
       message: messages.join(' '),
       yesText: 'Yes',
       noText: 'Cancel',

--- a/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
@@ -10,7 +10,7 @@ import * as pluginContexts from '../../../plugins/context';
 import { RENDER_PURPOSE_NO_RENDER } from '../../../common/render';
 import type { ApiSpec } from '../../../models/api-spec';
 import { parseApiSpec } from '../../../common/api-specs';
-import Strings from '../../../common/strings';
+import { strings } from '../../../common/strings';
 import * as db from '../../../common/database';
 import * as models from '../../../models';
 import AskModal from '../modals/ask-modal';
@@ -42,7 +42,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
     const { fileName } = apiSpec;
 
     showPrompt({
-      title: `Duplicate ${Strings.apiSpec}`,
+      title: `Duplicate ${strings.apiSpec}`,
       defaultValue: fileName,
       submitName: 'Create',
       selectText: true,
@@ -62,7 +62,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
     const { apiSpec } = this.props;
 
     showPrompt({
-      title: `Rename ${Strings.apiSpec}`,
+      title: `Rename ${strings.apiSpec}`,
       defaultValue: apiSpec.fileName,
       submitName: 'Rename',
       selectText: true,
@@ -79,12 +79,12 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
     const messages = [
       `Do you really want to delete "${apiSpec.fileName}"?`,
       isLastWorkspace
-        ? ` This is the only ${Strings.apiSpec.toLowerCase()} so a new one will be created for you.`
+        ? ` This is the only ${strings.apiSpec.toLowerCase()} so a new one will be created for you.`
         : null,
     ];
 
     showModal(AskModal, {
-      title: `Delete ${Strings.apiSpec}`,
+      title: `Delete ${strings.apiSpec}`,
       message: messages.join(' '),
       yesText: 'Yes',
       noText: 'Cancel',

--- a/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
@@ -15,7 +15,7 @@ import * as db from '../../../common/database';
 import * as models from '../../../models';
 import AskModal from '../modals/ask-modal';
 import type { Workspace } from '../../../models/workspace';
-import { isDocument } from '../../../models/helpers/is-model';
+import { isDesigner } from '../../../models/helpers/is-model';
 import getWorkspaceName from '../../../models/helpers/get-workspace-name';
 
 type Props = {
@@ -69,7 +69,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
       selectText: true,
       label: 'Name',
       onComplete: async name => {
-        if (isDocument) {
+        if (isDesigner(workspace)) {
           await models.apiSpec.update(apiSpec, { fileName: name });
         } else {
           await models.workspace.update(workspace, { name });

--- a/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
@@ -142,20 +142,12 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {
-      children,
-      workspaceId,
-      className,
-      handleDuplicateWorkspaceById,
-      handleRenameWorkspaceById,
-      handleDeleteWorkspaceById,
-      ...extraProps
-    } = this.props;
+    const { children, className } = this.props;
 
     const { actionPlugins, loadingActions } = this.state;
 
     return (
-      <Dropdown beside onOpen={this._onOpen} {...extraProps}>
+      <Dropdown beside onOpen={this._onOpen}>
         <DropdownButton className={className}>{children}</DropdownButton>
 
         <DropdownItem onClick={this._handleDuplicate}>Duplicate</DropdownItem>

--- a/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
@@ -11,12 +11,11 @@ import { RENDER_PURPOSE_NO_RENDER } from '../../../common/render';
 import type { ApiSpec } from '../../../models/api-spec';
 import { parseApiSpec } from '../../../common/api-specs';
 import { getWorkspaceLabel } from '../../../common/strings';
-import * as db from '../../../common/database';
 import * as models from '../../../models';
 import AskModal from '../modals/ask-modal';
 import type { Workspace } from '../../../models/workspace';
-import { isDesigner } from '../../../models/helpers/is-model';
 import getWorkspaceName from '../../../models/helpers/get-workspace-name';
+import * as workspaceOperations from '../../../models/helpers/workspace-operations';
 
 type Props = {
   apiSpec: ?ApiSpec,
@@ -49,10 +48,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
       selectText: true,
       label: 'New Name',
       onComplete: async newName => {
-        const newWorkspace = await db.duplicate(workspace, { name: newName });
-        await models.apiSpec.updateOrCreateForParentId(newWorkspace._id, { fileName: newName });
-
-        models.stats.incrementCreatedRequestsForDescendents(newWorkspace);
+        const newWorkspace = workspaceOperations.duplicate(workspace, newName);
 
         handleSetActiveWorkspace(newWorkspace._id);
       },
@@ -69,11 +65,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
       selectText: true,
       label: 'Name',
       onComplete: async name => {
-        if (isDesigner(workspace)) {
-          await models.apiSpec.update(apiSpec, { fileName: name });
-        } else {
-          await models.workspace.update(workspace, { name });
-        }
+        await workspaceOperations.rename(workspace, apiSpec, name);
       },
     });
   }

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.js
@@ -25,6 +25,8 @@ import * as pluginContexts from '../../../plugins/context';
 import { RENDER_PURPOSE_NO_RENDER } from '../../../common/render';
 import type { Environment } from '../../../models/environment';
 import { showGenerateConfigModal } from '../modals/generate-config-modal';
+import { getWorkspaceLabel } from '../../../common/strings';
+import { isDesigner } from '../../../models/helpers/is-model';
 
 type Props = {
   displayName: string,
@@ -126,8 +128,6 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
 
     const { actionPlugins, loadingActions, configGeneratorPlugins } = this.state;
 
-    const isDesigner = activeWorkspace.scope === 'designer';
-
     return (
       <KeydownBinder onKeydown={this._handleKeydown}>
         <Dropdown
@@ -148,7 +148,7 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
             {getAppName()} v{getAppVersion()}
           </DropdownDivider>
           <DropdownItem onClick={WorkspaceDropdown._handleShowWorkspaceSettings}>
-            <i className="fa fa-wrench" /> Workspace Settings
+            <i className="fa fa-wrench" /> {getWorkspaceLabel(activeWorkspace)} Settings
             <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.WORKSPACE_SHOW_SETTINGS.id]} />
           </DropdownItem>
 
@@ -170,7 +170,7 @@ class WorkspaceDropdown extends React.PureComponent<Props, State> {
               {p.label}
             </DropdownItem>
           ))}
-          {isDesigner && (
+          {isDesigner(activeWorkspace) && (
             <>
               {configGeneratorPlugins.length > 0 && (
                 <DropdownDivider>Config Generators</DropdownDivider>

--- a/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.js
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.js
@@ -15,9 +15,9 @@ import MarkdownEditor from '../markdown-editor';
 import type { Workspace } from '../../../models/workspace';
 import type { ClientCertificate } from '../../../models/client-certificate';
 import type { ApiSpec } from '../../../models/api-spec';
-import { isDesigner } from '../../../models/helpers/is-model';
 import getWorkspaceName from '../../../models/helpers/get-workspace-name';
 import { getWorkspaceLabel } from '../../../common/strings';
+import * as workspaceOperations from '../../../models/helpers/workspace-operations';
 
 type Props = {
   clientCertificates: Array<ClientCertificate>,
@@ -111,11 +111,7 @@ class WorkspaceSettingsModal extends React.PureComponent<Props, State> {
   async _handleRename(name: string) {
     const { workspace, apiSpec } = this.props;
 
-    if (isDesigner(workspace)) {
-      await models.apiSpec.update(apiSpec, { fileName: name });
-    } else {
-      await models.workspace.update(workspace, { name });
-    }
+    await workspaceOperations.rename(workspace, apiSpec, name);
   }
 
   _handleDescriptionChange(description: string) {

--- a/packages/insomnia-app/app/ui/components/settings/import-export.js
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.js
@@ -5,7 +5,7 @@ import { AUTOBIND_CFG } from '../../../common/constants';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import Link from '../base/link';
 import { showPrompt } from '../modals/index';
-import Strings from '../../../common/strings';
+import { strings } from '../../../common/strings';
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class ImportExport extends PureComponent {
@@ -59,11 +59,11 @@ class ImportExport extends PureComponent {
             <DropdownDivider>Choose Export Type</DropdownDivider>
             <DropdownItem onClick={handleShowExportRequestsModal}>
               <i className="fa fa-home" />
-              Current {Strings.workspace}
+              Current {strings.workspace}
             </DropdownItem>
             <DropdownItem onClick={handleExportAll}>
               <i className="fa fa-empty" />
-              All {Strings.workspaces}
+              All {strings.workspaces}
             </DropdownItem>
           </Dropdown>
           &nbsp;&nbsp;

--- a/packages/insomnia-app/app/ui/components/workspace-page-header.js
+++ b/packages/insomnia-app/app/ui/components/workspace-page-header.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { ACTIVITY_HOME } from '../../common/constants';
 import coreLogo from '../images/insomnia-core-logo.png';
-import strings from '../../common/strings';
+import { strings } from '../../common/strings';
 import WorkspaceDropdown from './dropdowns/workspace-dropdown';
 import ActivityToggle from './activity-toggle';
 import type { WrapperProps } from './wrapper';

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -532,6 +532,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
       activeGitRepository,
       activeRequest,
       activeWorkspace,
+      activeApiSpec,
       activeWorkspaceClientCertificates,
       activity,
       gitVCS,
@@ -661,6 +662,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
               ref={registerModal}
               clientCertificates={activeWorkspaceClientCertificates}
               workspace={activeWorkspace}
+              apiSpec={activeApiSpec}
               editorFontSize={settings.editorFontSize}
               editorIndentSize={settings.editorIndentSize}
               editorKeyMap={settings.editorKeyMap}

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -94,7 +94,7 @@ import GitVCS, { GIT_CLONE_DIR, GIT_INSOMNIA_DIR, GIT_INTERNAL_DIR } from '../..
 import NeDBPlugin from '../../sync/git/ne-db-plugin';
 import FSPlugin from '../../sync/git/fs-plugin';
 import { routableFSPlugin } from '../../sync/git/routable-fs-plugin';
-import AppContext from '../../common/strings';
+import { strings } from '../../common/strings';
 import { isGrpcRequest, isGrpcRequestId, isRequestGroup } from '../../models/helpers/is-model';
 import * as requestOperations from '../../models/helpers/request-operations';
 import { GrpcProvider } from '../context/grpc';
@@ -416,9 +416,8 @@ class App extends PureComponent {
 
   _workspaceRename(callback, workspaceId) {
     const workspace = this.props.workspaces.find(w => w._id === workspaceId);
-    console.dir(AppContext);
     showPrompt({
-      title: `Rename ${AppContext.workspace}`,
+      title: `Rename ${strings.workspace}`,
       defaultValue: workspace.name,
       submitName: 'Rename',
       selectText: true,
@@ -433,7 +432,7 @@ class App extends PureComponent {
   _workspaceDeleteById(callback, workspaceId) {
     const workspace = this.props.workspaces.find(w => w._id === workspaceId);
     showModal(AskModal, {
-      title: `Delete ${AppContext.workspace}`,
+      title: `Delete ${strings.workspace}`,
       message: `Do you really want to delete ${workspace.name}?`,
       yesText: 'Yes',
       noText: 'Cancel',
@@ -453,7 +452,7 @@ class App extends PureComponent {
     const workspace = this.props.workspaces.find(w => w._id === workspaceId);
 
     showPrompt({
-      title: `Duplicate ${AppContext.workspace}`,
+      title: `Duplicate ${strings.workspace}`,
       defaultValue: workspace.name,
       submitName: 'Create',
       selectText: true,

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -418,14 +418,16 @@ class App extends PureComponent {
 
   _workspaceRename(callback, workspaceId) {
     const workspace = this.props.workspaces.find(w => w._id === workspaceId);
+    const apiSpec = this.props.apiSpecs.find(s => s.parentId === workspaceId);
+
     showPrompt({
-      title: `Rename ${strings.workspace}`,
-      defaultValue: workspace.name,
+      title: `Rename ${getWorkspaceLabel(workspace)}`,
+      defaultValue: getWorkspaceName(workspace, apiSpec),
       submitName: 'Rename',
       selectText: true,
       label: 'Name',
       onComplete: async name => {
-        await models.workspace.update(workspace, { name: name });
+        await workspaceOperations.rename(workspace, apiSpec, name);
         callback();
       },
     });

--- a/packages/insomnia-app/app/ui/containers/app.js
+++ b/packages/insomnia-app/app/ui/containers/app.js
@@ -101,6 +101,7 @@ import { GrpcProvider } from '../context/grpc';
 import { sortMethodMap } from '../../common/sorting';
 import withDragDropContext from '../context/app/drag-drop-context';
 import getWorkspaceName from '../../models/helpers/get-workspace-name';
+import * as workspaceOperations from '../../models/helpers/workspace-operations';
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class App extends PureComponent {
@@ -460,13 +461,10 @@ class App extends PureComponent {
       selectText: true,
       label: 'New Name',
       onComplete: async name => {
-        const newWorkspace = await db.duplicate(workspace, { name });
-        await models.apiSpec.updateOrCreateForParentId(newWorkspace._id, { fileName: name });
+        const newWorkspace = await workspaceOperations.duplicate(workspace, name);
 
         await this.props.handleSetActiveWorkspace(newWorkspace._id);
         callback();
-
-        models.stats.incrementCreatedRequestsForDescendents(newWorkspace);
       },
     });
   }


### PR DESCRIPTION
For collections, the source of truth name is `workspace.name`. For documents, the source of truth name is `apiSpec.fileName`.

This PR updates labels and rename/duplicate behavior to follow the above rules. These include:
- rename/duplicate from the card context menu on the homepage
  <img width="378" alt="image" src="https://user-images.githubusercontent.com/4312346/109247633-22662f80-7849-11eb-9bf4-dac1ec802d90.png">
- rename/duplicate from document/collection settings after opening
  <img width="484" alt="image" src="https://user-images.githubusercontent.com/4312346/109247584-0a8eab80-7849-11eb-9519-b8979976b6b1.png">
