### PR TITLE
Fix regression in empty folder state

### DIFF
--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.tsx
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-request-group-row.tsx
@@ -167,7 +167,7 @@ class SidebarRequestGroupRow extends PureComponent<Props, State> {
           className={classnames('sidebar__list', {
             'sidebar__list--collapsed': isCollapsed,
           })}>
-          {!isCollapsed && children ? (
+          {!isCollapsed && React.Children.count(children) > 0 ? (
             children
           ) : (
             <SidebarRequestRow


### PR DESCRIPTION
During the TS merge, the children check was updated from `!isCollapsed && children.length > 0` to `!isCollapsed && children`. In this particular use case, children can be defined but be an empty array, and if so we want to show a placeholder. This PR brings the folder empty state back by altering the condition to cater for am empty array.