### PR TITLE
adds redux-devtools back

### DIFF
--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -38,13 +38,12 @@ if (!isDevelopment()) {
 global.window = global.window || undefined;
 // When the app is first launched
 app.on('ready', async () => {
-  // Enable react dev tools if development
   if (isDevelopment()) {
     try {
       const extensions = [REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS];
-      const names = await Promise.all(extensions.map(extension => installExtension(extension)));
       const extensionsPlural = extensions.length > 0 ? 's' : '';
-      console.log(`[electron-extensions] Added Extension${extensionsPlural}: ${names.join(', ')}`);
+      const names = await Promise.all(extensions.map(extension => installExtension(extension)));
+      console.log(`[electron-extensions] Added DevTools Extension${extensionsPlural}: ${names.join(', ')}`);
     } catch (err) {
       console.log('[electron-extensions] An error occurred: ', err);
     }

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -41,8 +41,10 @@ app.on('ready', async () => {
   // Enable react dev tools if development
   if (isDevelopment()) {
     try {
-      const names = await installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS]);
-      console.log(`[electron-extensions] Added Extension:  ${names}`);
+      const extensions = [REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS];
+      const names = await Promise.all(extensions.map(extension => installExtension(extension)));
+      const extensionsPlural = extensions.length > 0 ? 's' : '';
+      console.log(`[electron-extensions] Added Extension${extensionsPlural}: ${names.join(', ')}`);
     } catch (err) {
       console.log('[electron-extensions] An error occurred: ', err);
     }

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -13,7 +13,7 @@ import type { ToastNotification } from './ui/components/toast';
 import type { Stats } from './models/stats';
 import { trackNonInteractiveEventQueueable } from './common/analytics';
 import log, { initializeLogging } from './common/log';
-import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
+import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer';
 
 // Handle potential auto-update
 if (checkIfRestartNeeded()) {
@@ -41,7 +41,7 @@ app.on('ready', async () => {
   // Enable react dev tools if development
   if (isDevelopment()) {
     try {
-      const names = await installExtension([REACT_DEVELOPER_TOOLS]);
+      const names = await installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS]);
       console.log(`[electron-extensions] Added Extension:  ${names}`);
     } catch (err) {
       console.log('[electron-extensions] An error occurred: ', err);


### PR DESCRIPTION
I had to delete anything under `~/.config/insomnia-app/extensions/lmhkpmbekcpmknklioeibfkpmmfibljd*` to get this to work.  Apparently there's some old state left around from the prior version or something when it was broken that prevents a migration?