### PR TITLE
adds 'brace-style' and 'keyword-spacing' lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,6 +56,7 @@ module.exports = {
   ],
   rules: {
     'array-bracket-spacing': 'error',
+    'brace-style': 'off', // successor('@typescript-eslint/brace-style')
     'camelcase': ['error', { allow: ['__export_format', '__export_date', '__export_source'] }],
     'comma-dangle': ['error', 'always-multiline'],
     'comma-spacing': 'error',
@@ -63,6 +64,7 @@ module.exports = {
     'default-case-last': 'error',
     'filenames/match-exported': ['error', 'kebab'],
     'indent': ['error', 2, { SwitchCase: 1 }],
+    'keyword-spacing': 'off', // successor('@typescript-eslint/keyword-spacing')
     'no-async-promise-executor': 'off',
     'no-case-declarations': 'off',
     'no-duplicate-imports': 'off',
@@ -99,8 +101,10 @@ module.exports = {
 
     '@typescript-eslint/array-type': ['error', { default: 'array', readonly: 'array' }],
     '@typescript-eslint/ban-types': 'off',
+    '@typescript-eslint/brace-style': ['error', '1tbs', { 'allowSingleLine': true }],
     '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/keyword-spacing': 'error',
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-namespace': ['error', { allowDeclarations: true }],
     '@typescript-eslint/no-redeclare': 'error',


### PR DESCRIPTION
I noticed the following lines in a PR (https://github.com/Kong/insomnia/pull/3843/files#diff-7c2e8703c3df6a6a2f9181cec27e260e332011da55fd1dc54115428bcdf6ee1dR46-R47)

```ts
}
else{
```

It should be:
```ts
} else {
```

And these two rules fix exactly that.  I'm happy to report that upon running `npm run lint:fix` there are no existing violations of this rule (at this moment).  sweet!