### PR TITLE
chore(o2k) better error message

### DIFF
--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -44,7 +44,12 @@ export function generateRequestValidatorPlugin(obj: Object, operation: OA3Operat
   if (operation.parameters) {
     for (const p of operation.parameters) {
       if (!(p: Object).schema) {
-        throw new Error("Parameter using 'content' type validation is not supported");
+        if ((p: Object).content) {
+          throw new Error("Parameter validation of type 'content' is not supported");
+        }
+        throw new Error(
+          "Parameter validation requires either 'schema' or 'content' (only 'schema' is supported)",
+        );
       }
       config.parameter_schema.push({
         in: (p: Object).in,


### PR DESCRIPTION
Parameter validation requires either 'schema' or 'content' to be set.
The validation assumed that if it wasn't 'schema', it was automatically
'content'. This change provides a better error message.
