### PR TITLE
Response Timer: Tabular Nums Styling

### DIFF
--- a/packages/insomnia-app/app/ui/components/response-timer.tsx
+++ b/packages/insomnia-app/app/ui/components/response-timer.tsx
@@ -32,7 +32,7 @@ export const ResponseTimer: FunctionComponent<Props> = ({ handleCancel, loadStar
   const seconds = milliseconds / 1000;
   return (
     <div className="overlay theme--transparent-overlay">
-      <h2>
+      <h2 style={{ fontVariantNumeric: 'tabular-nums' }}>
         {seconds >= REQUEST_TIME_TO_SHOW_COUNTER ? `${seconds.toFixed(1)} seconds` : 'Loading'}...
       </h2>
       <div className="pad">


### PR DESCRIPTION
This prevents the timer to constantly change its width → the text doesn't jump anymore.

**`BEFORE`**


https://user-images.githubusercontent.com/12849807/125127540-f3b46b80-e0fc-11eb-867a-dc314ce4a820.mov



**`AFTER`**


https://user-images.githubusercontent.com/12849807/125127651-1e062900-e0fd-11eb-9d6e-606439ed7905.mov



