### PR TITLE
fixes error code used when build fails

### DIFF
--- a/packages/insomnia-app/scripts/build.ts
+++ b/packages/insomnia-app/scripts/build.ts
@@ -198,7 +198,7 @@ export const start = async ({ forceFromGitRef }: { forceFromGitRef: boolean }) =
         console.log(`[build] git ref \`${gitRef}\` found`);
       }
       console.log('[build] Skipping build because no version was found (the version is derived from the git ref)');
-      process.exit(0);
+      process.exit(1);
     }
 
     if (appConfig.version !== version) {


### PR DESCRIPTION
closes: INS-709

So far as I can tell, this behavior was introduced more than a year ago in https://github.com/Kong/insomnia/commit/c6a7c4d68272b3c4f3d78d4dc9031ae8e49b3f7a#diff-a3f8249a67ca4e9b7a97494a05d806944b48ea1ff0a37ca4774c3782d5e90607R24.

Since this just caused a bug (https://github.com/Kong/insomnia/pull/3401), it seems like a good thing to fix.

## Before
Before this PR, it would look like this:
![Screenshot_20210519_120001](https://user-images.githubusercontent.com/15232461/118845424-c2a48100-b899-11eb-8111-8bd4c9bc0f02.png)

## After
And with this change, it looks like this:
![Screenshot_20210519_115848](https://user-images.githubusercontent.com/15232461/118845220-938e0f80-b899-11eb-8333-e92adfcc27d6.png)


## Thoughts?

I can't think of a reason or use-case where we'd want the exit code to be success (exit code `0`) when it didn't build.  I sorta can understand that it's a tad murky in this case, but still.  We really need `npm run build` to like... actually work locally without hacking it with a `SMOKE_TEST` environment variable.