### PR TITLE
Add Support for Postman 2.1 Export (most but not all elements/cases)

### DIFF
--- a/packages/insomnia-app/app/common/postman-export.ts
+++ b/packages/insomnia-app/app/common/postman-export.ts
@@ -1,0 +1,199 @@
+import { PostmanV210Types } from 'insomnia-importers';
+import * as models from '../models/index';
+import uuid from 'uuid';
+
+export function convert(
+  inputData: Array<models.BaseModel>,
+  fileName: string,
+) {
+  const outputData = <PostmanV210Types.HttpsSchemaGetpostmanComJsonCollectionV210>{
+    info: {
+      _postman_id: '',
+      name: '',
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+    },
+    item: [],
+  };
+  outputData.info._postman_id = uuid.v4();
+
+  const insomniaParentChildrenNodesMap = generateInsomniaParentChildrenNodesMap(inputData);
+  const postmanItemTrees = getPostmanItemTrees(insomniaParentChildrenNodesMap);
+  outputData.item.push(...postmanItemTrees);
+  outputData.info.name = fileName;
+
+  return outputData;
+}
+
+const rootId = 'd1097c3b-2011-47a4-8f95-87b8f4b54d6d'; // unique guid for root
+
+function generateInsomniaParentChildrenNodesMap(
+  insomniaParentChildAdjacencyList: Array<models.BaseModel>,
+) {
+  const insomniaParentChildrenNodesMap = new Map<string, Array<models.BaseModel>>();
+  let tempChildrenNodesArray: Array<models.BaseModel> | undefined;
+  insomniaParentChildAdjacencyList.forEach(insomniaElement => {
+    // @ts-expect-error -- First fix the older _type assignments in getExportData() in packages/insomnia-app/app/common/import.tsx
+    const insomniaElementType = insomniaElement._type;
+    switch (insomniaElementType) {
+      case 'workspace':
+        tempChildrenNodesArray = insomniaParentChildrenNodesMap.get(rootId);
+        if (tempChildrenNodesArray === undefined) tempChildrenNodesArray = [];
+        tempChildrenNodesArray.push(insomniaElement);
+        insomniaParentChildrenNodesMap.set(rootId, tempChildrenNodesArray);
+        break;
+      case 'request':
+      case 'request_group':
+        tempChildrenNodesArray = insomniaParentChildrenNodesMap.get(insomniaElement.parentId);
+        if (tempChildrenNodesArray === undefined) tempChildrenNodesArray = [];
+        tempChildrenNodesArray.push(insomniaElement);
+        insomniaParentChildrenNodesMap.set(insomniaElement.parentId, tempChildrenNodesArray);
+        break;
+      default:
+        console.warn('Warning: Item type unsupported; skipped!!! ... ' + insomniaElementType);
+    }
+  });
+  return insomniaParentChildrenNodesMap;
+}
+
+function getPostmanItemTrees(
+  insomniaParentChildrenNodesMap: Map<string, Array<models.BaseModel>>,
+) {
+  const postmanItemTrees: Array<PostmanV210Types.Items1> = [];
+  const roots = insomniaParentChildrenNodesMap.get(rootId); // 'roots' means root workspaces
+  if (roots && roots.length > 0) {
+    if (roots.length === 1) { // if only one workspace is involved, directly process for the workspace child elements to avoid extra workspace folder
+      const firstRoot = roots[0];
+      const rootChildren = insomniaParentChildrenNodesMap.get(firstRoot._id);
+      if (rootChildren) {
+        rootChildren.forEach(insomniaElement => {
+          postmanItemTrees.push(generatePostmanItemTreeRecursively(insomniaElement, insomniaParentChildrenNodesMap));
+        });
+      }
+    } else { // if multiple workspaces are involved, pass them for processing so that folders for the workspaces are created
+      roots.forEach(root => {
+        postmanItemTrees.push(generatePostmanItemTreeRecursively(root, insomniaParentChildrenNodesMap));
+      });
+    }
+  }
+  return postmanItemTrees;
+}
+
+function generatePostmanItemTreeRecursively(insomniaElement, insomniaParentChildrenNodesMap) {
+  let postmanItem: PostmanV210Types.Items1 = <PostmanV210Types.Items1>{};
+  switch (insomniaElement._type) {
+    case 'request_group':
+    case 'workspace':
+      postmanItem.name = insomniaElement.name;
+      const itemList: Array<PostmanV210Types.Items1> = [];
+      insomniaParentChildrenNodesMap.get(insomniaElement._id).forEach(child => {
+        itemList.push(generatePostmanItemTreeRecursively(child, insomniaParentChildrenNodesMap));
+      });
+      postmanItem.item = itemList;
+      break;
+    case 'request':
+      postmanItem = transformItem(insomniaElement);
+      break;
+    default:
+      console.warn('Warning: Item type unsupported; skipped!!! ... ' + insomniaElement._type);
+  }
+  return postmanItem;
+}
+
+function transformItem(insomniaItem) {
+  const postmanItem: PostmanV210Types.Items1 = <PostmanV210Types.Items1>{};
+  postmanItem.name = insomniaItem.name;
+  const request: PostmanV210Types.Request1 = <PostmanV210Types.Request1>{};
+  request.method = insomniaItem.method;
+  request.header = transformHeaders(insomniaItem.headers);
+  if (Object.keys(insomniaItem.body).length > 0) {
+    request.body = transformBody(insomniaItem.body);
+  }
+  request.url = transformUrl(insomniaItem.url);
+  if (insomniaItem.parameters && insomniaItem.parameters.length > 0) {
+    if (request.url.raw !== undefined && request.url.raw.includes('?')) {
+      console.warn('Warning: Query params detected in both the raw query and the "parameters" object of Insomnia request!!! Exported Postman collection may need manual editing for erroneous "?" in url.');
+    }
+    const queryParams: Array<PostmanV210Types.QueryParam> = [];
+    insomniaItem.parameters.forEach(param => {
+      queryParams.push({ key: param.name, value: param.value });
+    });
+    request.url.query = queryParams;
+  }
+  request.auth = <PostmanV210Types.Auth>{}; // todo
+  if (Object.keys(insomniaItem.authentication).length > 0) {
+    console.warn('Warning: Auth param export not yet supported!!!');
+  }
+  postmanItem.request = request;
+  postmanItem.response = [];
+  return postmanItem;
+}
+
+function transformUrl(insomniaUrl) {
+  const postmanUrl: PostmanV210Types.Url = {};
+  if (insomniaUrl === '') return postmanUrl;
+  postmanUrl.raw = insomniaUrl;
+  const urlParts = insomniaUrl.split(/:\/\//);
+  let rawHostAndPath = '';
+  if (urlParts.length === 1) {
+    rawHostAndPath = urlParts[0];
+  } else if (urlParts.length === 2) {
+    postmanUrl.protocol = urlParts[0];
+    rawHostAndPath = urlParts[1];
+  } else {
+    console.error('Error: Unexpected number of components found in the URL string.');
+    throw new Error('Unexpected number of components found in the URL string.');
+  }
+  const hostAndPath = rawHostAndPath.split(/\/(.+)/);
+  postmanUrl.host = hostAndPath[0].split(/\./);
+  postmanUrl.path = hostAndPath[1] === undefined ? [] : hostAndPath[1].split(/\//);
+  return postmanUrl;
+}
+
+function transformHeaders(insomniaHeaders) {
+  const outputHeaders: Array<PostmanV210Types.Header> = [];
+  insomniaHeaders.forEach(element => {
+    const header: PostmanV210Types.Header = <PostmanV210Types.Header>{};
+    header.key = element.name;
+    header.value = element.value;
+    outputHeaders.push(header);
+  });
+  return outputHeaders;
+}
+
+function transformBody(insomniaBody) {
+  const body: PostmanV210Types.Request1['body'] = {};
+  switch (insomniaBody.mimeType) {
+    case '':
+    case 'application/json':
+    case 'application/xml':
+      body.mode = 'raw';
+      body.raw = insomniaBody.text;
+      break;
+    case 'multipart/form-data':
+      body.mode = 'formdata';
+      body.formdata = [];
+      insomniaBody.params.forEach(param => {
+        body.formdata?.push({ key: param.name, value: param.value });
+      });
+      break;
+    case 'application/x-www-form-urlencoded':
+      body.mode = 'urlencoded';
+      body.urlencoded = [];
+      insomniaBody.params.forEach(param => {
+        body.urlencoded?.push({ key: param.name, value: param.value });
+      });
+      break;
+    case 'application/octet-stream':
+      body.mode = 'file';
+      body.file = {};
+      body.file.src = '/C:/PleaseSelectAFile';
+      console.warn('Warning: A file is supposed to be a part of the request!!! Would need to be manually selected in Postman.');
+      break;
+    default:
+      console.warn('Warning: Body type unsupported; skipped!!! ... ' + insomniaBody.mimeType);
+      body.mode = 'raw';
+      body.raw = 'Insomnia to Postman export: Unsupported body type ' + insomniaBody.mimeType;
+      break;
+  }
+  return body;
+}

--- a/packages/insomnia-app/app/ui/redux/modules/global.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/global.tsx
@@ -10,6 +10,8 @@ import {
   exportRequestsHAR,
   exportWorkspacesData,
   exportWorkspacesHAR,
+  exportWorkspacesPostman,
+  exportRequestsPostman,
 } from '../../../common/export';
 import AlertModal from '../../components/modals/alert-modal';
 import PaymentNotificationModal from '../../components/modals/payment-notification-modal';
@@ -385,11 +387,13 @@ export const setActiveWorkspace = (workspaceId: string | null) => {
 const VALUE_JSON = 'json';
 const VALUE_YAML = 'yaml';
 const VALUE_HAR = 'har';
+const VALUE_POSTMAN = 'postman_collection.json';
 
 export type SelectedFormat =
   | typeof VALUE_HAR
   | typeof VALUE_JSON
   | typeof VALUE_YAML
+  | typeof VALUE_POSTMAN
   ;
 
 const showSelectExportTypeModal = ({ onCancel, onDone }: {
@@ -408,6 +412,10 @@ const showSelectExportTypeModal = ({ onCancel, onDone }: {
     {
       name: 'HAR – HTTP Archive Format',
       value: VALUE_HAR,
+    },
+    {
+      name: 'Postman Collection v2.1.0',
+      value: VALUE_POSTMAN,
     },
   ];
 
@@ -494,6 +502,10 @@ export const exportAllToFile = () => async (dispatch: Dispatch, getState) => {
         switch (selectedFormat) {
           case VALUE_HAR:
             stringifiedExport = await exportWorkspacesHAR(workspaces, exportPrivateEnvironments);
+            break;
+
+          case VALUE_POSTMAN:
+            stringifiedExport = await exportWorkspacesPostman(workspaces, exportPrivateEnvironments, fileName);
             break;
 
           case VALUE_YAML:
@@ -587,6 +599,10 @@ export const exportRequestsToFile = (requestIds: string[]) => async (dispatch: D
         switch (selectedFormat) {
           case VALUE_HAR:
             stringifiedExport = await exportRequestsHAR(requests, exportPrivateEnvironments);
+            break;
+
+          case VALUE_POSTMAN:
+            stringifiedExport = await exportRequestsPostman(requests, exportPrivateEnvironments, fileName);
             break;
 
           case VALUE_YAML:

--- a/packages/insomnia-importers/src/index.ts
+++ b/packages/insomnia-importers/src/index.ts
@@ -1,3 +1,4 @@
 export { convert, RootConverter } from './convert';
 export * from './importers';
 export { ImportRequest, Converter, Importer } from './entities';
+export * as PostmanV210Types from './importers/postman-2.1.types';


### PR DESCRIPTION
Closes #1156 (it was actually converted to a discussion, but this PR closes it properly)
Have discussed a bit with @dimitropoulos: https://github.com/Vyoam/InsomniaToPostmanFormat/issues/4
Let's get this done. :)

Main notes:
* Adds support for Postman 2.1 export; mostly based on https://github.com/Vyoam/InsomniaToPostmanFormat
* Limitations listed here: https://github.com/Kong/insomnia/discussions/3703#discussioncomment-1022038
* See the individual files in the PR for specific notes
* Verified import of the output json with Postman 8.8.0
* Started on May 29; worked on and off; completed around Jul 18; Develop branch changes were merged on Jul 18
* At one point, I did wonder if future changes in Insomnia's data structure will affect this export code. It might, but...
    1. this Postman export code simply uses the same object used for Insomnia's self export.
    2. any breaking change be easy to detect via the added UT.
    3. I guess har export code would anyway be updated in that situation, and this one can be done mostly along the same lines.
