### PR TITLE
[o2k] fix parameter default styles

### DIFF
--- a/packages/openapi-2-kong/src/__fixtures__/httpbin.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/httpbin.expected.json
@@ -177,7 +177,7 @@
                 "parameter_schema": [
                   {
                     "schema": "{\"anyOf\":[{\"type\":\"string\"}]}",
-                    "style": "form",
+                    "style": "simple",
                     "in": "path",
                     "name": "human_timestamp",
                     "required": true,

--- a/packages/openapi-2-kong/src/__fixtures__/request-validator-plugin.expected.json
+++ b/packages/openapi-2-kong/src/__fixtures__/request-validator-plugin.expected.json
@@ -77,9 +77,9 @@
           "methods": [
             "GET"
           ],
-          "name": "Example-params-get",
+          "name": "Example-params_pathid-get",
           "paths": [
-            "/params$"
+            "/params/(?<pathid>[^\\/\\s]+)/$"
           ],
           "plugins": [
             {
@@ -87,11 +87,35 @@
                 "parameter_schema": [
                   {
                     "explode": false,
-                    "in": "path",
-                    "name": "userId",
+                    "in": "query",
+                    "name": "queryid",
                     "required": true,
                     "schema": "{\"type\":\"integer\"}",
                     "style": "form"
+                  },
+                  {
+                    "explode": false,
+                    "in": "header",
+                    "name": "User-Id",
+                    "required": true,
+                    "schema": "{\"type\":\"integer\"}",
+                    "style": "simple"
+                  },
+                  {
+                    "explode": false,
+                    "in": "cookie",
+                    "name": "cookieid",
+                    "required": true,
+                    "schema": "{\"type\":\"integer\"}",
+                    "style": "form"
+                  },
+                  {
+                    "explode": false,
+                    "in": "path",
+                    "name": "pathid",
+                    "required": true,
+                    "schema": "{\"type\":\"integer\"}",
+                    "style": "simple"
                   }
                 ],
                 "version": "draft4"

--- a/packages/openapi-2-kong/src/__fixtures__/request-validator-plugin.yaml
+++ b/packages/openapi-2-kong/src/__fixtures__/request-validator-plugin.yaml
@@ -17,15 +17,30 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/jsonSchema'
-  /params:
+  /params/{pathid}/:
     get:
       x-kong-plugin-request-validator:
         enabled: true
         config:
           body_scheme: '{}'
       parameters:
+        - in: query
+          name: queryid
+          schema:
+            type: integer
+          required: true
+        - in: header
+          name: User-Id
+          schema:
+            type: integer
+          required: true
+        - in: cookie
+          name: cookieid
+          schema:
+            type: integer
+          required: true
         - in: path
-          name: userId
+          name: pathid
           schema:
             type: integer
           required: true

--- a/packages/openapi-2-kong/src/declarative-config/plugins.js
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.js
@@ -38,6 +38,13 @@ function generatePlugin([key, value]: [string, Object]): DCPlugin {
  */
 const ALLOW_ALL_SCHEMA = '{}';
 
+const DEFAULT_PARAM_STYLE = {
+  header: 'simple',
+  cookie: 'form',
+  query: 'form',
+  path: 'simple',
+};
+
 function generateParameterSchema(operation?: OA3Operation): Array<Object> | typeof undefined {
   let parameterSchema;
 
@@ -56,13 +63,19 @@ function generateParameterSchema(operation?: OA3Operation): Array<Object> | type
         schema = ALLOW_ALL_SCHEMA;
       }
 
+      const paramStyle = (p: Object).style ?? DEFAULT_PARAM_STYLE[(p: Object).in];
+      if (typeof paramStyle === 'undefined') {
+        const name = (p: Object).name;
+        throw new Error(`invalid 'in' property (parameter '${name}')`);
+      }
+
       parameterSchema.push({
         in: (p: Object).in,
         explode: !!(p: Object).explode,
         required: !!(p: Object).required,
         name: (p: Object).name,
         schema,
-        style: (p: Object).style ?? 'form',
+        style: paramStyle,
       });
     }
   }


### PR DESCRIPTION
PR #3256 changed the default style from "simple" to "form". But that is not correct, the default style depends on the type of parameter.

This PR corrects it and adds the proper style for each of the 4 types of parameters, as specified in the OAS docs here: https://swagger.io/docs/specification/serialization/

fixes INS-654