### PR TITLE
Make _getOrCreateRemoteProject able to specify what team the project should belong to

### DIFF
--- a/packages/insomnia-app/app/sync/vcs/index.ts
+++ b/packages/insomnia-app/app/sync/vcs/index.ts
@@ -1212,7 +1212,7 @@ export default class VCS {
     const symmetricKey = await crypt.generateAES256Key();
     const symmetricKeyStr = JSON.stringify(symmetricKey);
 
-    const teamKeys: any[] = [];
+    const teamKeys: {accountId: string, encSymmetricKey: string}[] = [];
     let encSymmetricKey: string | undefined;
 
     if (teamId && teamPublicKeys) {

--- a/packages/insomnia-app/app/sync/vcs/index.ts
+++ b/packages/insomnia-app/app/sync/vcs/index.ts
@@ -1215,7 +1215,11 @@ export default class VCS {
     const teamKeys: {accountId: string, encSymmetricKey: string}[] = [];
     let encSymmetricKey: string | undefined;
 
-    if (teamId && teamPublicKeys) {
+    if (teamId) {
+      if (!teamPublicKeys?.length) {
+        throw new Error('teamPublicKeys must not be null or empty!');
+      }
+
       // Encrypt the symmetric key with the public keys of all the team members, ourselves included
       for (const { accountId, publicKey } of teamPublicKeys) {
         teamKeys.push({

--- a/packages/insomnia-app/app/sync/vcs/index.ts
+++ b/packages/insomnia-app/app/sync/vcs/index.ts
@@ -514,11 +514,11 @@ export default class VCS {
 
   async _createRemoteProject(workspaceId: string, workspaceName: string, teamId?: string) {
     if (teamId) {
-      var teamKeys = await this._queryTeamMemberKeys(teamId)
-      return this._queryCreateProject(workspaceId, workspaceName, teamId, teamKeys.memberKeys)
+      const teamKeys = await this._queryTeamMemberKeys(teamId);
+      return this._queryCreateProject(workspaceId, workspaceName, teamId, teamKeys.memberKeys);
     }
 
-    return this._queryCreateProject(workspaceId, workspaceName)
+    return this._queryCreateProject(workspaceId, workspaceName);
   }
 
   async push() {

--- a/packages/insomnia-app/app/sync/vcs/index.ts
+++ b/packages/insomnia-app/app/sync/vcs/index.ts
@@ -505,11 +505,20 @@ export default class VCS {
     let project = await this._queryProject();
 
     if (!project) {
-      project = await this._queryCreateProject(localProject.rootDocumentId, localProject.name);
+      project = await this._createRemoteProject(localProject.rootDocumentId, localProject.name);
     }
 
     await this._storeProject(project);
     return project;
+  }
+
+  async _createRemoteProject(workspaceId: string, workspaceName: string, teamId?: string) {
+    if (teamId) {
+      var teamKeys = await this._queryTeamMemberKeys(teamId)
+      return this._queryCreateProject(workspaceId, workspaceName, teamId, teamKeys.memberKeys)
+    }
+
+    return this._queryCreateProject(workspaceId, workspaceName)
   }
 
   async push() {
@@ -1163,18 +1172,81 @@ export default class VCS {
     return project.teams;
   }
 
-  async _queryCreateProject(workspaceId: string, workspaceName: string) {
-    const { publicKey } = this._assertSession();
+  async _queryTeamMemberKeys(
+    teamId: string,
+  ): Promise<{
+    memberKeys: {
+      accountId: string;
+      publicKey: string;
+    }[];
+  }> {
+    const { teamMemberKeys } = await this._runGraphQL(
+      `
+        query ($teamId: ID!) {
+          teamMemberKeys(teamId: $teamId) {
+            memberKeys {
+              accountId
+              publicKey
+            }
+          }
+        }
+      `,
+      {
+        teamId: teamId,
+      },
+      'teamMemberKeys',
+    );
+    return teamMemberKeys;
+  }
 
+  async _queryCreateProject(
+    workspaceId: string,
+    workspaceName: string,
+    teamId?: string,
+    teamPublicKeys?: {
+      accountId: string;
+      publicKey: string;
+    }[],
+  ) {
     // Generate symmetric key for ResourceGroup
     const symmetricKey = await crypt.generateAES256Key();
     const symmetricKeyStr = JSON.stringify(symmetricKey);
-    // Encrypt the symmetric key with Account public key
-    const encSymmetricKey = crypt.encryptRSAWithJWK(publicKey, symmetricKeyStr);
+
+    const teamKeys: any[] = [];
+    let encSymmetricKey: string | undefined;
+
+    if (teamId && teamPublicKeys) {
+      // Encrypt the symmetric key with the public keys of all the team members, ourselves included
+      for (const { accountId, publicKey } of teamPublicKeys) {
+        teamKeys.push({
+          accountId,
+          encSymmetricKey: crypt.encryptRSAWithJWK(JSON.parse(publicKey), symmetricKeyStr),
+        });
+      }
+    } else {
+      const { publicKey } = this._assertSession();
+      // Encrypt the symmetric key with the account public key
+      encSymmetricKey = crypt.encryptRSAWithJWK(publicKey, symmetricKeyStr);
+    }
+
     const { projectCreate } = await this._runGraphQL(
       `
-        mutation ($rootDocumentId: ID!, $name: String!, $id: ID!, $key: String!) {
-          projectCreate(name: $name, id: $id, rootDocumentId: $rootDocumentId, encSymmetricKey: $key) {
+        mutation (
+          $name: String!,
+          $id: ID!,
+          $rootDocumentId: ID!,
+          $encSymmetricKey: String,
+          $teamId: ID,
+          $teamKeys: [ProjectCreateKeyInput!],
+        ) {
+          projectCreate(
+            name: $name,
+            id: $id,
+            rootDocumentId: $rootDocumentId,
+            encSymmetricKey: $encSymmetricKey,
+            teamId: $teamId,
+            teamKeys: $teamKeys,
+          ) {
             id
             name
             rootDocumentId
@@ -1182,13 +1254,16 @@ export default class VCS {
         }
       `,
       {
+        name: workspaceName,
         id: this._projectId(),
         rootDocumentId: workspaceId,
-        name: workspaceName,
-        key: encSymmetricKey,
+        encSymmetricKey: encSymmetricKey,
+        teamId: teamId,
+        teamKeys: teamKeys,
       },
-      'switchAndCreateProjectIfNotExist',
+      'createProject',
     );
+
     console.log(`[sync] Created remote project ${projectCreate.id} (${projectCreate.name})`);
     return projectCreate as Project;
   }


### PR DESCRIPTION
Implements the new functionality from https://github.com/Kong/insomnia-api/pull/151, while leaving current behaviour untouched.

The `teamId` (current active space `remoteId`) needs to be passed to `_createRemoteProject` somehow, the easiest way would probably be to just pass it through the push/pull callsites, but I'll leave that up to what you think is best when implementing the functionality that uses this @develohpanda 

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
