### PR TITLE
Reduced header padding

### DIFF
--- a/packages/insomnia-app/app/ui/css/components/wrapper.less
+++ b/packages/insomnia-app/app/ui/css/components/wrapper.less
@@ -123,6 +123,7 @@
     grid-row-start: 1;
     grid-row-end: span 1;
     background: var(--color-bg);
+    padding: 0.65rem;
   }
 
   .layout-body {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

I have added `padding: 0.65rem;` to `.app-header` class, which makes the UI look much cleaner and uniform.

The Header in the new update is extremely big and does not match the Insomnia UI I have been using for years.


This closes #3168 

