### PR TITLE
Correctly log uncaught errors/unhandled promises

### DIFF
--- a/packages/insomnia-app/app/ui/index.tsx
+++ b/packages/insomnia-app/app/ui/index.tsx
@@ -68,11 +68,11 @@ window['styled-components'] = styledComponents;
 // Catch uncaught errors and report them
 if (window && !isDevelopment()) {
   window.addEventListener('error', e => {
-    console.error('Uncaught Error', e);
+    console.error('Uncaught Error', e.error || e);
     trackEvent('Error', 'Uncaught Error');
   });
   window.addEventListener('unhandledrejection', e => {
-    console.error('Unhandled Promise', e);
+    console.error('Unhandled Promise', e.reason);
     trackEvent('Error', 'Uncaught Promise');
   });
 }


### PR DESCRIPTION
Logging and uncaught promise/error handling is disabled in development, so in order to test this yourself you need to add an error that always gets thrown somewhere in the app, and then either disable the `isDevelopment` checks in `packages/insomnia-app/app/ui/index.tsx ` and `packages/insomnia-app/app/common/log.ts`, or package the app.

Log output before this change:
```
[2021-07-28 10:11:19.476] [error] Unhandled Promise { isTrusted: true }
[2021-07-28 10:11:41.235] [error] Uncaught Error { isTrusted: true }
```

Log output after this change:
```
[2021-07-28 12:47:06.435] [error] Unhandled Promise Error: Failed to deserialize key=/projects/test/meta.json err=SyntaxError: Unexpected end of JSON input
    at Store.getItem (webpack-internal:///./sync/store/index.ts:42:19)
    at async VCS._allProjects (webpack-internal:///./sync/vcs/index.ts:1036:23)
    at async VCS._getProjectByRootDocument (webpack-internal:///./sync/vcs/index.ts:990:26)
    at async VCS.switchProject (webpack-internal:///./sync/vcs/index.ts:74:25)
    at async App._updateVCS (webpack-internal:///./ui/containers/app.tsx:1059:9)
    at async App.componentDidMount (webpack-internal:///./ui/containers/app.tsx:1104:9)
[2021-07-28 12:48:52.558] [error] Uncaught Error Error: Modal was not registered with the app
    at _getModal (webpack-internal:///./ui/components/modals/index.ts:53:15)
    at Object.showModal (webpack-internal:///./ui/components/modals/index.ts:22:12)
    at showSyncShareModal (webpack-internal:///./ui/components/modals/sync-share-modal.tsx:170:42)
    at HTMLUnknownElement.callCallback (webpack-internal:///../node_modules/@hot-loader/react-dom/cjs/react-dom.development.js:189:14)
    at Object.invokeGuardedCallbackDev (webpack-internal:///../node_modules/@hot-loader/react-dom/cjs/react-dom.development.js:238:16)
    at invokeGuardedCallback (webpack-internal:///../node_modules/@hot-loader/react-dom/cjs/react-dom.development.js:293:31)
    at invokeGuardedCallbackAndCatchFirstError (webpack-internal:///../node_modules/@hot-loader/react-dom/cjs/react-dom.development.js:307:25)
    at executeDispatch (webpack-internal:///../node_modules/@hot-loader/react-dom/cjs/react-dom.development.js:390:3)
    at executeDispatchesInOrder (webpack-internal:///../node_modules/@hot-loader/react-dom/cjs/react-dom.development.js:415:5)
    at executeDispatchesAndRelease (webpack-internal:///../node_modules/@hot-loader/react-dom/cjs/react-dom.development.js:3279:5)
 ```