### PR TITLE
Don't auto create a workspace if none exist

### DIFF
--- a/packages/insomnia-app/app/__jest__/redux-state-for-test.ts
+++ b/packages/insomnia-app/app/__jest__/redux-state-for-test.ts
@@ -2,7 +2,7 @@ import { ACTIVITY_DEBUG } from '../common/constants';
 import { RootState } from '../ui/redux/modules';
 import * as entities from '../ui/redux/modules/entities';
 
-const reduxStateForTest = async (activeWorkspaceId: string): Promise<RootState> => ({
+const reduxStateForTest = async (activeWorkspaceId: string | null = null): Promise<RootState> => ({
   entities: entities.reducer(entities.initialEntitiesState, entities.initializeWith(await entities.allDocs())),
   global: {
     activeWorkspaceId,

--- a/packages/insomnia-app/app/models/workspace.ts
+++ b/packages/insomnia-app/app/models/workspace.ts
@@ -1,7 +1,6 @@
 import type { BaseModel } from './index';
 import * as models from './index';
 import { database as db } from '../common/database';
-import { getAppName } from '../common/constants';
 import { strings } from '../common/strings';
 import { Merge } from 'type-fest';
 import { isSpaceId } from './space';
@@ -70,18 +69,7 @@ export async function create(patch: Partial<Workspace> = {}) {
 }
 
 export async function all() {
-  const workspaces = await db.all<Workspace>(type);
-
-  if (workspaces.length > 0) {
-    return workspaces;
-  }
-
-  // Create default workspace
-  await create({
-    name: getAppName(),
-    scope: WorkspaceScopeKeys.collection,
-  });
-  return db.all<Workspace>(type);
+  return await db.all<Workspace>(type);
 }
 
 export function count() {

--- a/packages/insomnia-app/app/ui/redux/modules/__tests__/git.test.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/__tests__/git.test.tsx
@@ -19,6 +19,7 @@ import {
   getAndClearShowPromptMockArgs,
 } from '../../../../test-utils';
 import { shallowClone } from '../../../../sync/git/shallow-clone';
+import reduxStateForTest from '../../../../__jest__/redux-state-for-test';
 
 jest.mock('../../../components/modals');
 jest.mock('../../../../sync/git/shallow-clone');
@@ -31,7 +32,7 @@ describe('git', () => {
   let store;
   beforeEach(async () => {
     await globalBeforeEach();
-    store = mockStore({ entities: { spaces: [] }, global: {} });
+    store = mockStore(await reduxStateForTest());
   });
   // Check loading events
   afterEach(() => {

--- a/packages/insomnia-app/app/ui/redux/modules/__tests__/space.test.js
+++ b/packages/insomnia-app/app/ui/redux/modules/__tests__/space.test.js
@@ -8,6 +8,7 @@ import { ACTIVITY_HOME } from '../../../../common/constants';
 import { SET_ACTIVE_ACTIVITY, SET_ACTIVE_SPACE } from '../global';
 import { getAndClearShowAlertMockArgs, getAndClearShowPromptMockArgs } from '../../../../test-utils';
 import { BASE_SPACE_ID } from '../../../../models/space';
+import reduxStateForTest from '../../../../__jest__/redux-state-for-test';
 
 jest.mock('../../../components/modals');
 jest.mock('../../../../common/analytics');
@@ -19,7 +20,7 @@ describe('space', () => {
   beforeEach(globalBeforeEach);
   describe('createSpace', () => {
     it('should create space', async () => {
-      const store = mockStore();
+      const store = mockStore(await reduxStateForTest());
       store.dispatch(createSpace());
 
       const {
@@ -63,7 +64,7 @@ describe('space', () => {
 
   describe('removeSpace', () => {
     it('should remove space', async () => {
-      const store = mockStore();
+      const store = mockStore(await reduxStateForTest());
       const spaceOne = await models.space.create({ name: 'My Space' });
       const spaceTwo = await models.space.create();
 

--- a/packages/insomnia-app/app/ui/redux/modules/__tests__/workspace.test.ts
+++ b/packages/insomnia-app/app/ui/redux/modules/__tests__/workspace.test.ts
@@ -13,6 +13,7 @@ import { Environment } from '../../../../models/environment';
 import { CookieJar } from '../../../../models/cookie-jar';
 import { WorkspaceMeta } from '../../../../models/workspace-meta';
 import { ApiSpec } from '../../../../models/api-spec';
+import reduxStateForTest from '../../../../__jest__/redux-state-for-test';
 
 jest.mock('../../../components/modals');
 jest.mock('../../../../common/analytics');
@@ -111,9 +112,7 @@ describe('workspace', () => {
     });
 
     it('should create with no space', async () => {
-      const entities = { spaces: {} };
-      const global = { };
-      const store = mockStore({ entities, global });
+      const store = mockStore(await reduxStateForTest());
 
       // @ts-expect-error redux-thunk types
       store.dispatch(createWorkspace({ scope: WorkspaceScopeKeys.collection }));

--- a/packages/insomnia-smoke-test/core/app.test.ts
+++ b/packages/insomnia-smoke-test/core/app.test.ts
@@ -59,6 +59,7 @@ describe('Application launch', function() {
       // Click dropdown and open import modal
       await home.documentListingShown(app);
       await home.createNewCollection(app);
+      await debug.pageDisplayed(app);
       const workspaceDropdown = await debug.clickWorkspaceDropdown(app);
       await dropdown.clickDropdownItemByText(workspaceDropdown, 'Import/Export');
 
@@ -155,6 +156,8 @@ describe('Application launch', function() {
     // Expect one document at home
     await home.documentListingShown(app);
     const collectionName = await home.createNewCollection(app);
+    await debug.pageDisplayed(app);
+
     await debug.goToDashboard(app);
     await home.expectTotalDocuments(app, 1);
     await home.expectDocumentWithTitle(app, collectionName);

--- a/packages/insomnia-smoke-test/core/app.test.ts
+++ b/packages/insomnia-smoke-test/core/app.test.ts
@@ -58,8 +58,7 @@ describe('Application launch', function() {
 
       // Click dropdown and open import modal
       await home.documentListingShown(app);
-      await home.expectTotalDocuments(app, 1);
-      await home.openDocumentWithTitle(app, 'Insomnia');
+      await home.createNewCollection(app);
       const workspaceDropdown = await debug.clickWorkspaceDropdown(app);
       await dropdown.clickDropdownItemByText(workspaceDropdown, 'Import/Export');
 
@@ -155,8 +154,10 @@ describe('Application launch', function() {
 
     // Expect one document at home
     await home.documentListingShown(app);
+    const collectionName = await home.createNewCollection(app);
+    await debug.goToDashboard(app);
     await home.expectTotalDocuments(app, 1);
-    await home.expectDocumentWithTitle(app, 'Insomnia');
+    await home.expectDocumentWithTitle(app, collectionName);
     const name = 'E2E testing specification - swagger 2 1.0.0';
 
     // Import from clipboard as collection

--- a/packages/insomnia-smoke-test/core/migration.test.ts
+++ b/packages/insomnia-smoke-test/core/migration.test.ts
@@ -27,8 +27,7 @@ describe('Migration', function() {
     await onboarding.skipOnboardingFlow(app);
 
     await home.documentListingShown(app);
-    await home.expectTotalDocuments(app, 1);
-    await home.expectDocumentWithTitle(app, 'Insomnia');
+    await home.expectTotalDocuments(app, 0);
 
     await app.restart();
     await client.focusAfterRestart(app);
@@ -55,8 +54,7 @@ describe('Migration', function() {
     await onboarding.skipOnboardingFlow(app);
 
     await home.documentListingShown(app);
-    await home.expectTotalDocuments(app, 2);
-    await home.expectDocumentWithTitle(app, 'Insomnia');
+    await home.expectTotalDocuments(app, 1);
     await home.expectDocumentWithTitle(app, 'BASIC-DESIGNER-FIXTURE'); // imported from fixture
 
     await app.restart();


### PR DESCRIPTION
Follow up to https://github.com/Kong/insomnia/pull/3494

This means we can start using correctly initialized redux state in unit tests (where possible, for now)