### PR TITLE
[o2k] add defaults for services & upstreams

### DIFF
--- a/packages/openapi-2-kong/README.md
+++ b/packages/openapi-2-kong/README.md
@@ -147,7 +147,7 @@ services:
   - ...
     routes:
       - name: ApiName-create-pet         # Taken from x-kong-name, summary, or generated
-        strip_path: true                 # Always `true`
+        strip_path: false                # Defaults to `false`
         methods: [ PUT ]                 # Only ever a single-entry array
         paths: [ '\/pets/(?<id>\S+)$' ]  # Kong regex-formatted path with variables
         tags: [ Tag ]                    # <documented later>

--- a/packages/openapi-2-kong/src/__fixtures__/api-with-examples.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/api-with-examples.expected.json
@@ -6,6 +6,10 @@
       "port": 80,
       "path": "/path",
       "name": "Simple_API_overview",
+      "retries": 10,
+      "connect_timeout": 30000,
+      "write_timeout": 30000,
+      "read_timeout": 30000,
       "plugins": [],
       "routes": [
         {

--- a/packages/openapi-2-kong/src/__fixtures__/api-with-examples.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/api-with-examples.expected.json
@@ -34,6 +34,16 @@
     {
       "tags": ["OAS3_import", "OAS3file_api-with-examples.yaml"],
       "name": "Simple_API_overview",
+      "hash_on": "ip",
+      "healthchecks": {
+        "passive": {
+          "unhealthy": {
+            "http_failures": 3,
+            "tcp_failures": 3,
+            "timeouts": 3
+          }
+        }
+      },
       "targets": [{"target": "backend.com:80"}]
     }
   ],

--- a/packages/openapi-2-kong/src/__fixtures__/api-with-examples.yaml
+++ b/packages/openapi-2-kong/src/__fixtures__/api-with-examples.yaml
@@ -9,6 +9,14 @@ x-kong-service-defaults:
   connect_timeout: 30000
   write_timeout: 30000
   read_timeout: 30000
+x-kong-upstream-defaults:
+  hash_on: ip
+  healthchecks:
+    passive:
+      unhealthy:
+        http_failures: 3
+        tcp_failures: 3
+        timeouts: 3
 paths:
   /:
     x-kong-name: x-kong-name-override-at-path-item

--- a/packages/openapi-2-kong/src/__fixtures__/api-with-examples.yaml
+++ b/packages/openapi-2-kong/src/__fixtures__/api-with-examples.yaml
@@ -4,6 +4,11 @@ info:
   version: v2
 servers:
   - url: http://backend.com/path
+x-kong-service-defaults:
+  retries: 10
+  connect_timeout: 30000
+  write_timeout: 30000
+  read_timeout: 30000
 paths:
   /:
     x-kong-name: x-kong-name-override-at-path-item

--- a/packages/openapi-2-kong/src/declarative-config/services.js
+++ b/packages/openapi-2-kong/src/declarative-config/services.js
@@ -64,8 +64,22 @@ export function generateService(
     tags,
   };
 
+  // x-kong-route-defaults is free format so we do not want type checking.
+  // If added, it would tightly couple these objects to Kong, and that would
+  // make future maintenance a lot harder.
+  // $FlowFixMe
+  const routeDefaultsRoot = api['x-kong-route-defaults'] || {};
+  if (typeof routeDefaultsRoot !== 'object') {
+    throw new Error(`expected root-level 'x-kong-route-defaults' to be an object`);
+  }
+
   for (const routePath of Object.keys(api.paths)) {
     const pathItem: OA3PathItem = api.paths[routePath];
+    // $FlowFixMe
+    const routeDefaultsPath = api.paths[routePath]['x-kong-route-defaults'] || routeDefaultsRoot;
+    if (typeof routeDefaultsPath !== 'object') {
+      throw new Error(`expected 'x-kong-route-defaults' to be an object (at path '${routePath}')`);
+    }
 
     const pathValidatorPlugin = getRequestValidatorPluginDirective(pathItem);
     const pathPlugins = generatePathPlugins(pathItem);
@@ -85,6 +99,13 @@ export function generateService(
       }
 
       const operation: ?OA3Operation = pathItem[method];
+      // $FlowFixMe
+      const routeDefaultsOperation = pathItem[method]['x-kong-route-defaults'] || routeDefaultsPath;
+      if (typeof routeDefaultsOperation !== 'object') {
+        throw new Error(
+          `expected 'x-kong-route-defaults' to be an object (at operation '${method}' of path '${routePath}')`,
+        );
+      }
 
       // This check is here to make Flow happy
       if (!operation) {
@@ -93,13 +114,22 @@ export function generateService(
 
       // Create the base route object
       const fullPathRegex = pathVariablesToRegex(routePath);
+
+      // $FlowFixMe
       const route: DCRoute = {
+        ...routeDefaultsOperation,
         tags,
         name: generateRouteName(api, routePath, method),
         methods: [method.toUpperCase()],
         paths: [fullPathRegex],
-        strip_path: false,
       };
+
+      if (typeof route.strip_path === 'undefined') {
+        // must override the Kong default of 'true' since we match based on
+        // full path regexes, which would lead Kong to always strip the full
+        // path down to a single '/' if it used that default.
+        route.strip_path = false;
+      }
 
       // Generate generic and security-related plugin objects
       const securityPlugins = generateSecurityPlugins(operation, api);

--- a/packages/openapi-2-kong/src/declarative-config/services.js
+++ b/packages/openapi-2-kong/src/declarative-config/services.js
@@ -42,7 +42,17 @@ export function generateService(
   // Service plugins
   const globalPlugins = generateGlobalPlugins(api);
 
+  // x-kong-service-defaults is free format so we do not want type checking.
+  // If added, it would tightly couple these objects to Kong, and that would
+  // make future maintenance a lot harder.
+  // $FlowFixMe
+  const serviceDefaults = api['x-kong-service-defaults'] || {};
+  if (typeof serviceDefaults !== 'object') {
+    throw new Error(`expected 'x-kong-service-defaults' to be an object`);
+  }
+
   const service: DCService = {
+    ...serviceDefaults,
     name,
     // remove semicolon ie. convert https: to https
     protocol: parsedUrl.protocol.substring(0, parsedUrl.protocol.length - 1),

--- a/packages/openapi-2-kong/src/declarative-config/upstreams.js
+++ b/packages/openapi-2-kong/src/declarative-config/upstreams.js
@@ -9,7 +9,17 @@ export function generateUpstreams(api: OpenApi3Spec, tags: Array<string>) {
     return [];
   }
 
+  // x-kong-upstream-defaults is free format so we do not want type checking.
+  // If added, it would tightly couple these objects to Kong, and that would
+  // make future maintenance a lot harder.
+  // $FlowFixMe
+  const upstreamDefaults = api['x-kong-upstream-defaults'] || {};
+  if (typeof upstreamDefaults !== 'object') {
+    throw new Error(`expected 'x-kong-upstream-defaults' to be an object`);
+  }
+
   const upstream: DCUpstream = {
+    ...upstreamDefaults,
     name: getName(api),
     targets: [],
     tags,

--- a/packages/openapi-2-kong/types/openapi3.flow.js
+++ b/packages/openapi-2-kong/types/openapi3.flow.js
@@ -4,10 +4,6 @@ declare type XKongName = {
   'x-kong-name'?: string,
 };
 
-declare type XKongUpstreamDefaults = {
-  'x-kong-upstream-defaults'?: DCUpstream,
-};
-
 declare type OA3Info = {|
   title: string,
   version: string,
@@ -217,8 +213,7 @@ declare type OpenApi3Spec = {
   security?: Array<OA3SecurityRequirement>,
   tags?: Array<string>,
   externalDocs?: OA3ExternalDocs,
-} & XKongName &
-  XKongUpstreamDefaults;
+} & XKongName;
 
 const HttpMethod = {
   get: 'GET',

--- a/packages/openapi-2-kong/types/openapi3.flow.js
+++ b/packages/openapi-2-kong/types/openapi3.flow.js
@@ -4,6 +4,10 @@ declare type XKongName = {
   'x-kong-name'?: string,
 };
 
+declare type XKongUpstreamDefaults = {
+  'x-kong-upstream-defaults'?: DCUpstream,
+};
+
 declare type OA3Info = {|
   title: string,
   version: string,
@@ -213,7 +217,8 @@ declare type OpenApi3Spec = {
   security?: Array<OA3SecurityRequirement>,
   tags?: Array<string>,
   externalDocs?: OA3ExternalDocs,
-} & XKongName;
+} & XKongName &
+  XKongUpstreamDefaults;
 
 const HttpMethod = {
   get: 'GET',


### PR DESCRIPTION
This adds support for 2 keys; `x-kong-service-defaults`, and `x-kong-upstream-defaults`.

This allows to configure specific techincal properties for the generated Kong configuration that cannot be derived from the OAS spec itself.

for example:
```yaml
openapi: "3.0.0"
info:
  title: Simple API overview
  version: v2
servers:
  - url: http://backend.com/path
x-kong-service-defaults:
  retries: 10
  connect_timeout: 30000
  write_timeout: 30000
  read_timeout: 30000
x-kong-upstream-defaults:
  hash_on: ip
  healthchecks:
    passive:
      unhealthy:
        http_failures: 3
        tcp_failures: 3
        timeouts: 3
paths:
  /:
    x-kong-name: x-kong-name-override-at-path-item
    get:
      x-kong-name: x-kong-name-override-at-method
      operationId: listVersionsv2
      summary: List API versions
 ```

closes INS-653

EDIT: also added a replacement commit for PR #3273, which fixes INS-122