### PR TITLE
Request validator plugin respects existing properties and generates required ones

### DIFF
--- a/packages/openapi-2-kong/src/__fixtures__/request-validator-plugin.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/request-validator-plugin.expected.json
@@ -1,0 +1,93 @@
+{
+  "_format_version": "1.1",
+  "services": [
+    {
+      "name": "Example",
+      "plugins": [],
+      "routes": [
+        {
+          "methods": [
+            "POST"
+          ],
+          "name": "Example-body-post",
+          "paths": [
+            "/body$"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "allowed_content_types": [
+                  "application/json",
+                  "application/xml"
+                ],
+                "body_schema": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}}}",
+                "verbose_response": true,
+                "version": "draft4"
+              },
+              "enabled": true,
+              "name": "request-validator"
+            }
+          ],
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_request-validator-plugin.yaml"
+          ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "name": "Example-params-get",
+          "paths": [
+            "/params$"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "parameter_schema": [
+                  {
+                    "explode": false,
+                    "in": "path",
+                    "name": "userId",
+                    "required": true,
+                    "schema": "{\"type\":\"integer\"}",
+                    "style": "form"
+                  }
+                ],
+                "verbose_response": true,
+                "version": "draft4"
+              },
+              "enabled": true,
+              "name": "request-validator"
+            }
+          ],
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_request-validator-plugin.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_request-validator-plugin.yaml"
+      ],
+      "url": "http://backend.com/path"
+    }
+  ],
+  "upstreams": [
+    {
+      "name": "Example",
+      "tags": [
+        "OAS3_import",
+        "OAS3file_request-validator-plugin.yaml"
+      ],
+      "targets": [
+        {
+          "target": "backend.com:80"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/openapi-2-kong/src/__fixtures__/request-validator-plugin.yaml
+++ b/packages/openapi-2-kong/src/__fixtures__/request-validator-plugin.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.2
+
+info:
+  title: Example
+  version: 1.0.0
+
+servers:
+  - url: http://backend.com/path
+
+paths:
+  /params:
+    get:
+      x-kong-plugin-request-validator:
+        enabled: true
+        config:
+          verbose_response: true
+      parameters:
+        - in: path
+          name: userId
+          schema:
+            type: integer
+          required: true
+  /body:
+    post:
+      x-kong-plugin-request-validator:
+        enabled: true
+        config:
+          verbose_response: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/jsonSchema'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/xmlSchema'
+
+components:
+  schemas:
+    jsonSchema:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    xmlSchema:
+      type: object
+      properties:
+        prop:
+          type: integer

--- a/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
+++ b/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { generateServerPlugins, generatePlugin } from '../plugins';
+import { generateServerPlugins, generatePlugin, generateRequestValidatorPlugin } from '../plugins';
 
 describe('plugins', () => {
   describe('generateServerPlugins()', () => {
@@ -60,6 +60,262 @@ describe('plugins', () => {
         config: {
           key_names: ['x-api-key'],
         },
+      });
+    });
+  });
+
+  describe('generateRequestValidatorPlugin()', () => {
+    const parameterSchema = [
+      {
+        schema: '{"anyOf":[{"type":"string"}]}',
+        style: 'form',
+        in: 'path',
+        name: 'human_timestamp',
+        required: true,
+        explode: false,
+      },
+    ];
+
+    it('should retain config properties', () => {
+      const plugin = {
+        enabled: true,
+        config: {
+          parameter_schema: [parameterSchema],
+          body_schema: '[{"name":{"type": "string", "required": true}}]',
+          verbose_response: true,
+          allowed_content_types: 'application/json',
+        },
+      };
+
+      const operation = {};
+
+      const generated = generateRequestValidatorPlugin(plugin, operation);
+
+      expect(generated).toStrictEqual({
+        name: 'request-validator',
+        enabled: plugin.enabled,
+        config: { version: 'draft4', ...plugin.config },
+      });
+    });
+
+    it('should not add properties if they are not defined', () => {
+      const plugin = {
+        enabled: true,
+        config: {
+          parameter_schema: [parameterSchema],
+          body_schema: '[{"name":{"type": "string", "required": true}}]',
+          // The following properties are missing
+          // verbose_response: true,
+          // allowed_content_types: 'application/json',
+        },
+      };
+
+      const operation = {};
+
+      const generated = generateRequestValidatorPlugin(plugin, operation);
+
+      expect(generated).toStrictEqual({
+        name: 'request-validator',
+        enabled: plugin.enabled,
+        config: { version: 'draft4', ...plugin.config },
+      });
+    });
+
+    describe('parameter_schema', () => {
+      it('should return empty array for parameter schema if no parameters exist in operation', () => {
+        const plugin = {
+          enabled: true,
+          config: {},
+        };
+
+        const operation = {};
+
+        const generated = generateRequestValidatorPlugin(plugin, operation);
+
+        expect(generated).toStrictEqual({
+          name: 'request-validator',
+          enabled: plugin.enabled,
+          config: { version: 'draft4', parameter_schema: [] },
+        });
+      });
+
+      it('should convert operation parameters to parameter_schema', () => {
+        const plugin = {
+          config: {},
+        };
+
+        const param = {
+          in: 'query',
+          explode: true,
+          required: false,
+          name: 'some_name',
+          schema: {
+            anyOf: [{ type: 'string' }],
+          },
+          style: 'form',
+        };
+
+        const operation: OA3Operation = {
+          parameters: [param],
+        };
+
+        const generated = generateRequestValidatorPlugin(plugin, operation);
+
+        expect(generated.config).toStrictEqual({
+          version: 'draft4',
+          parameter_schema: [
+            {
+              schema: '{"anyOf":[{"type":"string"}]}',
+              style: param.style,
+              in: param.in,
+              name: param.name,
+              explode: param.explode,
+              required: param.required,
+            },
+          ],
+        });
+      });
+
+      it('should throw error if no operation parameter schema defined', () => {
+        const plugin = {};
+
+        const operation: OA3Operation = {
+          parameters: [
+            {
+              in: 'query',
+              name: 'some_name',
+            },
+          ],
+        };
+
+        expect(() => generateRequestValidatorPlugin(plugin, operation)).toThrowError(
+          "Parameter using 'content' type validation is not supported",
+        );
+      });
+    });
+
+    describe('body_schema', () => {
+      it('should not add body_schema if no body present', () => {
+        const plugin = {
+          config: {},
+        };
+
+        const operation = {};
+
+        const generated = generateRequestValidatorPlugin(plugin, operation);
+
+        expect(generated.config).toStrictEqual({
+          version: 'draft4',
+          parameter_schema: [],
+        });
+      });
+
+      it('should throw error if no operation request body content defined', () => {
+        const plugin = {};
+
+        const operation: OA3Operation = {
+          requestBody: {},
+        };
+
+        expect(() => generateRequestValidatorPlugin(plugin, operation)).toThrowError(
+          'content property is missing for request-validator!',
+        );
+      });
+
+      it('should throw error if operation request body content is not json', () => {
+        const plugin = {};
+
+        const operation: OA3Operation = {
+          requestBody: {
+            content: {
+              'application/xml': {},
+              'text/yaml': {},
+            },
+          },
+        };
+
+        // just fails on the first one
+        expect(() => generateRequestValidatorPlugin(plugin, operation)).toThrowError(
+          `Body validation supports only 'application/json', not application/xml`,
+        );
+      });
+
+      it('should add body_schema', () => {
+        const plugin = {};
+
+        const schema = {
+          type: 'Object',
+          properties: {
+            id: {
+              type: 'integer',
+              format: 'int64',
+            },
+          },
+        };
+
+        const operation: OA3Operation = {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema,
+              },
+            },
+          },
+        };
+
+        const generated = generateRequestValidatorPlugin(plugin, operation);
+
+        expect(generated.config).toStrictEqual({
+          version: 'draft4',
+          body_schema: JSON.stringify(schema),
+          parameter_schema: [],
+        });
+      });
+
+      // This currently throws an error but it should pass
+      it.skip('should add body_schema for JSON only', () => {
+        const plugin = {};
+
+        const schemaXml = {
+          type: 'Object',
+          properties: {
+            name: {
+              type: 'integer',
+              format: 'int64',
+            },
+          },
+        };
+
+        const schemaJson = {
+          type: 'Object',
+          properties: {
+            id: {
+              type: 'integer',
+              format: 'int64',
+            },
+          },
+        };
+
+        const operation: OA3Operation = {
+          requestBody: {
+            content: {
+              'application/xml': {
+                schemaXml,
+              },
+              'application/json': {
+                schemaJson,
+              },
+            },
+          },
+        };
+
+        const generated = generateRequestValidatorPlugin(plugin, operation);
+
+        expect(generated.config).toStrictEqual({
+          version: 'draft4',
+          body_schema: JSON.stringify(schemaJson),
+          parameter_schema: [],
+        });
       });
     });
   });

--- a/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
+++ b/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
@@ -194,7 +194,16 @@ describe('plugins', () => {
 
         expect(generated.config).toStrictEqual({
           version: 'draft4',
-          body_schema: '{}',
+          parameter_schema: [
+            {
+              explode: false,
+              in: 'query',
+              name: 'some_name',
+              required: false,
+              schema: '{}',
+              style: 'form',
+            },
+          ],
         });
       });
 
@@ -230,6 +239,14 @@ describe('plugins', () => {
               name: paramWithSchema.name,
               explode: paramWithSchema.explode,
               required: paramWithSchema.required,
+            },
+            {
+              schema: '{}',
+              style: 'form',
+              in: paramWithoutSchema.in,
+              name: paramWithoutSchema.name,
+              explode: false,
+              required: false,
             },
           ],
         });

--- a/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
+++ b/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
@@ -133,9 +133,11 @@ describe('plugins', () => {
 
         expect(generated1.config).toStrictEqual({
           version: 'draft4',
+          body_schema: '{}',
         });
         expect(generated2.config).toStrictEqual({
           version: 'draft4',
+          body_schema: '{}',
         });
       });
 
@@ -206,6 +208,7 @@ describe('plugins', () => {
 
         expect(generated.config).toStrictEqual({
           version: 'draft4',
+          body_schema: '{}',
         });
       });
 
@@ -237,6 +240,7 @@ describe('plugins', () => {
 
         expect(generated.config).toStrictEqual({
           version: 'draft4',
+          body_schema: '{}',
           allowed_content_types: ['application/xml', 'text/yaml'],
         });
       });
@@ -283,6 +287,18 @@ describe('plugins', () => {
           version: 'draft4',
           body_schema: JSON.stringify(schemaJson),
           allowed_content_types: ['application/xml', 'application/json'],
+        });
+      });
+
+      it('should default body_schema if no schema is defined or generated', () => {
+        const plugin = {};
+        const operation = {};
+
+        const generated = generateRequestValidatorPlugin(plugin, operation);
+
+        expect(generated.config).toStrictEqual({
+          version: 'draft4',
+          body_schema: '{}',
         });
       });
     });

--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -35,7 +35,7 @@ export function generatePlugin(key: string, value: Object): DCPlugin {
 }
 
 export function generateParameterSchema(operation: OA3Operation): Array<Object> {
-  const parameterSchema = [];
+  const parameterSchema = []; // TODO: should this default to [] or undefined? undefined
 
   if (operation.parameters) {
     for (const p of operation.parameters) {

--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -93,14 +93,22 @@ export function generateRequestValidatorPlugin(plugin: Object, operation: OA3Ope
 
   // Use original or generated parameter_schema
   const parameterSchema = pluginConfig.parameter_schema ?? generateParameterSchema(operation);
-  if (parameterSchema !== undefined) {
-    config.parameter_schema = parameterSchema;
-  }
 
   const generated = generateBodyOptions(operation);
 
   // Use original or generated body_schema
-  const bodySchema = pluginConfig.body_schema ?? generated.bodySchema;
+  let bodySchema = pluginConfig.body_schema ?? generated.bodySchema;
+
+  // If no schema is defined or generated, default to allow all content to pass
+  if (parameterSchema === undefined && bodySchema === undefined) {
+    bodySchema = '{}'; // valid config to allow all content to pass
+  }
+
+  // Apply parameter_schema and body_schema to the config object
+  if (parameterSchema !== undefined) {
+    config.parameter_schema = parameterSchema;
+  }
+
   if (bodySchema !== undefined) {
     config.body_schema = bodySchema;
   }

--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -99,9 +99,11 @@ export function generateRequestValidatorPlugin(plugin: Object, operation: OA3Ope
   // Use original or generated body_schema
   let bodySchema = pluginConfig.body_schema ?? generated.bodySchema;
 
-  // If no schema is defined or generated, default to allow all content to pass
+  // If no schema is defined or generated, all content to pass
+  // The following is valid config to allow all content to pass
+  // See: https://github.com/Kong/kong-plugin-enterprise-request-validator/pull/34/files#diff-1a1d2d5ce801cc1cfb2aa91ae15686d81ef900af1dbef00f004677bc727bfd3cR284
   if (parameterSchema === undefined && bodySchema === undefined) {
-    bodySchema = '{}'; // valid config to allow all content to pass
+    bodySchema = '{}';
   }
 
   // Apply parameter_schema and body_schema to the config object

--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -37,11 +37,13 @@ export function generatePlugin(key: string, value: Object): DCPlugin {
 function generateParameterSchema(operation: OA3Operation): Array<Object> | typeof undefined {
   let parameterSchema;
 
-  if (operation.parameters?.length) {
+  const parametersWithSchema = operation.parameters?.filter(p => (p: Object).schema);
+
+  if (parametersWithSchema?.length) {
     parameterSchema = [];
-    for (const p of operation.parameters) {
+    for (const p of parametersWithSchema) {
       if (!(p: Object).schema) {
-        throw new Error("Parameter using 'content' type validation is not supported");
+        continue;
       }
       parameterSchema.push({
         in: (p: Object).in,
@@ -66,17 +68,13 @@ function generateBodyOptions(
   let bodySchema;
   let allowedContentTypes;
 
-  if (operation.requestBody) {
-    const content = (operation.requestBody: Object).content;
-    if (!content) {
-      throw new Error('content property is missing for request-validator!');
-    }
-
+  const bodyContent = (operation.requestBody: Object)?.content;
+  if (bodyContent) {
     const jsonContentType = 'application/json';
 
-    allowedContentTypes = Object.keys(content);
+    allowedContentTypes = Object.keys(bodyContent);
     if (allowedContentTypes.includes(jsonContentType)) {
-      const item = content[jsonContentType];
+      const item = bodyContent[jsonContentType];
       bodySchema = JSON.stringify(item.schema);
     }
   }

--- a/packages/openapi-2-kong/src/declarative-config/services.js
+++ b/packages/openapi-2-kong/src/declarative-config/services.js
@@ -42,6 +42,7 @@ export function generateService(
   for (const routePath of Object.keys(api.paths)) {
     const pathItem: OA3PathItem = api.paths[routePath];
 
+    // TODO: Add path plugins to route
     for (const method of Object.keys(pathItem)) {
       if (
         method !== 'get' &&

--- a/packages/openapi-2-kong/types/openapi3.flow.js
+++ b/packages/openapi-2-kong/types/openapi3.flow.js
@@ -37,9 +37,13 @@ declare type OA3Parameter = {|
   deprecated?: boolean,
   allowEmptyValue?: boolean,
   style?: 'form' | 'spaceDelimited' | 'pipeDelimited' | 'deepObject',
+  schema?: Object,
+  content?: Object,
+  explode?: boolean,
 |};
 
 declare type OA3RequestBody = {|
+  content?: Object,
   // TODO
 |};
 


### PR DESCRIPTION
The [request-validator plugin](https://docs.konghq.com/hub/kong-inc/request-validator/#parameters) has several options to be send under the `config` object. These parameters are:
- `parameter_schema`
- `body_schema`
- `allowed_content_types`
- `verbose_response`

Out of these four, the first three can be generated or be user-defined, and the fourth must be user defined.

In an OpenAPI spec, the user may specify an object with none or some of the config parameters. If a user defines a config parameter, then that config parameter will be used and not generated. If a parameter that can be generated is not defined, then O2K will attempt to generate.

Here is an example spec with the plugin defined on each operation. This is not an exhaustive example, but should server as a good base to begin testing from.

```yaml
openapi: 3.0.2

info:
  title: Example
  version: 1.0.0

servers:
  - url: http://backend.com/path

paths:
  /params:
    get:
      x-kong-plugin-request-validator:
        enabled: true
        config: 
          verbose_response: true
      parameters:
        - in: path
          name: userId
          schema:
            type: integer
          required: true
  /body:
    post:
      x-kong-plugin-request-validator:
        enabled: true
        config: 
          verbose_response: true
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/jsonSchema'
          application/xml:
            schema:
              $ref: '#/components/schemas/xmlSchema'

components:
  schemas:
    jsonSchema:
      type: object
      properties:
        id:
          type: integer
        name:
          type: string
    xmlSchema:
      type: object
      properties:
        prop:
          type: integer
```

If O2K is unable to generate the `body_schema` (from the operation request JSON body) or `parameter_schema` (from the operation parameters), then a default "pass-all" config should be applied, where the `body_schema` is set to `'{}'`.

See the unit tests added, which checks of these rules. Also see [FTI-2252](https://konghq.atlassian.net/browse/FTI-2252). This doesn't address all of the requirements outlined in the FTI, there is a subsequent PR to support plugins (request validator or otherwise) at other levels of the spec (root, server, path, operation).

Fixes INS-457, closes #2867