### PR TITLE
Plugin API: Add getHeaders method to context.response

### DIFF
--- a/packages/insomnia-app/app/plugins/context/__tests__/response.test.js
+++ b/packages/insomnia-app/app/plugins/context/__tests__/response.test.js
@@ -15,6 +15,7 @@ describe('init()', () => {
       'getBodyStream',
       'getBytesRead',
       'getHeader',
+      'getHeaders',
       'getRequestId',
       'getStatusCode',
       'getStatusMessage',
@@ -70,6 +71,11 @@ describe('response.*', () => {
       ],
     };
     const result = plugin.init(response);
+    expect(result.response.getHeaders()).toEqual([
+      { name: 'content-type', value: 'application/json' },
+      { name: 'set-cookie', value: 'foo=bar' },
+      { name: 'set-cookie', value: 'baz=qux' },
+    ]);
     expect(result.response.getHeader('Does-Not-Exist')).toBeNull();
     expect(result.response.getHeader('CONTENT-TYPE')).toBe('application/json');
     expect(result.response.getHeader('set-cookie')).toEqual(['foo=bar', 'baz=qux']);

--- a/packages/insomnia-app/app/plugins/context/response.js
+++ b/packages/insomnia-app/app/plugins/context/response.js
@@ -68,6 +68,12 @@ export function init(response: MaybeResponse): { response: Object } {
           return null;
         }
       },
+      getHeaders(): Array<{ name: string, value: string }> {
+        return response.headers.map(h => ({
+          name: h.name,
+          value: h.value,
+        }));
+      },
       hasHeader(name: string): boolean {
         return this.getHeader(name) !== null;
       },


### PR DESCRIPTION
- This closes #3282
- The method is based on the `context.request.getHeaders` method
- Test file was also modified to verify this method. Passed all tests
- Ran the Insomnia app with a plugin. It all works as expected
