### PR TITLE
Implement color scheme badge artifact workaround.

### DIFF
--- a/packages/insomnia-app/app/ui/components/settings/theme-panel.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/theme-panel.tsx
@@ -26,15 +26,34 @@ const ThemeButton = styled.div<{ $isActive: boolean; $isInOsThemeMode: boolean }
   margin: 'var(--padding-md) var(--padding-md)',
   fontSize: 0,
   borderRadius: 'var(--radius-md)',
-  boxShadow: '0 0 0 1px var(--hl-sm)',
   transition: 'all 150ms ease-out',
+  // This is a workaround for some anti-aliasing artifacts that impact the color scheme badges.
+  // The box shadow is placed on a pseudo-element. When it is active, it is configured to overlap
+  // 1px with the underlying geometry to prevent gaps caused by anti-aliasing.
+  '&:before': {
+    display: 'block',
+    position: 'absolute',
+    boxShadow: '0 0 0 1px var(--hl-sm)',
+    transition: 'all 150ms ease-out',
+    borderRadius: 'var(--radius-md)',
+    width: '100%',
+    height: '100%',
+    content: "''",
+    ...($isActive ? {
+      boxShadow: '0 0 0 var(--padding-xs) var(--color-surprise)',
+      width: 'calc(100% - 2px)',
+      height: 'calc(100% - 2px)',
+      margin: '1px',
+    } : {}),
+  },
+  '&:hover:before': {
+    ...($isInOsThemeMode ? { boxShadow: 'none' } : {}),
+  },
   ...($isActive ? {
-    boxShadow: '0 0 0 var(--padding-xs) var(--color-surprise)',
     transform: 'scale(1.05)',
   } : {}),
   '&:hover': {
     transform: 'scale(1.05)',
-    ...($isInOsThemeMode ? { boxShadow: 'none' } : {}),
   },
   ...($isInOsThemeMode ? {
     '&:hover .overlay-wrapper': {
@@ -42,19 +61,6 @@ const ThemeButton = styled.div<{ $isActive: boolean; $isInOsThemeMode: boolean }
     },
     '&:hover .theme-preview': {
       visibility: 'hidden', // this prevents alpha-blending problems with the underlying svg bleeding through
-    },
-  } : {}),
-  // This is a workaround for some anti-aliasing artifacts that impact the color scheme badges.
-  ...($isActive && $isInOsThemeMode ? {
-    '&:not(:hover):before': {
-      display: 'block',
-      position: 'absolute',
-      margin: '-1px 0 0 -1px',
-      border: '2px solid var(--color-surprise)',
-      borderRadius: 'var(--radius-md)',
-      width: 'calc(100% - 2px)',
-      height: 'calc(100% - 2px)',
-      content: "''",
     },
   } : {}),
 }));
@@ -80,7 +86,8 @@ const ColorSchemeBadge = styled.div<{ $theme: 'dark' | 'light'}>(({ $theme }) =>
   height: 12,
   fill: 'white',
   padding: 4,
-  background: 'var(--color-surprise)',
+  transition: 'background-color 150ms ease-out',
+  backgroundColor: 'var(--color-surprise)',
   ...(isDark($theme) ? {
     right: 0,
     borderTopRightRadius: 'var(--radius-md)',

--- a/packages/insomnia-app/app/ui/components/settings/theme-panel.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/theme-panel.tsx
@@ -26,7 +26,6 @@ const ThemeButton = styled.div<{ $isActive: boolean; $isInOsThemeMode: boolean }
   margin: 'var(--padding-md) var(--padding-md)',
   fontSize: 0,
   borderRadius: 'var(--radius-md)',
-  overflow: 'hidden',
   boxShadow: '0 0 0 1px var(--hl-sm)',
   transition: 'all 150ms ease-out',
   ...($isActive ? {
@@ -43,6 +42,19 @@ const ThemeButton = styled.div<{ $isActive: boolean; $isInOsThemeMode: boolean }
     },
     '&:hover .theme-preview': {
       visibility: 'hidden', // this prevents alpha-blending problems with the underlying svg bleeding through
+    },
+  } : {}),
+  // This is a workaround for some anti-aliasing artifacts that impact the color scheme badges.
+  ...($isActive && $isInOsThemeMode ? {
+    '&:not(:hover):before': {
+      display: 'block',
+      position: 'absolute',
+      margin: '-1px 0 0 -1px',
+      border: '2px solid var(--color-surprise)',
+      borderRadius: 'var(--radius-md)',
+      width: 'calc(100% - 2px)',
+      height: 'calc(100% - 2px)',
+      content: "''",
     },
   } : {}),
 }));
@@ -71,10 +83,12 @@ const ColorSchemeBadge = styled.div<{ $theme: 'dark' | 'light'}>(({ $theme }) =>
   background: 'var(--color-surprise)',
   ...(isDark($theme) ? {
     right: 0,
+    borderTopRightRadius: 'var(--radius-md)',
     borderBottomLeftRadius: 'var(--radius-md)',
   } : {}),
   ...(isLight($theme) ? {
     left: 0,
+    borderTopLeftRadius: 'var(--radius-md)',
     borderBottomRightRadius: 'var(--radius-md)',
   } : {}),
 }));
@@ -155,6 +169,7 @@ const ThemePreview: FC<{ theme: PluginTheme }> = ({ theme: { name: themeName } }
     width="100%"
     height="100%"
     viewBox="0 0 500 300"
+    style={{ borderRadius: 'var(--radius-md)' }}
   >
     {/*
       A WORD TO THE WISE: If you, dear traveler from the future, are here

--- a/packages/insomnia-app/app/ui/components/settings/theme-panel.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/theme-panel.tsx
@@ -47,7 +47,7 @@ const ThemeButton = styled.div<{ $isActive: boolean; $isInOsThemeMode: boolean }
     } : {}),
   },
   '&:hover:before': {
-    ...($isInOsThemeMode ? { boxShadow: 'none' } : {}),
+    ...($isInOsThemeMode ? { boxShadow: '0 0 0 0 var(--color-surprise)' } : {}),
   },
   ...($isActive ? {
     transform: 'scale(1.05)',


### PR DESCRIPTION
Color scheme badges have a small gap artifact caused by an interplay between anti-aliasing and alpha blending. Here, we use pseudo-classes to ensure one opaque pixel of intersection between the shadow border and the color badge.

### Explanation
For an explanation on _why_ this is necessary, please [see this codepen](https://codepen.io/john-chadwick/pen/mdmmWKG).

### Preview
This fix is not entirely perfect; a more rigorous fix might involve putting the box shadow itself into a pseudo-element and making it overlap that way. (Since box-shadows are always clipped by the shape of the element, this would be necessary to work around the problem.)
![SHAIHRK2z2](https://user-images.githubusercontent.com/86682572/126001016-6789a53c-982c-4335-89c4-7aeb451e030d.gif)