### PR TITLE
Improve spec preview code font color

### DIFF
--- a/packages/insomnia-app/app/ui/css/components/spec-editor.less
+++ b/packages/insomnia-app/app/ui/css/components/spec-editor.less
@@ -41,7 +41,7 @@
   }
 
   code {
-    color: var(--color-font);
+    color: var(--color-warning);
     background-color: var(--hl-md);
   }
 


### PR DESCRIPTION
This PR should fix #3010 and also #2948 🎉

In any of the two issues a preferred font color wasn't specified, so I decided to use ```--color-warning``` after trying different values and testing it with dark and light themes. Feel free to suggest another font color if it better suits the platform and I'll update the PR ASAP.

The main problem here is that in some themes, usually the light ones, the font color matches the dark background of the editor preview, making the text unreadable. Using another font color solves the issue.

<details>
<summary><b>Screenshots</b></summary>
Core default:

![image](https://user-images.githubusercontent.com/30463479/117582614-21803280-b103-11eb-93d6-7f205c8aeb28.png)

Designer light:

![image](https://user-images.githubusercontent.com/30463479/117582539-bc2c4180-b102-11eb-961b-6f78a57e43d6.png)

Hyper:

![image](https://user-images.githubusercontent.com/30463479/117582580-ed0c7680-b102-11eb-99bd-e9ea4a4bd975.png)

Solarized Light:

![image](https://user-images.githubusercontent.com/30463479/117582602-0ca39f00-b103-11eb-8b88-847b67f880e7.png)
</details>