### PR TITLE
removes .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,0 @@
-[*.{js,json,html,md,graphql,gql}]
-charset = utf-8
-indent_style = space
-indent_size = 2
-insert_final_newline = true
-trim_trailing_whitespace = true
-end_of_line = lf
-quote_type = single

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ For more generic product questions and feedback, join the [Slack Team](https://c
 Please read through our [contributing guidelines](CONTRIBUTING.md) and [code of conduct](CODE_OF_CONDUCT.md). Included are directions
 for opening issues, coding standards, and notes on development.
 
-Editor preferences are available in the [editor config](.editorconfig) for easy use in
-common text editors. Read more and download plugins at [editorconfig.org](http://editorconfig.org).
-
 ## Developing
 
 Development on Insomnia can be done on Mac, Windows, or Linux as long as you have


### PR DESCRIPTION
I didn't realize there was an editorconfig file in this project.  There's no need for one.  The aim is for us to be leveraging eslint (or other specialized linting like markdownlint) for all of these things.

Other reasons to remove this file include:
- It means avoiding inconsistencies with the eslint tooling.
  - For example, eslint can handle windows `CRLF`, but the editorconfig requires `LF` line endings.  This just plain wrong in windows environments (despite how much I wish it wasn't.
  - For another example, the quote_type `single` is not flexible enough to handle the cases that the corresponding lint rule handles.  For example, we may use double quotes in strings with a `'` to avoid escape characters.  The eslint rule already covers this.
- It means we won't be enforcing rules that are not run in the CI (which, is always the goal).