### PR TITLE
INS-674 - First pass at making the send button more visible

### DIFF
--- a/packages/insomnia-app/app/ui/components/buttons/grpc-send-button.tsx
+++ b/packages/insomnia-app/app/ui/components/buttons/grpc-send-button.tsx
@@ -12,8 +12,9 @@ interface Props {
 
 const buttonProps: ButtonProps = {
   className: 'tall',
+  bg: 'surprise',
   size: 'medium',
-  variant: 'text',
+  variant: 'contained',
   radius: '0',
 };
 

--- a/packages/insomnia-app/app/ui/components/settings/theme.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/theme.tsx
@@ -69,6 +69,10 @@ class Theme extends PureComponent<Props, State> {
               height="10%"
               className="theme--pane__header--sub bg-fill"
             />
+            {/* Send Button */}
+            <g>
+              <rect x="53%" y="10%" width="9%" height="10%" className="success-fill" />
+            </g>
           </g>
 
           {/* Sidebar */}

--- a/packages/insomnia-app/app/ui/components/settings/theme.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/theme.tsx
@@ -71,7 +71,7 @@ class Theme extends PureComponent<Props, State> {
             />
             {/* Send Button */}
             <g>
-              <rect x="53%" y="10%" width="9%" height="10%" className="success-fill" />
+              <rect x="53%" y="10%" width="9%" height="10%" className="surprise-fill" />
             </g>
           </g>
 

--- a/packages/insomnia-app/app/ui/css/components/request-url-bar.less
+++ b/packages/insomnia-app/app/ui/css/components/request-url-bar.less
@@ -28,6 +28,8 @@
     padding-left: var(--padding-md);
     min-width: 5em;
     text-align: center;
+    background: var(--color-surprise);
+    color: #fff;
   }
 
   form {
@@ -48,7 +50,7 @@
 
   button:focus,
   button:hover {
-    background-color: var(--hl-xs);
+    filter: brightness(0.8);
   }
 
   & > .dropdown > button {

--- a/packages/insomnia-app/app/ui/css/components/request-url-bar.less
+++ b/packages/insomnia-app/app/ui/css/components/request-url-bar.less
@@ -26,6 +26,7 @@
   .urlbar__send-btn {
     padding-right: var(--padding-md);
     padding-left: var(--padding-md);
+    margin-left: 0.75em;
     min-width: 5em;
     text-align: center;
     background: var(--color-surprise);

--- a/packages/insomnia-components/src/button/button.tsx
+++ b/packages/insomnia-components/src/button/button.tsx
@@ -8,12 +8,17 @@ export const ButtonSizeEnum = {
   Medium: 'medium',
 } as const;
 
+// These variants determine how the `bg` color variable is handled
+// Outlined sets the `bg` color as an outline
+// Contained sets the `bg` color as the background color
+// Text sets the `bg` color as the text color
 export const ButtonVariantEnum = {
   Outlined: 'outlined',
   Contained: 'contained',
   Text: 'text',
 } as const;
 
+// Sets the `bg` color to a themed color
 export const ButtonThemeEnum = {
   Default: 'default',
   Surprise: 'surprise',


### PR DESCRIPTION
Closes #3152
Closes INS-674

This is a first pass attempt at a way to make the send button more visible in the current layout. I verified all current core themes to make sure each had the improvement.

Below are some example screenshots of different themes, with hover states as well.

<img width="626" alt="Screen Shot 2021-05-21 at 2 12 20 PM" src="https://user-images.githubusercontent.com/5934780/119198739-b1e14000-ba3e-11eb-8620-602b3fe43f02.png">
<img width="628" alt="Screen Shot 2021-05-21 at 2 14 14 PM" src="https://user-images.githubusercontent.com/5934780/119198860-eb19b000-ba3e-11eb-852a-86b47ec020da.png">
<img width="624" alt="Screen Shot 2021-05-21 at 2 12 30 PM" src="https://user-images.githubusercontent.com/5934780/119198742-b279d680-ba3e-11eb-8123-9c31e4cae868.png">
<img width="626" alt="Screen Shot 2021-05-21 at 2 14 33 PM" src="https://user-images.githubusercontent.com/5934780/119198862-ec4add00-ba3e-11eb-9a12-701d194d8b59.png">
<img width="617" alt="Screen Shot 2021-05-21 at 2 12 48 PM" src="https://user-images.githubusercontent.com/5934780/119198746-b3126d00-ba3e-11eb-94ac-a57273e044d6.png">
<img width="622" alt="Screen Shot 2021-05-21 at 2 14 44 PM" src="https://user-images.githubusercontent.com/5934780/119198866-ece37380-ba3e-11eb-8aaa-827728222ee6.png">





