### PR TITLE
Replace Netlify with Vercel for Storybook

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,0 @@
-[build]
-  publish = "storybook-static"
-  base = "packages/insomnia-components/"
-  command = "npm run convert-svg && npm run build-storybook"
-  ignore = "git diff --quiet HEAD^ HEAD ./"

--- a/packages/insomnia-components/vercel.json
+++ b/packages/insomnia-components/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+      "silent": true
+  }
+}


### PR DESCRIPTION
Storybook is now live on Vercel at http://storybook.insomnia.rest

All build configuration is done through their web interface as per their documentations recommendation, I have added a vercel config file to stop it from posting comments however, as otherwise it gets really noisy, as it posts comments regardless of whether changes has been made or not (we cancel builds if there aren't any changes to the `packages/insomnia-components` directory: 
![image](https://user-images.githubusercontent.com/174626/111773047-ef461780-88ad-11eb-88df-2517d3d8ef64.png)

Since the build status/preview link are still accessible through the deployment status and the checks at the bottom of PR/on a commit, I think this is fine.

Fixes INS-453