### PR TITLE
remove duplication of all jest configs

### DIFF
--- a/jest-preset.js
+++ b/jest-preset.js
@@ -1,20 +1,16 @@
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
+  collectCoverage: false,
   globals: {
     'ts-jest': {
       isolatedModules: true,
     },
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  testEnvironment: 'node',
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  testMatch: [
-    '**/*.test.ts',
-  ],
-  verbose: false,
   resetMocks: true,
   resetModules: true,
-  collectCoverage: false,
+  testEnvironment: 'node',
+  testRegex: ['.+\\.test\\.tsx?$'],
+  transform: { '^.+\\.tsx?$': 'ts-jest' },
+  verbose: false,
 };

--- a/packages/insomnia-app/jest.config.js
+++ b/packages/insomnia-app/jest.config.js
@@ -1,35 +1,29 @@
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
+  // preset: '../../jest-preset.js', // DOES NOT WORK
+  // same as preset:
+  collectCoverage: false,
   globals: {
     'ts-jest': {
       isolatedModules: true,
     },
   },
-  testEnvironment: 'jsdom',
-  cache: false,
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  verbose: true,
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   resetMocks: true,
   resetModules: true,
   testRegex: ['.+\\.test\\.tsx?$'],
-  collectCoverage: false,
-  collectCoverageFrom: ['app/**/*.{js,jsx,ts,tsx}'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  coverageReporters: ['text-summary', 'lcov'],
-  setupFiles: [
-    './__jest__/setup.ts',
-  ],
-  setupFilesAfterEnv: [
-    './__jest__/setup-after-env.ts',
-  ],
+  transform: { '^.+\\.tsx?$': 'ts-jest' },
+
+  // extended from preset:
+  cache: false,
+  modulePathIgnorePatterns: ['<rootDir>/network/.*/__mocks__'],
+  rootDir: 'app',
+  setupFiles: ['./__jest__/setup.ts'],
+  setupFilesAfterEnv: ['./__jest__/setup-after-env.ts'],
+  testEnvironment: 'jsdom',
+  verbose: true,
   moduleNameMapper: {
     '\\.(css|less|png)$': '<rootDir>/__mocks__/dummy.ts',
     '^worker-loader!': '<rootDir>/__mocks__/dummy.ts',
   },
-  modulePathIgnorePatterns: [
-    '<rootDir>/network/.*/__mocks__',
-  ],
-  rootDir: 'app',
 };

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -9,7 +9,7 @@
   "main": "app/main.min.js",
   "scripts": {
     "clean": "tsc --build tsconfig.webpack.json --clean && tsc --build tsconfig.build.json --clean",
-    "test": "npm run test:jest",
+    "test": "jest",
     "test:jest": "cross-env NODE_ENV=test jest --silent",
     "test-appveyor": "npm run test -- --maxWorkers 1",
     "start:electron": "cross-env TS_NODE_PROJECT=\"tsconfig.webpack.json\" cross-env NODE_ENV=development webpack --config webpack/webpack.config.electron.ts && electron .",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "clean": "tsc --build tsconfig.webpack.json --clean && tsc --build tsconfig.build.json --clean",
     "test": "jest",
-    "test:jest": "cross-env NODE_ENV=test jest --silent",
     "test-appveyor": "npm run test -- --maxWorkers 1",
     "start:electron": "cross-env TS_NODE_PROJECT=\"tsconfig.webpack.json\" cross-env NODE_ENV=development webpack --config webpack/webpack.config.electron.ts && electron .",
     "start:dev-server": "cross-env TS_NODE_PROJECT=\"tsconfig.webpack.json\" webpack-dev-server --config webpack/webpack.config.development.ts",

--- a/packages/insomnia-components/jest.config.js
+++ b/packages/insomnia-components/jest.config.js
@@ -1,21 +1,6 @@
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
-  },
-  testEnvironment: 'jsdom',
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
+  preset: '../../jest-preset.js',
   setupFilesAfterEnv: ['./src/jest/setup-after-env.ts'],
-  verbose: false,
-  resetMocks: true,
-  resetModules: true,
-  testRegex: ['.+\\.test\\.tsx?$'],
-  collectCoverage: false,
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  coverageReporters: ['text-summary', 'lcov'],
+  testEnvironment: 'jsdom',
 };

--- a/packages/insomnia-cookies/jest.config.js
+++ b/packages/insomnia-cookies/jest.config.js
@@ -1,17 +1,4 @@
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
-  },
-  testEnvironment: 'node',
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  testRegex: ['.+\\.test\\.ts$'],
-  collectCoverage: false,
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  coverageReporters: ['text-summary', 'lcov'],
+  preset: '../../jest-preset.js',
 };

--- a/packages/insomnia-importers/jest.config.js
+++ b/packages/insomnia-importers/jest.config.js
@@ -1,17 +1,4 @@
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
-  },
-  testEnvironment: 'node',
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  testRegex: ['.+\\.test\\.ts$'],
-  collectCoverage: false,
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  coverageReporters: ['text-summary', 'lcov'],
+  preset: '../../jest-preset.js',
 };

--- a/packages/insomnia-inso/jest.config.js
+++ b/packages/insomnia-inso/jest.config.js
@@ -1,29 +1,8 @@
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
-  },
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  testEnvironment: 'node',
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  testMatch: [
-    '**/*.test.ts',
-  ],
-  verbose: false,
-  resetMocks: true,
-  resetModules: true,
-
-  setupFiles: [
-    './src/jest/setup.ts',
-  ],
+  preset: '../../jest-preset.js',
   collectCoverage: true,
-  coveragePathIgnorePatterns: [
-    '/node_modules/',
-  ],
+  coveragePathIgnorePatterns: ['/node_modules/'],
   coverageThreshold: {
     global: {
       branches: 88,
@@ -32,4 +11,5 @@ module.exports = {
       statements: 95,
     },
   },
+  setupFiles: ['./src/jest/setup.ts'],
 };

--- a/packages/insomnia-prettify/jest.config.js
+++ b/packages/insomnia-prettify/jest.config.js
@@ -1,17 +1,4 @@
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
-  },
-  testEnvironment: 'node',
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  testRegex: ['.+\\.test\\.ts$'],
-  collectCoverage: false,
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  coverageReporters: ['text-summary', 'lcov'],
+  preset: '../../jest-preset.js',
 };

--- a/packages/insomnia-testing/jest.config.js
+++ b/packages/insomnia-testing/jest.config.js
@@ -1,20 +1,4 @@
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
-  },
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  testEnvironment: 'node',
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  testMatch: [
-    '**/*.test.ts',
-  ],
-  verbose: false,
-  resetMocks: true,
-  resetModules: true,
-  collectCoverage: false,
+  preset: '../../jest-preset.js',
 };

--- a/packages/insomnia-url/jest.config.js
+++ b/packages/insomnia-url/jest.config.js
@@ -1,17 +1,4 @@
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
-  },
-  testEnvironment: 'node',
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  testRegex: ['.+\\.test\\.ts$'],
-  collectCoverage: false,
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  coverageReporters: ['text-summary', 'lcov'],
+  preset: '../../jest-preset.js',
 };

--- a/packages/insomnia-xpath/jest.config.js
+++ b/packages/insomnia-xpath/jest.config.js
@@ -1,17 +1,4 @@
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
-  },
-  testEnvironment: 'node',
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  testRegex: ['.+\\.test\\.ts$'],
-  collectCoverage: false,
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  coverageReporters: ['text-summary', 'lcov'],
+  preset: '../../jest-preset.js',
 };

--- a/packages/openapi-2-kong/jest.config.js
+++ b/packages/openapi-2-kong/jest.config.js
@@ -1,19 +1,4 @@
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
-  },
-  testEnvironment: 'node',
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  testRegex: ['.+\\.test\\.ts$'],
-  collectCoverage: false,
-  resetMocks: true,
-  resetModules: true,
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  coverageReporters: ['text-summary', 'lcov'],
+  preset: '../../jest-preset.js',
 };

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.base.json",
   "include": [
     ".eslintrc.js",
-    "jest.config.js"
+    "jest-preset.js"
   ]
 }


### PR DESCRIPTION
This was an issue we came across during the initial TypeScript conversion.  I posted about it in https://github.com/facebook/jest/issues/11399 and they provided a solution which _appears_ to work in all cases but `app`, which fails for a strange reason.

Using, from what I can tell, is exactly the same syntax using exactly the same npm script in app's package.json, you get

```
Preset ../../jest-preset.js not found.
```

If you try to run it.  See 138c3242dfd42784ab2ac0fa6f9f5047ab82b2f8

If we can get past this, we're golden.  Even if not, we can still merge this PR as-is and hope to figure out what's going on with app's config later, maybe.