### PR TITLE
fix node-libcurl imports

### DIFF
--- a/packages/insomnia-app/app/__mocks__/node-libcurl.ts
+++ b/packages/insomnia-app/app/__mocks__/node-libcurl.ts
@@ -1,11 +1,13 @@
 import { EventEmitter } from 'events';
 import fs from 'fs';
-import { CurlAuth } from 'node-libcurl/dist/enum/CurlAuth';
-import { CurlCode } from 'node-libcurl/dist/enum/CurlCode';
-import { CurlInfoDebug } from 'node-libcurl/dist/enum/CurlInfoDebug';
-import { CurlFeature } from 'node-libcurl/dist/enum/CurlFeature';
-import { CurlNetrc } from 'node-libcurl/dist/enum/CurlNetrc';
-import { CurlHttpVersion } from 'node-libcurl/dist/enum/CurlHttpVersion';
+import {
+  CurlAuth,
+  CurlCode,
+  CurlInfoDebug,
+  CurlFeature,
+  CurlNetrc,
+  CurlHttpVersion,
+} from 'node-libcurl';
 
 class Curl extends EventEmitter {
   _options = {};

--- a/packages/insomnia-app/app/__mocks__/node-libcurl.ts
+++ b/packages/insomnia-app/app/__mocks__/node-libcurl.ts
@@ -1,21 +1,20 @@
 import { EventEmitter } from 'events';
 import fs from 'fs';
-import {
-  CurlAuth,
-  CurlCode,
-  CurlInfoDebug,
-  CurlFeature,
-  CurlNetrc,
-  CurlHttpVersion,
-} from 'node-libcurl';
+
+// Note: we cannot import these from `node-libcurl` like normal because they come from the native library and it's not possible to load it while testing because it was built to run with Electron.
+// That applies to these Enum type imports, but also applies to the members of the class below.
+import { CurlAuth } from 'node-libcurl/dist/enum/CurlAuth';
+import { CurlCode } from 'node-libcurl/dist/enum/CurlCode';
+import { CurlInfoDebug } from 'node-libcurl/dist/enum/CurlInfoDebug';
+import { CurlFeature } from 'node-libcurl/dist/enum/CurlFeature';
+import { CurlNetrc } from 'node-libcurl/dist/enum/CurlNetrc';
+import { CurlHttpVersion } from 'node-libcurl/dist/enum/CurlHttpVersion';
 
 class Curl extends EventEmitter {
   _options = {};
   _meta = {};
   _features = {};
 
-  // cannot include these from node-libcurl because they come from the native library
-  // and it's not possible to load it while testing (as it was built to run with Electron)
   static info = {
     COOKIELIST: 'COOKIELIST',
     EFFECTIVE_URL: 'EFFECTIVE_URL',

--- a/packages/insomnia-app/app/common/render.ts
+++ b/packages/insomnia-app/app/common/render.ts
@@ -277,6 +277,7 @@ export async function render<T>(
 
   return next<T>(newObj, name, true);
 }
+
 export async function getRenderContext(
   request: Request | GrpcRequest | null,
   environmentId: string | null,
@@ -373,6 +374,7 @@ export async function getRenderContext(
   // Generate the context we need to render
   return buildRenderContext(ancestors, rootEnvironment, subEnvironment, baseContext);
 }
+
 export async function getRenderedGrpcRequest(
   request: GrpcRequest,
   environmentId: string | null,
@@ -419,9 +421,10 @@ export async function getRenderedGrpcRequestMessage(
   const renderedBody: RenderedGrpcRequestBody = await render(request.body, renderContext);
   return renderedBody;
 }
+
 export async function getRenderedRequestAndContext(
   request: Request,
-  environmentId: string | null,
+  environmentId?: string | null,
   purpose?: RenderPurpose,
   extraInfo?: ExtraRenderInfo,
 ) {
@@ -431,7 +434,7 @@ export async function getRenderedRequestAndContext(
   const cookieJar = await models.cookieJar.getOrCreateForParentId(parentId);
   const renderContext = await getRenderContext(
     request,
-    environmentId,
+    environmentId || null,
     ancestors,
     purpose,
     extraInfo || null,

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -97,7 +97,7 @@ describe('actuallySend()', () => {
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
-    const body = JSON.parse(bodyBuffer);
+    const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
       features: {
@@ -172,7 +172,7 @@ describe('actuallySend()', () => {
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
-    const body = JSON.parse(bodyBuffer);
+    const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
       features: {
@@ -272,7 +272,7 @@ describe('actuallySend()', () => {
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
-    const body = JSON.parse(bodyBuffer);
+    const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
       features: {
@@ -332,7 +332,7 @@ describe('actuallySend()', () => {
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
-    const body = JSON.parse(bodyBuffer);
+    const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
       features: {
@@ -412,7 +412,7 @@ describe('actuallySend()', () => {
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
-    const body = JSON.parse(bodyBuffer);
+    const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
       features: {
@@ -473,7 +473,7 @@ describe('actuallySend()', () => {
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
-    const body = JSON.parse(bodyBuffer);
+    const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
       features: {
@@ -513,7 +513,7 @@ describe('actuallySend()', () => {
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
-    const body = JSON.parse(bodyBuffer);
+    const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
       features: {
@@ -552,7 +552,7 @@ describe('actuallySend()', () => {
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
-    const body = JSON.parse(bodyBuffer);
+    const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
       features: {
@@ -592,7 +592,7 @@ describe('actuallySend()', () => {
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
-    const body = JSON.parse(bodyBuffer);
+    const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
       features: {
@@ -648,12 +648,12 @@ describe('actuallySend()', () => {
       preferredHttpVersion: 'blah',
     });
     const r = models.response;
-    expect(JSON.parse(r.getBodyBuffer(responseV1)).options.HTTP_VERSION).toBe('V1_0');
-    expect(JSON.parse(r.getBodyBuffer(responseV11)).options.HTTP_VERSION).toBe('V1_1');
-    expect(JSON.parse(r.getBodyBuffer(responseV2)).options.HTTP_VERSION).toBe('V2_0');
-    expect(JSON.parse(r.getBodyBuffer(responseV3)).options.HTTP_VERSION).toBe('v3');
-    expect(JSON.parse(r.getBodyBuffer(responseDefault)).options.HTTP_VERSION).toBe(undefined);
-    expect(JSON.parse(r.getBodyBuffer(responseInvalid)).options.HTTP_VERSION).toBe(undefined);
+    expect(JSON.parse(String(r.getBodyBuffer(responseV1))).options.HTTP_VERSION).toBe('V1_0');
+    expect(JSON.parse(String(r.getBodyBuffer(responseV11))).options.HTTP_VERSION).toBe('V1_1');
+    expect(JSON.parse(String(r.getBodyBuffer(responseV2))).options.HTTP_VERSION).toBe('V2_0');
+    expect(JSON.parse(String(r.getBodyBuffer(responseV3))).options.HTTP_VERSION).toBe('v3');
+    expect(JSON.parse(String(r.getBodyBuffer(responseDefault))).options.HTTP_VERSION).toBe(undefined);
+    expect(JSON.parse(String(r.getBodyBuffer(responseInvalid))).options.HTTP_VERSION).toBe(undefined);
   });
 
   it('requests can be cancelled by requestId', async () => {

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -645,6 +645,7 @@ describe('actuallySend()', () => {
     });
     const responseInvalid = await networkUtils._actuallySend(renderedRequest, CONTEXT, workspace, {
       ...settings,
+      // @ts-expect-error intentionally invalid
       preferredHttpVersion: 'blah',
     });
     const r = models.response;

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -238,10 +238,6 @@ export async function _actuallySend(
       }
     }
 
-    function enable(feature: number) {
-      curl.enable(feature);
-    }
-
     try {
       // Setup the cancellation logic
       cancelRequestFunctionMap[renderedRequest._id] = async () => {
@@ -272,7 +268,7 @@ export async function _actuallySend(
       setOpt(Curl.option.ACCEPT_ENCODING, '');
 
       // Auto decode everything
-      enable(CurlFeature.Raw);
+      curl.enable(CurlFeature.Raw);
 
       // Set follow redirects setting
       switch (renderedRequest.settingFollowRedirects) {

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -138,7 +138,7 @@ export async function _actuallySend(
   renderContext: Record<string, any>,
   workspace: Workspace,
   settings: Settings,
-  environment: Environment | null,
+  environment?: Environment | null,
 ) {
   return new Promise<ResponsePatch>(async resolve => {
     const timeline: Array<ResponseTimelineEntry> = [];

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -19,6 +19,7 @@ import {
   CurlInfoDebug,
   CurlFeature,
   CurlNetrc,
+  CurlOptionName,
   CurlHttpVersion,
 } from 'node-libcurl';
 import { join as pathJoin } from 'path';
@@ -67,7 +68,6 @@ import { urlMatchesCertHost } from './url-matches-cert-host';
 import aws4 from 'aws4';
 import { buildMultipart } from './multipart';
 import type { Environment } from '../models/environment';
-import { CurlOptionName } from 'node-libcurl/dist/generated/CurlOption';
 
 export interface ResponsePatch {
   bodyCompression?: 'zip' | null;


### PR DESCRIPTION
Back in the flow days, we needed to reach into these files to get at the enum, but now we can import directly.  It's a fairly strong anti-pattern to reach into `/dist` like this on npms because there are no guarantees about what will be there in the future, which greatly increases the surface-area for breakage in our own code.