### PR TITLE
fixes `redux-devtools`-specific error, `"sync" is not available`

### DIFF
--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -13,7 +13,7 @@ import type { ToastNotification } from './ui/components/toast';
 import type { Stats } from './models/stats';
 import { trackNonInteractiveEventQueueable } from './common/analytics';
 import log, { initializeLogging } from './common/log';
-import installExtension, { REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
+import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 
 // Handle potential auto-update
 if (checkIfRestartNeeded()) {
@@ -41,7 +41,7 @@ app.on('ready', async () => {
   // Enable react dev tools if development
   if (isDevelopment()) {
     try {
-      const names = await installExtension([REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS]);
+      const names = await installExtension([REACT_DEVELOPER_TOOLS]);
       console.log(`[electron-extensions] Added Extension:  ${names}`);
     } catch (err) {
       console.log('[electron-extensions] An error occurred: ', err);


### PR DESCRIPTION
closes: INS-702

until https://github.com/reduxjs/redux-devtools/pull/711 is available to us, our best course of action is to remove it for now.
