### PR TITLE
fix pluralization of Document in bottom bar

### DIFF
--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -367,7 +367,7 @@ class WrapperHome extends PureComponent<Props, State> {
       // @ts-expect-error -- TSCONVERSION appears to be a genuine error
       .sort((a: RenderedCard, b: RenderedCard) => descendingNumberSort(a.lastModifiedTimestamp, b.lastModifiedTimestamp))
       .map(c => c?.card);
-    const countLabel = cards.length > 1 ? strings.document.plural : strings.document.singular;
+    const countLabel = cards.length === 1 ? strings.document.singular : strings.document.plural;
     return (
       <PageLayout
         wrapperProps={this.props.wrapperProps}


### PR DESCRIPTION
I noticed this in the footer when testing another PR

0 => plural
1 => singular
1+ => plural

THANKS ENGLISH.