### PR TITLE
fix DebouncedInput (and delay handling) and change handlers

### DIFF
--- a/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
+++ b/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
@@ -22,24 +22,22 @@ interface State {
   debouncedOnChange: ExtendedAttributes['onChange'];
 }
 
-const defaultDelay = 500;
-
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class DebouncedInput extends PureComponent<Props, State> {
   _hasFocus = false;
   _input: HTMLTextAreaElement | HTMLInputElement | null = null;
 
   state: State = {
-    delay: defaultDelay,
+    delay: this.props.delay ?? 500,
     onChange: this.props.onChange,
-    debouncedOnChange: debounce(this.props.onChange, this.props.delay || defaultDelay),
+    debouncedOnChange: debounce(this.props.onChange, this.props.delay),
   }
 
   static getDerivedStateFromProps(props: Props, state: State) {
     if (state.delay !== props.delay || state.onChange !== props.onChange) {
       return {
         onChange: props.onChange,
-        debouncedOnChange: debounce(props.onChange, props.delay || defaultDelay),
+        debouncedOnChange: debounce(props.onChange, props.delay),
         delay: props.delay,
       };
     }

--- a/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
+++ b/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
@@ -13,7 +13,7 @@ type InheritedAttributes = Omit<InputHTMLAttributes<TargetElement>, keyof Extend
 
 interface Props extends InheritedAttributes, ExtendedAttributes {
   textarea?: boolean;
-  delay?: number;
+  delay: number;
 }
 
 interface State {
@@ -27,14 +27,14 @@ export class DebouncedInput extends PureComponent<Props, State> {
   _input: HTMLTextAreaElement | HTMLInputElement | null = null;
 
   state: State = {
-    delay: this.props.delay ?? 500,
-    onChange: this.props.delay ? debounce(this.props.onChange, this.props.delay) : this.props.onChange,
+    delay: this.props.delay,
+    onChange: debounce(this.props.onChange, this.props.delay),
   }
 
   static getDerivedStateFromProps(props: Props, state: State) {
     if (state.delay !== props.delay || state.onChange !== props.onChange) {
       return {
-        onChange: props.delay ? debounce(props.onChange, props.delay) : props.onChange,
+        onChange: debounce(props.onChange, props.delay),
         delay: props.delay,
       };
     }

--- a/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
+++ b/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
@@ -16,18 +16,44 @@ interface Props extends InheritedAttributes, ExtendedAttributes {
   delay?: number;
 }
 
+interface State {
+  delay: number;
+  onChange: ExtendedAttributes['onChange'];
+  debouncedOnChange: ExtendedAttributes['onChange'];
+}
+
+const defaultDelay = 500;
+
 @autoBindMethodsForReact(AUTOBIND_CFG)
-export class DebouncedInput extends PureComponent<Props> {
+export class DebouncedInput extends PureComponent<Props, State> {
   _hasFocus = false;
   _input: HTMLTextAreaElement | HTMLInputElement | null = null;
 
+  state: State = {
+    delay: defaultDelay,
+    onChange: this.props.onChange,
+    debouncedOnChange: debounce(this.props.onChange, this.props.delay || defaultDelay),
+  }
+
+  static getDerivedStateFromProps(props: Props, state: State) {
+    if (state.delay !== props.delay || state.onChange !== props.onChange) {
+      return {
+        onChange: props.onChange,
+        debouncedOnChange: debounce(props.onChange, props.delay || defaultDelay),
+        delay: props.delay,
+      };
+    }
+    return null;
+  }
+
   _handleChange(event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) {
-    const { delay, onChange } = this.props;
+    const { delay } = this.props;
+    const { onChange, debouncedOnChange } = this.state;
     const { value } = event.target;
     if (!delay) {
       onChange(value);
     } else {
-      debounce(onChange, delay || 500)(value);
+      debouncedOnChange(value);
     }
   }
 

--- a/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
+++ b/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { ChangeEvent, PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { debounce } from '../../../common/misc';
@@ -15,20 +15,15 @@ interface Props {
 export class DebouncedInput extends PureComponent<Props> {
   _hasFocus = false;
   _input: HTMLTextAreaElement | HTMLInputElement | null = null;
-  _handleValueChange: Props['onChange'] | null = null;
 
-  constructor(props: Props) {
-    super(props);
-
-    if (!props.delay) {
-      this._handleValueChange = props.onChange;
+  _handleChange(event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) {
+    const { delay, onChange } = this.props;
+    const { value } = event.target;
+    if (!delay) {
+      onChange(value);
     } else {
-      this._handleValueChange = debounce(props.onChange, props.delay || 500);
+      debounce(onChange, delay || 500)(value);
     }
-  }
-
-  _handleChange(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) {
-    this._handleValueChange?.(e.target.value);
   }
 
   _handleFocus(e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>) {

--- a/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
+++ b/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
@@ -19,7 +19,6 @@ interface Props extends InheritedAttributes, ExtendedAttributes {
 interface State {
   delay: number;
   onChange: ExtendedAttributes['onChange'];
-  debouncedOnChange: ExtendedAttributes['onChange'];
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -29,15 +28,13 @@ export class DebouncedInput extends PureComponent<Props, State> {
 
   state: State = {
     delay: this.props.delay ?? 500,
-    onChange: this.props.onChange,
-    debouncedOnChange: debounce(this.props.onChange, this.props.delay),
+    onChange: this.props.delay ? debounce(this.props.onChange, this.props.delay) : this.props.onChange,
   }
 
   static getDerivedStateFromProps(props: Props, state: State) {
     if (state.delay !== props.delay || state.onChange !== props.onChange) {
       return {
-        onChange: props.onChange,
-        debouncedOnChange: debounce(props.onChange, props.delay),
+        onChange: props.delay ? debounce(props.onChange, props.delay) : props.onChange,
         delay: props.delay,
       };
     }
@@ -45,14 +42,9 @@ export class DebouncedInput extends PureComponent<Props, State> {
   }
 
   _handleChange(event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) {
-    const { delay } = this.props;
-    const { onChange, debouncedOnChange } = this.state;
+    const { onChange } = this.state;
     const { value } = event.target;
-    if (!delay) {
-      onChange(value);
-    } else {
-      debouncedOnChange(value);
-    }
+    onChange(value);
   }
 
   _handleFocus(e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>) {

--- a/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
+++ b/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
@@ -1,12 +1,17 @@
-import React, { ChangeEvent, PureComponent } from 'react';
+import React, { ChangeEvent, InputHTMLAttributes, PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { debounce } from '../../../common/misc';
 
-interface Props {
-  onChange: (value: string) => void;
-  onFocus?: Function;
-  onBlur?: Function;
+type TargetElement = HTMLTextAreaElement | HTMLInputElement;
+
+interface ExtendedAttributes {
+  onChange: (value?: string) => void;
+}
+
+type InheritedAttributes = Omit<InputHTMLAttributes<TargetElement>, keyof ExtendedAttributes>
+
+interface Props extends InheritedAttributes, ExtendedAttributes {
   textarea?: boolean;
   delay?: number;
 }

--- a/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
+++ b/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
@@ -78,30 +78,23 @@ export class DebouncedInput extends PureComponent<Props> {
   }
 
   focus() {
-    if (this._input) {
-      this._input.focus();
-    }
+    this._input?.focus();
   }
 
   focusEnd() {
     if (this._input) {
       // Hack to focus the end (set value to current value);
       this._input.value = this.getValue();
-
-      this._input.focus();
     }
+    this._input?.focus();
   }
 
   blur() {
-    if (this._input) {
-      this._input.blur();
-    }
+    this._input?.blur();
   }
 
   select() {
-    if (this._input) {
-      this._input.select();
-    }
+    this._input?.select();
   }
 
   getValue() {

--- a/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
+++ b/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-class DebouncedInput extends PureComponent<Props> {
+export class DebouncedInput extends PureComponent<Props> {
   _hasFocus = false;
   _input: HTMLTextAreaElement | HTMLInputElement | null = null;
   _handleValueChange: Props['onChange'] | null = null;
@@ -149,5 +149,3 @@ class DebouncedInput extends PureComponent<Props> {
     }
   }
 }
-
-export default DebouncedInput;

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -1,4 +1,4 @@
-import React, { Component, CSSProperties, ReactNode } from 'react';
+import React, { Component, CSSProperties, HTMLAttributes, ReactNode } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import {
   AUTOBIND_CFG,
@@ -80,19 +80,29 @@ const BASE_CODEMIRROR_OPTIONS: CodeMirror.EditorConfiguration = {
   gutters: ['CodeMirror-lint-markers'],
 };
 
-export type CodeEditorOnChange = (value: string) => void;
+type InheritedAttributes = Pick<HTMLAttributes<HTMLDivElement>,
+  | 'onBlur'
+  | 'onFocus'
+  | 'onMouseLeave'
+  | 'onMouseLeave'
+  | 'onClick'
+  | 'onPaste'
+  | 'placeholder'
+  | 'id'
+  | 'className'
+  | 'style'
+>
 
-interface Props {
+interface ExtendedAttributes {
+  onKeyDown?: (event: React.KeyboardEvent, value?: string) => void;
+  onChange?: (value?: string) => void;
+}
+
+interface Props extends InheritedAttributes, ExtendedAttributes {
   indentWithTabs?: boolean,
-  onChange?: CodeEditorOnChange,
   onCursorActivity?: Function,
-  onFocus?: Function,
-  onBlur?: Function,
   onClickLink?: CodeMirrorLinkClickCallback,
-  onKeyDown?: Function,
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>,
-  onClick?: React.MouseEventHandler<HTMLDivElement>,
-  onPaste?: Function,
   onCodeMirrorInit?: (editor: CodeMirror.EditorFromTextArea) => void,
   render?: HandleRender,
   nunjucksPowerUserMode?: boolean,
@@ -101,8 +111,6 @@ interface Props {
   getAutocompleteSnippets?: Function,
   keyMap?: string,
   mode?: string,
-  id?: string,
-  placeholder?: string,
   lineWrapping?: boolean,
   hideLineNumbers?: boolean,
   hideGutters?: boolean,
@@ -117,8 +125,6 @@ interface Props {
   noLint?: boolean,
   noDragDrop?: boolean,
   noStyleActiveLine?: boolean,
-  className?: string,
-  style?: Object,
   updateFilter?: (filter: string) => void,
   defaultTabBehavior?: boolean,
   readOnly?: boolean,

--- a/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
@@ -403,6 +403,7 @@ class OneLineEditor extends PureComponent<Props, State> {
           ref={ref => { this._input = ref; }}
           id={id}
           type={type}
+          delay={500}
           className={className}
           style={{
             // background: 'rgba(255, 0, 0, 0.05)', // For debugging

--- a/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import CodeEditor from './code-editor';
-import Input from '../base/debounced-input';
+import { DebouncedInput } from '../base/debounced-input';
 const MODE_INPUT = 'input';
 const MODE_EDITOR = 'editor';
 const TYPE_TEXT = 'text';
@@ -40,7 +40,7 @@ interface State {
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class OneLineEditor extends PureComponent<Props, State> {
   _editor: CodeEditor | null = null;
-  _input: Input | null = null;
+  _input: DebouncedInput | null = null;
   _mouseEnterTimeout: NodeJS.Timeout | null = null;
 
   constructor(props: Props) {
@@ -324,10 +324,6 @@ class OneLineEditor extends PureComponent<Props, State> {
     this._editor = n;
   }
 
-  _setInputRef(n: Input) {
-    this._input = n;
-  }
-
   _mayContainNunjucks(text) {
     // Not sure, but sometimes this isn't a string
     if (typeof text !== 'string') {
@@ -398,8 +394,8 @@ class OneLineEditor extends PureComponent<Props, State> {
       );
     } else {
       return (
-        <Input
-          ref={this._setInputRef}
+        <DebouncedInput
+          ref={ref => { this._input = ref; }}
           // @ts-expect-error -- TSCONVERSION
           id={id}
           type={type}

--- a/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
@@ -5,6 +5,7 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import CodeEditor from './code-editor';
 import { DebouncedInput } from '../base/debounced-input';
+import { HandleGetRenderContext, HandleRender } from '../../../common/render';
 const MODE_INPUT = 'input';
 const MODE_EDITOR = 'editor';
 const TYPE_TEXT = 'text';
@@ -28,8 +29,8 @@ interface ExtendedAttributes {
 interface Props extends InheritedAttributes, ExtendedAttributes {
   defaultValue: string;
   mode?: string;
-  render?: Function;
-  getRenderContext?: Function;
+  render?: HandleRender;
+  getRenderContext?: HandleGetRenderContext;
   nunjucksPowerUserMode?: boolean;
   getAutocompleteConstants?: Function | null;
   forceEditor?: boolean;

--- a/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, PureComponent } from 'react';
+import React, { Fragment, InputHTMLAttributes, PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
@@ -10,29 +10,34 @@ const MODE_EDITOR = 'editor';
 const TYPE_TEXT = 'text';
 const NUNJUCKS_REGEX = /({%|%}|{{|}})/;
 
-interface Props {
+type InheritedAttributes = Pick<InputHTMLAttributes<HTMLInputElement>,
+  | 'onPaste'
+  | 'onFocus'
+  | 'className'
+  | 'placeholder'
+  | 'type'
+  | 'id'
+>
+
+interface ExtendedAttributes {
+  onKeyDown?: (event: React.KeyboardEvent, value?: string) => void;
+  onChange?: (value: string) => void;
+  onBlur?: () => void;
+}
+
+interface Props extends InheritedAttributes, ExtendedAttributes {
   defaultValue: string;
-  id?: string;
-  type?: string;
   mode?: string;
-  onBlur?: Function;
-  onKeyDown?: Function;
-  onFocus?: Function;
-  onChange?: Function;
-  onPaste?: Function;
   render?: Function;
   getRenderContext?: Function;
   nunjucksPowerUserMode?: boolean;
   getAutocompleteConstants?: Function | null;
-  placeholder?: string;
-  className?: string;
   forceEditor?: boolean;
   forceInput?: boolean;
   isVariableUncovered?: boolean;
   // TODO(TSCONVERSION) figure out why so many components pass this in yet it isn't used anywhere in this
   disabled?: boolean;
 }
-
 interface State {
   mode: string;
 }
@@ -377,7 +382,6 @@ class OneLineEditor extends PureComponent<Props, State> {
             onKeyDown={this._handleKeyDown}
             onFocus={this._handleEditorFocus}
             onMouseLeave={this._handleEditorMouseLeave}
-            // @ts-expect-error -- TSCONVERSION
             onChange={onChange}
             // @ts-expect-error -- TSCONVERSION
             render={render}
@@ -396,7 +400,6 @@ class OneLineEditor extends PureComponent<Props, State> {
       return (
         <DebouncedInput
           ref={ref => { this._input = ref; }}
-          // @ts-expect-error -- TSCONVERSION
           id={id}
           type={type}
           className={className}

--- a/packages/insomnia-app/app/ui/components/editors/body/body-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/body-editor.tsx
@@ -35,8 +35,8 @@ import AskModal from '../../modals/ask-modal';
 import { HandleGetRenderContext, HandleRender } from '../../../../common/render';
 
 interface Props {
-  onChange: (r: Request, body: RequestBody) => Promise<Request>;
-  onChangeHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
+  onChange: (request: Request, body: RequestBody) => Promise<Request>;
+  onChangeHeaders: (request: Request, headers: RequestHeader[]) => Promise<Request>;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;

--- a/packages/insomnia-app/app/ui/components/editors/body/form-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/form-editor.tsx
@@ -7,7 +7,7 @@ import { RequestBodyParameter } from '../../../../models/request';
 
 interface Props {
   onChange: (parameters: RequestBodyParameter[]) => void,
-  parameters: any[],
+  parameters: RequestBodyParameter[],
   nunjucksPowerUserMode: boolean,
   isVariableUncovered: boolean,
   handleRender?: HandleRender,

--- a/packages/insomnia-app/app/ui/components/editors/body/form-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/form-editor.tsx
@@ -3,9 +3,10 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { AUTOBIND_CFG } from '../../../../common/constants';
 import KeyValueEditor from '../../key-value-editor/editor';
 import { HandleGetRenderContext, HandleRender } from '../../../../common/render';
+import { RequestBodyParameter } from '../../../../models/request';
 
 interface Props {
-  onChange: Function,
+  onChange: (parameters: RequestBodyParameter[]) => void,
   parameters: any[],
   nunjucksPowerUserMode: boolean,
   isVariableUncovered: boolean,

--- a/packages/insomnia-app/app/ui/components/editors/body/raw-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/raw-editor.tsx
@@ -1,11 +1,11 @@
 import React, { Fragment, PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { AUTOBIND_CFG } from '../../../../common/constants';
-import CodeEditor, { CodeEditorOnChange } from '../../codemirror/code-editor';
+import CodeEditor from '../../codemirror/code-editor';
 import { HandleGetRenderContext, HandleRender } from '../../../../common/render';
 
 interface Props {
-  onChange: CodeEditorOnChange;
+  onChange: (value: string) => void;
   content: string;
   contentType: string;
   fontSize: number;

--- a/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.tsx
@@ -7,7 +7,7 @@ import { RequestBodyParameter } from '../../../../models/request';
 
 interface Props {
   onChange: (parameters: RequestBodyParameter[]) => void;
-  parameters: any[];
+  parameters: RequestBodyParameter[];
   nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   handleRender?: HandleRender;

--- a/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.tsx
@@ -3,9 +3,10 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { AUTOBIND_CFG } from '../../../../common/constants';
 import KeyValueEditor from '../../key-value-editor/editor';
 import { HandleGetRenderContext, HandleRender } from '../../../../common/render';
+import { RequestBodyParameter } from '../../../../models/request';
 
 interface Props {
-  onChange: Function;
+  onChange: (parameters: RequestBodyParameter[]) => void;
   parameters: any[];
   nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;

--- a/packages/insomnia-app/app/ui/components/editors/grpc-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/grpc-editor.tsx
@@ -5,7 +5,7 @@ import { HandleGetRenderContext, HandleRender } from '../../../common/render';
 
 interface Props {
   content?: string;
-  handleChange?: (arg0: string) => void;
+  handleChange?: (value: string) => void;
   settings: Settings;
   readOnly?: boolean;
   handleRender?: HandleRender;

--- a/packages/insomnia-app/app/ui/components/editors/password-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/password-editor.tsx
@@ -10,7 +10,7 @@ interface Props {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
   nunjucksPowerUserMode: boolean;
-  onChange: (...args: any[]) => any;
+  onChange: (value: string) => void;
   password: string;
   disabled: boolean;
   isVariableUncovered: boolean;

--- a/packages/insomnia-app/app/ui/components/key-value-editor/editor.tsx
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/editor.tsx
@@ -22,7 +22,7 @@ const RIGHT = 39;
 
 interface Props {
   onChange: (headers: RequestHeader[]) => void;
-  pairs: any[];
+  pairs: RequestHeader[];
   handleRender?: HandleRender;
   handleGetRenderContext?: HandleGetRenderContext;
   nunjucksPowerUserMode?: boolean;

--- a/packages/insomnia-app/app/ui/components/key-value-editor/editor.tsx
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/editor.tsx
@@ -8,6 +8,7 @@ import { generateId, nullFn } from '../../../common/misc';
 import { Dropdown, DropdownItem, DropdownButton } from '../base/dropdown';
 import PromptButton from '../base/prompt-button';
 import { HandleGetRenderContext, HandleRender } from '../../../common/render';
+import { RequestHeader } from '../../../models/request';
 
 const NAME = 'name';
 const VALUE = 'value';
@@ -20,7 +21,7 @@ const LEFT = 37;
 const RIGHT = 39;
 
 interface Props {
-  onChange: Function;
+  onChange: (headers: RequestHeader[]) => void;
   pairs: any[];
   handleRender?: HandleRender;
   handleGetRenderContext?: HandleGetRenderContext;

--- a/packages/insomnia-app/app/ui/components/key-value-editor/row.tsx
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/row.tsx
@@ -15,6 +15,16 @@ import { showModal } from '../modals/index';
 import { describeByteSize } from '../../../common/misc';
 import { HandleGetRenderContext, HandleRender } from '../../../common/render';
 
+interface Pair {
+  id: string,
+  name: string,
+  value: string,
+  description: string,
+  fileName: string,
+  type: string,
+  disabled: boolean,
+}
+
 interface Props {
   onChange: Function,
   onDelete: Function,
@@ -23,20 +33,11 @@ interface Props {
   onFocusDescription: Function,
   displayDescription: boolean,
   index: number,
-  pair: {
-    id: string,
-    name: string,
-    value: string,
-    description: string,
-    fileName: string,
-    type: string,
-    disabled: boolean,
-  },
-  readOnly?: boolean,
+  pair: Pair,
   onMove?: Function,
   onKeyDown?: Function,
-  onBlurName?: Function,
-  onBlurValue?: Function,
+  onBlurName?: (pair?: Pair) => void,
+  onBlurValue?: (pair?: Pair) => void,
   onBlurDescription?: Function,
   handleRender?: HandleRender,
   handleGetRenderContext?: HandleGetRenderContext,
@@ -74,20 +75,17 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
   _nameInput: OneLineEditor | null = null;
   _valueInput: OneLineEditor | FileInputButton | null = null;
   _descriptionInput: OneLineEditor | null = null;
+
   state: State = {
     dragDirection: 0,
   };
 
   focusNameEnd() {
-    if (this._nameInput) {
-      this._nameInput.focusEnd();
-    }
+    this._nameInput?.focusEnd();
   }
 
   focusValueEnd() {
-    if (this._valueInput) {
-      this._valueInput?.focusEnd();
-    }
+    this._valueInput?.focusEnd();
   }
 
   focusDescriptionEnd() {
@@ -96,9 +94,7 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
 
   setDragDirection(dragDirection) {
     if (dragDirection !== this.state.dragDirection) {
-      this.setState({
-        dragDirection,
-      });
+      this.setState({ dragDirection });
     }
   }
 
@@ -111,10 +107,8 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
     this.props.onChange && this.props.onChange(pair);
   }
 
-  _handleNameChange(name) {
-    this._sendChange({
-      name,
-    });
+  _handleNameChange(name: string) {
+    this._sendChange({ name });
   }
 
   _handleValuePaste(e) {
@@ -148,22 +142,16 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
     }
   }
 
-  _handleValueChange(value) {
-    this._sendChange({
-      value,
-    });
+  _handleValueChange(value: string) {
+    this._sendChange({ value });
   }
 
-  _handleFileNameChange(fileName) {
-    this._sendChange({
-      fileName,
-    });
+  _handleFileNameChange(fileName: string) {
+    this._sendChange({ fileName });
   }
 
-  _handleDescriptionChange(description) {
-    this._sendChange({
-      description,
-    });
+  _handleDescriptionChange(description: string) {
+    this._sendChange({ description });
   }
 
   _handleTypeChange(def) {
@@ -181,10 +169,8 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
     });
   }
 
-  _handleDisableChange(disabled) {
-    this._sendChange({
-      disabled,
-    });
+  _handleDisableChange(disabled: boolean) {
+    this._sendChange({ disabled });
   }
 
   _handleFocusName(e) {
@@ -199,34 +185,24 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
     this.props.onFocusDescription(this.props.pair, e);
   }
 
-  _handleBlurName(e) {
-    if (this.props.onBlurName) {
-      this.props.onBlurName(this.props.pair, e);
-    }
+  _handleBlurName() {
+    this.props.onBlurName?.(this.props.pair);
   }
 
-  _handleBlurValue(e) {
-    if (this.props.onBlurName) {
-      this.props.onBlurValue?.(this.props.pair, e);
-    }
+  _handleBlurValue() {
+    this.props.onBlurValue?.(this.props.pair);
   }
 
-  _handleBlurDescription(e) {
-    if (this.props.onBlurDescription) {
-      this.props.onBlurDescription(this.props.pair, e);
-    }
+  _handleBlurDescription() {
+    this.props.onBlurDescription?.(this.props.pair);
   }
 
   _handleDelete() {
-    if (this.props.onDelete) {
-      this.props.onDelete(this.props.pair);
-    }
+    this.props.onDelete?.(this.props.pair);
   }
 
   _handleKeyDown(e, value) {
-    if (this.props.onKeyDown) {
-      this.props.onKeyDown(this.props.pair, e, value);
-    }
+    this.props.onKeyDown?.(this.props.pair, e, value);
   }
 
   _handleAutocompleteNames() {
@@ -268,7 +244,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
   renderPairDescription() {
     const {
       displayDescription,
-      readOnly,
       forceInput,
       descriptionPlaceholder,
       pair,
@@ -287,8 +262,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
         )}>
         <OneLineEditor
           ref={this._setDescriptionInputRef}
-          // @ts-expect-error -- TSCONVERSION very strange that one of the `OneLineEditor`s in this file _doesn't_ error with this...
-          readOnly={readOnly}
           forceInput={forceInput}
           placeholder={descriptionPlaceholder || 'Description'}
           defaultValue={pair.description || ''}
@@ -308,7 +281,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
   renderPairValue() {
     const {
       pair,
-      readOnly,
       forceInput,
       valueInputType,
       valuePlaceholder,
@@ -344,8 +316,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
       return (
         <OneLineEditor
           ref={ref => { this._valueInput = ref; }}
-          // @ts-expect-error -- TSCONVERSION very strange that one of the `OneLineEditor`s in this file _doesn't_ error with this...
-          readOnly={readOnly}
           forceInput={forceInput}
           type={valueInputType || 'text'}
           placeholder={valuePlaceholder || 'Value'}
@@ -434,7 +404,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
       noDropZone,
       hideButtons,
       forceInput,
-      readOnly,
       className,
       isDragging,
       isDraggingOver,
@@ -485,8 +454,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
               isVariableUncovered={isVariableUncovered}
               getAutocompleteConstants={this._handleAutocompleteNames}
               forceInput={forceInput}
-              // @ts-expect-error -- TSCONVERSION very strange that one of the `OneLineEditor`s in this file _doesn't_ error with this...
-              readOnly={readOnly}
               onBlur={this._handleBlurName}
               onChange={this._handleNameChange}
               onFocus={this._handleFocusName}

--- a/packages/insomnia-app/app/ui/components/key-value-editor/row.tsx
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/row.tsx
@@ -104,7 +104,7 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
 
   _sendChange(patch) {
     const pair = Object.assign({}, this.props.pair, patch);
-    this.props.onChange && this.props.onChange(pair);
+    this.props.onChange?.(pair);
   }
 
   _handleNameChange(name: string) {
@@ -518,10 +518,8 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
 }
 
 const dragSource = {
-  beginDrag(props: Props) {
-    return {
-      pair: props.pair,
-    };
+  beginDrag({ pair }: Props) {
+    return { pair };
   },
 };
 

--- a/packages/insomnia-app/app/ui/components/markdown-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/markdown-editor.tsx
@@ -9,7 +9,7 @@ import MarkdownPreview from './markdown-preview';
 import { HandleGetRenderContext, HandleRender } from '../../common/render';
 
 interface Props {
-  onChange: Function,
+  onChange: (markdown: string) => void;
   defaultValue: string,
   fontSize: number,
   indentSize: number,
@@ -41,11 +41,9 @@ class MarkdownEditor extends PureComponent<Props, State> {
     };
   }
 
-  _handleChange(markdown) {
+  _handleChange(markdown: string) {
     this.props.onChange(markdown);
-    this.setState({
-      markdown,
-    });
+    this.setState({ markdown });
   }
 
   _setEditorRef(n: CodeEditor) {

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
@@ -452,7 +452,6 @@ class RequestSettingsModal extends PureComponent<Props, State> {
             <span className="txt-sm faint italic">(also rename by double-clicking in sidebar)</span>
             <DebouncedInput
               delay={500}
-              // @ts-expect-error -- TSCONVERSION props expand into an input but are difficult to type
               type="text"
               placeholder={request.url || 'My Request'}
               defaultValue={request.name}

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
@@ -6,7 +6,7 @@ import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';
 import HelpTooltip from '../help-tooltip';
 import * as models from '../../../models';
-import DebouncedInput from '../base/debounced-input';
+import { DebouncedInput } from '../base/debounced-input';
 import MarkdownEditor from '../markdown-editor';
 import { database as db } from '../../../common/database';
 import { isWorkspace, Workspace } from '../../../models/workspace';

--- a/packages/insomnia-app/app/ui/components/modals/space-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/space-settings-modal.tsx
@@ -73,7 +73,6 @@ class SpaceSettingsModal extends PureComponent<Props> {
             <label>
               Name
               <DebouncedInput
-              // @ts-expect-error -- TSCONVERSION props are spread into an input element
                 type="text"
                 delay={500}
                 placeholder="My Space"

--- a/packages/insomnia-app/app/ui/components/modals/space-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/space-settings-modal.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { AUTOBIND_CFG } from '../../../common/constants';
-import DebouncedInput from '../base/debounced-input';
+import { DebouncedInput } from '../base/debounced-input';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';
 import ModalHeader from '../base/modal-header';

--- a/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
@@ -307,7 +307,6 @@ class WorkspaceSettingsModal extends PureComponent<Props, State> {
               <label>
                 Name
                 <DebouncedInput
-                  // @ts-expect-error -- TSCONVERSION props are spread into an input element
                   type="text"
                   delay={500}
                   placeholder="Awesome API"

--- a/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
-import DebouncedInput from '../base/debounced-input';
+import { DebouncedInput } from '../base/debounced-input';
 import FileInputButton from '../base/file-input-button';
 import Modal from '../base/modal';
 import ModalBody from '../base/modal-body';

--- a/packages/insomnia-app/app/ui/components/wrapper-design.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.tsx
@@ -67,7 +67,7 @@ class WrapperDesign extends PureComponent<Props, State> {
     await models.workspaceMeta.updateByParentId(workspaceId, { previewHidden: !previewHidden });
   }
 
-  _handleOnChange(v: string) {
+  _handleOnChange(contents: string) {
     const {
       wrapperProps: { activeApiSpec },
       handleUpdateApiSpec,
@@ -84,7 +84,7 @@ class WrapperDesign extends PureComponent<Props, State> {
     }
 
     this.debounceTimeout = setTimeout(async () => {
-      await handleUpdateApiSpec({ ...activeApiSpec, contents: v });
+      await handleUpdateApiSpec({ ...activeApiSpec, contents });
     }, 500);
   }
 

--- a/packages/insomnia-app/app/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-unit-test.tsx
@@ -168,10 +168,8 @@ class WrapperUnitTest extends PureComponent<Props, State> {
     });
   }
 
-  async _handleUnitTestCodeChange(unitTest: UnitTest, v: string) {
-    await models.unitTest.update(unitTest, {
-      code: v,
-    });
+  async _handleUnitTestCodeChange(unitTest: UnitTest, code: string) {
+    await models.unitTest.update(unitTest, { code });
   }
 
   async _handleRunTests() {


### PR DESCRIPTION
During the review in a prior PR, a bug in DebouncedInput was discovered, namely that if the delay (which is a prop) changes, the component behavior will not change to debounce (or not) since the behavior is set only in the constructor.

Along the way, there were a few other low-hanging fruit to address, so I did those in a limited capacity.