### PR TITLE
Designer workspace scope

### DIFF
--- a/packages/insomnia-app/app/common/migrate-from-designer.js
+++ b/packages/insomnia-app/app/common/migrate-from-designer.js
@@ -214,7 +214,7 @@ export default async function migrateFromDesigner({
       // For each workspace coming from Designer, mark workspace.scope as 'designer'
       if (modelType === models.workspace.type) {
         for (const workspace of entries) {
-          (workspace: Workspace).scope = 'designer';
+          (workspace: Workspace).scope = 'design';
         }
       }
 

--- a/packages/insomnia-app/app/models/helpers/is-model.js
+++ b/packages/insomnia-app/app/models/helpers/is-model.js
@@ -37,5 +37,5 @@ export function isWorkspace(obj: BaseModel): boolean {
 }
 
 export function isDesigner({ scope }: Workspace): boolean {
-  return scope === 'designer';
+  return scope === 'design';
 }

--- a/packages/insomnia-app/app/models/workspace.js
+++ b/packages/insomnia-app/app/models/workspace.js
@@ -12,7 +12,7 @@ export const canDuplicate = true;
 export const canSync = true;
 
 export const WorkspaceScopeKeys = {
-  designer: 'design',
+  design: 'design',
   collection: 'collection',
 };
 
@@ -120,6 +120,7 @@ async function _migrateEnsureName(workspace: Workspace): Promise<Workspace> {
  */
 function _migrateScope(workspace: Workspace): Workspace {
   if (
+    workspace.scope === WorkspaceScopeKeys.designer ||
     workspace.scope === WorkspaceScopeKeys.design ||
     workspace.scope === WorkspaceScopeKeys.collection
   ) {
@@ -127,9 +128,13 @@ function _migrateScope(workspace: Workspace): Workspace {
   }
 
   // Translate the old value
-  type OldScopeTypes = 'spec' | 'debug' | null;
+  type OldScopeTypes = 'spec' | 'debug' | 'designer' | null;
   switch ((workspace.scope: OldScopeTypes)) {
     case 'spec': {
+      workspace.scope = WorkspaceScopeKeys.design;
+      break;
+    }
+    case 'designer': {
       workspace.scope = WorkspaceScopeKeys.design;
       break;
     }

--- a/packages/insomnia-app/app/models/workspace.js
+++ b/packages/insomnia-app/app/models/workspace.js
@@ -12,7 +12,7 @@ export const canDuplicate = true;
 export const canSync = true;
 
 export const WorkspaceScopeKeys = {
-  designer: 'designer',
+  designer: 'design',
   collection: 'collection',
 };
 
@@ -120,7 +120,7 @@ async function _migrateEnsureName(workspace: Workspace): Promise<Workspace> {
  */
 function _migrateScope(workspace: Workspace): Workspace {
   if (
-    workspace.scope === WorkspaceScopeKeys.designer ||
+    workspace.scope === WorkspaceScopeKeys.design ||
     workspace.scope === WorkspaceScopeKeys.collection
   ) {
     return workspace;
@@ -130,7 +130,7 @@ function _migrateScope(workspace: Workspace): Workspace {
   type OldScopeTypes = 'spec' | 'debug' | null;
   switch ((workspace.scope: OldScopeTypes)) {
     case 'spec': {
-      workspace.scope = WorkspaceScopeKeys.designer;
+      workspace.scope = WorkspaceScopeKeys.design;
       break;
     }
     case 'debug':

--- a/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.js
@@ -94,7 +94,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
 
         if (isLastWorkspace) {
           // Create a new workspace and default scope to designer
-          await models.workspace.create({ name: getAppName(), scope: 'designer' });
+          await models.workspace.create({ name: getAppName(), scope: 'design' });
         }
 
         await models.stats.incrementDeletedRequestsForDescendents(workspace);
@@ -106,7 +106,7 @@ class DocumentCardDropdown extends React.PureComponent<Props, State> {
 
   async _onOpen() {
     // Only load document plugins if the scope is designer, for now
-    if (this.props.workspace.scope === 'designer') {
+    if (this.props.workspace.scope === 'design') {
       const plugins = await getDocumentActions();
       this.setState({ actionPlugins: plugins });
     }

--- a/packages/insomnia-app/app/ui/components/workspace-page-header.js
+++ b/packages/insomnia-app/app/ui/components/workspace-page-header.js
@@ -30,7 +30,7 @@ const WorkspacePageHeader = ({
   },
 }: Props) => {
   const collection = activeWorkspace.scope === 'collection';
-  const designer = !collection;
+  const design = !collection;
 
   const homeCallback = React.useCallback(
     () => handleActivityChange(activeWorkspace._id, ACTIVITY_HOME),
@@ -62,7 +62,7 @@ const WorkspacePageHeader = ({
         </React.Fragment>
       }
       gridCenter={
-        designer && (
+        design && (
           <ActivityToggle
             activity={activity}
             handleActivityChange={handleActivityChange}

--- a/packages/insomnia-app/app/ui/components/wrapper-debug.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-debug.js
@@ -59,7 +59,7 @@ class WrapperDebug extends React.PureComponent<Props> {
     const { vcs, activeWorkspace, syncItems } = this.props.wrapperProps;
 
     const collection = activeWorkspace.scope === 'collection';
-    const designer = !collection;
+    const design = !collection;
 
     const share = session.isLoggedIn() && collection && (
       <Button variant="contained" onClick={showSyncShareModal}>
@@ -71,7 +71,7 @@ class WrapperDebug extends React.PureComponent<Props> {
       <SyncDropdown workspace={activeWorkspace} vcs={vcs} syncItems={syncItems} />
     );
 
-    const gitSync = designer && gitSyncDropdown;
+    const gitSync = design && gitSyncDropdown;
     const sync = betaSync || gitSync;
 
     return (

--- a/packages/insomnia-app/app/ui/components/wrapper-home.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.js
@@ -96,7 +96,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
     this.props.wrapperProps.handleSetActiveWorkspace(workspace._id);
     trackEvent('Workspace', 'Create');
 
-    workspace.scope === 'designer'
+    workspace.scope === 'design'
       ? handleSetActiveActivity(ACTIVITY_SPEC)
       : handleSetActiveActivity(ACTIVITY_DEBUG);
   }
@@ -109,7 +109,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
       onComplete: async name => {
         await this.__actuallyCreate({
           name,
-          scope: 'designer',
+          scope: 'design',
         });
         trackSegmentEvent('Document Created');
       },
@@ -359,14 +359,14 @@ class WrapperHome extends React.PureComponent<Props, State> {
     // WorkspaceMeta is a good proxy for last modified time
     const workspaceModified = workspaceMeta ? workspaceMeta.modified : workspace.modified;
     const modifiedLocally =
-      apiSpec && workspace.scope === WorkspaceScopeKeys.designer
+      apiSpec && workspace.scope === WorkspaceScopeKeys.design
         ? apiSpec.modified
         : workspaceModified;
 
     let log = <TimeFromNow timestamp={modifiedLocally} />;
     let branch = lastActiveBranch;
     if (
-      workspace.scope === WorkspaceScopeKeys.designer &&
+      workspace.scope === WorkspaceScopeKeys.design &&
       lastCommitTime &&
       apiSpec?.modified > lastCommitTime
     ) {
@@ -404,7 +404,7 @@ class WrapperHome extends React.PureComponent<Props, State> {
     let defaultActivity = ACTIVITY_DEBUG;
     let title = workspace.name;
 
-    if (workspace.scope === WorkspaceScopeKeys.designer) {
+    if (workspace.scope === WorkspaceScopeKeys.design) {
       label = 'Document';
       labelIcon = <i className="fa fa-file-o" />;
       if (specFormat === 'openapi') {

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.js
@@ -82,7 +82,7 @@ class WrapperOnboarding extends React.PureComponent<Props, State> {
     const { handleImportFile } = this.props;
     handleImportFile({
       forceToWorkspace: ForceToWorkspaceKeys.new,
-      forceToScope: WorkspaceScopeKeys.designer,
+      forceToScope: WorkspaceScopeKeys.design,
     });
   }
 
@@ -97,7 +97,7 @@ class WrapperOnboarding extends React.PureComponent<Props, State> {
       onComplete: value => {
         handleImportUri(value, {
           forceToWorkspace: ForceToWorkspaceKeys.new,
-          forceToScope: WorkspaceScopeKeys.designer,
+          forceToScope: WorkspaceScopeKeys.design,
         });
       },
     });

--- a/packages/insomnia-app/app/ui/redux/modules/helpers.js
+++ b/packages/insomnia-app/app/ui/redux/modules/helpers.js
@@ -37,7 +37,7 @@ export function askToSetWorkspaceScope(scope?: WorkspaceScope) {
   return function(name: string) {
     switch (scope) {
       case WorkspaceScopeKeys.collection:
-      case WorkspaceScopeKeys.designer:
+      case WorkspaceScopeKeys.design:
         return scope;
       default:
         return new Promise(resolve => {
@@ -47,7 +47,7 @@ export function askToSetWorkspaceScope(scope?: WorkspaceScope) {
             noText: 'Request Collection',
             yesText: 'Design Document',
             onDone: yes => {
-              resolve(yes ? WorkspaceScopeKeys.designer : WorkspaceScopeKeys.collection);
+              resolve(yes ? WorkspaceScopeKeys.design : WorkspaceScopeKeys.collection);
             },
           });
         });


### PR DESCRIPTION
This PR covers the shift away from "designer" as a workspace scope name in favor of "design". 

- Existing workspaces
- Imported workspaces from (legacy core & designer)
- Updated for export (from insomnia)

Fixes INS-533