### PR TITLE
fixes build artifact location for local development

### DIFF
--- a/packages/insomnia-app/.eslintignore
+++ b/packages/insomnia-app/.eslintignore
@@ -1,6 +1,7 @@
 build
 bin
 send-request
+**/main.min.js
 webpack.config.*.js
 webpack.config.*.js.map
 webpack.config.*.d.ts

--- a/packages/insomnia-app/.gitignore
+++ b/packages/insomnia-app/.gitignore
@@ -1,5 +1,5 @@
 dist
 build
 
-# Was the old location of the build artifact. While this line is no longer strictly needed, it's being left here for developer experience reasons, at least for the rest of 2021.
+# Generated
 app/main.min.js

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -6,7 +6,7 @@
   "description": "The Collaborative API Design Tool",
   "author": "Kong <office@konghq.com>",
   "license": "MIT",
-  "main": "build/main.min.js",
+  "main": "app/main.min.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/Kong/insomnia.git",

--- a/packages/insomnia-app/tsconfig.build.json
+++ b/packages/insomnia-app/tsconfig.build.json
@@ -22,6 +22,7 @@
     "**/__mocks__",
     "**/__snapshots__",
     "**/__tests__",
+    "**/main.min.js",
     "__jest__",
     "assets",
     "bin",

--- a/packages/insomnia-app/tsconfig.json
+++ b/packages/insomnia-app/tsconfig.json
@@ -12,6 +12,7 @@
   ],
   "exclude": [
     "**/@types/mocha",
+    "**/main.min.js",
     "bin",
     "config",
     "node_modules"


### PR DESCRIPTION
In the prior PR (https://github.com/Kong/insomnia/pull/3400) on updating the clean the following sequence of events happened.

1. I ran the `build` script on the `insomnia-app` package
1. The build succeeded
1. I updated the `clean` script to remove all build artifacts (the subject matter of that PR)
1. I ran the `build` script on the `insomnia-app` package
1. The build succeeded
1. I noticed that the recent build did not include `app/main.min.js`.
    - I, therefore, concluded that this file was not output by the build.
    - It would make sense that it was still there because
        - I know it _used to be_ output by the build script
        - the build scripts were recently updated
        - it would still be there in my filetree from days or weeks ago because it's in the `.gitignore`
  
The wrong assumption turned out to be that the build produced artifacts in either case, despite it actually succeeding.  Unlike every other package, to _actually_ build `insomnia-app` locally, you must trick it by running `SMOKE_TEST=true npm run build`.  The exit code if you don't do this is `0`.  This should be changed, but I have done so in a separate PR https://github.com/Kong/insomnia/pull/3402 to allow for discussion there.

For now, I want to make sure `develop` is good, so I am submitting this PR to fix the immediate problem.

The good thing to note is that the change required only affects local development, at least so far as I can tell.