### PR TITLE
Fix password editor props

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/auth/basic-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/basic-auth.js
@@ -103,8 +103,8 @@ class BasicAuth extends React.PureComponent<Props> {
                   password={authentication.password}
                   onChange={this._handleChangePassword}
                   nunjucksPowerUserMode={nunjucksPowerUserMode}
-                  render={handleRender}
-                  getRenderContext={handleGetRenderContext}
+                  handleRender={handleRender}
+                  handleGetRenderContext={handleGetRenderContext}
                   isVariableUncovered={isVariableUncovered}
                 />
               </td>

--- a/packages/insomnia-app/app/ui/components/editors/auth/digest-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/digest-auth.js
@@ -95,8 +95,8 @@ class DigestAuth extends React.PureComponent<Props> {
                   password={authentication.password}
                   onChange={this._handleChangePassword}
                   nunjucksPowerUserMode={nunjucksPowerUserMode}
-                  render={handleRender}
-                  getRenderContext={handleGetRenderContext}
+                  handleRender={handleRender}
+                  handleGetRenderContext={handleGetRenderContext}
                   isVariableUncovered={isVariableUncovered}
                 />
               </td>

--- a/packages/insomnia-app/app/ui/components/editors/auth/ntlm-auth.js
+++ b/packages/insomnia-app/app/ui/components/editors/auth/ntlm-auth.js
@@ -94,8 +94,8 @@ class NTLMAuth extends React.PureComponent<Props> {
                   password={authentication.password}
                   onChange={this._handleChangePassword}
                   nunjucksPowerUserMode={nunjucksPowerUserMode}
-                  render={handleRender}
-                  getRenderContext={handleGetRenderContext}
+                  handleRender={handleRender}
+                  handleGetRenderContext={handleGetRenderContext}
                   isVariableUncovered={isVariableUncovered}
                 />
               </td>

--- a/packages/insomnia-app/app/ui/components/editors/password-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/password-editor.js
@@ -11,8 +11,8 @@ type State = {
 };
 
 type Props = {
-  render: Function,
-  getRenderContext: Function,
+  handleRender: Function,
+  handleGetRenderContext: Function,
   nunjucksPowerUserMode: boolean,
   onChange: Function,
   password: string,

--- a/packages/insomnia-app/app/ui/components/editors/password-editor.js
+++ b/packages/insomnia-app/app/ui/components/editors/password-editor.js
@@ -56,7 +56,6 @@ class PasswordEditor extends React.PureComponent<Props, State> {
           <OneLineEditor
             type={showAllPasswords || showPassword ? 'text' : 'password'}
             id="password"
-            testId="password"
             onChange={onChange}
             defaultValue={password || ''}
             nunjucksPowerUserMode={nunjucksPowerUserMode}
@@ -69,8 +68,7 @@ class PasswordEditor extends React.PureComponent<Props, State> {
           <Button
             className="btn btn--super-duper-compact pointer"
             onClick={this._handleShowPassword}
-            value={showPassword}
-            testId="password-reveal">
+            value={showPassword}>
             {showPassword ? <i className="fa fa-eye-slash" /> : <i className="fa fa-eye" />}
           </Button>
         )}


### PR DESCRIPTION
In the future, TypeScript should handle this better. Sadly Flow didn't pick up on this error.

Closes #3192 