### PR TITLE
Integrating loading state on Collection sync setup, refresh on local project setup

### DIFF
--- a/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
+++ b/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.js
@@ -255,8 +255,10 @@ class SyncDropdown extends React.PureComponent<Props, State> {
   }
 
   async _handleEnableSync() {
+    this.setState({ loadingProjectPull: true });
     const { vcs, workspace } = this.props;
     await vcs.switchAndCreateProjectIfNotExist(workspace._id, workspace.name);
+    await this.refreshMainAttributes({ loadingProjectPull: false });
   }
 
   _handleShowDeleteModal() {


### PR DESCRIPTION
This PR covers the usage of our loading state (labeled initializing...) into the Sync Setup flow on collections. On setup, we are now refreshing state.

![2021-03-18 09 32 17](https://user-images.githubusercontent.com/52717970/111634508-f9dcb000-87cc-11eb-9c4e-c29365820614.gif)
 
Fixes INS-448