### PR TITLE
Change it block from lambda to anonymous function

### DIFF
--- a/packages/insomnia-testing/src/generate/__fixtures__/03_basic-suite.output.js
+++ b/packages/insomnia-testing/src/generate/__fixtures__/03_basic-suite.output.js
@@ -4,11 +4,11 @@ const { expect } = chai;
 beforeEach(() => insomnia.clearActiveRequest());
 
 describe('Example Suite', () => {
-  it('should return -1 when the value is not present', async () => {
+  it('should return -1 when the value is not present', async function() {
     expect([1, 2, 3].indexOf(4)).to.equal(-1);
     expect(true).to.equal(true);
   });
 
-  it('is an empty test', async () => {
+  it('is an empty test', async function() {
   });
 });

--- a/packages/insomnia-testing/src/generate/__fixtures__/04_nested-suite.output.js
+++ b/packages/insomnia-testing/src/generate/__fixtures__/04_nested-suite.output.js
@@ -5,12 +5,12 @@ beforeEach(() => insomnia.clearActiveRequest());
 
 describe('Parent Suite', () => {
   describe('Nested Suite', () => {
-    it('should return -1 when the value is not present', async () => {
+    it('should return -1 when the value is not present', async function() {
       expect([1, 2, 3].indexOf(4)).to.equal(-1);
       expect(true).to.equal(true);
     });
 
-    it('is an empty test', async () => {
+    it('is an empty test', async function() {
     });
   });
 });

--- a/packages/insomnia-testing/src/generate/__fixtures__/05_complex-suite.output.js
+++ b/packages/insomnia-testing/src/generate/__fixtures__/05_complex-suite.output.js
@@ -6,22 +6,22 @@ beforeEach(() => insomnia.clearActiveRequest());
 describe('Parent Suite', () => {
   describe('Nested Suite', () => {
     describe('Nested Again Suite', () => {
-      it('should return -1 when the value is not present', async () => {
+      it('should return -1 when the value is not present', async function() {
         expect([1, 2, 3].indexOf(4)).to.equal(-1);
         expect(true).to.equal(true);
       });
 
-      it('should be true', async () => {
+      it('should be true', async function() {
         expect(true).to.equal(true);
       });
     });
   });
 
-  it('should return -1 when the value is not present', async () => {
+  it('should return -1 when the value is not present', async function() {
     expect([1, 2, 3].indexOf(4)).to.equal(-1);
     expect(true).to.equal(true);
   });
 
-  it('is an empty test', async () => {
+  it('is an empty test', async function() {
   });
 });

--- a/packages/insomnia-testing/src/generate/index.js
+++ b/packages/insomnia-testing/src/generate/index.js
@@ -85,7 +85,7 @@ function generateTestLines(n: number, test: ?Test): Array<string> {
   const lines = [];
 
   // Define test it() block (all test cases are async by default)
-  lines.push(indent(n, `it('${escapeJsStr(test.name)}', async () => {`));
+  lines.push(indent(n, `it('${escapeJsStr(test.name)}', async function() {`));
 
   // Add helper variables that are necessary
   const { defaultRequestId } = test;


### PR DESCRIPTION
Changing the function passed to the it block from a lambda to an anonymous function allows access to the mocha context from within the test. This allows users to change the timeouts for individual unit tests via the exposed code blocks.
ex:

this.timeout(10000);
const response1 = await insomnia.send();
expect(response1.status).to.equal(200);

will timeout after 10 seconds instead of 5.

Closes #3214 
