### PR TITLE
makes all package.json author fields consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "insomnia",
   "private": true,
   "version": "1.0.0",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia is a cross-platform REST client, built on top of Electron.",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia",

--- a/packages/insomnia-components/package.json
+++ b/packages/insomnia-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-components",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia UI component library",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/develop/packages/insomnia-components",

--- a/packages/insomnia-cookies/package.json
+++ b/packages/insomnia-cookies/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-cookies",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Cookie utilities",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/insomnia-importers/package.json
+++ b/packages/insomnia-importers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-importers",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Various data importers for Insomnia",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/packages/insomnia-importers",

--- a/packages/insomnia-prettify/package.json
+++ b/packages/insomnia-prettify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-prettify",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Prettification utilities for Insomnia",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -2,6 +2,7 @@
   "name": "insomnia-send-request",
   "license": "Apache-2.0",
   "version": "2.2.35",
+  "author": "Kong <office@konghq.com>",
   "main": "dist/index.js",
   "types": "dist/send-request/index.d.ts",
   "dependencies": {

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "insomnia-smoke-test",
+  "author": "Kong <office@konghq.com>",
   "license": "Apache-2.0",
   "version": "2.2.35",
   "type": "module",

--- a/packages/insomnia-testing/package.json
+++ b/packages/insomnia-testing/package.json
@@ -2,6 +2,7 @@
   "name": "insomnia-testing",
   "license": "Apache-2.0",
   "version": "2.2.35",
+  "author": "Kong <office@konghq.com>",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/insomnia-url/package.json
+++ b/packages/insomnia-url/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-url",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "URL Utilities",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/insomnia-xpath/package.json
+++ b/packages/insomnia-xpath/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-xpath",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Query XML using XPath",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/openapi-2-kong/package.json
+++ b/packages/openapi-2-kong/package.json
@@ -2,6 +2,7 @@
   "name": "openapi-2-kong",
   "license": "Apache-2.0",
   "version": "2.2.35",
+  "author": "Kong <office@konghq.com>",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/plugins/insomnia-plugin-base64/package.json
+++ b/plugins/insomnia-plugin-base64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-base64",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia base64 template tag",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-base64",

--- a/plugins/insomnia-plugin-cookie-jar/package.json
+++ b/plugins/insomnia-plugin-cookie-jar/package.json
@@ -2,6 +2,12 @@
   "name": "insomnia-plugin-cookie-jar",
   "version": "2.2.35",
   "author": "Kong <office@konghq.com>",
+  "contributors": [
+    {
+      "name": "Preston Alvarado",
+      "email": "pjalva1@hotmail.com"
+    }
+  ],
   "description": "Insomnia cookie jar template tag",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-cookie-jar",

--- a/plugins/insomnia-plugin-cookie-jar/package.json
+++ b/plugins/insomnia-plugin-cookie-jar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-cookie-jar",
   "version": "2.2.35",
-  "author": "Preston Alvarado <pjalva1@hotmail.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia cookie jar template tag",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-cookie-jar",

--- a/plugins/insomnia-plugin-core-themes/package.json
+++ b/plugins/insomnia-plugin-core-themes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-core-themes",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia core themes",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-core-themes",

--- a/plugins/insomnia-plugin-default-headers/package.json
+++ b/plugins/insomnia-plugin-default-headers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-default-headers",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Various data importers for Insomnia",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-default-headers",

--- a/plugins/insomnia-plugin-file/package.json
+++ b/plugins/insomnia-plugin-file/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-file",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia file templte tag",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-file",

--- a/plugins/insomnia-plugin-hash/package.json
+++ b/plugins/insomnia-plugin-hash/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-hash",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia hash template tag",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-hash",

--- a/plugins/insomnia-plugin-jsonpath/package.json
+++ b/plugins/insomnia-plugin-jsonpath/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-jsonpath",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Template tag to pull data from JSON strings",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-json-path",

--- a/plugins/insomnia-plugin-kong-bundle/package.json
+++ b/plugins/insomnia-plugin-kong-bundle/package.json
@@ -2,6 +2,7 @@
   "name": "insomnia-plugin-kong-bundle",
   "version": "2.2.35",
   "main": "index.js",
+  "author": "Kong <office@konghq.com>",
   "insomnia": {
     "name": "kong-bundle",
     "displayName": "Kong Plugin Bundle",

--- a/plugins/insomnia-plugin-kong-declarative-config/package.json
+++ b/plugins/insomnia-plugin-kong-declarative-config/package.json
@@ -2,6 +2,7 @@
   "name": "insomnia-plugin-kong-declarative-config",
   "version": "2.2.35",
   "main": "index.js",
+  "author": "Kong <office@konghq.com>",
   "insomnia": {
     "name": "kong-declarative-config",
     "description": "Generate Kong Declarative Config"

--- a/plugins/insomnia-plugin-kong-kubernetes-config/package.json
+++ b/plugins/insomnia-plugin-kong-kubernetes-config/package.json
@@ -2,6 +2,7 @@
   "name": "insomnia-plugin-kong-kubernetes-config",
   "version": "2.2.35",
   "main": "index.js",
+  "author": "Kong <office@konghq.com>",
   "insomnia": {
     "name": "kong-kubernetes-config",
     "description": "Generate Kong For Kubernetes configuration"

--- a/plugins/insomnia-plugin-kong-portal/package.json
+++ b/plugins/insomnia-plugin-kong-portal/package.json
@@ -2,6 +2,7 @@
   "name": "insomnia-plugin-kong-portal",
   "version": "2.2.35",
   "main": "dist/index.js",
+  "author": "Kong <office@konghq.com>",
   "scripts": {
     "build": "webpack --config webpack.config.js --display errors-only",
     "watch": "webpack --config webpack.config.js --watch",

--- a/plugins/insomnia-plugin-now/package.json
+++ b/plugins/insomnia-plugin-now/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-now",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia now template tag",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-now",

--- a/plugins/insomnia-plugin-os/package.json
+++ b/plugins/insomnia-plugin-os/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-os",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Template tag to get information about the OS",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-os",

--- a/plugins/insomnia-plugin-prompt/package.json
+++ b/plugins/insomnia-plugin-prompt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-prompt",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia prompt template tag",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-prompt",

--- a/plugins/insomnia-plugin-request/package.json
+++ b/plugins/insomnia-plugin-request/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-request",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia request template tag",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-request",

--- a/plugins/insomnia-plugin-response/package.json
+++ b/plugins/insomnia-plugin-response/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-response",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia response template tag",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-response",

--- a/plugins/insomnia-plugin-uuid/package.json
+++ b/plugins/insomnia-plugin-uuid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-uuid",
   "version": "2.2.35",
-  "author": "Gregory Schier <greg.schier@konghq.com>",
+  "author": "Kong <office@konghq.com>",
   "description": "Insomnia uuid template tag",
   "license": "MIT",
   "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-uuid",


### PR DESCRIPTION
While we were releasing, I noticed that Greg and his kong email (not a valid email now, anyway) was on many of the packages.  This PR fixes that and also adds it to any package I saw that was missing it.