### PR TITLE
Remove netlify configuration for storybook

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,0 @@
-[build]
-  publish = "storybook-static"
-  base = "packages/insomnia-components/"
-  command = "npm run convert-svg && npm run build-storybook"
-  ignore = "git diff --quiet HEAD^ HEAD ./"


### PR DESCRIPTION
Storybook is now live on Vercel at http://storybook.insomnia.rest

All Vercel build configuration is done through their interface as per their documentations recommendation, so no need for any additional config file.