### PR TITLE
GH release workflow improvements

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -48,7 +48,7 @@ jobs:
       - run: npm run bootstrap
       - run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          npm run publish
+          npm run release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN}}
   Windows:

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -38,15 +38,18 @@ jobs:
     name: npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout branch
+        uses: actions/checkout@v1
       - name: Read Node version from .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
-      - run: npm run bootstrap
-      - run: |
+      - name: Bootstrap packages
+        run: npm run bootstrap
+      - name: Release NPM packages
+        run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
           npm run release
         env:
@@ -56,15 +59,18 @@ jobs:
     name: Windows
     runs-on: windows-2016
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout branch
+        uses: actions/checkout@v1
       - name: Read Node version from .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
-      - run: npm run bootstrap
-      - run: npm run app-release
+      - name: Bootstrap packages
+        run: npm run bootstrap
+      - name: Release app
+        run: npm run app-release
         env:
           CSC_LINK: ${{ secrets.CORE_WINDOWS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CORE_WINDOWS_CSC_KEY_PASSWORD }}
@@ -73,15 +79,18 @@ jobs:
     name: Mac
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout branch
+        uses: actions/checkout@v1
       - name: Read Node version from .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
-      - run: npm run bootstrap
-      - run: npm run app-release
+      - name: Bootstrap packages
+        run: npm run bootstrap
+      - name: Release app
+        run: npm run app-release
         env:
           APPLE_ID: ${{ secrets.DESIGNER_APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.DESIGNER_APPLE_ID_PASSWORD }}
@@ -92,17 +101,21 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - name: Install Snapcraft
+        run: |
           sudo snap install snapcraft --classic
           echo "${{ secrets.SNAPCRAFT_LOGIN_FILE }}" > snapcraft.txt && snapcraft login --with snapcraft.txt
-      - uses: actions/checkout@v1
+      - name: Checkout branch
+        uses: actions/checkout@v1
       - name: Read Node version from .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
-      - run: npm run bootstrap
-      - run: npm run app-release
+      - name: Bootstrap packages
+        run: npm run bootstrap
+      - name: Release app
+        run: npm run app-release
         env:
           BUILD_TARGETS: AppImage,deb,tar.gz,rpm,snap

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bootstrap": "npm install && lerna bootstrap && lerna run --stream bootstrap",
     "version": "lerna version --exact --preid beta --force-publish",
     "version:dry": "npm run version -- --no-git-tag-version",
-    "publish": "lerna publish from-git --pre-dist-tag beta",
+    "release": "lerna publish from-git --pre-dist-tag beta",
     "clean": "lerna run clean --parallel --stream && lerna clean --yes && rimraf node_modules",
     "test": "lerna run --stream --parallel test",
     "inso-start": "npm start --prefix packages/insomnia-inso",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "publish": "lerna publish from-git --pre-dist-tag beta",
     "clean": "lerna run clean --parallel --stream && lerna clean --yes && rimraf node_modules",
     "test": "lerna run --stream --parallel test",
-    "test:pre-release": "npm run test --prefix packages/insomnia-app",
     "inso-start": "npm start --prefix packages/insomnia-inso",
     "app-start": "npm start --prefix packages/insomnia-app",
     "app-build": "npm run build --prefix packages/insomnia-app",


### PR DESCRIPTION
Commit by commit, mainly following advice from Lerna to not use `publish` as a script name - renamed to `release`.