### PR TITLE
On create nav to new

### DIFF
--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -90,9 +90,13 @@ class WrapperHome extends React.PureComponent<Props, State> {
 
   async __actuallyCreate(patch: $Shape<Workspace>) {
     const workspace = await models.workspace.create(patch);
+    const { handleSetActiveActivity } = this.props.wrapperProps;
     this.props.wrapperProps.handleSetActiveWorkspace(workspace._id);
-
     trackEvent('Workspace', 'Create');
+
+    workspace.scope === 'designer'
+      ? handleSetActiveActivity(ACTIVITY_SPEC)
+      : handleSetActiveActivity(ACTIVITY_DEBUG);
   }
 
   _handleDocumentCreate() {

--- a/packages/insomnia-smoke-test/core/app.test.js
+++ b/packages/insomnia-smoke-test/core/app.test.js
@@ -34,8 +34,8 @@ describe('Application launch', function() {
     await onboarding.skipOnboardingFlow(app);
 
     await home.documentListingShown(app);
-    const name = await home.createNewCollection(app);
-    await home.openDocumentWithTitle(app, name);
+    await home.createNewCollection(app);
+    await debug.pageDisplayed(app);
 
     await debug.createNewRequest(app, 'json');
     await debug.typeInUrlBar(app, url);
@@ -91,8 +91,8 @@ describe('Application launch', function() {
     await onboarding.skipOnboardingFlow(app);
 
     await home.documentListingShown(app);
-    const name = await home.createNewCollection(app);
-    await home.openDocumentWithTitle(app, name);
+    await home.createNewCollection(app);
+    await debug.pageDisplayed(app);
 
     await debug.createNewRequest(app, 'csv');
     await debug.typeInUrlBar(app, url);
@@ -110,8 +110,8 @@ describe('Application launch', function() {
     await onboarding.skipOnboardingFlow(app);
 
     await home.documentListingShown(app);
-    const name = await home.createNewCollection(app);
-    await home.openDocumentWithTitle(app, name);
+    await home.createNewCollection(app);
+    await debug.pageDisplayed(app);
 
     await debug.createNewRequest(app, 'pdf');
     await debug.typeInUrlBar(app, url);
@@ -129,6 +129,7 @@ describe('Application launch', function() {
 
     await home.documentListingShown(app);
     const docName = await home.createNewDocument(app);
+    await debug.goToDashboard(app);
 
     // Open card dropdown for the document
     const card = await home.findCardWithTitle(app, docName);
@@ -198,8 +199,8 @@ describe('Application launch', function() {
     await onboarding.skipOnboardingFlow(app);
 
     await home.documentListingShown(app);
-    const name = await home.createNewCollection(app);
-    await home.openDocumentWithTitle(app, name);
+    await home.createNewCollection(app);
+    await debug.pageDisplayed(app);
 
     await debug.createNewRequest(app, 'basic-auth');
     await debug.typeInUrlBar(app, url);


### PR DESCRIPTION
On document or collection creation, the user is taken to the newly created asset rather than landing on the docs home. 

[Demo](https://p191.p3.n0.cdn.getcloudapp.com/items/Jru1Yyq7/fce332ae-838a-4aa4-b33f-bbcde2c4a9bf.mp4?source=client)

Fixes INS-518
