### PR TITLE
adds operator spacing rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,8 @@ module.exports = {
     'quotes': 'off',
     'semi': ['error', 'always'],
     'space-before-function-paren': ['error', { anonymous: 'never', named: 'never', asyncArrow: 'always' }],
+    'space-infix-ops': 'off', // successor('@typescript-eslint/space-infix-ops')
+    'space-unary-ops': 'error',
     'space-in-parens': 'error',
     'spaced-comment': ['error', 'always', {
       exceptions: ['/', '*', '-', '* '], // for ASCII art :)
@@ -129,6 +131,7 @@ module.exports = {
     '@typescript-eslint/no-redeclare': 'error',
     '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
     '@typescript-eslint/no-use-before-define': 'error',
+    '@typescript-eslint/space-infix-ops': 'error',
     '@typescript-eslint/quotes': ['error', 'single', { avoidEscape: true }],
 
     'simple-import-sort/imports': 'error',


### PR DESCRIPTION
I noticed the following line in a recent PR

```ts
const segmentEvent = design ? SegmentEvent.documentCreate: SegmentEvent.collectionCreate;
```

This PR would (autofix) the following:
```diff
- const segmentEvent = design ? SegmentEvent.documentCreate: SegmentEvent.collectionCreate;
+ const segmentEvent = design ? SegmentEvent.documentCreate : SegmentEvent.collectionCreate;
```

I ran `lint:fix` and there are presently no violations to these two rules in the project.

until the next eslint PR!
![](https://media1.giphy.com/media/RfEbMBTPQ7MOY/giphy.gif)