### PR TITLE
use isWorkspace guards

### DIFF
--- a/packages/insomnia-app/app/common/render.ts
+++ b/packages/insomnia-app/app/common/render.ts
@@ -12,6 +12,7 @@ import orderedJSON from 'json-order';
 import * as templatingUtils from '../templating/utils';
 import type { GrpcRequest, GrpcRequestBody } from '../models/grpc-request';
 import { isRequestGroup } from '../models/request-group';
+import { isWorkspace } from '../models/workspace';
 
 export const KEEP_ON_ERROR = 'keep';
 export const THROW_ON_ERROR = 'throw';
@@ -289,7 +290,7 @@ export async function getRenderContext(
     ancestors = await _getRequestAncestors(request);
   }
 
-  const workspace = ancestors.find(doc => doc.type === models.workspace.type);
+  const workspace = ancestors.find(isWorkspace);
 
   if (!workspace) {
     throw new Error('Failed to render. Could not find workspace');
@@ -429,7 +430,7 @@ export async function getRenderedRequestAndContext(
   extraInfo?: ExtraRenderInfo,
 ) {
   const ancestors = await _getRequestAncestors(request);
-  const workspace = ancestors.find(doc => doc.type === models.workspace.type);
+  const workspace = ancestors.find(isWorkspace);
   const parentId = workspace ? workspace._id : 'n/a';
   const cookieJar = await models.cookieJar.getOrCreateForParentId(parentId);
   const renderContext = await getRenderContext(

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -1,6 +1,6 @@
 import type { ResponseHeader, ResponseTimelineEntry } from '../models/response';
 import type { Request, RequestHeader } from '../models/request';
-import type { Workspace } from '../models/workspace';
+import { isWorkspace, Workspace } from '../models/workspace';
 import type { Settings } from '../models/settings';
 import type { ExtraRenderInfo, RenderedRequest } from '../common/render';
 import {
@@ -872,7 +872,7 @@ export async function sendWithSettings(
     models.requestGroup.type,
     models.workspace.type,
   ]);
-  const workspaceDoc = ancestors.find(doc => doc.type === models.workspace.type);
+  const workspaceDoc = ancestors.find(isWorkspace);
   const workspaceId = workspaceDoc ? workspaceDoc._id : 'n/a';
   const workspace = await models.workspace.getById(workspaceId);
 
@@ -951,7 +951,7 @@ export async function send(
   );
   const renderedRequestBeforePlugins = renderResult.request;
   const renderedContextBeforePlugins = renderResult.context;
-  const workspaceDoc = ancestors.find(doc => doc.type === models.workspace.type);
+  const workspaceDoc = ancestors.find(isWorkspace);
   const workspace = await models.workspace.getById(workspaceDoc ? workspaceDoc._id : 'n/a');
 
   if (!workspace) {

--- a/packages/insomnia-app/app/sync/git/ne-db-client.ts
+++ b/packages/insomnia-app/app/sync/git/ne-db-client.ts
@@ -56,7 +56,7 @@ export class NeDBClient {
     //
     // if (doc.type !== models.workspace.type) {
     //   const ancestors = await db.withAncestors(doc);
-    //   if (!ancestors.find(d => d.type === models.workspace.type)) {
+    //   if (!ancestors.find(isWorkspace)) {
     //     throw new Error(`Not found under workspace ${filePath}`);
     //   }
     // }

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
@@ -9,7 +9,7 @@ import * as models from '../../../models';
 import DebouncedInput from '../base/debounced-input';
 import MarkdownEditor from '../markdown-editor';
 import { database as db } from '../../../common/database';
-import type { Workspace } from '../../../models/workspace';
+import { isWorkspace, Workspace } from '../../../models/workspace';
 import type { Request } from '../../../models/request';
 import { GrpcRequest, isGrpcRequest } from '../../../models/grpc-request';
 import * as requestOperations from '../../../models/helpers/request-operations';
@@ -204,7 +204,7 @@ class RequestSettingsModal extends PureComponent<Props, State> {
     const hasDescription = !!request.description;
     // Find workspaces for use with moving workspace
     const ancestors = await db.withAncestors(request);
-    const doc = ancestors.find(doc => doc.type === models.workspace.type);
+    const doc = ancestors.find(isWorkspace);
     const workspaceId = doc ? doc._id : 'should-never-happen';
     const workspace = workspaces.find(w => w._id === workspaceId);
     this.setState(

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.tsx
@@ -3,13 +3,12 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import 'swagger-ui-react/swagger-ui.css';
 import { showPrompt } from './modals';
 import type { BaseModel } from '../../models';
-import * as models from '../../models';
 import { AUTOBIND_CFG, getAppLongName, getAppName, getAppSynopsis } from '../../common/constants';
 import type { HandleImportFileCallback, HandleImportUriCallback, WrapperProps } from './wrapper';
 import { database as db } from '../../common/database';
 import { ForceToWorkspaceKeys } from '../redux/modules/helpers';
 import OnboardingContainer from './onboarding-container';
-import { WorkspaceScopeKeys } from '../../models/workspace';
+import { isWorkspace, WorkspaceScopeKeys } from '../../models/workspace';
 import Analytics from './analytics';
 
 interface Props {
@@ -39,7 +38,7 @@ class WrapperOnboarding extends PureComponent<Props, State> {
 
   _handleDbChange(changes: [string, BaseModel, boolean][]) {
     for (const change of changes) {
-      if (change[1].type === models.workspace.type) {
+      if (isWorkspace(change[1])) {
         setTimeout(() => {
           this._handleDone();
         }, 400);

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -115,7 +115,7 @@ import { trackSegmentEvent } from '../../common/analytics';
 import getWorkspaceName from '../../models/helpers/get-workspace-name';
 import * as workspaceOperations from '../../models/helpers/workspace-operations';
 import { Settings } from '../../models/settings';
-import { isCollection, Workspace } from '../../models/workspace';
+import { isCollection, isWorkspace, Workspace } from '../../models/workspace';
 import { GrpcRequest, isGrpcRequest, isGrpcRequestId } from '../../models/grpc-request';
 import { Environment, isEnvironment } from '../../models/environment';
 import { GrpcRequestMeta } from '../../models/grpc-request-meta';
@@ -1337,7 +1337,7 @@ class App extends PureComponent<Props, State> {
       }
 
       // Delete VCS project if workspace deleted
-      if (vcs && doc.type === models.workspace.type && type === db.CHANGE_REMOVE) {
+      if (vcs && isWorkspace(doc) && type === db.CHANGE_REMOVE) {
         await vcs.removeProjectsForRoot(doc._id);
       }
     }

--- a/packages/insomnia-app/app/ui/redux/modules/global.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/global.tsx
@@ -37,7 +37,7 @@ import { createPlugin } from '../../../plugins/create';
 import { reloadPlugins } from '../../../plugins';
 import { setTheme } from '../../../plugins/misc';
 import type { GlobalActivity } from '../../../common/constants';
-import type { Workspace, WorkspaceScope } from '../../../models/workspace';
+import { isWorkspace, Workspace, WorkspaceScope } from '../../../models/workspace';
 import {
   ACTIVITY_DEBUG,
   ACTIVITY_HOME,
@@ -673,7 +673,7 @@ export const exportRequestsToFile = (requestIds: string[]) => async (dispatch: D
           models.workspace.type,
           models.requestGroup.type,
         ]);
-        const workspace = ancestors.find(ancestor => ancestor.type === models.workspace.type);
+        const workspace = ancestors.find(isWorkspace);
 
         if (workspace == null || workspaceLookup.hasOwnProperty(workspace._id)) {
           continue;


### PR DESCRIPTION
After rebasing another branch, I noticed that in the original PR it looks like this one was missed.  I did them all one by one and I must have just missed this one.  I used the regex `=== models\.[a-zA-Z0-9]*\.type` to make sure no other obvious ones were missed.  Looks like it was just `isWorkspace`

https://github.com/Kong/insomnia/pull/3480