### PR TITLE
use same `array-type` rule, project-wide

### DIFF
--- a/packages/insomnia-app/.eslintrc.js
+++ b/packages/insomnia-app/.eslintrc.js
@@ -4,7 +4,6 @@ module.exports = {
   rules: {
     'filenames/match-exported': 'off',
     camelcase: 'off',
-    '@typescript-eslint/array-type': ['error', { default: 'generic', readonly: 'generic' }],
     '@typescript-eslint/no-use-before-define': 'off', // TSCONVERSION
     '@typescript-eslint/no-explicit-any': 'off', // TSCONVERSION
     'no-restricted-properties': ['error', {

--- a/packages/insomnia-app/app/account/fetch.ts
+++ b/packages/insomnia-app/app/account/fetch.ts
@@ -3,7 +3,7 @@ import { parse as urlParse } from 'url';
 import zlib from 'zlib';
 let _userAgent = '';
 let _baseUrl = '';
-const _commandListeners: Array<Function> = [];
+const _commandListeners: Function[] = [];
 
 export function setup(userAgent, baseUrl) {
   _userAgent = userAgent;

--- a/packages/insomnia-app/app/account/session.ts
+++ b/packages/insomnia-app/app/account/session.ts
@@ -2,7 +2,7 @@ import * as srp from 'srp-js';
 import * as crypt from './crypt';
 import * as fetch from './fetch';
 
-const loginCallbacks: Array<Function> = [];
+const loginCallbacks: Function[] = [];
 
 function _callCallbacks() {
   const loggedIn = isLoggedIn();

--- a/packages/insomnia-app/app/common/__fixtures__/nestedfolders.ts
+++ b/packages/insomnia-app/app/common/__fixtures__/nestedfolders.ts
@@ -1,6 +1,6 @@
 import { workspace, requestGroup, request, BaseModel } from '../../models';
 
-export const data: Record<string, Array<Partial<BaseModel>>> = {
+export const data: Record<string, Partial<BaseModel>[]> = {
   [workspace.type]: [
     {
       _id: 'wrk_1',

--- a/packages/insomnia-app/app/common/__tests__/database.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/database.test.ts
@@ -4,7 +4,7 @@ import { globalBeforeEach } from '../../__jest__/before-each';
 import { data as fixtures } from '../__fixtures__/nestedfolders';
 
 function loadFixture() {
-  const promises: Array<Promise<models.BaseModel>> = [];
+  const promises: Promise<models.BaseModel>[] = [];
   for (const type of Object.keys(fixtures)) {
     for (const doc of fixtures[type]) {
       // @ts-expect-error -- TSCONVERSION
@@ -37,7 +37,7 @@ describe('onChange()', () => {
       parentId: 'nothing',
       name: 'foo',
     };
-    const changesSeen: Array<Function> = [];
+    const changesSeen: Function[] = [];
 
     const callback = change => {
       changesSeen.push(change);
@@ -68,7 +68,7 @@ describe('bufferChanges()', () => {
       parentId: 'n/a',
       name: 'foo',
     };
-    const changesSeen: Array<Function> = [];
+    const changesSeen: Function[] = [];
 
     const callback = change => {
       changesSeen.push(change);
@@ -105,7 +105,7 @@ describe('bufferChanges()', () => {
       parentId: 'n/a',
       name: 'foo',
     };
-    const changesSeen: Array<Function> = [];
+    const changesSeen: Function[] = [];
 
     const callback = change => {
       changesSeen.push(change);
@@ -132,7 +132,7 @@ describe('bufferChanges()', () => {
       parentId: 'n/a',
       name: 'foo',
     };
-    const changesSeen: Array<Function> = [];
+    const changesSeen: Function[] = [];
 
     const callback = change => {
       changesSeen.push(change);
@@ -162,7 +162,7 @@ describe('bufferChangesIndefinitely()', () => {
       parentId: 'n/a',
       name: 'foo',
     };
-    const changesSeen: Array<Function> = [];
+    const changesSeen: Function[] = [];
 
     const callback = change => {
       changesSeen.push(change);

--- a/packages/insomnia-app/app/common/analytics.ts
+++ b/packages/insomnia-app/app/common/analytics.ts
@@ -232,7 +232,7 @@ export async function _trackPageView(location: string) {
   await _sendToGoogle(params, false);
 }
 
-async function _getDefaultParams(): Promise<Array<RequestParameter>> {
+async function _getDefaultParams(): Promise<RequestParameter[]> {
   const deviceId = await getDeviceId();
   // Prepping user agent string prior to sending to GA due to Electron base UA not being GA friendly.
   const ua = String(window?.navigator?.userAgent)
@@ -357,7 +357,7 @@ async function _sendToGoogle(params: RequestParameter, queueable: boolean) {
       console.warn('[ga] Bad status code ' + statusCode);
     }
 
-    const chunks: Array<Buffer> = [];
+    const chunks: Buffer[] = [];
     const [contentType] = response.headers['content-type'] || [];
 
     if (contentType !== 'application/json') {
@@ -398,7 +398,7 @@ async function _sendToGoogle(params: RequestParameter, queueable: boolean) {
  * @returns {Promise<void>}
  * @private
  */
-let _queuedEvents: Array<RequestParameter> = [];
+let _queuedEvents: RequestParameter[] = [];
 
 async function _flushQueuedEvents() {
   console.log(`[ga] Flushing ${_queuedEvents.length} queued events`);

--- a/packages/insomnia-app/app/common/grpc-paths.ts
+++ b/packages/insomnia-app/app/common/grpc-paths.ts
@@ -35,7 +35,7 @@ export interface GrpcMethodInfo {
   type: GrpcMethodType;
   fullPath: string;
 }
-type GroupedGrpcMethodInfo = Record<string, Array<GrpcMethodInfo>>;
+type GroupedGrpcMethodInfo = Record<string, GrpcMethodInfo[]>;
 export const NO_PACKAGE_KEY = 'no-package';
 
 const getMethodInfo = (method: GrpcMethodDefinition): GrpcMethodInfo => ({
@@ -45,6 +45,6 @@ const getMethodInfo = (method: GrpcMethodDefinition): GrpcMethodInfo => ({
 });
 
 export const groupGrpcMethodsByPackage = (
-  methods: Array<GrpcMethodDefinition>,
+  methods: GrpcMethodDefinition[],
 ): GroupedGrpcMethodInfo =>
   groupBy(methods.map(getMethodInfo), m => m.segments.packageName || NO_PACKAGE_KEY);

--- a/packages/insomnia-app/app/common/har.ts
+++ b/packages/insomnia-app/app/common/har.ts
@@ -50,7 +50,7 @@ export interface HarPostParam {
 
 export interface HarPostData {
   mimeType: string;
-  params: Array<HarPostParam>;
+  params: HarPostParam[];
   text: string;
   comment?: string;
 }
@@ -59,9 +59,9 @@ export interface HarRequest {
   method: string;
   url: string;
   httpVersion: string;
-  cookies: Array<HarCookie>;
-  headers: Array<HarHeader>;
-  queryString: Array<HarQueryString>;
+  cookies: HarCookie[];
+  headers: HarHeader[];
+  queryString: HarQueryString[];
   postData?: HarPostData;
   headersSize: number;
   bodySize: number;
@@ -82,8 +82,8 @@ export interface HarResponse {
   status: number;
   statusText: string;
   httpVersion: string;
-  cookies: Array<HarCookie>;
-  headers: Array<HarHeader>;
+  cookies: HarCookie[];
+  headers: HarHeader[];
   content: HarContent;
   redirectURL: string;
   headersSize: number;
@@ -159,8 +159,8 @@ export interface HarLog {
   version: string;
   creator: HarCreator;
   browser?: HarBrowser;
-  pages?: Array<HarPage>;
-  entries: Array<HarEntry>;
+  pages?: HarPage[];
+  entries: HarEntry[];
   comment?: string;
 }
 
@@ -173,10 +173,10 @@ export interface ExportRequest {
   environmentId: string | null;
 }
 
-export async function exportHar(exportRequests: Array<ExportRequest>) {
+export async function exportHar(exportRequests: ExportRequest[]) {
   // Export HAR entries with the same start time in order to keep their workspace sort order.
   const startedDateTime = new Date().toISOString();
-  const entries: Array<HarEntry> = [];
+  const entries: HarEntry[] = [];
 
   for (const exportRequest of exportRequests) {
     const request: Request | null = await models.request.getById(exportRequest.requestId);
@@ -376,12 +376,12 @@ export async function exportHarWithRenderedRequest(
 function getRequestCookies(renderedRequest: RenderedRequest) {
   const jar = jarFromCookies(renderedRequest.cookieJar.cookies);
   const domainCookies = jar.getCookiesSync(renderedRequest.url);
-  const harCookies: Array<HarCookie> = domainCookies.map(mapCookie);
+  const harCookies: HarCookie[] = domainCookies.map(mapCookie);
   return harCookies;
 }
 
 function getReponseCookies(response: ResponseModel) {
-  const headers = response.headers.filter(Boolean) as Array<HarCookie>;
+  const headers = response.headers.filter(Boolean) as HarCookie[];
   const responseCookies = getSetCookieHeaders(headers)
   .reduce((accumulator, harCookie) => {
     let cookie: null | undefined | toughCookie = null;
@@ -398,7 +398,7 @@ function getReponseCookies(response: ResponseModel) {
       ...accumulator,
       mapCookie(cookie as unknown as Cookie),
     ];
-  }, [] as Array<HarCookie>);
+  }, [] as HarCookie[]);
   return responseCookies;
 }
 
@@ -477,7 +477,7 @@ function getRequestHeaders(renderedRequest: RenderedRequest) {
     }));
 }
 
-function getRequestQueryString(renderedRequest: RenderedRequest): Array<HarQueryString> {
+function getRequestQueryString(renderedRequest: RenderedRequest): HarQueryString[] {
   return renderedRequest.parameters.map<HarQueryString>(parameter => ({
     name: parameter.name,
     value: parameter.value,

--- a/packages/insomnia-app/app/common/hotkeys.ts
+++ b/packages/insomnia-app/app/common/hotkeys.ts
@@ -26,9 +26,9 @@ export interface KeyCombination {
  * The collection of a hotkey's key combinations for each platforms.
  */
 export interface KeyBindings {
-  macKeys: Array<KeyCombination>;
+  macKeys: KeyCombination[];
   // The key combinations for both Windows and Linux.
-  winLinuxKeys: Array<KeyCombination>;
+  winLinuxKeys: KeyCombination[];
 }
 
 /**
@@ -61,8 +61,8 @@ function keyComb(
 }
 
 function keyBinds(
-  mac: KeyCombination | Array<KeyCombination>,
-  winLinux: KeyCombination | Array<KeyCombination>,
+  mac: KeyCombination | KeyCombination[],
+  winLinux: KeyCombination | KeyCombination[],
 ): KeyBindings {
   if (!Array.isArray(mac)) {
     mac = [mac];
@@ -295,8 +295,8 @@ const defaultRegistry: HotKeyRegistry = {
   ),
 };
 
-function copyKeyCombs(sources: Array<KeyCombination>): Array<KeyCombination> {
-  const targets: Array<KeyCombination> = [];
+function copyKeyCombs(sources: KeyCombination[]): KeyCombination[] {
+  const targets: KeyCombination[] = [];
   sources.forEach(keyComb => {
     targets.push(Object.assign({}, keyComb));
   });
@@ -339,7 +339,7 @@ export function newDefaultRegistry(): HotKeyRegistry {
  * @param bindings
  * @returns {Array<KeyCombination>}
  */
-export function getPlatformKeyCombinations(bindings: KeyBindings): Array<KeyCombination> {
+export function getPlatformKeyCombinations(bindings: KeyBindings): KeyCombination[] {
   if (isMac()) {
     return bindings.macKeys;
   }
@@ -415,7 +415,7 @@ export function getChar(keyCode: number) {
   return char || 'unknown';
 }
 
-function joinHotKeys(mustUsePlus: boolean, keys: Array<string>) {
+function joinHotKeys(mustUsePlus: boolean, keys: string[]) {
   if (!mustUsePlus && isMac()) {
     return keys.join('');
   }
@@ -454,7 +454,7 @@ export function constructKeyCombinationDisplay(
   mustUsePlus: boolean,
 ) {
   const { ctrl, alt, shift, meta, keyCode } = keyComb;
-  const chars: Array<string> = [];
+  const chars: string[] = [];
   alt && chars.push(ALT_SYM);
   shift && chars.push(SHIFT_SYM);
   ctrl && chars.push(CTRL_SYM);
@@ -492,7 +492,7 @@ export function getHotKeyDisplay(
     return '';
   }
 
-  const keyCombs: Array<KeyCombination> = getPlatformKeyCombinations(hotKey);
+  const keyCombs: KeyCombination[] = getPlatformKeyCombinations(hotKey);
 
   if (keyCombs.length === 0) {
     return '';

--- a/packages/insomnia-app/app/common/import.ts
+++ b/packages/insomnia-app/app/common/import.ts
@@ -56,7 +56,7 @@ const MODELS = {
 export interface ImportResult {
   source: string;
   error: Error | null;
-  summary: Record<string, Array<BaseModel>>;
+  summary: Record<string, BaseModel[]>;
 }
 
 interface ConvertResultType {
@@ -68,7 +68,7 @@ interface ConvertResultType {
 interface ConvertResult {
   type: ConvertResultType;
   data: {
-    resources: Array<Record<string, any>>;
+    resources: Record<string, any>[];
   };
 }
 
@@ -164,7 +164,7 @@ export async function importRaw(
 
   const { data, type: resultsType } = results;
   // Generate all the ids we may need
-  const generatedIds: Record<string, string | ((...args: Array<any>) => any)> = {};
+  const generatedIds: Record<string, string | ((...args: any[]) => any)> = {};
 
   for (const r of data.resources) {
     for (const key of r._id.match(REPLACE_ID_REGEX) || []) {
@@ -372,21 +372,21 @@ export async function exportWorkspacesHAR(
   parentDoc: BaseModel | null = null,
   includePrivateDocs = false,
 ) {
-  const docs: Array<BaseModel> = await getDocWithDescendants(parentDoc, includePrivateDocs);
-  const requests: Array<BaseModel> = docs.filter(isRequest);
+  const docs: BaseModel[] = await getDocWithDescendants(parentDoc, includePrivateDocs);
+  const requests: BaseModel[] = docs.filter(isRequest);
   return exportRequestsHAR(requests, includePrivateDocs);
 }
 
 export async function exportRequestsHAR(
-  requests: Array<BaseModel>,
+  requests: BaseModel[],
   includePrivateDocs = false,
 ) {
-  const workspaces: Array<BaseModel> = [];
+  const workspaces: BaseModel[] = [];
   const mapRequestIdToWorkspace: Record<string, any> = {};
   const workspaceLookup: Record<string, any> = {};
 
   for (const request of requests) {
-    const ancestors: Array<BaseModel> = await db.withAncestors(request, [
+    const ancestors: BaseModel[] = await db.withAncestors(request, [
       models.workspace.type,
       models.requestGroup.type,
     ]);
@@ -418,7 +418,7 @@ export async function exportRequestsHAR(
   requests = requests.sort((a: Record<string, any>, b: Record<string, any>) =>
     a.metaSortKey < b.metaSortKey ? -1 : 1,
   );
-  const harRequests: Array<har.ExportRequest> = [];
+  const harRequests: har.ExportRequest[] = [];
 
   for (const request of requests) {
     const workspace = mapRequestIdToWorkspace[request._id];
@@ -445,13 +445,13 @@ export async function exportWorkspacesData(
   includePrivateDocs: boolean,
   format: 'json' | 'yaml',
 ) {
-  const docs: Array<BaseModel> = await getDocWithDescendants(parentDoc, includePrivateDocs);
-  const requests: Array<BaseModel> = docs.filter(doc => isRequest(doc) || isGrpcRequest(doc));
+  const docs: BaseModel[] = await getDocWithDescendants(parentDoc, includePrivateDocs);
+  const requests: BaseModel[] = docs.filter(doc => isRequest(doc) || isGrpcRequest(doc));
   return exportRequestsData(requests, includePrivateDocs, format);
 }
 
 export async function exportRequestsData(
-  requests: Array<BaseModel>,
+  requests: BaseModel[],
   includePrivateDocs: boolean,
   format: 'json' | 'yaml',
 ) {
@@ -463,12 +463,12 @@ export async function exportRequestsData(
     __export_source: `insomnia.desktop.app:v${getAppVersion()}`,
     resources: [],
   };
-  const docs: Array<BaseModel> = [];
-  const workspaces: Array<BaseModel> = [];
+  const docs: BaseModel[] = [];
+  const workspaces: BaseModel[] = [];
   const mapTypeAndIdToDoc: Record<string, any> = {};
 
   for (const req of requests) {
-    const ancestors: Array<BaseModel> = clone(await db.withAncestors(req));
+    const ancestors: BaseModel[] = clone(await db.withAncestors(req));
 
     for (const ancestor of ancestors) {
       const key = ancestor.type + '___' + ancestor._id;
@@ -487,7 +487,7 @@ export async function exportRequestsData(
   }
 
   for (const workspace of workspaces) {
-    const descendants: Array<BaseModel> = (await db.withDescendants(workspace)).filter(d => {
+    const descendants: BaseModel[] = (await db.withDescendants(workspace)).filter(d => {
       // Only interested in these additional model types.
       return (
         d.type === models.cookieJar.type ||
@@ -585,7 +585,7 @@ export async function exportRequestsData(
 async function getDocWithDescendants(
   parentDoc: BaseModel | null = null,
   includePrivateDocs = false,
-): Promise<Array<BaseModel>> {
+): Promise<BaseModel[]> {
   const docs = await db.withDescendants(parentDoc);
   return docs.filter(
     // Don't include if private, except if we want to

--- a/packages/insomnia-app/app/common/migrate-from-designer.ts
+++ b/packages/insomnia-app/app/common/migrate-from-designer.ts
@@ -13,7 +13,7 @@ import { trackEvent } from './analytics';
 import { WorkspaceScopeKeys } from '../models/workspace';
 
 async function loadDesignerDb(
-  types: Array<string>,
+  types: string[],
   designerDataDir: string,
 ): Promise<Record<string, any>> {
   const designerDb = {};
@@ -37,12 +37,12 @@ async function loadDesignerDb(
           corruptAlertThreshold: 0.9,
         });
         // Find every entry and store in memory
-        collection.find({}, (err, docs: Array<BaseModel>) => {
+        collection.find({}, (err, docs: BaseModel[]) => {
           if (err) {
             return reject(err);
           }
 
-          (designerDb[type] as Array<Record<string, any>>).push(...docs);
+          (designerDb[type] as Record<string, any>[]).push(...docs);
           resolve();
         });
       }),
@@ -52,7 +52,7 @@ async function loadDesignerDb(
   return designerDb;
 }
 
-type DBType = Record<string, Array<BaseModel>>;
+type DBType = Record<string, BaseModel[]>;
 
 export interface MigrationOptions {
   useDesignerSettings: boolean;
@@ -66,7 +66,7 @@ export interface MigrationResult {
   error?: Error;
 }
 
-async function createCoreBackup(modelTypes: Array<string>, coreDataDir: string) {
+async function createCoreBackup(modelTypes: string[], coreDataDir: string) {
   console.log('[db-merge] creating backup');
   const backupDir = fsPath.join(coreDataDir, 'core-backup');
   await fsx.remove(backupDir);
@@ -112,7 +112,7 @@ async function readDirs(srcDir: string) {
   }
 }
 
-async function copyDirs(dirs: Array<string>, srcDir: string, destDir: string) {
+async function copyDirs(dirs: string[], srcDir: string, destDir: string) {
   for (const dir of dirs.filter(c => c)) {
     const src = fsPath.join(srcDir, dir);
     const dest = fsPath.join(destDir, dir);
@@ -125,7 +125,7 @@ async function copyDirs(dirs: Array<string>, srcDir: string, destDir: string) {
   }
 }
 
-async function removeDirs(dirs: Array<string>, srcDir: string) {
+async function removeDirs(dirs: string[], srcDir: string) {
   for (const dir of dirs.filter(c => c)) {
     const dirToRemove = fsPath.join(srcDir, dir);
 

--- a/packages/insomnia-app/app/common/misc.ts
+++ b/packages/insomnia-app/app/common/misc.ts
@@ -18,9 +18,9 @@ interface Parameter {
 }
 
 export function filterParameters<T extends Parameter>(
-  parameters: Array<T>,
+  parameters: T[],
   name: string,
-): Array<T> {
+): T[] {
   if (!Array.isArray(parameters) || !name) {
     return [];
   }
@@ -28,7 +28,7 @@ export function filterParameters<T extends Parameter>(
   return parameters.filter(h => (!h || !h.name ? false : h.name === name));
 }
 
-export function filterHeaders<T extends Header>(headers: Array<T>, name?: string): Array<T> {
+export function filterHeaders<T extends Header>(headers: T[], name?: string): T[] {
   if (!Array.isArray(headers) || !name || typeof name !== 'string') {
     return [];
   }
@@ -43,60 +43,60 @@ export function filterHeaders<T extends Header>(headers: Array<T>, name?: string
   });
 }
 
-export function hasContentTypeHeader<T extends Header>(headers: Array<T>) {
+export function hasContentTypeHeader<T extends Header>(headers: T[]) {
   return filterHeaders(headers, 'content-type').length > 0;
 }
 
-export function hasContentLengthHeader<T extends Header>(headers: Array<T>) {
+export function hasContentLengthHeader<T extends Header>(headers: T[]) {
   return filterHeaders(headers, 'content-length').length > 0;
 }
 
-export function hasAuthHeader<T extends Header>(headers: Array<T>) {
+export function hasAuthHeader<T extends Header>(headers: T[]) {
   return filterHeaders(headers, 'authorization').length > 0;
 }
 
-export function hasAcceptHeader<T extends Header>(headers: Array<T>) {
+export function hasAcceptHeader<T extends Header>(headers: T[]) {
   return filterHeaders(headers, 'accept').length > 0;
 }
 
-export function hasUserAgentHeader<T extends Header>(headers: Array<T>) {
+export function hasUserAgentHeader<T extends Header>(headers: T[]) {
   return filterHeaders(headers, 'user-agent').length > 0;
 }
 
-export function hasAcceptEncodingHeader<T extends Header>(headers: Array<T>) {
+export function hasAcceptEncodingHeader<T extends Header>(headers: T[]) {
   return filterHeaders(headers, 'accept-encoding').length > 0;
 }
 
-export function getSetCookieHeaders<T extends Header>(headers: Array<T>): Array<T> {
+export function getSetCookieHeaders<T extends Header>(headers: T[]): T[] {
   return filterHeaders(headers, 'set-cookie');
 }
 
-export function getLocationHeader<T extends Header>(headers: Array<T>): T | null {
+export function getLocationHeader<T extends Header>(headers: T[]): T | null {
   const matches = filterHeaders(headers, 'location');
   return matches.length ? matches[0] : null;
 }
 
-export function getContentTypeHeader<T extends Header>(headers: Array<T>): T | null {
+export function getContentTypeHeader<T extends Header>(headers: T[]): T | null {
   const matches = filterHeaders(headers, 'content-type');
   return matches.length ? matches[0] : null;
 }
 
-export function getMethodOverrideHeader<T extends Header>(headers: Array<T>): T | null {
+export function getMethodOverrideHeader<T extends Header>(headers: T[]): T | null {
   const matches = filterHeaders(headers, 'x-http-method-override');
   return matches.length ? matches[0] : null;
 }
 
-export function getHostHeader<T extends Header>(headers: Array<T>): T | null {
+export function getHostHeader<T extends Header>(headers: T[]): T | null {
   const matches = filterHeaders(headers, 'host');
   return matches.length ? matches[0] : null;
 }
 
-export function getContentDispositionHeader<T extends Header>(headers: Array<T>): T | null {
+export function getContentDispositionHeader<T extends Header>(headers: T[]): T | null {
   const matches = filterHeaders(headers, 'content-disposition');
   return matches.length ? matches[0] : null;
 }
 
-export function getContentLengthHeader<T extends Header>(headers: Array<T>): T | null {
+export function getContentLengthHeader<T extends Header>(headers: T[]): T | null {
   const matches = filterHeaders(headers, 'content-length');
   return matches.length ? matches[0] : null;
 }
@@ -199,7 +199,7 @@ export function preventDefault(e: Event) {
   e.preventDefault();
 }
 
-export function fnOrString(v: string | ((...args: Array<any>) => any), ...args: Array<any>) {
+export function fnOrString(v: string | ((...args: any[]) => any), ...args: any[]) {
   if (typeof v === 'string') {
     return v;
   } else {
@@ -261,14 +261,14 @@ export function fuzzyMatch(
   } = {},
 ): null | {
   score: number;
-  indexes: Array<number>;
+  indexes: number[];
 } {
   return fuzzyMatchAll(searchString, [text], options);
 }
 
 export function fuzzyMatchAll(
   searchString: string,
-  allText: Array<string>,
+  allText: string[],
   options: {
     splitSpace?: boolean;
     loose?: boolean;
@@ -281,7 +281,7 @@ export function fuzzyMatchAll(
   const words = searchString.split(' ').filter(w => w.trim());
   const terms = options.splitSpace ? [...words, searchString] : [searchString];
   let maxScore: number | null = null;
-  let indexes: Array<number> = [];
+  let indexes: number[] = [];
   let termsMatched = 0;
 
   for (const term of terms) {
@@ -349,8 +349,8 @@ export async function waitForStreamToFinish(stream: Readable | Writable) {
   });
 }
 
-export function chunkArray<T>(arr: Array<T>, chunkSize: number) {
-  const chunks: Array<Array<T>> = [];
+export function chunkArray<T>(arr: T[], chunkSize: number) {
+  const chunks: T[][] = [];
 
   for (let i = 0, j = arr.length; i < j; i += chunkSize) {
     chunks.push(arr.slice(i, i + chunkSize));

--- a/packages/insomnia-app/app/common/render.ts
+++ b/packages/insomnia-app/app/common/render.ts
@@ -21,17 +21,17 @@ export const RENDER_PURPOSE_GENERAL: RenderPurpose = 'general';
 export const RENDER_PURPOSE_NO_RENDER: RenderPurpose = 'no-render';
 
 /** Key/value pairs to be provided to the render context */
-export type ExtraRenderInfo = Array<{
+export type ExtraRenderInfo = {
   name: string;
   value: any;
-}>;
+}[];
 
 export type RenderedRequest = Request & {
-  cookies: Array<{
+  cookies: {
     name: string;
     value: string;
     disabled?: boolean;
-  }>;
+  }[];
   cookieJar: CookieJar;
 };
 
@@ -41,10 +41,10 @@ export type RenderedGrpcRequestBody = GrpcRequestBody;
 
 export interface RenderContextAndKeys {
   context: Record<string, any>;
-  keys: Array<{
+  keys: {
     name: string;
     value: any;
-  }>
+  }[]
 }
 
 export type HandleGetRenderContext = () => Promise<RenderContextAndKeys>;
@@ -52,12 +52,12 @@ export type HandleGetRenderContext = () => Promise<RenderContextAndKeys>;
 export type HandleRender = <T>(object: T, contextCacheKey?: string | null) => Promise<T>;
 
 export async function buildRenderContext(
-  ancestors: Array<BaseModel> | null,
+  ancestors: BaseModel[] | null,
   rootEnvironment: Environment | null,
   subEnvironment: Environment | null,
   baseContext: Record<string, any> = {},
 ) {
-  const envObjects: Array<Record<string, any>> = [];
+  const envObjects: Record<string, any>[] = [];
 
   // Get root environment keys in correct order
   // Then get sub environment keys in correct order
@@ -281,7 +281,7 @@ export async function render<T>(
 export async function getRenderContext(
   request: Request | GrpcRequest | null,
   environmentId: string | null,
-  ancestors: Array<BaseModel> | null = null,
+  ancestors: BaseModel[] | null = null,
   purpose: RenderPurpose | null = null,
   extraInfo: ExtraRenderInfo | null = null,
 ): Promise<Record<string, any>> {
@@ -527,7 +527,7 @@ function _nunjucksSortValue(v) {
   return v && v.match && v.match(/({{|{%)/) ? 2 : 1;
 }
 
-function _getOrderedEnvironmentKeys(finalRenderContext: Record<string, any>): Array<string> {
+function _getOrderedEnvironmentKeys(finalRenderContext: Record<string, any>): string[] {
   return Object.keys(finalRenderContext).sort((k1, k2) => {
     const k1Sort = _nunjucksSortValue(finalRenderContext[k1]);
 
@@ -537,7 +537,7 @@ function _getOrderedEnvironmentKeys(finalRenderContext: Record<string, any>): Ar
   });
 }
 
-async function _getRequestAncestors(request: Request | GrpcRequest | null): Promise<Array<BaseModel>> {
+async function _getRequestAncestors(request: Request | GrpcRequest | null): Promise<BaseModel[]> {
   return await db.withAncestors(request, [
     models.request.type,
     models.grpcRequest.type,

--- a/packages/insomnia-app/app/common/select-file-or-folder.ts
+++ b/packages/insomnia-app/app/common/select-file-or-folder.ts
@@ -1,7 +1,7 @@
 import { OpenDialogOptions, remote } from 'electron';
 interface Options {
-  itemTypes?: Array<'file' | 'directory'>;
-  extensions?: Array<string>;
+  itemTypes?: ('file' | 'directory')[];
+  extensions?: string[];
 }
 interface FileSelection {
   filePath: string;

--- a/packages/insomnia-app/app/common/send-request.ts
+++ b/packages/insomnia-app/app/common/send-request.ts
@@ -14,7 +14,7 @@ export async function getSendRequestCallbackMemDb(environmentId, memDB) {
     true,
     () => {},
   );
-  const docs: Array<BaseModel> = [];
+  const docs: BaseModel[] = [];
 
   for (const type of Object.keys(memDB)) {
     for (const doc of memDB[type]) {

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -469,7 +469,7 @@ export function createWindow() {
       },
     ],
   };
-  const template: Array<MenuItemConstructorOptions> = [];
+  const template: MenuItemConstructorOptions[] = [];
   template.push(applicationMenu);
   template.push(editMenu);
   template.push(viewMenu);

--- a/packages/insomnia-app/app/models/cookie-jar.ts
+++ b/packages/insomnia-app/app/models/cookie-jar.ts
@@ -21,7 +21,7 @@ export interface Cookie {
   path: string;
   secure: boolean;
   httpOnly: boolean;
-  extensions?: Array<any>;
+  extensions?: any[];
   creation?: Date;
   creationIndex?: number;
   hostOnly?: boolean;
@@ -31,7 +31,7 @@ export interface Cookie {
 
 interface BaseCookieJar {
   name: string;
-  cookies: Array<Cookie>;
+  cookies: Cookie[];
 }
 
 export type CookieJar = BaseModel & BaseCookieJar;

--- a/packages/insomnia-app/app/models/helpers/query-all-workspace-urls.ts
+++ b/packages/insomnia-app/app/models/helpers/query-all-workspace-urls.ts
@@ -7,7 +7,7 @@ export const queryAllWorkspaceUrls = async (
   workspace: Workspace | null,
   reqType: typeof RequestType | typeof GrpcRequestType,
   reqId = 'n/a',
-): Promise<Array<string>> => {
+): Promise<string[]> => {
   const docs = await db.withDescendants(workspace, reqType);
   const urls = docs
     .filter(

--- a/packages/insomnia-app/app/models/index.ts
+++ b/packages/insomnia-app/app/models/index.ts
@@ -141,7 +141,7 @@ export function getModelName(type: string, count = 1) {
   }
 }
 
-export async function initModel<T extends BaseModel>(type: string, ...sources: Array<Record<string, any>>): Promise<T> {
+export async function initModel<T extends BaseModel>(type: string, ...sources: Record<string, any>[]): Promise<T> {
   const model = getModel(type);
 
   if (!model) {

--- a/packages/insomnia-app/app/models/proto-directory.ts
+++ b/packages/insomnia-app/app/models/proto-directory.ts
@@ -52,7 +52,7 @@ export function remove(obj: ProtoDirectory) {
   return db.remove(obj);
 }
 
-export async function batchRemoveIds(ids: Array<string>) {
+export async function batchRemoveIds(ids: string[]) {
   const dirs = await db.find(type, {
     _id: {
       $in: ids,

--- a/packages/insomnia-app/app/models/proto-file.ts
+++ b/packages/insomnia-app/app/models/proto-file.ts
@@ -41,7 +41,7 @@ export function remove(protoFile: ProtoFile) {
   return db.remove(protoFile);
 }
 
-export async function batchRemoveIds(ids: Array<string>) {
+export async function batchRemoveIds(ids: string[]) {
   const files = await db.find(type, {
     _id: {
       $in: ids,

--- a/packages/insomnia-app/app/models/request-meta.ts
+++ b/packages/insomnia-app/app/models/request-meta.ts
@@ -16,7 +16,7 @@ interface BaseRequestMeta {
   parentId: string;
   previewMode: string;
   responseFilter: string;
-  responseFilterHistory: Array<string>;
+  responseFilterHistory: string[];
   activeResponseId: string | null;
   savedRequestBody: Record<string, any>;
   pinned: boolean;

--- a/packages/insomnia-app/app/models/request.ts
+++ b/packages/insomnia-app/app/models/request.ts
@@ -69,7 +69,7 @@ export interface RequestBody {
   mimeType?: string | null;
   text?: string;
   fileName?: string;
-  params?: Array<RequestBodyParameter>;
+  params?: RequestBodyParameter[];
 }
 
 interface BaseRequest {
@@ -78,8 +78,8 @@ interface BaseRequest {
   description: string;
   method: string;
   body: RequestBody;
-  parameters: Array<RequestParameter>;
-  headers: Array<RequestHeader>;
+  parameters: RequestParameter[];
+  headers: RequestHeader[];
   authentication: RequestAuthentication;
   metaSortKey: number;
   isPrivate: boolean;
@@ -240,7 +240,7 @@ export function newBodyGraphQL(rawBody: string): RequestBody {
   }
 }
 
-export function newBodyFormUrlEncoded(parameters: Array<RequestBodyParameter> | null): RequestBody {
+export function newBodyFormUrlEncoded(parameters: RequestBodyParameter[] | null): RequestBody {
   return {
     mimeType: CONTENT_TYPE_FORM_URLENCODED,
     params: parameters || [],
@@ -254,7 +254,7 @@ export function newBodyFile(path: string): RequestBody {
   };
 }
 
-export function newBodyForm(parameters: Array<RequestBodyParameter>): RequestBody {
+export function newBodyForm(parameters: RequestBodyParameter[]): RequestBody {
   return {
     mimeType: CONTENT_TYPE_FORM_DATA,
     params: parameters || [],

--- a/packages/insomnia-app/app/models/response.ts
+++ b/packages/insomnia-app/app/models/response.ts
@@ -42,7 +42,7 @@ interface BaseResponse {
   bytesRead: number;
   bytesContent: number;
   elapsedTime: number;
-  headers: Array<ResponseHeader>;
+  headers: ResponseHeader[];
   bodyPath: string;
   // Actual bodies are stored on the filesystem
   timelinePath: string;
@@ -285,7 +285,7 @@ function getTimelineFromPath(timelinePath: string) {
 
   try {
     const rawBuffer = fs.readFileSync(timelinePath);
-    return JSON.parse(rawBuffer.toString()) as Array<ResponseTimelineEntry>;
+    return JSON.parse(rawBuffer.toString()) as ResponseTimelineEntry[];
   } catch (err) {
     console.warn('Failed to read response body', err.message);
     return [];
@@ -359,7 +359,7 @@ export async function cleanDeletedResponses() {
     return;
   }
 
-  const whitelistFiles: Array<string> = [];
+  const whitelistFiles: string[] = [];
 
   for (const r of (await db.all<Response>(type) || [])) {
     whitelistFiles.push(r.bodyPath.slice(responsesDir.length + 1));

--- a/packages/insomnia-app/app/network/grpc/index.ts
+++ b/packages/insomnia-app/app/network/grpc/index.ts
@@ -209,7 +209,7 @@ export const sendMessage = (
 // @ts-expect-error -- TSCONVERSION only end if the call is ClientWritableStream | ClientDuplexStream
 export const commit = (requestId: string) => callCache.get(requestId)?.end();
 export const cancel = (requestId: string) => callCache.get(requestId)?.cancel();
-export const cancelMultiple = (requestIds: Array<string>) => requestIds.forEach(cancel);
+export const cancelMultiple = (requestIds: string[]) => requestIds.forEach(cancel);
 
 const _setupStatusListener = (call: Call, requestId: string, respond: ResponseCallbacks) => {
   call.on('status', s => respond.sendStatus(requestId, s));

--- a/packages/insomnia-app/app/network/grpc/proto-loader/index.ts
+++ b/packages/insomnia-app/app/network/grpc/proto-loader/index.ts
@@ -22,7 +22,7 @@ const isServiceDefinition = (obj: AnyDefinition): obj is ServiceDefinition => !i
 //  writing to a file in those cases, but it becomes more important to cache
 export const loadMethods = async (
   protoFile?: ProtoFile | null,
-): Promise<Array<GrpcMethodDefinition>> => {
+): Promise<GrpcMethodDefinition[]> => {
   if (!protoFile?.protoText) {
     return [];
   }
@@ -33,8 +33,8 @@ export const loadMethods = async (
 
 export const loadMethodsFromPath = async (
   filePath: string,
-  includeDirs?: Array<string>,
-): Promise<Array<GrpcMethodDefinition>> => {
+  includeDirs?: string[],
+): Promise<GrpcMethodDefinition[]> => {
   const definition = await protoLoader.load(filePath, { ...GRPC_LOADER_OPTIONS, includeDirs });
   return Object.values(definition).filter(isServiceDefinition).flatMap(Object.values);
 };

--- a/packages/insomnia-app/app/network/grpc/proto-loader/write-proto-file.ts
+++ b/packages/insomnia-app/app/network/grpc/proto-loader/write-proto-file.ts
@@ -17,7 +17,7 @@ const getProtoTempDirectoryName = ({ _id, modified }: ProtoDirectory): string =>
 
 interface WriteResult {
   filePath: string;
-  dirs: Array<string>;
+  dirs: string[];
 }
 
 const writeIndividualProtoFile = async (protoFile: ProtoFile): Promise<WriteResult> => {
@@ -54,8 +54,8 @@ const writeNestedProtoFile = async (protoFile: ProtoFile, dirPath: string) => {
 };
 
 const writeProtoFileTree = async (
-  ancestors: Array<ProtoDirectory | Workspace>,
-): Promise<Array<string>> => {
+  ancestors: (ProtoDirectory | Workspace)[],
+): Promise<string[]> => {
   // Find the ancestor workspace
   const ancestorWorkspace = ancestors.find(isWorkspace);
 
@@ -91,9 +91,9 @@ const writeProtoFileTree = async (
 
 const recursiveWriteProtoDirectory = async (
   dir: ProtoDirectory,
-  descendants: Array<BaseModel>,
+  descendants: BaseModel[],
   currentDirPath: string,
-): Promise<Array<string>> => {
+): Promise<string[]> => {
   // Increment folder path
   const dirPath = path.join(currentDirPath, dir.name);
   mkdirp.sync(dirPath);

--- a/packages/insomnia-app/app/network/grpc/proto-manager/index.tsx
+++ b/packages/insomnia-app/app/network/grpc/proto-manager/index.tsx
@@ -28,7 +28,7 @@ export async function deleteFile(protoFile: ProtoFile, callback: (arg0: string) 
   });
 }
 
-export async function deleteDirectory(protoDirectory: ProtoDirectory, callback: (arg0: Array<string>) => void) {
+export async function deleteDirectory(protoDirectory: ProtoDirectory, callback: (arg0: string[]) => void) {
   showAlert({
     title: `Delete ${protoDirectory.name}`,
     message: (
@@ -48,7 +48,7 @@ export async function deleteDirectory(protoDirectory: ProtoDirectory, callback: 
 
 export async function addDirectory(workspaceId: string) {
   let rollback = false;
-  let createdIds: Array<string>;
+  let createdIds: string[];
   const bufferId = await db.bufferChangesIndefinitely();
 
   try {

--- a/packages/insomnia-app/app/network/grpc/proto-manager/ingest-proto-directory.ts
+++ b/packages/insomnia-app/app/network/grpc/proto-manager/ingest-proto-directory.ts
@@ -5,12 +5,12 @@ import fs from 'fs';
 
 interface IngestResult {
   createdDir?: ProtoDirectory | null;
-  createdIds: Array<string>;
+  createdIds: string[];
   error?: Error | null;
 }
 
 class ProtoDirectoryLoader {
-  createdIds: Array<string> = [];
+  createdIds: string[] = [];
   rootDirPath: string;
   workspaceId: string;
 

--- a/packages/insomnia-app/app/network/multipart.ts
+++ b/packages/insomnia-app/app/network/multipart.ts
@@ -12,7 +12,7 @@ interface Multipart {
   contentLength: number;
 }
 
-export async function buildMultipart(params: Array<RequestBodyParameter>) {
+export async function buildMultipart(params: RequestBodyParameter[]) {
   return new Promise<Multipart>(async (resolve, reject) => {
     const filePath = path.join(electron.remote.app.getPath('temp'), Math.random() + '.body');
     const writeStream = fs.createWriteStream(filePath);

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -77,7 +77,7 @@ export interface ResponsePatch {
   elapsedTime?: number;
   environmentId?: string | null;
   error?: string;
-  headers?: Array<ResponseHeader>;
+  headers?: ResponseHeader[];
   httpVersion?: string;
   message?: string;
   parentId?: string;
@@ -141,7 +141,7 @@ export async function _actuallySend(
   environment?: Environment | null,
 ) {
   return new Promise<ResponsePatch>(async resolve => {
-    const timeline: Array<ResponseTimelineEntry> = [];
+    const timeline: ResponseTimelineEntry[] = [];
 
     function addTimeline(name, value) {
       timeline.push({
@@ -765,7 +765,7 @@ export async function _actuallySend(
         const contentType = contentTypeHeader ? contentTypeHeader.value : '';
         // Update Cookie Jar
         let currentUrl = finalUrl;
-        let setCookieStrings: Array<string> = [];
+        let setCookieStrings: string[] = [];
         const jar = jarFromCookies(renderedRequest.cookieJar.cookies);
 
         for (const { headers } of allCurlHeadersObjects) {
@@ -1049,7 +1049,7 @@ async function _applyResponsePluginHooks(
 }
 
 interface HeaderResult {
-  headers: Array<ResponseHeader>;
+  headers: ResponseHeader[];
   version: string;
   code: number;
   reason: string;
@@ -1058,7 +1058,7 @@ interface HeaderResult {
 export function _parseHeaders(
   buffer: Buffer,
 ) {
-  const results: Array<HeaderResult> = [];
+  const results: HeaderResult[] = [];
   const lines = buffer.toString('utf8').split(/\r?\n|\r/g);
 
   for (let i = 0, currentResult: HeaderResult | null = null; i < lines.length; i++) {
@@ -1100,18 +1100,18 @@ export function _getAwsAuthHeaders(
     secretAccessKey: string;
     sessionToken: string;
   },
-  headers: Array<RequestHeader>,
+  headers: RequestHeader[],
   body: string,
   url: string,
   method: string,
   region?: string,
   service?: string,
-): Array<{
+): {
   name: string;
   value: string;
   description?: string;
   disabled?: boolean;
-}> {
+}[] {
   const parsedUrl = urlParse(url);
   const contentTypeHeader = getContentTypeHeader(headers);
   // AWS uses host header for signing so prioritize that if the user set it manually
@@ -1139,7 +1139,7 @@ export function _getAwsAuthHeaders(
     }));
 }
 
-function storeTimeline(timeline: Array<ResponseTimelineEntry>) {
+function storeTimeline(timeline: ResponseTimelineEntry[]) {
   return new Promise<string>((resolve, reject) => {
     const timelineStr = JSON.stringify(timeline, null, '\t');
     const timelineHash = crypto.createHash('sha1').update(timelineStr).digest('hex');

--- a/packages/insomnia-app/app/plugins/context/request.ts
+++ b/packages/insomnia-app/app/plugins/context/request.ts
@@ -51,7 +51,7 @@ export function init(
 
     getEnvironmentVariable(
       name: string,
-    ): string | number | boolean | Record<string, any> | Array<any> | null {
+    ): string | number | boolean | Record<string, any> | any[] | null {
       return renderedContext[name];
     },
 

--- a/packages/insomnia-app/app/plugins/context/response.ts
+++ b/packages/insomnia-app/app/plugins/context/response.ts
@@ -10,7 +10,7 @@ interface MaybeResponse {
   bytesContent?: number;
   bodyPath?: string;
   elapsedTime?: number;
-  headers?: Array<ResponseHeader>;
+  headers?: ResponseHeader[];
 }
 
 export function init(response?: MaybeResponse) {
@@ -65,7 +65,7 @@ export function init(response?: MaybeResponse) {
         response.bytesContent = body.length;
       },
 
-      getHeader(name: string): string | Array<string> | null {
+      getHeader(name: string): string | string[] | null {
         const headers = response.headers || [];
         const matchedHeaders = headers.filter(h => h.name.toLowerCase() === name.toLowerCase());
 

--- a/packages/insomnia-app/app/plugins/context/store.ts
+++ b/packages/insomnia-app/app/plugins/context/store.ts
@@ -8,10 +8,10 @@ export interface PluginStore {
   removeItem(arg0: string): Promise<void>;
   clear(): Promise<void>;
   all(): Promise<
-    Array<{
+    {
       key: string;
       value: string;
-    }>
+    }[]
   >;
 }
 
@@ -41,10 +41,10 @@ export function init(plugin: Plugin) {
       },
 
       async all(): Promise<
-        Array<{
+        {
           key: string;
           value: string;
-        }>
+        }[]
       > {
         const docs = await models.pluginData.all(plugin.name) || [];
         return docs.map(d => ({

--- a/packages/insomnia-app/app/plugins/index.ts
+++ b/packages/insomnia-app/app/plugins/index.ts
@@ -15,15 +15,15 @@ import type { Workspace } from '../models/workspace';
 import { GrpcRequest } from '../models/grpc-request';
 
 export interface Module {
-  templateTags?: Array<PluginTemplateTag>,
-  requestHooks?: Array<(requstContext: any) => void>,
-  responseHooks?: Array<(responseContext: any) => void>,
-  themes?: Array<PluginTheme>,
-  requestGroupActions?: Array<OmitInternal<RequestGroupAction>>,
-  requestActions?: Array<OmitInternal<RequestAction>>,
-  workspaceActions?: Array<OmitInternal<WorkspaceAction>>,
-  documentActions?: Array<OmitInternal<DocumentAction>>,
-  configGenerators?: Array<OmitInternal<ConfigGenerator>>,
+  templateTags?: PluginTemplateTag[],
+  requestHooks?: ((requstContext: any) => void)[],
+  responseHooks?: ((responseContext: any) => void)[],
+  themes?: PluginTheme[],
+  requestGroupActions?: OmitInternal<RequestGroupAction>[],
+  requestActions?: OmitInternal<RequestAction>[],
+  workspaceActions?: OmitInternal<WorkspaceAction>[],
+  documentActions?: OmitInternal<DocumentAction>[],
+  configGenerators?: OmitInternal<ConfigGenerator>[],
 }
 
 export interface Plugin {
@@ -48,7 +48,7 @@ export interface RequestGroupAction extends InternalProperties {
     context: Record<string, any>,
     models: {
       requestGroup: RequestGroup;
-      requests: Array<Request | GrpcRequest>;
+      requests: (Request | GrpcRequest)[];
     },
   ) => void | Promise<void>;
   label: string;
@@ -72,8 +72,8 @@ export interface WorkspaceAction extends InternalProperties {
     context: Record<string, any>,
     models: {
       workspace: Workspace;
-      requestGroups: Array<RequestGroup>;
-      requests: Array<Request>;
+      requestGroups: RequestGroup[];
+      requests: Request[];
     },
   ) => void | Promise<void>;
   label: string;
@@ -120,9 +120,9 @@ export interface Theme extends InternalProperties {
 
 export type ColorScheme = 'default' | 'light' | 'dark';
 
-let plugins: Array<Plugin> | null | undefined = null;
+let plugins: Plugin[] | null | undefined = null;
 
-let ignorePlugins: Array<string> = [];
+let ignorePlugins: string[] = [];
 
 export async function init() {
   clearIgnores();
@@ -141,7 +141,7 @@ export function clearIgnores() {
 
 async function _traversePluginPath(
   pluginMap: Record<string, any>,
-  allPaths: Array<string>,
+  allPaths: string[],
   allConfigs: PluginConfigMap,
 ) {
   for (const p of allPaths) {
@@ -201,7 +201,7 @@ async function _traversePluginPath(
   }
 }
 
-export async function getPlugins(force = false): Promise<Array<Plugin>> {
+export async function getPlugins(force = false): Promise<Plugin[]> {
   if (force) {
     plugins = null;
   }
@@ -253,12 +253,12 @@ export async function reloadPlugins() {
   await getPlugins(true);
 }
 
-async function getActivePlugins(): Promise<Array<Plugin>> {
+async function getActivePlugins(): Promise<Plugin[]> {
   return (await getPlugins()).filter(p => !p.config.disabled);
 }
 
-export async function getRequestGroupActions(): Promise<Array<RequestGroupAction>> {
-  let extensions: Array<RequestGroupAction> = [];
+export async function getRequestGroupActions(): Promise<RequestGroupAction[]> {
+  let extensions: RequestGroupAction[] = [];
 
   for (const plugin of await getActivePlugins()) {
     const actions = plugin.module.requestGroupActions || [];
@@ -274,8 +274,8 @@ export async function getRequestGroupActions(): Promise<Array<RequestGroupAction
   return extensions;
 }
 
-export async function getRequestActions(): Promise<Array<RequestAction>> {
-  let extensions: Array<RequestAction> = [];
+export async function getRequestActions(): Promise<RequestAction[]> {
+  let extensions: RequestAction[] = [];
 
   for (const plugin of await getActivePlugins()) {
     const actions = plugin.module.requestActions || [];
@@ -291,8 +291,8 @@ export async function getRequestActions(): Promise<Array<RequestAction>> {
   return extensions;
 }
 
-export async function getWorkspaceActions(): Promise<Array<WorkspaceAction>> {
-  let extensions: Array<WorkspaceAction> = [];
+export async function getWorkspaceActions(): Promise<WorkspaceAction[]> {
+  let extensions: WorkspaceAction[] = [];
 
   for (const plugin of await getActivePlugins()) {
     const actions = plugin.module.workspaceActions || [];
@@ -308,8 +308,8 @@ export async function getWorkspaceActions(): Promise<Array<WorkspaceAction>> {
   return extensions;
 }
 
-export async function getDocumentActions(): Promise<Array<DocumentAction>> {
-  let extensions: Array<DocumentAction> = [];
+export async function getDocumentActions(): Promise<DocumentAction[]> {
+  let extensions: DocumentAction[] = [];
 
   for (const plugin of await getActivePlugins()) {
     const actions = plugin.module.documentActions || [];
@@ -325,8 +325,8 @@ export async function getDocumentActions(): Promise<Array<DocumentAction>> {
   return extensions;
 }
 
-export async function getTemplateTags(): Promise<Array<TemplateTag>> {
-  let extensions: Array<TemplateTag> = [];
+export async function getTemplateTags(): Promise<TemplateTag[]> {
+  let extensions: TemplateTag[] = [];
 
   for (const plugin of await getActivePlugins()) {
     const templateTags = plugin.module.templateTags || [];
@@ -342,8 +342,8 @@ export async function getTemplateTags(): Promise<Array<TemplateTag>> {
   return extensions;
 }
 
-export async function getRequestHooks(): Promise<Array<RequestHook>> {
-  let functions: Array<RequestHook> = [];
+export async function getRequestHooks(): Promise<RequestHook[]> {
+  let functions: RequestHook[] = [];
 
   for (const plugin of await getActivePlugins()) {
     const moreFunctions = plugin.module.requestHooks || [];
@@ -359,8 +359,8 @@ export async function getRequestHooks(): Promise<Array<RequestHook>> {
   return functions;
 }
 
-export async function getResponseHooks(): Promise<Array<ResponseHook>> {
-  let functions: Array<ResponseHook> = [];
+export async function getResponseHooks(): Promise<ResponseHook[]> {
+  let functions: ResponseHook[] = [];
 
   for (const plugin of await getActivePlugins()) {
     const moreFunctions = plugin.module.responseHooks || [];
@@ -376,8 +376,8 @@ export async function getResponseHooks(): Promise<Array<ResponseHook>> {
   return functions;
 }
 
-export async function getThemes(): Promise<Array<Theme>> {
-  let extensions: Array<Theme> = [];
+export async function getThemes(): Promise<Theme[]> {
+  let extensions: Theme[] = [];
 
   for (const plugin of await getActivePlugins()) {
     const themes = plugin.module.themes || [];
@@ -393,8 +393,8 @@ export async function getThemes(): Promise<Array<Theme>> {
   return extensions;
 }
 
-export async function getConfigGenerators(): Promise<Array<ConfigGenerator>> {
-  let functions: Array<ConfigGenerator> = [];
+export async function getConfigGenerators(): Promise<ConfigGenerator[]> {
+  let functions: ConfigGenerator[] = [];
 
   for (const plugin of await getActivePlugins()) {
     const moreFunctions = plugin.module.configGenerators || [];

--- a/packages/insomnia-app/app/plugins/misc.ts
+++ b/packages/insomnia-app/app/plugins/misc.ts
@@ -262,7 +262,7 @@ export async function setTheme(themeName: string) {
     return;
   }
 
-  const themes: Array<Theme> = await getThemes();
+  const themes: Theme[] = await getThemes();
 
   // If theme isn't installed for some reason, set to the default
   if (!themes.find(t => t.theme.name === themeName)) {

--- a/packages/insomnia-app/app/sync/delta/diff.ts
+++ b/packages/insomnia-app/app/sync/delta/diff.ts
@@ -19,8 +19,8 @@ interface Block {
   hash: string;
 }
 
-export function diff(source: string, target: string, blockSize: number): Array<Operation> {
-  const operations: Array<Operation> = [];
+export function diff(source: string, target: string, blockSize: number): Operation[] {
+  const operations: Operation[] = [];
   const sourceBlockMap = getBlockMap(source, blockSize);
   // Iterate over source blocks in order and match them to target
   let lastTargetMatch = 0;

--- a/packages/insomnia-app/app/sync/delta/patch.ts
+++ b/packages/insomnia-app/app/sync/delta/patch.ts
@@ -1,6 +1,6 @@
 import type { Operation } from './diff';
 
-export function patch(a: string, operations: Array<Operation>) {
+export function patch(a: string, operations: Operation[]) {
   let result = '';
 
   for (const op of operations) {

--- a/packages/insomnia-app/app/sync/git/__tests__/git-rollback.test.ts
+++ b/packages/insomnia-app/app/sync/git/__tests__/git-rollback.test.ts
@@ -30,7 +30,7 @@ describe('git rollback', () => {
     it('should remove and delete added and *added files', async () => {
       const aTxt = 'a.txt';
       const bTxt = 'b.txt';
-      const files: Array<FileWithStatus> = [
+      const files: FileWithStatus[] = [
         {
           filePath: aTxt,
           status: 'added',
@@ -53,7 +53,7 @@ describe('git rollback', () => {
     it('should undo pending changes for non-added files', async () => {
       const aTxt = 'a.txt';
       const bTxt = 'b.txt';
-      const files: Array<FileWithStatus> = [
+      const files: FileWithStatus[] = [
         {
           filePath: aTxt,
           status: 'modified',
@@ -75,7 +75,7 @@ describe('git rollback', () => {
       const bTxt = 'b.txt';
       const cTxt = 'c.txt';
       const dTxt = 'd.txt';
-      const files: Array<FileWithStatus> = [
+      const files: FileWithStatus[] = [
         {
           filePath: aTxt,
           status: 'added',
@@ -143,7 +143,7 @@ describe('git rollback', () => {
       expect(fooStatus).toBe('*added');
       expect(barStatus).toBe('added');
       expect(bazStatus).toBe('*modified');
-      const files: Array<FileWithStatus> = [
+      const files: FileWithStatus[] = [
         {
           filePath: fooTxt,
           status: fooStatus,

--- a/packages/insomnia-app/app/sync/git/fs-client.ts
+++ b/packages/insomnia-app/app/sync/git/fs-client.ts
@@ -19,7 +19,7 @@ export const fsClient = (basePath: string) => {
   console.log(`[fsClient] Created in ${basePath}`);
   mkdirp.sync(basePath);
 
-  const wrap = (fn: FSWraps) => async (filePath: string, ...args: Array<any>) => {
+  const wrap = (fn: FSWraps) => async (filePath: string, ...args: any[]) => {
     const modifiedPath = path.join(basePath, path.normalize(filePath));
     // @ts-expect-error -- TSCONVERSION
     return fn(modifiedPath, ...args);

--- a/packages/insomnia-app/app/sync/git/git-rollback.ts
+++ b/packages/insomnia-app/app/sync/git/git-rollback.ts
@@ -9,7 +9,7 @@ const isAdded = ({ status }: FileWithStatus) => status.includes('added');
 
 const isNotAdded = ({ status }: FileWithStatus) => !status.includes('added');
 
-export const gitRollback = async (vcs: GitVCS, files: Array<FileWithStatus>) => {
+export const gitRollback = async (vcs: GitVCS, files: FileWithStatus[]) => {
   const addedFiles = files.filter(isAdded);
   // Remove and delete added (unversioned) files
   const promises = addedFiles.map(async ({ filePath }) => {

--- a/packages/insomnia-app/app/sync/git/git-vcs.ts
+++ b/packages/insomnia-app/app/sync/git/git-vcs.ts
@@ -43,7 +43,7 @@ export interface GitLogEntry {
     tree: GitRef;
     author: GitAuthor & GitTimestamp;
     committer: GitAuthor & GitTimestamp;
-    parent: Array<GitRef>;
+    parent: GitRef[];
   };
   payload: string;
 }
@@ -197,7 +197,7 @@ export class GitVCS {
     return config;
   }
 
-  async listRemotes(): Promise<Array<GitRemoteConfig>> {
+  async listRemotes(): Promise<GitRemoteConfig[]> {
     return git.listRemotes({ ...this._baseOpts });
   }
 
@@ -359,7 +359,7 @@ export class GitVCS {
     }
   }
 
-  async undoPendingChanges(fileFilter?: Array<String>) {
+  async undoPendingChanges(fileFilter?: String[]) {
     console.log('[git] Undo pending changes');
     await git.checkout({
       ...this._baseOpts,
@@ -398,7 +398,7 @@ export class GitVCS {
     return this._baseOpts.fs;
   }
 
-  static sortBranches(branches: Array<string>) {
+  static sortBranches(branches: string[]) {
     const newBranches = [...branches];
     newBranches.sort((a: string, b: string) => {
       if (a === 'master') {

--- a/packages/insomnia-app/app/sync/git/mem-client.ts
+++ b/packages/insomnia-app/app/sync/git/mem-client.ts
@@ -27,7 +27,7 @@ interface FSDir {
   readonly mtimeMs: number;
   readonly name: string;
   readonly path: string;
-  readonly children: Array<FSFile | FSDir | FSLink>;
+  readonly children: (FSFile | FSDir | FSLink)[];
 }
 
 type FSEntry = FSDir | FSFile | FSLink;

--- a/packages/insomnia-app/app/sync/git/ne-db-client.ts
+++ b/packages/insomnia-app/app/sync/git/ne-db-client.ts
@@ -161,7 +161,7 @@ export class NeDBClient {
   async stat(filePath: string) {
     filePath = path.normalize(filePath);
     let fileBuff: Buffer | string | null = null;
-    let dir: Array<string> | null = null;
+    let dir: string[] | null = null;
 
     try {
       fileBuff = await this.readFile(filePath);
@@ -202,7 +202,7 @@ export class NeDBClient {
     }
   }
 
-  async readlink(filePath: string, ...x: Array<any>) {
+  async readlink(filePath: string, ...x: any[]) {
     return this.readFile(filePath, ...x);
   }
 

--- a/packages/insomnia-app/app/sync/git/routable-fs-client.ts
+++ b/packages/insomnia-app/app/sync/git/routable-fs-client.ts
@@ -12,7 +12,7 @@ export function routableFSClient(
   defaultFS: git.PromiseFsClient,
   otherFS: Record<string, git.PromiseFsClient>,
 ) {
-  const execMethod = async (method: string, filePath: string, ...args: Array<any>) => {
+  const execMethod = async (method: string, filePath: string, ...args: any[]) => {
     filePath = path.normalize(filePath);
 
     for (const prefix of Object.keys(otherFS)) {

--- a/packages/insomnia-app/app/sync/lib/deterministicStringify.ts
+++ b/packages/insomnia-app/app/sync/lib/deterministicStringify.ts
@@ -2,7 +2,7 @@ export function deterministicStringify(value: any) {
   const t = Object.prototype.toString.call(value);
 
   if (t === '[object Object]') {
-    const pairs: Array<string> = [];
+    const pairs: string[] = [];
 
     for (const key of Object.keys(value).sort()) {
       const k = deterministicStringify(key);
@@ -15,7 +15,7 @@ export function deterministicStringify(value: any) {
 
     return `{${pairs.join(',')}}`;
   } else if (t === '[object Array]') {
-    const items: Array<string> = [];
+    const items: string[] = [];
 
     for (const v of value) {
       const vStr = deterministicStringify(v);

--- a/packages/insomnia-app/app/sync/store/drivers/base.ts
+++ b/packages/insomnia-app/app/sync/store/drivers/base.ts
@@ -4,6 +4,6 @@ export interface BaseDriver {
   setItem(key: string, value: Buffer): Promise<void>;
   getItem(key: string): Promise<Buffer | null>;
   removeItem(key: string): Promise<void>;
-  keys(prefix: string, recursive: boolean): Promise<Array<string>>;
+  keys(prefix: string, recursive: boolean): Promise<string[]>;
   clear(): Promise<void>;
 }

--- a/packages/insomnia-app/app/sync/store/drivers/file-system-driver.ts
+++ b/packages/insomnia-app/app/sync/store/drivers/file-system-driver.ts
@@ -97,9 +97,9 @@ export default class FileSystemDriver implements BaseDriver {
 
   async keys(prefix: string, recursive: boolean) {
     const next = dir => {
-      return new Promise<Array<string>>(async (resolve, reject) => {
-        let keys: Array<string> = [];
-        let names: Array<string> = [];
+      return new Promise<string[]>(async (resolve, reject) => {
+        let keys: string[] = [];
+        let names: string[] = [];
 
         try {
           names = fs.readdirSync(dir);
@@ -133,7 +133,7 @@ export default class FileSystemDriver implements BaseDriver {
     };
 
     const rawKeys = await next(this._getKeyPath(prefix));
-    const keys: Array<string> = [];
+    const keys: string[] = [];
 
     for (const rawKey of rawKeys) {
       keys.push(rawKey.substring(this._directory.length));

--- a/packages/insomnia-app/app/sync/store/drivers/memory-driver.ts
+++ b/packages/insomnia-app/app/sync/store/drivers/memory-driver.ts
@@ -35,7 +35,7 @@ export default class MemoryDriver implements BaseDriver {
   }
 
   async keys(prefix: string, recursive: boolean) {
-    const keys: Array<string> = [];
+    const keys: string[] = [];
     const baseLevels = prefix.split('/').length;
 
     for (const key of Object.keys(this._db)) {

--- a/packages/insomnia-app/app/sync/store/index.ts
+++ b/packages/insomnia-app/app/sync/store/index.ts
@@ -13,9 +13,9 @@ export interface Hook {
 
 export default class Store {
   _driver: BaseDriver;
-  _hooks: Array<Hook>;
+  _hooks: Hook[];
 
-  constructor(driver: BaseDriver, hooks?: Array<Hook>) {
+  constructor(driver: BaseDriver, hooks?: Hook[]) {
     this._driver = driver;
     this._hooks = hooks || [];
   }

--- a/packages/insomnia-app/app/sync/types.ts
+++ b/packages/insomnia-app/app/sync/types.ts
@@ -24,7 +24,7 @@ export interface SnapshotStateEntry {
   name: string;
 }
 
-export type SnapshotState = Array<SnapshotStateEntry>;
+export type SnapshotState = SnapshotStateEntry[];
 
 export type SnapshotStateMap = Record<DocumentKey, SnapshotStateEntry>;
 
@@ -37,7 +37,7 @@ export interface Snapshot {
   author: string;
   name: string;
   description: string;
-  state: Array<SnapshotStateEntry>;
+  state: SnapshotStateEntry[];
   // Only exists in Snapshots that are pulled from the server
   authorAccount?: {
     firstName: string;
@@ -50,7 +50,7 @@ export interface Branch {
   name: string;
   created: Date;
   modified: Date;
-  snapshots: Array<string>;
+  snapshots: string[];
 }
 
 export interface StageEntryDelete {

--- a/packages/insomnia-app/app/sync/vcs/util.ts
+++ b/packages/insomnia-app/app/sync/vcs/util.ts
@@ -38,7 +38,7 @@ export function generateStateMap(state: SnapshotState | null): SnapshotStateMap 
   return map;
 }
 
-export function generateCandidateMap(candidates: Array<StatusCandidate>): StatusCandidateMap {
+export function generateCandidateMap(candidates: StatusCandidate[]): StatusCandidateMap {
   const map = {};
 
   for (const candidate of candidates) {
@@ -49,8 +49,8 @@ export function generateCandidateMap(candidates: Array<StatusCandidate>): Status
 }
 
 export function combinedMapKeys<T extends SnapshotStateMap | StatusCandidateMap>(
-  ...maps: Array<T>
-): Array<DocumentKey> {
+  ...maps: T[]
+): DocumentKey[] {
   const keyMap = {};
 
   for (const map of maps) {
@@ -68,14 +68,14 @@ export function threeWayMerge(
   other: SnapshotState,
 ): {
   state: SnapshotState;
-  conflicts: Array<MergeConflict>;
+  conflicts: MergeConflict[];
 } {
   const stateRoot = generateStateMap(root);
   const stateTrunk = generateStateMap(trunk);
   const stateOther = generateStateMap(other);
   const allKeys = combinedMapKeys(stateRoot, stateTrunk, stateOther);
   const newState: SnapshotState = [];
-  const conflicts: Array<MergeConflict> = [];
+  const conflicts: MergeConflict[] = [];
 
   for (const key of allKeys) {
     const root = stateRoot[key] || null;
@@ -280,9 +280,9 @@ export function compareBranches(
 }
 
 export interface StateDelta {
-  add: Array<SnapshotStateEntry>;
-  update: Array<SnapshotStateEntry>;
-  remove: Array<SnapshotStateEntry>;
+  add: SnapshotStateEntry[];
+  update: SnapshotStateEntry[];
+  remove: SnapshotStateEntry[];
 }
 
 export function stateDelta(
@@ -320,8 +320,8 @@ export function stateDelta(
   return result;
 }
 
-export function getStagable(state: SnapshotState, candidates: Array<StatusCandidate>) {
-  const stagable: Array<StageEntry> = [];
+export function getStagable(state: SnapshotState, candidates: StatusCandidate[]) {
+  const stagable: StageEntry[] = [];
   const stateMap = generateStateMap(state);
   const candidateMap = generateCandidateMap(candidates);
 
@@ -394,10 +394,10 @@ export function getRootSnapshot(a: Branch | null, b: Branch | null): string | nu
 export function preMergeCheck(
   trunkState: SnapshotState,
   otherState: SnapshotState,
-  candidates: Array<StatusCandidate>,
+  candidates: StatusCandidate[],
 ) {
-  const conflicts: Array<StatusCandidate> = [];
-  const dirty: Array<StatusCandidate> = [];
+  const conflicts: StatusCandidate[] = [];
+  const dirty: StatusCandidate[] = [];
   const trunkMap = generateStateMap(trunkState);
   const otherMap = generateStateMap(otherState);
 
@@ -476,7 +476,7 @@ export function hashDocument(
   };
 }
 
-export function updateStateWithConflictResolutions(state: SnapshotState, conflicts: Array<MergeConflict>) {
+export function updateStateWithConflictResolutions(state: SnapshotState, conflicts: MergeConflict[]) {
   const newStateMap = generateStateMap(state);
 
   for (const { choose, key, name } of conflicts) {
@@ -509,7 +509,7 @@ export function updateStateWithConflictResolutions(state: SnapshotState, conflic
   return Object.keys(newStateMap).map(k => newStateMap[k]);
 }
 
-export function describeChanges(a: any, b: any): Array<string> {
+export function describeChanges(a: any, b: any): string[] {
   const aT = Object.prototype.toString.call(a);
   const bT = Object.prototype.toString.call(b);
 
@@ -517,7 +517,7 @@ export function describeChanges(a: any, b: any): Array<string> {
     return [];
   }
 
-  const changes: Array<string> = [];
+  const changes: string[] = [];
   const allKeys = [...Object.keys({ ...a, ...b })];
 
   for (const key of allKeys) {

--- a/packages/insomnia-app/app/templating/base-extension.ts
+++ b/packages/insomnia-app/app/templating/base-extension.ts
@@ -10,7 +10,7 @@ const EMPTY_ARG = '__EMPTY_NUNJUCKS_ARG__';
 export default class BaseExtension {
   _ext: PluginTemplateTag | null = null;
   _plugin: Plugin | null = null;
-  tags: Array<PluginTemplateTag['name']> | null = null;
+  tags: PluginTemplateTag['name'][] | null = null;
 
   constructor(ext: PluginTemplateTag, plugin: Plugin) {
     this._ext = ext;

--- a/packages/insomnia-app/app/templating/extensions/index.ts
+++ b/packages/insomnia-app/app/templating/extensions/index.ts
@@ -5,13 +5,13 @@ import type { PluginStore } from '../../plugins/context';
 
 export type PluginArgumentValue = string | number | boolean;
 
-type DisplayName = string | ((args: Array<NunjucksParsedTagArg>) => string);
+type DisplayName = string | ((args: NunjucksParsedTagArg[]) => string);
 
 interface PluginArgumentBase {
   displayName: DisplayName;
   description?: string;
   help?: string;
-  hide?: (args: Array<NunjucksParsedTagArg>) => boolean;
+  hide?: (args: NunjucksParsedTagArg[]) => boolean;
 }
 
 export interface PluginArgumentEnumOption {
@@ -23,7 +23,7 @@ export interface PluginArgumentEnumOption {
 
 export type PluginArgumentEnum = PluginArgumentBase & {
   type: 'enum';
-  options: Array<PluginArgumentEnumOption>;
+  options: PluginArgumentEnumOption[];
   defaultValue?: PluginArgumentValue;
 };
 
@@ -87,13 +87,13 @@ export interface PluginTemplateTagAction {
 }
 
 export interface PluginTemplateTag {
-  args: Array<PluginArgument>;
+  args: PluginArgument[];
   name: string;
   displayName: DisplayName;
   disablePreview: () => boolean;
   description: string;
-  actions: Array<PluginTemplateTagAction>;
-  run: (context: PluginTemplateTagContext, ...arg: Array<any>) => Promise<any> | any;
+  actions: PluginTemplateTagAction[];
+  run: (context: PluginTemplateTagContext, ...arg: any[]) => Promise<any> | any;
   deprecated?: boolean;
   validate?: (value: any) => string | null;
   priority?: number;

--- a/packages/insomnia-app/app/templating/index.ts
+++ b/packages/insomnia-app/app/templating/index.ts
@@ -160,7 +160,7 @@ async function getNunjucks(renderMode: string) {
   // Create Env with Extensions //
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~ //
   const nj = nunjucks.configure(config);
-  let allTemplateTagPlugins: Array<TemplateTag>;
+  let allTemplateTagPlugins: TemplateTag[];
 
   try {
     plugins.ignorePlugin('insomnia-plugin-kong-bundle');

--- a/packages/insomnia-app/app/templating/utils.ts
+++ b/packages/insomnia-app/app/templating/utils.ts
@@ -13,11 +13,11 @@ export interface NunjucksParsedTagArg {
   displayName?: string;
   quotedBy?: '"' | "'";
   validate?: (value: any) => string;
-  hide?: (arg0: Array<NunjucksParsedTagArg>) => boolean;
+  hide?: (arg0: NunjucksParsedTagArg[]) => boolean;
   model?: string;
-  options?: Array<PluginArgumentEnumOption>;
-  itemTypes?: Array<'file' | 'directory'>;
-  extensions?: Array<string>;
+  options?: PluginArgumentEnumOption[];
+  itemTypes?: ('file' | 'directory')[];
+  extensions?: string[];
 }
 
 export interface NunjucksActionTag {
@@ -28,12 +28,12 @@ export interface NunjucksActionTag {
 
 export interface NunjucksParsedTag {
   name: string;
-  args: Array<NunjucksParsedTagArg>;
-  actions?: Array<NunjucksActionTag>;
+  args: NunjucksParsedTagArg[];
+  actions?: NunjucksActionTag[];
   rawValue?: string;
   displayName?: string;
   description?: string;
-  disablePreview?: (arg0: Array<NunjucksParsedTagArg>) => boolean;
+  disablePreview?: (arg0: NunjucksParsedTagArg[]) => boolean;
 }
 
 interface Key {
@@ -50,8 +50,8 @@ interface Key {
 export function getKeys(
   obj: any,
   prefix = '',
-): Array<Key> {
-  let allKeys: Array<Key> = [];
+): Key[] {
+  let allKeys: Key[] = [];
   const typeOfObj = Object.prototype.toString.call(obj);
 
   if (typeOfObj === '[object Array]') {
@@ -100,7 +100,7 @@ export function tokenizeTag(tagStr: string) {
   // ~~~~~~~~~~~~~ //
   // Tokenize Args //
   // ~~~~~~~~~~~~~ //
-  const args: Array<NunjucksParsedTagArg> = [];
+  const args: NunjucksParsedTagArg[] = [];
   let quotedBy: string | null = null;
   let currentArg: string | null = null;
 
@@ -196,7 +196,7 @@ export function tokenizeTag(tagStr: string) {
 
 /** Convert a tokenized tag back into a Nunjucks string */
 export function unTokenizeTag(tagData: NunjucksParsedTag) {
-  const args: Array<string> = [];
+  const args: string[] = [];
 
   for (const arg of tagData.args) {
     if (['string', 'model', 'file', 'enum'].includes(arg.type)) {
@@ -217,8 +217,8 @@ export function unTokenizeTag(tagData: NunjucksParsedTag) {
 }
 
 /** Get the default Nunjucks string for an extension */
-export function getDefaultFill(name: string, args: Array<NunjucksParsedTagArg>) {
-  const stringArgs: Array<string> = (args || []).map(argDefinition => {
+export function getDefaultFill(name: string, args: NunjucksParsedTagArg[]) {
+  const stringArgs: string[] = (args || []).map(argDefinition => {
     switch (argDefinition.type) {
       case 'enum':
         const { defaultValue, options } = argDefinition;

--- a/packages/insomnia-app/app/ui/components/analytics.tsx
+++ b/packages/insomnia-app/app/ui/components/analytics.tsx
@@ -8,7 +8,7 @@ import chartSrc from '../images/chart.svg';
 
 interface Props {
   wrapperProps: WrapperProps;
-  handleDone: (...args: Array<any>) => any;
+  handleDone: (...args: any[]) => any;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)

--- a/packages/insomnia-app/app/ui/components/base/dropdown/dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/base/dropdown/dropdown.tsx
@@ -29,7 +29,7 @@ interface State {
   dropUp: boolean,
   filter: string,
   filterVisible: boolean,
-  filterItems?: Array<number> | null,
+  filterItems?: number[] | null,
   filterActiveIndex: number,
   forcedPosition?: {x: number, y: number} | null,
   uniquenessKey: number,
@@ -80,7 +80,7 @@ class Dropdown extends PureComponent<DropdownProps, State> {
     }
 
     // Filter the list items that are filterable (have data-filter-index property)
-    const filterItems: Array<number> = [];
+    const filterItems: number[] = [];
 
     // @ts-expect-error -- TSCONVERSION convert to array or use querySelectorAll().forEach
     for (const listItem of this._dropdownList.querySelectorAll('li')) {
@@ -256,7 +256,7 @@ class Dropdown extends PureComponent<DropdownProps, State> {
   }
 
   _getFlattenedChildren(children) {
-    let newChildren: Array<ReactNode> = [];
+    let newChildren: ReactNode[] = [];
     // Ensure children is an array
     children = Array.isArray(children) ? children : [children];
 
@@ -348,8 +348,8 @@ class Dropdown extends PureComponent<DropdownProps, State> {
       'dropdown__menu--up': dropUp,
       'dropdown__menu--right': right,
     });
-    const dropdownButtons: Array<ReactNode> = [];
-    const dropdownItems: Array<ReactNode> = [];
+    const dropdownButtons: ReactNode[] = [];
+    const dropdownItems: ReactNode[] = [];
 
     const allChildren = this._getFlattenedChildren(children);
 

--- a/packages/insomnia-app/app/ui/components/base/file-input-button.tsx
+++ b/packages/insomnia-app/app/ui/components/base/file-input-button.tsx
@@ -7,8 +7,8 @@ import selectFileOrFolder from '../../../common/select-file-or-folder';
 interface Props extends Omit<HTMLAttributes<HTMLButtonElement>, 'onChange'> {
   onChange: (path: string) => void;
   path?: string;
-  itemtypes?: Array<'file' | 'directory'>;
-  extensions?: Array<string>;
+  itemtypes?: ('file' | 'directory')[];
+  extensions?: string[];
   showFileName?: boolean;
   showFileIcon?: boolean;
   name?: string;

--- a/packages/insomnia-app/app/ui/components/base/link.tsx
+++ b/packages/insomnia-app/app/ui/components/base/link.tsx
@@ -8,7 +8,7 @@ interface Props {
   href: string;
   title?: string;
   button?: boolean;
-  onClick?: (...args: Array<any>) => any;
+  onClick?: (...args: any[]) => any;
   className?: string;
   children?: ReactNode;
   disabled?: boolean;

--- a/packages/insomnia-app/app/ui/components/base/mailto.tsx
+++ b/packages/insomnia-app/app/ui/components/base/mailto.tsx
@@ -15,7 +15,7 @@ interface Props {
 class Mailto extends PureComponent<Props> {
   render() {
     const { email, body, subject, children } = this.props;
-    const params: Array<{name: string; value: string}> = [];
+    const params: {name: string; value: string}[] = [];
 
     if (subject) {
       params.push({

--- a/packages/insomnia-app/app/ui/components/base/modal.tsx
+++ b/packages/insomnia-app/app/ui/components/base/modal.tsx
@@ -15,7 +15,7 @@ export interface ModalProps {
   skinny?: boolean,
   noEscape?: boolean,
   dontFocus?: boolean,
-  closeOnKeyCodes?: Array<any>,
+  closeOnKeyCodes?: any[],
   onHide?: Function,
   onCancel?: Function,
   onKeyDown?: Function,

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -125,7 +125,7 @@ interface Props {
   readOnly?: boolean,
   type?: string,
   filter?: string,
-  filterHistory?: Array<string>,
+  filterHistory?: string[],
   singleLine?: boolean,
   debounceMillis?: number,
   dynamicHeight?: boolean,
@@ -787,8 +787,8 @@ class CodeEditor extends Component<Props, State> {
 
     // Setup the hint options
     if (getRenderContext || getAutocompleteConstants || getAutocompleteSnippets) {
-      let getVariables: (() => Promise<Array<Object>>) | undefined;
-      let getTags: (() => Promise<Array<NunjucksParsedTag>>) | undefined;
+      let getVariables: (() => Promise<Object[]>) | undefined;
+      let getTags: (() => Promise<NunjucksParsedTag[]>) | undefined;
 
       if (getRenderContext) {
         getVariables = async () => {
@@ -799,7 +799,7 @@ class CodeEditor extends Component<Props, State> {
 
         // Only allow tags if we have variables too
         getTags = async () => {
-          const expandedTags: Array<NunjucksParsedTag> = [];
+          const expandedTags: NunjucksParsedTag[] = [];
 
           for (const tagDef of await getTagDefinitions()) {
             const firstArg = tagDef.args[0];
@@ -1140,7 +1140,7 @@ class CodeEditor extends Component<Props, State> {
       'editor--readonly': readOnly,
       'raw-editor': raw,
     });
-    const toolbarChildren: Array<ReactNode> = [];
+    const toolbarChildren: ReactNode[] = [];
 
     if (this.props.updateFilter && (CodeEditor._isJSON(mode) || CodeEditor._isXML(mode))) {
       toolbarChildren.push(

--- a/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.ts
@@ -45,7 +45,7 @@ async function _highlightNunjucksTags(render, renderContext, isVariableUncovered
 
   const renderString = text => render(text, renderCacheKey);
 
-  const activeMarks: Array<CodeMirror.TextMarker> = [];
+  const activeMarks: CodeMirror.TextMarker[] = [];
   const doc: CodeMirror.Doc = this.getDoc();
 
   // Only mark up Nunjucks tokens that are in the viewport
@@ -56,7 +56,7 @@ async function _highlightNunjucksTags(render, renderContext, isVariableUncovered
     const tokens = line.filter(({ type }) => type && type.indexOf('nunjucks') >= 0);
 
     // Aggregate same tokens
-    const newTokens: Array<Token> = [];
+    const newTokens: Token[] = [];
     let currTok: Token | null = null;
 
     for (let i = 0; i < tokens.length; i++) {

--- a/packages/insomnia-app/app/ui/components/cookie-list.tsx
+++ b/packages/insomnia-app/app/ui/components/cookie-list.tsx
@@ -14,7 +14,7 @@ interface Props {
   handleCookieAdd: Function;
   handleCookieDelete: Function;
   handleDeleteAll: Function;
-  cookies: Array<Cookie>;
+  cookies: Cookie[];
   newCookieDomainName: string;
   handleShowModifyCookieModal: Function;
   handleRender: HandleRender;

--- a/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.tsx
@@ -27,7 +27,7 @@ interface Props {
 }
 
 interface State {
-  actionPlugins: Array<DocumentAction>;
+  actionPlugins: DocumentAction[];
   loadingActions: Record<string, boolean>;
 }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.tsx
@@ -21,7 +21,7 @@ import { executeHotKey } from '../../../common/hotkeys-listener';
 interface Props {
   handleChangeEnvironment: Function;
   workspace: Workspace;
-  environments: Array<Environment>;
+  environments: Environment[];
   environmentHighlightColorStyle: string;
   hotKeyRegistry: HotKeyRegistry;
   className?: string;

--- a/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -43,9 +43,9 @@ interface State {
   initializing: boolean;
   loadingPush: boolean;
   loadingPull: boolean;
-  log: Array<GitLogEntry>;
+  log: GitLogEntry[];
   branch: string;
-  branches: Array<string>;
+  branches: string[];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)

--- a/packages/insomnia-app/app/ui/components/dropdowns/grpc-method-dropdown/grpc-method-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/grpc-method-dropdown/grpc-method-dropdown.tsx
@@ -13,7 +13,7 @@ import GrpcMethodDropdownButton from './grpc-method-dropdown-button';
 
 interface Props {
   disabled?: boolean;
-  methods: Array<GrpcMethodDefinition>;
+  methods: GrpcMethodDefinition[];
   selectedMethod?: GrpcMethodDefinition;
   handleChange: (arg0: string) => Promise<void>;
   handleChangeProtoFile: (arg0: string) => Promise<void>;

--- a/packages/insomnia-app/app/ui/components/dropdowns/remote-workspaces-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/remote-workspaces-dropdown.tsx
@@ -15,14 +15,14 @@ import { stringsPlural } from '../../../common/strings';
 interface Props {
   className?: string;
   vcs?: VCS | null;
-  workspaces: Array<Workspace>;
+  workspaces: Workspace[];
 }
 
 interface State {
   loading: boolean;
-  localProjects: Array<Project>;
+  localProjects: Project[];
   pullingProjects: Record<string, boolean>;
-  remoteProjects: Array<Project>;
+  remoteProjects: Project[];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -42,7 +42,7 @@ interface Props extends Partial<DropdownProps> {
 
 // Setup state for plugin actions
 interface State {
-  actionPlugins: Array<RequestAction>;
+  actionPlugins: RequestAction[];
   loadingActions: Record<string, boolean>;
 }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -35,7 +35,7 @@ interface Props {
 }
 
 interface State {
-  actionPlugins: Array<RequestGroupAction>;
+  actionPlugins: RequestGroupAction[];
   loadingActions: Record<string, boolean>;
 }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
@@ -23,8 +23,8 @@ interface Props {
   handleDeleteResponses: Function;
   handleDeleteResponse: Function;
   requestId: string;
-  responses: Array<Response>;
-  requestVersions: Array<RequestVersion>;
+  responses: Response[];
+  requestVersions: RequestVersion[];
   activeResponse: Response;
   activeEnvironment?: Environment | null;
   className?: string;
@@ -94,15 +94,15 @@ class ResponseHistoryDropdown extends PureComponent<Props> {
     );
   }
 
-  renderPastResponses(responses: Array<Response>) {
+  renderPastResponses(responses: Response[]) {
     const now = moment();
     // Four arrays for four time groups
     const categories = {
-      minutes: [] as Array<Response>,
-      hours: [] as Array<Response>,
-      today: [] as Array<Response>,
-      week: [] as Array<Response>,
-      other: [] as Array<Response>,
+      minutes: [] as Response[],
+      hours: [] as Response[],
+      today: [] as Response[],
+      week: [] as Response[],
+      other: [] as Response[],
     };
 
     responses.forEach(response => {

--- a/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.tsx
@@ -32,13 +32,13 @@ const DEFAULT_BRANCH_NAME = 'master';
 interface Props {
   workspace: Workspace;
   vcs: VCS;
-  syncItems: Array<StatusCandidate>;
+  syncItems: StatusCandidate[];
   className?: string;
 }
 
 interface State {
   currentBranch: string;
-  localBranches: Array<string>;
+  localBranches: string[];
   compare: {
     ahead: number;
     behind: number;
@@ -49,7 +49,7 @@ interface State {
   loadingPull: boolean;
   loadingProjectPull: boolean;
   loadingPush: boolean;
-  remoteProjects: Array<Project>;
+  remoteProjects: Project[];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
@@ -38,8 +38,8 @@ interface Props {
 }
 
 interface State {
-  actionPlugins: Array<WorkspaceAction>;
-  configGeneratorPlugins: Array<ConfigGenerator>;
+  actionPlugins: WorkspaceAction[];
+  configGeneratorPlugins: ConfigGenerator[];
   loadingActions: Record<string, boolean>;
 }
 

--- a/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.tsx
@@ -76,7 +76,7 @@ class AsapAuth extends PureComponent<Props> {
     label: string,
     property: string,
     mode: string,
-    onChange: (...args: Array<any>) => any,
+    onChange: (...args: any[]) => any,
   ): ReactElement<any> {
     const {
       handleRender,

--- a/packages/insomnia-app/app/ui/components/editors/auth/aws-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/aws-auth.tsx
@@ -52,7 +52,7 @@ class AWSAuth extends PureComponent<Props> {
     onChange(request, { ...request.authentication, sessionToken: value });
   }
 
-  renderRow(key: string, label: string, onChange: (...args: Array<any>) => any, help?: string) {
+  renderRow(key: string, label: string, onChange: (...args: any[]) => any, help?: string) {
     const {
       request,
       nunjucksPowerUserMode,

--- a/packages/insomnia-app/app/ui/components/editors/auth/hawk-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/hawk-auth.tsx
@@ -86,11 +86,11 @@ class HawkAuth extends PureComponent<Props> {
   renderSelectRow(
     label: string,
     property: string,
-    options: Array<{
+    options: {
       name: string;
       value: string;
-    }>,
-    onChange: (...args: Array<any>) => any,
+    }[],
+    onChange: (...args: any[]) => any,
     help: string | null = null,
   ) {
     const { authentication } = this.props.request;
@@ -125,7 +125,7 @@ class HawkAuth extends PureComponent<Props> {
   renderInputRow(
     label: string,
     property: string,
-    onChange: (...args: Array<any>) => any,
+    onChange: (...args: any[]) => any,
   ) {
     const {
       handleRender,

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.tsx
@@ -188,9 +188,9 @@ class OAuth1Auth extends PureComponent<Props> {
   renderInputRow(
     label: string,
     property: string,
-    onChange: (...args: Array<any>) => any,
+    onChange: (...args: any[]) => any,
     help: string | null = null,
-    handleAutocomplete: ((...args: Array<any>) => any) | null = null,
+    handleAutocomplete: ((...args: any[]) => any) | null = null,
   ) {
     const {
       handleRender,
@@ -235,11 +235,11 @@ class OAuth1Auth extends PureComponent<Props> {
   renderSelectRow(
     label: string,
     property: string,
-    options: Array<{
+    options: {
       name: string;
       value: string;
-    }>,
-    onChange: (...args: Array<any>) => any,
+    }[],
+    onChange: (...args: any[]) => any,
     help: string | null = null,
   ) {
     const { request } = this.props;

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -301,9 +301,9 @@ class OAuth2Auth extends PureComponent<Props, State> {
   renderInputRow(
     label: string,
     property: string,
-    onChange: (...args: Array<any>) => any,
+    onChange: (...args: any[]) => any,
     help: string | null = null,
-    handleAutocomplete: ((...args: Array<any>) => any) | null = null,
+    handleAutocomplete: ((...args: any[]) => any) | null = null,
   ) {
     const {
       handleRender,
@@ -348,11 +348,11 @@ class OAuth2Auth extends PureComponent<Props, State> {
   renderSelectRow(
     label: string,
     property: string,
-    options: Array<{
+    options: {
       name: string;
       value: string;
-    }>,
-    onChange: (...args: Array<any>) => any,
+    }[],
+    onChange: (...args: any[]) => any,
     help: string | null = null,
   ) {
     const { request } = this.props;
@@ -388,8 +388,8 @@ class OAuth2Auth extends PureComponent<Props, State> {
   }
 
   renderGrantTypeFields(grantType: string) {
-    let basicFields: Array<JSX.Element> = [];
-    let advancedFields: Array<JSX.Element> = [];
+    let basicFields: JSX.Element[] = [];
+    let advancedFields: JSX.Element[] = [];
     const clientId = this.renderInputRow('Client ID', 'clientId', this._handleChangeClientId);
     const clientSecret = this.renderInputRow(
       'Client Secret',

--- a/packages/insomnia-app/app/ui/components/editors/body/body-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/body-editor.tsx
@@ -36,7 +36,7 @@ import { HandleGetRenderContext, HandleRender } from '../../../../common/render'
 
 interface Props {
   onChange: (r: Request, body: RequestBody) => Promise<Request>;
-  onChangeHeaders: (r: Request, headers: Array<RequestHeader>) => Promise<Request>;
+  onChangeHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
@@ -62,13 +62,13 @@ class BodyEditor extends PureComponent<Props> {
     onChange(request, newBody);
   }
 
-  _handleFormUrlEncodedChange(parameters: Array<RequestBodyParameter>) {
+  _handleFormUrlEncodedChange(parameters: RequestBodyParameter[]) {
     const { onChange, request } = this.props;
     const newBody = newBodyFormUrlEncoded(parameters);
     onChange(request, newBody);
   }
 
-  _handleFormChange(parameters: Array<RequestBodyParameter>) {
+  _handleFormChange(parameters: RequestBodyParameter[]) {
     const { onChange, request } = this.props;
     const newBody = newBodyForm(parameters);
     onChange(request, newBody);

--- a/packages/insomnia-app/app/ui/components/editors/body/form-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/form-editor.tsx
@@ -6,7 +6,7 @@ import { HandleGetRenderContext, HandleRender } from '../../../../common/render'
 
 interface Props {
   onChange: Function,
-  parameters: Array<any>,
+  parameters: any[],
   nunjucksPowerUserMode: boolean,
   isVariableUncovered: boolean,
   handleRender?: HandleRender,

--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
@@ -79,7 +79,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class GraphQLEditor extends PureComponent<Props, State> {
-  _disabledOperationMarkers: Array<TextMarker> = [];
+  _disabledOperationMarkers: TextMarker[] = [];
   _documentAST: null | Record<string, any> = null;
   _isMounted = false;
   _queryEditor: null | EditorFromTextArea = null;
@@ -132,7 +132,7 @@ class GraphQLEditor extends PureComponent<Props, State> {
     const cursorIndex = _queryEditor.indexFromPos(cursor);
 
     let operationName: string | null = null;
-    const allOperationNames: Array<string | null> = [];
+    const allOperationNames: (string | null)[] = [];
 
     // Loop through all operations to see if one contains the cursor.
     for (let i = 0; i < operations.length; i++) {
@@ -398,7 +398,7 @@ class GraphQLEditor extends PureComponent<Props, State> {
     }
   }
 
-  _getOperations(): Array<any> {
+  _getOperations(): any[] {
     if (!this._documentAST) {
       return [];
     }

--- a/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.tsx
@@ -6,7 +6,7 @@ import { HandleGetRenderContext, HandleRender } from '../../../../common/render'
 
 interface Props {
   onChange: Function;
-  parameters: Array<any>;
+  parameters: any[];
   nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   handleRender?: HandleRender;

--- a/packages/insomnia-app/app/ui/components/editors/environment-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/environment-editor.tsx
@@ -26,12 +26,12 @@ export interface EnvironmentInfo {
 
 interface Props {
   environmentInfo: EnvironmentInfo;
-  didChange: (...args: Array<any>) => any;
+  didChange: (...args: any[]) => any;
   editorFontSize: number;
   editorIndentSize: number;
   editorKeyMap: string;
-  render: (...args: Array<any>) => any;
-  getRenderContext: (...args: Array<any>) => any;
+  render: (...args: any[]) => any;
+  getRenderContext: (...args: any[]) => any;
   nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   lineWrapping: boolean;

--- a/packages/insomnia-app/app/ui/components/editors/password-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/password-editor.tsx
@@ -10,7 +10,7 @@ interface Props {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
   nunjucksPowerUserMode: boolean;
-  onChange: (...args: Array<any>) => any;
+  onChange: (...args: any[]) => any;
   password: string;
   disabled: boolean;
   isVariableUncovered: boolean;

--- a/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
@@ -11,7 +11,7 @@ import type { Request, RequestHeader } from '../../../models/request';
 import { HandleGetRenderContext, HandleRender } from '../../../common/render';
 
 interface Props {
-  onChange: (r: Request, headers: Array<RequestHeader>) => Promise<Request>;
+  onChange: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   bulk: boolean;
   editorFontSize: number;
   editorIndentSize: number;
@@ -33,13 +33,13 @@ class RequestHeadersEditor extends PureComponent<Props> {
     onChange(request, headers);
   }
 
-  _handleKeyValueUpdate(headers: Array<RequestHeader>) {
+  _handleKeyValueUpdate(headers: RequestHeader[]) {
     const { onChange, request } = this.props;
     onChange(request, headers);
   }
 
   static _getHeadersFromString(headersString: string) {
-    const headers: Array<{ name: string; value: string }> = [];
+    const headers: { name: string; value: string }[] = [];
     const rows = headersString.split(/\n+/);
 
     for (const row of rows) {

--- a/packages/insomnia-app/app/ui/components/editors/request-parameters-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/request-parameters-editor.tsx
@@ -7,7 +7,7 @@ import type { Request, RequestParameter } from '../../../models/request';
 import { HandleGetRenderContext, HandleRender } from '../../../common/render';
 
 interface Props {
-  onChange: (r: Request, parameters: Array<RequestParameter>) => Promise<Request>;
+  onChange: (r: Request, parameters: RequestParameter[]) => Promise<Request>;
   bulk: boolean;
   editorFontSize: number;
   editorIndentSize: number;
@@ -29,13 +29,13 @@ class RequestParametersEditor extends PureComponent<Props> {
     onChange(request, params);
   }
 
-  _handleKeyValueUpdate(parameters: Array<RequestParameter>) {
+  _handleKeyValueUpdate(parameters: RequestParameter[]) {
     const { onChange, request } = this.props;
     onChange(request, parameters);
   }
 
   static _getParamsFromString(paramsString: string) {
-    const params: Array<{ name: string; value: string }> = [];
+    const params: { name: string; value: string }[] = [];
     const rows = paramsString.split(/\n+/);
 
     for (const row of rows) {

--- a/packages/insomnia-app/app/ui/components/export-requests/request-group-row.tsx
+++ b/packages/insomnia-app/app/ui/components/export-requests/request-group-row.tsx
@@ -5,8 +5,8 @@ import classnames from 'classnames';
 import type { RequestGroup } from '../../../models/request-group';
 
 interface Props {
-  handleSetRequestGroupCollapsed: (...args: Array<any>) => any;
-  handleSetItemSelected: (...args: Array<any>) => any;
+  handleSetRequestGroupCollapsed: (...args: any[]) => any;
+  handleSetItemSelected: (...args: any[]) => any;
   isCollapsed: boolean;
   totalRequests: number;
   selectedRequests: number;

--- a/packages/insomnia-app/app/ui/components/export-requests/request-row.tsx
+++ b/packages/insomnia-app/app/ui/components/export-requests/request-row.tsx
@@ -8,7 +8,7 @@ import { isGrpcRequest } from '../../../models/helpers/is-model';
 import GrpcTag from '../tags/grpc-tag';
 
 interface Props {
-  handleSetItemSelected: (...args: Array<any>) => any;
+  handleSetItemSelected: (...args: any[]) => any;
   isSelected: boolean;
   request: Request | GrpcRequest;
 }

--- a/packages/insomnia-app/app/ui/components/export-requests/tree.tsx
+++ b/packages/insomnia-app/app/ui/components/export-requests/tree.tsx
@@ -9,8 +9,8 @@ import type { GrpcRequest } from '../../../models/grpc-request';
 
 interface Props {
   root?: Node | null;
-  handleSetRequestGroupCollapsed: (...args: Array<any>) => any;
-  handleSetItemSelected: (...args: Array<any>) => any;
+  handleSetRequestGroupCollapsed: (...args: any[]) => any;
+  handleSetItemSelected: (...args: any[]) => any;
 }
 
 class Tree extends PureComponent<Props> {

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type.tsx
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer-type.tsx
@@ -43,7 +43,7 @@ class GraphQLExplorerType extends PureComponent<Props> {
     }
 
     let title = 'Types';
-    let types: Array<GraphQLInterfaceType> | Array<GraphQLObjectType> = [];
+    let types: GraphQLInterfaceType[] | GraphQLObjectType[] = [];
 
     if (type instanceof GraphQLUnionType) {
       title = 'Possible Types';

--- a/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer.tsx
+++ b/packages/insomnia-app/app/ui/components/graph-ql-explorer/graph-ql-explorer.tsx
@@ -25,7 +25,7 @@ interface HistoryItem {
 }
 
 interface State extends HistoryItem {
-  history: Array<HistoryItem>;
+  history: HistoryItem[];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)

--- a/packages/insomnia-app/app/ui/components/key-value-editor/editor.tsx
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/editor.tsx
@@ -21,7 +21,7 @@ const RIGHT = 39;
 
 interface Props {
   onChange: Function;
-  pairs: Array<any>;
+  pairs: any[];
   handleRender?: HandleRender;
   handleGetRenderContext?: HandleGetRenderContext;
   nunjucksPowerUserMode?: boolean;
@@ -55,7 +55,7 @@ class Editor extends PureComponent<Props, State> {
   _focusedPairId: string | null = null;
   _focusedField: string | null = NAME;
   // @ts-expect-error -- TSCONVERSION being imported as a value but should be usable as a type
-  private _rows: Array<KeyValueEditorRow> = [];
+  private _rows: KeyValueEditorRow[] = [];
   _triggerTimeout: NodeJS.Timeout | null = null;
 
   constructor(props: Props) {

--- a/packages/insomnia-app/app/ui/components/keydown-binder.ts
+++ b/packages/insomnia-app/app/ui/components/keydown-binder.ts
@@ -5,8 +5,8 @@ import { isMac, AUTOBIND_CFG } from '../../common/constants';
 
 interface Props {
   children: ReactNode;
-  onKeydown?: (...args: Array<any>) => any;
-  onKeyup?: (...args: Array<any>) => any;
+  onKeydown?: (...args: any[]) => any;
+  onKeyup?: (...args: any[]) => any;
   disabled?: boolean;
   scoped?: boolean;
   stopMetaPropagation?: boolean;

--- a/packages/insomnia-app/app/ui/components/modals/add-key-combination-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/add-key-combination-modal.tsx
@@ -12,8 +12,8 @@ import * as misc from '../../../common/misc';
 
 interface State {
   hotKeyRefId: string | null;
-  checkKeyCombinationDuplicate: (...args: Array<any>) => any;
-  onAddKeyCombination: (...args: Array<any>) => any;
+  checkKeyCombinationDuplicate: (...args: any[]) => any;
+  onAddKeyCombination: (...args: any[]) => any;
   pressedKeyCombination: KeyCombination | null;
 }
 
@@ -91,8 +91,8 @@ class AddKeyCombinationModal extends PureComponent<{}, State> {
 
   show(
     hotKeyRefId: string,
-    checkKeyCombinationDuplicate: (...args: Array<any>) => any,
-    onAddKeyCombination: (...args: Array<any>) => any,
+    checkKeyCombinationDuplicate: (...args: any[]) => any,
+    onAddKeyCombination: (...args: any[]) => any,
   ) {
     this.setState({
       hotKeyRefId: hotKeyRefId,

--- a/packages/insomnia-app/app/ui/components/modals/cookies-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/cookies-modal.tsx
@@ -22,7 +22,7 @@ interface Props extends ModalProps {
 
 interface State {
   filter: string;
-  visibleCookieIndexes: Array<number> | null;
+  visibleCookieIndexes: number[] | null;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -90,8 +90,8 @@ class CookiesModal extends PureComponent<Props, State> {
     }
   }
 
-  async _applyFilter(filter: string, cookies: Array<Cookie>) {
-    const renderedCookies: Array<Cookie> = [];
+  async _applyFilter(filter: string, cookies: Cookie[]) {
+    const renderedCookies: Cookie[] = [];
 
     for (const cookie of cookies) {
       try {
@@ -128,7 +128,7 @@ class CookiesModal extends PureComponent<Props, State> {
     });
   }
 
-  _getVisibleCookies(): Array<Cookie> {
+  _getVisibleCookies(): Cookie[] {
     const { cookieJar } = this.props;
     const { visibleCookieIndexes } = this.state;
 

--- a/packages/insomnia-app/app/ui/components/modals/export-requests-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/export-requests-modal.tsx
@@ -15,14 +15,14 @@ import { Child } from '../sidebar/sidebar-children';
 
 export interface Node {
   doc: Request | GrpcRequest | RequestGroup;
-  children: Array<Node>;
+  children: Node[];
   collapsed: boolean;
   totalRequests: number;
   selectedRequests: number;
 }
 
 interface Props extends ModalProps {
-  childObjects: Array<Child>;
+  childObjects: Child[];
   handleExportRequestsToFile: Function;
 }
 
@@ -65,14 +65,14 @@ class ExportRequestsModal extends PureComponent<Props, State> {
     this.hide();
   }
 
-  getSelectedRequestIds(node: Node): Array<string> {
+  getSelectedRequestIds(node: Node): string[] {
     const docIsRequest = isRequest(node.doc) || isGrpcRequest(node.doc);
 
     if (docIsRequest && node.selectedRequests === node.totalRequests) {
       return [node.doc._id];
     }
 
-    const requestIds: Array<string> = [];
+    const requestIds: string[] = [];
 
     for (const child of node.children) {
       const reqIds = this.getSelectedRequestIds(child);
@@ -84,7 +84,7 @@ class ExportRequestsModal extends PureComponent<Props, State> {
 
   createTree() {
     const { childObjects } = this.props;
-    const children: Array<Node> = childObjects.map(child => this.createNode(child));
+    const children: Node[] = childObjects.map(child => this.createNode(child));
     const totalRequests = children
       .map(child => child.totalRequests)
       .reduce((acc, totalRequests) => acc + totalRequests, 0);
@@ -109,7 +109,7 @@ class ExportRequestsModal extends PureComponent<Props, State> {
   }
 
   createNode(item: Record<string, any>): Node {
-    const children: Array<Node> = item.children.map(child => this.createNode(child));
+    const children: Node[] = item.children.map(child => this.createNode(child));
     let totalRequests = children
       .map(child => child.totalRequests)
       .reduce((acc, totalRequests) => acc + totalRequests, 0);

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
@@ -28,7 +28,7 @@ interface Config {
 }
 
 interface State {
-  configs: Array<Config>;
+  configs: Config[];
   activeTab: number;
 }
 
@@ -73,7 +73,7 @@ class GenerateConfigModal extends PureComponent<Props, State> {
   }
 
   async show({ activeTabLabel, apiSpec }: ShowOptions) {
-    const configs: Array<Config> = [];
+    const configs: Config[] = [];
 
     for (const p of await plugins.getConfigGenerators()) {
       configs.push(await this._generate(p, apiSpec));

--- a/packages/insomnia-app/app/ui/components/modals/git-branches-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/git-branches-modal.tsx
@@ -20,8 +20,8 @@ interface Props {
 
 interface State {
   error: string;
-  branches: Array<string>;
-  remoteBranches: Array<string>;
+  branches: string[];
+  remoteBranches: string[];
   branch: string;
   newBranchName: string;
 }

--- a/packages/insomnia-app/app/ui/components/modals/git-log-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/git-log-modal.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 interface State {
-  logs: Array<GitLogEntry>;
+  logs: GitLogEntry[];
   branch: string;
 }
 

--- a/packages/insomnia-app/app/ui/components/modals/git-staging-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/git-staging-modal.tsx
@@ -105,7 +105,7 @@ class GitStagingModal extends PureComponent<Props, State> {
     this.modal && this.modal.hide();
   }
 
-  async _toggleAll(items: Array<Item>, forceAdd = false) {
+  async _toggleAll(items: Item[], forceAdd = false) {
     const allStaged = items.every(i => i.staged);
     const doStage = !allStaged;
     const newItems = { ...this.state.items };
@@ -137,11 +137,11 @@ class GitStagingModal extends PureComponent<Props, State> {
     });
   }
 
-  async getAllPaths(): Promise<Array<string>> {
+  async getAllPaths(): Promise<string[]> {
     const { vcs } = this.props;
     // @ts-expect-error -- TSCONVERSION
     const f = vcs.getFs().promises;
-    const fsPaths: Array<string> = [];
+    const fsPaths: string[] = [];
 
     for (const type of await f.readdir(GIT_INSOMNIA_DIR)) {
       const typeDir = path.join(GIT_INSOMNIA_DIR, type);
@@ -292,7 +292,7 @@ class GitStagingModal extends PureComponent<Props, State> {
     );
   }
 
-  async _handleRollback(items: Array<Item>) {
+  async _handleRollback(items: Item[]) {
     const { vcs } = this.props;
     const files = items.map(i => ({
       filePath: i.path,
@@ -334,7 +334,7 @@ class GitStagingModal extends PureComponent<Props, State> {
     );
   }
 
-  renderTable(title: string, items: Array<Item>, rollbackLabel: string) {
+  renderTable(title: string, items: Item[], rollbackLabel: string) {
     if (items.length === 0) {
       return null;
     }
@@ -386,7 +386,7 @@ class GitStagingModal extends PureComponent<Props, State> {
     return <>No changes to commit.</>;
   }
 
-  _renderItems(items: Array<Item>) {
+  _renderItems(items: Item[]) {
     const { message } = this.state;
     const newItems = items.filter(i => i.status.includes('added'));
     const existingItems = items.filter(i => !i.status.includes('added'));

--- a/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/move-request-group-modal.tsx
@@ -11,7 +11,7 @@ import * as models from '../../../models';
 import HelpTooltip from '../help-tooltip';
 
 interface Props extends ModalProps {
-  workspaces: Array<Workspace>;
+  workspaces: Workspace[];
   activeWorkspace: Workspace;
 }
 

--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.tsx
@@ -11,7 +11,7 @@ import PromptButton from '../base/prompt-button';
 
 interface State {
   title: string;
-  hints: Array<string>;
+  hints: string[];
   defaultValue?: string | null;
   submitName?: string | null;
   selectText?: boolean | null;
@@ -116,7 +116,7 @@ class PromptModal extends PureComponent<{}, State> {
     placeholder?: string;
     validate?: (arg0: string) => string;
     label?: string;
-    hints?: Array<string>;
+    hints?: string[];
     onComplete?: (arg0: string) => void;
     onDeleteHint?: (arg0: string) => void;
     onCancel?: () => void;
@@ -224,7 +224,7 @@ class PromptModal extends PureComponent<{}, State> {
         placeholder={placeholder || ''}
       />
     );
-    let sanitizedHints: Array<ReactNode> = [];
+    let sanitizedHints: ReactNode[] = [];
 
     if (Array.isArray(hints)) {
       sanitizedHints = hints.slice(0, 15).map(this._renderHintButton);

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.tsx
@@ -21,7 +21,7 @@ import * as protoManager from '../../../network/grpc/proto-manager';
 interface Props {
   grpcDispatch: GrpcDispatch;
   workspace: Workspace;
-  protoDirectories: Array<ExpandedProtoDirectory>;
+  protoDirectories: ExpandedProtoDirectory[];
 }
 
 interface State {

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
@@ -25,7 +25,7 @@ interface Props {
   isVariableUncovered: boolean;
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
-  workspaces: Array<Workspace>;
+  workspaces: Workspace[];
 }
 
 interface State {
@@ -34,7 +34,7 @@ interface State {
   defaultPreviewMode: boolean;
   activeWorkspaceIdToCopyTo: string | null;
   workspace?: Workspace;
-  workspaces: Array<Workspace>;
+  workspaces: Workspace[];
   justCopied: boolean;
   justMoved: boolean;
 }

--- a/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.tsx
@@ -25,17 +25,17 @@ interface Props {
   handleSetActiveWorkspace: (id: string) => void;
   activateRequest: (id: string) => void;
   activeRequest?: Request | null;
-  workspaceChildren: Array<Request | RequestGroup>;
+  workspaceChildren: (Request | RequestGroup)[];
   workspace: Workspace;
-  workspaces: Array<Workspace>;
-  requestMetas: Array<RequestMeta>;
+  workspaces: Workspace[];
+  requestMetas: RequestMeta[];
 }
 
 interface State {
   searchString: string;
-  workspaces: Array<Workspace>;
-  matchedRequests: Array<Request>;
-  matchedWorkspaces: Array<Workspace>;
+  workspaces: Workspace[];
+  matchedRequests: Request[];
+  matchedWorkspaces: Workspace[];
   activeIndex: number;
   maxRequests: number;
   maxWorkspaces: number;
@@ -165,7 +165,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
   }
 
   /** Return array of path segments for given request or folder */
-  _groupOf(requestOrRequestGroup: BaseModel): Array<string> {
+  _groupOf(requestOrRequestGroup: BaseModel): string[] {
     const { workspaceChildren } = this.props;
     const requestGroups = workspaceChildren.filter(d => d.type === models.requestGroup.type);
     const matchedGroups = requestGroups.filter(g => g._id === requestOrRequestGroup.parentId);
@@ -270,7 +270,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
     this.setState({
       searchString,
       activeIndex: indexOfFirstNonActiveRequest >= 0 ? indexOfFirstNonActiveRequest : 0,
-      matchedRequests: (matchedRequests as Array<any>).slice(0, maxRequests),
+      matchedRequests: (matchedRequests as any[]).slice(0, maxRequests),
       matchedWorkspaces: matchedWorkspaces.slice(0, maxWorkspaces),
     });
   }

--- a/packages/insomnia-app/app/ui/components/modals/select-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/select-modal.tsx
@@ -8,20 +8,20 @@ import ModalFooter from '../base/modal-footer';
 
 interface State {
   title: string;
-  options: Array<{
+  options: {
     name: string;
     value: string;
-  }>;
+  }[];
   value: string;
   message: string;
-  onCancel?: (...args: Array<any>) => any;
+  onCancel?: (...args: any[]) => any;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class SelectModal extends PureComponent<{}, State> {
   modal: Modal | null = null;
   doneButton: HTMLButtonElement | null = null;
-  _doneCallback: ((...args: Array<any>) => any) | null = null;
+  _doneCallback: ((...args: any[]) => any) | null = null;
 
   state: State = {
     title: '',

--- a/packages/insomnia-app/app/ui/components/modals/sync-branches-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/sync-branches-modal.tsx
@@ -14,7 +14,7 @@ import SyncPullButton from '../sync-pull-button';
 
 interface Props {
   workspace: Workspace;
-  syncItems: Array<StatusCandidate>;
+  syncItems: StatusCandidate[];
   vcs: VCS;
 }
 
@@ -22,8 +22,8 @@ interface State {
   error: string;
   newBranchName: string;
   currentBranch: string;
-  branches: Array<string>;
-  remoteBranches: Array<string>;
+  branches: string[];
+  remoteBranches: string[];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -164,7 +164,7 @@ class SyncBranchesModal extends PureComponent<Props, State> {
     this.modal && this.modal.hide();
   }
 
-  async show(options: { onHide: (...args: Array<any>) => any }) {
+  async show(options: { onHide: (...args: any[]) => any }) {
     this.modal &&
       this.modal.show({
         onHide: options.onHide,

--- a/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.tsx
@@ -62,7 +62,7 @@ class SyncDeleteModal extends PureComponent<Props, State> {
     }
   }
 
-  async show(options: { onHide: (...args: Array<any>) => any }) {
+  async show(options: { onHide: (...args: any[]) => any }) {
     this.modal &&
       this.modal.show({
         onHide: options.onHide,

--- a/packages/insomnia-app/app/ui/components/modals/sync-history-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/sync-history-modal.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 interface State {
   branch: string;
-  history: Array<Snapshot>;
+  history: Snapshot[];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)

--- a/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.tsx
@@ -12,17 +12,17 @@ import ModalFooter from '../base/modal-footer';
 interface Props {
   workspace: Workspace;
   vcs: VCS;
-  syncItems: Array<StatusCandidate>;
+  syncItems: StatusCandidate[];
 }
 
 interface State {
-  conflicts: Array<MergeConflict>;
+  conflicts: MergeConflict[];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class SyncMergeModal extends PureComponent<Props, State> {
   modal: Modal | null = null;
-  _handleDone: (arg0: Array<MergeConflict>) => void;
+  _handleDone: (arg0: MergeConflict[]) => void;
 
   state: State = {
     conflicts: [],
@@ -52,8 +52,8 @@ class SyncMergeModal extends PureComponent<Props, State> {
   }
 
   async show(options: {
-    conflicts: Array<MergeConflict>;
-    handleDone: (arg0: Array<MergeConflict>) => void;
+    conflicts: MergeConflict[];
+    handleDone: (arg0: MergeConflict[]) => void;
   }) {
     this.modal && this.modal.show();
     this._handleDone = options.handleDone;

--- a/packages/insomnia-app/app/ui/components/modals/sync-share-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/sync-share-modal.tsx
@@ -25,7 +25,7 @@ interface Team {
 interface State {
   loading: boolean;
   selectedTeam: null | Team;
-  teams: Array<Team>;
+  teams: Team[];
   error: string;
 }
 

--- a/packages/insomnia-app/app/ui/components/modals/sync-staging-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/sync-staging-modal.tsx
@@ -16,7 +16,7 @@ import { strings } from '../../../common/strings';
 
 interface Props {
   workspace: Workspace;
-  syncItems: Array<StatusCandidate>;
+  syncItems: StatusCandidate[];
   vcs: VCS;
 }
 
@@ -29,7 +29,7 @@ interface State {
     string,
     {
       entry: StageEntry;
-      changes: null | Array<string>;
+      changes: null | string[];
       type: string;
       checked: boolean;
     }
@@ -83,13 +83,13 @@ class SyncStagingModal extends PureComponent<Props, State> {
     await this.refreshMainAttributes({}, newStage);
   }
 
-  async _handleAllToggle(keys: Array<DocumentKey>, doStage: boolean) {
+  async _handleAllToggle(keys: DocumentKey[], doStage: boolean) {
     const { vcs } = this.props;
     const { status } = this.state;
     let stage;
 
     if (doStage) {
-      const entries: Array<StageEntry> = [];
+      const entries: StageEntry[] = [];
 
       for (const k of Object.keys(status.unstaged)) {
         if (keys.includes(k)) {
@@ -99,7 +99,7 @@ class SyncStagingModal extends PureComponent<Props, State> {
 
       stage = await vcs.stage(status.stage, entries);
     } else {
-      const entries: Array<StageEntry> = [];
+      const entries: StageEntry[] = [];
 
       for (const k of Object.keys(status.stage)) {
         if (keys.includes(k)) {
@@ -163,7 +163,7 @@ class SyncStagingModal extends PureComponent<Props, State> {
         continue;
       }
 
-      let changes: Array<string> | null = null;
+      let changes: string[] | null = null;
 
       if (item && item.document && oldDoc) {
         changes = describeChanges(item.document, oldDoc);
@@ -201,7 +201,7 @@ class SyncStagingModal extends PureComponent<Props, State> {
     this.setState(_initialState);
     // Add everything to stage by default except new items
     const status: Status = await vcs.status(syncItems, {});
-    const toStage: Array<StageEntry> = [];
+    const toStage: StageEntry[] = [];
 
     for (const key of Object.keys(status.unstaged)) {
       // @ts-expect-error -- TSCONVERSION
@@ -218,7 +218,7 @@ class SyncStagingModal extends PureComponent<Props, State> {
     this.textarea && this.textarea.focus();
   }
 
-  static renderOperation(entry: StageEntry, type: string, changes: Array<string>) {
+  static renderOperation(entry: StageEntry, type: string, changes: string[]) {
     let child: JSX.Element | null = null;
     let message = '';
 
@@ -252,7 +252,7 @@ class SyncStagingModal extends PureComponent<Props, State> {
     );
   }
 
-  renderTable(keys: Array<DocumentKey>, title: ReactNode) {
+  renderTable(keys: DocumentKey[], title: ReactNode) {
     const { status, lookupMap } = this.state;
 
     if (keys.length === 0) {
@@ -332,8 +332,8 @@ class SyncStagingModal extends PureComponent<Props, State> {
 
   render() {
     const { status, message, error, branch } = this.state;
-    const nonAddedKeys: Array<string> = [];
-    const addedKeys: Array<string> = [];
+    const nonAddedKeys: string[] = [];
+    const addedKeys: string[] = [];
     const allMap = { ...status.stage, ...status.unstaged };
     const allKeys = Object.keys(allMap);
 

--- a/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -39,7 +39,7 @@ interface Props extends ModalProps {
 interface State {
   workspace: Workspace | null;
   isValid: boolean;
-  subEnvironments: Array<Environment>;
+  subEnvironments: Environment[];
   rootEnvironment: Environment | null;
   selectedEnvironmentId: string | null;
 }
@@ -318,7 +318,7 @@ class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> {
   async _handleSortEnd(results: {
     oldIndex: number;
     newIndex: number;
-    collection: Array<Environment>;
+    collection: Environment[];
   }) {
     const { oldIndex, newIndex } = results;
 

--- a/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
@@ -20,7 +20,7 @@ import * as workspaceOperations from '../../../models/helpers/workspace-operatio
 import { HandleGetRenderContext, HandleRender } from '../../../common/render';
 
 interface Props {
-  clientCertificates: Array<ClientCertificate>;
+  clientCertificates: ClientCertificate[];
   workspace: Workspace;
   apiSpec: ApiSpec;
   editorFontSize: number;

--- a/packages/insomnia-app/app/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/request-pane.tsx
@@ -36,7 +36,7 @@ import { HandleGetRenderContext, HandleRender } from '../../../common/render';
 interface Props {
   // Functions
   forceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
-  forceUpdateRequestHeaders: (r: Request, headers: Array<RequestHeader>) => Promise<Request>;
+  forceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleSend: () => void;
   handleSendAndDownload: (filepath?: string) => Promise<void>;
   handleCreateRequest: () => void;
@@ -47,9 +47,9 @@ interface Props {
   updateRequestUrl: (r: Request, url: string) => Promise<Request>;
   updateRequestMethod: (r: Request, method: string) => Promise<Request>;
   updateRequestBody: (r: Request, body: RequestBody) => Promise<Request>;
-  updateRequestParameters: (r: Request, params: Array<RequestParameter>) => Promise<Request>;
+  updateRequestParameters: (r: Request, params: RequestParameter[]) => Promise<Request>;
   updateRequestAuthentication: (r: Request, auth: RequestAuthentication) => Promise<Request>;
-  updateRequestHeaders: (r: Request, headers: Array<RequestHeader>) => Promise<Request>;
+  updateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   updateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   updateSettingsShowPasswords: (showPasswords: boolean) => Promise<Settings>;
   updateSettingsUseBulkHeaderEditor: Function;
@@ -80,7 +80,7 @@ class RequestPane extends PureComponent<Props> {
     });
   }
 
-  _autocompleteUrls(): Promise<Array<string>> {
+  _autocompleteUrls(): Promise<string[]> {
     const { workspace, request } = this.props;
     return queryAllWorkspaceUrls(workspace, models.request.type, request?._id);
   }

--- a/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
@@ -43,17 +43,17 @@ interface Props {
   handleShowRequestSettings: Function;
   previewMode: string;
   filter: string;
-  filterHistory: Array<string>;
+  filterHistory: string[];
   disableHtmlPreviewJs: boolean;
   editorFontSize: number;
   editorIndentSize: number;
   editorKeyMap: string;
   editorLineWrapping: boolean;
   loadStartTime: number;
-  responses: Array<Response>;
+  responses: Response[];
   hotKeyRegistry: HotKeyRegistry;
   disableResponsePreviewLinks: boolean;
-  requestVersions: Array<RequestVersion>;
+  requestVersions: RequestVersion[];
   request?: Request | null;
   response?: Response | null;
   environment?: Environment | null;
@@ -99,7 +99,7 @@ class ResponsePane extends PureComponent<Props> {
     }
 
     const readStream = models.response.getBodyStream(response);
-    const dataBuffers: Array<any> = [];
+    const dataBuffers: any[] = [];
 
     if (readStream) {
       readStream.on('data', data => {

--- a/packages/insomnia-app/app/ui/components/proto-file/proto-file-list.tsx
+++ b/packages/insomnia-app/app/ui/components/proto-file/proto-file-list.tsx
@@ -13,7 +13,7 @@ export type UpdateProtoFileHandler = (protofile: ProtoFile) => Promise<void>;
 export type RenameProtoFileHandler = (protoFile: ProtoFile, name: string) => Promise<void>;
 
 interface Props {
-  protoDirectories: Array<ExpandedProtoDirectory>;
+  protoDirectories: ExpandedProtoDirectory[];
   selectedId?: string;
   handleSelect: SelectProtoFileHandler;
   handleDelete: DeleteProtoFileHandler;

--- a/packages/insomnia-app/app/ui/components/rendered-text.tsx
+++ b/packages/insomnia-app/app/ui/components/rendered-text.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 
 interface Props {
   children: string;
-  render: (...args: Array<any>) => any;
+  render: (...args: any[]) => any;
 }
 interface State {
   renderedText: string;

--- a/packages/insomnia-app/app/ui/components/settings/general.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/general.tsx
@@ -47,14 +47,14 @@ interface Props {
 }
 
 interface State {
-  fonts: Array<{
+  fonts: {
     family: string;
     monospace: boolean;
-  }> | null;
-  fontsMono: Array<{
+  }[] | null;
+  fontsMono: {
     family: string;
     monospace: boolean;
-  }> | null;
+  }[] | null;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -125,10 +125,10 @@ class General extends PureComponent<Props, State> {
   renderEnumSetting(
     label: string,
     name: string,
-    values: Array<{
+    values: {
       name: string;
       value: any;
-    }>,
+    }[],
     help: string,
     forceRestart?: boolean,
   ) {
@@ -400,10 +400,10 @@ class General extends PureComponent<Props, State> {
                 value: HttpVersions.V2_0,
               }, // Enable when our version of libcurl supports HTTP/3
               // { name: 'HTTP/3', value: HttpVersions.v3 },
-            ] as Array<{
+            ] as {
               name: string;
               value: HttpVersion;
-            }>,
+            }[],
             'Preferred HTTP version to use for requests which will fall back if it cannot be' +
             'negotiated',
           )}

--- a/packages/insomnia-app/app/ui/components/settings/plugins.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.tsx
@@ -24,11 +24,11 @@ import { docsPlugins } from '../../../common/documentation';
 
 interface Props {
   settings: Settings;
-  updateSetting: (...args: Array<any>) => any;
+  updateSetting: (...args: any[]) => any;
 }
 
 interface State {
-  plugins: Array<Plugin>;
+  plugins: Plugin[];
   npmPluginValue: string;
   error: Error | null;
   installPluginErrMsg: string;

--- a/packages/insomnia-app/app/ui/components/settings/shortcuts.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/shortcuts.tsx
@@ -19,10 +19,10 @@ import PromptButton from '../base/prompt-button';
 
 interface Props {
   hotKeyRegistry: HotKeyRegistry;
-  handleUpdateKeyBindings: (...args: Array<any>) => any;
+  handleUpdateKeyBindings: (...args: any[]) => any;
 }
 
-const HOT_KEY_DEFS: Array<HotKeyDefinition> = Object.keys(hotKeyRefs).map(k => hotKeyRefs[k]);
+const HOT_KEY_DEFS: HotKeyDefinition[] = Object.keys(hotKeyRefs).map(k => hotKeyRefs[k]);
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class Shortcuts extends PureComponent<Props> {

--- a/packages/insomnia-app/app/ui/components/settings/theme.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/theme.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 interface State {
-  themes: Array<ThemeType>;
+  themes: ThemeType[];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -108,8 +108,8 @@ class Theme extends PureComponent<Props, State> {
 
   renderThemeRows() {
     const { themes } = this.state;
-    const rows: Array<Array<ThemeType>> = [];
-    let row: Array<ThemeType> = [];
+    const rows: ThemeType[][] = [];
+    let row: ThemeType[] = [];
 
     for (const theme of themes) {
       row.push(theme);

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.tsx
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-children.tsx
@@ -16,14 +16,14 @@ import { HandleRender } from '../../../common/render';
 
 export interface Child {
   doc: Request | GrpcRequest | RequestGroup;
-  children: Array<Child>;
+  children: Child[];
   collapsed: boolean;
   hidden: boolean;
   pinned: boolean;
 }
 export interface SidebarChildObjects {
-  pinned: Array<Child>;
-  all: Array<Child>;
+  pinned: Child[];
+  all: Child[];
 }
 interface Props {
   handleActivateRequest: Function;
@@ -74,7 +74,7 @@ class SidebarChildren extends PureComponent<Props> {
     this._contextMenu = n;
   }
 
-  _renderChildren(children: Array<Child>, isInPinnedList: boolean) {
+  _renderChildren(children: Child[], isInPinnedList: boolean) {
     const {
       filter,
       handleCreateRequest,
@@ -167,7 +167,7 @@ class SidebarChildren extends PureComponent<Props> {
     });
   }
 
-  _renderList(children: Array<Child>, pinnedList: boolean) {
+  _renderList(children: Child[], pinnedList: boolean) {
     return (
       <ul
         className="sidebar__list sidebar__list-root theme--sidebar__list"

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar.tsx
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar.tsx
@@ -14,15 +14,15 @@ interface Props {
   activeEnvironment: Environment | null;
   children: ReactNode;
   environmentHighlightColorStyle: string;
-  handleSetActiveEnvironment: (...args: Array<any>) => any;
-  handleSetActiveWorkspace: (...args: Array<any>) => any;
+  handleSetActiveEnvironment: (...args: any[]) => any;
+  handleSetActiveWorkspace: (...args: any[]) => any;
   hidden: boolean;
   hotKeyRegistry: HotKeyRegistry;
   isLoading: boolean;
-  showEnvironmentsModal: (...args: Array<any>) => any;
-  unseenWorkspaces: Array<Workspace>;
+  showEnvironmentsModal: (...args: any[]) => any;
+  unseenWorkspaces: Workspace[];
   width: number;
-  workspaces: Array<Workspace>;
+  workspaces: Workspace[];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)

--- a/packages/insomnia-app/app/ui/components/spec-editor/spec-editor-sidebar.tsx
+++ b/packages/insomnia-app/app/ui/components/spec-editor/spec-editor-sidebar.tsx
@@ -47,7 +47,7 @@ class SpecEditorSidebar extends Component<Props, State> {
     handleSetSelection(pos.start.col - 1, pos.end.col - 1, pos.start.line - 1, pos.end.line - 1);
   }
 
-  _mapPosition(itemPath: Array<any>) {
+  _mapPosition(itemPath: any[]) {
     const sourceMap = new YAMLSourceMap();
     const { contents } = this.props.apiSpec;
     const scrollPosition = {

--- a/packages/insomnia-app/app/ui/components/sync-pull-button.tsx
+++ b/packages/insomnia-app/app/ui/components/sync-pull-button.tsx
@@ -7,7 +7,7 @@ import { showError } from './modals';
 interface Props {
   vcs: VCS;
   branch: string;
-  onPull: (...args: Array<any>) => any;
+  onPull: (...args: any[]) => any;
   disabled?: boolean;
   className?: string;
   children?: ReactNode;

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.tsx
@@ -31,23 +31,23 @@ interface Props {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
   defaultValue: string;
-  onChange: (...args: Array<any>) => any;
+  onChange: (...args: any[]) => any;
   workspace: Workspace;
 }
 
 interface State {
   activeTagData: NunjucksParsedTag | null;
   activeTagDefinition: NunjucksParsedTag | null;
-  tagDefinitions: Array<NunjucksParsedTag>;
+  tagDefinitions: NunjucksParsedTag[];
   loadingDocs: boolean;
-  allDocs: Record<string, Array<BaseModel>>;
+  allDocs: Record<string, BaseModel[]>;
   rendering: boolean;
   preview: string;
   error: string;
-  variables: Array<{
+  variables: {
     name: string;
     value: string;
-  }>;
+  }[];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -114,8 +114,8 @@ class TagEditor extends PureComponent<Props, State> {
     );
   }
 
-  _sortRequests(_models: Array<Request | RequestGroup>, parentId: string) {
-    let sortedModels: Array<Request | RequestGroup> = [];
+  _sortRequests(_models: (Request | RequestGroup)[], parentId: string) {
+    let sortedModels: (Request | RequestGroup)[] = [];
 
     _models
       .filter(model => model.parentId === parentId)
@@ -333,7 +333,7 @@ class TagEditor extends PureComponent<Props, State> {
   }
 
   async _update(
-    tagDefinitions: Array<NunjucksParsedTag>,
+    tagDefinitions: NunjucksParsedTag[],
     tagDefinition: NunjucksParsedTag | null,
     tagData: NunjucksParsedTag | null,
     noCallback = false,
@@ -451,8 +451,8 @@ class TagEditor extends PureComponent<Props, State> {
   renderArgFile(
     value: string,
     argIndex: number,
-    itemTypes?: Array<'file' | 'directory'>,
-    extensions?: Array<string>,
+    itemTypes?: ('file' | 'directory')[],
+    extensions?: string[],
   ) {
     return (
       <FileInputButton
@@ -467,7 +467,7 @@ class TagEditor extends PureComponent<Props, State> {
     );
   }
 
-  renderArgEnum(value: string, options: Array<PluginArgumentEnumOption>) {
+  renderArgEnum(value: string, options: PluginArgumentEnumOption[]) {
     const argDatas = this.state.activeTagData ? this.state.activeTagData.args : [];
     let unsetOption: ReactNode = null;
 
@@ -499,7 +499,7 @@ class TagEditor extends PureComponent<Props, State> {
     );
   }
 
-  resolveRequestGroupPrefix(requestGroupId: string, allRequestGroups: Array<any>) {
+  resolveRequestGroupPrefix(requestGroupId: string, allRequestGroups: any[]) {
     let prefix = '';
     let reqGroup: any;
 
@@ -563,7 +563,7 @@ class TagEditor extends PureComponent<Props, State> {
 
   renderArg(
     argDefinition: NunjucksParsedTagArg,
-    argDatas: Array<NunjucksParsedTagArg>,
+    argDatas: NunjucksParsedTagArg[],
     argIndex: number,
   ) {
     // Decide whether or not to show it
@@ -693,7 +693,7 @@ class TagEditor extends PureComponent<Props, State> {
     );
   }
 
-  renderActions(actions: Array<NunjucksActionTag> = []) {
+  renderActions(actions: NunjucksActionTag[] = []) {
     return (
       <div className="form-row">
         <div className="form-control">

--- a/packages/insomnia-app/app/ui/components/templating/variable-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/templating/variable-editor.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 interface State {
-  variables: Array<any>;
+  variables: any[];
   value: string;
   preview: string;
   error: string;

--- a/packages/insomnia-app/app/ui/components/viewers/grpc-tabbed-messages.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/grpc-tabbed-messages.tsx
@@ -14,7 +14,7 @@ interface Message {
 
 interface Props {
   settings: Settings;
-  messages?: Array<Message>;
+  messages?: Message[];
   tabNamePrefix: 'Stream' | 'Response';
   bodyText?: string;
   uniquenessKey: string;

--- a/packages/insomnia-app/app/ui/components/viewers/response-cookies-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-cookies-viewer.tsx
@@ -7,7 +7,7 @@ interface Props {
   showCookiesModal: Function;
   cookiesSent?: boolean | null;
   cookiesStored?: boolean | null;
-  headers: Array<any>;
+  headers: any[];
   handleShowRequestSettings: Function;
 }
 

--- a/packages/insomnia-app/app/ui/components/viewers/response-csv-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-csv-viewer.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 interface State {
   result: null | {
-    data: Array<Array<string>>;
+    data: string[][];
   };
 }
 
@@ -23,7 +23,7 @@ class ResponseCSVViewer extends PureComponent<Props, State> {
 
   update(body: Buffer) {
     const csv = body.toString('utf8');
-    Papa.parse<Array<string>>(csv, {
+    Papa.parse<string[]>(csv, {
       skipEmptyLines: true,
       complete: result => {
         this.setState({ result });

--- a/packages/insomnia-app/app/ui/components/viewers/response-headers-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-headers-viewer.tsx
@@ -5,7 +5,7 @@ import Link from '../base/link';
 import { URL } from 'url';
 
 interface Props {
-  headers: Array<ResponseHeader>;
+  headers: ResponseHeader[];
 }
 
 function validateURL(urlString) {

--- a/packages/insomnia-app/app/ui/components/viewers/response-multipart.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-multipart.tsx
@@ -24,18 +24,18 @@ interface Part {
   bytes: number;
   value: Buffer;
   filename: string | null;
-  headers: Array<ResponseHeader>;
+  headers: ResponseHeader[];
 }
 
 interface Props {
-  download: (...args: Array<any>) => any;
+  download: (...args: any[]) => any;
   responseId: string;
   bodyBuffer: Buffer | null;
   contentType: string;
   disableHtmlPreviewJs: boolean;
   disablePreviewLinks: boolean;
   filter: string;
-  filterHistory: Array<string>;
+  filterHistory: string[];
   editorFontSize: number;
   editorIndentSize: number;
   editorKeyMap: string;
@@ -45,7 +45,7 @@ interface Props {
 
 interface State {
   activePart: number;
-  parts: Array<Part>;
+  parts: Part[];
   error: string | null;
 }
 
@@ -164,10 +164,10 @@ class ResponseMultipart extends PureComponent<Props, State> {
     }
   }
 
-  _getParts(): Promise<Array<Part>> {
+  _getParts(): Promise<Part[]> {
     return new Promise((resolve, reject) => {
       const { bodyBuffer, contentType } = this.props;
-      const parts: Array<Part> = [];
+      const parts: Part[] = [];
 
       if (!bodyBuffer) {
         return resolve(parts);
@@ -180,7 +180,7 @@ class ResponseMultipart extends PureComponent<Props, State> {
       };
       const form = new multiparty.Form();
       form.on('part', part => {
-        const dataBuffers: Array<any> = [];
+        const dataBuffers: any[] = [];
         part.on('data', data => {
           dataBuffers.push(data);
         });

--- a/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 interface State {
-  timeline: Array<any>;
+  timeline: any[];
   timelineKey: string;
 }
 

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
@@ -27,14 +27,14 @@ interface Props {
   contentType: string;
   disableHtmlPreviewJs: boolean;
   disablePreviewLinks: boolean;
-  download: (...args: Array<any>) => any;
+  download: (...args: any[]) => any;
   editorFontSize: number;
   editorIndentSize: number;
   editorKeyMap: string;
   editorLineWrapping: boolean;
   filter: string;
-  filterHistory: Array<string>;
-  getBody: (...args: Array<any>) => any;
+  filterHistory: string[];
+  getBody: (...args: any[]) => any;
   previewMode: string;
   responseId: string;
   url: string;

--- a/packages/insomnia-app/app/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-debug.tsx
@@ -29,7 +29,7 @@ interface Props {
   handleDeleteResponse: Function;
   handleDeleteResponses: Function;
   handleForceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
-  handleForceUpdateRequestHeaders: (r: Request, headers: Array<RequestHeader>) => Promise<Request>;
+  handleForceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleImport: Function;
   handleImportFile: HandleImportFileCallback;
   handleRequestCreate: () => void;
@@ -44,9 +44,9 @@ interface Props {
   handleSidebarSort: (sortOrder: SortOrder) => void;
   handleUpdateRequestAuthentication: (r: Request, auth: RequestAuthentication) => Promise<Request>;
   handleUpdateRequestBody: (r: Request, body: RequestBody) => Promise<Request>;
-  handleUpdateRequestHeaders: (r: Request, headers: Array<RequestHeader>) => Promise<Request>;
+  handleUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleUpdateRequestMethod: (r: Request, method: string) => Promise<Request>;
-  handleUpdateRequestParameters: (r: Request, params: Array<RequestParameter>) => Promise<Request>;
+  handleUpdateRequestParameters: (r: Request, params: RequestParameter[]) => Promise<Request>;
   handleUpdateRequestUrl: (r: Request, url: string) => Promise<Request>;
   handleUpdateSettingsShowPasswords: (showPasswords: boolean) => Promise<Settings>;
   handleUpdateSettingsUseBulkHeaderEditor: Function;

--- a/packages/insomnia-app/app/ui/components/wrapper-design.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.tsx
@@ -27,11 +27,11 @@ interface Props {
 
 interface State {
   previewHidden: boolean;
-  lintMessages: Array<{
+  lintMessages: {
     message: string;
     line: number;
     type: 'error' | 'warning';
-  }>;
+  }[];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.tsx
@@ -37,7 +37,7 @@ class WrapperOnboarding extends PureComponent<Props, State> {
     db.offChange(this._handleDbChange);
   }
 
-  _handleDbChange(changes: Array<[string, BaseModel, boolean]>) {
+  _handleDbChange(changes: [string, BaseModel, boolean][]) {
     for (const change of changes) {
       if (change[1].type === models.workspace.type) {
         setTimeout(() => {

--- a/packages/insomnia-app/app/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-unit-test.tsx
@@ -36,7 +36,7 @@ interface Props {
 }
 
 interface State {
-  testsRunning: Array<UnitTest> | null;
+  testsRunning: UnitTest[] | null;
   resultsError: string | null;
 }
 
@@ -249,13 +249,13 @@ class WrapperUnitTest extends PureComponent<Props, State> {
     });
   }
 
-  async _runTests(unitTests: Array<UnitTest>) {
+  async _runTests(unitTests: UnitTest[]) {
     const { requests, activeWorkspace, activeEnvironment } = this.props.wrapperProps;
     this.setState({
       testsRunning: unitTests,
       resultsError: null,
     });
-    const tests: Array<Test> = [];
+    const tests: Test[] = [];
 
     for (const t of unitTests) {
       tests.push({
@@ -301,15 +301,15 @@ class WrapperUnitTest extends PureComponent<Props, State> {
     });
   }
 
-  buildSelectableRequests(): Array<{
+  buildSelectableRequests(): {
     name: string;
     request: Request;
-  }> {
+  }[] {
     const { children } = this.props;
-    const selectableRequests: Array<{
+    const selectableRequests: {
       name: string;
       request: Request;
-    }> = [];
+    }[] = [];
 
     const next = (p, children) => {
       for (const c of children) {

--- a/packages/insomnia-app/app/ui/components/wrapper.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper.tsx
@@ -152,49 +152,49 @@ export interface WrapperProps {
   handleGoToNextActivity: () => void;
   // Properties
   activity: GlobalActivity;
-  apiSpecs: Array<ApiSpec>;
+  apiSpecs: ApiSpec[];
   loadStartTime: number;
   isLoading: boolean;
   paneWidth: number;
   paneHeight: number;
   responsePreviewMode: string;
   responseFilter: string;
-  responseFilterHistory: Array<string>;
+  responseFilterHistory: string[];
   responseDownloadPath: string | null;
   sidebarWidth: number;
   sidebarHidden: boolean;
   sidebarFilter: string;
   sidebarChildren: SidebarChildObjects;
   settings: Settings;
-  workspaces: Array<Workspace>;
-  requestMetas: Array<RequestMeta>;
-  requests: Array<Request>;
-  requestVersions: Array<RequestVersion>;
-  unseenWorkspaces: Array<Workspace>;
-  workspaceChildren: Array<Request | RequestGroup>;
+  workspaces: Workspace[];
+  requestMetas: RequestMeta[];
+  requests: Request[];
+  requestVersions: RequestVersion[];
+  unseenWorkspaces: Workspace[];
+  workspaceChildren: (Request | RequestGroup)[];
   activeWorkspaceMeta: WorkspaceMeta;
-  environments: Array<Environment>;
+  environments: Environment[];
   activeApiSpec: ApiSpec;
   activeUnitTestSuite: UnitTestSuite | null;
-  activeRequestResponses: Array<Response>;
+  activeRequestResponses: Response[];
   activeWorkspace: Workspace;
   activeCookieJar: CookieJar;
   activeEnvironment: Environment | null;
   activeGitRepository: GitRepository | null;
   activeUnitTestResult: UnitTestResult | null;
-  activeUnitTestSuites: Array<UnitTestSuite>;
-  activeUnitTests: Array<UnitTest>;
-  activeWorkspaceClientCertificates: Array<ClientCertificate>;
+  activeUnitTestSuites: UnitTestSuite[];
+  activeUnitTests: UnitTest[];
+  activeWorkspaceClientCertificates: ClientCertificate[];
   headerEditorKey: string;
   isVariableUncovered: boolean;
   vcs: VCS | null;
   gitVCS: GitVCS | null;
-  gitRepositories: Array<GitRepository>;
-  syncItems: Array<StatusCandidate>;
+  gitRepositories: GitRepository[];
+  syncItems: StatusCandidate[];
   oAuth2Token?: OAuth2Token | null;
   activeRequest?: Request | null;
   activeResponse?: Response | null;
-  workspaceMetas?: Array<WorkspaceMeta>;
+  workspaceMetas?: WorkspaceMeta[];
 }
 
 export type HandleImportFileCallback = (options?: ImportOptions) => void;
@@ -206,7 +206,7 @@ interface State {
   activeGitBranch: string;
 }
 
-const rUpdate = (request, ...args: Array<Partial<Request>>) => {
+const rUpdate = (request, ...args: Partial<Request>[]) => {
   if (!request) {
     throw new Error('Tried to update null request');
   }
@@ -234,7 +234,7 @@ class Wrapper extends PureComponent<WrapperProps, State> {
     return newRequest;
   }
 
-  _handleForceUpdateRequestHeaders(r: Request, headers: Array<RequestHeader>) {
+  _handleForceUpdateRequestHeaders(r: Request, headers: RequestHeader[]) {
     return this._handleForceUpdateRequest(r, {
       headers,
     });
@@ -250,7 +250,7 @@ class Wrapper extends PureComponent<WrapperProps, State> {
     });
   }
 
-  static _handleUpdateRequestParameters(r: Request, parameters: Array<RequestParameter>) {
+  static _handleUpdateRequestParameters(r: Request, parameters: RequestParameter[]) {
     return rUpdate(r, {
       parameters,
     });
@@ -262,7 +262,7 @@ class Wrapper extends PureComponent<WrapperProps, State> {
     });
   }
 
-  static _handleUpdateRequestHeaders(r: Request, headers: Array<RequestHeader>) {
+  static _handleUpdateRequestHeaders(r: Request, headers: RequestHeader[]) {
     return rUpdate(r, {
       headers,
     });

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -139,12 +139,12 @@ interface Props {
   activeEnvironment?: Environment,
   isVariableUncovered: boolean,
   sidebarHidden: boolean,
-  workspaces: Array<Workspace>,
-  apiSpecs: Array<ApiSpec>,
+  workspaces: Workspace[],
+  apiSpecs: ApiSpec[],
   activeWorkspaceMeta: WorkspaceMeta,
   activeGitRepository: GitRepository,
   activeCookieJar: CookieJar,
-  environments: Array<Environment>,
+  environments: Environment[],
   handleStartLoading: Function,
   handleStopLoading: Function
   handleImportUriToWorkspace: Function,
@@ -437,7 +437,7 @@ class App extends PureComponent<Props, State> {
     });
   }
 
-  async _recalculateMetaSortKey(docs: Array<RequestGroup | Request | GrpcRequest>) {
+  async _recalculateMetaSortKey(docs: (RequestGroup | Request | GrpcRequest)[]) {
     function __updateDoc(doc, metaSortKey) {
       // @ts-expect-error -- TSCONVERSION the fetched model will only ever be a RequestGroup, Request, or GrpcRequest
       // Which all have the .update method. How do we better filter types?

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-actions.ts
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-actions.ts
@@ -34,7 +34,7 @@ interface Action<T extends GrpcActionType> {
 
 interface ActionMany<T extends GrpcActionType> {
   type: T;
-  requestIds: Array<string>;
+  requestIds: string[];
 }
 
 interface Payload<T> {
@@ -61,7 +61,7 @@ export type ErrorAction = Action<typeof GrpcActionTypeEnum.error> & Payload<Serv
 export type StatusAction = Action<typeof GrpcActionTypeEnum.status> & Payload<StatusObject>;
 
 export type LoadMethodsAction = Action<typeof GrpcActionTypeEnum.loadMethods> &
-  Payload<Array<GrpcMethodDefinition>>;
+  Payload<GrpcMethodDefinition[]>;
 
 type InvalidateManyAction = ActionMany<typeof GrpcActionTypeEnum.invalidateMany>;
 

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-ipc-renderer.ts
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-ipc-renderer.ts
@@ -54,7 +54,7 @@ export const grpcIpcRenderer = {
   init,
   destroy,
 };
-export const sendGrpcIpcMultiple = (channel: GrpcRequestEvent, requestIds?: Array<string>) => {
+export const sendGrpcIpcMultiple = (channel: GrpcRequestEvent, requestIds?: string[]) => {
   if (requestIds?.length) {
     ipcRenderer.send(channel, requestIds);
   }

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.ts
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-reducer.ts
@@ -14,11 +14,11 @@ import { ServiceError, StatusObject } from '@grpc/grpc-js';
 
 export interface GrpcRequestState {
   running: boolean;
-  requestMessages: Array<GrpcMessage>;
-  responseMessages: Array<GrpcMessage>;
+  requestMessages: GrpcMessage[];
+  responseMessages: GrpcMessage[];
   status?: StatusObject;
   error?: ServiceError;
-  methods: Array<GrpcMethodDefinition>;
+  methods: GrpcMethodDefinition[];
   reloadMethods: boolean;
 }
 

--- a/packages/insomnia-app/app/ui/redux/modules/git.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/git.tsx
@@ -91,7 +91,7 @@ export const setupGitRepository: SetupGitRepositoryCallback = ({ createFsClient,
 };
 
 const containsInsomniaDir = async (fsClient: Record<string, any>): Promise<boolean> => {
-  const rootDirs: Array<string> = await fsClient.promises.readdir(GIT_CLONE_DIR);
+  const rootDirs: string[] = await fsClient.promises.readdir(GIT_CLONE_DIR);
   return rootDirs.includes(GIT_INSOMNIA_DIR_NAME);
 };
 
@@ -100,7 +100,7 @@ const containsInsomniaWorkspaceDir = async (fsClient: Record<string, any>): Prom
     return false;
   }
 
-  const rootDirs: Array<string> = await fsClient.promises.readdir(GIT_INSOMNIA_DIR);
+  const rootDirs: string[] = await fsClient.promises.readdir(GIT_INSOMNIA_DIR);
   return rootDirs.includes(models.workspace.type);
 };
 

--- a/packages/insomnia-app/app/ui/redux/modules/global.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/global.tsx
@@ -415,7 +415,7 @@ export function importFile(
   };
 }
 
-function handleImportResult(result: ImportResult, errorMessage: string): Array<Workspace> {
+function handleImportResult(result: ImportResult, errorMessage: string): Workspace[] {
   const { error, summary } = result;
 
   if (error) {
@@ -661,8 +661,8 @@ export function exportRequestsToFile(requestIds) {
     showSelectExportTypeModal(
       () => dispatch(loadStop()),
       async selectedFormat => {
-        const requests: Array<GrpcRequest | Request> = [];
-        const privateEnvironments: Array<Environment> = [];
+        const requests: (GrpcRequest | Request)[] = [];
+        const privateEnvironments: Environment[] = [];
         const workspaceLookup = {};
 
         for (const requestId of requestIds) {

--- a/packages/insomnia-app/app/ui/redux/proto-selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/proto-selectors.ts
@@ -4,9 +4,9 @@ import type { ProtoDirectory } from '../../models/proto-directory';
 import type { ProtoFile } from '../../models/proto-file';
 
 export interface ExpandedProtoDirectory {
-  files: Array<ProtoFile>;
+  files: ProtoFile[];
   dir: ProtoDirectory | null;
-  subDirs: Array<ExpandedProtoDirectory>;
+  subDirs: ExpandedProtoDirectory[];
 }
 
 const selectAllProtoFiles = createSelector(
@@ -25,7 +25,7 @@ export const selectExpandedActiveProtoDirectories = createSelector(
   selectActiveWorkspace,
   selectAllProtoFiles,
   selectAllProtoDirectories,
-  (workspace, allFiles, allDirs): Array<ExpandedProtoDirectory> => {
+  (workspace, allFiles, allDirs): ExpandedProtoDirectory[] => {
     // Get files where the parent is the workspace
     const individualFiles = allFiles.filter(pf => pf.parentId === workspace._id);
     // Get directories where the parent is the workspace
@@ -50,8 +50,8 @@ export const selectExpandedActiveProtoDirectories = createSelector(
 
 const expandDir = (
   dir: ProtoDirectory,
-  allFiles: Array<ProtoFile>,
-  allDirs: Array<ProtoDirectory>,
+  allFiles: ProtoFile[],
+  allDirs: ProtoDirectory[],
 ): ExpandedProtoDirectory => {
   const filesInDir = allFiles.filter(pf => pf.parentId === dir._id);
   const subDirs = allDirs.filter(pd => pd.parentId === dir._id);

--- a/packages/insomnia-app/app/ui/redux/sidebar-selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/sidebar-selectors.ts
@@ -39,7 +39,7 @@ export const selectSidebarChildren = createSelector(
     const sidebarFilter = activeWorkspaceMeta ? activeWorkspaceMeta.sidebarFilter : '';
 
     function next(parentId, pinnedChildren) {
-      const children: Array<SidebarModels> = (childrenMap[parentId] || [])
+      const children: SidebarModels[] = (childrenMap[parentId] || [])
         .filter(shouldShowInSidebar)
         .sort(sortByMetaKeyOrId);
 
@@ -66,7 +66,7 @@ export const selectSidebarChildren = createSelector(
       }
     }
 
-    function matchChildren(children, parentNames: Array<string> = []) {
+    function matchChildren(children, parentNames: string[] = []) {
       // Bail early if no filter defined
       if (!sidebarFilter) {
         return children;


### PR DESCRIPTION
This was a holdover from the initial TypeScript conversion that we had planned to fix after the initial large merge.  That time is now.