### PR TITLE
Add segment metrics for plugin data context

### DIFF
--- a/packages/insomnia-app/app/plugins/context/data.ts
+++ b/packages/insomnia-app/app/plugins/context/data.ts
@@ -1,3 +1,4 @@
+import { trackSegmentEvent } from '../../common/analytics';
 import { exportWorkspacesData, exportWorkspacesHAR } from '../../common/export';
 import type { ImportRawConfig } from '../../common/import';
 import { importRaw, importUri } from '../../common/import';
@@ -26,11 +27,15 @@ const buildImportRawConfig = (options: PluginImportOptions, activeSpaceId: strin
   getSpaceId: () => Promise.resolve(activeSpaceId),
 });
 
-// TODO: add metrics here to track how frequently this fallback is being used
-const getWorkspaces = (activeSpaceId?: string) =>
-  activeSpaceId
-    ? models.workspace.findByParentId(activeSpaceId)
-    : models.workspace.all();
+const getWorkspaces = (activeSpaceId?: string) => {
+  if (activeSpaceId) {
+    trackSegmentEvent('Plugin export loading workspaces for active space');
+    return models.workspace.findByParentId(activeSpaceId);
+  } else {
+    trackSegmentEvent('Plugin export loading all workspace');
+    return models.workspace.all();
+  }
+};
 
 // Only in the case of running unit tests from Inso via send-request can activeSpaceId be undefined. This is because the concept of a space doesn't exist in git/insomnia sync or an export file
 export const init = (activeSpaceId?: string) => ({


### PR DESCRIPTION
This is an initial attempt. When looking at other places segment is used, it seems like the even is a plain string, but please advise if the event should be something else.

We had to set up this fallback for the plugin API to avoid introducing a breaking change, but we should try to track how often this code-path is hit.