### PR TITLE
Prompt for import as collection or document

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/import.test.js
+++ b/packages/insomnia-app/app/common/__tests__/import.test.js
@@ -378,12 +378,24 @@ describe('export', () => {
 
 describe('isApiSpecImport()', () => {
   it.each(['swagger2', 'openapi3'])('should return true if spec id is %o', (id: string) => {
-    expect(importUtil.isApiSpecImport(id)).toBe(true);
+    expect(importUtil.isApiSpecImport({ id })).toBe(true);
   });
 
   it('should return false if spec id is not valid', () => {
     const id = 'invalid-id';
 
-    expect(importUtil.isApiSpecImport(id)).toBe(false);
+    expect(importUtil.isApiSpecImport({ id })).toBe(false);
+  });
+});
+
+describe('isApiSpecImport()', () => {
+  it.each(['insomnia-4'])('should return true if spec id is %o', (id: string) => {
+    expect(importUtil.isInsomniaV4Import({ id })).toBe(true);
+  });
+
+  it('should return false if spec id is not valid', () => {
+    const id = 'invalid-id';
+
+    expect(importUtil.isInsomniaV4Import({ id })).toBe(false);
   });
 });

--- a/packages/insomnia-app/app/common/__tests__/import.test.js
+++ b/packages/insomnia-app/app/common/__tests__/import.test.js
@@ -388,7 +388,7 @@ describe('isApiSpecImport()', () => {
   });
 });
 
-describe('isApiSpecImport()', () => {
+describe('isInsomniaV4Import()', () => {
   it.each(['insomnia-4'])('should return true if spec id is %o', (id: string) => {
     expect(importUtil.isInsomniaV4Import({ id })).toBe(true);
   });

--- a/packages/insomnia-app/app/common/__tests__/import.test.js
+++ b/packages/insomnia-app/app/common/__tests__/import.test.js
@@ -376,14 +376,14 @@ describe('export', () => {
   });
 });
 
-describe('isApiSpec()', () => {
+describe('isApiSpecImport()', () => {
   it.each(['swagger2', 'openapi3'])('should return true if spec id is %o', (id: string) => {
-    expect(importUtil.isApiSpec(id)).toBe(true);
+    expect(importUtil.isApiSpecImport(id)).toBe(true);
   });
 
   it('should return false if spec id is not valid', () => {
     const id = 'invalid-id';
 
-    expect(importUtil.isApiSpec(id)).toBe(false);
+    expect(importUtil.isApiSpecImport(id)).toBe(false);
   });
 });

--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -244,9 +244,13 @@ export async function importRaw(
     } else {
       // Set the workspace scope if creating a new workspace
       //  IF is creating a new workspace
-      //  AND imported resource has no preset scope property
+      //  AND imported resource has no preset scope property OR scope is null
       //  AND we have a function to get scope
-      if (isWorkspace(model) && !resource.hasOwnProperty('scope') && getWorkspaceScope) {
+      if (
+        isWorkspace(model) &&
+        (!resource.hasOwnProperty('scope') || resource.scope === null) &&
+        getWorkspaceScope
+      ) {
         (resource: Workspace).scope = await getWorkspaceScope();
       }
       newDoc = await db.docCreate(model.type, resource);

--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -76,12 +76,12 @@ type ConvertResult = {
   },
 };
 
-export type ImportOptions = {
+export type ImportRawConfig = {
   getWorkspaceId: () => Promise<string | null>,
   getWorkspaceScope?: string => Promise<WorkspaceScope>,
 };
 
-export async function importUri(uri: string, options: ImportOptions): Promise<ImportResult> {
+export async function importUri(uri: string, importConfig: ImportRawConfig): Promise<ImportResult> {
   let rawText;
 
   // If GH preview, force raw
@@ -103,7 +103,7 @@ export async function importUri(uri: string, options: ImportOptions): Promise<Im
     rawText = decodeURIComponent(uri);
   }
 
-  const result = await importRaw(rawText, options);
+  const result = await importRaw(rawText, importConfig);
   const { summary, error } = result;
 
   if (error) {
@@ -136,7 +136,7 @@ export async function importUri(uri: string, options: ImportOptions): Promise<Im
 
 export async function importRaw(
   rawContent: string,
-  { getWorkspaceId, getWorkspaceScope }: ImportOptions,
+  { getWorkspaceId, getWorkspaceScope }: ImportRawConfig,
 ): Promise<ImportResult> {
   let results: ConvertResult;
   try {

--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -62,11 +62,12 @@ export type ImportResult = {
   summary: { [string]: Array<BaseModel> },
 };
 
-export async function importUri(
+export type ImportOptions = {
   getWorkspaceId: () => Promise<string | null>,
-  uri: string,
   getWorkspaceScope?: () => Promise<WorkspaceScope>,
-): Promise<ImportResult> {
+};
+
+export async function importUri(uri: string, options: ImportOptions): Promise<ImportResult> {
   let rawText;
 
   // If GH preview, force raw
@@ -88,7 +89,7 @@ export async function importUri(
     rawText = decodeURIComponent(uri);
   }
 
-  const result = await importRaw(getWorkspaceId, rawText, getWorkspaceScope);
+  const result = await importRaw(rawText, options);
   const { summary, error } = result;
 
   if (error) {
@@ -120,9 +121,8 @@ export async function importUri(
 }
 
 export async function importRaw(
-  getWorkspaceId: () => Promise<string | null>,
   rawContent: string,
-  getWorkspaceScope?: () => Promise<WorkspaceScope>,
+  { getWorkspaceId, getWorkspaceScope }: ImportOptions,
 ): Promise<ImportResult> {
   let results;
   try {

--- a/packages/insomnia-app/app/common/import.js
+++ b/packages/insomnia-app/app/common/import.js
@@ -65,7 +65,7 @@ export type ImportResult = {
 export async function importUri(
   getWorkspaceId: () => Promise<string | null>,
   uri: string,
-  getWorkspaceScope?: () => Promise<WorkspaceScope | null>,
+  getWorkspaceScope?: () => Promise<WorkspaceScope>,
 ): Promise<ImportResult> {
   let rawText;
 
@@ -122,7 +122,7 @@ export async function importUri(
 export async function importRaw(
   getWorkspaceId: () => Promise<string | null>,
   rawContent: string,
-  getWorkspaceScope?: () => Promise<WorkspaceScope | null>,
+  getWorkspaceScope?: () => Promise<WorkspaceScope>,
 ): Promise<ImportResult> {
   let results;
   try {

--- a/packages/insomnia-app/app/models/api-spec.js
+++ b/packages/insomnia-app/app/models/api-spec.js
@@ -29,7 +29,7 @@ export async function migrate(doc: ApiSpec): Promise<ApiSpec> {
   return doc;
 }
 
-export function getByParentId(workspaceId: string): Promise<ApiSpec> {
+export function getByParentId(workspaceId: string): Promise<ApiSpec | null> {
   return db.getWhere(type, { parentId: workspaceId });
 }
 

--- a/packages/insomnia-app/app/models/workspace.js
+++ b/packages/insomnia-app/app/models/workspace.js
@@ -11,10 +11,17 @@ export const prefix = 'wrk';
 export const canDuplicate = true;
 export const canSync = true;
 
+export const WorkspaceScopeKeys = {
+  designer: 'designer',
+  collection: 'collection',
+};
+
+export type WorkspaceScope = $Keys<typeof WorkspaceScopeKeys>;
+
 type BaseWorkspace = {
   name: string,
   description: string,
-  scope: 'designer' | 'collection',
+  scope: WorkspaceScope,
 };
 
 export type Workspace = BaseModel & BaseWorkspace;
@@ -48,7 +55,7 @@ export async function all(): Promise<Array<Workspace>> {
 
   if (workspaces.length === 0) {
     // Create default workspace
-    await create({ name: getAppName(), scope: 'collection' });
+    await create({ name: getAppName(), scope: WorkspaceScopeKeys.collection });
     return all();
   } else {
     return workspaces;
@@ -112,7 +119,10 @@ async function _migrateEnsureName(workspace: Workspace): Promise<Workspace> {
  * Ensure workspace scope is set to a valid entry
  */
 function _migrateScope(workspace: Workspace): Workspace {
-  if (workspace.scope === 'designer' || workspace.scope === 'collection') {
+  if (
+    workspace.scope === WorkspaceScopeKeys.designer ||
+    workspace.scope === WorkspaceScopeKeys.collection
+  ) {
     return workspace;
   }
 
@@ -120,13 +130,13 @@ function _migrateScope(workspace: Workspace): Workspace {
   type OldScopeTypes = 'spec' | 'debug' | null;
   switch ((workspace.scope: OldScopeTypes)) {
     case 'spec': {
-      workspace.scope = 'designer';
+      workspace.scope = WorkspaceScopeKeys.designer;
       break;
     }
     case 'debug':
     case null:
     default:
-      workspace.scope = 'collection';
+      workspace.scope = WorkspaceScopeKeys.collection;
       break;
   }
 

--- a/packages/insomnia-app/app/plugins/context/data.js
+++ b/packages/insomnia-app/app/plugins/context/data.js
@@ -6,20 +6,19 @@ import {
   importUri,
 } from '../../common/import';
 import type { Workspace, WorkspaceScope } from '../../models/workspace';
+import type { ImportOptions } from '../../common/import';
 
-type ImportOptions = { workspaceId?: string, scope?: WorkspaceScope };
+type PluginImportOptions = { workspaceId?: string, scope?: WorkspaceScope };
 
 export function init(): { data: { import: Object, export: Object } } {
   return {
     data: {
       import: {
-        async uri(uri: string, options: ImportOptions = {}): Promise<void> {
-          const { getWorkspaceId, getWorkspaceScope } = buildImportCallbacks(options);
-          await importUri(getWorkspaceId, uri, getWorkspaceScope);
+        async uri(uri: string, options: PluginImportOptions = {}): Promise<void> {
+          await importUri(uri, buildImportOptions(options));
         },
-        async raw(text: string, options: ImportOptions = {}): Promise<void> {
-          const { getWorkspaceId, getWorkspaceScope } = buildImportCallbacks(options);
-          await importRaw(getWorkspaceId, text, getWorkspaceScope);
+        async raw(text: string, options: PluginImportOptions = {}): Promise<void> {
+          await importRaw(text, buildImportOptions(options));
         },
       },
       export: {
@@ -47,12 +46,7 @@ export function init(): { data: { import: Object, export: Object } } {
   };
 }
 
-type ImportCallbacks = {
-  getWorkspaceId: () => Promise<string | null>,
-  getWorkspaceScope?: () => Promise<WorkspaceScope>,
-};
-
-function buildImportCallbacks(options: ImportOptions): ImportCallbacks {
+function buildImportOptions(options: PluginImportOptions): ImportOptions {
   const getWorkspaceId = () => Promise.resolve(options.workspaceId || null);
   const getWorkspaceScope = options.scope && (() => Promise.resolve(options.scope));
   return { getWorkspaceId, getWorkspaceScope };

--- a/packages/insomnia-app/app/plugins/context/data.js
+++ b/packages/insomnia-app/app/plugins/context/data.js
@@ -6,7 +6,7 @@ import {
   importUri,
 } from '../../common/import';
 import type { Workspace, WorkspaceScope } from '../../models/workspace';
-import type { ImportOptions } from '../../common/import';
+import type { ImportRawConfig } from '../../common/import';
 
 type PluginImportOptions = { workspaceId?: string, scope?: WorkspaceScope };
 
@@ -15,10 +15,10 @@ export function init(): { data: { import: Object, export: Object } } {
     data: {
       import: {
         async uri(uri: string, options: PluginImportOptions = {}): Promise<void> {
-          await importUri(uri, buildImportOptions(options));
+          await importUri(uri, buildImportRawConfig(options));
         },
         async raw(text: string, options: PluginImportOptions = {}): Promise<void> {
-          await importRaw(text, buildImportOptions(options));
+          await importRaw(text, buildImportRawConfig(options));
         },
       },
       export: {
@@ -46,7 +46,7 @@ export function init(): { data: { import: Object, export: Object } } {
   };
 }
 
-function buildImportOptions(options: PluginImportOptions): ImportOptions {
+function buildImportRawConfig(options: PluginImportOptions): ImportRawConfig {
   const getWorkspaceId = () => Promise.resolve(options.workspaceId || null);
   const getWorkspaceScope = options.scope && (() => Promise.resolve(options.scope));
   return { getWorkspaceId, getWorkspaceScope };

--- a/packages/insomnia-app/app/ui/components/panes/placeholder-request-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/placeholder-request-pane.js
@@ -4,12 +4,12 @@ import Hotkey from '../hotkey';
 import { hotKeyRefs } from '../../../common/hotkeys';
 import * as hotkeys from '../../../common/hotkeys';
 import type { Request } from '../../../models/request';
-import type { ForceToWorkspace } from '../../redux/modules/helpers';
 import { Pane, PaneBody, PaneHeader } from './pane';
+import type { HandleImportFileCallback } from '../wrapper';
 
 type Props = {
   hotKeyRegistry: hotkeys.HotKeyRegistry,
-  handleImportFile: (forceToWorkspace?: ForceToWorkspace) => void,
+  handleImportFile: HandleImportFileCallback,
   handleCreateRequest: () => Promise<Request>,
 };
 

--- a/packages/insomnia-app/app/ui/components/panes/request-pane.js
+++ b/packages/insomnia-app/app/ui/components/panes/request-pane.js
@@ -28,11 +28,11 @@ import RenderedQueryString from '../rendered-query-string';
 import RequestUrlBar from '../request-url-bar.js';
 import type { Settings } from '../../../models/settings';
 import RequestParametersEditor from '../editors/request-parameters-editor';
-import type { ForceToWorkspace } from '../../redux/modules/helpers';
 import PlaceholderRequestPane from './placeholder-request-pane';
 import { Pane, paneBodyClasses, PaneHeader } from './pane';
 import classnames from 'classnames';
 import { queryAllWorkspaceUrls } from '../../../models/helpers/query-all-workspace-urls';
+import type { HandleImportFileCallback } from '../wrapper';
 
 type Props = {
   // Functions
@@ -56,7 +56,7 @@ type Props = {
   updateSettingsUseBulkHeaderEditor: Function,
   updateSettingsUseBulkParametersEditor: Function,
   handleImport: Function,
-  handleImportFile: (forceToWorkspace?: ForceToWorkspace) => void,
+  handleImportFile: HandleImportFileCallback,
 
   // Other
   workspace: Workspace,

--- a/packages/insomnia-app/app/ui/components/wrapper-debug.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-debug.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import PageLayout from './page-layout';
-import type { WrapperProps } from './wrapper';
+import type { HandleImportFileCallback, WrapperProps } from './wrapper';
 import RequestPane from './panes/request-pane';
 import ErrorBoundary from './error-boundary';
 import ResponsePane from './panes/response-pane';
@@ -11,7 +11,6 @@ import SidebarFilter from './sidebar/sidebar-filter';
 import EnvironmentsDropdown from './dropdowns/environments-dropdown';
 import { AUTOBIND_CFG } from '../../common/constants';
 import { isGrpcRequest } from '../../models/helpers/is-model';
-import type { ForceToWorkspace } from '../redux/modules/helpers';
 import GrpcRequestPane from './panes/grpc-request-pane';
 import GrpcResponsePane from './panes/grpc-response-pane';
 import WorkspacePageHeader from './workspace-page-header';
@@ -31,7 +30,7 @@ type Props = {
   handleForceUpdateRequest: Function,
   handleForceUpdateRequestHeaders: Function,
   handleImport: Function,
-  handleImportFile: (forceToWorkspace?: ForceToWorkspace) => void,
+  handleImportFile: HandleImportFileCallback,
   handleRequestCreate: Function,
   handleRequestGroupCreate: Function,
   handleSendAndDownloadRequestWithActiveEnvironment: Function,

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -499,7 +499,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { workspaces } = this.props.wrapperProps;
+    const { workspaces, isLoading } = this.props.wrapperProps;
     const { filter } = this.state;
 
     // Render each card, removing all the ones that don't match the filter
@@ -515,6 +515,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
               <React.Fragment>
                 <img src={coreLogo} alt="Insomnia" width="24" height="24" />
                 <Breadcrumb className="breadcrumb" crumbs={[getAppName()]} />
+                {isLoading ? <i className="fa fa-refresh fa-spin space-left" /> : null}
               </React.Fragment>
             }
             gridRight={

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -450,7 +450,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
       <Dropdown renderButton={button}>
         <DropdownDivider>New</DropdownDivider>
         <DropdownItem icon={<i className="fa fa-file-o" />} onClick={this._handleDocumentCreate}>
-          Blank Document
+          Design Document
         </DropdownItem>
         <DropdownItem icon={<i className="fa fa-bars" />} onClick={this._handleCollectionCreate}>
           Request Collection

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -37,11 +37,15 @@ import Highlight from './base/highlight';
 import type { GlobalActivity } from '../../common/constants';
 
 import { fuzzyMatchAll } from '../../common/misc';
-import type { WrapperProps } from './wrapper';
+import type {
+  HandleImportClipboardCallback,
+  HandleImportFileCallback,
+  HandleImportUriCallback,
+  WrapperProps,
+} from './wrapper';
 import Notice from './notice';
 import GitRepositorySettingsModal from '../components/modals/git-repository-settings-modal';
 import PageLayout from './page-layout';
-import type { ForceToWorkspace } from '../redux/modules/helpers';
 import { ForceToWorkspaceKeys } from '../redux/modules/helpers';
 import coreLogo from '../images/insomnia-core-logo.png';
 import { MemPlugin } from '../../sync/git/mem-plugin';
@@ -58,9 +62,9 @@ import AccountDropdown from './dropdowns/account-dropdown';
 
 type Props = {|
   wrapperProps: WrapperProps,
-  handleImportFile: (forceToWorkspace: ForceToWorkspace) => void,
-  handleImportUri: (uri: string, forceToWorkspace: ForceToWorkspace) => void,
-  handleImportClipboard: (forceToWorkspace: ForceToWorkspace) => void,
+  handleImportFile: HandleImportFileCallback,
+  handleImportUri: HandleImportUriCallback,
+  handleImportClipboard: HandleImportClipboardCallback,
 |};
 
 type State = {|
@@ -121,11 +125,11 @@ class WrapperHome extends React.PureComponent<Props, State> {
   }
 
   _handleImportFile() {
-    this.props.handleImportFile(ForceToWorkspaceKeys.new);
+    this.props.handleImportFile({ forceToWorkspace: ForceToWorkspaceKeys.new });
   }
 
   _handleImportClipBoard() {
-    this.props.handleImportClipboard(ForceToWorkspaceKeys.new);
+    this.props.handleImportClipboard({ forceToWorkspace: ForceToWorkspaceKeys.new });
   }
 
   _handleImportUri() {
@@ -135,7 +139,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
       label: 'URL',
       placeholder: 'https://website.com/insomnia-import.json',
       onComplete: uri => {
-        this.props.handleImportUri(uri, ForceToWorkspaceKeys.new);
+        this.props.handleImportUri(uri, { forceToWorkspace: ForceToWorkspaceKeys.new });
       },
     });
   }

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
@@ -6,17 +6,17 @@ import { showPrompt } from './modals';
 import type { BaseModel } from '../../models';
 import * as models from '../../models';
 import { AUTOBIND_CFG, getAppLongName, getAppName } from '../../common/constants';
-import type { WrapperProps } from './wrapper';
+import type { HandleImportFileCallback, HandleImportUriCallback, WrapperProps } from './wrapper';
 import * as db from '../../common/database';
 import chartSrc from '../images/chart.svg';
-import type { ForceToWorkspace } from '../redux/modules/helpers';
 import { ForceToWorkspaceKeys } from '../redux/modules/helpers';
 import OnboardingContainer from './onboarding-container';
+import { WorkspaceScopeKeys } from '../../models/workspace';
 
 type Props = {|
   wrapperProps: WrapperProps,
-  handleImportFile: (forceToWorkspace: ForceToWorkspace) => any,
-  handleImportUri: (uri: string, forceToWorkspace: ForceToWorkspace) => any,
+  handleImportFile: HandleImportFileCallback,
+  handleImportUri: HandleImportUriCallback,
 |};
 
 type State = {|
@@ -77,7 +77,10 @@ class WrapperOnboarding extends React.PureComponent<Props, State> {
 
   _handleImportFile() {
     const { handleImportFile } = this.props;
-    handleImportFile(ForceToWorkspaceKeys.new);
+    handleImportFile({
+      forceToWorkspace: ForceToWorkspaceKeys.new,
+      forceToScope: WorkspaceScopeKeys.designer,
+    });
   }
 
   _handleImportUri(defaultValue: string) {
@@ -89,7 +92,10 @@ class WrapperOnboarding extends React.PureComponent<Props, State> {
       placeholder: 'https://example.com/openapi-spec.yaml',
       label: 'URI to Import',
       onComplete: value => {
-        handleImportUri(value, ForceToWorkspaceKeys.new);
+        handleImportUri(value, {
+          forceToWorkspace: ForceToWorkspaceKeys.new,
+          forceToScope: WorkspaceScopeKeys.designer,
+        });
       },
     });
   }

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -345,7 +345,7 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
     // Delaying generation so design to debug mode is smooth
     handleSetActiveActivity(nextActivity);
     setTimeout(() => {
-      importRaw(activeApiSpec.content, {
+      importRaw(activeApiSpec.contents, {
         getWorkspaceId: () => Promise.resolve(workspaceId),
       });
     }, 1000);

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -86,7 +86,6 @@ import WrapperDebug from './wrapper-debug';
 import { importRaw } from '../../common/import';
 import GitSyncDropdown from './dropdowns/git-sync-dropdown';
 import { DropdownButton } from './base/dropdown';
-import type { ForceToWorkspace } from '../redux/modules/helpers';
 import type { UnitTest } from '../../models/unit-test';
 import type { UnitTestResult } from '../../models/unit-test-result';
 import type { UnitTestSuite } from '../../models/unit-test-suite';
@@ -95,6 +94,7 @@ import { Spectral } from '@stoplight/spectral';
 import ProtoFilesModal from './modals/proto-files-modal';
 import { GrpcDispatchModalWrapper } from '../context/grpc';
 import WrapperMigration from './wrapper-migration';
+import type { ImportOptions } from '../redux/modules/global';
 
 const spectral = new Spectral();
 
@@ -103,16 +103,9 @@ export type WrapperProps = {
   handleActivateRequest: Function,
   handleSetSidebarFilter: Function,
   handleToggleMenuBar: Function,
-  handleImportFileToWorkspace: (workspaceId: string, forceToWorkspace?: ForceToWorkspace) => void,
-  handleImportClipBoardToWorkspace: (
-    workspaceId: string,
-    forceToWorkspace?: ForceToWorkspace,
-  ) => void,
-  handleImportUriToWorkspace: (
-    workspaceId: string,
-    uri: string,
-    forceToWorkspace?: ForceToWorkspace,
-  ) => void,
+  handleImportFileToWorkspace: (workspaceId: string, options?: ImportOptions) => void,
+  handleImportClipBoardToWorkspace: (workspaceId: string, options?: ImportOptions) => void,
+  handleImportUriToWorkspace: (workspaceId: string, uri: string, options?: ImportOptions) => void,
   handleInitializeEntities: () => Promise<void>,
   handleExportFile: Function,
   handleShowExportRequestsModal: Function,
@@ -204,6 +197,10 @@ export type WrapperProps = {
   activeRequest: Request | null,
   activeResponse: Response | null,
 };
+
+export type HandleImportFileCallback = (options?: ImportOptions) => void;
+export type HandleImportClipboardCallback = (options?: ImportOptions) => void;
+export type HandleImportUriCallback = (uri: string, options?: ImportOptions) => void;
 
 type State = {
   forceRefreshKey: number,
@@ -369,16 +366,16 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
     return sUpdate(this.props.settings, { useBulkParametersEditor });
   }
 
-  _handleImportFile(forceToWorkspace?: ForceToWorkspace): void {
-    this.props.handleImportFileToWorkspace(this.props.activeWorkspace._id, forceToWorkspace);
+  _handleImportFile(options?: ImportOptions): void {
+    this.props.handleImportFileToWorkspace(this.props.activeWorkspace._id, options);
   }
 
-  _handleImportUri(uri: string, forceToWorkspace?: ForceToWorkspace): void {
-    this.props.handleImportUriToWorkspace(this.props.activeWorkspace._id, uri, forceToWorkspace);
+  _handleImportUri(uri: string, options?: ImportOptions): void {
+    this.props.handleImportUriToWorkspace(this.props.activeWorkspace._id, uri, options);
   }
 
-  _handleImportClipBoard(forceToWorkspace?: ForceToWorkspace): void {
-    this.props.handleImportClipBoardToWorkspace(this.props.activeWorkspace._id, forceToWorkspace);
+  _handleImportClipBoard(options?: ImportOptions): void {
+    this.props.handleImportClipBoardToWorkspace(this.props.activeWorkspace._id, options);
   }
 
   _handleSetActiveResponse(responseId: string | null): void {

--- a/packages/insomnia-app/app/ui/components/wrapper.js
+++ b/packages/insomnia-app/app/ui/components/wrapper.js
@@ -348,7 +348,9 @@ class Wrapper extends React.PureComponent<WrapperProps, State> {
     // Delaying generation so design to debug mode is smooth
     handleSetActiveActivity(nextActivity);
     setTimeout(() => {
-      importRaw(() => Promise.resolve(workspaceId), activeApiSpec.contents);
+      importRaw(activeApiSpec.content, {
+        getWorkspaceId: () => Promise.resolve(workspaceId),
+      });
     }, 1000);
   }
 

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -7,7 +7,7 @@ import path from 'path';
 import AskModal from '../../../ui/components/modals/ask-modal';
 import * as moment from 'moment';
 
-import type { ImportResult } from '../../../common/import';
+import type { ImportOptions, ImportResult } from '../../../common/import';
 import * as importUtils from '../../../common/import';
 import AlertModal from '../../components/modals/alert-modal';
 import PaymentNotificationModal from '../../components/modals/payment-notification-modal';
@@ -333,11 +333,12 @@ export function importFile(workspaceId: string, forceToWorkspace?: ForceToWorksp
     for (const p of paths) {
       try {
         const uri = `file://${p}`;
-        const result = await importUtils.importUri(
-          askToImportIntoWorkspace(workspaceId, forceToWorkspace),
-          uri,
-          askToSetWorkspaceScope(),
-        );
+
+        const options: ImportOptions = {
+          getWorkspaceScope: askToSetWorkspaceScope(),
+          getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
+        };
+        const result = await importUtils.importUri(uri, options);
         importedWorkspaces = handleImportResult(
           result,
           'The file does not contain a valid specification.',
@@ -384,11 +385,11 @@ export function importClipBoard(workspaceId: string, forceToWorkspace?: ForceToW
     // Let's import all the paths!
     let importedWorkspaces = [];
     try {
-      const result = await importUtils.importRaw(
-        askToImportIntoWorkspace(workspaceId, forceToWorkspace),
-        schema,
-        askToSetWorkspaceScope(),
-      );
+      const options: ImportOptions = {
+        getWorkspaceScope: askToSetWorkspaceScope(),
+        getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
+      };
+      const result = await importUtils.importRaw(schema, options);
       importedWorkspaces = handleImportResult(
         result,
         'Your clipboard does not contain a valid specification.',
@@ -413,11 +414,11 @@ export function importUri(workspaceId: string, uri: string, forceToWorkspace?: F
 
     let importedWorkspaces = [];
     try {
-      const result = await importUtils.importUri(
-        askToImportIntoWorkspace(workspaceId, forceToWorkspace),
-        uri,
-        askToSetWorkspaceScope(),
-      );
+      const options: ImportOptions = {
+        getWorkspaceScope: askToSetWorkspaceScope(),
+        getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
+      };
+      const result = await importUtils.importUri(uri, options);
       importedWorkspaces = handleImportResult(
         result,
         'The URI does not contain a valid specification.',

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -337,7 +337,6 @@ export function importFile(
     }
 
     // Let's import all the paths!
-    let importedWorkspaces = [];
     for (const p of paths) {
       try {
         const uri = `file://${p}`;
@@ -347,19 +346,12 @@ export function importFile(
           getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
         };
         const result = await importUtils.importUri(uri, options);
-        importedWorkspaces = handleImportResult(
-          result,
-          'The file does not contain a valid specification.',
-        );
+        handleImportResult(result, 'The file does not contain a valid specification.');
       } catch (err) {
         showModal(AlertModal, { title: 'Import Failed', message: err + '' });
       } finally {
         dispatch(loadStop());
       }
-    }
-
-    if (importedWorkspaces.length === 1) {
-      dispatch(setActiveWorkspace(importedWorkspaces[0]._id));
     }
   };
 }
@@ -394,17 +386,13 @@ export function importClipBoard(
       return;
     }
     // Let's import all the paths!
-    let importedWorkspaces = [];
     try {
       const options: ImportRawConfig = {
         getWorkspaceScope: askToSetWorkspaceScope(forceToScope),
         getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
       };
       const result = await importUtils.importRaw(schema, options);
-      importedWorkspaces = handleImportResult(
-        result,
-        'Your clipboard does not contain a valid specification.',
-      );
+      handleImportResult(result, 'Your clipboard does not contain a valid specification.');
     } catch (err) {
       showModal(AlertModal, {
         title: 'Import Failed',
@@ -412,9 +400,6 @@ export function importClipBoard(
       });
     } finally {
       dispatch(loadStop());
-    }
-    if (importedWorkspaces.length === 1) {
-      dispatch(setActiveWorkspace(importedWorkspaces[0]._id));
     }
   };
 }
@@ -427,25 +412,17 @@ export function importUri(
   return async dispatch => {
     dispatch(loadStart());
 
-    let importedWorkspaces = [];
     try {
       const options: ImportRawConfig = {
         getWorkspaceScope: askToSetWorkspaceScope(forceToScope),
         getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
       };
       const result = await importUtils.importUri(uri, options);
-      importedWorkspaces = handleImportResult(
-        result,
-        'The URI does not contain a valid specification.',
-      );
+      handleImportResult(result, 'The URI does not contain a valid specification.');
     } catch (err) {
       showModal(AlertModal, { title: 'Import Failed', message: err + '' });
     } finally {
       dispatch(loadStop());
-    }
-
-    if (importedWorkspaces.length === 1) {
-      dispatch(setActiveWorkspace(importedWorkspaces[0]._id));
     }
   };
 }

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -24,7 +24,7 @@ import SettingsModal, {
 } from '../../components/modals/settings-modal';
 import install from '../../../plugins/install';
 import type { ForceToWorkspace } from './helpers';
-import { askToImportIntoWorkspace } from './helpers';
+import { askToImportIntoWorkspace, askToSetWorkspaceScope } from './helpers';
 import { createPlugin } from '../../../plugins/create';
 import { reloadPlugins } from '../../../plugins';
 import { setTheme } from '../../../plugins/misc';
@@ -386,6 +386,7 @@ export function importClipBoard(workspaceId: string, forceToWorkspace?: ForceToW
       const result = await importUtils.importRaw(
         askToImportIntoWorkspace(workspaceId, forceToWorkspace),
         schema,
+        askToSetWorkspaceScope(),
       );
       importedWorkspaces = handleImportResult(
         result,

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -7,7 +7,7 @@ import path from 'path';
 import AskModal from '../../../ui/components/modals/ask-modal';
 import * as moment from 'moment';
 
-import type { ImportOptions, ImportResult } from '../../../common/import';
+import type { ImportRawConfig, ImportResult } from '../../../common/import';
 import * as importUtils from '../../../common/import';
 import AlertModal from '../../components/modals/alert-modal';
 import PaymentNotificationModal from '../../components/modals/payment-notification-modal';
@@ -334,7 +334,7 @@ export function importFile(workspaceId: string, forceToWorkspace?: ForceToWorksp
       try {
         const uri = `file://${p}`;
 
-        const options: ImportOptions = {
+        const options: ImportRawConfig = {
           getWorkspaceScope: askToSetWorkspaceScope(),
           getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
         };
@@ -385,7 +385,7 @@ export function importClipBoard(workspaceId: string, forceToWorkspace?: ForceToW
     // Let's import all the paths!
     let importedWorkspaces = [];
     try {
-      const options: ImportOptions = {
+      const options: ImportRawConfig = {
         getWorkspaceScope: askToSetWorkspaceScope(),
         getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
       };
@@ -414,7 +414,7 @@ export function importUri(workspaceId: string, uri: string, forceToWorkspace?: F
 
     let importedWorkspaces = [];
     try {
-      const options: ImportOptions = {
+      const options: ImportRawConfig = {
         getWorkspaceScope: askToSetWorkspaceScope(),
         getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
       };

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -29,7 +29,7 @@ import { createPlugin } from '../../../plugins/create';
 import { reloadPlugins } from '../../../plugins';
 import { setTheme } from '../../../plugins/misc';
 import type { GlobalActivity } from '../../../common/constants';
-import type { Workspace } from '../../../models/workspace';
+import type { Workspace, WorkspaceScope } from '../../../models/workspace';
 import {
   ACTIVITY_DEBUG,
   ACTIVITY_HOME,
@@ -293,7 +293,15 @@ export function setActiveWorkspace(workspaceId: string) {
   return { type: SET_ACTIVE_WORKSPACE, workspaceId };
 }
 
-export function importFile(workspaceId: string, forceToWorkspace?: ForceToWorkspace) {
+export type ImportOptions = {
+  forceToWorkspace?: ForceToWorkspace,
+  forceToScope?: WorkspaceScope,
+};
+
+export function importFile(
+  workspaceId: string,
+  { forceToScope, forceToWorkspace }: ImportOptions = {},
+) {
   return async dispatch => {
     dispatch(loadStart());
 
@@ -335,7 +343,7 @@ export function importFile(workspaceId: string, forceToWorkspace?: ForceToWorksp
         const uri = `file://${p}`;
 
         const options: ImportRawConfig = {
-          getWorkspaceScope: askToSetWorkspaceScope(),
+          getWorkspaceScope: askToSetWorkspaceScope(forceToScope),
           getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
         };
         const result = await importUtils.importUri(uri, options);
@@ -371,7 +379,10 @@ function handleImportResult(result: ImportResult, errorMessage: string): Array<W
   return summary[models.workspace.type] || [];
 }
 
-export function importClipBoard(workspaceId: string, forceToWorkspace?: ForceToWorkspace) {
+export function importClipBoard(
+  workspaceId: string,
+  { forceToScope, forceToWorkspace }: ImportOptions = {},
+) {
   return async dispatch => {
     dispatch(loadStart());
     const schema = electron.clipboard.readText();
@@ -386,7 +397,7 @@ export function importClipBoard(workspaceId: string, forceToWorkspace?: ForceToW
     let importedWorkspaces = [];
     try {
       const options: ImportRawConfig = {
-        getWorkspaceScope: askToSetWorkspaceScope(),
+        getWorkspaceScope: askToSetWorkspaceScope(forceToScope),
         getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
       };
       const result = await importUtils.importRaw(schema, options);
@@ -408,14 +419,18 @@ export function importClipBoard(workspaceId: string, forceToWorkspace?: ForceToW
   };
 }
 
-export function importUri(workspaceId: string, uri: string, forceToWorkspace?: ForceToWorkspace) {
+export function importUri(
+  workspaceId: string,
+  uri: string,
+  { forceToScope, forceToWorkspace }: ImportOptions = {},
+) {
   return async dispatch => {
     dispatch(loadStart());
 
     let importedWorkspaces = [];
     try {
       const options: ImportRawConfig = {
-        getWorkspaceScope: askToSetWorkspaceScope(),
+        getWorkspaceScope: askToSetWorkspaceScope(forceToScope),
         getWorkspaceId: askToImportIntoWorkspace(workspaceId, forceToWorkspace),
       };
       const result = await importUtils.importUri(uri, options);

--- a/packages/insomnia-app/app/ui/redux/modules/global.js
+++ b/packages/insomnia-app/app/ui/redux/modules/global.js
@@ -336,6 +336,7 @@ export function importFile(workspaceId: string, forceToWorkspace?: ForceToWorksp
         const result = await importUtils.importUri(
           askToImportIntoWorkspace(workspaceId, forceToWorkspace),
           uri,
+          askToSetWorkspaceScope(),
         );
         importedWorkspaces = handleImportResult(
           result,
@@ -415,6 +416,7 @@ export function importUri(workspaceId: string, uri: string, forceToWorkspace?: F
       const result = await importUtils.importUri(
         askToImportIntoWorkspace(workspaceId, forceToWorkspace),
         uri,
+        askToSetWorkspaceScope(),
       );
       importedWorkspaces = handleImportResult(
         result,

--- a/packages/insomnia-app/app/ui/redux/modules/helpers.js
+++ b/packages/insomnia-app/app/ui/redux/modules/helpers.js
@@ -35,9 +35,6 @@ export function askToImportIntoWorkspace(workspaceId: string, forceToWorkspace?:
 
 export function askToSetWorkspaceScope(scope?: WorkspaceScope) {
   return function(name: string) {
-    const designerFullName = 'Design Document';
-    const collectionFullName = 'Request Collection';
-
     switch (scope) {
       case WorkspaceScopeKeys.collection:
       case WorkspaceScopeKeys.designer:
@@ -45,12 +42,12 @@ export function askToSetWorkspaceScope(scope?: WorkspaceScope) {
       default:
         return new Promise(resolve => {
           showModal(AskModal, {
-            title: 'Import',
-            message: `Do you want to import "${name}" as a ${designerFullName} or ${collectionFullName}?`,
-            noText: designerFullName,
-            yesText: collectionFullName,
+            title: 'Import As',
+            message: `How would you like to import "${name}"?`,
+            noText: 'Request Collection',
+            yesText: 'Design Document',
             onDone: yes => {
-              resolve(yes ? WorkspaceScopeKeys.collection : WorkspaceScopeKeys.designer);
+              resolve(yes ? WorkspaceScopeKeys.designer : WorkspaceScopeKeys.collection);
             },
           });
         });

--- a/packages/insomnia-app/app/ui/redux/modules/helpers.js
+++ b/packages/insomnia-app/app/ui/redux/modules/helpers.js
@@ -34,7 +34,10 @@ export function askToImportIntoWorkspace(workspaceId: string, forceToWorkspace?:
 }
 
 export function askToSetWorkspaceScope(scope?: WorkspaceScope) {
-  return function() {
+  return function(name: string) {
+    const designerFullName = 'Design Document';
+    const collectionFullName = 'Request Collection';
+
     switch (scope) {
       case WorkspaceScopeKeys.collection:
       case WorkspaceScopeKeys.designer:
@@ -43,9 +46,9 @@ export function askToSetWorkspaceScope(scope?: WorkspaceScope) {
         return new Promise(resolve => {
           showModal(AskModal, {
             title: 'Import',
-            message: 'Do you want to import as a new request collection or new design document?',
-            yesText: 'Collection',
-            noText: 'Document',
+            message: `Do you want to import "${name}" as a ${designerFullName} or ${collectionFullName}?`,
+            noText: designerFullName,
+            yesText: collectionFullName,
             onDone: yes => {
               resolve(yes ? WorkspaceScopeKeys.collection : WorkspaceScopeKeys.designer);
             },

--- a/packages/insomnia-app/app/ui/redux/modules/helpers.js
+++ b/packages/insomnia-app/app/ui/redux/modules/helpers.js
@@ -1,6 +1,7 @@
 // @flow
 import { showModal } from '../../components/modals';
 import AskModal from '../../components/modals/ask-modal';
+import { WorkspaceScopeKeys } from '../../../models/workspace';
 
 export const ForceToWorkspaceKeys = {
   new: 'new',
@@ -25,6 +26,28 @@ export function askToImportIntoWorkspace(workspaceId: string, forceToWorkspace?:
             noText: 'New Workspace',
             onDone: yes => {
               resolve(yes ? workspaceId : null);
+            },
+          });
+        });
+    }
+  };
+}
+
+export function askToSetWorkspaceScope(scope?: WorkspaceScope) {
+  return function() {
+    switch (scope) {
+      case WorkspaceScopeKeys.collection:
+      case WorkspaceScopeKeys.designer:
+        return scope;
+      default:
+        return new Promise(resolve => {
+          showModal(AskModal, {
+            title: 'Import',
+            message: 'Do you want to import as a new request collection or new design document?',
+            yesText: 'Collection',
+            noText: 'Document',
+            onDone: yes => {
+              resolve(yes ? WorkspaceScopeKeys.collection : WorkspaceScopeKeys.designer);
             },
           });
         });

--- a/packages/insomnia-importers/src/importers/openapi3.js
+++ b/packages/insomnia-importers/src/importers/openapi3.js
@@ -60,6 +60,7 @@ module.exports.convert = async function(rawData) {
     parentId: null,
     name: `${api.info.title} ${api.info.version}`,
     description: api.info.description || '',
+    // scope is not set because it could be imported for design OR to generate requests
   };
 
   const baseEnv = {

--- a/packages/insomnia-importers/src/importers/swagger2.js
+++ b/packages/insomnia-importers/src/importers/swagger2.js
@@ -41,6 +41,7 @@ module.exports.convert = async function(rawData) {
     parentId: null,
     name: `${api.info.title} ${api.info.version}`,
     description: api.info.description || '',
+    // scope is not set because it could be imported for design OR to generate requests
   };
 
   const baseEnv = {


### PR DESCRIPTION
Example docs to test with:
- [OpenAPI](https://gist.githubusercontent.com/gschier/4e2278d5a50b4bbf1110755d9b48a9f9/raw/801c05266ae102bcb9288ab92c60f52d45557425/petstore-spec.yaml) (should prompt once)
- [Single document](https://gist.githubusercontent.com/develohpanda/6f1709f64343a334eb9cde2f573be685/raw/337f2f2e898bddb605d6f90ff2a4bd89e3fd1113/single-doc-export.json) exported from Designer (should prompt once)
- [Multiple documents](https://gist.githubusercontent.com/develohpanda/3d709b194a395b7fdb66f1003a3cf1d0/raw/24a57a787452939d5b411de0a24e7c55a8c75fb2/multiple-docs.json) exported from Designer (should prompt twice and import 3rd & 4th without prompt)


Should not prompt at all if importing from onboarding flow - it should auto import as a Design Document from there. (@nijikokun pls confirm)

![2021-03-02 16 37 36](https://user-images.githubusercontent.com/4312346/109593537-05499d80-7b76-11eb-8dda-ff3a6f0522c3.gif)

![2021-03-02 16 40 13](https://user-images.githubusercontent.com/4312346/109593579-14c8e680-7b76-11eb-9419-0698f0e077c6.gif)