### PR TITLE
[o2k] fix name generation

### DIFF
--- a/packages/openapi-2-kong/src/__fixtures__/api-with-examples.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/api-with-examples.expected.json
@@ -16,14 +16,14 @@
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_api-with-examples.yaml"],
-          "name": "x_kong_name_override_at_method",
+          "name": "Simple_API_overview-x_kong_name_override_at_method",
           "paths": ["/$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_api-with-examples.yaml"],
-          "name": "getVersionDetailsv2",
+          "name": "Simple_API_overview-getVersionDetailsv2",
           "paths": ["/v2$"]
         }
       ],

--- a/packages/openapi-2-kong/src/__fixtures__/link-example.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/link-example.expected.json
@@ -12,35 +12,35 @@
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
-          "name": "getUserByName",
+          "name": "Link_Example-getUserByName",
           "paths": ["\/2.0\/users\/(?<username>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
-          "name": "getRepositoriesByOwner",
+          "name": "Link_Example-getRepositoriesByOwner",
           "paths": ["\/2.0\/repositories\/(?<username>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
-          "name": "getRepository",
+          "name": "Link_Example-getRepository",
           "paths": ["\/2.0\/repositories\/(?<username>[^\\\/\\s]+)\/(?<slug>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
-          "name": "getPullRequestsByRepository",
+          "name": "Link_Example-getPullRequestsByRepository",
           "paths": ["\/2.0\/repositories\/(?<username>[^\\\/\\s]+)\/(?<slug>[^\\\/\\s]+)\/pullrequests$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
-          "name": "getPullRequestsById",
+          "name": "Link_Example-getPullRequestsById",
           "paths": [
             "\/2.0\/repositories\/(?<username>[^\\\/\\s]+)\/(?<slug>[^\\\/\\s]+)\/pullrequests\/(?<pid>[^\\\/\\s]+)$"
           ]
@@ -49,7 +49,7 @@
           "methods": ["POST"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
-          "name": "mergePullRequest",
+          "name": "Link_Example-mergePullRequest",
           "paths": [
             "\/2.0\/repositories\/(?<username>[^\\\/\\s]+)\/(?<slug>[^\\\/\\s]+)\/pullrequests\/(?<pid>[^\\\/\\s]+)\/merge$"
           ]

--- a/packages/openapi-2-kong/src/__fixtures__/no-targets-example.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/no-targets-example.expected.json
@@ -12,14 +12,14 @@
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_no-targets-example.yaml"],
-          "name": "x_kong_name_override_at_method",
+          "name": "Simple_API_overview-x_kong_name_override_at_method",
           "paths": ["/$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_no-targets-example.yaml"],
-          "name": "getVersionDetailsv2",
+          "name": "Simple_API_overview-getVersionDetailsv2",
           "paths": ["/v2$"]
         }
       ],

--- a/packages/openapi-2-kong/src/__fixtures__/petstore-expanded.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/petstore-expanded.expected.json
@@ -12,28 +12,28 @@
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore-expanded.yaml"],
-          "name": "findPets",
+          "name": "Swagger_Petstore-findPets",
           "paths": ["/pets$"]
         },
         {
           "methods": ["POST"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore-expanded.yaml"],
-          "name": "addPet",
+          "name": "Swagger_Petstore-addPet",
           "paths": ["/pets$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore-expanded.yaml"],
-          "name": "find pet by id",
+          "name": "Swagger_Petstore-find_pet_by_id",
           "paths": ["\/pets\/(?<id>[^\\\/\\s]+)$"]
         },
         {
           "methods": ["DELETE"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore-expanded.yaml"],
-          "name": "deletePet",
+          "name": "Swagger_Petstore-deletePet",
           "paths": ["\/pets\/(?<id>[^\\\/\\s]+)$"]
         }
       ],

--- a/packages/openapi-2-kong/src/__fixtures__/petstore.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/petstore.expected.json
@@ -12,21 +12,21 @@
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore.yaml"],
-          "name": "listPets",
+          "name": "Swagger_Petstore-listPets",
           "paths": ["/pets$"]
         },
         {
           "methods": ["POST"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore.yaml"],
-          "name": "createPets",
+          "name": "Swagger_Petstore-createPets",
           "paths": ["/pets$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore.yaml"],
-          "name": "showPetById",
+          "name": "Swagger_Petstore-showPetById",
           "paths": ["\/pets\/(?<petId>[^\\\/\\s]+)$"]
         }
       ],

--- a/packages/openapi-2-kong/src/__fixtures__/uspto.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/uspto.expected.json
@@ -12,21 +12,21 @@
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_uspto.yaml"],
-          "name": "list-data-sets",
+          "name": "USPTO_Data_Set_API-list_data_sets",
           "paths": ["/$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_uspto.yaml"],
-          "name": "list-searchable-fields",
+          "name": "USPTO_Data_Set_API-list_searchable_fields",
           "paths": ["\/(?<dataset>[^\\\/\\s]+)\/(?<version>[^\\\/\\s]+)\/fields$"]
         },
         {
           "methods": ["POST"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_uspto.yaml"],
-          "name": "perform-search",
+          "name": "USPTO_Data_Set_API-perform_search",
           "paths": ["\/(?<dataset>[^\\\/\\s]+)\/(?<version>[^\\\/\\s]+)\/records$"]
         }
       ],

--- a/packages/openapi-2-kong/src/declarative-config/__tests__/names.test.js
+++ b/packages/openapi-2-kong/src/declarative-config/__tests__/names.test.js
@@ -27,7 +27,7 @@ const compare = (expected: string, pathItem: OA3PathItem) => {
 
 describe('names', () => {
   it(`api.paths[path][method]['x-kong-name'] is highest priority`, () => {
-    compare('method_smash', {
+    compare('Nebulo_9-method_smash', {
       'x-kong-name': 'pathItem-smash',
       post: {
         'x-kong-name': 'method-smash',
@@ -37,7 +37,7 @@ describe('names', () => {
   });
 
   it('api.paths[path][method].operationId is second priority (and not slugified)', () => {
-    compare('operationId-smash', {
+    compare('Nebulo_9-operationId_smash', {
       'x-kong-name': 'pathItem-smash',
       post: {
         operationId: 'operationId-smash',

--- a/packages/openapi-2-kong/src/declarative-config/services.js
+++ b/packages/openapi-2-kong/src/declarative-config/services.js
@@ -157,11 +157,13 @@ export function generateRouteName(
   const pathItem = api.paths[routePath];
 
   if (pathItem[method] && typeof pathItem[method]['x-kong-name'] === 'string') {
-    return generateSlug(pathItem[method]['x-kong-name']);
+    const opsName = generateSlug(pathItem[method]['x-kong-name']);
+    return `${name}-${opsName}`;
   }
 
   if (pathItem[method] && pathItem[method].operationId) {
-    return pathItem[method].operationId;
+    const opsName = generateSlug(pathItem[method].operationId);
+    return `${name}-${opsName}`;
   }
 
   // replace all `/` with `-` except the ones at the beginng or end of a string


### PR DESCRIPTION
1. OperationId was not slugified, which could cause illegal names
2. OperationId and x-kong-name on operation level were not prefixed with the spec name

wrt 2; OperationId is required to be unique within a spec, yet since multiple specs are combined within Kong installation, we prefix them by the spec name to prevent accidental name collisions.

Closes INS-652
