### PR TITLE
Migration flow stylistic updates

### DIFF
--- a/packages/insomnia-app/app/ui/components/onboarding-container.js
+++ b/packages/insomnia-app/app/ui/components/onboarding-container.js
@@ -3,13 +3,12 @@ import React from 'react';
 import type { WrapperProps } from './wrapper';
 import PageLayout from './page-layout';
 import coreLogo from '../images/insomnia-core-logo.png';
-import { getAppLongName, getAppSynopsis } from '../../common/constants';
 
 type Props = {
   wrapperProps: WrapperProps,
 };
 
-const OnboardingContainer = ({ wrapperProps, children }: Props) => (
+const OnboardingContainer = ({ wrapperProps, children, header, subHeader }: Props) => (
   <PageLayout
     wrapperProps={wrapperProps}
     renderPageBody={() => (
@@ -20,8 +19,8 @@ const OnboardingContainer = ({ wrapperProps, children }: Props) => (
             <img src={coreLogo} alt="Kong" />
           </div>
           <header className="onboarding__content__header">
-            <h1>Welcome to {getAppLongName()}</h1>
-            <h2>{getAppSynopsis()}</h2>
+            <h1>{header}</h1>
+            <h2>{subHeader}</h2>
           </header>
           <div className="onboarding__content__body">{children}</div>
         </div>

--- a/packages/insomnia-app/app/ui/components/wrapper-migration.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-migration.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import type { WrapperProps } from './wrapper';
-import { ToggleSwitch } from 'insomnia-components';
+import { ToggleSwitch, Button } from 'insomnia-components';
 import type { MigrationOptions } from '../../common/migrate-from-designer';
 import migrateFromDesigner, { restartApp } from '../../common/migrate-from-designer';
 import { getDataDirectory, getDesignerDataDir } from '../../common/misc';
@@ -90,13 +90,9 @@ const Options = ({ start, cancel }: OptionsProps) => {
   return (
     <>
       <p>
-        <strong>Migrate from Insomnia Designer</strong>
+        From the list below, select the individual items you would like to migrate from Designer.
       </p>
-      <p>
-        Insomnia Designer and Core are now Insomnia! Select the items below you'd like to migrate
-        from Designer.
-      </p>
-      <div className="text-left margin-top">
+      <div className="text-left">
         <BooleanSetting
           label="Copy Workspaces"
           name="copyWorkspaces"
@@ -140,13 +136,16 @@ const Options = ({ start, cancel }: OptionsProps) => {
       </div>
 
       <div className="margin-top">
-        <button
+        <Button
           key="start"
-          className="btn btn--clicky"
+          bg="surprise"
+          radius="3px"
+          size="medium"
+          variant="contained"
           onClick={() => start(options)}
           disabled={!canStart}>
           Start Migration
-        </button>
+        </Button>
         <button key="cancel" className="btn btn--super-compact" onClick={cancel}>
           Skip for now
         </button>
@@ -259,7 +258,10 @@ type Props = {|
 |};
 
 const WrapperMigration = ({ wrapperProps }: Props) => (
-  <OnboardingContainer wrapperProps={wrapperProps}>
+  <OnboardingContainer
+    wrapperProps={wrapperProps}
+    header="Migrate from Insomnia Designer"
+    subHeader="Insomnia Designer and Core are now Insomnia!">
     <MigrationBody />
   </OnboardingContainer>
 );

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import 'swagger-ui-react/swagger-ui.css';
+import { Button } from 'insomnia-components';
 import { showPrompt } from './modals';
 import type { BaseModel } from '../../models';
 import * as models from '../../models';
@@ -122,9 +123,15 @@ class WrapperOnboarding extends React.PureComponent<Props, State> {
           Help us understand how <strong>you</strong> use {getAppLongName()} so we can make it
           better.
         </p>
-        <button key="enable" className="btn btn--clicky" onClick={this._handleClickEnableAnalytics}>
+        <Button
+          key="enable"
+          bg="surprise"
+          radius="3px"
+          size="medium"
+          variant="contained"
+          onClick={this._handleClickEnableAnalytics}>
           Share Usage Analytics
-        </button>
+        </Button>
         <button
           key="disable"
           className="btn btn--super-compact"

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
@@ -176,7 +176,7 @@ class WrapperOnboarding extends React.PureComponent<Props, State> {
     return (
       <OnboardingContainer
         wrapperProps={this.props.wrapperProps}
-        header={getAppLongName()}
+        header={'Welcome to ' + getAppLongName()}
         subHeader={getAppSynopsis()}>
         {stepBody}
       </OnboardingContainer>

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
@@ -18,6 +18,8 @@ type Props = {|
   wrapperProps: WrapperProps,
   handleImportFile: HandleImportFileCallback,
   handleImportUri: HandleImportUriCallback,
+  header: string,
+  subHeader: string,
 |};
 
 type State = {|

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
@@ -5,7 +5,7 @@ import 'swagger-ui-react/swagger-ui.css';
 import { showPrompt } from './modals';
 import type { BaseModel } from '../../models';
 import * as models from '../../models';
-import { AUTOBIND_CFG, getAppLongName, getAppName } from '../../common/constants';
+import { AUTOBIND_CFG, getAppLongName, getAppName, getAppSynopsis } from '../../common/constants';
 import type { WrapperProps } from './wrapper';
 import * as db from '../../common/database';
 import chartSrc from '../images/chart.svg';
@@ -17,6 +17,8 @@ type Props = {|
   wrapperProps: WrapperProps,
   handleImportFile: (forceToWorkspace: ForceToWorkspace) => any,
   handleImportUri: (uri: string, forceToWorkspace: ForceToWorkspace) => any,
+  header: string,
+  subHeader: string,
 |};
 
 type State = {|
@@ -172,7 +174,12 @@ class WrapperOnboarding extends React.PureComponent<Props, State> {
     }
 
     return (
-      <OnboardingContainer wrapperProps={this.props.wrapperProps}>{stepBody}</OnboardingContainer>
+      <OnboardingContainer
+        wrapperProps={this.props.wrapperProps}
+        header={getAppLongName()}
+        subHeader={getAppSynopsis()}>
+        {stepBody}
+      </OnboardingContainer>
     );
   }
 }

--- a/packages/insomnia-app/app/ui/css/components/onboarding.less
+++ b/packages/insomnia-app/app/ui/css/components/onboarding.less
@@ -46,8 +46,8 @@
       border-bottom: 1px solid var(--hl-sm);
 
       h1 {
-        color: var(--brand-purple);
-        font-size: var(--font-size-xxxl);
+        color: var(--color-font);
+        font-size: var(--font-size-xxl);
         margin-bottom: var(--padding-sm);
       }
 
@@ -65,9 +65,21 @@
       padding: var(--padding-md) var(--padding-lg) var(--padding-md);
       color: var(--color-font);
 
+			h1 {
+        color: var(--color-font);
+        font-size: var(--font-size-xxl);
+        margin-bottom: var(--padding-sm);
+      }
+
+      h2 {
+        color: var(--hl-xl);
+        font-size: var(--font-size-lg);
+        margin-top: 0;
+        margin-bottom: var(--padding-md);
+      }
+
       p {
         font-size: var(--font-size-lg);
-
         strong {
           font-weight: 600;
         }

--- a/packages/insomnia-smoke-test/modules/migration.js
+++ b/packages/insomnia-smoke-test/modules/migration.js
@@ -1,6 +1,6 @@
 export const migrationMessageShown = async app => {
   await app.client.waitUntilTextExists(
-    '.onboarding__content__body p strong',
+    '.onboarding__content__header h1',
     'Migrate from Insomnia Designer',
   );
 };


### PR DESCRIPTION
This PR covers a handful of stylistic updates to the designer to core migration UI. 

- Header & sub-header are styled consistently with on-boarding
- Styled deader & sub-header used for primary verbiage, reducing redundancy
- Theme support updates

Fixes INS-494

Examples in various themes:

![Screen Shot 2021-03-01 at 11 47 19 AM](https://user-images.githubusercontent.com/52717970/109535353-790e7c00-7a8a-11eb-853a-255f48b9b8f0.png)

![Screen Shot 2021-03-01 at 11 47 02 AM](https://user-images.githubusercontent.com/52717970/109535364-7c096c80-7a8a-11eb-90de-68773cb25d88.png)

![Screen Shot 2021-03-01 at 11 47 56 AM](https://user-images.githubusercontent.com/52717970/109535305-698f3300-7a8a-11eb-95f2-29808d8dc554.png)

![Screen Shot 2021-03-01 at 11 48 52 AM](https://user-images.githubusercontent.com/52717970/109535296-64ca7f00-7a8a-11eb-8551-02262410649f.png)
