### PR TITLE
add vscode debug configuration for insomnia-app

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,66 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch: Electron",
+      "type": "node",
+      "request": "launch",
+      "protocol": "inspector",
+      "sourceMaps": true,
+      "presentation": {
+        "hidden": false,
+        "group": "Insomnia",
+        "order": 1
+      },
+      "cwd": "${workspaceFolder}/packages/insomnia-app",
+      "runtimeExecutable": "${workspaceFolder}/packages/insomnia-app/node_modules/.bin/electron",
+      "runtimeArgs": ["--remote-debugging-port=9222", "."],
+      "outputCapture": "std",
+      "sourceMapPathOverrides": {
+        "webpack:///./*": "${workspaceFolder}/packages/insomnia-app/app/*"
+      },
+      "windows": {
+        "type": "node",
+        "request": "launch",
+        "name": "Launch: Electron",
+        "runtimeExecutable": "${workspaceFolder}/packages/insomnia-app/node_modules/.bin/electron.cmd"
+      },
+      "env": {
+        "TS_NODE_PROJECT": "tsconfig.webpack.json",
+        "NODE_ENV": "development",
+        "ELECTRON_IS_DEV": "1"
+      }
+    },
+    {
+      "name": "Attach: Electron Renderer",
+      "type": "chrome",
+      "request": "attach",
+      "presentation": {
+        "hidden": false,
+        "group": "Insomnia",
+        "order": 2
+      },
+      "port": 9222,
+      "sourceMapPathOverrides": {
+        "webpack:///./*": "${workspaceFolder}/packages/insomnia-app/app/*"
+      },
+      "webRoot": "${workspaceFolder}/packages/insomnia-app/app",
+      "timeout": 60000
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Insomnia",
+      "presentation": {
+        "hidden": false,
+        "group": "Insomnia",
+        "order": 0
+      },
+      "preLaunchTask": "Insomnia: Compile",
+      "configurations": [
+        "Launch: Electron",
+        "Attach: Electron Renderer",
+      ],
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,13 +2,13 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Launch: Electron",
+      "name": "Electron: main",
       "type": "node",
       "request": "launch",
       "protocol": "inspector",
       "sourceMaps": true,
       "presentation": {
-        "hidden": false,
+        "hidden": true,
         "group": "Insomnia",
         "order": 1
       },
@@ -22,7 +22,7 @@
       "windows": {
         "type": "node",
         "request": "launch",
-        "name": "Launch: Electron",
+        "name": "Electron: main",
         "runtimeExecutable": "${workspaceFolder}/packages/insomnia-app/node_modules/.bin/electron.cmd"
       },
       "env": {
@@ -32,11 +32,11 @@
       }
     },
     {
-      "name": "Attach: Electron Renderer",
-      "type": "chrome",
+      "name": "Electron: renderer",
+      "type": "pwa-chrome",
       "request": "attach",
       "presentation": {
-        "hidden": false,
+        "hidden": true,
         "group": "Insomnia",
         "order": 2
       },
@@ -56,10 +56,10 @@
         "group": "Insomnia",
         "order": 0
       },
-      "preLaunchTask": "Insomnia: Compile",
+      "preLaunchTask": "Insomnia: Compile (Watch)",
       "configurations": [
-        "Launch: Electron",
-        "Attach: Electron Renderer",
+        "Electron: main",
+        "Electron: renderer",
       ],
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -56,7 +56,7 @@
       "command": "${workspaceRoot}/packages/insomnia-app/node_modules/.bin/webpack-dev-server --config webpack/webpack.config.development.ts"
     },
     {
-      "label": "Insomnia: Compile",
+      "label": "Insomnia: Compile (Watch)",
       "detail": "Compile Renderer (Watch) | Compile Main",
       "dependsOn": [
         "Insomnia: Compile Renderer (Watch)",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,67 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Insomnia: Compile Main",
+      "detail": "webpack --config webpack/webpack.config.electron.ts",
+      "type": "shell",
+      "promptOnClose": false,
+      "options": {
+        "cwd": "${workspaceFolder}/packages/insomnia-app",
+        "env": {
+          "NODE_ENV": "development",
+          "TS_NODE_PROJECT": "tsconfig.webpack.json"
+        }
+      },
+      "command": "${workspaceRoot}/packages/insomnia-app/node_modules/.bin/webpack --config webpack/webpack.config.electron.ts"
+    },
+    {
+      "label": "Insomnia: Compile Renderer (Watch)",
+      "detail": "webpack-dev-server --config webpack/webpack.config.development.ts",
+      "type": "shell",
+      "promptOnClose": false,
+      "options": {
+        "cwd": "${workspaceFolder}/packages/insomnia-app",
+        "env": {
+          "TS_NODE_PROJECT": "tsconfig.webpack.json"
+        }
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "webpack",
+        "severity": "error",
+        "fileLocation": "absolute",
+        "pattern": [
+          {
+            "regexp": "ERROR in (.*)",
+            "file": 1
+          },
+          {
+            "regexp": "\\((\\d+),(\\d+)\\):(.*)",
+            "line": 1,
+            "column": 2,
+            "message": 3
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "Compiling\\.\\.\\.",
+          "endsPattern": {
+            "regexp": "Compiled"
+          }
+        },
+      },
+      "command": "${workspaceRoot}/packages/insomnia-app/node_modules/.bin/webpack-dev-server --config webpack/webpack.config.development.ts"
+    },
+    {
+      "label": "Insomnia: Compile",
+      "detail": "Compile Renderer (Watch) | Compile Main",
+      "dependsOn": [
+        "Insomnia: Compile Renderer (Watch)",
+        "Insomnia: Compile Main",
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a vscode launch config to run insomnia from vscode and debug both the main and renderer processes.

![debug](https://user-images.githubusercontent.com/12115431/129624592-6e4b882f-309f-40f9-924a-7c824748124e.gif)
