### PR TITLE
Mutate the error message instead of throwing a new error

### DIFF
--- a/packages/openapi-2-kong/src/declarative-config/generate.ts
+++ b/packages/openapi-2-kong/src/declarative-config/generate.ts
@@ -25,7 +25,11 @@ export function generateDeclarativeConfigFromSpec(
     // see: https://github.com/Kong/studio/issues/93
     const result: DeclarativeConfigResult = JSON.parse(JSON.stringify(declarativeConfigResult));
     return result;
-  } catch (err) {
-    throw new Error('Failed to generate spec: ' + err.message);
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      err.message = `Failed to generate spec: ${err.message}`;
+      throw err;
+    }
+    throw err;
   }
 }


### PR DESCRIPTION
Catching and throwing a new error loses the stack trace, this PR mutates the error messages and re-throws the same error.

