### PR TITLE
updates node-libcurl to 2.3.3

### DIFF
--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -14088,9 +14088,9 @@
 			"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
 		},
 		"ignore-walk": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-			"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
+			"integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
 			"requires": {
 				"minimatch": "^3.0.4"
 			}
@@ -18551,9 +18551,9 @@
 			"dev": true
 		},
 		"node-libcurl": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/node-libcurl/-/node-libcurl-2.3.2.tgz",
-			"integrity": "sha512-RlKwqxqBwvDOtDxPXRXVkVCVhIVfO8icBj51KiLaChQGuecGGdpzTWa1Byu/C2PhLJntq+lCBA++QO673Uxxmw==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/node-libcurl/-/node-libcurl-2.3.3.tgz",
+			"integrity": "sha512-F97m95qppV/Kb/h5EtzpGLj1uZIAG9e/4XZPXkZ5nsYF3vK5IQ5V/c5HD1L/4sBV+vV0qGAXi5ygUAEHI7E2wA==",
 			"requires": {
 				"env-paths": "2.2.0",
 				"nan": "2.14.1",
@@ -18854,9 +18854,9 @@
 			}
 		},
 		"npm-bundled": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-			"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
+			"integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
 			"requires": {
 				"npm-normalize-package-bin": "^1.0.1"
 			}

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -133,7 +133,7 @@
     "multiparty": "^4.2.1",
     "nedb": "^1.8.0",
     "node-forge": "^0.10.0",
-    "node-libcurl": "2.3.2",
+    "node-libcurl": "2.3.3",
     "nunjucks": "^3.2.0",
     "oauth-1.0a": "^2.2.2",
     "objectpath": "^2.0.0",

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -1643,9 +1643,9 @@
 			"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
 		},
 		"ignore-walk": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-			"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
+			"integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
 			"requires": {
 				"minimatch": "^3.0.4"
 			}
@@ -2292,9 +2292,9 @@
 			}
 		},
 		"node-libcurl": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/node-libcurl/-/node-libcurl-2.3.2.tgz",
-			"integrity": "sha512-RlKwqxqBwvDOtDxPXRXVkVCVhIVfO8icBj51KiLaChQGuecGGdpzTWa1Byu/C2PhLJntq+lCBA++QO673Uxxmw==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/node-libcurl/-/node-libcurl-2.3.3.tgz",
+			"integrity": "sha512-F97m95qppV/Kb/h5EtzpGLj1uZIAG9e/4XZPXkZ5nsYF3vK5IQ5V/c5HD1L/4sBV+vV0qGAXi5ygUAEHI7E2wA==",
 			"requires": {
 				"env-paths": "2.2.0",
 				"nan": "2.14.1",
@@ -2443,9 +2443,9 @@
 			"optional": true
 		},
 		"npm-bundled": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-			"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
+			"integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
 			"requires": {
 				"npm-normalize-package-bin": "^1.0.1"
 			}

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -31,7 +31,7 @@
     "multiparty": "^4.2.1",
     "nedb": "^1.8.0",
     "node-forge": "^0.10.0",
-    "node-libcurl": "2.3.2",
+    "node-libcurl": "2.3.3",
     "nunjucks": "^3.2.1",
     "oauth-1.0a": "^2.2.6",
     "openapi-2-kong": "2.3.0-beta.2",


### PR DESCRIPTION
recently we got the feedback:

> I am trying to install inso cli by npm install -g insomnia-inso  but it is failing. I have node v16.3.0 and npm 7.16.0
> I suspect the problem is:
>  ```
>  npm ERR! node-pre-gyp info check checked for "/usr/local/lib/node_modules/insomnia-inso/node_modules/node- 
>  libcurl/lib/binding/node_libcurl.node" (not found)
>  npm ERR! node-pre-gyp http GET https://github.com/JCMais/node-libcurl/releases/download/v2.3.2/node_libcurl-v2.3.2-node-v93-darwin-x64-unknown.tar.gz
>  npm ERR! node-pre-gyp http 404 https://github.com/JCMais/node-libcurl/releases/download/v2.3.2/node_libcurl-v2.3.2-node-v93-darwin-x64-unknown.tar.gz
> ```
> it seems node-libcurl v2.3.2 has been removed, but v2.3.3 is available
> Is this a problem on our side? Is there a workaround to install it locally? I tried installing v2.3.3 but the error is the same.
> Thanks!!

the only thing mentioned in the nodelibcurl 2.3.3 release notes:
> Fix support for Node.js v16
https://github.com/JCMais/node-libcurl/releases

we're on 2.3.2.  this PR updates to 2.3.3