### PR TITLE
updates codemirror

### DIFF
--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -8244,9 +8244,9 @@
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"codemirror": {
-			"version": "5.61.0",
-			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.0.tgz",
-			"integrity": "sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg=="
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.0.tgz",
+			"integrity": "sha512-Xnl3304iCc8nyVZuRkzDVVwc794uc9QNX0UcPGeNic1fbzkSrO4l4GVXho9tRNKBgPYZXgocUqXyfIv3BILhCQ=="
 		},
 		"codemirror-graphql": {
 			"version": "1.0.1",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -81,7 +81,7 @@
     "class-autobind-decorator": "^3.0.1",
     "classnames": "^2.3.1",
     "clone": "^2.1.0",
-    "codemirror": "^5.61.0",
+    "codemirror": "^5.62.0",
     "codemirror-graphql": "^1.0.1",
     "color": "^3.1.2",
     "deep-equal": "^1.0.1",


### PR DESCRIPTION
closes INS-745

this clears the `hasGutter` error we've been seeing for a while (INS-710).