### PR TITLE
o2k: reorder object members to prettify the yaml output

### DIFF
--- a/packages/openapi-2-kong/src/common.ts
+++ b/packages/openapi-2-kong/src/common.ts
@@ -175,3 +175,27 @@ export function distinctByProperty<T>(arr: T[], propertySelector: (item: T) => a
 
   return result;
 }
+
+/** reorders object members for nicer yaml output */
+export function reorderObjectMembers(objIn: any, first: string[], last: string[]): any {
+  const objOut = {};
+
+  first.forEach(propName => {
+    if (typeof objIn[propName] !== 'undefined') {
+      objOut[propName] = objIn[propName];
+    }
+  });
+
+  for (const [propName, value] of Object.entries(objIn)) {
+    if (typeof objOut[propName] === 'undefined' && !last.includes(propName)) {
+      objOut[propName] = value;
+    }
+  }
+
+  last.forEach(propName => {
+    if (typeof objIn[propName] !== 'undefined') {
+      objOut[propName] = objIn[propName];
+    }
+  });
+  return objOut;
+}

--- a/packages/openapi-2-kong/src/declarative-config/common.ts
+++ b/packages/openapi-2-kong/src/declarative-config/common.ts
@@ -1,0 +1,30 @@
+import { reorderObjectMembers } from '../common';
+import { DCPlugin, DCRoute, DCService, DCUpstream } from '../types/declarative-config';
+
+export function reorderService(service: DCService): DCService {
+  const first: string[] = ['name', 'protocol', 'host', 'port', 'path'];
+  const last: string[] = ['tags', 'plugins', 'routes'];
+  return reorderObjectMembers(service, first, last);
+}
+
+export function reorderUpstream(upstream: DCUpstream): DCUpstream {
+  const first: string[] = ['name'];
+  const last: string[] = ['tags', 'targets'];
+  return reorderObjectMembers(upstream, first, last);
+}
+
+export function reorderRoute(route: DCRoute): DCRoute {
+  const first: string[] = ['name', 'paths', 'methods'];
+  const last: string[] = ['tags', 'plugins'];
+  return reorderObjectMembers(route, first, last);
+}
+
+export function reorderPlugins(plugins: DCPlugin[]): DCPlugin[] {
+  const first: string[] = ['name'];
+  const last: string[] = ['tags', 'config'];
+  const pluginsOut: DCPlugin[] = [];
+  plugins.forEach(plugin => {
+    pluginsOut.push(reorderObjectMembers(plugin, first, last));
+  });
+  return pluginsOut;
+}

--- a/packages/openapi-2-kong/src/declarative-config/services.ts
+++ b/packages/openapi-2-kong/src/declarative-config/services.ts
@@ -16,6 +16,7 @@ import {
 } from './plugins';
 import { DCService, DCRoute } from '../types/declarative-config';
 import { OpenApi3Spec, OA3Server, OA3PathItem, OA3Operation } from '../types/openapi3';
+import { reorderService, reorderRoute, reorderPlugins } from './common';
 
 export function generateServices(api: OpenApi3Spec, tags: string[]) {
   const servers = getAllServers(api);
@@ -53,7 +54,7 @@ export function generateService(server: OA3Server, api: OpenApi3Spec, tags: stri
     // not a hostname, but the Upstream name
     port: Number(parsedUrl.port || '80'),
     path: parsedUrl.pathname,
-    plugins: globalPlugins.plugins,
+    plugins: reorderPlugins(globalPlugins.plugins),
     routes: [],
     tags,
   };
@@ -135,14 +136,14 @@ export function generateService(server: OA3Server, api: OpenApi3Spec, tags: stri
 
       // Add plugins if there are any
       if (plugins.length) {
-        route.plugins = plugins;
+        route.plugins = reorderPlugins(plugins);
       }
 
-      service.routes.push(route);
+      service.routes.push(reorderRoute(route));
     }
   }
 
-  return service;
+  return reorderService(service);
 }
 
 export function generateRouteName(

--- a/packages/openapi-2-kong/src/declarative-config/upstreams.ts
+++ b/packages/openapi-2-kong/src/declarative-config/upstreams.ts
@@ -1,6 +1,7 @@
 import { getName, parseUrl, fillServerVariables } from '../common';
 import { DCUpstream } from '../types/declarative-config';
 import { OpenApi3Spec } from '../types/openapi3';
+import { reorderUpstream } from './common';
 
 export function generateUpstreams(api: OpenApi3Spec, tags: string[]) {
   const servers = api.servers || [];
@@ -36,5 +37,5 @@ export function generateUpstreams(api: OpenApi3Spec, tags: string[]) {
     }
   }
 
-  return [upstream];
+  return [reorderUpstream(upstream)];
 }


### PR DESCRIPTION
The o2k output has the object members in random order, depending on where they were generated. This adds a reordering that prettifies the final yaml output to be more readable.

fixes INS-671