### PR TITLE
Fix vercel deployments

### DIFF
--- a/packages/insomnia-components/package-lock.json
+++ b/packages/insomnia-components/package-lock.json
@@ -28694,6 +28694,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true
+    },
     "typescript-plugin-styled-components": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/typescript-plugin-styled-components/-/typescript-plugin-styled-components-1.5.0.tgz",

--- a/packages/insomnia-components/package.json
+++ b/packages/insomnia-components/package.json
@@ -57,6 +57,7 @@
     "styled-components": "^4.4.1",
     "ts-loader": "^8.2.0",
     "type-fest": "^1.0.2",
+    "typescript": "^4.2.3",
     "typescript-plugin-styled-components": "^1.5.0",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.11",


### PR DESCRIPTION
Vercel couldn't find TS because it's root directory is not the lerna root, it's `packages/insomnia-components`, so `insomnia-components` needs to work on it's own (currently)