### PR TITLE
Focus on newly created resource

### DIFF
--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -90,9 +90,13 @@ class WrapperHome extends React.PureComponent<Props, State> {
 
   async __actuallyCreate(patch: $Shape<Workspace>) {
     const workspace = await models.workspace.create(patch);
+    const { handleSetActiveActivity } = this.props.wrapperProps;
     this.props.wrapperProps.handleSetActiveWorkspace(workspace._id);
-
     trackEvent('Workspace', 'Create');
+
+    workspace.scope === 'designer'
+      ? handleSetActiveActivity(ACTIVITY_SPEC)
+      : handleSetActiveActivity(ACTIVITY_DEBUG);
   }
 
   _handleDocumentCreate() {


### PR DESCRIPTION
On the creation of a new document or collection, take the user to the newly created resource.

[Demo](https://p191.p3.n0.cdn.getcloudapp.com/items/Jru1Yyq7/fce332ae-838a-4aa4-b33f-bbcde2c4a9bf.mp4)

Fixes INS-518