### PR TITLE
Fix markdown-preview styling regression

### DIFF
--- a/packages/insomnia-app/app/ui/components/markdown-preview.tsx
+++ b/packages/insomnia-app/app/ui/components/markdown-preview.tsx
@@ -120,9 +120,9 @@ class MarkdownPreview extends PureComponent<Props, State> {
     return (
       <div ref={this._setPreviewRef} className={classnames('markdown-preview', className)}>
         {renderError && <p className="notice error no-margin">Failed to render: {renderError}</p>}
-        <div className="markdown-preview__content selectable">
-          {heading ? <h1>{heading}</h1> : null}
-          <div dangerouslySetInnerHTML={{ __html: compiled }} />
+        <div className="selectable">
+          {heading ? <h1 className="markdown-preview__content-title">{heading}</h1> : null}
+          <div className="markdown-preview__content" dangerouslySetInnerHTML={{ __html: compiled }} />
         </div>
       </div>
     );

--- a/packages/insomnia-app/app/ui/css/components/markdown-preview.less
+++ b/packages/insomnia-app/app/ui/css/components/markdown-preview.less
@@ -1,6 +1,16 @@
 // .markdown-preview {
 // }
 
+.markdown-preview__content-title {
+  font-size: var(--font-size-xxl);
+  border-bottom: 1px solid var(--hl-sm);
+  font-weight: bold;
+  max-width: 50rem;
+  line-height: 1.7em;
+  margin: 0 0 var(--padding-md) 0;
+  padding: 0;
+}
+
 .markdown-preview__content {
   margin-right: auto;
 


### PR DESCRIPTION
After upgrading the markdown-preview title we moved the compiled html into another element.
This changed how the styles get applied to the compiled html since the `markdown-preview__content` className
is not in the parent element anymore.

This solution introduces a new className `markdown-preview__content-title` which applies the same styles to the title so that it appears exactly the same as before.
I also moved the `markdown-preview__content` className to the compiled html's parent element for the styles to be applied correctly.

## Regression:

![regression_840](https://user-images.githubusercontent.com/12115431/129240632-9a44d59d-355c-4044-9bfd-99d7f9f83dc5.gif)


## Demo:

![fix_840](https://user-images.githubusercontent.com/12115431/129240658-578f78d9-d1e8-4e89-a0fa-f32d4a546c96.gif)

Closes INS-840