### PR TITLE
Portable windows builds

### DIFF
--- a/packages/insomnia-app/app/common/constants.js
+++ b/packages/insomnia-app/app/common/constants.js
@@ -85,8 +85,17 @@ export function isLinux() {
 }
 
 export function updatesSupported() {
-  // Updates are not supported on Linux, or for Windows portable binaries
-  return !(isLinux() || (isWindows() && process.env.PORTABLE_EXECUTABLE_DIR));
+  // Updates are not supported on Linux
+  if (isLinux()) {
+    return false;
+  }
+
+  // Updates are not supported for Windows portable binaries
+  if (isWindows() && process.env.PORTABLE_EXECUTABLE_DIR) {
+    return false;
+  }
+
+  return true;
 }
 
 export function isWindows() {

--- a/packages/insomnia-app/app/common/constants.js
+++ b/packages/insomnia-app/app/common/constants.js
@@ -84,6 +84,11 @@ export function isLinux() {
   return getAppPlatform() === 'linux';
 }
 
+export function updatesSupported() {
+  // Updates are not supported on Linux, or for Windows portable binaries
+  return !(isLinux() || (isWindows() && process.env.PORTABLE_EXECUTABLE_DIR));
+}
+
 export function isWindows() {
   return getAppPlatform() === 'win32';
 }

--- a/packages/insomnia-app/app/main/updates.js
+++ b/packages/insomnia-app/app/main/updates.js
@@ -7,6 +7,7 @@ import {
   isDevelopment,
   UPDATE_URL_MAC,
   UPDATE_URL_WINDOWS,
+  updatesSupported,
 } from '../common/constants';
 import * as models from '../models/index';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
@@ -18,6 +19,10 @@ async function getUpdateUrl(force: boolean): Promise<string | null> {
   const platform = process.platform;
   const settings = await models.settings.getOrCreate();
   let updateUrl = null;
+
+  if (!updatesSupported()) {
+    return null;
+  }
 
   if (platform === 'win32') {
     updateUrl = UPDATE_URL_WINDOWS;

--- a/packages/insomnia-app/app/ui/components/settings/general.js
+++ b/packages/insomnia-app/app/ui/components/settings/general.js
@@ -12,9 +12,8 @@ import {
   EDITOR_KEY_MAP_VIM,
   HttpVersions,
   isDevelopment,
-  isLinux,
   isMac,
-  isWindows,
+  updatesSupported,
   UPDATE_CHANNEL_BETA,
   UPDATE_CHANNEL_STABLE,
   MIN_INTERFACE_FONT_SIZE,
@@ -471,7 +470,7 @@ class General extends React.PureComponent<Props, State> {
           )}
         </div>
 
-        {(isWindows() || isMac()) && (
+        {updatesSupported() && (
           <React.Fragment>
             <hr className="pad-top" />
             <div>
@@ -502,7 +501,7 @@ class General extends React.PureComponent<Props, State> {
           </React.Fragment>
         )}
 
-        {isLinux() && (
+        {!updatesSupported() && (
           <React.Fragment>
             <hr className="pad-top" />
             <h2>Software Updates</h2>

--- a/packages/insomnia-app/app/ui/components/toast.js
+++ b/packages/insomnia-app/app/ui/components/toast.js
@@ -12,7 +12,7 @@ import {
   getAppPlatform,
   getAppId,
   getAppVersion,
-  isLinux,
+  updatesSupported,
 } from '../../common/constants';
 import * as db from '../../common/database';
 import * as session from '../../account/session';
@@ -122,7 +122,7 @@ class Toast extends React.PureComponent<Props, State> {
         requestGroups: await db.count(models.requestGroup.type),
         environments: await db.count(models.environment.type),
         workspaces: await db.count(models.workspace.type),
-        updatesNotSupported: isLinux(),
+        updatesNotSupported: !updatesSupported(),
         autoUpdatesDisabled: !settings.updateAutomatically,
         disableUpdateNotification: settings.disableUpdateNotification,
         updateChannel: settings.updateChannel,

--- a/packages/insomnia-app/config/electronbuilder.json
+++ b/packages/insomnia-app/config/electronbuilder.json
@@ -63,12 +63,15 @@
   "win": {
     "target": [
       "squirrel",
-      "zip"
+      "portable"
     ]
   },
   "squirrelWindows": {
     "artifactName": "__BINARY_PREFIX__-${version}.${ext}",
     "iconUrl": "__ICON_URL__"
+  },
+  "portable": {
+    "artifactName": "__BINARY_PREFIX__-${version}-portable.${ext}"
   },
   "linux": {
     "artifactName": "__BINARY_PREFIX__-${version}.${ext}",

--- a/packages/insomnia-app/scripts/release.js
+++ b/packages/insomnia-app/scripts/release.js
@@ -32,7 +32,7 @@ async function start(app, version) {
   const distGlob = ext => path.posix.join('dist', '**', `*${ext}`);
   const assetGlobs = {
     darwin: [distGlob('.zip'), distGlob('.dmg')],
-    win32: [path.posix.join('dist', 'squirrel-windows', '*')],
+    win32: [path.posix.join('dist', 'squirrel-windows', '*'), path.posix.join('dist', '*.exe')],
     linux: [
       distGlob('.snap'),
       distGlob('.rpm'),


### PR DESCRIPTION
Adds a portable windows build target, disables auto-updates for it and enables it to get update notifications from the API.

Fixes INS-496