### PR TITLE
Publish NPM packages through CI

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -46,7 +46,11 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - run: npm run bootstrap
-      - run: npm run publish
+      - run: |
+          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          npm run publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN}}
   Windows:
     needs: [ npm ]
     name: Windows

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -14,7 +14,27 @@ env:
   NPM_CONFIG_RUNTIME: electron
 
 jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ macos-latest, windows-latest, ubuntu-latest ]
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v1
+      - name: Read Node version from .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
+      - name: Bootstrap packages
+        run: npm run bootstrap
+      - name: Run tests
+        run: npm test
   npm:
+    needs: [ test ]
     name: npm
     runs-on: ubuntu-latest
     steps:
@@ -26,7 +46,6 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - run: npm run bootstrap
-      - run: npm run test
       - run: npm run publish
   Windows:
     needs: [ npm ]

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -14,7 +14,22 @@ env:
   NPM_CONFIG_RUNTIME: electron
 
 jobs:
+  npm:
+    name: npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Read Node version from .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
+      - run: npm run bootstrap
+      - run: npm run test
+      - run: npm run publish
   Windows:
+    needs: [ npm ]
     name: Windows
     runs-on: windows-2016
     steps:
@@ -26,12 +41,12 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - run: npm run bootstrap
-      - run: npm run test:pre-release
       - run: npm run app-release
         env:
           CSC_LINK: ${{ secrets.CORE_WINDOWS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CORE_WINDOWS_CSC_KEY_PASSWORD }}
   Mac:
+    needs: [ npm ]
     name: Mac
     runs-on: macos-latest
     steps:
@@ -43,7 +58,6 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - run: npm run bootstrap
-      - run: npm run test:pre-release
       - run: npm run app-release
         env:
           APPLE_ID: ${{ secrets.DESIGNER_APPLE_ID }}
@@ -51,6 +65,7 @@ jobs:
           CSC_LINK: ${{ secrets.DESIGNER_MAC_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.DESIGNER_MAC_CSC_KEY_PASSWORD }}
   Linux:
+    needs: [ npm ]
     name: Linux
     runs-on: ubuntu-latest
     steps:
@@ -65,7 +80,6 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - run: npm run bootstrap
-      - run: npm run test:pre-release
       - run: npm run app-release
         env:
           BUILD_TARGETS: AppImage,deb,tar.gz,rpm,snap


### PR DESCRIPTION
What it says on the tin. The updated release workflow will:
- run tests on all OSs
- then, publish NPM packages
- then, release each OS bundle

Closes INS-630