### PR TITLE
removes hardcoded import names

### DIFF
--- a/packages/insomnia-app/app/ui/components/settings/import-export.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.tsx
@@ -66,7 +66,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
       <div className="no-margin-top">
         Import format will be automatically detected.
         <HelpTooltip className="space-left">
-          supported formats include: {importers.map(importer => importer.name).join(', ')}
+          Supported formats include: {importers.map(importer => importer.name).join(', ')}
         </HelpTooltip>
       </div>
       <p>

--- a/packages/insomnia-app/app/ui/components/settings/import-export.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.tsx
@@ -70,7 +70,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
         </HelpTooltip>
       </div>
       <p>
-        Don't see your format here? <Link href={docsImportExport}>Add Your Own</Link>.
+        Your format isn't supported? <Link href={docsImportExport}>Add Your Own</Link>.
       </p>
       <div className="pad-top">
         <Dropdown outline>

--- a/packages/insomnia-app/app/ui/components/settings/import-export.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.tsx
@@ -11,6 +11,7 @@ import { importClipBoard, importFile, importUri } from '../../redux/modules/impo
 import { selectActiveProjectName, selectActiveWorkspace } from '../../redux/selectors';
 import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from '../base/dropdown';
 import Link from '../base/link';
+import HelpTooltip from '../help-tooltip';
 import ExportRequestsModal from '../modals/export-requests-modal';
 import { showModal, showPrompt } from '../modals/index';
 
@@ -62,10 +63,12 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
 
   return (
     <div>
-      <p className="no-margin-top">
-        Import format will be automatically detected (
-        <strong>{importers.map(importer => importer.name).join(', ')}</strong>)
-      </p>
+      <div className="no-margin-top">
+        Import format will be automatically detected.
+        <HelpTooltip className="space-left">
+          supported formats include: {importers.map(importer => importer.name).join(', ')}
+        </HelpTooltip>
+      </div>
       <p>
         Don't see your format here? <Link href={docsImportExport}>Add Your Own</Link>.
       </p>

--- a/packages/insomnia-app/app/ui/components/settings/import-export.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.tsx
@@ -1,7 +1,7 @@
+import { importers } from 'insomnia-importers';
 import React, { FC, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { importers } from '../../../../../insomnia-importers/dist/src';
 import { getAppName } from '../../../common/constants';
 import { docsImportExport } from '../../../common/documentation';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';

--- a/packages/insomnia-app/app/ui/components/settings/import-export.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { importers } from '../../../../../insomnia-importers/dist/src';
 import { getAppName } from '../../../common/constants';
 import { docsImportExport } from '../../../common/documentation';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
@@ -63,7 +64,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
     <div>
       <p className="no-margin-top">
         Import format will be automatically detected (
-        <strong>Insomnia, Postman v2, HAR, Curl, Swagger, OpenAPI v3</strong>)
+        <strong>{importers.map(importer => importer.name).join(', ')}</strong>)
       </p>
       <p>
         Don't see your format here? <Link href={docsImportExport}>Add Your Own</Link>.


### PR DESCRIPTION
I noticed while QA'ing for the next release that these names are hardcoded.  I see no reason that doing so benefits us - and it's a 1-line change to update it.

before:
![before](https://user-images.githubusercontent.com/15232461/130515049-364e0b5f-9be2-4127-8e0e-307102c1f904.png)

after:
![image](https://user-images.githubusercontent.com/15232461/131745423-75d4a1be-9e85-4191-8bdc-d99debe6c17d.png)
