### PR TITLE
fix typo in space settings modal

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/space-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/space-settings-modal.tsx
@@ -68,7 +68,7 @@ class SpaceSettingsModal extends PureComponent<Props> {
               {isRemote && (
                 <>
                   <HelpTooltip className="space-left">
-                    To rename a ${strings.remoteSpace.singular.toLowerCase()} ${strings.space.singular.toLowerCase()} please visit <a href="https://app.insomnia.rest/app/teams">the insomnia website.</a>
+                    To rename a {strings.remoteSpace.singular.toLowerCase()} {strings.space.singular.toLowerCase()} please visit <a href="https://app.insomnia.rest/app/teams">the insomnia website.</a>
                   </HelpTooltip>
                   <input disabled readOnly defaultValue={space.name} />
                 </>


### PR DESCRIPTION
Found a typo in the settings modal where I added the extra $ around brackets 😅