### PR TITLE
fix CodeMirror crash

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -430,11 +430,10 @@ class CodeEditor extends Component<Props, State> {
   _restoreState() {
     const { uniquenessKey } = this.props;
 
-    // @ts-expect-error -- TSCONVERSION only try access if uniquenessKey is defined
-    if (!editorStates.hasOwnProperty(uniquenessKey)) {
+    if (uniquenessKey === undefined) {
       return;
     }
-    if (uniquenessKey === undefined) {
+    if (!editorStates.hasOwnProperty(uniquenessKey)) {
       return;
     }
     if (!this.codeMirror) {

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -442,7 +442,7 @@ class CodeEditor extends Component<Props, State> {
     this.codeMirror?.setHistory(history);
     // NOTE: These won't be visible unless the editor is focused
     this.codeMirror?.setCursor(cursor.line, cursor.ch, { scroll: false });
-    this.codeMirror?.setSelection(selections, undefined, { scroll: false });
+    this.codeMirror?.setSelections(selections, undefined, { scroll: false });
 
     // Restore marks one-by-one
     for (const { from, to } of marks || []) {

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -437,17 +437,20 @@ class CodeEditor extends Component<Props, State> {
     if (uniquenessKey === undefined) {
       return;
     }
+    if (!this.codeMirror) {
+      return;
+    }
 
     const { scroll, selections, cursor, history, marks } = editorStates[uniquenessKey];
-    this.codeMirror?.scrollTo(scroll.left, scroll.top);
-    this.codeMirror?.setHistory(history);
+    this.codeMirror.scrollTo(scroll.left, scroll.top);
+    this.codeMirror.setHistory(history);
     // NOTE: These won't be visible unless the editor is focused
-    this.codeMirror?.setCursor(cursor.line, cursor.ch, { scroll: false });
-    this.codeMirror?.setSelections(selections, undefined, { scroll: false });
+    this.codeMirror.setCursor(cursor.line, cursor.ch, { scroll: false });
+    this.codeMirror.setSelections(selections, undefined, { scroll: false });
 
     // Restore marks one-by-one
     for (const { from, to } of marks || []) {
-      this.codeMirror?.foldCode(from, to);
+      this.codeMirror.foldCode(from, to);
     }
   }
 

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -291,7 +291,10 @@ class CodeEditor extends Component<Props, State> {
   }
 
   getSelectionStart() {
-    // @ts-expect-error -- TSCONVERSION
+    if (!this.codeMirror) {
+      return;
+    }
+
     const selections = this.codeMirror.listSelections();
 
     if (selections.length) {
@@ -302,7 +305,10 @@ class CodeEditor extends Component<Props, State> {
   }
 
   getSelectionEnd() {
-    // @ts-expect-error -- TSCONVERSION
+    if (!this.codeMirror) {
+      return;
+    }
+
     const selections = this.codeMirror.listSelections();
 
     if (selections.length) {
@@ -313,14 +319,16 @@ class CodeEditor extends Component<Props, State> {
   }
 
   focusEnd() {
-    if (this.codeMirror) {
-      if (!this.hasFocus()) {
-        this.focus();
-      }
-
-      const doc = this.codeMirror.getDoc();
-      doc.setCursor(doc.lineCount(), 0);
+    if (!this.codeMirror) {
+      return;
     }
+
+    if (!this.hasFocus()) {
+      this.focus();
+    }
+
+    const doc = this.codeMirror.getDoc();
+    doc.setCursor(doc.lineCount(), 0);
   }
 
   hasFocus() {
@@ -331,42 +339,55 @@ class CodeEditor extends Component<Props, State> {
     }
   }
 
-  setAttribute(name, value) {
-    // @ts-expect-error -- TSCONVERSION
-    this.codeMirror.getTextArea().parentNode.setAttribute(name, value);
+  setAttribute(name: string, value: string) {
+    if (!this.codeMirror) {
+      return;
+    }
+
+    // @ts-expect-error this is a (Node & ParentNode) in the types, but I think it's actually supposed to be Element
+    this.codeMirror.getTextArea().parentNode?.setAttribute(name, value);
   }
 
   removeAttribute(name) {
-    // @ts-expect-error -- TSCONVERSION
-    this.codeMirror.getTextArea().parentNode.removeAttribute(name);
+    if (!this.codeMirror) {
+      return;
+    }
+
+    // @ts-expect-error this is a (Node & ParentNode) in the types, but I think it's actually supposed to be Element
+    this.codeMirror.getTextArea().parentNode?.removeAttribute(name);
   }
 
   getAttribute(name) {
-    // @ts-expect-error -- TSCONVERSION
-    this.codeMirror.getTextArea().parentNode.getAttribute(name);
+    if (!this.codeMirror) {
+      return;
+    }
+
+    // @ts-expect-error this is a (Node & ParentNode) in the types, but I think it's actually supposed to be Element
+    this.codeMirror.getTextArea().parentNode?.getAttribute(name);
   }
 
   clearSelection() {
-    // Never do this if dropdown is open
+    if (!this.codeMirror) {
+      return;
+    }
+
     if (this.codeMirror?.isHintDropdownActive()) {
       return;
     }
 
-    if (this.codeMirror) {
-      this.codeMirror.setSelection(
-        {
-          line: -1,
-          ch: -1,
-        },
-        {
-          line: -1,
-          ch: -1,
-        },
-        {
-          scroll: false,
-        },
-      );
-    }
+    this.codeMirror.setSelection(
+      {
+        line: -1,
+        ch: -1,
+      },
+      {
+        line: -1,
+        ch: -1,
+      },
+      {
+        scroll: false,
+      },
+    );
   }
 
   getValue() {
@@ -412,27 +433,20 @@ class CodeEditor extends Component<Props, State> {
     if (!editorStates.hasOwnProperty(uniquenessKey)) {
       return;
     }
+    if (uniquenessKey === undefined) {
+      return;
+    }
 
-    // @ts-expect-error -- TSCONVERSION only try access if uniquenessKey is defined
     const { scroll, selections, cursor, history, marks } = editorStates[uniquenessKey];
-    // @ts-expect-error -- TSCONVERSION
-    this.codeMirror.scrollTo(scroll.left, scroll.top);
-    // @ts-expect-error -- TSCONVERSION
-    this.codeMirror.setHistory(history);
+    this.codeMirror?.scrollTo(scroll.left, scroll.top);
+    this.codeMirror?.setHistory(history);
     // NOTE: These won't be visible unless the editor is focused
-    // @ts-expect-error -- TSCONVERSION
-    this.codeMirror.setCursor(cursor.line, cursor.ch, {
-      scroll: false,
-    });
-    // @ts-expect-error -- TSCONVERSION
-    this.codeMirror.setSelection(selections, null, {
-      scroll: false,
-    });
+    this.codeMirror?.setCursor(cursor.line, cursor.ch, { scroll: false });
+    this.codeMirror?.setSelection(selections, undefined, { scroll: false });
 
     // Restore marks one-by-one
     for (const { from, to } of marks || []) {
-      // @ts-expect-error -- TSCONVERSION
-      this.codeMirror.foldCode(from, to);
+      this.codeMirror?.foldCode(from, to);
     }
   }
 
@@ -459,8 +473,7 @@ class CodeEditor extends Component<Props, State> {
         let endToken = '}';
         // Prevent retrieving an invalid content if undefined
         if (!from?.line || !to?.line) return '\u2194';
-        // @ts-expect-error -- TSCONVERSION
-        const prevLine = this.codeMirror.getLine(from.line);
+        const prevLine = this.codeMirror?.getLine(from.line);
         if (!prevLine) return '\u2194';
 
         if (prevLine.lastIndexOf('[') > prevLine.lastIndexOf('{')) {
@@ -469,8 +482,7 @@ class CodeEditor extends Component<Props, State> {
         }
 
         // Get json content
-        // @ts-expect-error -- TSCONVERSION
-        const internal = this.codeMirror.getRange(from, to);
+        const internal = this.codeMirror?.getRange(from, to);
         const toParse = startToken + internal + endToken;
 
         // Get key count
@@ -607,16 +619,13 @@ class CodeEditor extends Component<Props, State> {
   }
 
   _indentChars() {
-    // @ts-expect-error -- TSCONVERSION
-    return this.codeMirror.getOption('indentWithTabs')
+    return this.codeMirror?.getOption('indentWithTabs')
       ? '\t'
-      // @ts-expect-error -- TSCONVERSION
-      : new Array(this.codeMirror.getOption('indentUnit') + 1).join(' ');
+      : new Array((this.codeMirror?.getOption?.('indentUnit') || 0) + 1).join(' ');
   }
 
   _handleBeautify() {
-    // @ts-expect-error -- TSCONVERSION
-    this._prettify(this.codeMirror.getValue());
+    this._prettify(this.codeMirror?.getValue());
   }
 
   _prettify(code) {
@@ -969,8 +978,7 @@ class CodeEditor extends Component<Props, State> {
   }
 
   _codemirrorValueBeforeChange(doc, change) {
-    // @ts-expect-error -- TSCONVERSION
-    const value = this.codeMirror.getDoc().getValue();
+    const value = this.codeMirror?.getDoc().getValue();
 
     // If we're in single-line mode, merge all changed lines into one
     if (this.props.singleLine && change.text && change.text.length > 1) {
@@ -982,7 +990,7 @@ class CodeEditor extends Component<Props, State> {
     }
 
     // Suppress lint on empty doc or single space exists (default value)
-    if (value.trim() === '') {
+    if (value?.trim() === '') {
       this._codemirrorSmartSetOption('lint', false);
     } else {
       this._codemirrorSmartSetOption('lint', this.props.lintOptions || true);
@@ -1018,13 +1026,12 @@ class CodeEditor extends Component<Props, State> {
       return;
     }
 
-    // @ts-expect-error -- TSCONVERSION
-    const value = this.codeMirror.getDoc().getValue();
+    const value = this.codeMirror?.getDoc().getValue() || '';
     // Disable linting if the document reaches a maximum size or is empty
-    const shouldLint =
-      value.length > MAX_SIZE_FOR_LINTING || value.length === 0 ? false : !this.props.noLint;
-    // @ts-expect-error -- TSCONVERSION
-    const existingLint = this.codeMirror.options.lint || false;
+    const isOverMaxSize = value.length > MAX_SIZE_FOR_LINTING;
+    const shouldLint = isOverMaxSize || value.length === 0 ? false : !this.props.noLint;
+    // @ts-expect-error TSCONVERSION
+    const existingLint = this.codeMirror?.options.lint || false;
 
     if (shouldLint !== existingLint) {
       const { lintOptions } = this.props;
@@ -1066,8 +1073,7 @@ class CodeEditor extends Component<Props, State> {
       }
     }
 
-    // @ts-expect-error -- TSCONVERSION
-    this.codeMirror.setValue(code || '');
+    this.codeMirror?.setValue(code || '');
   }
 
   _handleFilterHistorySelect(filter) {
@@ -1223,8 +1229,8 @@ class CodeEditor extends Component<Props, State> {
               display: 'none',
             }}
             readOnly={readOnly}
-            autoComplete="off" // NOTE: When setting this to empty string, it breaks the _ignoreNextChange
-            //   logic on initial component mount
+            autoComplete="off"
+            // NOTE: When setting this to empty string, it breaks the _ignoreNextChange logic on initial component mount
             defaultValue=" "
           />
         </div>

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -371,6 +371,7 @@ class CodeEditor extends Component<Props, State> {
       return;
     }
 
+    // Never do this if dropdown is open
     if (this.codeMirror?.isHintDropdownActive()) {
       return;
     }


### PR DESCRIPTION
I noticed the following crash of CodeMirror occurring when you switch between different states of the response viewer:
![Screenshot_20210604_152527](https://user-images.githubusercontent.com/15232461/120858444-c9e1b500-c550-11eb-8622-4807de0def11.png)

This leaves the app in a pretty nasty state that you have to restart to get out of:
![Screenshot_20210604_152557](https://user-images.githubusercontent.com/15232461/120858539-ebdb3780-c550-11eb-8fcc-98064c062a3d.png)

I bisected and confirmed that this started when we updated CodeMirror in https://github.com/Kong/insomnia/pull/3405

I searched the CodeMirror repo and found https://github.com/codemirror/CodeMirror/issues/4135 which suggested what I had already suspected, that we are calling something wrong.  That means the first course of action is to remove some of the places we ignored TypeScript errors and see if I uncover something.

and sure enough...

Thankfully, TypeScript alerted me to the fact that we were calling this wrong in the first place:
![Screenshot_20210604_161744](https://user-images.githubusercontent.com/15232461/120858172-6788b480-c550-11eb-87cb-6caa9d68f4dc.png)

I looked at the TypeScript types, and the problem became clear.

`setSelection`, which is what we were calling, has an API like this:
```ts
{
  /** Set a single selection range. anchor and head should be {line, ch} objects. head defaults to anchor when not given. */
  setSelection(
      anchor: Position,
      head?: Position,
      options?: { bias?: number; origin?: string; scroll?: boolean },
  ): void;
}
```

but `setSelections`, which is what we wanted to call, has an API like this:
```ts
{
  /**
   * Sets a new set of selections. There must be at least one selection in the given array. When primary is a
   * number, it determines which selection is the primary one. When it is not given, the primary index is taken from
   * the previous selection, or set to the last range if the previous selection had less ranges than the new one.
   * Supports the same options as setSelection.
   */
  setSelections(
      ranges: Array<{ anchor: Position; head: Position }>,
      primary?: number,
      options?: { bias?: number; origin?: string; scroll?: boolean },
  ): void;
}
```

and the fix:
![Screenshot_20210604_162317](https://user-images.githubusercontent.com/15232461/120858731-352b8700-c551-11eb-879c-5d6378b5d4f3.png)


I feel that I definitely would have missed this subtle but critical distinction without TypeScript.