### PR TITLE
Add migration analytics events

### DIFF
--- a/packages/insomnia-app/app/ui/components/wrapper-migration.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-migration.js
@@ -10,6 +10,7 @@ import { useDispatch } from 'react-redux';
 import OnboardingContainer from './onboarding-container';
 import { goToNextActivity } from '../redux/modules/global';
 import HelpTooltip from './help-tooltip';
+import { trackEvent } from '../../common/analytics';
 
 type Step = 'options' | 'migrating' | 'results';
 
@@ -239,6 +240,7 @@ const MigrationBody = () => {
 
   const reduxDispatch = useDispatch();
   const cancel = React.useCallback(() => {
+    trackEvent('Data', 'Migration', 'Skip');
     reduxDispatch(goToNextActivity());
   }, [reduxDispatch]);
 

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -272,6 +272,7 @@ export function setActiveActivity(activity: GlobalActivity) {
   // Don't need to await settings update
   switch (activity) {
     case ACTIVITY_MIGRATION:
+      trackEvent('Data', 'Migration', 'Manual');
       models.settings.patch({ hasPromptedToMigrateFromDesigner: true });
       break;
     case ACTIVITY_ONBOARDING:
@@ -727,6 +728,7 @@ export function initActiveActivity() {
       // Always check if user has been prompted to migrate or onboard
       default:
         if (!settings.hasPromptedToMigrateFromDesigner && fs.existsSync(getDesignerDataDir())) {
+          trackEvent('Data', 'Migration', 'Auto');
           overrideActivity = ACTIVITY_MIGRATION;
         } else if (!settings.hasPromptedOnboarding) {
           overrideActivity = ACTIVITY_ONBOARDING;


### PR DESCRIPTION
What it says on the tin. The events added are:
- Data
  - Migration
  	- Auto
  	- Manual
  	- Skip
  	- Settings
  	- Workspaces
  	- Plugins
  	- Success
  	- Failure	