### PR TITLE
Add Space selector, with the logic to select a space

### DIFF
--- a/packages/insomnia-app/app/models/space.ts
+++ b/packages/insomnia-app/app/models/space.ts
@@ -8,8 +8,8 @@ export const prefix = 'sp';
 export const canDuplicate = false;
 export const canSync = false;
 
-// This base space represents "no" space, when viewing this base space show
-// fetch all workspaces with no parent. Using this instead of null.
+// A base space represents "no" space, when viewing this base space fetch all workspaces with no parent.
+// Using this instead of null.
 export const BASE_SPACE_ID = 'base-space';
 
 interface BaseSpace {

--- a/packages/insomnia-app/app/models/space.ts
+++ b/packages/insomnia-app/app/models/space.ts
@@ -8,6 +8,10 @@ export const prefix = 'sp';
 export const canDuplicate = false;
 export const canSync = false;
 
+// This base space represents "no" space, when viewing this base space show
+// fetch all workspaces with no parent. Using this instead of null.
+export const BASE_SPACE_ID = 'base-space';
+
 interface BaseSpace {
   name: string;
 }

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -9,6 +9,8 @@ import { selectActiveSpace, selectSpaces } from '../../redux/selectors';
 const mapSpace = ({ _id, name }: Space) => ({ id: _id, name });
 const defaultSpace = { id: BASE_SPACE_ID, name: getAppName() };
 
+const check = <i className="fa fa-check" />;
+
 export const SpaceDropdown: FC = () => {
   // get list of spaces
   const loadedSpaces = useSelector(selectSpaces);
@@ -29,8 +31,6 @@ export const SpaceDropdown: FC = () => {
       <i className="fa fa-caret-down space-left" />
     </button>),
   [selectedSpace]);
-
-  const check = useMemo(() => <i className="fa fa-check" />, []);
 
   return <Dropdown renderButton={button}>
     {spaces.map(({ id, name }) => (

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -29,7 +29,9 @@ export const SpaceDropdown: FC = () => {
 
   return <Dropdown renderButton={button}>
     {spaces.map(({ id, name }) => (
-      <DropdownItem key={id} icon={icon} right={id === selectedSpace.id && check}>
+      <DropdownItem key={id} icon={icon} right={id === selectedSpace.id && check}
+        value={id} onClick={(_e, id) => console.log(`clicked space ${id}`)}
+      >
         {name}
       </DropdownItem>
     ))}

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -1,8 +1,9 @@
 import { Dropdown, DropdownItem } from 'insomnia-components';
-import React, { FC, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import React, { FC, useCallback, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { getAppName } from '../../../common/constants';
 import { BASE_SPACE_ID, Space } from '../../../models/space';
+import { setActiveSpace } from '../../redux/modules/global';
 import { selectActiveSpace, selectSpaces } from '../../redux/selectors';
 
 const mapSpace = ({ _id, name }: Space) => ({ id: _id, name });
@@ -17,6 +18,11 @@ export const SpaceDropdown: FC = () => {
   const activeSpace = useSelector(selectActiveSpace);
   const selectedSpace = spaces.find(space => space.id === activeSpace?._id) || defaultSpace;
 
+  // select a new space
+  const dispatch = useDispatch();
+  const setActive = useCallback((id) => dispatch(setActiveSpace(id)), [dispatch]);
+
+  // dropdown button
   const button = useMemo(() => (
     <button type="button" className="row" title={selectedSpace.name}>
       {selectedSpace.name}
@@ -24,17 +30,15 @@ export const SpaceDropdown: FC = () => {
     </button>),
   [selectedSpace]);
 
-  const icon = useMemo(() => <i className="fa fa-cog" />, []);
   const check = useMemo(() => <i className="fa fa-check" />, []);
 
   return <Dropdown renderButton={button}>
     {spaces.map(({ id, name }) => (
       <DropdownItem
         key={id}
-        icon={icon}
         right={id === selectedSpace.id && check}
         value={id}
-        onClick={(_e, id) => console.log(`clicked space ${id}`)}
+        onClick={setActive}
       >
         {name}
       </DropdownItem>

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -1,31 +1,37 @@
-import { Dropdown, DropdownDivider, DropdownItem } from 'insomnia-components';
-import React, { FC } from 'react';
+import { Dropdown, DropdownItem } from 'insomnia-components';
+import React, { FC, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getAppName } from '../../../common/constants';
-import { Space } from '../../../models/space';
+import { BASE_SPACE_ID, Space } from '../../../models/space';
 import { selectActiveSpace, selectSpaces } from '../../redux/selectors';
 
+const mapSpace = ({ _id, name }: Space) => ({ id: _id, name });
+const defaultSpace = { id: BASE_SPACE_ID, name: getAppName() };
+
 export const SpaceDropdown: FC = () => {
-  const loadedSpaces = (useSelector(selectSpaces) as Space[]).map(space => ({ id: space._id, name: space.name }));
-  const activeSpaceId = (useSelector(selectActiveSpace) as Space | null)?._id;
+  // get list of spaces
+  const loadedSpaces = useSelector(selectSpaces);
+  const spaces = [defaultSpace, ...(loadedSpaces.map(mapSpace))];
 
-  const defaultSpace = { id: null, name: getAppName() };
+  // figure out which space is selected
+  const activeSpace = useSelector(selectActiveSpace);
+  const selectedSpace = spaces.find(space => space.id === activeSpace?._id) || defaultSpace;
 
-  const spaces = [defaultSpace, ...loadedSpaces];
+  const button = useMemo(() => (
+    <button type="button" className="row" title={selectedSpace.name}>
+      {selectedSpace.name}
+      <i className="fa fa-caret-down space-left" />
+    </button>),
+  [selectedSpace]);
 
-  const button = <button type="button" className="row">
-    <div
-      title={spaceName}>
-      {spaceName}
-    </div>
-    <i className="fa fa-caret-down space-left" />
-  </button>;
+  const icon = useMemo(() => <i className="fa fa-cog" />, []);
+  const check = useMemo(() => <i className="fa fa-check" />, []);
 
   return <Dropdown renderButton={button}>
-    <DropdownItem icon={<i className="fa fa-cog" />} right={<i className="fa fa-check" />}>Space 1</DropdownItem>
-    <DropdownItem icon={<i className="fa fa-cog" />}>Space 2</DropdownItem>
-    <DropdownDivider />
-    <DropdownItem icon={<></>}>Settings</DropdownItem>
-    <DropdownItem icon={<></>}>Create a space</DropdownItem>
+    {spaces.map(({ id, name }) => (
+      <DropdownItem key={id} icon={icon} right={id === selectedSpace.id && check}>
+        {name}
+      </DropdownItem>
+    ))}
   </Dropdown>;
 };

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -1,0 +1,31 @@
+import { Dropdown, DropdownDivider, DropdownItem } from 'insomnia-components';
+import React, { FC } from 'react';
+import { useSelector } from 'react-redux';
+import { getAppName } from '../../../common/constants';
+import { Space } from '../../../models/space';
+import { selectActiveSpace, selectSpaces } from '../../redux/selectors';
+
+export const SpaceDropdown: FC = () => {
+  const loadedSpaces = (useSelector(selectSpaces) as Space[]).map(space => ({ id: space._id, name: space.name }));
+  const activeSpaceId = (useSelector(selectActiveSpace) as Space | null)?._id;
+
+  const defaultSpace = { id: null, name: getAppName() };
+
+  const spaces = [defaultSpace, ...loadedSpaces];
+
+  const button = <button type="button" className="row">
+    <div
+      title={spaceName}>
+      {spaceName}
+    </div>
+    <i className="fa fa-caret-down space-left" />
+  </button>;
+
+  return <Dropdown renderButton={button}>
+    <DropdownItem icon={<i className="fa fa-cog" />} right={<i className="fa fa-check" />}>Space 1</DropdownItem>
+    <DropdownItem icon={<i className="fa fa-cog" />}>Space 2</DropdownItem>
+    <DropdownDivider />
+    <DropdownItem icon={<></>}>Settings</DropdownItem>
+    <DropdownItem icon={<></>}>Create a space</DropdownItem>
+  </Dropdown>;
+};

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -29,8 +29,12 @@ export const SpaceDropdown: FC = () => {
 
   return <Dropdown renderButton={button}>
     {spaces.map(({ id, name }) => (
-      <DropdownItem key={id} icon={icon} right={id === selectedSpace.id && check}
-        value={id} onClick={(_e, id) => console.log(`clicked space ${id}`)}
+      <DropdownItem
+        key={id}
+        icon={icon}
+        right={id === selectedSpace.id && check}
+        value={id}
+        onClick={(_e, id) => console.log(`clicked space ${id}`)}
       >
         {name}
       </DropdownItem>

--- a/packages/insomnia-app/app/ui/components/workspace-page-header.tsx
+++ b/packages/insomnia-app/app/ui/components/workspace-page-header.tsx
@@ -53,7 +53,7 @@ const WorkspacePageHeader: FunctionComponent<Props> = ({
         <Fragment>
           <img src={coreLogo} alt="Insomnia" width="24" height="24" />
           <Breadcrumb crumbs={[{ id: 'home', node: strings.home, onClick: homeCallback },
-{ id: 'workspace', node: <Fragment key="workspace-dd">{workspace}</Fragment> }]}/>
+            { id: 'workspace', node: <Fragment key="workspace-dd">{workspace}</Fragment> }]}/>
         </Fragment>
       }
       gridCenter={

--- a/packages/insomnia-app/app/ui/components/workspace-page-header.tsx
+++ b/packages/insomnia-app/app/ui/components/workspace-page-header.tsx
@@ -34,6 +34,7 @@ const WorkspacePageHeader: FunctionComponent<Props> = ({
     () => handleActivityChange(activeWorkspace._id, ACTIVITY_HOME),
     [activeWorkspace._id, handleActivityChange],
   );
+
   const workspace = (
     <WorkspaceDropdown
       displayName={collection ? activeWorkspace.name : activeApiSpec.fileName}
@@ -44,18 +45,15 @@ const WorkspacePageHeader: FunctionComponent<Props> = ({
       isLoading={isLoading}
     />
   );
+
   return (
     <Header
       className="app-header theme--app-header"
       gridLeft={
         <Fragment>
           <img src={coreLogo} alt="Insomnia" width="24" height="24" />
-          <Breadcrumb
-            className="breadcrumb"
-            // @ts-expect-error -- TSCONVERSION
-            crumbs={[strings.home, <Fragment key="workspace-dd">{workspace}</Fragment>]}
-            onClick={homeCallback}
-          />
+          <Breadcrumb crumbs={[{ id: 'home', node: strings.home, onClick: homeCallback },
+{ id: 'workspace', node: <Fragment key="workspace-dd">{workspace}</Fragment> }]}/>
         </Fragment>
       }
       gridCenter={

--- a/packages/insomnia-app/app/ui/components/workspace-page-header.tsx
+++ b/packages/insomnia-app/app/ui/components/workspace-page-header.tsx
@@ -52,8 +52,9 @@ const WorkspacePageHeader: FunctionComponent<Props> = ({
       gridLeft={
         <Fragment>
           <img src={coreLogo} alt="Insomnia" width="24" height="24" />
-          <Breadcrumb crumbs={[{ id: 'home', node: strings.home, onClick: homeCallback },
-            { id: 'workspace', node: <Fragment key="workspace-dd">{workspace}</Fragment> }]}/>
+          <Breadcrumb
+            crumbs={[{ id: 'home', node: strings.home, onClick: homeCallback },
+              { id: 'workspace', node: <Fragment key="workspace-dd">{workspace}</Fragment> }]}/>
         </Fragment>
       }
       gridCenter={

--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -1,11 +1,10 @@
 import React, { Fragment, PureComponent, ReactNode } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import type { GlobalActivity } from '../../common/constants';
 import {
+  GlobalActivity,
   ACTIVITY_DEBUG,
   ACTIVITY_SPEC,
   AUTOBIND_CFG,
-  getAppName,
   isWorkspaceActivity,
 } from '../../common/constants';
 import type { Workspace } from '../../models/workspace';
@@ -331,6 +330,27 @@ class WrapperHome extends PureComponent<Props, State> {
     );
   }
 
+  renderSpaceMenu() {
+    const spaceName = 'Space 1';
+    const button = (
+      <button type="button" className="row">
+        <div
+          title={spaceName}>
+          {spaceName}
+        </div>
+        <i className="fa fa-caret-down space-left" />
+      </button>
+    );
+
+    return <Dropdown renderButton={button}>
+      <DropdownItem icon={<i className="fa fa-cog" />} right={<i className="fa fa-check" />}>Space 1</DropdownItem>
+      <DropdownItem icon={<i className="fa fa-cog" />}>Space 2</DropdownItem>
+      <DropdownDivider />
+      <DropdownItem icon={<></>}>Settings</DropdownItem>
+      <DropdownItem icon={<></>}>Create a workspace</DropdownItem>
+    </Dropdown>;
+  }
+
   renderDashboardMenu() {
     const { vcs, workspaces } = this.props.wrapperProps;
     return (
@@ -377,7 +397,7 @@ class WrapperHome extends PureComponent<Props, State> {
             gridLeft={
               <Fragment>
                 <img src={coreLogo} alt="Insomnia" width="24" height="24" />
-                <Breadcrumb className="breadcrumb" crumbs={[getAppName()]} />
+                <Breadcrumb crumbs={[{ id: 'space', node: this.renderSpaceMenu() }]} />
                 {isLoading ? <i className="fa fa-refresh fa-spin space-left" /> : null}
               </Fragment>
             }

--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -51,6 +51,7 @@ import { bindActionCreators } from 'redux';
 import * as workspaceActions from '../redux/modules/workspace';
 import * as gitActions from '../redux/modules/git';
 import { MemClient } from '../../sync/git/mem-client';
+import { SpaceDropdown } from './dropdowns/space-dropdown';
 
 interface RenderedCard {
   card: ReactNode;
@@ -330,27 +331,6 @@ class WrapperHome extends PureComponent<Props, State> {
     );
   }
 
-  renderSpaceMenu() {
-    const spaceName = 'Space 1';
-    const button = (
-      <button type="button" className="row">
-        <div
-          title={spaceName}>
-          {spaceName}
-        </div>
-        <i className="fa fa-caret-down space-left" />
-      </button>
-    );
-
-    return <Dropdown renderButton={button}>
-      <DropdownItem icon={<i className="fa fa-cog" />} right={<i className="fa fa-check" />}>Space 1</DropdownItem>
-      <DropdownItem icon={<i className="fa fa-cog" />}>Space 2</DropdownItem>
-      <DropdownDivider />
-      <DropdownItem icon={<></>}>Settings</DropdownItem>
-      <DropdownItem icon={<></>}>Create a workspace</DropdownItem>
-    </Dropdown>;
-  }
-
   renderDashboardMenu() {
     const { vcs, workspaces } = this.props.wrapperProps;
     return (
@@ -397,7 +377,7 @@ class WrapperHome extends PureComponent<Props, State> {
             gridLeft={
               <Fragment>
                 <img src={coreLogo} alt="Insomnia" width="24" height="24" />
-                <Breadcrumb crumbs={[{ id: 'space', node: this.renderSpaceMenu() }]} />
+                <Breadcrumb crumbs={[{ id: 'space', node: <SpaceDropdown /> }]} />
                 {isLoading ? <i className="fa fa-refresh fa-spin space-left" /> : null}
               </Fragment>
             }

--- a/packages/insomnia-app/app/ui/redux/modules/__tests__/global.test.ts
+++ b/packages/insomnia-app/app/ui/redux/modules/__tests__/global.test.ts
@@ -22,10 +22,14 @@ import {
   SET_ACTIVE_WORKSPACE,
   setActiveActivity,
   setActiveWorkspace,
+  SET_ACTIVE_SPACE,
+  setActiveSpace,
+  initActiveSpace,
 } from '../global';
 import * as models from '../../../../models';
 import fs from 'fs';
 import { getDesignerDataDir } from '../../../../common/electron-helpers';
+import { BASE_SPACE_ID } from '../../../../models/space';
 
 jest.mock('../../../../common/analytics');
 
@@ -99,6 +103,20 @@ describe('global', () => {
       const settings = await models.settings.getOrCreate();
       expect(settings.hasPromptedToMigrateFromDesigner).toBe(true);
       expect(settings.hasPromptedOnboarding).toBe(false);
+    });
+  });
+
+  describe('setActiveSpace', () => {
+    it('should update local storage', () => {
+      const spaceId = 'id';
+      const expectedEvent = {
+        type: SET_ACTIVE_SPACE,
+        spaceId,
+      };
+      expect(setActiveSpace(spaceId)).toStrictEqual(expectedEvent);
+      expect(global.localStorage.getItem(`${LOCALSTORAGE_PREFIX}::activeSpaceId`)).toBe(
+        JSON.stringify(spaceId),
+      );
     });
   });
 
@@ -227,6 +245,29 @@ describe('global', () => {
         workspaceId,
       };
       expect(initActiveWorkspace()).toStrictEqual(expectedEvent);
+    });
+  });
+
+  describe('initActiveSpace', () => {
+    it('should initialize from local storage', () => {
+      const spaceId = 'id';
+      global.localStorage.setItem(
+        `${LOCALSTORAGE_PREFIX}::activeSpaceId`,
+        JSON.stringify(spaceId),
+      );
+      const expectedEvent = {
+        type: SET_ACTIVE_SPACE,
+        spaceId,
+      };
+      expect(initActiveSpace()).toStrictEqual(expectedEvent);
+    });
+
+    it('should default to base space if not exist', () => {
+      const expectedEvent = {
+        type: SET_ACTIVE_SPACE,
+        spaceId: BASE_SPACE_ID,
+      };
+      expect(initActiveSpace()).toStrictEqual(expectedEvent);
     });
   });
 

--- a/packages/insomnia-app/app/ui/redux/selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import * as models from '../../models';
+import { Space } from '../../models/space';
 import { UnitTestResult } from '../../models/unit-test-result';
 // ~~~~~~~~~ //
 // Selectors //
@@ -298,7 +299,8 @@ export const selectActiveUnitTests = createSelector(
   },
 );
 
-export const selectSpaces = createSelector(
+// TODO(TSCONVERSION) type this properly when doing the rest of this file
+export const selectSpaces = createSelector<any, {}, Space[]>(
   selectEntitiesLists,
   (entities) => {
     // @ts-expect-error -- TSCONVERSION
@@ -306,10 +308,13 @@ export const selectSpaces = createSelector(
   },
 );
 
-export const selectActiveSpace = createSelector(
-  selectSpaces,
-  (spaces) => {
-    return spaces[0];
+// TODO(TSCONVERSION) type this properly when doing the rest of this file
+export const selectActiveSpace = createSelector<any, {}, {}, Space | null>(
+  selectEntitiesLists,
+  state => state.global.activeSpaceId,
+  (entities, activeSpaceId) => {
+    // @ts-expect-error -- TSCONVERSION
+    return entities.spaces[activeSpaceId] || null;
   },
 );
 

--- a/packages/insomnia-app/app/ui/redux/selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/selectors.ts
@@ -310,7 +310,7 @@ export const selectSpaces = createSelector<any, {}, Space[]>(
 
 // TODO(TSCONVERSION) type this properly when doing the rest of this file
 export const selectActiveSpace = createSelector<any, {}, {}, Space | null>(
-  selectEntitiesLists,
+  state => state.entities,
   state => state.global.activeSpaceId,
   (entities, activeSpaceId) => {
     // @ts-expect-error -- TSCONVERSION

--- a/packages/insomnia-app/app/ui/redux/selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/selectors.ts
@@ -309,12 +309,12 @@ export const selectSpaces = createSelector<any, {}, Space[]>(
 );
 
 // TODO(TSCONVERSION) type this properly when doing the rest of this file
-export const selectActiveSpace = createSelector<any, {}, {}, Space | null>(
+export const selectActiveSpace = createSelector<any, {}, {}, Space | undefined>(
   state => state.entities,
   state => state.global.activeSpaceId,
   (entities, activeSpaceId) => {
     // @ts-expect-error -- TSCONVERSION
-    return entities.spaces[activeSpaceId] || null;
+    return entities.spaces[activeSpaceId];
   },
 );
 

--- a/packages/insomnia-app/app/ui/redux/selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/selectors.ts
@@ -297,6 +297,22 @@ export const selectActiveUnitTests = createSelector(
     return entities.unitTests.filter(s => s.parentId === activeUnitTestSuite._id);
   },
 );
+
+export const selectSpaces = createSelector(
+  selectEntitiesLists,
+  (entities) => {
+    // @ts-expect-error -- TSCONVERSION
+    return entities.spaces;
+  },
+);
+
+export const selectActiveSpace = createSelector(
+  selectSpaces,
+  (spaces) => {
+    return spaces[0];
+  },
+);
+
 export const selectActiveUnitTestSuites = createSelector(
   selectEntitiesLists,
   selectActiveWorkspace,

--- a/packages/insomnia-components/src/breadcrumb.stories.tsx
+++ b/packages/insomnia-components/src/breadcrumb.stories.tsx
@@ -8,6 +8,6 @@ export default {
 export const _default = () => (
   <Breadcrumb
     className="breadcrumb"
-    crumbs={['Documents', 'Deployment']}
+    crumbs={[{ id: '1', node: 'Documents' }, { id: '2', node: 'Deployment', onClick: () => {} }, { id: '3', node: 'Another' }]}
   />
 );

--- a/packages/insomnia-components/src/breadcrumb.tsx
+++ b/packages/insomnia-components/src/breadcrumb.tsx
@@ -47,8 +47,8 @@ const StyledBreadcrumb = styled.ul`
 `;
 
 const Crumb: FC<CrumbProps> = ({ id, node, onClick }) => <li key={id}>
-    {onClick ? <a href="#" onClick={onClick}>{node}</a> : node}
-  </li>;
+  {onClick ? <a href="#" onClick={onClick}>{node}</a> : node}
+</li>;
 
 export const Breadcrumb: FC<BreadcrumbProps> = ({ crumbs, className }) => (
   <StyledBreadcrumb className={className}>

--- a/packages/insomnia-components/src/breadcrumb.tsx
+++ b/packages/insomnia-components/src/breadcrumb.tsx
@@ -1,10 +1,15 @@
-import React, { PureComponent } from 'react';
+import React, { FC, ReactNode } from 'react';
 import styled from 'styled-components';
 
-export interface BreadcrumbProps {
-  crumbs: string[];
-  className: string;
+interface CrumbProps {
+  id: string;
+  node: ReactNode;
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+}
+
+export interface BreadcrumbProps {
+  crumbs: CrumbProps[];
+  className?: string;
 }
 
 const StyledBreadcrumb = styled.ul`
@@ -41,25 +46,12 @@ const StyledBreadcrumb = styled.ul`
   }
 `;
 
-export class Breadcrumb extends PureComponent<BreadcrumbProps> {
-  render() {
-    const { className, crumbs, onClick } = this.props;
-    return (
-      <StyledBreadcrumb className={className}>
-        {crumbs.map((crumb, i, arr) => {
-          if (arr.length - 1 === i) {
-            return <li key={crumb}>{crumb}</li>;
-          } else {
-            return (
-              <li key={crumb}>
-                <a href="#" onClick={onClick}>
-                  {crumb}
-                </a>
-              </li>
-            );
-          }
-        })}
-      </StyledBreadcrumb>
-    );
-  }
-}
+const Crumb: FC<CrumbProps> = ({ id, node, onClick }) => <li key={id}>
+    {onClick ? <a href="#" onClick={onClick}>{node}</a> : node}
+  </li>;
+
+export const Breadcrumb: FC<BreadcrumbProps> = ({ crumbs, className }) => (
+  <StyledBreadcrumb className={className}>
+    {crumbs.map(Crumb)}
+  </StyledBreadcrumb>
+);

--- a/packages/insomnia-components/src/dropdown/dropdown-item.tsx
+++ b/packages/insomnia-components/src/dropdown/dropdown-item.tsx
@@ -2,12 +2,12 @@ import React, { PureComponent, ReactNode } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import styled, { css } from 'styled-components';
 
-export interface DropdownItemProps<T> {
+export interface DropdownItemProps {
   buttonClass?: string,
   stayOpenAfterClick?: boolean,
-  value?: T,
+  value?: any,
   disabled?: boolean,
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>, value?: T) => void,
+  onClick?: Function,
   children?: ReactNode,
   icon?: ReactNode,
   right?: ReactNode,
@@ -86,7 +86,7 @@ const StyledIconContainer = styled.div`
 `;
 
 @autoBindMethodsForReact
-export class DropdownItem<T> extends PureComponent<DropdownItemProps<T>> {
+export class DropdownItem extends PureComponent<DropdownItemProps> {
   _handleClick(event: React.MouseEvent<HTMLButtonElement>) {
     const { stayOpenAfterClick, onClick, disabled } = this.props;
 
@@ -98,7 +98,11 @@ export class DropdownItem<T> extends PureComponent<DropdownItemProps<T>> {
       return;
     }
 
-    onClick(event, this.props.value);
+    if (this.props.hasOwnProperty('value')) {
+      onClick(this.props.value, event);
+    } else {
+      onClick(event);
+    }
   }
 
   render() {

--- a/packages/insomnia-components/src/dropdown/dropdown-item.tsx
+++ b/packages/insomnia-components/src/dropdown/dropdown-item.tsx
@@ -2,12 +2,12 @@ import React, { PureComponent, ReactNode } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import styled, { css } from 'styled-components';
 
-export interface DropdownItemProps {
+export interface DropdownItemProps<T> {
   buttonClass?: string,
   stayOpenAfterClick?: boolean,
-  value?: any,
+  value?: T,
   disabled?: boolean,
-  onClick?: Function,
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>, value?: T) => void,
   children?: ReactNode,
   icon?: ReactNode,
   right?: ReactNode,
@@ -86,7 +86,7 @@ const StyledIconContainer = styled.div`
 `;
 
 @autoBindMethodsForReact
-export class DropdownItem extends PureComponent<DropdownItemProps> {
+export class DropdownItem<T> extends PureComponent<DropdownItemProps<T>> {
   _handleClick(event: React.MouseEvent<HTMLButtonElement>) {
     const { stayOpenAfterClick, onClick, disabled } = this.props;
 
@@ -98,11 +98,7 @@ export class DropdownItem extends PureComponent<DropdownItemProps> {
       return;
     }
 
-    if (this.props.hasOwnProperty('value')) {
-      onClick(this.props.value, event);
-    } else {
-      onClick(event);
-    }
+    onClick(event, this.props.value);
   }
 
   render() {
@@ -114,11 +110,7 @@ export class DropdownItem extends PureComponent<DropdownItemProps> {
       disabled,
       right,
       icon,
-      onClick,
-      // eslint-disable-line no-unused-vars
-      stayOpenAfterClick,
-      // eslint-disable-line no-unused-vars
-      ...props
+      selected,
     } = this.props;
 
     const styles = color ? { color } : {};
@@ -134,7 +126,7 @@ export class DropdownItem extends PureComponent<DropdownItemProps> {
         type="button"
         onClick={this._handleClick}
         disabled={disabled}
-        {...props}>
+        selected={selected}>
         {icon && <StyledIconContainer>{icon}</StyledIconContainer>}
         {inner}
         {right && <StyledRightNode>{right}</StyledRightNode>}

--- a/packages/insomnia-components/src/header.stories.tsx
+++ b/packages/insomnia-components/src/header.stories.tsx
@@ -14,8 +14,7 @@ export const _primary = () => (
     gridLeft={
       <Fragment>
         <Breadcrumb
-          className="breadcrumb"
-          crumbs={['Documents', 'Deployment']}
+          crumbs={[{ id: '1', node: 'Documents' }, { id: '2', node: 'Deployment' }]}
         />
       </Fragment>
     }


### PR DESCRIPTION
This PR introduces the space selector, and links it into Redux. It uses a constant - `BASE_SPACE_ID` - to determine the base space, which doesn't actually exist, but will be used to filter the list of workspaces with no parent, in the future.

This PR does not have any UI for creating or deleting a space, however for testing purposes you can do so via the command line. When running in dev mode, run `await models.space.create({name: 'some name'});` in the developer console to create spaces, which will then show in the space dropdown and be selectable.

Any additional items in the dropdown list (eg settings, logout, create) will be added when implementing their functionality too.

![2021-05-27 20 29 06](https://user-images.githubusercontent.com/4312346/119793009-51fd0480-bf2a-11eb-8150-2c026ef213c0.gif)

This PR also tidies up the breadcrumbs component and its props.
