### PR TITLE
Force to design workspace when coming from git

### DIFF
--- a/packages/insomnia-app/app/common/migrate-from-designer.ts
+++ b/packages/insomnia-app/app/common/migrate-from-designer.ts
@@ -6,11 +6,10 @@ import * as models from '../models';
 import { database as db } from './database';
 import { getModelName } from '../models';
 import { difference } from 'lodash';
-import type { Workspace } from '../models/workspace';
 import type { Settings } from '../models/settings';
 import fsx from 'fs-extra';
 import { trackEvent } from './analytics';
-import { WorkspaceScopeKeys } from '../models/workspace';
+import { forceWorkspaceScopeToDesign } from '../sync/git/force-workspace-scope-to-design';
 
 async function loadDesignerDb(
   types: string[],
@@ -201,9 +200,7 @@ export default async function migrateFromDesigner({
 
       // For each workspace coming from Designer, mark workspace.scope as 'design'
       if (modelType === models.workspace.type) {
-        for (const workspace of entries) {
-          (workspace as Workspace).scope = WorkspaceScopeKeys.design;
-        }
+        entries.forEach(forceWorkspaceScopeToDesign);
       }
 
       const entryCount = entries.length;

--- a/packages/insomnia-app/app/sync/git/force-workspace-scope-to-design.ts
+++ b/packages/insomnia-app/app/sync/git/force-workspace-scope-to-design.ts
@@ -1,0 +1,13 @@
+import { BaseModel } from '../../models';
+import { isWorkspace, WorkspaceScopeKeys } from '../../models/workspace';
+
+/**
+ * When a workspace comes from a git repository, the scope should always be a design document.
+ * Sometimes, a repository that was created from an older version of Insomnia Designer might have scope = null, which automatically migrates to a collection which disables all git functionality.
+ * So, if we are coming from git then always force the scope to design.
+ */
+export const forceWorkspaceScopeToDesign = (doc: BaseModel) => {
+  if (isWorkspace(doc)) {
+    doc.scope = WorkspaceScopeKeys.design;
+  }
+};

--- a/packages/insomnia-app/app/sync/git/ne-db-client.ts
+++ b/packages/insomnia-app/app/sync/git/ne-db-client.ts
@@ -7,6 +7,8 @@ import { GIT_INSOMNIA_DIR_NAME } from './git-vcs';
 import parseGitPath from './parse-git-path';
 import { BufferEncoding } from './utils';
 import { SystemError } from './system-error';
+import { BaseModel } from '../../models';
+import { forceWorkspaceScopeToDesign } from './force-workspace-scope-to-design';
 
 export class NeDBClient {
   _workspaceId: string;
@@ -78,7 +80,7 @@ export class NeDBClient {
       return;
     }
 
-    const doc = YAML.parse(data.toString());
+    const doc: BaseModel = YAML.parse(data.toString());
 
     if (id !== doc._id) {
       throw new Error(`Doc _id does not match file path [${doc._id} != ${id || 'null'}]`);
@@ -87,6 +89,8 @@ export class NeDBClient {
     if (type !== doc.type) {
       throw new Error(`Doc type does not match file path [${doc.type} != ${type || 'null'}]`);
     }
+
+    forceWorkspaceScopeToDesign(doc);
 
     await db.upsert(doc, true);
   }
@@ -111,45 +115,32 @@ export class NeDBClient {
   async readdir(filePath: string) {
     filePath = path.normalize(filePath);
     const { root, type, id } = parseGitPath(filePath);
-    let docs = [];
-    let otherFolders = [];
+    let docs: BaseModel[] = [];
+    let otherFolders: string[] = [];
 
     if (root === null && id === null && type === null) {
-      // @ts-expect-error -- TSCONVERSION
       otherFolders = [GIT_INSOMNIA_DIR_NAME];
     } else if (id === null && type === null) {
       otherFolders = [
-        // @ts-expect-error -- TSCONVERSION
         models.workspace.type,
-        // @ts-expect-error -- TSCONVERSION
         models.environment.type,
-        // @ts-expect-error -- TSCONVERSION
         models.requestGroup.type,
-        // @ts-expect-error -- TSCONVERSION
         models.request.type,
-        // @ts-expect-error -- TSCONVERSION
         models.apiSpec.type,
-        // @ts-expect-error -- TSCONVERSION
         models.unitTestSuite.type,
-        // @ts-expect-error -- TSCONVERSION
         models.unitTest.type,
-        // @ts-expect-error -- TSCONVERSION
         models.grpcRequest.type,
-        // @ts-expect-error -- TSCONVERSION
         models.protoFile.type,
-        // @ts-expect-error -- TSCONVERSION
         models.protoDirectory.type,
       ];
     } else if (type !== null && id === null) {
       const workspace = await db.get(models.workspace.type, this._workspaceId);
       const children = await db.withDescendants(workspace);
-      // @ts-expect-error -- TSCONVERSION
       docs = children.filter(d => d.type === type && !d.isPrivate);
     } else {
       throw this._errMissing(filePath);
     }
 
-    // @ts-expect-error -- TSCONVERSION
     const ids = docs.map(d => `${d._id}.yml`);
     return [...ids, ...otherFolders].sort();
   }
@@ -182,13 +173,13 @@ export class NeDBClient {
     }
 
     if (fileBuff) {
-      const doc = YAML.parse(fileBuff.toString());
+      const doc: BaseModel = YAML.parse(fileBuff.toString());
       return new Stat({
         type: 'file',
         mode: 0o777,
         size: fileBuff.length,
+        // @ts-expect-error should be number instead of string https://nodejs.org/api/fs.html#fs_stats_ino I think flow should have detected this
         ino: doc._id,
-        // should be number instead of string https://nodejs.org/api/fs.html#fs_stats_ino I think flow should have detected this
         mtimeMs: doc.modified,
       });
     } else {

--- a/packages/insomnia-app/app/sync/git/ne-db-client.ts
+++ b/packages/insomnia-app/app/sync/git/ne-db-client.ts
@@ -178,7 +178,7 @@ export class NeDBClient {
         type: 'file',
         mode: 0o777,
         size: fileBuff.length,
-        // @ts-expect-error should be number instead of string https://nodejs.org/api/fs.html#fs_stats_ino I think flow should have detected this
+        // @ts-expect-error should be number instead of string https://nodejs.org/api/fs.html#fs_stats_ino
         ino: doc._id,
         mtimeMs: doc.modified,
       });

--- a/packages/insomnia-app/app/ui/components/modals/git-staging-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/git-staging-modal.tsx
@@ -295,10 +295,12 @@ class GitStagingModal extends PureComponent<Props, State> {
 
   async _handleRollback(items: Item[]) {
     const { vcs } = this.props;
-    const files = items.map(i => ({
-      filePath: i.path,
-      status: i.status,
-    }));
+    const files = items
+      .filter(i => i.editable) // only rollback if editable
+      .map(i => ({
+        filePath: i.path,
+        status: i.status,
+      }));
     await gitRollback(vcs, files);
     await this._refresh();
   }
@@ -322,13 +324,13 @@ class GitStagingModal extends PureComponent<Props, State> {
           </label>
         </td>
         <td className="text-right">
-          <Tooltip message={item.added ? 'Delete' : 'Rollback'}>
+          {item.editable && <Tooltip message={item.added ? 'Delete' : 'Rollback'}>
             <button
               className="btn btn--micro space-right"
               onClick={() => this._handleRollback([item])}>
               <i className={classnames('fa', item.added ? 'fa-trash' : 'fa-undo')} />
             </button>
-          </Tooltip>
+          </Tooltip>}
           {this.renderOperation(item)}
         </td>
       </tr>

--- a/packages/insomnia-app/app/ui/components/modals/git-staging-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/git-staging-modal.tsx
@@ -231,12 +231,13 @@ class GitStagingModal extends PureComponent<Props, State> {
 
       const added = status.includes('added');
       let staged = !added;
-      // We want to enforce that the workspace is committed because otherwise
-      // others won't be able to clone from it. So here we're preventing
-      // people from un-staging the workspace if it's not added yet.
       let editable = true;
 
-      if (type === models.workspace.type && added) {
+      // We want to enforce that workspace changes are always committed because otherwise
+      // others won't be able to clone from it. We also make fundamental migrations to the
+      // scope property which need to be committed.
+      // So here we're preventing people from un-staging the workspace.
+      if (type === models.workspace.type) {
         editable = false;
         staged = true;
       }

--- a/packages/insomnia-app/app/ui/redux/modules/git.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/git.tsx
@@ -3,8 +3,8 @@ import type { GitRepository } from '../../../models/git-repository';
 import { showAlert, showError, showModal } from '../../components/modals';
 import GitRepositorySettingsModal from '../../components/modals/git-repository-settings-modal';
 import * as models from '../../../models';
-import type { Workspace } from '../../../models/workspace';
-import { WorkspaceScopeKeys } from '../../../models/workspace';
+import { Workspace, WorkspaceScopeKeys } from '../../../models/workspace';
+
 import { GIT_CLONE_DIR, GIT_INSOMNIA_DIR, GIT_INSOMNIA_DIR_NAME } from '../../../sync/git/git-vcs';
 import path from 'path';
 import { loadStart, loadStop, setActiveWorkspace } from './global';
@@ -17,6 +17,8 @@ import { database as db } from '../../../common/database';
 import { createWorkspace } from './workspace';
 import { addDotGit, translateSSHtoHTTP } from '../../../sync/git/utils';
 import * as git from 'isomorphic-git';
+import { BaseModel } from '../../../models';
+import { forceWorkspaceScopeToDesign } from '../../../sync/git/force-workspace-scope-to-design';
 
 export type UpdateGitRepositoryCallback = (arg0: { gitRepository: GitRepository }) => void;
 
@@ -249,7 +251,8 @@ export const cloneGitRepository = ({ createFsClient }: {
               for (const docFileName of await fsClient.promises.readdir(modelDir)) {
                 const docPath = path.join(modelDir, docFileName);
                 const docYaml = await fsClient.promises.readFile(docPath);
-                const doc = YAML.parse(docYaml.toString());
+                const doc: BaseModel = YAML.parse(docYaml.toString());
+                forceWorkspaceScopeToDesign(doc);
                 await db.upsert(doc);
               }
             }


### PR DESCRIPTION
When cloning a git repository, any workspaces coming from it should always be design documents (`scope = 'design'`).

However, sometimes when a repository that was created from an early version of Insomnia Designer, the workspace might have `scope = null`, which [automatically migrates](https://github.com/Kong/insomnia/blob/611d73804f058dc59ef1b6adbbe64677aa974763/packages/insomnia-app/app/models/workspace.ts#L144-L165) (correctly) to a `collection`, which unfortunately disables all git functionality.

If we are coming from git then always force the scope to design, this is a safe assumption to make.

To test, I synced a repository from Insomnia, deleted the workspace from Insomnia, and in GitHub manually changed the scope to be null, then cloned again in Insomnia.

<img width="903" alt="image" src="https://user-images.githubusercontent.com/4312346/124070089-61272300-da91-11eb-90b0-41f24c7fb797.png">

On the live app, after cloning and opening the cloned workspace, a user is presented with the following:
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/4312346/124070236-9d5a8380-da91-11eb-916f-6e7ce5adeaef.png">

But they should be presented with the following, as per this PR:
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/4312346/124070339-c8dd6e00-da91-11eb-85b9-1242676f99b3.png">

This PR also will force the workspace to always be committed when viewed in the git staging modal, to make sure migrations are persisted. This is okay, because the workspace model itself has very few properties and it is safe to force any changes to be committed.

<img width="252" alt="image" src="https://user-images.githubusercontent.com/4312346/124070398-e6123c80-da91-11eb-9efe-e2ab2da2947c.png">

> Note, git sync only works in the base space for the time being, so do not test in a different space (INS-781 will address this)
