### PR TITLE
Add menu separators in view and help menus

### DIFF
--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -272,6 +272,9 @@ export function createWindow() {
         },
       },
       {
+        type: 'separator',
+      },
+      {
         label: 'Toggle Sidebar',
         click: () => {
           const w = BrowserWindow.getFocusedWindow();
@@ -336,6 +339,9 @@ export function createWindow() {
         },
       },
       {
+        type: 'separator',
+      },
+      {
         label: `Show App ${MNEMONIC_SYM}Data Folder`,
         click: () => {
           const directory = getDataDirectory();
@@ -348,6 +354,9 @@ export function createWindow() {
           const directory = log.getLogDirectory();
           shell.showItemInFolder(directory);
         },
+      },
+      {
+        type: 'separator',
       },
       {
         label: 'Show Open Source Licenses',
@@ -410,6 +419,9 @@ export function createWindow() {
   } else {
     // @ts-expect-error -- TSCONVERSION type splitting
     helpMenu.submenu?.push({
+      type: 'separator',
+    },
+    {
       label: `${MNEMONIC_SYM}About`,
       click: aboutMenuClickHandler,
     });


### PR DESCRIPTION
This small PR adds menu separators in the view and help menus
![view_menu_before](https://user-images.githubusercontent.com/69011/125170651-33885b00-e1b0-11eb-88e7-90af6f67c88f.png) ![view_menu_after](https://user-images.githubusercontent.com/69011/125170648-31be9780-e1b0-11eb-87be-6cfd54d72fcf.png)


![help_meny_before](https://user-images.githubusercontent.com/69011/125170643-2bc8b680-e1b0-11eb-8f50-dc82eab9b6f4.png) ![help_menu_after](https://user-images.githubusercontent.com/69011/125170645-2e2b1080-e1b0-11eb-9f07-bf526b0de26b.png)


