### PR TITLE
Upstream target host variable inclusion

### DIFF
--- a/packages/openapi-2-kong/src/declarative-config/upstreams.js
+++ b/packages/openapi-2-kong/src/declarative-config/upstreams.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { getName, parseUrl } from '../common';
+import { getName, parseUrl, fillServerVariables } from '../common';
 
 export function generateUpstreams(api: OpenApi3Spec, tags: Array<string>) {
   const servers = api.servers || [];
@@ -16,8 +16,9 @@ export function generateUpstreams(api: OpenApi3Spec, tags: Array<string>) {
   };
 
   for (const server of servers) {
+    const serverWithVars = fillServerVariables(server);
     upstream.targets.push({
-      target: parseUrl(server.url).host,
+      target: parseUrl(serverWithVars).host,
     });
   }
 


### PR DESCRIPTION
This PR covers the insertion of the default host on upstream targets.

![2021-03-24 12 44 13](https://user-images.githubusercontent.com/52717970/112349776-65c48a00-8c9f-11eb-9772-47a2486fc1c5.gif)

Fixes #INS-456