### PR TITLE
fix(o2k) update path param regex to match 1 segment only

### DIFF
--- a/packages/openapi-2-kong/src/__fixtures__/httpbin.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/httpbin.expected.json
@@ -18,21 +18,21 @@
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-basic_auth_user_password-get",
           "plugins": [{"config": {"hide_credentials": true}, "name": "basic-auth"}],
-          "paths": ["\/basic-auth\/(?<user>\\S+)\/(?<password>\\S+)$"]
+          "paths": ["\/basic-auth\/(?<user>[^\\\/\\s]+)\/(?<password>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-image_format-get",
-          "paths": ["\/image\/(?<format>\\S+)$"]
+          "paths": ["\/image\/(?<format>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-delay_n-get",
-          "paths": ["\/delay\/(?<n>\\S+)$"]
+          "paths": ["\/delay\/(?<n>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
@@ -46,35 +46,35 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-status_statusCode-delete",
-          "paths": ["\/status\/(?<statusCode>\\S+)$"]
+          "paths": ["\/status\/(?<statusCode>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["PUT"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-status_statusCode-put",
-          "paths": ["\/status\/(?<statusCode>\\S+)$"]
+          "paths": ["\/status\/(?<statusCode>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["PATCH"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-status_statusCode-patch",
-          "paths": ["\/status\/(?<statusCode>\\S+)$"]
+          "paths": ["\/status\/(?<statusCode>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["POST"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-status_statusCode-post",
-          "paths": ["\/status\/(?<statusCode>\\S+)$"]
+          "paths": ["\/status\/(?<statusCode>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-status_statusCode-get",
-          "paths": ["\/status\/(?<statusCode>\\S+)$"]
+          "paths": ["\/status\/(?<statusCode>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
@@ -89,7 +89,7 @@
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-hidden_basic_auth_user_password-get",
           "plugins": [{"config": {"hide_credentials": true}, "name": "basic-auth"}],
-          "paths": ["\/hidden-basic-auth\/(?<user>\\S+)\/(?<password>\\S+)$"]
+          "paths": ["\/hidden-basic-auth\/(?<user>[^\\\/\\s]+)\/(?<password>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
@@ -139,7 +139,7 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-parse_machine_timestamp-get",
-          "paths": ["\/parse\/(?<machine_timestamp>\\S+)$"]
+          "paths": ["\/parse\/(?<machine_timestamp>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["POST"],
@@ -186,7 +186,7 @@
               "enabled": true
             }
           ],
-          "paths": ["\/when\/(?<human_timestamp>\\S+)$"]
+          "paths": ["\/when\/(?<human_timestamp>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],

--- a/packages/openapi-2-kong/src/__fixtures__/link-example.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/link-example.expected.json
@@ -10,28 +10,28 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "getUserByName",
-          "paths": ["\/2.0\/users\/(?<username>\\S+)$"]
+          "paths": ["\/2.0\/users\/(?<username>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "getRepositoriesByOwner",
-          "paths": ["\/2.0\/repositories\/(?<username>\\S+)$"]
+          "paths": ["\/2.0\/repositories\/(?<username>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "getRepository",
-          "paths": ["\/2.0\/repositories\/(?<username>\\S+)\/(?<slug>\\S+)$"]
+          "paths": ["\/2.0\/repositories\/(?<username>[^\\\/\\s]+)\/(?<slug>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "getPullRequestsByRepository",
-          "paths": ["\/2.0\/repositories\/(?<username>\\S+)\/(?<slug>\\S+)\/pullrequests$"]
+          "paths": ["\/2.0\/repositories\/(?<username>[^\\\/\\s]+)\/(?<slug>[^\\\/\\s]+)\/pullrequests$"]
         },
         {
           "methods": ["GET"],
@@ -39,7 +39,7 @@
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "getPullRequestsById",
           "paths": [
-            "\/2.0\/repositories\/(?<username>\\S+)\/(?<slug>\\S+)\/pullrequests\/(?<pid>\\S+)$"
+            "\/2.0\/repositories\/(?<username>[^\\\/\\s]+)\/(?<slug>[^\\\/\\s]+)\/pullrequests\/(?<pid>[^\\\/\\s]+)$"
           ]
         },
         {
@@ -48,7 +48,7 @@
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "mergePullRequest",
           "paths": [
-            "\/2.0\/repositories\/(?<username>\\S+)\/(?<slug>\\S+)\/pullrequests\/(?<pid>\\S+)\/merge$"
+            "\/2.0\/repositories\/(?<username>[^\\\/\\s]+)\/(?<slug>[^\\\/\\s]+)\/pullrequests\/(?<pid>[^\\\/\\s]+)\/merge$"
           ]
         }
       ],

--- a/packages/openapi-2-kong/src/__fixtures__/petstore-expanded.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/petstore-expanded.expected.json
@@ -24,14 +24,14 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore-expanded.yaml"],
           "name": "find pet by id",
-          "paths": ["\/pets\/(?<id>\\S+)$"]
+          "paths": ["\/pets\/(?<id>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["DELETE"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore-expanded.yaml"],
           "name": "deletePet",
-          "paths": ["\/pets\/(?<id>\\S+)$"]
+          "paths": ["\/pets\/(?<id>[^\\\/\\s]+)$"]
         }
       ],
       "tags": ["OAS3_import", "OAS3file_petstore-expanded.yaml"]

--- a/packages/openapi-2-kong/src/__fixtures__/petstore.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/petstore.expected.json
@@ -24,7 +24,7 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore.yaml"],
           "name": "showPetById",
-          "paths": ["\/pets\/(?<petId>\\S+)$"]
+          "paths": ["\/pets\/(?<petId>[^\\\/\\s]+)$"]
         }
       ],
       "tags": ["OAS3_import", "OAS3file_petstore.yaml"]

--- a/packages/openapi-2-kong/src/__fixtures__/uspto.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/uspto.expected.json
@@ -17,14 +17,14 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_uspto.yaml"],
           "name": "list-searchable-fields",
-          "paths": ["\/(?<dataset>\\S+)\/(?<version>\\S+)\/fields$"]
+          "paths": ["\/(?<dataset>[^\\\/\\s]+)\/(?<version>[^\\\/\\s]+)\/fields$"]
         },
         {
           "methods": ["POST"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_uspto.yaml"],
           "name": "perform-search",
-          "paths": ["\/(?<dataset>\\S+)\/(?<version>\\S+)\/records$"]
+          "paths": ["\/(?<dataset>[^\\\/\\s]+)\/(?<version>[^\\\/\\s]+)\/records$"]
         }
       ],
       "tags": ["OAS3_import", "OAS3file_uspto.yaml"]

--- a/packages/openapi-2-kong/src/__tests__/common.test.js
+++ b/packages/openapi-2-kong/src/__tests__/common.test.js
@@ -187,7 +187,9 @@ describe('common', () => {
 
   describe('pathVariablesToRegex()', () => {
     it('converts variables to regex path', () => {
-      expect(pathVariablesToRegex('/foo/{bar}/{baz}')).toBe('/foo/(?<bar>\\S+)/(?<baz>\\S+)$');
+      expect(pathVariablesToRegex('/foo/{bar}/{baz}')).toBe(
+        '/foo/(?<bar>[^\\/\\s]+)/(?<baz>[^\\/\\s]+)$',
+      );
     });
 
     it('does not convert to regex if no variables present', () => {

--- a/packages/openapi-2-kong/src/common.js
+++ b/packages/openapi-2-kong/src/common.js
@@ -68,7 +68,8 @@ export function generateSlug(str: string, options: SlugifyOptions = {}): string 
 const pathVariableSearchValue = /{([^}]+)}(?!:\/\/)/g;
 
 export function pathVariablesToRegex(p: string): string {
-  const result = p.replace(pathVariableSearchValue, '(?<$1>\\S+)');
+  // match anything except whitespace and '/'
+  const result = p.replace(pathVariableSearchValue, '(?<$1>[^\\/\\s]+)');
   // add a line ending because it is a regex
   return result + '$';
 }

--- a/packages/openapi-2-kong/src/declarative-config/__tests__/services.test.js
+++ b/packages/openapi-2-kong/src/declarative-config/__tests__/services.test.js
@@ -59,7 +59,7 @@ describe('services', () => {
               name: 'My_API-birds_id-get',
               strip_path: false,
               methods: ['GET'],
-              paths: ['/birds/(?<id>\\S+)$'],
+              paths: ['/birds/(?<id>[^\\/\\s]+)$'],
               tags: ['Tag'],
             },
           ],


### PR DESCRIPTION
existing regex `\S+` is equivalent to `[^\s]+` by adding the `/` character as not allowed, we limit the regex to match only 1 path segment

This path: `/tracks/{hello}/world/{there}`
Would create: `/tracks/(?<hello>\S+)/world/(?<there>\S+)$`

When published, this path matches `/tracks/xxx/world/yyy` as it should
With captures:
  `hello`: `xxx`
  `there`: yyy

This path also matches `/tracks/xxx/zzz/world/yyy/andthensome` but it should not
With captures:
  `hello`: `xxx/zzz`
  `there`: `yyy/andthensome`

The last one should have matched only a single path segment, but actually matches multiple.