### PR TITLE
docs: update instructions for development on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ Also on Linux, if Electron is failing during the bootstrap process, run the foll
 rm -rf ~/.cache/electron
 ```
 
-If you are on Windows and have problems, you may need to install [Windows Build Tools](https://github.com/felixrieseberg/windows-build-tools)
+If you are on Windows and have problems, you may need to install:
+* [Windows Build Tools](https://github.com/felixrieseberg/windows-build-tools)
+* [nasm](https://www.nasm.us/), and add it to your `PATH` (it should be `C:\Program Files\NASM`)
 
 </details>
 


### PR DESCRIPTION
In order to install `node-libcurl` dependency properly on windows, we need to have [nasm](https://www.nasm.us/) installed.

If you don't have `nasm`, dependency is installed but not its bindings, so there will be an error when you start the app (an error about `binding` folder not existing in `node_modules/node-libcurl` package).
I found this on `node-libcurl` [docs](https://github.com/JCMais/node-libcurl#building-on-windows).

So I updated the doc to specify that you may need `nasm` when developing on windows.
