### PR TITLE
Custom & default tagging for plugins

### DIFF
--- a/packages/openapi-2-kong/src/__fixtures__/httpbin.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/httpbin.expected.json
@@ -103,7 +103,7 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-cookies-get",
-          "plugins": [{"name": "correlation-id"}],
+          "plugins": [{"config": {"tags": ["OAS3_import"]}, "name": "correlation-id"}],
           "paths": ["/cookies$"]
         },
         {

--- a/packages/openapi-2-kong/src/__fixtures__/httpbin.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/httpbin.expected.json
@@ -101,9 +101,9 @@
         {
           "methods": ["GET"],
           "strip_path": false,
-          "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-cookies-get",
-          "plugins": [{"config": {"tags": ["OAS3_import"]}, "name": "correlation-id"}],
+          "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
+          "plugins": [{"name": "correlation-id", "tags": ["OAS3_import"]}],
           "paths": ["/cookies$"]
         },
         {

--- a/packages/openapi-2-kong/src/common.js
+++ b/packages/openapi-2-kong/src/common.js
@@ -73,6 +73,8 @@ export function pathVariablesToRegex(p: string): string {
   return result + '$';
 }
 
+export const defaultTags = ['OAS3_import'];
+
 export function getPluginNameFromKey(key: string): string {
   return key.replace(/^x-kong-plugin-/, '');
 }

--- a/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
+++ b/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
@@ -20,6 +20,7 @@ describe('plugins', () => {
         {
           name: 'key-auth',
           config: {
+            tags: ['OAS3_import'],
             key_names: ['x-api-key'],
           },
         },
@@ -41,6 +42,7 @@ describe('plugins', () => {
       expect(result).toEqual({
         name: 'key-auth',
         config: {
+          tags: ['OAS3_import'],
           key_names: ['x-api-key'],
         },
       });
@@ -58,6 +60,7 @@ describe('plugins', () => {
       expect(result).toEqual({
         name: 'key-auth',
         config: {
+          tags: ['OAS3_import'],
           key_names: ['x-api-key'],
         },
       });

--- a/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
+++ b/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
@@ -33,6 +33,7 @@ describe('plugins', () => {
       expect(result.plugins).toEqual([
         {
           name: 'abcd', // name from plugin tag
+          tags: ['OAS3_import'],
           config: {
             some_config: ['something'],
           },
@@ -93,7 +94,6 @@ describe('plugins', () => {
 
       expect(generated).toStrictEqual({
         name: 'request-validator',
-        tags: ['OAS3_import'],
         enabled: plugin.enabled,
         config: { version: 'draft4', ...plugin.config },
       });
@@ -117,7 +117,6 @@ describe('plugins', () => {
 
       expect(generated).toStrictEqual({
         name: 'request-validator',
-        tags: ['OAS3_import'],
         enabled: plugin.enabled,
         config: { version: 'draft4', ...plugin.config },
       });

--- a/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
+++ b/packages/openapi-2-kong/src/declarative-config/__tests__/plugins.test.js
@@ -19,8 +19,8 @@ describe('plugins', () => {
       expect(result).toEqual([
         {
           name: 'key-auth',
+          tags: ['OAS3_import'],
           config: {
-            tags: ['OAS3_import'],
             key_names: ['x-api-key'],
           },
         },
@@ -41,8 +41,8 @@ describe('plugins', () => {
       const result = generatePlugin(pluginKey, pluginValue);
       expect(result).toEqual({
         name: 'key-auth',
+        tags: ['OAS3_import'],
         config: {
-          tags: ['OAS3_import'],
           key_names: ['x-api-key'],
         },
       });
@@ -59,8 +59,8 @@ describe('plugins', () => {
       const result = generatePlugin(pluginKey, pluginValue);
       expect(result).toEqual({
         name: 'key-auth',
+        tags: ['OAS3_import'],
         config: {
-          tags: ['OAS3_import'],
           key_names: ['x-api-key'],
         },
       });

--- a/packages/openapi-2-kong/src/declarative-config/__tests__/services.test.js
+++ b/packages/openapi-2-kong/src/declarative-config/__tests__/services.test.js
@@ -230,6 +230,7 @@ describe('services', () => {
               plugins: [
                 {
                   name: 'key-auth',
+                  tags: ['OAS3_import'],
                   // should apply path plugin
                   config: { key_names: ['path'] },
                 },
@@ -244,6 +245,7 @@ describe('services', () => {
               plugins: [
                 {
                   name: 'key-auth',
+                  tags: ['OAS3_import'],
                   // should apply path plugin
                   config: { key_names: ['operation'] },
                 },

--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -25,11 +25,15 @@ export function generatePlugins(item: Object, generator: GeneratorFn): Array<DCP
 export function generatePlugin(key: string, value: Object): DCPlugin {
   const plugin: DCPlugin = {
     name: value.name || getPluginNameFromKey(key),
-    config: value.config ? value.config : { tags: [''] },
+    config: value.config ? value.config : {},
   };
-
   // Add tags to plugins while appending defaults tags
-  plugin.config.tags ? plugin.config.tags.push(...defaultTags) : (plugin.config.tags = defaultTags);
+  // make flow happy
+  if (!plugin.config) {
+    plugin.config = {};
+  }
+
+  plugin.config.tags = plugin.config.tags ? defaultTags.concat(plugin.config.tags) : defaultTags;
 
   return plugin;
 }

--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -25,7 +25,7 @@ export function generatePlugins(item: Object, generator: GeneratorFn): Array<DCP
 export function generatePlugin(key: string, value: Object): DCPlugin {
   const plugin: DCPlugin = {
     name: value.name || getPluginNameFromKey(key),
-    config: value.config ? value.config : {},
+    config: value.config,
   };
   // Add tags to plugins while appending defaults tags
   // make flow happy

--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { getPluginNameFromKey, isPluginKey } from '../common';
+import { getPluginNameFromKey, isPluginKey, defaultTags } from '../common';
 
 export function isRequestValidatorPluginKey(key: string): boolean {
   return key.match(/-request-validator$/) != null;
@@ -25,11 +25,11 @@ export function generatePlugins(item: Object, generator: GeneratorFn): Array<DCP
 export function generatePlugin(key: string, value: Object): DCPlugin {
   const plugin: DCPlugin = {
     name: value.name || getPluginNameFromKey(key),
+    config: value.config ? value.config : { tags: [''] },
   };
 
-  if (value.config) {
-    plugin.config = value.config;
-  }
+  // Add tags to plugins while appending defaults tags
+  plugin.config.tags ? plugin.config.tags.push(...defaultTags) : (plugin.config.tags = defaultTags);
 
   return plugin;
 }

--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -25,15 +25,12 @@ export function generatePlugins(item: Object, generator: GeneratorFn): Array<DCP
 export function generatePlugin(key: string, value: Object): DCPlugin {
   const plugin: DCPlugin = {
     name: value.name || getPluginNameFromKey(key),
+    tags: value.tags,
     config: value.config,
   };
-  // Add tags to plugins while appending defaults tags
-  // make flow happy
-  if (!plugin.config) {
-    plugin.config = {};
-  }
 
-  plugin.config.tags = plugin.config.tags ? defaultTags.concat(plugin.config.tags) : defaultTags;
+  // Add tags to plugins while appending defaults tags
+  plugin.tags = plugin.tags ? defaultTags.concat(plugin.tags) : defaultTags;
 
   return plugin;
 }

--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -25,12 +25,14 @@ export function generatePlugins(item: Object, generator: GeneratorFn): Array<DCP
 export function generatePlugin(key: string, value: Object): DCPlugin {
   const plugin: DCPlugin = {
     name: value.name || getPluginNameFromKey(key),
-    tags: value.tags,
-    config: value.config,
   };
 
+  if (value.config) {
+    plugin.config = value.config;
+  }
+
   // Add tags to plugins while appending defaults tags
-  plugin.tags = plugin.tags ? defaultTags.concat(plugin.tags) : defaultTags;
+  plugin.tags = [...defaultTags, ...(value.tags ?? [])];
 
   return plugin;
 }

--- a/packages/openapi-2-kong/src/index.js
+++ b/packages/openapi-2-kong/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 import fs from 'fs';
 import path from 'path';
+import { defaultTags } from './common';
 import { generateDeclarativeConfigFromSpec } from './declarative-config';
 import { generateKongForKubernetesConfigFromSpec } from './kubernetes';
 import SwaggerParser from 'swagger-parser';
@@ -30,7 +31,7 @@ export async function generateFromString(
   tags: Array<string> = [],
 ): Promise<ConversionResult> {
   const api: OpenApi3Spec = await parseSpec(specStr);
-  return generateFromSpec(api, type, ['OAS3_import', ...tags]);
+  return generateFromSpec(api, type, [defaultTags.join(), ...tags]);
 }
 
 export function generateFromSpec(

--- a/packages/openapi-2-kong/src/index.js
+++ b/packages/openapi-2-kong/src/index.js
@@ -31,7 +31,7 @@ export async function generateFromString(
   tags: Array<string> = [],
 ): Promise<ConversionResult> {
   const api: OpenApi3Spec = await parseSpec(specStr);
-  return generateFromSpec(api, type, [defaultTags.join(), ...tags]);
+  return generateFromSpec(api, type, [...defaultTags, ...tags]);
 }
 
 export function generateFromSpec(

--- a/packages/openapi-2-kong/types/declarative-config.flow.js
+++ b/packages/openapi-2-kong/types/declarative-config.flow.js
@@ -3,6 +3,7 @@
 declare type DCPlugin = {|
   name: string,
   enabled?: boolean,
+  tags?: Array<string>,
   config?: {
     [string]: Object,
   },


### PR DESCRIPTION
Abstracting out our default 'OAS3_import' tag to be re-used, applying custom tags to plugins while including the default OAS3_import tag.

![2021-04-19 14 19 01](https://user-images.githubusercontent.com/52717970/115284121-44c64c00-a11a-11eb-8d25-9982e67cacbb.gif)

Fixes INS-611, closes https://github.com/Kong/insomnia/issues/2682

