### PR TITLE
Add repository, bug urls, and license to package json

### DIFF
--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -7,6 +7,14 @@
   "author": "Kong <office@konghq.com>",
   "license": "MIT",
   "main": "app/main.min.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "packages/insomnia-app"
+  },
+  "bugs": {
+    "url": "https://github.com/Kong/insomnia/issues"
+  },
   "scripts": {
     "clean": "tsc --build tsconfig.webpack.json --clean && tsc --build tsconfig.build.json --clean",
     "test": "jest",

--- a/packages/insomnia-components/package.json
+++ b/packages/insomnia-components/package.json
@@ -4,7 +4,14 @@
   "author": "Kong <office@konghq.com>",
   "description": "Insomnia UI component library",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/develop/packages/insomnia-components",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "packages/insomnia-components"
+  },
+  "bugs": {
+    "url": "https://github.com/Kong/insomnia/issues"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/insomnia-cookies/package.json
+++ b/packages/insomnia-cookies/package.json
@@ -4,6 +4,14 @@
   "author": "Kong <office@konghq.com>",
   "description": "Cookie utilities",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "packages/insomnia-cookies"
+  },
+  "bugs": {
+    "url": "https://github.com/Kong/insomnia/issues"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/insomnia-importers/package.json
+++ b/packages/insomnia-importers/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Various data importers for Insomnia",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/packages/insomnia-importers",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "packages/insomnia-importers"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -5,9 +5,13 @@
   "description": "A CLI for Insomnia Designer - the collaborative API design tool.",
   "author": "Kong <office@konghq.com>",
   "license": "Apache-2.0",
-  "repository": "https://github.com/kong/insomnia/tree/develop/packages/insomnia-inso",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "packages/insomnia-inso"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/kong/insomnia/issues"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/insomnia-prettify/package.json
+++ b/packages/insomnia-prettify/package.json
@@ -4,6 +4,14 @@
   "author": "Kong <office@konghq.com>",
   "description": "Prettification utilities for Insomnia",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "packages/insomnia-prettify"
+  },
+  "bugs": {
+    "url": "https://github.com/Kong/insomnia/issues"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -3,6 +3,14 @@
   "name": "insomnia-smoke-test",
   "author": "Kong <office@konghq.com>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "packages/insomnia-smoke-test"
+  },
+  "bugs": {
+    "url": "https://github.com/kong/insomnia/issues"
+  },
   "version": "2.2.35",
   "type": "module",
   "scripts": {

--- a/packages/insomnia-testing/package.json
+++ b/packages/insomnia-testing/package.json
@@ -3,6 +3,14 @@
   "license": "Apache-2.0",
   "version": "2.2.35",
   "author": "Kong <office@konghq.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "packages/insomnia-testing"
+  },
+  "bugs": {
+    "url": "https://github.com/Kong/insomnia/issues"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/insomnia-url/package.json
+++ b/packages/insomnia-url/package.json
@@ -4,6 +4,14 @@
   "author": "Kong <office@konghq.com>",
   "description": "URL Utilities",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "packages/insomnia-url"
+  },
+  "bugs": {
+    "url": "https://github.com/Kong/insomnia/issues"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/insomnia-xpath/package.json
+++ b/packages/insomnia-xpath/package.json
@@ -4,6 +4,14 @@
   "author": "Kong <office@konghq.com>",
   "description": "Query XML using XPath",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "packages/insomnia-xpath"
+  },
+  "bugs": {
+    "url": "https://github.com/Kong/insomnia/issues"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/plugins/insomnia-plugin-base64/package.json
+++ b/plugins/insomnia-plugin-base64/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Insomnia base64 template tag",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-base64",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-base64"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-cookie-jar/package.json
+++ b/plugins/insomnia-plugin-cookie-jar/package.json
@@ -10,9 +10,13 @@
   ],
   "description": "Insomnia cookie jar template tag",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-cookie-jar",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-cookie-jar"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-core-themes/package.json
+++ b/plugins/insomnia-plugin-core-themes/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Insomnia core themes",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-core-themes",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-core-themes"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-default-headers/package.json
+++ b/plugins/insomnia-plugin-default-headers/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Various data importers for Insomnia",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-default-headers",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-default-headers"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-file/package.json
+++ b/plugins/insomnia-plugin-file/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Insomnia file templte tag",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-file",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-plugin-file"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-hash/package.json
+++ b/plugins/insomnia-plugin-hash/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Insomnia hash template tag",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-hash",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-hash"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-jsonpath/package.json
+++ b/plugins/insomnia-plugin-jsonpath/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Template tag to pull data from JSON strings",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-json-path",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-jsonpath"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-kong-bundle/package.json
+++ b/plugins/insomnia-plugin-kong-bundle/package.json
@@ -3,6 +3,15 @@
   "version": "2.2.35",
   "main": "index.js",
   "author": "Kong <office@konghq.com>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-kong-bundle"
+  },
+  "bugs": {
+    "url": "https://github.com/Kong/insomnia/issues"
+  },
   "insomnia": {
     "name": "kong-bundle",
     "displayName": "Kong Plugin Bundle",

--- a/plugins/insomnia-plugin-kong-declarative-config/package.json
+++ b/plugins/insomnia-plugin-kong-declarative-config/package.json
@@ -3,6 +3,15 @@
   "version": "2.2.35",
   "main": "index.js",
   "author": "Kong <office@konghq.com>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-kong-declarative-config"
+  },
+  "bugs": {
+    "url": "https://github.com/Kong/insomnia/issues"
+  },
   "insomnia": {
     "name": "kong-declarative-config",
     "description": "Generate Kong Declarative Config"

--- a/plugins/insomnia-plugin-kong-kubernetes-config/package.json
+++ b/plugins/insomnia-plugin-kong-kubernetes-config/package.json
@@ -3,6 +3,15 @@
   "version": "2.2.35",
   "main": "index.js",
   "author": "Kong <office@konghq.com>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-kong-kubernetes-config"
+  },
+  "bugs": {
+    "url": "https://github.com/Kong/insomnia/issues"
+  },
   "insomnia": {
     "name": "kong-kubernetes-config",
     "description": "Generate Kong For Kubernetes configuration"

--- a/plugins/insomnia-plugin-kong-portal/package.json
+++ b/plugins/insomnia-plugin-kong-portal/package.json
@@ -3,6 +3,15 @@
   "version": "2.2.35",
   "main": "dist/index.js",
   "author": "Kong <office@konghq.com>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-kong-portal"
+  },
+  "bugs": {
+    "url": "https://github.com/Kong/insomnia/issues"
+  },
   "scripts": {
     "build": "webpack --config webpack.config.js --display errors-only",
     "watch": "webpack --config webpack.config.js --watch",

--- a/plugins/insomnia-plugin-now/package.json
+++ b/plugins/insomnia-plugin-now/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Insomnia now template tag",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-now",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-now"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-os/package.json
+++ b/plugins/insomnia-plugin-os/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Template tag to get information about the OS",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-os",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-os"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-prompt/package.json
+++ b/plugins/insomnia-plugin-prompt/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Insomnia prompt template tag",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-prompt",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-prompt"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-request/package.json
+++ b/plugins/insomnia-plugin-request/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Insomnia request template tag",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-request",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-request"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-response/package.json
+++ b/plugins/insomnia-plugin-response/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Insomnia response template tag",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-response",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-response"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {

--- a/plugins/insomnia-plugin-uuid/package.json
+++ b/plugins/insomnia-plugin-uuid/package.json
@@ -4,9 +4,13 @@
   "author": "Kong <office@konghq.com>",
   "description": "Insomnia uuid template tag",
   "license": "MIT",
-  "repository": "https://github.com/kong/insomnia/tree/master/plugins/insomnia-plugin-uuid",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kong/insomnia.git",
+    "directory": "plugins/insomnia-plugin-uuid"
+  },
   "bugs": {
-    "url": "https://github.com/kong/insomnia"
+    "url": "https://github.com/Kong/insomnia/issues"
   },
   "main": "index.js",
   "insomnia": {


### PR DESCRIPTION
Following the guidelines from npm for monorepos: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository.

* Added repository and bugs url on all packages and plugins
* Added Apache-2.0 license on `plugins/insomnia-plugin-kong-*`