### PR TITLE
use optional chaining

### DIFF
--- a/packages/insomnia-app/app/common/import.ts
+++ b/packages/insomnia-app/app/common/import.ts
@@ -185,7 +185,7 @@ export async function importRaw(
     for (const key of Object.keys(generatedIds)) {
       const { parentId, _id } = resource;
 
-      if (parentId && parentId.includes(key)) {
+      if (parentId?.includes(key)) {
         resource.parentId = parentId.replace(key, await fnOrString(generatedIds[key]));
       }
 

--- a/packages/insomnia-app/app/common/render.ts
+++ b/packages/insomnia-app/app/common/render.ts
@@ -543,7 +543,7 @@ export async function getRenderedRequestAndContext(
  * @returns {number}
  */
 function _nunjucksSortValue(v) {
-  return v && v.match && v.match(/({{|{%)/) ? 2 : 1;
+  return v?.match?.(/({{|{%)/) ? 2 : 1;
 }
 
 function _getOrderedEnvironmentKeys(finalRenderContext: Record<string, any>): string[] {

--- a/packages/insomnia-app/app/network/o-auth-2/misc.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/misc.ts
@@ -43,7 +43,7 @@ export function responseToObject(body, keys, defaults = {}) {
   for (const key of keys) {
     if (data[key] !== undefined) {
       results[key] = data[key];
-    } else if (defaults && defaults.hasOwnProperty(key)) {
+    } else if (defaults?.hasOwnProperty(key)) {
       results[key] = defaults[key];
     } else {
       results[key] = null;

--- a/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
+++ b/packages/insomnia-app/app/ui/components/base/debounced-input.tsx
@@ -34,12 +34,12 @@ class DebouncedInput extends PureComponent<Props> {
 
   _handleFocus(e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>) {
     this._hasFocus = true;
-    this.props.onFocus && this.props.onFocus(e);
+    this.props.onFocus?.(e);
   }
 
   _handleBlur(e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement>) {
     this._hasFocus = false;
-    this.props.onBlur && this.props.onBlur(e);
+    this.props.onBlur?.(e);
   }
 
   _setRef(n: HTMLTextAreaElement | HTMLInputElement) {

--- a/packages/insomnia-app/app/ui/components/base/dropdown/dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/base/dropdown/dropdown.tsx
@@ -68,7 +68,7 @@ class Dropdown extends PureComponent<DropdownProps, State> {
       const button = this._dropdownList?.querySelector(selector);
 
       // @ts-expect-error -- TSCONVERSION
-      button && button.click();
+      button?.click();
     }
   }
 
@@ -288,13 +288,13 @@ class Dropdown extends PureComponent<DropdownProps, State> {
     if (this._node) {
       const button = this._node.querySelector('button');
 
-      button && button.focus();
+      button?.focus();
     }
 
     this.setState({
       open: false,
     });
-    this.props.onHide && this.props.onHide();
+    this.props.onHide?.();
   }
 
   show(filterVisible = false, forcedPosition: { x: number; y: number } | null = null) {
@@ -314,7 +314,7 @@ class Dropdown extends PureComponent<DropdownProps, State> {
       filterActiveIndex: -1,
       uniquenessKey: this.state.uniquenessKey + 1,
     });
-    this.props.onOpen && this.props.onOpen();
+    this.props.onOpen?.();
   }
 
   toggle(filterVisible = false) {

--- a/packages/insomnia-app/app/ui/components/base/editable.tsx
+++ b/packages/insomnia-app/app/ui/components/base/editable.tsx
@@ -58,8 +58,8 @@ class Editable extends PureComponent<Props, State> {
       editing: true,
     });
     setTimeout(() => {
-      this._input && this._input.focus();
-      this._input && this._input.select();
+      this._input?.focus();
+      this._input?.select();
     });
 
     if (this.props.onEditStart) {

--- a/packages/insomnia-app/app/ui/components/base/file-input-button.tsx
+++ b/packages/insomnia-app/app/ui/components/base/file-input-button.tsx
@@ -20,11 +20,11 @@ class FileInputButton extends PureComponent<Props> {
   _button: HTMLButtonElement | null = null;
 
   focus() {
-    this._button && this._button.focus();
+    this._button?.focus();
   }
 
   focusEnd() {
-    this._button && this._button.focus();
+    this._button?.focus();
   }
 
   _setRef(n: HTMLButtonElement) {

--- a/packages/insomnia-app/app/ui/components/base/link.tsx
+++ b/packages/insomnia-app/app/ui/components/base/link.tsx
@@ -19,10 +19,10 @@ interface Props {
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class Link extends PureComponent<Props> {
   _handleClick(e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) {
-    e && e.preventDefault();
+    e?.preventDefault();
     const { href, onClick } = this.props;
     // Also call onClick that was passed to us if there was one
-    onClick && onClick(e);
+    onClick?.(e);
     clickLink(href);
   }
 

--- a/packages/insomnia-app/app/ui/components/base/modal.tsx
+++ b/packages/insomnia-app/app/ui/components/base/modal.tsx
@@ -48,7 +48,7 @@ class Modal extends PureComponent<ModalProps, State> {
       return;
     }
 
-    this.props.onKeyDown && this.props.onKeyDown(e);
+    this.props.onKeyDown?.(e);
 
     // Don't check for close keys if we don't want them
     if (this.props.noEscape) {
@@ -63,7 +63,7 @@ class Modal extends PureComponent<ModalProps, State> {
     if (pressedEscape || pressedCloseButton) {
       e.preventDefault();
       this.hide();
-      this.props.onCancel && this.props.onCancel();
+      this.props.onCancel?.();
     }
   }
 
@@ -90,7 +90,7 @@ class Modal extends PureComponent<ModalProps, State> {
 
     if (shouldHide) {
       this.hide();
-      this.props.onCancel && this.props.onCancel();
+      this.props.onCancel?.();
     }
   }
 
@@ -116,7 +116,7 @@ class Modal extends PureComponent<ModalProps, State> {
 
     // Allow instance-based onHide method
     this.onHide = options?.onHide ?? null;
-    setTimeout(() => this._node && this._node.focus());
+    setTimeout(() => this._node?.focus());
   }
 
   toggle() {
@@ -135,8 +135,8 @@ class Modal extends PureComponent<ModalProps, State> {
     this.setState({
       open: false,
     });
-    this.props.onHide && this.props.onHide();
-    this.onHide && this.onHide();
+    this.props.onHide?.();
+    this.onHide?.();
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia-app/app/ui/components/codemirror/extensions/nunjucks-tags.ts
@@ -57,7 +57,7 @@ async function _highlightNunjucksTags(render, renderContext, isVariableUncovered
 
   for (let lineNo = vp.from; lineNo < vp.to; lineNo++) {
     const line = this.getLineTokens(lineNo);
-    const tokens = line.filter(({ type }) => type && type.indexOf('nunjucks') >= 0);
+    const tokens = line.filter(({ type }) => type?.indexOf('nunjucks') >= 0);
 
     // Aggregate same tokens
     const newTokens: Token[] = [];

--- a/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/environments-dropdown.tsx
@@ -65,7 +65,7 @@ class EnvironmentsDropdown extends PureComponent<Props> {
 
   _handleKeydown(e: KeyboardEvent) {
     executeHotKey(e, hotKeyRefs.ENVIRONMENT_SHOW_SWITCH_MENU, () => {
-      this._dropdown && this._dropdown.toggle(true);
+      this._dropdown?.toggle(true);
     });
   }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -186,7 +186,7 @@ class GitSyncDropdown extends PureComponent<Props, State> {
       await vcs.push(gitRepository.credentials, force);
     } catch (err) {
       if (err.code === 'PushRejectedError') {
-        this._dropdown && this._dropdown.hide();
+        this._dropdown?.hide();
         showAlert({
           title: 'Push Rejected',
           message: 'Do you want to force push?',

--- a/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -87,7 +87,7 @@ export class UnconnectedRequestGroupActionsDropdown extends PureComponent<Props,
   }
 
   async show() {
-    this._dropdown && this._dropdown.show();
+    this._dropdown?.show();
   }
 
   async _handlePluginClick(p: RequestGroupAction) {
@@ -120,7 +120,7 @@ export class UnconnectedRequestGroupActionsDropdown extends PureComponent<Props,
     this.setState(state => ({
       loadingActions: { ...state.loadingActions, [p.label]: false },
     }));
-    this._dropdown && this._dropdown.hide();
+    this._dropdown?.hide();
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
@@ -51,7 +51,7 @@ class ResponseHistoryDropdown extends PureComponent<Props> {
 
   _handleKeydown(e: KeyboardEvent) {
     executeHotKey(e, hotKeyRefs.REQUEST_TOGGLE_HISTORY, () => {
-      this._dropdown && this._dropdown.toggle(true);
+      this._dropdown?.toggle(true);
     });
   }
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
@@ -91,7 +91,7 @@ class WorkspaceDropdown extends PureComponent<Props, State> {
     this.setState(state => ({
       loadingActions: { ...state.loadingActions, [p.label]: false },
     }));
-    this._dropdown && this._dropdown.hide();
+    this._dropdown?.hide();
   }
 
   async _handleDropdownOpen() {
@@ -117,7 +117,7 @@ class WorkspaceDropdown extends PureComponent<Props, State> {
 
   _handleKeydown(e: KeyboardEvent) {
     executeHotKey(e, hotKeyRefs.TOGGLE_MAIN_MENU, () => {
-      this._dropdown && this._dropdown.toggle(true);
+      this._dropdown?.toggle(true);
     });
   }
 

--- a/packages/insomnia-app/app/ui/components/key-value-editor/editor.tsx
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/editor.tsx
@@ -259,7 +259,7 @@ class Editor extends PureComponent<Props, State> {
 
     this._onChange(pairs);
 
-    this.props.onCreate && this.props.onCreate();
+    this.props.onCreate?.();
   }
 
   _deletePair(position, breakFocus = false) {
@@ -270,7 +270,7 @@ class Editor extends PureComponent<Props, State> {
     const focusedPosition = this._getFocusedPairIndex();
 
     const pair = this.state.pairs[position];
-    this.props.onDelete && this.props.onDelete(pair);
+    this.props.onDelete?.(pair);
     const pairs = [...this.state.pairs.slice(0, position), ...this.state.pairs.slice(position + 1)];
 
     if (focusedPosition >= position) {

--- a/packages/insomnia-app/app/ui/components/key-value-editor/row.tsx
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/row.tsx
@@ -109,7 +109,7 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
 
   _sendChange(patch) {
     const pair = Object.assign({}, this.props.pair, patch);
-    this.props.onChange && this.props.onChange(pair);
+    this.props.onChange?.(pair);
   }
 
   _handleNameChange(name) {
@@ -125,7 +125,7 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
 
     const value = e.clipboardData.getData('text/plain');
 
-    if (value && value.includes('\n')) {
+    if (value?.includes('\n')) {
       e.preventDefault();
 
       // Insert the pasted text into the current selection.

--- a/packages/insomnia-app/app/ui/components/keydown-binder.ts
+++ b/packages/insomnia-app/app/ui/components/keydown-binder.ts
@@ -54,8 +54,8 @@ class KeydownBinder extends PureComponent<Props> {
   componentDidMount() {
     if (this.props.scoped) {
       const el = ReactDOM.findDOMNode(this);
-      el && el.addEventListener('keydown', this._handleKeydown);
-      el && el.addEventListener('keyup', this._handleKeyup);
+      el?.addEventListener('keydown', this._handleKeydown);
+      el?.addEventListener('keyup', this._handleKeyup);
     } else {
       document.body && document.body.addEventListener('keydown', this._handleKeydown);
       document.body && document.body.addEventListener('keyup', this._handleKeyup);
@@ -65,8 +65,8 @@ class KeydownBinder extends PureComponent<Props> {
   componentWillUnmount() {
     if (this.props.scoped) {
       const el = ReactDOM.findDOMNode(this);
-      el && el.removeEventListener('keydown', this._handleKeydown);
-      el && el.removeEventListener('keyup', this._handleKeyup);
+      el?.removeEventListener('keydown', this._handleKeydown);
+      el?.removeEventListener('keyup', this._handleKeyup);
     } else {
       document.body && document.body.removeEventListener('keydown', this._handleKeydown);
       document.body && document.body.removeEventListener('keyup', this._handleKeyup);

--- a/packages/insomnia-app/app/ui/components/markdown-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/markdown-editor.tsx
@@ -54,11 +54,11 @@ class MarkdownEditor extends PureComponent<Props, State> {
   }
 
   focusEnd() {
-    this._editor && this._editor.focusEnd();
+    this._editor?.focusEnd();
   }
 
   focus() {
-    this._editor && this._editor.focus();
+    this._editor?.focus();
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/modals/add-key-combination-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/add-key-combination-modal.tsx
@@ -101,11 +101,11 @@ class AddKeyCombinationModal extends PureComponent<{}, State> {
       onAddKeyCombination: onAddKeyCombination,
       pressedKeyCombination: null,
     });
-    this._modal && this._modal.show();
+    this._modal?.show();
   }
 
   hide() {
-    this._modal && this._modal.hide();
+    this._modal?.hide();
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/modals/alert-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/alert-modal.tsx
@@ -66,10 +66,10 @@ class AlertModal extends PureComponent<{}, State> {
       addCancel,
       okLabel,
     });
-    this.modal && this.modal.show();
+    this.modal?.show();
     // Need to do this after render because modal focuses itself too
     setTimeout(() => {
-      this._cancel && this._cancel.focus();
+      this._cancel?.focus();
     }, 100);
     this._okCallback2 = onConfirm;
     return new Promise<void>(resolve => {

--- a/packages/insomnia-app/app/ui/components/modals/ask-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/ask-modal.tsx
@@ -83,7 +83,7 @@ class AskModal extends PureComponent<{}, State> {
     this.modal?.show();
 
     setTimeout(() => {
-      this.yesButton && this.yesButton.focus();
+      this.yesButton?.focus();
     }, 100);
 
     return new Promise<boolean>(resolve => {

--- a/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.tsx
@@ -59,11 +59,11 @@ class CookieModifyModal extends PureComponent<Props, State> {
     this.setState({
       cookie,
     });
-    this.modal && this.modal.show();
+    this.modal?.show();
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   static async _saveChanges(cookieJar: CookieJar) {

--- a/packages/insomnia-app/app/ui/components/modals/cookies-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/cookies-modal.tsx
@@ -142,15 +142,15 @@ class CookiesModal extends PureComponent<Props, State> {
 
   async show() {
     setTimeout(() => {
-      this.filterInput && this.filterInput.focus();
+      this.filterInput?.focus();
     }, 100);
     // make sure the filter is up to date
     await this._applyFilter(this.state.filter, this.props.cookieJar.cookies);
-    this.modal && this.modal.show();
+    this.modal?.show();
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
@@ -85,7 +85,7 @@ class GenerateConfigModal extends PureComponent<Props, State> {
       configs,
       activeTab: foundIndex < 0 ? 0 : foundIndex,
     });
-    this.modal && this.modal.show();
+    this.modal?.show();
   }
 
   renderConfigTabPanel(config: Config) {

--- a/packages/insomnia-app/app/ui/components/modals/git-branches-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/git-branches-modal.tsx
@@ -59,10 +59,10 @@ class GitBranchesModal extends PureComponent<Props, State> {
       newBranchName: '',
     });
     this._onHide = options.onHide || null;
-    this.modal && this.modal.show();
+    this.modal?.show();
     // Focus input when modal shows
     setTimeout(() => {
-      this.input && this.input.focus();
+      this.input?.focus();
     }, 100);
     // Do a fetch of remotes and refresh again. NOTE: we're doing this
     // last because it's super slow
@@ -163,7 +163,7 @@ class GitBranchesModal extends PureComponent<Props, State> {
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/modals/git-log-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/git-log-modal.tsx
@@ -40,11 +40,11 @@ class GitLogModal extends PureComponent<Props, State> {
       logs,
       branch,
     });
-    this.modal && this.modal.show();
+    this.modal?.show();
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   renderLogEntryRow(entry: GitLogEntry) {

--- a/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/git-repository-settings-modal.tsx
@@ -116,14 +116,14 @@ class GitRepositorySettingsModal extends PureComponent<{}, State> {
       gitRepository,
       inputs,
     });
-    this.modal && this.modal.show();
+    this.modal?.show();
     setTimeout(() => {
-      this.input && this.input.focus();
+      this.input?.focus();
     }, 100);
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/modals/git-staging-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/git-staging-modal.tsx
@@ -96,7 +96,7 @@ class GitStagingModal extends PureComponent<Props, State> {
     }
 
     await vcs.commit(message);
-    this.modal && this.modal.hide();
+    this.modal?.hide();
 
     if (typeof this.onCommit === 'function') {
       this.onCommit();
@@ -104,7 +104,7 @@ class GitStagingModal extends PureComponent<Props, State> {
   }
 
   _hideModal() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   async _toggleAll(items: Item[], forceAdd = false) {
@@ -166,11 +166,11 @@ class GitStagingModal extends PureComponent<Props, State> {
 
   async show(options: { onCommit?: () => void }) {
     this.onCommit = options.onCommit || null;
-    this.modal && this.modal.show();
+    this.modal?.show();
     // Reset state
     this.setState(INITIAL_STATE);
     await this._refresh(() => {
-      this.textarea && this.textarea.focus();
+      this.textarea?.focus();
     });
   }
 

--- a/packages/insomnia-app/app/ui/components/modals/index.ts
+++ b/packages/insomnia-app/app/ui/components/modals/index.ts
@@ -38,7 +38,7 @@ export function showError(config: ErrorModalOptions) {
 export function hideAllModals() {
   for (const key of Object.keys(modals)) {
     const modal = modals[key];
-    modal.hide && modal.hide();
+    modal.hide?.();
   }
 }
 

--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.tsx
@@ -103,7 +103,7 @@ class PromptModal extends PureComponent<{}, State> {
 
   _handleDeleteHint(hint: string) {
     const { onDeleteHint } = this.state;
-    onDeleteHint && onDeleteHint(hint);
+    onDeleteHint?.(hint);
     const hints = this.state.hints.filter(h => h !== hint);
     this.setState({
       hints,
@@ -143,7 +143,7 @@ class PromptModal extends PureComponent<{}, State> {
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   show({
@@ -182,7 +182,7 @@ class PromptModal extends PureComponent<{}, State> {
       hints: hints || [],
       loading: false,
     });
-    this.modal && this.modal.show();
+    this.modal?.show();
 
     // Need to do this after render because modal focuses itself too
     setTimeout(() => {
@@ -198,7 +198,7 @@ class PromptModal extends PureComponent<{}, State> {
 
       this._input.focus();
 
-      selectText && this._input && this._input.select();
+      selectText && this._input?.select();
     }, 100);
   }
 

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.tsx
@@ -60,7 +60,7 @@ class ProtoFilesModal extends PureComponent<Props, State> {
     this.setState({
       selectedProtoFileId: options.preselectProtoFileId || '',
     });
-    this.modal && this.modal.show();
+    this.modal?.show();
   }
 
   async _handleSave(e: React.SyntheticEvent<HTMLButtonElement>) {
@@ -73,7 +73,7 @@ class ProtoFilesModal extends PureComponent<Props, State> {
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   _handleSelect(id: string) {

--- a/packages/insomnia-app/app/ui/components/modals/request-group-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-group-settings-modal.tsx
@@ -182,11 +182,11 @@ class RequestGroupSettingsModal extends React.PureComponent<Props, State> {
         defaultPreviewMode: hasDescription && !forceEditMode,
       },
       () => {
-        this.modal && this.modal.show();
+        this.modal?.show();
 
         if (forceEditMode) {
           setTimeout(() => {
-            this._editor && this._editor.focus();
+            this._editor?.focus();
           }, 400);
         }
       },
@@ -194,7 +194,7 @@ class RequestGroupSettingsModal extends React.PureComponent<Props, State> {
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   _renderDescription() {

--- a/packages/insomnia-app/app/ui/components/modals/request-render-error-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-render-error-modal.tsx
@@ -50,7 +50,7 @@ class RequestRenderErrorModal extends PureComponent<{}, State> {
     const result = jq.query(request, `$.${error.path}`);
     const template = result && result.length ? result[0] : null;
     const locationLabel =
-      template && template.includes('\n') ? `line ${error.location.line} of` : null;
+      template?.includes('\n') ? `line ${error.location.line} of` : null;
     return (
       <div className="pad">
         <div className="notice warning">

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
@@ -217,11 +217,11 @@ class RequestSettingsModal extends PureComponent<Props, State> {
         defaultPreviewMode: hasDescription && !forceEditMode,
       },
       () => {
-        this.modal && this.modal.show();
+        this.modal?.show();
 
         if (forceEditMode) {
           setTimeout(() => {
-            this._editor && this._editor.focus();
+            this._editor?.focus();
           }, 400);
         }
       },
@@ -229,7 +229,7 @@ class RequestSettingsModal extends PureComponent<Props, State> {
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   renderCheckboxInput(setting: string) {
@@ -309,7 +309,7 @@ class RequestSettingsModal extends PureComponent<Props, State> {
             Follow redirects <span className="txt-sm faint italic">(overrides global setting)</span>
             <select
               // @ts-expect-error -- TSCONVERSION this setting only exists for a Request not GrpcRequest
-              defaultValue={this.state.request && this.state.request.settingFollowRedirects}
+              defaultValue={this.state.request?.settingFollowRedirects}
               name="settingFollowRedirects"
               onChange={this._updateRequestSettingString}>
               <option value={'global'}>Use global setting</option>

--- a/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.tsx
@@ -176,7 +176,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
   async _activateWorkspace(workspace: Workspace) {
     await this.props.handleActivateWorkspace(workspace);
 
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   _activateRequest(request: Request) {
@@ -185,7 +185,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
     }
 
     this.props.activateRequest(request._id);
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   _handleChange(e: React.SyntheticEvent<HTMLInputElement>) {
@@ -312,7 +312,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
     } = {},
   ) {
     // Don't show if we're already showing
-    if (this.modal && this.modal.isOpen()) {
+    if (this.modal?.isOpen()) {
       return;
     }
 
@@ -342,19 +342,19 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
       // Change value after because it accesses state properties
       this._handleChangeValue('');
     });
-    this.modal && this.modal.show();
-    setTimeout(() => this._input && this._input.focus(), 100);
+    this.modal?.show();
+    setTimeout(() => this._input?.focus(), 100);
   }
 
   hide() {
     if (this._openTimeout !== null) {
       clearTimeout(this._openTimeout);
     }
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   toggle() {
-    if (this.modal && this.modal.isOpen()) {
+    if (this.modal?.isOpen()) {
       this.hide();
     } else {
       this.show();
@@ -387,7 +387,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
     // the user unpresses the hotkey that triggered this modal but we currently do not
     // have the facilities to do that.
     const isMetaKeyDown = e.ctrlKey || e.shiftKey || e.metaKey || e.altKey;
-    const isActive = this.modal && this.modal.isOpen();
+    const isActive = this.modal?.isOpen();
 
     if (selectOnKeyup && isActive && !isMetaKeyDown) {
       await this._activateCurrentIndex();

--- a/packages/insomnia-app/app/ui/components/modals/response-debug-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/response-debug-modal.tsx
@@ -44,7 +44,7 @@ class ResponseDebugModal extends PureComponent<Props, State> {
       response,
       title: options.title || null,
     });
-    this.modal && this.modal.show();
+    this.modal?.show();
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/modals/sync-branches-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/sync-branches-modal.tsx
@@ -164,7 +164,7 @@ class SyncBranchesModal extends PureComponent<Props, State> {
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   async show(options: { onHide: (...args: any[]) => any }) {

--- a/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/sync-delete-modal.tsx
@@ -72,12 +72,12 @@ class SyncDeleteModal extends PureComponent<Props, State> {
     this.setState(INITIAL_STATE);
     // Focus input when modal shows
     setTimeout(() => {
-      this.input && this.input.focus();
+      this.input?.focus();
     }, 100);
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/modals/sync-history-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/sync-history-modal.tsx
@@ -55,11 +55,11 @@ class SyncHistoryModal extends PureComponent<Props, State> {
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   async show(options: { handleRollback: (arg0: Snapshot) => Promise<void> }) {
-    this.modal && this.modal.show();
+    this.modal?.show();
     this.handleRollback = options.handleRollback;
     await this.refreshState();
   }

--- a/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/sync-merge-modal.tsx
@@ -56,7 +56,7 @@ class SyncMergeModal extends PureComponent<Props, State> {
     conflicts: MergeConflict[];
     handleDone: (arg0: MergeConflict[]) => void;
   }) {
-    this.modal && this.modal.show();
+    this.modal?.show();
     this._handleDone = options.handleDone;
     this.setState({
       conflicts: options.conflicts,
@@ -64,7 +64,7 @@ class SyncMergeModal extends PureComponent<Props, State> {
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/modals/sync-staging-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/sync-staging-modal.tsx
@@ -119,7 +119,7 @@ class SyncStagingModal extends PureComponent<Props, State> {
     const success = await this._handleTakeSnapshot();
 
     if (success) {
-      this._handlePush && this._handlePush();
+      this._handlePush?.();
     }
   }
 
@@ -139,7 +139,7 @@ class SyncStagingModal extends PureComponent<Props, State> {
       return false;
     }
 
-    this._onSnapshot && this._onSnapshot();
+    this._onSnapshot?.();
     await this.refreshMainAttributes({
       message: '',
       error: '',
@@ -190,12 +190,12 @@ class SyncStagingModal extends PureComponent<Props, State> {
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   async show(options: { onSnapshot?: () => any; handlePush: () => Promise<void> }) {
     const { vcs, syncItems } = this.props;
-    this.modal && this.modal.show();
+    this.modal?.show();
     // @ts-expect-error -- TSCONVERSION
     this._onSnapshot = options.onSnapshot;
     this._handlePush = options.handlePush;
@@ -217,7 +217,7 @@ class SyncStagingModal extends PureComponent<Props, State> {
 
     const stage = await vcs.stage(status.stage, toStage);
     await this.refreshMainAttributes({}, stage);
-    this.textarea && this.textarea.focus();
+    this.textarea?.focus();
   }
 
   static renderOperation(entry: StageEntry, type: string, changes: string[]) {

--- a/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -179,7 +179,7 @@ class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> {
     }
 
     await this._load(workspace);
-    this.modal && this.modal.show();
+    this.modal?.show();
   }
 
   async _load(workspace: Workspace | null, environmentToSelect: Environment | null = null) {

--- a/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
@@ -195,11 +195,11 @@ class WorkspaceSettingsModal extends PureComponent<Props, State> {
       defaultPreviewMode: hasDescription,
       showAddCertificateForm: false,
     });
-    this.modal && this.modal.show();
+    this.modal?.show();
   }
 
   hide() {
-    this.modal && this.modal.hide();
+    this.modal?.hide();
   }
 
   renderModalHeader() {

--- a/packages/insomnia-app/app/ui/components/modals/wrapper-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/wrapper-modal.tsx
@@ -42,7 +42,7 @@ class WrapperModal extends PureComponent<{}, State> {
       skinny: !!skinny,
       wide: !!wide,
     });
-    this.modal && this.modal.show();
+    this.modal?.show();
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/page-layout.tsx
+++ b/packages/insomnia-app/app/ui/components/page-layout.tsx
@@ -58,7 +58,7 @@ class PageLayout extends PureComponent<Props> {
       workspaces,
     } = wrapperProps;
     const realSidebarWidth = sidebarHidden ? 0 : sidebarWidth;
-    const paneTwo = renderPaneTwo && renderPaneTwo();
+    const paneTwo = renderPaneTwo?.();
     const gridRows = paneTwo
       ? `auto minmax(0, ${paneHeight}fr) 0 minmax(0, ${1 - paneHeight}fr)`
       : 'auto 1fr';

--- a/packages/insomnia-app/app/ui/components/request-url-bar.tsx
+++ b/packages/insomnia-app/app/ui/components/request-url-bar.tsx
@@ -74,7 +74,7 @@ class RequestUrlBar extends PureComponent<Props, State> {
 
   _handleMetaClickSend(e: React.MouseEvent<HTMLButtonElement>) {
     e.preventDefault();
-    this._dropdown && this._dropdown.show();
+    this._dropdown?.show();
   }
 
   _handleFormSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
@@ -149,14 +149,14 @@ class RequestUrlBar extends PureComponent<Props, State> {
     }
 
     executeHotKey(e, hotKeyRefs.REQUEST_FOCUS_URL, () => {
-      this._input && this._input.focus();
-      this._input && this._input.selectAll();
+      this._input?.focus();
+      this._input?.selectAll();
     });
     executeHotKey(e, hotKeyRefs.REQUEST_TOGGLE_HTTP_METHOD_MENU, () => {
-      this._methodDropdown && this._methodDropdown.toggle();
+      this._methodDropdown?.toggle();
     });
     executeHotKey(e, hotKeyRefs.REQUEST_SHOW_OPTIONS, () => {
-      this._dropdown && this._dropdown.toggle(true);
+      this._dropdown?.toggle(true);
     });
   }
 

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-filter.tsx
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-filter.tsx
@@ -57,7 +57,7 @@ class SidebarFilter extends PureComponent<Props> {
 
   _handleKeydown(e: KeyboardEvent) {
     executeHotKey(e, hotKeyRefs.SIDEBAR_FOCUS_FILTER, () => {
-      this._input && this._input.focus();
+      this._input?.focus();
     });
   }
 

--- a/packages/insomnia-app/app/ui/components/sync-pull-button.tsx
+++ b/packages/insomnia-app/app/ui/components/sync-pull-button.tsx
@@ -63,7 +63,7 @@ class SyncPullButton extends PureComponent<Props, State> {
     }, 400);
 
     if (!failed) {
-      onPull && onPull();
+      onPull?.();
     }
   }
 

--- a/packages/insomnia-app/app/ui/components/templating/tag-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/templating/tag-editor.tsx
@@ -261,7 +261,7 @@ class TagEditor extends PureComponent<Props, State> {
     let argIndex = -1;
 
     if (parent instanceof HTMLElement) {
-      const index = parent && parent.getAttribute('data-arg-index');
+      const index = parent?.getAttribute('data-arg-index');
       argIndex = typeof index === 'string' ? parseInt(index, 10) : -1;
     }
 

--- a/packages/insomnia-app/app/ui/components/viewers/response-error.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-error.tsx
@@ -14,13 +14,13 @@ class ResponseError extends PureComponent<Props> {
     const { error, fontSize } = this.props;
     let msg: React.ReactNode = null;
 
-    if (error && error.toLowerCase().indexOf('certificate') !== -1) {
+    if (error?.toLowerCase().indexOf('certificate') !== -1) {
       msg = (
         <button className="btn btn--clicky" onClick={() => showModal(SettingsModal)}>
           Disable SSL Validation
         </button>
       );
-    } else if (error && error.toLowerCase().indexOf('getaddrinfo') !== -1) {
+    } else if (error?.toLowerCase().indexOf('getaddrinfo') !== -1) {
       msg = (
         <button className="btn btn--clicky" onClick={() => showModal(SettingsModal)}>
           Setup Network Proxy

--- a/packages/insomnia-app/app/ui/components/wrapper.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper.tsx
@@ -345,7 +345,7 @@ class Wrapper extends PureComponent<WrapperProps, State> {
     }
 
     // Also unset active response it's the one we're deleting
-    if (this.props.activeResponse && this.props.activeResponse._id === response._id) {
+    if (this.props.activeResponse?._id === response._id) {
       this._handleSetActiveResponse(null);
     }
   }

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -630,7 +630,7 @@ class App extends PureComponent<AppProps, State> {
     });
     // Give it time to update and re-render
     setTimeout(() => {
-      this._wrapper && this._wrapper._forceRequestPaneRefresh();
+      this._wrapper?._forceRequestPaneRefresh();
     }, 300);
   }
 

--- a/packages/insomnia-components/src/dropdown/dropdown.tsx
+++ b/packages/insomnia-components/src/dropdown/dropdown.tsx
@@ -432,13 +432,13 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
     if (this._node) {
       const button = this._node.querySelector('button');
 
-      button && button.focus();
+      button?.focus();
     }
 
     this.setState({
       open: false,
     });
-    this.props.onHide && this.props.onHide();
+    this.props.onHide?.();
   }
 
   show(filterVisible = false, forcedPosition = null) {
@@ -457,7 +457,7 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
       filterActiveIndex: -1,
       uniquenessKey: this.state.uniquenessKey + 1,
     });
-    this.props.onOpen && this.props.onOpen();
+    this.props.onOpen?.();
   }
 
   toggle(filterVisible = false) {

--- a/packages/insomnia-smoke-test/modules/application.ts
+++ b/packages/insomnia-smoke-test/modules/application.ts
@@ -93,7 +93,7 @@ const launch = async config => {
 export const stop = async app => {
   await takeScreenshotOnFailure(app);
 
-  if (app && app.isRunning()) {
+  if (app?.isRunning()) {
     await app.stop();
   }
 };


### PR DESCRIPTION
I'm tired of fixing these all the time manually when I see them.  They're so formulaic that it feels fine to just do them all at once in a scope-constrained PR like this.

Normally I rely on a lint rule that autofixes this, but that rule requires the types to actually be pretty dang correct (or else you get runtime errors by not having the optional chain where you actually, it turns out in the end, really need it).

I just `grep`ed around for the most obvious use-cases and fixed the ones I found.