### PR TITLE
removes usage of deprecated graphql constant

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
@@ -5,8 +5,7 @@ import electron, { OpenDialogOptions } from 'electron';
 import { readFileSync } from 'fs';
 import type { GraphQLArgument, GraphQLField, GraphQLSchema, GraphQLType } from 'graphql';
 import { parse, print, typeFromAST } from 'graphql';
-import { buildClientSchema } from 'graphql/utilities/buildClientSchema';
-import { introspectionQuery } from 'graphql/utilities/introspectionQuery';
+import { buildClientSchema, getIntrospectionQuery } from 'graphql/utilities';
 import { json as jsonPrettify } from 'insomnia-prettify';
 import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
@@ -272,7 +271,7 @@ class GraphQLEditor extends PureComponent<Props, State> {
 
     try {
       const bodyJson = JSON.stringify({
-        query: introspectionQuery,
+        query: getIntrospectionQuery(),
         operationName: 'IntrospectionQuery',
       });
       const introspectionRequest = await db.upsert(


### PR DESCRIPTION
see: https://github.com/graphql/graphql-js/pull/2124/files that the `introspectionQuery` constant is deprecated and was removed in `graphql` v15 (https://github.com/graphql/graphql-js/releases/tag/v15.0.0).

I tried upgrading `graphql` to see if it would resolve https://github.com/Kong/insomnia/pull/3469.  Although it doesn't, it seemed worth it to just fix this deprecation now while I have it in front of me so we won't have to fix it later.

also fixes the import scheme to match what the docs do.

If you browse the code at the (now almost 2 year old (!!)) version of graphql that we're using you'll see that it just calls this function https://github.com/graphql/graphql-js/blob/b4bff0ba9c15c9d7245dd68556e754c41f263289/src/utilities/introspectionQuery.js#L113

```ts

/**
 * Deprecated, call getIntrospectionQuery directly.
 *
 * This function will be removed in v15
 */
export const introspectionQuery = getIntrospectionQuery();
```