### PR TITLE
Fetch and store remote spaces

### DIFF
--- a/packages/insomnia-app/app/common/database.ts
+++ b/packages/insomnia-app/app/common/database.ts
@@ -50,14 +50,16 @@ export const database = {
     const promisesUpserted: Promise<BaseModel>[] = [];
     const promisesDeleted: Promise<void>[] = [];
 
-    // @ts-expect-error -- TSCONVERSION upsert operations are optional
-    for (const doc of operation.upsert) {
-      promisesUpserted.push(database.upsert(doc, true));
+    if (operation.upsert !== undefined) {
+      for (const doc of operation.upsert) {
+        promisesUpserted.push(database.upsert(doc, true));
+      }
     }
 
-    // @ts-expect-error -- TSCONVERSION remove operations are optional
-    for (const doc of operation.remove) {
-      promisesDeleted.push(database.unsafeRemove(doc, true));
+    if (operation.remove !== undefined) {
+      for (const doc of operation.remove) {
+        promisesDeleted.push(database.unsafeRemove(doc, true));
+      }
     }
 
     // Perform from least to most dangerous

--- a/packages/insomnia-app/app/models/space.ts
+++ b/packages/insomnia-app/app/models/space.ts
@@ -22,6 +22,7 @@ export type Space = BaseModel & BaseSpace;
 export function init(): BaseSpace {
   return {
     name: 'My Space',
+    remoteId: undefined, // this is necessary for the model init logic to work properly
   };
 }
 

--- a/packages/insomnia-app/app/models/space.ts
+++ b/packages/insomnia-app/app/models/space.ts
@@ -14,6 +14,7 @@ export const BASE_SPACE_ID = 'base-space';
 
 interface BaseSpace {
   name: string;
+  remoteId?: string;
 }
 
 export type Space = BaseModel & BaseSpace;

--- a/packages/insomnia-app/app/models/space.ts
+++ b/packages/insomnia-app/app/models/space.ts
@@ -14,7 +14,7 @@ export const BASE_SPACE_ID = 'base-space';
 
 interface BaseSpace {
   name: string;
-  remoteId?: string;
+  remoteId: string | null;
 }
 
 export type Space = BaseModel & BaseSpace;
@@ -22,7 +22,7 @@ export type Space = BaseModel & BaseSpace;
 export function init(): BaseSpace {
   return {
     name: 'My Space',
-    remoteId: undefined, // this is necessary for the model init logic to work properly
+    remoteId: null, // `null` is necessary for the model init logic to work properly
   };
 }
 

--- a/packages/insomnia-app/app/sync/store/drivers/base.ts
+++ b/packages/insomnia-app/app/sync/store/drivers/base.ts
@@ -1,5 +1,4 @@
 export interface BaseDriver {
-  new (config: Record<string, any>): void;
   hasItem(key: string): Promise<boolean>;
   setItem(key: string, value: Buffer): Promise<void>;
   getItem(key: string): Promise<Buffer | null>;

--- a/packages/insomnia-app/app/sync/store/drivers/file-system-driver.ts
+++ b/packages/insomnia-app/app/sync/store/drivers/file-system-driver.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import mkdirp from 'mkdirp';
 import type { BaseDriver } from './base';
 
-// @ts-expect-error -- TSCONVERSION
 export default class FileSystemDriver implements BaseDriver {
   _directory: string;
 

--- a/packages/insomnia-app/app/sync/store/drivers/memory-driver.ts
+++ b/packages/insomnia-app/app/sync/store/drivers/memory-driver.ts
@@ -1,6 +1,4 @@
 import type { BaseDriver } from './base';
-
-// @ts-expect-error -- TSCONVERSION
 export default class MemoryDriver implements BaseDriver {
   _db: Record<string, Buffer>;
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -14,7 +14,11 @@ import SpaceSettingsModal from '../modals/space-settings-modal';
 
 type SpaceSubset = Pick<Space, '_id' | 'name' | 'remoteId'>;
 
-const defaultSpace: SpaceSubset = { _id: BASE_SPACE_ID, name: getAppName() };
+const defaultSpace: SpaceSubset = {
+  _id: BASE_SPACE_ID,
+  name: getAppName(),
+  remoteId: null,
+};
 
 const check = <i className="fa fa-check" />;
 const cog = <i className="fa fa-cog" />;
@@ -35,7 +39,7 @@ export const SpaceDropdown: FC<Props> = ({ vcs }) => {
   // figure out which space is selected
   const activeSpace = useSelector(selectActiveSpace);
   const selectedSpace = activeSpace || defaultSpace;
-  const spaceHasSettings = selectedSpace !== defaultSpace && selectedSpace.remoteId === undefined;
+  const spaceHasSettings = selectedSpace !== defaultSpace && selectedSpace.remoteId === null;
 
   // select a new space
   const dispatch = useDispatch();
@@ -60,8 +64,8 @@ export const SpaceDropdown: FC<Props> = ({ vcs }) => {
     <button type="button" className="row" title={selectedSpace.name}>
       {selectedSpace.name}
       <i className="fa fa-caret-down space-left" />
-    </button>),
-  [selectedSpace]);
+    </button>
+  ), [selectedSpace]);
 
   return (
     <Dropdown renderButton={button} onOpen={refresh}>

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -1,37 +1,77 @@
 import { Dropdown, DropdownDivider, DropdownItem } from 'insomnia-components';
-import React, { FC, useCallback, useMemo } from 'react';
+import React, { FC, useCallback, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { isLoggedIn } from '../../../account/session';
 import { getAppName } from '../../../common/constants';
 import { strings } from '../../../common/strings';
 import { BASE_SPACE_ID, Space } from '../../../models/space';
+import VCS from '../../../sync/vcs';
 import { setActiveSpace } from '../../redux/modules/global';
 import { createSpace } from '../../redux/modules/space';
 import { selectActiveSpace, selectSpaces } from '../../redux/selectors';
 import { showModal } from '../modals';
 import SpaceSettingsModal from '../modals/space-settings-modal';
+import * as models from '../../../models';
+import { database } from '../../../common/database';
 
-const mapSpace = ({ _id, name }: Space) => ({ id: _id, name });
-const defaultSpace = { id: BASE_SPACE_ID, name: getAppName() };
+type SpaceSubset = Pick<Space, '_id'> & Pick<Space, 'name'> & Pick<Space, 'remoteId'>;
+
+const defaultSpace: SpaceSubset = { _id: BASE_SPACE_ID, name: getAppName() };
 
 const check = <i className="fa fa-check" />;
 const cog = <i className="fa fa-cog" />;
 const plus = <i className="fa fa-plus" />;
+const spinner = <i className="fa fa-spin fa-refresh" />;
+const home = <i className="fa fa-home" />;
 
-export const SpaceDropdown: FC = () => {
+interface Props {
+  vcs?: VCS;
+}
+
+const useRemoteSpaces = (vcs?: VCS) => {
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (vcs && isLoggedIn()) {
+      setLoading(true);
+      const teams = await vcs.teams();
+      const spaces = await Promise.all(teams.map(team => models.initModel<Space>(models.space.type, { _id: team.id, name: team.name })));
+      await database.batchModifyDocs({ upsert: spaces });
+      setLoading(false);
+    }
+  }, [vcs]);
+
+  return { loading, refresh };
+};
+
+export const SpaceDropdown: FC<Props> = ({ vcs }) => {
+  const { loading, refresh } = useRemoteSpaces(vcs);
+
   // get list of spaces
-  const loadedSpaces = useSelector(selectSpaces);
-  const spaces = [defaultSpace, ...(loadedSpaces.map(mapSpace))];
+  const spaces = useSelector(selectSpaces);
 
   // figure out which space is selected
   const activeSpace = useSelector(selectActiveSpace);
-  const selectedSpace = spaces.find(space => space.id === activeSpace?._id) || defaultSpace;
+  const selectedSpace = activeSpace || defaultSpace;
+  const spaceHasSettings = selectedSpace !== defaultSpace;
 
   // select a new space
   const dispatch = useDispatch();
   const setActive = useCallback((id) => dispatch(setActiveSpace(id)), [dispatch]);
   const createNew = useCallback(() => dispatch(createSpace()), [dispatch]);
   const showSettings = useCallback(() => showModal(SpaceSettingsModal), []);
-  const spaceHasSettings = selectedSpace !== defaultSpace;
+
+  const renderDropdownItem = useCallback(({ _id, name }: SpaceSubset) => (
+    <DropdownItem
+      key={_id}
+      icon={_id === defaultSpace._id && home}
+      right={_id === selectedSpace._id && check}
+      value={_id}
+      onClick={setActive}
+    >
+      {name}
+    </DropdownItem>),
+  [selectedSpace, setActive]);
 
   // dropdown button
   const button = useMemo(() => (
@@ -42,17 +82,10 @@ export const SpaceDropdown: FC = () => {
   [selectedSpace]);
 
   return (
-    <Dropdown renderButton={button}>
-      {spaces.map(({ id, name }) => (
-        <DropdownItem
-          key={id}
-          right={id === selectedSpace.id && check}
-          value={id}
-          onClick={setActive}
-        >
-          {name}
-        </DropdownItem>
-      ))}
+    <Dropdown renderButton={button} onOpen={refresh}>
+      {renderDropdownItem(defaultSpace)}
+      <DropdownDivider>All spaces{' '}{loading && spinner}</DropdownDivider>
+      {spaces.map(renderDropdownItem)}
       {spaceHasSettings && <>
         <DropdownDivider />
         <DropdownItem icon={cog} onClick={showSettings}>

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -12,7 +12,7 @@ import { selectActiveSpace, selectSpaces } from '../../redux/selectors';
 import { showModal } from '../modals';
 import SpaceSettingsModal from '../modals/space-settings-modal';
 
-type SpaceSubset = Pick<Space, '_id'> & Pick<Space, 'name'> & Pick<Space, 'remoteId'>;
+type SpaceSubset = Pick<Space, '_id' | 'name' | 'remoteId'>;
 
 const defaultSpace: SpaceSubset = { _id: BASE_SPACE_ID, name: getAppName() };
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -1,18 +1,16 @@
 import { Dropdown, DropdownDivider, DropdownItem } from 'insomnia-components';
-import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { isLoggedIn } from '../../../account/session';
 import { getAppName } from '../../../common/constants';
 import { strings } from '../../../common/strings';
 import { BASE_SPACE_ID, Space } from '../../../models/space';
 import VCS from '../../../sync/vcs';
+import { useRemoteSpaces } from '../../hooks/space';
 import { setActiveSpace } from '../../redux/modules/global';
 import { createSpace } from '../../redux/modules/space';
 import { selectActiveSpace, selectSpaces } from '../../redux/selectors';
 import { showModal } from '../modals';
 import SpaceSettingsModal from '../modals/space-settings-modal';
-import * as models from '../../../models';
-import { database } from '../../../common/database';
 
 type SpaceSubset = Pick<Space, '_id'> & Pick<Space, 'name'> & Pick<Space, 'remoteId'>;
 
@@ -27,29 +25,6 @@ const home = <i className="fa fa-home" />;
 interface Props {
   vcs?: VCS;
 }
-
-const useRemoteSpaces = (vcs?: VCS) => {
-  const [loading, setLoading] = useState(false);
-
-  const refresh = useCallback(async () => {
-    if (vcs && isLoggedIn()) {
-      setLoading(true);
-      const teams = await vcs.teams();
-      const spaces = await Promise.all(teams.map(team => models.initModel<Space>(models.space.type, { _id: team.id, name: team.name })));
-      await database.batchModifyDocs({ upsert: spaces });
-      setLoading(false);
-    }
-  }, [vcs]);
-
-  useEffect(() => {
-    const fetch = async () => {
-      await refresh();
-    };
-    fetch();
-  }, [refresh]);
-
-  return { loading, refresh };
-};
 
 export const SpaceDropdown: FC<Props> = ({ vcs }) => {
   const { loading, refresh } = useRemoteSpaces(vcs);

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -1,5 +1,5 @@
 import { Dropdown, DropdownDivider, DropdownItem } from 'insomnia-components';
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { isLoggedIn } from '../../../account/session';
 import { getAppName } from '../../../common/constants';
@@ -40,6 +40,13 @@ const useRemoteSpaces = (vcs?: VCS) => {
       setLoading(false);
     }
   }, [vcs]);
+
+  useEffect(() => {
+    const fetch = async () => {
+      await refresh();
+    };
+    fetch();
+  }, [refresh]);
 
   return { loading, refresh };
 };

--- a/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/space-dropdown.tsx
@@ -35,7 +35,7 @@ export const SpaceDropdown: FC<Props> = ({ vcs }) => {
   // figure out which space is selected
   const activeSpace = useSelector(selectActiveSpace);
   const selectedSpace = activeSpace || defaultSpace;
-  const spaceHasSettings = selectedSpace !== defaultSpace;
+  const spaceHasSettings = selectedSpace !== defaultSpace && selectedSpace.remoteId === undefined;
 
   // select a new space
   const dispatch = useDispatch();

--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -358,7 +358,7 @@ class WrapperHome extends PureComponent<Props, State> {
   }
 
   render() {
-    const { workspaces, isLoading } = this.props.wrapperProps;
+    const { workspaces, isLoading, vcs } = this.props.wrapperProps;
     const { filter } = this.state;
     // Render each card, removing all the ones that don't match the filter
     const cards = workspaces
@@ -377,7 +377,7 @@ class WrapperHome extends PureComponent<Props, State> {
             gridLeft={
               <Fragment>
                 <img src={coreLogo} alt="Insomnia" width="24" height="24" />
-                <Breadcrumb crumbs={[{ id: 'space', node: <SpaceDropdown /> }]} />
+                <Breadcrumb crumbs={[{ id: 'space', node: <SpaceDropdown vcs={vcs || undefined} /> }]} />
                 {isLoading ? <i className="fa fa-refresh fa-spin space-left" /> : null}
               </Fragment>
             }

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -1292,7 +1292,6 @@ class App extends PureComponent<Props, State> {
         directory,
       });
 
-      // @ts-expect-error -- TSCONVERSION
       vcs = new VCS(driver, async conflicts => {
         return new Promise(resolve => {
           showModal(SyncMergeModal, {

--- a/packages/insomnia-app/app/ui/hooks/__tests__/space.test.ts
+++ b/packages/insomnia-app/app/ui/hooks/__tests__/space.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { isLoggedIn as _isLoggedIn } from '../../../account/session';
+import MemoryDriver from '../../../sync/store/drivers/memory-driver';
+import VCS from '../../../sync/vcs';
+import { globalBeforeEach } from '../../../__jest__/before-each';
+import { useRemoteSpaces } from '../space';
+import * as models from '../../../models';
+
+jest.mock('../../../account/session', () => ({
+  isLoggedIn: jest.fn(),
+}));
+
+jest.mock('../../../sync/vcs');
+
+const isLoggedIn = _isLoggedIn as jest.MockedFunction<typeof _isLoggedIn>;
+
+describe('useRemoteSpaces', () => {
+  beforeEach(globalBeforeEach);
+
+  it('should not load teams if VCS is not set', () => {
+    const { result } = renderHook(() => useRemoteSpaces());
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('should not load teams if not signed in', async () => {
+    const vcs = new VCS(new MemoryDriver());
+    isLoggedIn.mockReturnValue(false);
+
+    const { result } = renderHook(() => useRemoteSpaces(vcs));
+    result.current.refresh();
+
+    expect(vcs.teams).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    await expect(models.space.all()).resolves.toHaveLength(0);
+  });
+
+  it('should load teams each time VCS changes', async () => {
+    isLoggedIn.mockReturnValue(true);
+
+    const vcs1 = new VCS(new MemoryDriver());
+    const vcs2 = new VCS(new MemoryDriver());
+    (vcs1.teams as jest.MockedFunction<typeof vcs1.teams>).mockResolvedValue([{ id: 'id1', name: 'name' }]);
+    (vcs2.teams as jest.MockedFunction<typeof vcs2.teams>).mockResolvedValue([{ id: 'id2', name: 'name' }]);
+
+    const { result, rerender, waitFor } = renderHook(prop => useRemoteSpaces(prop), { initialProps: vcs1 });
+
+    // Wait for effect
+    await waitFor(() => result.current.loading === true);
+    await waitFor(() => result.current.loading === false);
+
+    expect(vcs1.teams).toHaveBeenCalledTimes(1);
+
+    act(() => rerender(vcs2));
+
+    // Wait for effect
+    await waitFor(() => result.current.loading === true);
+    await waitFor(() => result.current.loading === false);
+
+    expect(vcs2.teams).toHaveBeenCalledTimes(1);
+
+    await expect(models.space.all()).resolves.toHaveLength(2);
+  });
+
+  it('should load teams on refresh', async () => {
+    isLoggedIn.mockReturnValue(true);
+
+    const vcs = new VCS(new MemoryDriver());
+    (vcs.teams as jest.MockedFunction<typeof vcs.teams>).mockResolvedValue([]);
+
+    const { result, waitFor } = renderHook(() => useRemoteSpaces(vcs));
+
+    // Wait for effect
+    await waitFor(() => result.current.loading === true);
+    await waitFor(() => result.current.loading === false);
+
+    expect(vcs.teams).toHaveBeenCalledTimes(1);
+    await expect(models.space.all()).resolves.toHaveLength(0);
+
+    (vcs.teams as jest.MockedFunction<typeof vcs.teams>).mockResolvedValue([{ id: 'id1', name: 'name' }, { id: 'id2', name: 'name' }]);
+
+    await act(() => result.current.refresh());
+
+    expect(vcs.teams).toHaveBeenCalledTimes(2);
+    await expect(models.space.all()).resolves.toHaveLength(2);
+  });
+});

--- a/packages/insomnia-app/app/ui/hooks/space.ts
+++ b/packages/insomnia-app/app/ui/hooks/space.ts
@@ -12,18 +12,17 @@ export const useRemoteSpaces = (vcs?: VCS) => {
   const refresh = useCallback(async () => {
     if (vcs && isLoggedIn()) {
       setLoading(true);
+
       const teams = await vcs.teams();
       const spaces = await Promise.all(teams.map(team => models.initModel<Space>(models.space.type, { _id: team.id, name: team.name })));
       await database.batchModifyDocs({ upsert: spaces });
+
       setLoading(false);
     }
   }, [vcs]);
 
   useEffect(() => {
-    const fetch = async () => {
-      await refresh();
-    };
-    fetch();
+    (async () => { await refresh(); })();
   }, [refresh]);
 
   return { loading, refresh };

--- a/packages/insomnia-app/app/ui/hooks/space.ts
+++ b/packages/insomnia-app/app/ui/hooks/space.ts
@@ -14,7 +14,10 @@ export const useRemoteSpaces = (vcs?: VCS) => {
       setLoading(true);
 
       const teams = await vcs.teams();
-      const spaces = await Promise.all(teams.map(team => models.initModel<Space>(models.space.type, { remoteId: team.id, name: team.name })));
+      const spaces = await Promise.all(teams.map(team => models.initModel<Space>(
+        models.space.type,
+        { _id: `${models.space.prefix}_${team.id}`, remoteId: team.id, name: team.name },
+      )));
       await database.batchModifyDocs({ upsert: spaces });
 
       setLoading(false);

--- a/packages/insomnia-app/app/ui/hooks/space.ts
+++ b/packages/insomnia-app/app/ui/hooks/space.ts
@@ -16,7 +16,11 @@ export const useRemoteSpaces = (vcs?: VCS) => {
       const teams = await vcs.teams();
       const spaces = await Promise.all(teams.map(team => models.initModel<Space>(
         models.space.type,
-        { _id: `${models.space.prefix}_${team.id}`, remoteId: team.id, name: team.name },
+        {
+          _id: `${models.space.prefix}_${team.id}`,
+          remoteId: team.id,
+          name: team.name,
+        },
       )));
       await database.batchModifyDocs({ upsert: spaces });
 

--- a/packages/insomnia-app/app/ui/hooks/space.ts
+++ b/packages/insomnia-app/app/ui/hooks/space.ts
@@ -14,7 +14,7 @@ export const useRemoteSpaces = (vcs?: VCS) => {
       setLoading(true);
 
       const teams = await vcs.teams();
-      const spaces = await Promise.all(teams.map(team => models.initModel<Space>(models.space.type, { _id: team.id, name: team.name })));
+      const spaces = await Promise.all(teams.map(team => models.initModel<Space>(models.space.type, { remoteId: team.id, name: team.name })));
       await database.batchModifyDocs({ upsert: spaces });
 
       setLoading(false);

--- a/packages/insomnia-app/app/ui/hooks/space.tsx
+++ b/packages/insomnia-app/app/ui/hooks/space.tsx
@@ -1,0 +1,30 @@
+
+import * as models from '../../models';
+import { database } from '../../common/database';
+import VCS from '../../sync/vcs';
+import { useCallback, useEffect, useState } from 'react';
+import { isLoggedIn } from '../../account/session';
+import { Space } from '../../models/space';
+
+export const useRemoteSpaces = (vcs?: VCS) => {
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (vcs && isLoggedIn()) {
+      setLoading(true);
+      const teams = await vcs.teams();
+      const spaces = await Promise.all(teams.map(team => models.initModel<Space>(models.space.type, { _id: team.id, name: team.name })));
+      await database.batchModifyDocs({ upsert: spaces });
+      setLoading(false);
+    }
+  }, [vcs]);
+
+  useEffect(() => {
+    const fetch = async () => {
+      await refresh();
+    };
+    fetch();
+  }, [refresh]);
+
+  return { loading, refresh };
+};

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -19,7 +19,7 @@
     "clean": "tsc --build tsconfig.webpack.json --clean && tsc --build tsconfig.build.json --clean",
     "postclean": "rimraf build app/main.min.js",
     "test": "jest",
-    "test-appveyor": "npm run test -- --maxWorkers 1",
+    "test:watch": "jest --watch",
     "start:electron": "cross-env TS_NODE_PROJECT=\"tsconfig.webpack.json\" cross-env NODE_ENV=development webpack --config webpack/webpack.config.electron.ts && electron .",
     "start:dev-server": "cross-env TS_NODE_PROJECT=\"tsconfig.webpack.json\" webpack-dev-server --config webpack/webpack.config.development.ts",
     "start": "concurrently -n dev,app --kill-others \"npm run start:dev-server\" \"npm run start:electron\"",


### PR DESCRIPTION
This follows the same process as the "Pull" drop-down - it will load remote spaces each time it is opened or the VCS object is updated.

Remote spaces and local spaces currently show together, but settings are not available for remote spaces.

![2021-06-03 15 12 12](https://user-images.githubusercontent.com/4312346/120581052-4b1c4780-c47e-11eb-8946-49b8974cbaea.gif)

