### PR TITLE
Inso -> Inso CLI (in docs)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@ There are a few more technologies and tools worth mentioning:
 - [`Webpack`](https://webpack.js.org/) is the bundler used to compile the JS/Less/babel/etc
 - [`libcurl`](https://curl.se/libcurl/) is the library that Insomnia uses to make requests. Libcurl is the HTTP client of choice because it allows the deepest amount of debuggability and control of HTTP requests.
 - [`nedb`](https://github.com/louischatriot/nedb) a local in-memory database.
-- [`node-libcurl`](https://github.com/JCMais/node-libcurl) is a NodeJS wrapper around the native libcurl library.
+- [`node-libcurl`](https://github.com/JCMais/node-libcurl) is a Node.js wrapper around the native libcurl library.
 - [`Codemirror`](https://codemirror.net/) is a web-based, extendable, code editor used for
   highlighting and linting of data formats like JSON, GraphQL, and XML.
 - [`Commander.js`](https://github.com/tj/commander.js) is used for building the inso CLI.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ common text editors. Read more and download plugins at [editorconfig.org](http:/
 ## Developing
 
 Development on Insomnia can be done on Mac, Windows, or Linux as long as you have
-[NodeJS](https://nodejs.org) and [Git](https://git-scm.com/). See the `.nvmrc` file located in the project for the correct Node version.
+[Node.js](https://nodejs.org) and [Git](https://git-scm.com/). See the `.nvmrc` file located in the project for the correct Node version.
 
 <details>
 <summary>Initial Dev Setup</summary>

--- a/packages/insomnia-inso/README.md
+++ b/packages/insomnia-inso/README.md
@@ -324,7 +324,7 @@ winpty inso.cmd generate config
 
 # Continuous Integration
 
-`inso` has been designed to run in a CI environment, disabling prompts and providing exit codes to pass or fail the CI workflow accordingly. An example workflow run in Github Actions is as follows. This example will checkout > install NodeJS > install Inso CLI > run linting > run unit tests > generate configuration. If any of these steps fail, the GH workflow will as well.
+`inso` has been designed to run in a CI environment, disabling prompts and providing exit codes to pass or fail the CI workflow accordingly. An example workflow run in Github Actions is as follows. This example will checkout > install Node.js > install Inso CLI > run linting > run unit tests > generate configuration. If any of these steps fail, the GH workflow will as well.
 
 ``` yaml
 # .github/workflows/test.yml
@@ -338,7 +338,7 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v1
-      - name: Install NodeJS
+      - name: Install Node.js
         uses: actions/setup-node@v1
       - name: Install inso
         run: npm install --global insomnia-inso

--- a/packages/insomnia-inso/README.md
+++ b/packages/insomnia-inso/README.md
@@ -4,7 +4,7 @@
   <br />
   <img src="https://raw.githubusercontent.com/Kong/insomnia/develop/packages/insomnia-inso/assets/logo.svg" alt=""/>
   <h1>
-    Inso
+    Inso CLI
     <br />
     <br />
   </h1>

--- a/packages/insomnia-inso/README.md
+++ b/packages/insomnia-inso/README.md
@@ -269,9 +269,9 @@ inso gen-conf:k8s -o output.yaml    # generates kubernetes config to output.yaml
 
 # Configuration
 
-Inso can be configured with a configuration file, allowing you to specify options and scripts. For example, when running in a CI environment, you may choose to specify the steps as scripts in a config file, so that the same commands can be run both locally and in CI.
+Inso CLI can be configured with a configuration file, allowing you to specify options and scripts. For example, when running in a CI environment, you may choose to specify the steps as scripts in a config file, so that the same commands can be run both locally and in CI.
 
-Inso uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for config file management, meaning any of the following items found in the working tree are automatically used:
+Inso CLI uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for config file management, meaning any of the following items found in the working tree are automatically used:
 
   + `inso` property in `package.json`
   + `.insorc` file in JSON or YAML format
@@ -324,7 +324,7 @@ winpty inso.cmd generate config
 
 # Continuous Integration
 
-`inso` has been designed to run in a CI environment, disabling prompts and providing exit codes to pass or fail the CI workflow accordingly. An example workflow run in Github Actions is as follows. This example will checkout > install NodeJS > install inso > run linting > run unit tests > generate configuration. If any of these steps fail, the GH workflow will as well.
+`inso` has been designed to run in a CI environment, disabling prompts and providing exit codes to pass or fail the CI workflow accordingly. An example workflow run in Github Actions is as follows. This example will checkout > install NodeJS > install Inso CLI > run linting > run unit tests > generate configuration. If any of these steps fail, the GH workflow will as well.
 
 ``` yaml
 # .github/workflows/test.yml

--- a/plugins/insomnia-plugin-os/README.md
+++ b/plugins/insomnia-plugin-os/README.md
@@ -2,10 +2,8 @@
 
 [![Npm Version](https://img.shields.io/npm/v/insomnia-plugin-os.svg)](https://www.npmjs.com/package/insomnia-plugin-os)
 
-This is a plugin for [Insomnia](https://insomnia.rest) that provides access to some 
-convenient functions from the NodeJS `os` package.
+This is a plugin for [Insomnia](https://insomnia.rest) that provides access to some convenient functions from the Node.js `os` package.
 
 ## Installation
 
 Install the `insomnia-plugin-os` plugin from Preferences > Plugins.
-


### PR DESCRIPTION
In preparation for work on the new doc site, we decided that it's a clearer name to call this "Inso CLI" in the docs (and urls).  `Inso` is hard to search for, among other reasons.

This PR is just a supporting change to that, updating some markdown files to be consistent.

Made in separate commits so that if we want to drop any one of the commits it's easy to do.