### PR TITLE
keep the previous svgr assets dir in gitignore

### DIFF
--- a/packages/insomnia-components/.gitignore
+++ b/packages/insomnia-components/.gitignore
@@ -1,4 +1,5 @@
 .cache
 storybook-static
 src/assets/svgr
+assets/svgr
 dist


### PR DESCRIPTION
when a user pulls the new TS changes, these won't appear as new files to commit, because the SVGR generation location has changed

![image](https://user-images.githubusercontent.com/4312346/117956300-06b0f680-b36d-11eb-9252-f2b60b6abd65.png)
