### PR TITLE
Don't create a workspace unless it is absolutely the last

### DIFF
--- a/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/document-card-dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useCallback, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import { getAppName } from '../../../common/constants';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import { showError, showModal, showPrompt } from '../modals';
@@ -15,22 +15,22 @@ import type { Workspace } from '../../../models/workspace';
 import getWorkspaceName from '../../../models/helpers/get-workspace-name';
 import * as workspaceOperations from '../../../models/helpers/workspace-operations';
 import { WorkspaceScopeKeys } from '../../../models/workspace';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { setActiveWorkspace } from '../../redux/modules/global';
 import { useLoadingRecord } from '../../hooks/use-loading-record';
+import { selectIsLastWorkspace } from '../../redux/selectors';
+import { SvgIcon } from 'insomnia-components';
 
 interface Props {
   workspace: Workspace;
   apiSpec: ApiSpec;
-  isLastWorkspace: boolean;
-  children?: ReactNode | null;
-  className?: string;
 }
 
 const spinner = <i className="fa fa-refresh fa-spin" />;
 
-const useWorkspaceHandlers = ({ workspace, apiSpec, isLastWorkspace }: { workspace: Workspace; apiSpec: ApiSpec; isLastWorkspace: boolean; }) => {
+const useWorkspaceHandlers = ({ workspace, apiSpec }: { workspace: Workspace; apiSpec: ApiSpec; }) => {
   const dispatch = useDispatch();
+  const isLastWorkspace = useSelector(selectIsLastWorkspace);
 
   const handleDuplicate = useCallback(() => {
     showPrompt({
@@ -140,13 +140,13 @@ const useDocumentActionPlugins = ({ workspace, apiSpec }: { workspace: Workspace
   return { renderPluginDropdownItems, refresh };
 };
 
-export const DocumentCardDropdown: FC<Props> = ({ className, children, workspace, apiSpec, isLastWorkspace }) => {
-  const { handleDelete, handleDuplicate, handleRename } = useWorkspaceHandlers({ apiSpec, workspace, isLastWorkspace });
-  const { refresh, renderPluginDropdownItems } = useDocumentActionPlugins({ apiSpec, workspace });
+export const DocumentCardDropdown: FC<Props> = props => {
+  const { handleDelete, handleDuplicate, handleRename } = useWorkspaceHandlers(props);
+  const { refresh, renderPluginDropdownItems } = useDocumentActionPlugins(props);
 
   return (
     <Dropdown beside onOpen={refresh}>
-      <DropdownButton className={className}>{children}</DropdownButton>
+      <DropdownButton><SvgIcon icon="ellipsis" /></DropdownButton>
 
       <DropdownItem onClick={handleDuplicate}>Duplicate</DropdownItem>
       <DropdownItem onClick={handleRename}>Rename</DropdownItem>

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -99,7 +99,7 @@ const useDocumentActionPlugins = ({ workspace, apiSpec }: { workspace: Workspace
   const { startLoading, stopLoading, isLoading } = useLoadingRecord();
 
   const refresh = useCallback(async () => {
-    // Only load document plugins if the scope is designer, for now
+    // Only load document plugins if the scope is design, for now
     if (workspace.scope === WorkspaceScopeKeys.design) {
       setActionPlugins(await getDocumentActions());
     }
@@ -128,7 +128,7 @@ const useDocumentActionPlugins = ({ workspace, apiSpec }: { workspace: Workspace
 
   const renderPluginDropdownItems = useCallback(() => actionPlugins.map(p => (
     <DropdownItem
-      key={p.label}
+      key={`${p.plugin.name}:${p.label}`}
       value={p}
       onClick={handleClick}
       stayOpenAfterClick={!p.hideAfterClick}>
@@ -140,7 +140,7 @@ const useDocumentActionPlugins = ({ workspace, apiSpec }: { workspace: Workspace
   return { renderPluginDropdownItems, refresh };
 };
 
-export const DocumentCardDropdown: FC<Props> = props => {
+export const WorkspaceCardDropdown: FC<Props> = props => {
   const { handleDelete, handleDuplicate, handleRename } = useWorkspaceHandlers(props);
   const { refresh, renderPluginDropdownItems } = useDocumentActionPlugins(props);
 
@@ -154,6 +154,7 @@ export const DocumentCardDropdown: FC<Props> = props => {
       {renderPluginDropdownItems()}
 
       <DropdownDivider />
+
       <DropdownItem className="danger" onClick={handleDelete}>Delete</DropdownItem>
     </Dropdown>
   );

--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -20,7 +20,7 @@ import {
   DropdownItem,
   Header,
 } from 'insomnia-components';
-import { DocumentCardDropdown } from './dropdowns/document-card-dropdown';
+import { WorkspaceCardDropdown } from './dropdowns/workspace-card-dropdown';
 import KeydownBinder from './keydown-binder';
 import { executeHotKey } from '../../common/hotkeys-listener';
 import { hotKeyRefs } from '../../common/hotkeys';
@@ -230,7 +230,7 @@ class WrapperHome extends PureComponent<Props, State> {
       );
     }
 
-    const docMenu = <DocumentCardDropdown apiSpec={apiSpec} workspace={workspace} />
+    const docMenu = <WorkspaceCardDropdown apiSpec={apiSpec} workspace={workspace} />
     ;
     const version = spec?.info?.version || '';
     let label: string = strings.collection.singular;

--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -19,7 +19,6 @@ import {
   DropdownDivider,
   DropdownItem,
   Header,
-  SvgIcon,
 } from 'insomnia-components';
 import { DocumentCardDropdown } from './dropdowns/document-card-dropdown';
 import KeydownBinder from './keydown-binder';
@@ -161,7 +160,6 @@ class WrapperHome extends PureComponent<Props, State> {
     const {
       apiSpecs,
       workspaceMetas,
-      workspaces,
     } = this.props.wrapperProps;
     const { filter } = this.state;
     const apiSpec = apiSpecs.find(s => s.parentId === workspace._id);
@@ -232,14 +230,8 @@ class WrapperHome extends PureComponent<Props, State> {
       );
     }
 
-    const docMenu = (
-      <DocumentCardDropdown
-        apiSpec={apiSpec}
-        workspace={workspace}
-        isLastWorkspace={workspaces.length === 1}>
-        <SvgIcon icon="ellipsis" />
-      </DocumentCardDropdown>
-    );
+    const docMenu = <DocumentCardDropdown apiSpec={apiSpec} workspace={workspace} />
+    ;
     const version = spec?.info?.version || '';
     let label: string = strings.collection.singular;
     let format = '';

--- a/packages/insomnia-app/app/ui/hooks/use-loading-record.ts
+++ b/packages/insomnia-app/app/ui/hooks/use-loading-record.ts
@@ -1,0 +1,17 @@
+import { useState, useCallback } from 'react';
+
+export const useLoadingRecord = () => {
+  const [loading, setLoading] = useState<Record<string, boolean>>({});
+
+  const startLoading = useCallback((id: string) => {
+    setLoading(prevState => ({ ...prevState, [id]: true }));
+  }, []);
+
+  const stopLoading = useCallback((id: string) => {
+    setLoading(prevState => ({ ...prevState, [id]: false }));
+  }, []);
+
+  const isLoading = useCallback((id: string) => Boolean(loading[id]), [loading]);
+
+  return { startLoading, stopLoading, isLoading };
+};

--- a/packages/insomnia-app/app/ui/redux/selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/selectors.ts
@@ -67,9 +67,19 @@ export const selectActiveSpace = createSelector<any, {}, string, Space | undefin
   },
 );
 
-export const selectWorkspacesForActiveSpace = createSelector(
+const selectAllWorkspaces = createSelector(
+  selectEntitiesLists,
   // @ts-expect-error -- TSCONVERSION
-  state => selectEntitiesLists(state).workspaces as Workspace[],
+  entitiesLists => entitiesLists.workspaces as Workspace[],
+);
+
+export const selectIsLastWorkspace = createSelector(
+  selectAllWorkspaces,
+  workspaces => workspaces.length === 1,
+);
+
+export const selectWorkspacesForActiveSpace = createSelector(
+  selectAllWorkspaces,
   selectActiveSpace,
   (workspaces, activeSpace) => {
     const parentId = activeSpace?._id || null;
@@ -78,8 +88,7 @@ export const selectWorkspacesForActiveSpace = createSelector(
 );
 
 export const selectActiveWorkspace = createSelector(
-  // @ts-expect-error -- TSCONVERSION
-  state => selectEntitiesLists(state).workspaces as Workspace[],
+  selectAllWorkspaces,
   selectWorkspacesForActiveSpace,
   state => state.global.activeWorkspaceId,
   (allWorkspaces, workspaces, activeWorkspaceId) => {
@@ -230,14 +239,6 @@ export const selectActiveOAuth2Token = createSelector(
     return entities.oAuth2Tokens.find(t => t.parentId === id);
   },
 );
-
-export const selectAllWorkspaces = createSelector<any, {}, Workspace[]>(
-  selectEntitiesLists,
-  entities => {
-  // @ts-expect-error -- TSCONVERSION
-    const { workspaces } = entities;
-    return workspaces;
-  });
 
 export const selectUnseenWorkspaces = createSelector(selectEntitiesLists, entities => {
   // @ts-expect-error -- TSCONVERSION

--- a/packages/insomnia-app/app/ui/redux/selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/selectors.ts
@@ -67,7 +67,7 @@ export const selectActiveSpace = createSelector<any, {}, string, Space | undefin
   },
 );
 
-const selectAllWorkspaces = createSelector(
+export const selectAllWorkspaces = createSelector(
   selectEntitiesLists,
   // @ts-expect-error -- TSCONVERSION
   entitiesLists => entitiesLists.workspaces as Workspace[],

--- a/packages/insomnia-smoke-test/core/app.test.ts
+++ b/packages/insomnia-smoke-test/core/app.test.ts
@@ -134,7 +134,7 @@ describe('Application launch', function() {
 
     // Open card dropdown for the document
     const card = await home.findCardWithTitle(app, docName);
-    await home.openDocumentMenuDropdown(card);
+    await home.openWorkspaceCardDropdown(card);
 
     // Click the "Deploy to Portal" button, installed from that plugin
     await dropdown.clickOpenDropdownItemByText(app, 'Deploy to Portal');
@@ -170,7 +170,7 @@ describe('Application launch', function() {
     await home.cardHasBadge(collCard, 'Collection');
 
     // Delete the collection
-    await home.openDocumentMenuDropdown(collCard);
+    await home.openWorkspaceCardDropdown(collCard);
     await dropdown.clickDropdownItemByText(collCard, 'Delete');
     await modal.waitUntilOpened(app, { title: 'Delete Collection' });
     await modal.clickModalFooterByText(app, 'Yes');

--- a/packages/insomnia-smoke-test/designer/app.test.ts
+++ b/packages/insomnia-smoke-test/designer/app.test.ts
@@ -35,7 +35,7 @@ xdescribe('Application launch', function() {
     await settings.closeModal(app);
 
     // Open card dropdown for any card
-    const dd = await home.openDocumentMenuDropdown(app);
+    const dd = await home.openWorkspaceCardDropdown(app);
 
     // Click the "Deploy to Portal" button, installed from that plugin
     await dropdown.clickDropdownItemByText(dd, 'Deploy to Portal');

--- a/packages/insomnia-smoke-test/modules/home.ts
+++ b/packages/insomnia-smoke-test/modules/home.ts
@@ -44,8 +44,8 @@ export const expectTotalDocuments = async (app, count) => {
   await app.client.waitUntilTextExists('.document-listing__footer', `${count} ${label}`);
 };
 
-export const openDocumentMenuDropdown = async card => {
-  const dropdown = await card.react$('DocumentCardDropdown');
+export const openWorkspaceCardDropdown = async card => {
+  const dropdown = await card.react$('WorkspaceCardDropdown');
   await dropdown.click();
 };
 


### PR DESCRIPTION
Closes INS-770

Previously, deleting the last workspace in a space would force create a workspace. But now, it will only force create a workspace when there are truly no workspaces present in _any_ space.

This is because the app requires at least one workspace to always exist (hoping to remove this requirement in the future)

https://www.loom.com/share/0f6cb6d9816249eeb00d24d90b2dbf6d