### PR TITLE
Allow optional specification of Origin header for Auth Code flow + PKCE

### DIFF
--- a/packages/insomnia-app/app/network/o-auth-2/get-token.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/get-token.ts
@@ -71,6 +71,7 @@ async function _getOAuth2AuthorizationCodeHeader(
     authentication.resource,
     authentication.usePkce,
     authentication.pkceMethod,
+    authentication.origin,
   );
   return _updateOAuth2Token(requestId, results);
 }
@@ -190,6 +191,7 @@ async function _getAccessToken(
     authentication.clientSecret,
     token.refreshToken,
     authentication.scope,
+    authentication.origin,
   );
 
   // If we didn't receive an access token it means the refresh token didn't succeed,

--- a/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
@@ -23,6 +23,7 @@ export default async function(
   resource = '',
   usePkce = false,
   pkceMethod = c.PKCE_CHALLENGE_S256,
+  origin = '',
 ): Promise<Record<string, any>> {
   if (!authorizeUrl) {
     throw new Error('Invalid authorization URL');
@@ -80,6 +81,7 @@ export default async function(
     audience,
     resource,
     codeVerifier,
+    origin,
   );
 }
 
@@ -171,6 +173,7 @@ async function _getToken(
   audience = '',
   resource = '',
   codeVerifier = '',
+  origin = '',
 ): Promise<Record<string, any>> {
   const params = [
     {
@@ -230,6 +233,10 @@ async function _getToken(
     });
   } else {
     headers.push(getBasicAuthHeader(clientId, clientSecret));
+  }
+
+  if (origin) {
+    headers.push({ name: 'Origin', value: origin });
   }
 
   const responsePatch = await sendWithSettings(requestId, {

--- a/packages/insomnia-app/app/network/o-auth-2/refresh-token.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/refresh-token.ts
@@ -14,6 +14,7 @@ export default async function(
   clientSecret: string,
   refreshToken: string,
   scope: string,
+  origin: string,
 ): Promise<Record<string, any>> {
   const params = [
     {
@@ -53,6 +54,10 @@ export default async function(
     });
   } else {
     headers.push(getBasicAuthHeader(clientId, clientSecret));
+  }
+
+  if (origin) {
+    headers.push({ name: 'Origin', value: origin });
   }
 
   const url = setDefaultProtocol(accessTokenUrl);

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -241,6 +241,10 @@ class OAuth2Auth extends PureComponent<Props, State> {
     this._handleChangeProperty('resource', value);
   }
 
+  _handleChangeOrigin(value: string) {
+    this._handleChangeProperty('origin', value);
+  }
+
   _handleChangeGrantType(e: React.SyntheticEvent<HTMLInputElement>) {
     this._handleChangeProperty('grantType', e.currentTarget.value);
   }
@@ -497,6 +501,12 @@ class OAuth2Auth extends PureComponent<Props, State> {
       this._handleChangeResource,
       'Indicate what resource to access',
     );
+    const origin = this.renderInputRow(
+      'Origin',
+      'origin',
+      this._handleChangeOrigin,
+      'Specify Origin header when CORS is required for oauth endpoints',
+    );
     const credentialsInBody = this.renderSelectRow(
       'Credentials',
       'credentialsInBody',
@@ -527,7 +537,7 @@ class OAuth2Auth extends PureComponent<Props, State> {
         enabled,
       ];
 
-      advancedFields = [scope, state, credentialsInBody, tokenPrefix, audience, resource];
+      advancedFields = [scope, state, credentialsInBody, tokenPrefix, audience, resource, origin];
     } else if (grantType === GRANT_TYPE_CLIENT_CREDENTIALS) {
       basicFields = [accessTokenUrl, clientId, clientSecret, enabled];
       advancedFields = [scope, credentialsInBody, tokenPrefix, audience, resource];


### PR DESCRIPTION
Closes #794

@wdawson this is slightly lazier than the approach discussed in https://github.com/Kong/insomnia/discussions/3572 but it feels reasonable to stuff Origin header into the advanced options section.

![image](https://user-images.githubusercontent.com/2056399/124298710-7d3fc880-db54-11eb-9cc1-191b4b712b3f.png)
