### PR TITLE
Increase smoke test spectron timeouts

### DIFF
--- a/packages/insomnia-smoke-test/modules/application.ts
+++ b/packages/insomnia-smoke-test/modules/application.ts
@@ -65,6 +65,9 @@ const launch = async config => {
     chromeDriverArgs: ['remote-debugging-port=9222'],
 
     env: config.env,
+
+    startTimeout: 10000,
+    waitTimeout: 10000,
   });
 
   await app.start().then(async () => {


### PR DESCRIPTION
Spectron often fails to launch fast enough on Windows and occasionally on other OSs. This is a first pass to explore if there is a more systemic issue or it's just slow to launch (which we should explore to speed up, but for the time being we increase timeouts).

Defaults are 5,000ms, increased to 10,000ms.