### PR TITLE
adds mocha polyfill to clear it.each errors

### DIFF
--- a/packages/insomnia-app/app/mocha.d.ts
+++ b/packages/insomnia-app/app/mocha.d.ts
@@ -1,0 +1,7 @@
+declare namespace Mocha {
+  interface TestFunction {
+    // This is a hack until we can get rid of Mocha entirely from `insomnia-testing`.
+    // Until then, both declare global types which will always conflict and we need to do something like this to backport compatability.
+    each: jest.Each;
+  }
+}

--- a/packages/insomnia-inso/src/mocha.d.ts
+++ b/packages/insomnia-inso/src/mocha.d.ts
@@ -1,0 +1,7 @@
+declare namespace Mocha {
+  interface TestFunction {
+    // This is a hack until we can get rid of Mocha entirely from `insomnia-testing`.
+    // Until then, both declare global types which will always conflict and we need to do something like this to backport compatability.
+    each: jest.Each;
+  }
+}


### PR DESCRIPTION
Wherever `it.each` is called, but only in `insomnia-inso` and `insomnia-app`, we see the following error:

<img height="125" src="https://user-images.githubusercontent.com/15232461/118136067-b5871e00-b3d1-11eb-8fed-7d009b47ada7.png" />

if you dig in, you'll see that this is due to these projects importing `insomnia-testing` which uses the Mocha types.  What's shown here is that TypeScript is getting the types from two places for the same global definition for `it` (look at the pane on the right):

<img height="200" src="https://user-images.githubusercontent.com/15232461/118136219-de0f1800-b3d1-11eb-873f-92eeb0e770dd.png" />

so now, going back to `each`, if you hover over the error it tells you where there's a problem:

<img height="200" src="https://user-images.githubusercontent.com/15232461/118136240-e5cebc80-b3d1-11eb-84f2-ac0fd3701967.png" />

Jest defines:
```ts
declare var it: jest.It;
```

while Mocha defines:
```ts
declare var it: Mocha.TestFunction;
```

So we know it's from Mocha because the error complained about `TestFunction`.  Another way we know is you can just look at the `jest.It` definition, and sure enough, you'll see that `each` is defined.

<img height="200" src="https://user-images.githubusercontent.com/15232461/118136861-9046df80-b3d2-11eb-986b-88d7b2a9ac13.png" />

The problem, then, is that mocha's `TestFunction` is missing `each` and since they're both merged global definitions, that isn't something TypeScript will allow.  The thing is, though... we're not using Mocha.  There's no way to tell TypeScript this since they're both globals.

Other people seemed to solve this by making it a dev dependency (https://github.com/cypress-io/cypress/issues/6690#issuecomment-617067382, https://github.com/soundcloud/intervene/pull/3) but it already is for us, and, anyway, our situation is different because we actually need to consume and re-export these types from `insomnia-testing` so this wouldn't solve our issue.

This isn't a problem for other packages in the project, e.g. o2k (see [`generate.test.ts`](https://github.com/Kong/insomnia/blob/develop/packages/openapi-2-kong/src/kubernetes/generate.test.ts#L266)) which do not import insomnia-testing. 

Therefore, I've opted to solve this by adding a fake ambient definition for `Mocha.TestFunction['each']`.  This makes the errors go away and I don't think there's any real risk to us because we're not actually using mocha.

____

That said, I'll mention @reynolek that the long-term fix for us (in my non-product-person non-decision-making opinion) is to remove mocha from all projects and just use jest and jest-runner for insomnia-testing.  There are many other reasons to do this, but this hack we have to now impose is just another one to add to the pile.


