### PR TITLE
Update Spectral to latest release

### DIFF
--- a/packages/insomnia-app/app/common/spectral.ts
+++ b/packages/insomnia-app/app/common/spectral.ts
@@ -1,0 +1,12 @@
+import { IRuleResult, isOpenApiv2, isOpenApiv3, Spectral } from '@stoplight/spectral';
+
+export const initializeSpectral = () => {
+  const spectral = new Spectral();
+  spectral.registerFormat('oas2', isOpenApiv2);
+  spectral.registerFormat('oas3', isOpenApiv3);
+  spectral.loadRuleset('spectral:oas');
+
+  return spectral;
+};
+
+export const isLintError = (result: IRuleResult) => result.severity === 0;

--- a/packages/insomnia-app/app/ui/components/codemirror/lint/openapi.ts
+++ b/packages/insomnia-app/app/ui/components/codemirror/lint/openapi.ts
@@ -1,15 +1,10 @@
 import CodeMirror from 'codemirror';
-import { isOpenApiv2, isOpenApiv3, Spectral } from '@stoplight/spectral';
+import { isLintError, initializeSpectral } from '../../../../common/spectral';
 
-const spectral = new Spectral();
-spectral.registerFormat('oas2', isOpenApiv2);
-spectral.registerFormat('oas3', isOpenApiv3);
-spectral.loadRuleset('spectral:oas');
+const spectral = initializeSpectral();
 
 CodeMirror.registerHelper('lint', 'openapi', async function(text) {
-  const results = (await spectral.run(text)).filter(result => (
-    result.severity === 0 // filter for errors only
-  ));
+  const results = (await spectral.run(text)).filter(isLintError);
 
   return results.map(result => ({
     from: CodeMirror.Pos(result.range.start.line, result.range.start.character),

--- a/packages/insomnia-app/app/ui/components/codemirror/lint/openapi.ts
+++ b/packages/insomnia-app/app/ui/components/codemirror/lint/openapi.ts
@@ -1,10 +1,16 @@
 import CodeMirror from 'codemirror';
-import { Spectral } from '@stoplight/spectral';
+import { isOpenApiv2, isOpenApiv3, Spectral } from '@stoplight/spectral';
 
 const spectral = new Spectral();
+spectral.registerFormat('oas2', isOpenApiv2);
+spectral.registerFormat('oas3', isOpenApiv3);
+spectral.loadRuleset('spectral:oas');
 
 CodeMirror.registerHelper('lint', 'openapi', async function(text) {
-  const results = await spectral.run(text);
+  const results = (await spectral.run(text)).filter(result => (
+    result.severity === 0 // filter for errors only
+  ));
+
   return results.map(result => ({
     from: CodeMirror.Pos(result.range.start.line, result.range.start.character),
     to: CodeMirror.Pos(result.range.end.line, result.range.end.character),

--- a/packages/insomnia-app/app/ui/components/wrapper-design.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.tsx
@@ -6,7 +6,6 @@ import { Button, NoticeTable } from 'insomnia-components';
 import ErrorBoundary from './error-boundary';
 import SpecEditorSidebar from './spec-editor/spec-editor-sidebar';
 import CodeEditor from './codemirror/code-editor';
-import { isOpenApiv2, isOpenApiv3, Spectral } from '@stoplight/spectral';
 import SwaggerUI from 'swagger-ui-react';
 import type { ApiSpec } from '../../models/api-spec';
 import previewIcon from '../images/icn-eye.svg';
@@ -15,11 +14,9 @@ import { parseApiSpec, ParsedApiSpec } from '../../common/api-specs';
 import type { GlobalActivity } from '../../common/constants';
 import { ACTIVITY_HOME, AUTOBIND_CFG } from '../../common/constants';
 import WorkspacePageHeader from './workspace-page-header';
+import { initializeSpectral, isLintError } from '../../common/spectral';
 
-const spectral = new Spectral();
-spectral.registerFormat('oas2', isOpenApiv2);
-spectral.registerFormat('oas3', isOpenApiv3);
-spectral.loadRuleset('spectral:oas');
+const spectral = initializeSpectral();
 
 interface Props {
   gitSyncDropdown: ReactNode;
@@ -113,9 +110,7 @@ class WrapperDesign extends PureComponent<Props, State> {
 
     // Lint only if spec has content
     if (activeApiSpec.contents.length !== 0) {
-      const results = (await spectral.run(activeApiSpec.contents)).filter(result => (
-        result.severity === 0 // filter for errors only
-      ));
+      const results = (await spectral.run(activeApiSpec.contents)).filter(isLintError);
       this.setState({
         lintMessages: results.map(r => ({
           type: r.severity === 0 ? 'error' : 'warning',

--- a/packages/insomnia-app/app/ui/components/wrapper-design.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.tsx
@@ -109,7 +109,7 @@ class WrapperDesign extends PureComponent<Props, State> {
     const { activeApiSpec } = this.props.wrapperProps;
 
     // Lint only if spec has content
-    if (activeApiSpec.contents.length !== 0) {
+    if (activeApiSpec && activeApiSpec.contents.length !== 0) {
       const results = (await spectral.run(activeApiSpec.contents)).filter(isLintError);
       this.setState({
         lintMessages: results.map(r => ({

--- a/packages/insomnia-app/app/ui/components/wrapper.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper.tsx
@@ -76,7 +76,6 @@ import { importRaw } from '../../common/import';
 import GitSyncDropdown from './dropdowns/git-sync-dropdown';
 import { DropdownButton } from './base/dropdown';
 import type { GlobalActivity } from '../../common/constants';
-import { isOpenApiv2, isOpenApiv3, Spectral } from '@stoplight/spectral';
 import ProtoFilesModal from './modals/proto-files-modal';
 import { GrpcDispatchModalWrapper } from '../context/grpc';
 import WrapperMigration from './wrapper-migration';
@@ -86,11 +85,9 @@ import { HandleGetRenderContext, HandleRender } from '../../common/render';
 import { RequestGroup } from '../../models/request-group';
 import SpaceSettingsModal from './modals/space-settings-modal';
 import { AppProps } from '../containers/app';
+import { initializeSpectral, isLintError } from '../../common/spectral';
 
-const spectral = new Spectral();
-spectral.registerFormat('oas2', isOpenApiv2);
-spectral.registerFormat('oas3', isOpenApiv3);
-spectral.loadRuleset('spectral:oas');
+const spectral = initializeSpectral();
 
 export type WrapperProps = AppProps & {
   handleActivateRequest: (activeRequestId: string) => void;
@@ -262,9 +259,7 @@ class Wrapper extends PureComponent<WrapperProps, State> {
     // Handle switching away from the spec design activity. For this, we want to generate
     // requests that can be accessed from debug or test.
     // If there are errors in the spec, show the user a warning first
-    const results = (await spectral.run(activeApiSpec.contents)).filter(result => (
-      result.severity === 0 // filter for errors only
-    ));
+    const results = (await spectral.run(activeApiSpec.contents)).filter(isLintError);
     if (activeApiSpec.contents && results && results.length) {
       showModal(AlertModal, {
         title: 'Error Generating Configuration',

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -2519,10 +2519,19 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
+		"@stoplight/better-ajv-errors": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.4.tgz",
+			"integrity": "sha512-HFXOerq/6/6YisiTJwCOScwfNaXyGmX7ROAEUoKOrckK9+hJ/QLFm5EofQYEgX4aXkvHokLEbWBs4NMwZ6hQUw==",
+			"requires": {
+				"jsonpointer": "^4.0.1",
+				"leven": "^3.1.0"
+			}
+		},
 		"@stoplight/json": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.8.3.tgz",
-			"integrity": "sha512-HkW4QsiuAku4PHTML1HxpQV2eRjw8GObn1cfjt5pE5hMZlS3fmW2bwoqzMs1cifTcT+TanyarVX8GGPbch2qog==",
+			"version": "3.11.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.11.2.tgz",
+			"integrity": "sha512-6ePZkRBrcy/SVvnXH+Yi+sIBkKH4Nu4acG8dgaAi/pV8322lvnylyfZ21KLWEKYKON+Ll+NOZeIcaZNj5M0O9g==",
 			"requires": {
 				"@stoplight/ordered-object-literal": "^1.0.1",
 				"@stoplight/types": "^11.9.0",
@@ -2531,86 +2540,214 @@
 				"safe-stable-stringify": "^1.1"
 			}
 		},
-		"@stoplight/json-ref-resolver": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-2.4.1.tgz",
-			"integrity": "sha512-y9G0BybShiJ/1NaPPG1BPelL2zI8/0rKXRtUpD2JBHEb72L9n4Bin85+MfrHYoHeJxojDpewsJA3FVRnUVL1dw==",
+		"@stoplight/json-ref-readers": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/json-ref-readers/-/json-ref-readers-1.2.2.tgz",
+			"integrity": "sha512-nty0tHUq2f1IKuFYsLM4CXLZGHdMn+X/IwEUIpeSOXt0QjMUbL0Em57iJUDzz+2MkWG83smIigNZ3fauGjqgdQ==",
 			"requires": {
-				"@stoplight/json": "^3.1.2",
-				"@stoplight/path": "^1.3.0",
-				"@stoplight/types": "^11.0.0",
-				"@types/urijs": "1.x.x",
-				"dependency-graph": "~0.8.0",
-				"fast-memoize": "^2.5.1",
-				"immer": "^3.2.0",
-				"lodash": "^4.17.15",
-				"tslib": "^1.10.0",
-				"urijs": "~1.19.1"
+				"node-fetch": "^2.6.0",
+				"tslib": "^1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@stoplight/json-ref-resolver": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.1.tgz",
+			"integrity": "sha512-FUOu3nPwbX2COczcCwvUz1EpqRNYlw7Ng8keOWGiwKmlXVz4OKdRw4hi2HUg9QNSX1CyFVJ3A3pPtpkizfKqlg==",
+			"requires": {
+				"@stoplight/json": "^3.10.2",
+				"@stoplight/path": "^1.3.2",
+				"@stoplight/types": "^11.9.0",
+				"@types/urijs": "^1.19.14",
+				"dependency-graph": "~0.10.0",
+				"fast-memoize": "^2.5.2",
+				"immer": "^8.0.1",
+				"lodash.get": "^4.4.2",
+				"lodash.set": "^4.3.2",
+				"tslib": "^2.1.0",
+				"urijs": "^1.19.5"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+				}
+			}
+		},
+		"@stoplight/lifecycle": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/lifecycle/-/lifecycle-2.3.2.tgz",
+			"integrity": "sha512-v0u8p27FA/eg04b4z6QXw4s0NeeFcRzyvseBW0+k/q4jtpg7EhVCqy42EbbbU43NTNDpIeQ81OcvkFz+6CYshw==",
+			"requires": {
+				"wolfy87-eventemitter": "~5.2.8"
 			}
 		},
 		"@stoplight/ordered-object-literal": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.1.tgz",
-			"integrity": "sha512-kDcBIKwzAXZTkgzaiPXH2I0JXavBkOb3jFzYNFS5cBuvZS3s/K+knpk2wLVt0n8XrnRQsSffzN6XG9HqUhfq6Q=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.2.tgz",
+			"integrity": "sha512-0ZMS/9sNU3kVo/6RF3eAv7MK9DY8WLjiVJB/tVyfF2lhr2R4kqh534jZ0PlrFB9CRXrdndzn1DbX6ihKZXft2w=="
 		},
 		"@stoplight/path": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@stoplight/path/-/path-1.3.1.tgz",
-			"integrity": "sha512-I6YEfxspGglxt7MbgNbKThHdqh8CJWnDC1x1JUk2rka2D7mCpMSEu5I8IiAp997Dp4YIXDY6Did6gge8OY8KnA=="
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/path/-/path-1.3.2.tgz",
+			"integrity": "sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ=="
 		},
 		"@stoplight/spectral": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-4.2.0.tgz",
-			"integrity": "sha512-td5vZ0W8cGMpElG0UcdzFrqbEuJR81D9oPLCJoEEXsN5a8k2HGNkMxVJ5alC31wxahKTDzVmVIkBacJW+DzKRQ==",
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-5.9.1.tgz",
+			"integrity": "sha512-YgTtieZpYOva6vAwHRBQWom2muwtB6mzpbBG896C1vOiNq+ebAYA1PP9gzHyf+Uagt674CWTOfvsMrzVPosBqQ==",
 			"requires": {
-				"@stoplight/json": "^3.1.1",
-				"@stoplight/json-ref-resolver": "^2.2.0",
-				"@stoplight/path": "^1.2.0",
-				"@stoplight/types": "^11.0.0",
-				"@stoplight/yaml": "^3.1.0",
-				"abort-controller": "^3.0.0",
-				"ajv": "^6.7",
-				"ajv-oai": "^1.1.1",
-				"better-ajv-errors": "^0.6.7",
-				"chalk": "^2.4.2",
-				"deprecated-decorator": "^0.1.6",
-				"fast-glob": "^3.0.4",
-				"jsonpath-plus": "~1.0",
-				"lodash": ">=4.17.5",
-				"nanoid": "^2.0.3",
-				"node-fetch": "^2.6",
-				"proxy-agent": "^3.1.0",
-				"strip-ansi": "^5.2",
-				"text-table": "^0.2",
-				"tslib": "^1.10.0",
-				"typescript-json-schema": "~0.40",
-				"yargs": "^14.0.0"
+				"@stoplight/better-ajv-errors": "0.0.4",
+				"@stoplight/json": "3.11.2",
+				"@stoplight/json-ref-readers": "1.2.2",
+				"@stoplight/json-ref-resolver": "3.1.1",
+				"@stoplight/lifecycle": "2.3.2",
+				"@stoplight/path": "1.3.2",
+				"@stoplight/types": "11.10.0",
+				"@stoplight/yaml": "4.2.1",
+				"abort-controller": "3.0.0",
+				"ajv": "6.12.5",
+				"ajv-oai": "1.2.0",
+				"blueimp-md5": "2.18.0",
+				"chalk": "4.1.0",
+				"eol": "0.9.1",
+				"expression-eval": "3.1.2",
+				"fast-glob": "3.2.5",
+				"jsonpath-plus": "4.0.0",
+				"lodash": "4.17.20",
+				"nanoid": "2.1.11",
+				"nimma": "0.0.0",
+				"node-fetch": "2.6.1",
+				"proxy-agent": "4.0.1",
+				"strip-ansi": "6.0",
+				"text-table": "0.2",
+				"tslib": "1.13.0",
+				"yargs": "15.4.1"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.12.5",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"fast-glob": {
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+					"integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.0",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.2",
+						"picomatch": "^2.2.1"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+				},
+				"node-fetch": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@stoplight/types": {
-			"version": "11.9.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/types/-/types-11.9.0.tgz",
-			"integrity": "sha512-4bzPpWZobt0e+d0OtALCJyl1HGzKo6ur21qxnId9dTl8v3yeD+5HJKZ2h1mv7e94debH5QDtimMU80V6jbXM8Q==",
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/@stoplight/types/-/types-11.10.0.tgz",
+			"integrity": "sha512-ffHD9i4UHS8Gsg7Ar8pKjI9B4kq7MRekE7tCROFGcFDzQhfRx9T92AduoLAtP/010XNYq23yDKpLBRPIEk8+xg==",
 			"requires": {
 				"@types/json-schema": "^7.0.4",
 				"utility-types": "^3.10.0"
 			}
 		},
 		"@stoplight/yaml": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-3.8.1.tgz",
-			"integrity": "sha512-wbhcgo7dTjwjjwFziC/SAcQlwPucYhYq6vjzyOjj8zeOVnnmoa7hzU1i9Kj31473FG/re7xtt6j3LWu2VnYbxg==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.2.1.tgz",
+			"integrity": "sha512-EnSdRgOv/wrdMtdXdTiP5VvChg8lugDmSZVuhcdK/V1pibWd4+r9S4XpJlCx+xgCzg1oLM8pIv/d9cPwHU8XtA==",
 			"requires": {
 				"@stoplight/ordered-object-literal": "^1.0.1",
-				"@stoplight/types": "^11.1.1",
-				"@stoplight/yaml-ast-parser": "0.0.45",
-				"lodash": "^4.17.15"
+				"@stoplight/types": "^11.9.0",
+				"@stoplight/yaml-ast-parser": "0.0.48",
+				"tslib": "^1.12.0"
 			}
 		},
 		"@stoplight/yaml-ast-parser": {
-			"version": "0.0.45",
-			"resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.45.tgz",
-			"integrity": "sha512-0MTEvgp3XMdeMUSTCGiNECuC+YlLbzytDEIOJVDHrrmzVZpIR3gGnHI6mmPI4P7saPxUiHxFF2uuoTuCNlKjrw=="
+			"version": "0.0.48",
+			"resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.48.tgz",
+			"integrity": "sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg=="
 		},
 		"@storybook/addon-info": {
 			"version": "5.3.19",
@@ -3809,6 +3946,11 @@
 				}
 			}
 		},
+		"@tootallnate/once": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+		},
 		"@types/analytics-node": {
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/@types/analytics-node/-/analytics-node-3.1.4.tgz",
@@ -4634,9 +4776,9 @@
 			}
 		},
 		"@types/urijs": {
-			"version": "1.19.9",
-			"resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.9.tgz",
-			"integrity": "sha512-/tiJyrc0GPcsReHzgC0SXwOmoPjLqYe01W7dLYB0yasQXMbcRee+ZIk+g8MIQhoBS8fPoBQO3Y93+aeBrI93Ug=="
+			"version": "1.19.15",
+			"resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.15.tgz",
+			"integrity": "sha512-pEDVREIvkyRtzpWlO5nqsUgR/JpLv9+lAzvkERCwoH2jXxl+TmaTNshhL7gjQLhfqgFUzCM6ovmoB1JssTop1A=="
 		},
 		"@types/url-join": {
 			"version": "4.0.0",
@@ -5579,11 +5721,11 @@
 			"dev": true
 		},
 		"agent-base": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"requires": {
-				"es6-promisify": "^5.0.0"
+				"debug": "4"
 			}
 		},
 		"aggregate-error": {
@@ -5736,7 +5878,8 @@
 		"ansi-regex": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -6181,6 +6324,11 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+		},
+		"astring": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/astring/-/astring-1.7.4.tgz",
+			"integrity": "sha512-WiVqDJV0AayUUH65FfUrbnBO4KD10854cyU49lK30+2n/lEkJDRqBKj/2fYGhZSD3uIt1H1VfW/pQtO07kR2Xg=="
 		},
 		"async": {
 			"version": "0.2.10",
@@ -6906,20 +7054,6 @@
 			"integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
 			"dev": true
 		},
-		"better-ajv-errors": {
-			"version": "0.6.7",
-			"resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-0.6.7.tgz",
-			"integrity": "sha512-PYgt/sCzR4aGpyNy5+ViSQ77ognMnWq7745zM+/flYO4/Yisdtp9wDQW2IKCyVYPUxQt3E/b5GBSwfhd1LPdlg==",
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/runtime": "^7.0.0",
-				"chalk": "^2.4.1",
-				"core-js": "^3.2.1",
-				"json-to-ast": "^2.0.3",
-				"jsonpointer": "^4.0.1",
-				"leven": "^3.1.0"
-			}
-		},
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -7015,6 +7149,11 @@
 			"requires": {
 				"bluebird": "^3.5.5"
 			}
+		},
+		"blueimp-md5": {
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+			"integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
 		},
 		"bn.js": {
 			"version": "5.1.2",
@@ -8155,6 +8294,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
 			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+			"dev": true,
 			"requires": {
 				"string-width": "^3.1.0",
 				"strip-ansi": "^5.2.0",
@@ -8230,7 +8370,8 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"coa": {
 			"version": "2.0.2",
@@ -8242,11 +8383,6 @@
 				"chalk": "^2.4.1",
 				"q": "^1.1.2"
 			}
-		},
-		"code-error-fragment": {
-			"version": "0.0.230",
-			"resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
-			"integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw=="
 		},
 		"code-point-at": {
 			"version": "1.1.0",
@@ -8611,7 +8747,8 @@
 		"core-js": {
 			"version": "3.6.5",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+			"dev": true
 		},
 		"core-js-compat": {
 			"version": "3.6.5",
@@ -9168,9 +9305,9 @@
 			}
 		},
 		"data-uri-to-buffer": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-			"integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+			"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
 		},
 		"data-urls": {
 			"version": "2.0.0",
@@ -9357,13 +9494,13 @@
 			}
 		},
 		"degenerator": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
-			"integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
+			"integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
 			"requires": {
-				"ast-types": "0.x.x",
-				"escodegen": "1.x.x",
-				"esprima": "3.x.x"
+				"ast-types": "^0.13.2",
+				"escodegen": "^1.8.1",
+				"esprima": "^4.0.0"
 			}
 		},
 		"del": {
@@ -9432,14 +9569,9 @@
 			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
 		},
 		"dependency-graph": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.8.1.tgz",
-			"integrity": "sha512-g213uqF8fyk40W8SBjm079n3CZB4qSpCrA2ye1fLGzH/4HEgB6tzuW2CbLE7leb4t45/6h44Ud59Su1/ROTfqw=="
-		},
-		"deprecated-decorator": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
-			"integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.10.0.tgz",
+			"integrity": "sha512-c9amUgpgxSi1bE5/sbLwcs5diLD0ygCQYmhfM5H1s5VH1mCsYkcmAL3CcNdv4kdSw6JuMoHeDGzLgj/gAXdWVg=="
 		},
 		"deprecation": {
 			"version": "2.3.1",
@@ -10747,7 +10879,8 @@
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
 		},
 		"emojis-list": {
 			"version": "3.0.0",
@@ -10833,6 +10966,11 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
 			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+		},
+		"eol": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
+			"integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg=="
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -10971,19 +11109,6 @@
 				"es6-symbol": "^3.1.1"
 			}
 		},
-		"es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-		},
-		"es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"requires": {
-				"es6-promise": "^4.0.3"
-			}
-		},
 		"es6-shim": {
 			"version": "0.35.5",
 			"resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.5.tgz",
@@ -11062,9 +11187,9 @@
 			}
 		},
 		"esprima": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esrecurse": {
 			"version": "4.2.1",
@@ -11404,6 +11529,14 @@
 				}
 			}
 		},
+		"expression-eval": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/expression-eval/-/expression-eval-3.1.2.tgz",
+			"integrity": "sha512-c8ZN8fuAz0TRYKoGsrIq5kLNHtm81KAqWSBORHIY0DpJmZZrwK/r2zFDOhFIAJDV47gJ6irV7dWf1TOFpKvULQ==",
+			"requires": {
+				"jsep": "^0.3.0"
+			}
+		},
 		"ext": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -11596,6 +11729,7 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
 			"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -11788,7 +11922,9 @@
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
 		},
 		"filelist": {
 			"version": "1.0.1",
@@ -11938,6 +12074,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
 			"requires": {
 				"locate-path": "^3.0.0"
 			}
@@ -12763,30 +12900,45 @@
 			}
 		},
 		"get-uri": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.4.tgz",
-			"integrity": "sha512-v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
+			"integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
 			"requires": {
-				"data-uri-to-buffer": "1",
-				"debug": "2",
-				"extend": "~3.0.2",
-				"file-uri-to-path": "1",
-				"ftp": "~0.3.10",
-				"readable-stream": "2"
+				"@tootallnate/once": "1",
+				"data-uri-to-buffer": "3",
+				"debug": "4",
+				"file-uri-to-path": "2",
+				"fs-extra": "^8.1.0",
+				"ftp": "^0.3.10"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+				"file-uri-to-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
+					"integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg=="
+				},
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
 					"requires": {
-						"ms": "2.0.0"
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
 				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				"jsonfile": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				},
+				"universalify": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 				}
 			}
 		},
@@ -13293,7 +13445,8 @@
 		"grapheme-splitter": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+			"dev": true
 		},
 		"graphql": {
 			"version": "14.7.0",
@@ -13820,27 +13973,13 @@
 			}
 		},
 		"http-proxy-agent": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
 			"requires": {
-				"agent-base": "4",
-				"debug": "3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4"
 			}
 		},
 		"http-proxy-middleware": {
@@ -14001,22 +14140,12 @@
 			"dev": true
 		},
 		"https-proxy-agent": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-			"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
 			"requires": {
-				"agent-base": "^4.3.0",
-				"debug": "^3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
+				"agent-base": "6",
+				"debug": "4"
 			}
 		},
 		"httpsnippet": {
@@ -14157,9 +14286,9 @@
 			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
 		},
 		"immer": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-3.3.0.tgz",
-			"integrity": "sha512-vlWRjnZqoTHuEjadquVHK3GxsXe1gNoATffLEA8Qbrdd++Xb+wHEFiWtwAKTscMBoi1AsvEMXhYRzAXA8Ex9FQ=="
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-8.0.4.tgz",
+			"integrity": "sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ=="
 		},
 		"immutable": {
 			"version": "3.8.2",
@@ -16906,6 +17035,11 @@
 				}
 			}
 		},
+		"jsep": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz",
+			"integrity": "sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA=="
+		},
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -16965,27 +17099,10 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "~0.0.0"
-			}
-		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-		},
-		"json-to-ast": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
-			"integrity": "sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==",
-			"requires": {
-				"code-error-fragment": "0.0.230",
-				"grapheme-splitter": "^1.0.4"
-			}
 		},
 		"json3": {
 			"version": "3.3.3",
@@ -17015,11 +17132,6 @@
 				"graceful-fs": "^4.1.6",
 				"universalify": "^1.0.0"
 			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsonlint": {
 			"version": "1.6.3",
@@ -17053,9 +17165,9 @@
 			}
 		},
 		"jsonpath-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-1.0.0.tgz",
-			"integrity": "sha512-CXQJ/tsgFogKYBuCRmnlChIw66JBXp8kAkT+R4mSB2cuzCSBi88lx2A+vHvo27RY4Wtj5xVVGu2/2O7NwZ79mg=="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz",
+			"integrity": "sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A=="
 		},
 		"jsonpointer": {
 			"version": "4.1.0",
@@ -17481,6 +17593,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
 			"requires": {
 				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
@@ -17581,6 +17694,11 @@
 			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
 			"dev": true
 		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -17643,6 +17761,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
 			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
 			"dev": true
+		},
+		"lodash.set": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -18570,9 +18693,9 @@
 			"dev": true
 		},
 		"netmask": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-			"integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
 		},
 		"next-tick": {
 			"version": "1.1.0",
@@ -18584,6 +18707,15 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
+		},
+		"nimma": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/nimma/-/nimma-0.0.0.tgz",
+			"integrity": "sha512-if0VqyHpTMHKFORMiJ2WLWgoIF4xqwjybHZyvodQ/yCmiWag6RhLlMHeFukz4X31DanTBA26U+HwvXIrTaYQkQ==",
+			"requires": {
+				"astring": "^1.4.3",
+				"jsep": "^0.3.4"
+			}
 		},
 		"no-case": {
 			"version": "3.0.3",
@@ -19411,6 +19543,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
 			"requires": {
 				"p-limit": "^2.0.0"
 			}
@@ -19439,30 +19572,29 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"pac-proxy-agent": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz",
-			"integrity": "sha512-44DUg21G/liUZ48dJpUSjZnFfZro/0K5JTyFYLBcmh9+T6Ooi4/i4efwUiEy0+4oQusCBqWdhv16XohIj1GqnQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
+			"integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
 			"requires": {
-				"agent-base": "^4.2.0",
-				"debug": "^4.1.1",
-				"get-uri": "^2.0.0",
-				"http-proxy-agent": "^2.1.0",
-				"https-proxy-agent": "^3.0.0",
-				"pac-resolver": "^3.0.0",
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4",
+				"get-uri": "3",
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "5",
+				"pac-resolver": "^4.1.0",
 				"raw-body": "^2.2.0",
-				"socks-proxy-agent": "^4.0.1"
+				"socks-proxy-agent": "5"
 			}
 		},
 		"pac-resolver": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-			"integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
+			"integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
 			"requires": {
-				"co": "^4.6.0",
-				"degenerator": "^1.0.4",
+				"degenerator": "^2.2.0",
 				"ip": "^1.1.5",
-				"netmask": "^1.0.6",
-				"thunkify": "^2.1.2"
+				"netmask": "^2.0.1"
 			}
 		},
 		"package-json": {
@@ -19642,7 +19774,8 @@
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -20422,18 +20555,18 @@
 			}
 		},
 		"proxy-agent": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.1.tgz",
-			"integrity": "sha512-WudaR0eTsDx33O3EJE16PjBRZWcX8GqCEeERw1W3hZJgH/F2a46g7jty6UGty6NeJ4CKQy8ds2CJPMiyeqaTvw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
 			"requires": {
-				"agent-base": "^4.2.0",
+				"agent-base": "^6.0.0",
 				"debug": "4",
-				"http-proxy-agent": "^2.1.0",
-				"https-proxy-agent": "^3.0.0",
+				"http-proxy-agent": "^4.0.0",
+				"https-proxy-agent": "^5.0.0",
 				"lru-cache": "^5.1.1",
-				"pac-proxy-agent": "^3.0.1",
+				"pac-proxy-agent": "^4.1.0",
 				"proxy-from-env": "^1.0.0",
-				"socks-proxy-agent": "^4.0.1"
+				"socks-proxy-agent": "^5.0.0"
 			}
 		},
 		"proxy-from-env": {
@@ -23221,31 +23354,22 @@
 			}
 		},
 		"socks": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
-			"integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+			"integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
 			"requires": {
-				"ip": "1.1.5",
+				"ip": "^1.1.5",
 				"smart-buffer": "^4.1.0"
 			}
 		},
 		"socks-proxy-agent": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-			"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
 			"requires": {
-				"agent-base": "~4.2.1",
-				"socks": "~2.3.2"
-			},
-			"dependencies": {
-				"agent-base": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-					"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-					"requires": {
-						"es6-promisify": "^5.0.0"
-					}
-				}
+				"agent-base": "6",
+				"debug": "4",
+				"socks": "^2.3.3"
 			}
 		},
 		"sort-keys": {
@@ -23767,6 +23891,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+			"dev": true,
 			"requires": {
 				"emoji-regex": "^7.0.1",
 				"is-fullwidth-code-point": "^2.0.0",
@@ -23844,6 +23969,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^4.1.0"
 			}
@@ -24497,11 +24623,6 @@
 				"xtend": "~4.0.1"
 			}
 		},
-		"thunkify": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
-			"integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
-		},
 		"thunky": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -24910,25 +25031,6 @@
 			"integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
 			"dev": true
 		},
-		"typescript-json-schema": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.40.0.tgz",
-			"integrity": "sha512-C8D3Ca6+1x3caWOR+u45Shn3KqkRZi5M3+E8ePpEmYMqOh3xhhLdq+39pqT0Bf8+fCgAmpTFSJMT6Xwqbm0Tkw==",
-			"requires": {
-				"@types/json-schema": "^7.0.3",
-				"glob": "~7.1.4",
-				"json-stable-stringify": "^1.0.1",
-				"typescript": "^3.5.3",
-				"yargs": "^14.0.0"
-			},
-			"dependencies": {
-				"typescript": {
-					"version": "3.9.9",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-					"integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
-				}
-			}
-		},
 		"ua-parser-js": {
 			"version": "0.7.21",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
@@ -25295,9 +25397,9 @@
 			}
 		},
 		"urijs": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
-			"integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w=="
+			"version": "1.19.6",
+			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
+			"integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
 		},
 		"urix": {
 			"version": "0.1.0",
@@ -27764,6 +27866,11 @@
 				"execa": "^1.0.0"
 			}
 		},
+		"wolfy87-eventemitter": {
+			"version": "5.2.9",
+			"resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.9.tgz",
+			"integrity": "sha512-P+6vtWyuDw+MB01X7UeF8TaHBvbCovf4HPEMF/SV7BdDc1SMTiBy13SRD71lQh4ExFTG1d/WNzDGDCyOKSMblw=="
+		},
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -27819,6 +27926,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
 			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
 				"string-width": "^3.0.0",
@@ -27919,27 +28027,133 @@
 			"integrity": "sha512-eILAwrW4K1WA83mJXF0PLyeBhL4t6v9xyesRYhncG1zh9UPc43mMRgFTCi2FRYpOgUvGECNlNjoiksiX2xBKVg=="
 		},
 		"yargs": {
-			"version": "14.2.3",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-			"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
 			"requires": {
-				"cliui": "^5.0.0",
+				"cliui": "^6.0.0",
 				"decamelize": "^1.2.0",
-				"find-up": "^3.0.0",
+				"find-up": "^4.1.0",
 				"get-caller-file": "^2.0.1",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^2.0.0",
 				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
+				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
-				"yargs-parser": "^15.0.1"
+				"yargs-parser": "^18.1.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+				},
+				"string-width": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				}
 			}
 		},
 		"yargs-parser": {
-			"version": "15.0.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-			"integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -75,7 +75,7 @@
   ],
   "dependencies": {
     "@hot-loader/react-dom": "^16.8.6",
-    "@stoplight/spectral": "^4.1.1",
+    "@stoplight/spectral": "^5.9.0",
     "analytics-node": "^4.0.1",
     "aws4": "^1.9.0",
     "axios": "^0.21.1",

--- a/packages/insomnia-inso/package-lock.json
+++ b/packages/insomnia-inso/package-lock.json
@@ -974,6 +974,7 @@
 			"version": "7.10.3",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
 			"integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -1018,132 +1019,200 @@
 			}
 		},
 		"@nodelib/fs.scandir": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+			"integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
 			"requires": {
-				"@nodelib/fs.stat": "2.0.3",
+				"@nodelib/fs.stat": "2.0.4",
 				"run-parallel": "^1.1.9"
 			}
 		},
 		"@nodelib/fs.stat": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+			"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+			"integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
 			"requires": {
-				"@nodelib/fs.scandir": "2.1.3",
+				"@nodelib/fs.scandir": "2.1.4",
 				"fastq": "^1.6.0"
 			}
 		},
-		"@stoplight/json": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.6.0.tgz",
-			"integrity": "sha512-6hJN735r+aPzHP28HnBj30uC+RGyf/ZWEtAMlrXI4DntzocWvhgDqxLuLgOlmXkMd/4OAlD7fJQ/cI2RXNuWvQ==",
+		"@stoplight/better-ajv-errors": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.4.tgz",
+			"integrity": "sha512-HFXOerq/6/6YisiTJwCOScwfNaXyGmX7ROAEUoKOrckK9+hJ/QLFm5EofQYEgX4aXkvHokLEbWBs4NMwZ6hQUw==",
 			"requires": {
-				"@stoplight/types": "^11.4.0",
-				"jsonc-parser": "~2.2.0",
+				"jsonpointer": "^4.0.1",
+				"leven": "^3.1.0"
+			}
+		},
+		"@stoplight/json": {
+			"version": "3.11.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.11.2.tgz",
+			"integrity": "sha512-6ePZkRBrcy/SVvnXH+Yi+sIBkKH4Nu4acG8dgaAi/pV8322lvnylyfZ21KLWEKYKON+Ll+NOZeIcaZNj5M0O9g==",
+			"requires": {
+				"@stoplight/ordered-object-literal": "^1.0.1",
+				"@stoplight/types": "^11.9.0",
+				"jsonc-parser": "~2.2.1",
 				"lodash": "^4.17.15",
 				"safe-stable-stringify": "^1.1"
 			}
 		},
 		"@stoplight/json-ref-readers": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@stoplight/json-ref-readers/-/json-ref-readers-1.1.1.tgz",
-			"integrity": "sha512-yE6SpGaBlj+QM4ony1+ST1Unz4TimZglU1lSJOlyCrVrAC1VoFpoJ1exMnU8Cg/++YzmBN9qBa4jk9s0CBnrTA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/json-ref-readers/-/json-ref-readers-1.2.2.tgz",
+			"integrity": "sha512-nty0tHUq2f1IKuFYsLM4CXLZGHdMn+X/IwEUIpeSOXt0QjMUbL0Em57iJUDzz+2MkWG83smIigNZ3fauGjqgdQ==",
 			"requires": {
-				"node-fetch": "^2.6.0"
+				"node-fetch": "^2.6.0",
+				"tslib": "^1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
 			}
 		},
 		"@stoplight/json-ref-resolver": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.0.8.tgz",
-			"integrity": "sha512-Ns0jsq/qqDdhpd9iPXLUx5YRddUF5gfg0zkxmskV+srXrWlndg0S50dkX/GF0yrExKjru4veqW8Xx+Wo0noPtg==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.1.tgz",
+			"integrity": "sha512-FUOu3nPwbX2COczcCwvUz1EpqRNYlw7Ng8keOWGiwKmlXVz4OKdRw4hi2HUg9QNSX1CyFVJ3A3pPtpkizfKqlg==",
 			"requires": {
-				"@stoplight/json": "^3.1.2",
-				"@stoplight/path": "^1.3.0",
-				"@stoplight/types": "^11.1.1",
-				"@types/urijs": "^1.19",
-				"dependency-graph": "~0.8.0",
-				"fast-memoize": "^2.5.1",
-				"immer": "^4.0.1",
-				"lodash": "^4.17.15",
-				"tslib": "^1.10.0",
-				"urijs": "~1.19.1"
+				"@stoplight/json": "^3.10.2",
+				"@stoplight/path": "^1.3.2",
+				"@stoplight/types": "^11.9.0",
+				"@types/urijs": "^1.19.14",
+				"dependency-graph": "~0.10.0",
+				"fast-memoize": "^2.5.2",
+				"immer": "^8.0.1",
+				"lodash.get": "^4.4.2",
+				"lodash.set": "^4.3.2",
+				"tslib": "^2.1.0",
+				"urijs": "^1.19.5"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+				}
 			}
 		},
 		"@stoplight/lifecycle": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@stoplight/lifecycle/-/lifecycle-2.2.1.tgz",
-			"integrity": "sha512-XOyfoJyWp5tXRFWq43mvnOoYTvkupwqGjDQnQ2o1qRNnfTrE70bjNK5ptD9A6m3zajAXgbl0puFa7P2CMg7+ew==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/lifecycle/-/lifecycle-2.3.2.tgz",
+			"integrity": "sha512-v0u8p27FA/eg04b4z6QXw4s0NeeFcRzyvseBW0+k/q4jtpg7EhVCqy42EbbbU43NTNDpIeQ81OcvkFz+6CYshw==",
 			"requires": {
-				"strict-event-emitter-types": "^2.0.0",
 				"wolfy87-eventemitter": "~5.2.8"
 			}
 		},
+		"@stoplight/ordered-object-literal": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.2.tgz",
+			"integrity": "sha512-0ZMS/9sNU3kVo/6RF3eAv7MK9DY8WLjiVJB/tVyfF2lhr2R4kqh534jZ0PlrFB9CRXrdndzn1DbX6ihKZXft2w=="
+		},
 		"@stoplight/path": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@stoplight/path/-/path-1.3.1.tgz",
-			"integrity": "sha512-I6YEfxspGglxt7MbgNbKThHdqh8CJWnDC1x1JUk2rka2D7mCpMSEu5I8IiAp997Dp4YIXDY6Did6gge8OY8KnA=="
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/path/-/path-1.3.2.tgz",
+			"integrity": "sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ=="
 		},
 		"@stoplight/spectral": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-5.4.0.tgz",
-			"integrity": "sha512-c9NFKnzkiFqkF9RVgr7clfow6pXFKbEs+4bfKvn6PuUAYrTeOwxwYm7Nypf4KlxRGB+01epi9shrLMv4Nb2Kag==",
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-5.9.1.tgz",
+			"integrity": "sha512-YgTtieZpYOva6vAwHRBQWom2muwtB6mzpbBG896C1vOiNq+ebAYA1PP9gzHyf+Uagt674CWTOfvsMrzVPosBqQ==",
 			"requires": {
-				"@stoplight/json": "3.6.0",
-				"@stoplight/json-ref-readers": "1.1.1",
-				"@stoplight/json-ref-resolver": "3.0.8",
-				"@stoplight/lifecycle": "^2.2.1",
-				"@stoplight/path": "1.3.1",
-				"@stoplight/types": "^11.6.0",
-				"@stoplight/yaml": "3.7.0",
+				"@stoplight/better-ajv-errors": "0.0.4",
+				"@stoplight/json": "3.11.2",
+				"@stoplight/json-ref-readers": "1.2.2",
+				"@stoplight/json-ref-resolver": "3.1.1",
+				"@stoplight/lifecycle": "2.3.2",
+				"@stoplight/path": "1.3.2",
+				"@stoplight/types": "11.10.0",
+				"@stoplight/yaml": "4.2.1",
 				"abort-controller": "3.0.0",
-				"ajv": "6.12.2",
+				"ajv": "6.12.5",
 				"ajv-oai": "1.2.0",
-				"better-ajv-errors": "0.6.7",
-				"blueimp-md5": "2.13.0",
-				"chalk": "4.0.0",
+				"blueimp-md5": "2.18.0",
+				"chalk": "4.1.0",
 				"eol": "0.9.1",
-				"fast-glob": "3.1.0",
+				"expression-eval": "3.1.2",
+				"fast-glob": "3.2.5",
 				"jsonpath-plus": "4.0.0",
-				"lodash": "4.17.15",
+				"lodash": "4.17.20",
 				"nanoid": "2.1.11",
-				"node-fetch": "2.6",
-				"proxy-agent": "3.1.1",
+				"nimma": "0.0.0",
+				"node-fetch": "2.6.1",
+				"proxy-agent": "4.0.1",
 				"strip-ansi": "6.0",
 				"text-table": "0.2",
-				"tslib": "1.11.1",
-				"yargs": "15.3.1"
+				"tslib": "1.13.0",
+				"yargs": "15.4.1"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.12.5",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+				},
+				"tslib": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+					"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+				}
 			}
 		},
 		"@stoplight/types": {
-			"version": "11.8.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/types/-/types-11.8.0.tgz",
-			"integrity": "sha512-JSCLtuy9Buf89rRV9AmnK452mUqen3cpZgx0eOQdv+ayDuy8uuezU6hcsC93cfQ9E3OOpWs91El4sTrjZkv9IQ==",
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/@stoplight/types/-/types-11.10.0.tgz",
+			"integrity": "sha512-ffHD9i4UHS8Gsg7Ar8pKjI9B4kq7MRekE7tCROFGcFDzQhfRx9T92AduoLAtP/010XNYq23yDKpLBRPIEk8+xg==",
 			"requires": {
 				"@types/json-schema": "^7.0.4",
 				"utility-types": "^3.10.0"
 			}
 		},
 		"@stoplight/yaml": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-3.7.0.tgz",
-			"integrity": "sha512-lYs577C0tqs3WHtused0hclE+YHVshgeZT8i6kkqSIt1GUP3Hbe4AwZDEvFgZ9+9pa0JGlmKMrm0PJfvfKFxkw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.2.1.tgz",
+			"integrity": "sha512-EnSdRgOv/wrdMtdXdTiP5VvChg8lugDmSZVuhcdK/V1pibWd4+r9S4XpJlCx+xgCzg1oLM8pIv/d9cPwHU8XtA==",
 			"requires": {
-				"@stoplight/types": "^11.1.1",
-				"@stoplight/yaml-ast-parser": "0.0.44",
-				"lodash": "^4.17.15"
+				"@stoplight/ordered-object-literal": "^1.0.1",
+				"@stoplight/types": "^11.9.0",
+				"@stoplight/yaml-ast-parser": "0.0.48",
+				"tslib": "^1.12.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
 			}
 		},
 		"@stoplight/yaml-ast-parser": {
-			"version": "0.0.44",
-			"resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.44.tgz",
-			"integrity": "sha512-PdY8p2Ufgtorf4d2DbKMfknILMa8KwuyyMMR/2lgK1mLaU8F5PKWYc+h9hIzC+ar0bh7m9h2rINo32m7ADfVyA=="
+			"version": "0.0.48",
+			"resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.48.tgz",
+			"integrity": "sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg=="
+		},
+		"@tootallnate/once": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
 		},
 		"@types/anymatch": {
 			"version": "1.3.1",
@@ -1198,11 +1267,6 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
-		"@types/color-name": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-		},
 		"@types/glob": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -1214,9 +1278,9 @@
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
 		},
 		"@types/lodash": {
 			"version": "4.14.168",
@@ -1306,9 +1370,9 @@
 			}
 		},
 		"@types/urijs": {
-			"version": "1.19.9",
-			"resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.9.tgz",
-			"integrity": "sha512-/tiJyrc0GPcsReHzgC0SXwOmoPjLqYe01W7dLYB0yasQXMbcRee+ZIk+g8MIQhoBS8fPoBQO3Y93+aeBrI93Ug=="
+			"version": "1.19.15",
+			"resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.15.tgz",
+			"integrity": "sha512-pEDVREIvkyRtzpWlO5nqsUgR/JpLv9+lAzvkERCwoH2jXxl+TmaTNshhL7gjQLhfqgFUzCM6ovmoB1JssTop1A=="
 		},
 		"@types/webpack": {
 			"version": "4.41.26",
@@ -1557,17 +1621,18 @@
 			}
 		},
 		"agent-base": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"requires": {
-				"es6-promisify": "^5.0.0"
+				"debug": "4"
 			}
 		},
 		"ajv": {
 			"version": "6.12.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
 			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -1830,9 +1895,24 @@
 			"dev": true
 		},
 		"ast-types": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
-			"integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA=="
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"requires": {
+				"tslib": "^2.0.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+				}
+			}
+		},
+		"astring": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/astring/-/astring-1.7.4.tgz",
+			"integrity": "sha512-WiVqDJV0AayUUH65FfUrbnBO4KD10854cyU49lK30+2n/lEkJDRqBKj/2fYGhZSD3uIt1H1VfW/pQtO07kR2Xg=="
 		},
 		"async": {
 			"version": "0.2.10",
@@ -1928,32 +2008,6 @@
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
 			"dev": true
 		},
-		"better-ajv-errors": {
-			"version": "0.6.7",
-			"resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-0.6.7.tgz",
-			"integrity": "sha512-PYgt/sCzR4aGpyNy5+ViSQ77ognMnWq7745zM+/flYO4/Yisdtp9wDQW2IKCyVYPUxQt3E/b5GBSwfhd1LPdlg==",
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/runtime": "^7.0.0",
-				"chalk": "^2.4.1",
-				"core-js": "^3.2.1",
-				"json-to-ast": "^2.0.3",
-				"jsonpointer": "^4.0.1",
-				"leven": "^3.1.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
-			}
-		},
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1992,9 +2046,9 @@
 			"dev": true
 		},
 		"blueimp-md5": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.13.0.tgz",
-			"integrity": "sha512-lmp0m647R5e77ORduxLW5mISIDcvgJZa52vMBv5uVI3UmSWTQjkJsZVBfaFqQPw/QFogJwvY6e3Gl9nP+Loe+Q=="
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+			"integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
 		},
 		"bn.js": {
 			"version": "5.1.2",
@@ -2266,20 +2320,19 @@
 			"dev": true
 		},
 		"chalk": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-			"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"requires": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -2302,9 +2355,9 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -2409,16 +2462,6 @@
 				"kind-of": "^6.0.2",
 				"shallow-clone": "^3.0.0"
 			}
-		},
-		"co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-		},
-		"code-error-fragment": {
-			"version": "0.0.230",
-			"resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
-			"integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw=="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
@@ -2544,11 +2587,6 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-		},
 		"core-js-compat": {
 			"version": "3.6.5",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
@@ -2666,9 +2704,9 @@
 			"dev": true
 		},
 		"data-uri-to-buffer": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-			"integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+			"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
 		},
 		"debug": {
 			"version": "4.1.1",
@@ -2684,9 +2722,9 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decimal.js": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
-			"integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+			"integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -2750,13 +2788,13 @@
 			}
 		},
 		"degenerator": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
-			"integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
+			"integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
 			"requires": {
-				"ast-types": "0.x.x",
-				"escodegen": "1.x.x",
-				"esprima": "3.x.x"
+				"ast-types": "^0.13.2",
+				"escodegen": "^1.8.1",
+				"esprima": "^4.0.0"
 			}
 		},
 		"depd": {
@@ -2765,9 +2803,9 @@
 			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
 		},
 		"dependency-graph": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.8.1.tgz",
-			"integrity": "sha512-g213uqF8fyk40W8SBjm079n3CZB4qSpCrA2ye1fLGzH/4HEgB6tzuW2CbLE7leb4t45/6h44Ud59Su1/ROTfqw=="
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.10.0.tgz",
+			"integrity": "sha512-c9amUgpgxSi1bE5/sbLwcs5diLD0ygCQYmhfM5H1s5VH1mCsYkcmAL3CcNdv4kdSw6JuMoHeDGzLgj/gAXdWVg=="
 		},
 		"des.js": {
 			"version": "1.0.1",
@@ -2924,19 +2962,6 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
-		"es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-		},
-		"es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"requires": {
-				"es6-promise": "^4.0.3"
-			}
-		},
 		"escalade": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.1.tgz",
@@ -2958,13 +2983,6 @@
 				"esutils": "^2.0.2",
 				"optionator": "^0.8.1",
 				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-				}
 			}
 		},
 		"eslint-scope": {
@@ -2978,9 +2996,9 @@
 			}
 		},
 		"esprima": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esrecurse": {
 			"version": "4.2.1",
@@ -3098,10 +3116,13 @@
 				"homedir-polyfill": "^1.0.1"
 			}
 		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		"expression-eval": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/expression-eval/-/expression-eval-3.1.2.tgz",
+			"integrity": "sha512-c8ZN8fuAz0TRYKoGsrIq5kLNHtm81KAqWSBORHIY0DpJmZZrwK/r2zFDOhFIAJDV47gJ6irV7dWf1TOFpKvULQ==",
+			"requires": {
+				"jsep": "^0.3.0"
+			}
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -3195,15 +3216,16 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-glob": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
-			"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+			"integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.0",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.2"
+				"micromatch": "^4.0.2",
+				"picomatch": "^2.2.1"
 			}
 		},
 		"fast-json-stable-stringify": {
@@ -3222,9 +3244,9 @@
 			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
 		},
 		"fastq": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-			"integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+			"integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
 			"requires": {
 				"reusify": "^1.0.4"
 			}
@@ -3238,7 +3260,9 @@
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -3465,6 +3489,16 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
+		"fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"requires": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
+		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -3546,30 +3580,22 @@
 			"dev": true
 		},
 		"get-uri": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.4.tgz",
-			"integrity": "sha512-v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
+			"integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
 			"requires": {
-				"data-uri-to-buffer": "1",
-				"debug": "2",
-				"extend": "~3.0.2",
-				"file-uri-to-path": "1",
-				"ftp": "~0.3.10",
-				"readable-stream": "2"
+				"@tootallnate/once": "1",
+				"data-uri-to-buffer": "3",
+				"debug": "4",
+				"file-uri-to-path": "2",
+				"fs-extra": "^8.1.0",
+				"ftp": "^0.3.10"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
+				"file-uri-to-path": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
+					"integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg=="
 				}
 			}
 		},
@@ -3665,13 +3691,7 @@
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-			"dev": true
-		},
-		"grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -3824,27 +3844,13 @@
 			}
 		},
 		"http-proxy-agent": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
 			"requires": {
-				"agent-base": "4",
-				"debug": "3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4"
 			}
 		},
 		"https-browserify": {
@@ -3854,22 +3860,12 @@
 			"dev": true
 		},
 		"https-proxy-agent": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-			"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
 			"requires": {
-				"agent-base": "^4.3.0",
-				"debug": "^3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
+				"agent-base": "6",
+				"debug": "4"
 			}
 		},
 		"human-signals": {
@@ -3904,9 +3900,9 @@
 			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
 		},
 		"immer": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-4.0.2.tgz",
-			"integrity": "sha512-Q/tm+yKqnKy4RIBmmtISBlhXuSDrB69e9EKTYiIenIKQkXBQir43w+kN/eGiax3wt1J0O1b2fYcNqLSbEcXA7w=="
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-8.0.4.tgz",
+			"integrity": "sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ=="
 		},
 		"import-fresh": {
 			"version": "3.2.1",
@@ -4135,6 +4131,11 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
+		"jsep": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz",
+			"integrity": "sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA=="
+		},
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -4151,15 +4152,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
-		"json-to-ast": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
-			"integrity": "sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==",
-			"requires": {
-				"code-error-fragment": "0.0.230",
-				"grapheme-splitter": "^1.0.4"
-			}
-		},
 		"json5": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -4174,15 +4166,23 @@
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
 			"integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
 		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
 		"jsonpath-plus": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz",
 			"integrity": "sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A=="
 		},
 		"jsonpointer": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+			"integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
 		},
 		"kind-of": {
 			"version": "6.0.3",
@@ -4279,6 +4279,16 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+		},
+		"lodash.set": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -4556,9 +4566,9 @@
 			"dev": true
 		},
 		"netmask": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-			"integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
 		},
 		"nice-try": {
 			"version": "1.0.5",
@@ -4566,10 +4576,19 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
+		"nimma": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/nimma/-/nimma-0.0.0.tgz",
+			"integrity": "sha512-if0VqyHpTMHKFORMiJ2WLWgoIF4xqwjybHZyvodQ/yCmiWag6RhLlMHeFukz4X31DanTBA26U+HwvXIrTaYQkQ==",
+			"requires": {
+				"astring": "^1.4.3",
+				"jsep": "^0.3.4"
+			}
+		},
 		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
 		"node-libs-browser": {
 			"version": "2.2.1",
@@ -4843,30 +4862,29 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"pac-proxy-agent": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz",
-			"integrity": "sha512-44DUg21G/liUZ48dJpUSjZnFfZro/0K5JTyFYLBcmh9+T6Ooi4/i4efwUiEy0+4oQusCBqWdhv16XohIj1GqnQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
+			"integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
 			"requires": {
-				"agent-base": "^4.2.0",
-				"debug": "^4.1.1",
-				"get-uri": "^2.0.0",
-				"http-proxy-agent": "^2.1.0",
-				"https-proxy-agent": "^3.0.0",
-				"pac-resolver": "^3.0.0",
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4",
+				"get-uri": "3",
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "5",
+				"pac-resolver": "^4.1.0",
 				"raw-body": "^2.2.0",
-				"socks-proxy-agent": "^4.0.1"
+				"socks-proxy-agent": "5"
 			}
 		},
 		"pac-resolver": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-			"integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
+			"integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
 			"requires": {
-				"co": "^4.6.0",
-				"degenerator": "^1.0.4",
+				"degenerator": "^2.2.0",
 				"ip": "^1.1.5",
-				"netmask": "^1.0.6",
-				"thunkify": "^2.1.2"
+				"netmask": "^2.0.1"
 			}
 		},
 		"pako": {
@@ -5022,7 +5040,8 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -5031,18 +5050,18 @@
 			"dev": true
 		},
 		"proxy-agent": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.1.tgz",
-			"integrity": "sha512-WudaR0eTsDx33O3EJE16PjBRZWcX8GqCEeERw1W3hZJgH/F2a46g7jty6UGty6NeJ4CKQy8ds2CJPMiyeqaTvw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
 			"requires": {
-				"agent-base": "^4.2.0",
+				"agent-base": "^6.0.0",
 				"debug": "4",
-				"http-proxy-agent": "^2.1.0",
-				"https-proxy-agent": "^3.0.0",
+				"http-proxy-agent": "^4.0.0",
+				"https-proxy-agent": "^5.0.0",
 				"lru-cache": "^5.1.1",
-				"pac-proxy-agent": "^3.0.1",
+				"pac-proxy-agent": "^4.1.0",
 				"proxy-from-env": "^1.0.0",
-				"socks-proxy-agent": "^4.0.1"
+				"socks-proxy-agent": "^5.0.0"
 			}
 		},
 		"proxy-from-env": {
@@ -5128,6 +5147,11 @@
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
 			"dev": true
 		},
+		"queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5193,6 +5217,7 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -5206,12 +5231,14 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -5246,7 +5273,8 @@
 		"regenerator-runtime": {
 			"version": "0.13.5",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.14.4",
@@ -5403,9 +5431,12 @@
 			}
 		},
 		"run-parallel": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"requires": {
+				"queue-microtask": "^1.2.2"
+			}
 		},
 		"run-queue": {
 			"version": "1.0.3",
@@ -5419,7 +5450,8 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -5679,31 +5711,22 @@
 			}
 		},
 		"socks": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
-			"integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+			"integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
 			"requires": {
-				"ip": "1.1.5",
+				"ip": "^1.1.5",
 				"smart-buffer": "^4.1.0"
 			}
 		},
 		"socks-proxy-agent": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-			"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
 			"requires": {
-				"agent-base": "~4.2.1",
-				"socks": "~2.3.2"
-			},
-			"dependencies": {
-				"agent-base": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-					"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-					"requires": {
-						"es6-promisify": "^5.0.0"
-					}
-				}
+				"agent-base": "6",
+				"debug": "4",
+				"socks": "^2.3.3"
 			}
 		},
 		"source-list-map": {
@@ -5861,20 +5884,15 @@
 			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
 			"dev": true
 		},
-		"strict-event-emitter-types": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
-			"integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
-		},
 		"string-argv": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
 			"integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg=="
 		},
 		"string-width": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+			"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -5972,11 +5990,6 @@
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
 			}
-		},
-		"thunkify": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
-			"integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
 		},
 		"timers-browserify": {
 			"version": "2.0.11",
@@ -6146,7 +6159,8 @@
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+			"dev": true
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
@@ -6237,6 +6251,11 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -6304,9 +6323,9 @@
 			}
 		},
 		"urijs": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
-			"integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w=="
+			"version": "1.19.6",
+			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
+			"integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
 		},
 		"urix": {
 			"version": "0.1.0",
@@ -6358,7 +6377,8 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"utility-types": {
 			"version": "3.10.0",
@@ -7121,11 +7141,10 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -7177,9 +7196,9 @@
 			"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
 		},
 		"yargs": {
-			"version": "15.3.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-			"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
 			"requires": {
 				"cliui": "^6.0.0",
 				"decamelize": "^1.2.0",
@@ -7191,7 +7210,7 @@
 				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
-				"yargs-parser": "^18.1.1"
+				"yargs-parser": "^18.1.2"
 			}
 		},
 		"yargs-parser": {

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -58,7 +58,7 @@
     "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {
-    "@stoplight/spectral": "^5.4.0",
+    "@stoplight/spectral": "^5.9.0",
     "commander": "^5.1.0",
     "consola": "^2.15.0",
     "cosmiconfig": "^6.0.0",

--- a/packages/insomnia-inso/src/commands/fixtures/openapi-spec.yaml
+++ b/packages/insomnia-inso/src/commands/fixtures/openapi-spec.yaml
@@ -2,6 +2,9 @@ openapi: '3.0.2'
 info:
   title: Sample Spec
   version: '1.2'
+  description: A sample API specification
+  contact:
+    email: support@insomnia.rest
 servers:
   - url: https://200.insomnia.rest
 tags:
@@ -9,6 +12,8 @@ tags:
 paths:
   /global:
     get:
+      description: Global
+      operationId: get_global
       tags:
         - Folder
       responses:
@@ -16,6 +21,10 @@ paths:
           description: OK
   /override:
     get:
+      description: Override
+      operationId: get_override
+      tags:
+        - Folder
       responses:
         '200':
           description: OK

--- a/packages/insomnia-inso/src/commands/lint-specification.ts
+++ b/packages/insomnia-inso/src/commands/lint-specification.ts
@@ -51,6 +51,7 @@ export async function lintSpecification(
   spectral.registerFormat('oas2', isOpenApiv2);
   spectral.registerFormat('oas3', isOpenApiv3);
   await spectral.loadRuleset('spectral:oas');
+
   const results = (await spectral.run(specContent)).filter(result => (
     result.severity === 0 // filter for errors only
   ));

--- a/packages/insomnia-inso/src/commands/lint-specification.ts
+++ b/packages/insomnia-inso/src/commands/lint-specification.ts
@@ -1,4 +1,4 @@
-import { Spectral } from '@stoplight/spectral';
+import { Spectral, isOpenApiv2, isOpenApiv3 } from '@stoplight/spectral';
 import type { GlobalOptions } from '../get-options';
 import { loadDb } from '../db';
 import { loadApiSpec, promptApiSpec } from '../db/models/api-spec';
@@ -48,7 +48,12 @@ export async function lintSpecification(
   }
 
   const spectral = new Spectral();
-  const results = await spectral.run(specContent);
+  spectral.registerFormat('oas2', isOpenApiv2);
+  spectral.registerFormat('oas3', isOpenApiv3);
+  await spectral.loadRuleset('spectral:oas');
+  const results = (await spectral.run(specContent)).filter(result => (
+    result.severity === 0 // filter for errors only
+  ));
 
   if (results.length) {
     logger.log(`${results.length} lint errors found. \n`);

--- a/packages/insomnia-inso/src/db/fixtures/git-repo/.insomnia/ApiSpec/spc_46c5a4a40e83445a9bd9d9758b86c16c.yml
+++ b/packages/insomnia-inso/src/db/fixtures/git-repo/.insomnia/ApiSpec/spc_46c5a4a40e83445a9bd9d9758b86c16c.yml
@@ -5,6 +5,9 @@ contents: |
   info:
     title: Sample Spec
     version: '1.2'
+    description: A sample API specification
+    contact:
+      email: support@insomnia.rest
   servers:
     - url: https://200.insomnia.rest
   tags:
@@ -12,6 +15,8 @@ contents: |
   paths:
     /global:
       get:
+        description: Global
+        operationId: get_global
         tags:
           - Folder
         responses:
@@ -19,6 +24,10 @@ contents: |
             description: OK
     /override:
       get:
+        description: Override
+        operationId: get_override
+        tags:
+          - Folder
         responses:
           '200':
             description: OK

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -4,69 +4,26 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@babel/code-frame": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-			"requires": {
-				"@babel/highlight": "^7.10.4"
-			}
-		},
-		"@babel/helper-validator-identifier": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
-		},
-		"@babel/highlight": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
-			}
-		},
-		"@babel/runtime": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
-			"integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
-			"requires": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"@nodelib/fs.scandir": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+			"integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
 			"requires": {
-				"@nodelib/fs.stat": "2.0.3",
+				"@nodelib/fs.stat": "2.0.4",
 				"run-parallel": "^1.1.9"
 			}
 		},
 		"@nodelib/fs.stat": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+			"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+			"integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
 			"requires": {
-				"@nodelib/fs.scandir": "2.1.3",
+				"@nodelib/fs.scandir": "2.1.4",
 				"fastq": "^1.6.0"
 			}
 		},
@@ -79,125 +36,176 @@
 				"join-component": "^1.1.0"
 			}
 		},
-		"@stoplight/json": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.6.0.tgz",
-			"integrity": "sha512-6hJN735r+aPzHP28HnBj30uC+RGyf/ZWEtAMlrXI4DntzocWvhgDqxLuLgOlmXkMd/4OAlD7fJQ/cI2RXNuWvQ==",
+		"@stoplight/better-ajv-errors": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.4.tgz",
+			"integrity": "sha512-HFXOerq/6/6YisiTJwCOScwfNaXyGmX7ROAEUoKOrckK9+hJ/QLFm5EofQYEgX4aXkvHokLEbWBs4NMwZ6hQUw==",
 			"requires": {
-				"@stoplight/types": "^11.4.0",
-				"jsonc-parser": "~2.2.0",
+				"jsonpointer": "^4.0.1",
+				"leven": "^3.1.0"
+			}
+		},
+		"@stoplight/json": {
+			"version": "3.11.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.11.2.tgz",
+			"integrity": "sha512-6ePZkRBrcy/SVvnXH+Yi+sIBkKH4Nu4acG8dgaAi/pV8322lvnylyfZ21KLWEKYKON+Ll+NOZeIcaZNj5M0O9g==",
+			"requires": {
+				"@stoplight/ordered-object-literal": "^1.0.1",
+				"@stoplight/types": "^11.9.0",
+				"jsonc-parser": "~2.2.1",
 				"lodash": "^4.17.15",
 				"safe-stable-stringify": "^1.1"
 			}
 		},
 		"@stoplight/json-ref-readers": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@stoplight/json-ref-readers/-/json-ref-readers-1.1.1.tgz",
-			"integrity": "sha512-yE6SpGaBlj+QM4ony1+ST1Unz4TimZglU1lSJOlyCrVrAC1VoFpoJ1exMnU8Cg/++YzmBN9qBa4jk9s0CBnrTA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/json-ref-readers/-/json-ref-readers-1.2.2.tgz",
+			"integrity": "sha512-nty0tHUq2f1IKuFYsLM4CXLZGHdMn+X/IwEUIpeSOXt0QjMUbL0Em57iJUDzz+2MkWG83smIigNZ3fauGjqgdQ==",
 			"requires": {
-				"node-fetch": "^2.6.0"
+				"node-fetch": "^2.6.0",
+				"tslib": "^1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
 			}
 		},
 		"@stoplight/json-ref-resolver": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.0.8.tgz",
-			"integrity": "sha512-Ns0jsq/qqDdhpd9iPXLUx5YRddUF5gfg0zkxmskV+srXrWlndg0S50dkX/GF0yrExKjru4veqW8Xx+Wo0noPtg==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.1.tgz",
+			"integrity": "sha512-FUOu3nPwbX2COczcCwvUz1EpqRNYlw7Ng8keOWGiwKmlXVz4OKdRw4hi2HUg9QNSX1CyFVJ3A3pPtpkizfKqlg==",
 			"requires": {
-				"@stoplight/json": "^3.1.2",
-				"@stoplight/path": "^1.3.0",
-				"@stoplight/types": "^11.1.1",
-				"@types/urijs": "^1.19",
-				"dependency-graph": "~0.8.0",
-				"fast-memoize": "^2.5.1",
-				"immer": "^4.0.1",
-				"lodash": "^4.17.15",
-				"tslib": "^1.10.0",
-				"urijs": "~1.19.1"
+				"@stoplight/json": "^3.10.2",
+				"@stoplight/path": "^1.3.2",
+				"@stoplight/types": "^11.9.0",
+				"@types/urijs": "^1.19.14",
+				"dependency-graph": "~0.10.0",
+				"fast-memoize": "^2.5.2",
+				"immer": "^8.0.1",
+				"lodash.get": "^4.4.2",
+				"lodash.set": "^4.3.2",
+				"tslib": "^2.1.0",
+				"urijs": "^1.19.5"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+				}
 			}
 		},
 		"@stoplight/lifecycle": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@stoplight/lifecycle/-/lifecycle-2.2.1.tgz",
-			"integrity": "sha512-XOyfoJyWp5tXRFWq43mvnOoYTvkupwqGjDQnQ2o1qRNnfTrE70bjNK5ptD9A6m3zajAXgbl0puFa7P2CMg7+ew==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/lifecycle/-/lifecycle-2.3.2.tgz",
+			"integrity": "sha512-v0u8p27FA/eg04b4z6QXw4s0NeeFcRzyvseBW0+k/q4jtpg7EhVCqy42EbbbU43NTNDpIeQ81OcvkFz+6CYshw==",
 			"requires": {
-				"strict-event-emitter-types": "^2.0.0",
 				"wolfy87-eventemitter": "~5.2.8"
 			}
 		},
+		"@stoplight/ordered-object-literal": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.2.tgz",
+			"integrity": "sha512-0ZMS/9sNU3kVo/6RF3eAv7MK9DY8WLjiVJB/tVyfF2lhr2R4kqh534jZ0PlrFB9CRXrdndzn1DbX6ihKZXft2w=="
+		},
 		"@stoplight/path": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@stoplight/path/-/path-1.3.1.tgz",
-			"integrity": "sha512-I6YEfxspGglxt7MbgNbKThHdqh8CJWnDC1x1JUk2rka2D7mCpMSEu5I8IiAp997Dp4YIXDY6Did6gge8OY8KnA=="
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@stoplight/path/-/path-1.3.2.tgz",
+			"integrity": "sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ=="
 		},
 		"@stoplight/spectral": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-5.4.0.tgz",
-			"integrity": "sha512-c9NFKnzkiFqkF9RVgr7clfow6pXFKbEs+4bfKvn6PuUAYrTeOwxwYm7Nypf4KlxRGB+01epi9shrLMv4Nb2Kag==",
+			"version": "5.9.1",
+			"resolved": "https://registry.npmjs.org/@stoplight/spectral/-/spectral-5.9.1.tgz",
+			"integrity": "sha512-YgTtieZpYOva6vAwHRBQWom2muwtB6mzpbBG896C1vOiNq+ebAYA1PP9gzHyf+Uagt674CWTOfvsMrzVPosBqQ==",
 			"requires": {
-				"@stoplight/json": "3.6.0",
-				"@stoplight/json-ref-readers": "1.1.1",
-				"@stoplight/json-ref-resolver": "3.0.8",
-				"@stoplight/lifecycle": "^2.2.1",
-				"@stoplight/path": "1.3.1",
-				"@stoplight/types": "^11.6.0",
-				"@stoplight/yaml": "3.7.0",
+				"@stoplight/better-ajv-errors": "0.0.4",
+				"@stoplight/json": "3.11.2",
+				"@stoplight/json-ref-readers": "1.2.2",
+				"@stoplight/json-ref-resolver": "3.1.1",
+				"@stoplight/lifecycle": "2.3.2",
+				"@stoplight/path": "1.3.2",
+				"@stoplight/types": "11.10.0",
+				"@stoplight/yaml": "4.2.1",
 				"abort-controller": "3.0.0",
-				"ajv": "6.12.2",
+				"ajv": "6.12.5",
 				"ajv-oai": "1.2.0",
-				"better-ajv-errors": "0.6.7",
-				"blueimp-md5": "2.13.0",
-				"chalk": "4.0.0",
+				"blueimp-md5": "2.18.0",
+				"chalk": "4.1.0",
 				"eol": "0.9.1",
-				"fast-glob": "3.1.0",
+				"expression-eval": "3.1.2",
+				"fast-glob": "3.2.5",
 				"jsonpath-plus": "4.0.0",
-				"lodash": "4.17.15",
+				"lodash": "4.17.20",
 				"nanoid": "2.1.11",
-				"node-fetch": "2.6",
-				"proxy-agent": "3.1.1",
+				"nimma": "0.0.0",
+				"node-fetch": "2.6.1",
+				"proxy-agent": "4.0.1",
 				"strip-ansi": "6.0",
 				"text-table": "0.2",
-				"tslib": "1.11.1",
-				"yargs": "15.3.1"
+				"tslib": "1.13.0",
+				"yargs": "15.4.1"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.12.5",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+				}
 			}
 		},
 		"@stoplight/types": {
-			"version": "11.9.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/types/-/types-11.9.0.tgz",
-			"integrity": "sha512-4bzPpWZobt0e+d0OtALCJyl1HGzKo6ur21qxnId9dTl8v3yeD+5HJKZ2h1mv7e94debH5QDtimMU80V6jbXM8Q==",
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/@stoplight/types/-/types-11.10.0.tgz",
+			"integrity": "sha512-ffHD9i4UHS8Gsg7Ar8pKjI9B4kq7MRekE7tCROFGcFDzQhfRx9T92AduoLAtP/010XNYq23yDKpLBRPIEk8+xg==",
 			"requires": {
 				"@types/json-schema": "^7.0.4",
 				"utility-types": "^3.10.0"
 			}
 		},
 		"@stoplight/yaml": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-3.7.0.tgz",
-			"integrity": "sha512-lYs577C0tqs3WHtused0hclE+YHVshgeZT8i6kkqSIt1GUP3Hbe4AwZDEvFgZ9+9pa0JGlmKMrm0PJfvfKFxkw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.2.1.tgz",
+			"integrity": "sha512-EnSdRgOv/wrdMtdXdTiP5VvChg8lugDmSZVuhcdK/V1pibWd4+r9S4XpJlCx+xgCzg1oLM8pIv/d9cPwHU8XtA==",
 			"requires": {
-				"@stoplight/types": "^11.1.1",
-				"@stoplight/yaml-ast-parser": "0.0.44",
-				"lodash": "^4.17.15"
+				"@stoplight/ordered-object-literal": "^1.0.1",
+				"@stoplight/types": "^11.9.0",
+				"@stoplight/yaml-ast-parser": "0.0.48",
+				"tslib": "^1.12.0"
 			}
 		},
 		"@stoplight/yaml-ast-parser": {
-			"version": "0.0.44",
-			"resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.44.tgz",
-			"integrity": "sha512-PdY8p2Ufgtorf4d2DbKMfknILMa8KwuyyMMR/2lgK1mLaU8F5PKWYc+h9hIzC+ar0bh7m9h2rINo32m7ADfVyA=="
+			"version": "0.0.48",
+			"resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.48.tgz",
+			"integrity": "sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg=="
 		},
-		"@types/color-name": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		"@tootallnate/once": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
 		},
 		"@types/json-schema": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
 		},
 		"@types/urijs": {
-			"version": "1.19.9",
-			"resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.9.tgz",
-			"integrity": "sha512-/tiJyrc0GPcsReHzgC0SXwOmoPjLqYe01W7dLYB0yasQXMbcRee+ZIk+g8MIQhoBS8fPoBQO3Y93+aeBrI93Ug=="
+			"version": "1.19.15",
+			"resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.15.tgz",
+			"integrity": "sha512-pEDVREIvkyRtzpWlO5nqsUgR/JpLv9+lAzvkERCwoH2jXxl+TmaTNshhL7gjQLhfqgFUzCM6ovmoB1JssTop1A=="
 		},
 		"JSV": {
 			"version": "4.0.2",
@@ -223,11 +231,11 @@
 			}
 		},
 		"agent-base": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"requires": {
-				"es6-promisify": "^5.0.0"
+				"debug": "4"
 			}
 		},
 		"ajv": {
@@ -277,11 +285,26 @@
 			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 		},
 		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "^2.0.1"
+			},
+			"dependencies": {
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				}
 			}
 		},
 		"anymatch": {
@@ -332,9 +355,24 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"ast-types": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
-			"integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA=="
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"requires": {
+				"tslib": "^2.0.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+				}
+			}
+		},
+		"astring": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/astring/-/astring-1.7.4.tgz",
+			"integrity": "sha512-WiVqDJV0AayUUH65FfUrbnBO4KD10854cyU49lK30+2n/lEkJDRqBKj/2fYGhZSD3uIt1H1VfW/pQtO07kR2Xg=="
 		},
 		"async": {
 			"version": "0.2.10",
@@ -411,32 +449,6 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"better-ajv-errors": {
-			"version": "0.6.7",
-			"resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-0.6.7.tgz",
-			"integrity": "sha512-PYgt/sCzR4aGpyNy5+ViSQ77ognMnWq7745zM+/flYO4/Yisdtp9wDQW2IKCyVYPUxQt3E/b5GBSwfhd1LPdlg==",
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/runtime": "^7.0.0",
-				"chalk": "^2.4.1",
-				"core-js": "^3.2.1",
-				"json-to-ast": "^2.0.3",
-				"jsonpointer": "^4.0.1",
-				"leven": "^3.1.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
-			}
-		},
 		"binary-extensions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -459,9 +471,9 @@
 			}
 		},
 		"blueimp-md5": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.13.0.tgz",
-			"integrity": "sha512-lmp0m647R5e77ORduxLW5mISIDcvgJZa52vMBv5uVI3UmSWTQjkJsZVBfaFqQPw/QFogJwvY6e3Gl9nP+Loe+Q=="
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+			"integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
 		},
 		"boom": {
 			"version": "7.3.0",
@@ -513,49 +525,12 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chalk": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-			"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"requires": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"charenc": {
@@ -612,16 +587,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
 			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-		},
-		"co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-		},
-		"code-error-fragment": {
-			"version": "0.0.230",
-			"resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
-			"integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw=="
 		},
 		"code-point-at": {
 			"version": "1.1.0",
@@ -695,11 +660,6 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
-		"core-js": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -736,9 +696,9 @@
 			}
 		},
 		"data-uri-to-buffer": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-			"integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+			"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
 		},
 		"date-now": {
 			"version": "0.1.4",
@@ -746,11 +706,11 @@
 			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
 		},
 		"decamelize": {
@@ -759,9 +719,9 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decimal.js": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
-			"integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+			"integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
 		},
 		"decompress-response": {
 			"version": "4.2.1",
@@ -818,13 +778,13 @@
 			}
 		},
 		"degenerator": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
-			"integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
+			"integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
 			"requires": {
-				"ast-types": "0.x.x",
-				"escodegen": "1.x.x",
-				"esprima": "3.x.x"
+				"ast-types": "^0.13.2",
+				"escodegen": "^1.8.1",
+				"esprima": "^4.0.0"
 			}
 		},
 		"delayed-stream": {
@@ -843,9 +803,9 @@
 			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
 		},
 		"dependency-graph": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.8.1.tgz",
-			"integrity": "sha512-g213uqF8fyk40W8SBjm079n3CZB4qSpCrA2ye1fLGzH/4HEgB6tzuW2CbLE7leb4t45/6h44Ud59Su1/ROTfqw=="
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.10.0.tgz",
+			"integrity": "sha512-c9amUgpgxSi1bE5/sbLwcs5diLD0ygCQYmhfM5H1s5VH1mCsYkcmAL3CcNdv4kdSw6JuMoHeDGzLgj/gAXdWVg=="
 		},
 		"detect-libc": {
 			"version": "1.0.3",
@@ -983,19 +943,6 @@
 				"is-symbol": "^1.0.2"
 			}
 		},
-		"es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-		},
-		"es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"requires": {
-				"es6-promise": "^4.0.3"
-			}
-		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1021,9 +968,9 @@
 			}
 		},
 		"esprima": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"estraverse": {
 			"version": "4.3.0",
@@ -1064,6 +1011,14 @@
 			"resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
 			"integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
 		},
+		"expression-eval": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/expression-eval/-/expression-eval-3.1.2.tgz",
+			"integrity": "sha512-c8ZN8fuAz0TRYKoGsrIq5kLNHtm81KAqWSBORHIY0DpJmZZrwK/r2zFDOhFIAJDV47gJ6irV7dWf1TOFpKvULQ==",
+			"requires": {
+				"jsep": "^0.3.0"
+			}
+		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1080,15 +1035,16 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-glob": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
-			"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+			"integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.0",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.2"
+				"micromatch": "^4.0.2",
+				"picomatch": "^2.2.1"
 			}
 		},
 		"fast-json-stable-stringify": {
@@ -1107,9 +1063,9 @@
 			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
 		},
 		"fastq": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-			"integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+			"integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
 			"requires": {
 				"reusify": "^1.0.4"
 			}
@@ -1123,9 +1079,9 @@
 			}
 		},
 		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
+			"integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg=="
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -1322,30 +1278,40 @@
 			"integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
 		},
 		"get-uri": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.4.tgz",
-			"integrity": "sha512-v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
+			"integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
 			"requires": {
-				"data-uri-to-buffer": "1",
-				"debug": "2",
-				"extend": "~3.0.2",
-				"file-uri-to-path": "1",
-				"ftp": "~0.3.10",
-				"readable-stream": "2"
+				"@tootallnate/once": "1",
+				"data-uri-to-buffer": "3",
+				"debug": "4",
+				"file-uri-to-path": "2",
+				"fs-extra": "^8.1.0",
+				"ftp": "^0.3.10"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
 					"requires": {
-						"ms": "2.0.0"
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
 				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				"jsonfile": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				},
+				"universalify": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 				}
 			}
 		},
@@ -1382,11 +1348,6 @@
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
 			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
-		},
-		"grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -1431,9 +1392,9 @@
 			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 		},
 		"has-symbols": {
 			"version": "1.0.1",
@@ -1510,27 +1471,13 @@
 			}
 		},
 		"http-proxy-agent": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
 			"requires": {
-				"agent-base": "4",
-				"debug": "3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4"
 			}
 		},
 		"http-signature": {
@@ -1544,22 +1491,12 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-			"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
 			"requires": {
-				"agent-base": "^4.3.0",
-				"debug": "^3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
+				"agent-base": "6",
+				"debug": "4"
 			}
 		},
 		"httpsnippet": {
@@ -1656,9 +1593,9 @@
 			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
 		},
 		"immer": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-4.0.2.tgz",
-			"integrity": "sha512-Q/tm+yKqnKy4RIBmmtISBlhXuSDrB69e9EKTYiIenIKQkXBQir43w+kN/eGiax3wt1J0O1b2fYcNqLSbEcXA7w=="
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-8.0.4.tgz",
+			"integrity": "sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ=="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -1891,15 +1828,15 @@
 			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
 			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
 		},
-		"js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+		},
+		"jsep": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz",
+			"integrity": "sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA=="
 		},
 		"jshint": {
 			"version": "2.11.1",
@@ -1930,15 +1867,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-		},
-		"json-to-ast": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
-			"integrity": "sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==",
-			"requires": {
-				"code-error-fragment": "0.0.230",
-				"grapheme-splitter": "^1.0.4"
-			}
 		},
 		"jsonc-parser": {
 			"version": "2.2.1",
@@ -2049,10 +1977,20 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
 			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+		},
+		"lodash.set": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
 		},
 		"lru-cache": {
 			"version": "5.1.1",
@@ -2088,12 +2026,19 @@
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
 		},
 		"micromatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
 			"requires": {
 				"braces": "^3.0.1",
-				"picomatch": "^2.0.5"
+				"picomatch": "^2.2.3"
+			},
+			"dependencies": {
+				"picomatch": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+				}
 			}
 		},
 		"mime-db": {
@@ -2250,14 +2195,23 @@
 			}
 		},
 		"netmask": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-			"integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
+		},
+		"nimma": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/nimma/-/nimma-0.0.0.tgz",
+			"integrity": "sha512-if0VqyHpTMHKFORMiJ2WLWgoIF4xqwjybHZyvodQ/yCmiWag6RhLlMHeFukz4X31DanTBA26U+HwvXIrTaYQkQ==",
+			"requires": {
+				"astring": "^1.4.3",
+				"jsep": "^0.3.4"
+			}
 		},
 		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
 		"node-forge": {
 			"version": "0.10.0",
@@ -2606,30 +2560,29 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"pac-proxy-agent": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz",
-			"integrity": "sha512-44DUg21G/liUZ48dJpUSjZnFfZro/0K5JTyFYLBcmh9+T6Ooi4/i4efwUiEy0+4oQusCBqWdhv16XohIj1GqnQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
+			"integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
 			"requires": {
-				"agent-base": "^4.2.0",
-				"debug": "^4.1.1",
-				"get-uri": "^2.0.0",
-				"http-proxy-agent": "^2.1.0",
-				"https-proxy-agent": "^3.0.0",
-				"pac-resolver": "^3.0.0",
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4",
+				"get-uri": "3",
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "5",
+				"pac-resolver": "^4.1.0",
 				"raw-body": "^2.2.0",
-				"socks-proxy-agent": "^4.0.1"
+				"socks-proxy-agent": "5"
 			}
 		},
 		"pac-resolver": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-			"integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
+			"integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
 			"requires": {
-				"co": "^4.6.0",
-				"degenerator": "^1.0.4",
+				"degenerator": "^2.2.0",
 				"ip": "^1.1.5",
-				"netmask": "^1.0.6",
-				"thunkify": "^2.1.2"
+				"netmask": "^2.0.1"
 			}
 		},
 		"pako": {
@@ -2711,18 +2664,18 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"proxy-agent": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.1.tgz",
-			"integrity": "sha512-WudaR0eTsDx33O3EJE16PjBRZWcX8GqCEeERw1W3hZJgH/F2a46g7jty6UGty6NeJ4CKQy8ds2CJPMiyeqaTvw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
 			"requires": {
-				"agent-base": "^4.2.0",
+				"agent-base": "^6.0.0",
 				"debug": "4",
-				"http-proxy-agent": "^2.1.0",
-				"https-proxy-agent": "^3.0.0",
+				"http-proxy-agent": "^4.0.0",
+				"https-proxy-agent": "^5.0.0",
 				"lru-cache": "^5.1.1",
-				"pac-proxy-agent": "^3.0.1",
+				"pac-proxy-agent": "^4.1.0",
 				"proxy-from-env": "^1.0.0",
-				"socks-proxy-agent": "^4.0.1"
+				"socks-proxy-agent": "^5.0.0"
 			}
 		},
 		"proxy-from-env": {
@@ -2744,6 +2697,11 @@
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+		},
+		"queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
 		},
 		"random-bytes": {
 			"version": "1.0.0",
@@ -2816,11 +2774,6 @@
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
-		},
-		"regenerator-runtime": {
-			"version": "0.13.7",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 		},
 		"regexp.prototype.flags": {
 			"version": "1.3.0",
@@ -2913,9 +2866,12 @@
 			}
 		},
 		"run-parallel": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"requires": {
+				"queue-microtask": "^1.2.2"
+			}
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
@@ -3038,31 +2994,22 @@
 			}
 		},
 		"socks": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
-			"integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
+			"integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
 			"requires": {
-				"ip": "1.1.5",
+				"ip": "^1.1.5",
 				"smart-buffer": "^4.1.0"
 			}
 		},
 		"socks-proxy-agent": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-			"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
 			"requires": {
-				"agent-base": "~4.2.1",
-				"socks": "~2.3.2"
-			},
-			"dependencies": {
-				"agent-base": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-					"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-					"requires": {
-						"es6-promisify": "^5.0.0"
-					}
-				}
+				"agent-base": "6",
+				"debug": "4",
+				"socks": "^2.3.3"
 			}
 		},
 		"source-map": {
@@ -3116,15 +3063,10 @@
 				"duplexer": "~0.1.1"
 			}
 		},
-		"strict-event-emitter-types": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
-			"integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
-		},
 		"string-width": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+			"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -3178,11 +3120,11 @@
 			"integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
 		},
 		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "^4.0.0"
 			}
 		},
 		"tar": {
@@ -3220,11 +3162,6 @@
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
-		"thunkify": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
-			"integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
-		},
 		"to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3256,9 +3193,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -3313,9 +3250,9 @@
 			}
 		},
 		"urijs": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
-			"integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w=="
+			"version": "1.19.6",
+			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
+			"integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
 		},
 		"url-join": {
 			"version": "4.0.1",
@@ -3456,30 +3393,6 @@
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				}
 			}
 		},
 		"wrappy": {
@@ -3493,9 +3406,9 @@
 			"integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
 		},
 		"yallist": {
 			"version": "3.1.1",
@@ -3508,9 +3421,9 @@
 			"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
 		},
 		"yargs": {
-			"version": "15.3.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-			"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
 			"requires": {
 				"cliui": "^6.0.0",
 				"decamelize": "^1.2.0",
@@ -3522,7 +3435,7 @@
 				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
-				"yargs-parser": "^18.1.1"
+				"yargs-parser": "^18.1.2"
 			}
 		},
 		"yargs-parser": {

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/send-request/index.d.ts",
   "dependencies": {
-    "@stoplight/spectral": "^5.4.0",
+    "@stoplight/spectral": "^5.9.0",
     "analytics-node": "^4.0.1",
     "aws4": "^1.10.0",
     "axios": "^0.21.1",


### PR DESCRIPTION
This PR:

- Updates and standardizes all [Spectral](https://github.com/stoplightio/spectral) references to the latest v5.9.0 release. Previously different packages were using different versions of the library.
- Corrects the call structure when using Spectral, which looks like it wasn't being used properly in the `insomnia-app` package.
- Restricts run results to errors only (as opposed to warnings, which are more style-related).
- Updates the sample API spec test fixtures to make them syntactically correct.

To demonstrate the change to the designer itself, before this change (running `2021.01.0`):

![Screen Shot 2021-03-11 at 9 10 41 AM](https://user-images.githubusercontent.com/4060903/110810528-81657480-824b-11eb-8d44-1aa2e95d5564.png)

Note the lack of validations. And then after this change:

![image](https://user-images.githubusercontent.com/4060903/110822986-423d2080-8257-11eb-8b35-2435e2c5f7c7.png)

Validations are now being reported properly based on the contents of the specification. This will help provide immediate feedback to the user as they build out their specifications, and improve the overall value-add of the Insomnia Design view.

Feel free to ping me on company Slack to review.