### PR TITLE
Better handling of .DS_Store files during migration

### DIFF
--- a/packages/insomnia-app/app/common/migrate-from-designer.js
+++ b/packages/insomnia-app/app/common/migrate-from-designer.js
@@ -129,7 +129,7 @@ async function copyDirs(dirs: Array<string>, srcDir: string, destDir: string) {
     const dest = fsPath.join(destDir, dir);
 
     // If source exists, ensure the destination exists, and copy into it
-    if (fs.existsSync(src)) {
+    if (fs.existsSync(src) && isDirectory(src)) {
       await fsx.ensureDir(dest);
       await fsx.copy(src, dest);
     }
@@ -139,10 +139,14 @@ async function copyDirs(dirs: Array<string>, srcDir: string, destDir: string) {
 async function removeDirs(dirs: Array<string>, srcDir: string) {
   for (const dir of dirs.filter(c => c)) {
     const dirToRemove = fsPath.join(srcDir, dir);
-    if (fs.existsSync(dirToRemove)) {
+    if (fs.existsSync(dirToRemove) && isDirectory(dirToRemove)) {
       await fsx.remove(dirToRemove);
     }
   }
+}
+
+function isDirectory(name: string): boolean {
+  return fs.statSync(name).isDirectory();
 }
 
 export default async function migrateFromDesigner({

--- a/packages/insomnia-app/app/common/migrate-from-designer.js
+++ b/packages/insomnia-app/app/common/migrate-from-designer.js
@@ -116,7 +116,7 @@ async function migratePlugins(designerDataDir: string, coreDataDir: string) {
 }
 
 async function readDirs(srcDir: string): Array<string> {
-  if (fs.existsSync(srcDir)) {
+  if (existsAndIsDirectory(srcDir)) {
     return await fs.promises.readdir(srcDir);
   } else {
     return [];
@@ -129,7 +129,7 @@ async function copyDirs(dirs: Array<string>, srcDir: string, destDir: string) {
     const dest = fsPath.join(destDir, dir);
 
     // If source exists, ensure the destination exists, and copy into it
-    if (fs.existsSync(src) && isDirectory(src)) {
+    if (existsAndIsDirectory(src)) {
       await fsx.ensureDir(dest);
       await fsx.copy(src, dest);
     }
@@ -139,14 +139,14 @@ async function copyDirs(dirs: Array<string>, srcDir: string, destDir: string) {
 async function removeDirs(dirs: Array<string>, srcDir: string) {
   for (const dir of dirs.filter(c => c)) {
     const dirToRemove = fsPath.join(srcDir, dir);
-    if (fs.existsSync(dirToRemove) && isDirectory(dirToRemove)) {
+    if (existsAndIsDirectory(dirToRemove)) {
       await fsx.remove(dirToRemove);
     }
   }
 }
 
-function isDirectory(name: string): boolean {
-  return fs.statSync(name).isDirectory();
+export function existsAndIsDirectory(name: string): boolean {
+  return fs.existsSync(name) && fs.statSync(name).isDirectory();
 }
 
 export default async function migrateFromDesigner({
@@ -258,7 +258,7 @@ export async function restoreCoreBackup(backupDir: string, coreDataDir: string) 
     return;
   }
 
-  if (!fs.existsSync(backupDir)) {
+  if (!existsAndIsDirectory(backupDir)) {
     console.log(`[db-merge] nothing to restore: backup directory doesn't exist at ${backupDir}`);
     return;
   }

--- a/packages/insomnia-app/app/ui/components/wrapper-migration.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-migration.js
@@ -4,14 +4,16 @@ import * as React from 'react';
 import type { WrapperProps } from './wrapper';
 import { ToggleSwitch, Button } from 'insomnia-components';
 import type { MigrationOptions } from '../../common/migrate-from-designer';
-import migrateFromDesigner, { restartApp } from '../../common/migrate-from-designer';
+import migrateFromDesigner, {
+  existsAndIsDirectory,
+  restartApp,
+} from '../../common/migrate-from-designer';
 import { getDataDirectory, getDesignerDataDir } from '../../common/misc';
 import { useDispatch } from 'react-redux';
 import OnboardingContainer from './onboarding-container';
 import { goToNextActivity } from '../redux/modules/global';
 import HelpTooltip from './help-tooltip';
 import { trackEvent } from '../../common/analytics';
-import fs from 'fs';
 
 type Step = 'options' | 'migrating' | 'results';
 
@@ -106,9 +108,11 @@ const Options = ({ start, cancel }: OptionsProps) => {
     copyPlugins,
   } = options;
 
-  const coreExists = React.useMemo(() => fs.existsSync(coreDataDir), [coreDataDir]);
+  const coreExists = React.useMemo(() => existsAndIsDirectory(coreDataDir), [coreDataDir]);
 
-  const designerExists = React.useMemo(() => fs.existsSync(designerDataDir), [designerDataDir]);
+  const designerExists = React.useMemo(() => existsAndIsDirectory(designerDataDir), [
+    designerDataDir,
+  ]);
 
   const hasSomethingToMigrate = useDesignerSettings || copyWorkspaces || copyPlugins;
   const dirsExist = coreExists && designerExists;


### PR DESCRIPTION
When users manually copy-paste a plugin into the plugins folder in Designer, a `.DS_Store` file gets created. The migration should ignore this `.DS_Store` file. The expectation is that for the parts where the migration manually copies data across, it only does so for directories.

Therefore, the primary copy and remove helper functions in the migration can be restricted to only operate on directories.