### PR TITLE
o2k parameter style support & default

### DIFF
--- a/packages/openapi-2-kong/src/__fixtures__/httpbin.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/httpbin.expected.json
@@ -174,7 +174,7 @@
                 "parameter_schema": [
                   {
                     "schema": "{\"anyOf\":[{\"type\":\"string\"}]}",
-                    "style": "simple",
+                    "style": "form",
                     "in": "path",
                     "name": "human_timestamp",
                     "required": true,

--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -52,7 +52,7 @@ export function generateRequestValidatorPlugin(obj: Object, operation: OA3Operat
         required: !!(p: Object).required,
         name: (p: Object).name,
         schema: JSON.stringify((p: Object).schema),
-        style: 'simple',
+        style: (p: Object).style ?? 'form',
       });
     }
   }

--- a/packages/openapi-2-kong/types/openapi3.flow.js
+++ b/packages/openapi-2-kong/types/openapi3.flow.js
@@ -36,6 +36,7 @@ declare type OA3Parameter = {|
   required?: boolean,
   deprecated?: boolean,
   allowEmptyValue?: boolean,
+  style?: 'form' | 'spaceDelimited' | 'pipeDelimited' | 'deepObject',
 |};
 
 declare type OA3RequestBody = {|


### PR DESCRIPTION
This PR covers the setting of a user defined style value on query parameters while defaulting to 'form' if omitted. Previously we were setting this to 'simple' regardless, which is not a [valid option for query parameters](https://swagger.io/docs/specification/serialization/#query).

![2021-04-01 09 20 45](https://user-images.githubusercontent.com/52717970/113301466-0a148500-92cd-11eb-90ba-5c0f6922cbd9.gif)

Fixes #INS-557