### PR TITLE
renames base project to default project in code and copy

### DIFF
--- a/packages/insomnia-app/app/__jest__/redux-state-for-test.ts
+++ b/packages/insomnia-app/app/__jest__/redux-state-for-test.ts
@@ -1,5 +1,5 @@
 import { ACTIVITY_HOME } from '../common/constants';
-import { BASE_PROJECT_ID } from '../models/project';
+import { DEFAULT_PROJECT_ID } from '../models/project';
 import { RootState } from '../ui/redux/modules';
 import * as entities from '../ui/redux/modules/entities';
 import { GlobalState } from '../ui/redux/modules/global';
@@ -9,7 +9,7 @@ export const reduxStateForTest = async (global: Partial<GlobalState> = {}): Prom
   global: {
     activeWorkspaceId: null,
     activeActivity: ACTIVITY_HOME,
-    activeProjectId: BASE_PROJECT_ID,
+    activeProjectId: DEFAULT_PROJECT_ID,
     dashboardSortOrder: 'modified-desc',
     isLoading: false,
     isLoggedIn: false,

--- a/packages/insomnia-app/app/account/session.ts
+++ b/packages/insomnia-app/app/account/session.ts
@@ -112,7 +112,7 @@ export async function changePasswordWithToken(rawNewPassphrase, confirmationCode
   // Fetch some things
   const { saltEnc, encSymmetricKey } = await _whoami();
   const { saltKey, saltAuth } = await _getAuthSalts(newEmail);
-  // Generate some secrets for the user base'd on password
+  // Generate some secrets for the user based on password
   const newSecret = await crypt.deriveKey(newPassphrase, newEmail, saltEnc);
   const newAuthSecret = await crypt.deriveKey(newPassphrase, newEmail, saltKey);
   const newVerifier = srp

--- a/packages/insomnia-app/app/common/strings.ts
+++ b/packages/insomnia-app/app/common/strings.ts
@@ -9,7 +9,7 @@ type StringId =
   | 'home'
   | 'project'
   | 'workspace'
-  | 'baseProject'
+  | 'defaultProject'
   | 'localProject'
   | 'remoteProject'
   ;
@@ -35,9 +35,9 @@ export const strings: Record<StringId, StringInfo> = {
     singular: 'Workspace',
     plural: 'Workspaces',
   },
-  baseProject: {
-    singular: 'Base',
-    plural: 'Base',
+  defaultProject: {
+    singular: 'Default',
+    plural: 'Default',
   },
   localProject: {
     singular: 'Local',

--- a/packages/insomnia-app/app/models/project.ts
+++ b/packages/insomnia-app/app/models/project.ts
@@ -9,13 +9,13 @@ export const prefix = 'proj';
 export const canDuplicate = false;
 export const canSync = false;
 
-export const BASE_PROJECT_ID = `${prefix}_base-project`;
+export const DEFAULT_PROJECT_ID = `${prefix}_base-project`;
 
-export const isBaseProject = (project: Project) => project._id === BASE_PROJECT_ID;
-export const isNotBaseProject = (project: Project) => !isBaseProject(project);
+export const isDefaultProject = (project: Project) => project._id === DEFAULT_PROJECT_ID;
+export const isNotDefaultProject = (project: Project) => !isDefaultProject(project);
 export const isLocalProject = (project: Project): project is LocalProject => project.remoteId === null;
 export const isRemoteProject = (project: Project): project is RemoteProject => !isLocalProject(project);
-export const projectHasSettings = (project: Project) => !isBaseProject(project);
+export const projectHasSettings = (project: Project) => !isDefaultProject(project);
 
 interface CommonProject {
   name: string;
@@ -77,8 +77,8 @@ export function update(project: Project, patch: Partial<Project>) {
 export async function all() {
   const projects = await db.all<Project>(type);
 
-  if (!projects.find(c => c._id === BASE_PROJECT_ID)) {
-    await create({ _id: BASE_PROJECT_ID, name: getAppName(), remoteId: null });
+  if (!projects.find(c => c._id === DEFAULT_PROJECT_ID)) {
+    await create({ _id: DEFAULT_PROJECT_ID, name: getAppName(), remoteId: null });
     return db.all<Project>(type);
   }
 

--- a/packages/insomnia-app/app/models/project.ts
+++ b/packages/insomnia-app/app/models/project.ts
@@ -9,7 +9,7 @@ export const prefix = 'proj';
 export const canDuplicate = false;
 export const canSync = false;
 
-export const DEFAULT_PROJECT_ID = `${prefix}_base-project`;
+export const DEFAULT_PROJECT_ID = `${prefix}_default-project`;
 
 export const isDefaultProject = (project: Project) => project._id === DEFAULT_PROJECT_ID;
 export const isNotDefaultProject = (project: Project) => !isDefaultProject(project);

--- a/packages/insomnia-app/app/models/workspace.ts
+++ b/packages/insomnia-app/app/models/workspace.ts
@@ -4,7 +4,7 @@ import { database as db } from '../common/database';
 import { strings } from '../common/strings';
 import type { BaseModel } from './index';
 import * as models from './index';
-import { BASE_PROJECT_ID, isProjectId } from './project';
+import { DEFAULT_PROJECT_ID, isProjectId } from './project';
 
 export const name = 'Workspace';
 export const type = 'Workspace';
@@ -57,7 +57,7 @@ export async function migrate(doc: Workspace) {
     fileName: doc.name,
   });
   doc = _migrateScope(doc);
-  doc = _migrateIntoBaseProject(doc);
+  doc = _migrateIntoDefaultProject(doc);
   return doc;
 }
 
@@ -158,9 +158,9 @@ function _migrateScope(workspace: MigrationWorkspace) {
   return workspace as Workspace;
 }
 
-function _migrateIntoBaseProject(workspace: Workspace) {
+function _migrateIntoDefaultProject(workspace: Workspace) {
   if (!workspace.parentId) {
-    workspace.parentId = BASE_PROJECT_ID;
+    workspace.parentId = DEFAULT_PROJECT_ID;
   }
 
   return workspace;

--- a/packages/insomnia-app/app/plugins/context/__tests__/data.test.ts
+++ b/packages/insomnia-app/app/plugins/context/__tests__/data.test.ts
@@ -5,7 +5,7 @@ import { globalBeforeEach } from '../../../__jest__/before-each';
 import { getAppVersion } from '../../../common/constants';
 import { database as db } from '../../../common/database';
 import * as models from '../../../models/index';
-import { BASE_PROJECT_ID, Project } from '../../../models/project';
+import { DEFAULT_PROJECT_ID, Project } from '../../../models/project';
 import { WorkspaceScopeKeys } from '../../../models/workspace';
 import * as plugin from '../data';
 
@@ -15,7 +15,7 @@ describe('init()', () => {
   beforeEach(globalBeforeEach);
 
   it('initializes correctly', async () => {
-    const { data } = plugin.init(BASE_PROJECT_ID);
+    const { data } = plugin.init(DEFAULT_PROJECT_ID);
     expect(Object.keys(data)).toEqual(['import', 'export']);
     expect(Object.keys(data.export).sort()).toEqual(['har', 'insomnia']);
     expect(Object.keys(data.import).sort()).toEqual(['raw', 'uri']);

--- a/packages/insomnia-app/app/plugins/context/data.ts
+++ b/packages/insomnia-app/app/plugins/context/data.ts
@@ -3,7 +3,7 @@ import { exportWorkspacesData, exportWorkspacesHAR } from '../../common/export';
 import type { ImportRawConfig } from '../../common/import';
 import { importRaw, importUri } from '../../common/import';
 import * as models from '../../models';
-import { BASE_PROJECT_ID } from '../../models/project';
+import { DEFAULT_PROJECT_ID } from '../../models/project';
 import type { Workspace, WorkspaceScope } from '../../models/workspace';
 
 interface PluginImportOptions {
@@ -42,10 +42,10 @@ export const init = (activeProjectId?: string) => ({
   data: {
     import: {
       uri: async (uri: string, options: PluginImportOptions = {}) => {
-        await importUri(uri, buildImportRawConfig(options, activeProjectId || BASE_PROJECT_ID));
+        await importUri(uri, buildImportRawConfig(options, activeProjectId || DEFAULT_PROJECT_ID));
       },
       raw: async (text: string, options: PluginImportOptions = {}) => {
-        await importRaw(text, buildImportRawConfig(options, activeProjectId || BASE_PROJECT_ID));
+        await importRaw(text, buildImportRawConfig(options, activeProjectId || DEFAULT_PROJECT_ID));
       },
     },
     export: {

--- a/packages/insomnia-app/app/sync/git/__tests__/ne-db-client.test.ts
+++ b/packages/insomnia-app/app/sync/git/__tests__/ne-db-client.test.ts
@@ -6,7 +6,7 @@ import { globalBeforeEach } from '../../../__jest__/before-each';
 import { database as db } from '../../../common/database';
 import * as models from '../../../models';
 import { workspaceModelSchema } from '../../../models/__schemas__/model-schemas';
-import { BASE_PROJECT_ID } from '../../../models/project';
+import { DEFAULT_PROJECT_ID } from '../../../models/project';
 import { GIT_CLONE_DIR, GIT_INSOMNIA_DIR, GIT_INSOMNIA_DIR_NAME } from '../git-vcs';
 import { NeDBClient } from '../ne-db-client';
 import { assertAsyncError, setupDateMocks } from './util';
@@ -42,7 +42,7 @@ describe('NeDBClient', () => {
 
   describe('readdir()', () => {
     it('reads model IDs from model type folders', async () => {
-      const neDbClient = new NeDBClient('wrk_1', BASE_PROJECT_ID);
+      const neDbClient = new NeDBClient('wrk_1', DEFAULT_PROJECT_ID);
       const reqDir = path.join(GIT_INSOMNIA_DIR, models.request.type);
       const wrkDir = path.join(GIT_INSOMNIA_DIR, models.workspace.type);
       expect(await neDbClient.readdir(GIT_CLONE_DIR)).toEqual([GIT_INSOMNIA_DIR_NAME]);
@@ -68,7 +68,7 @@ describe('NeDBClient', () => {
       const wrk1Yml = path.join(GIT_INSOMNIA_DIR, models.workspace.type, 'wrk_1.yml');
       const req1Yml = path.join(GIT_INSOMNIA_DIR, models.request.type, 'req_1.yml');
       const reqXYml = path.join(GIT_INSOMNIA_DIR, models.request.type, 'req_x.yml');
-      const pNeDB = new NeDBClient('wrk_1', BASE_PROJECT_ID);
+      const pNeDB = new NeDBClient('wrk_1', DEFAULT_PROJECT_ID);
       expect(YAML.parse((await pNeDB.readFile(wrk1Yml, 'utf8')).toString())).toEqual(
         expect.objectContaining({
           _id: 'wrk_1',
@@ -97,7 +97,7 @@ describe('NeDBClient', () => {
         type: 'file',
       });
       // Act
-      const neDbClient = new NeDBClient('wrk_1', BASE_PROJECT_ID);
+      const neDbClient = new NeDBClient('wrk_1', DEFAULT_PROJECT_ID);
       // Assert
       expect(await neDbClient.stat(GIT_CLONE_DIR)).toEqual(dirType);
       expect(await neDbClient.stat(GIT_INSOMNIA_DIR)).toEqual(dirType);
@@ -112,7 +112,7 @@ describe('NeDBClient', () => {
       // Arrange
       const upsertSpy = jest.spyOn(db, 'upsert');
       const workspaceId = 'wrk_1';
-      const neDbClient = new NeDBClient(workspaceId, BASE_PROJECT_ID);
+      const neDbClient = new NeDBClient(workspaceId, DEFAULT_PROJECT_ID);
       const env = {
         _id: 'env_1',
         type: models.environment.type,
@@ -130,7 +130,7 @@ describe('NeDBClient', () => {
     it('should write files in GIT_INSOMNIA_DIR directory to db', async () => {
       // Arrange
       const workspaceId = 'wrk_1';
-      const neDbClient = new NeDBClient(workspaceId, BASE_PROJECT_ID);
+      const neDbClient = new NeDBClient(workspaceId, DEFAULT_PROJECT_ID);
       const upsertSpy = jest.spyOn(db, 'upsert');
       const env = {
         _id: 'env_1',
@@ -204,7 +204,7 @@ describe('NeDBClient', () => {
     it('should throw error if id does not match', async () => {
       // Arrange
       const workspaceId = 'wrk_1';
-      const neDbClient = new NeDBClient(workspaceId, BASE_PROJECT_ID);
+      const neDbClient = new NeDBClient(workspaceId, DEFAULT_PROJECT_ID);
       const env = {
         _id: 'env_1',
         type: models.environment.type,
@@ -222,7 +222,7 @@ describe('NeDBClient', () => {
     it('should throw error if type does not match', async () => {
       // Arrange
       const workspaceId = 'wrk_1';
-      const neDbClient = new NeDBClient(workspaceId, BASE_PROJECT_ID);
+      const neDbClient = new NeDBClient(workspaceId, DEFAULT_PROJECT_ID);
       const env = {
         _id: 'env_1',
         type: models.environment.type,
@@ -241,7 +241,7 @@ describe('NeDBClient', () => {
   describe('mkdir()', () => {
     it('should throw error', async () => {
       const workspaceId = 'wrk_1';
-      const neDbClient = new NeDBClient(workspaceId, BASE_PROJECT_ID);
+      const neDbClient = new NeDBClient(workspaceId, DEFAULT_PROJECT_ID);
       const promiseResult = neDbClient.mkdir();
       await expect(promiseResult).rejects.toThrowError('NeDBClient is not writable');
     });

--- a/packages/insomnia-app/app/sync/git/ne-db-client.ts
+++ b/packages/insomnia-app/app/sync/git/ne-db-client.ts
@@ -103,7 +103,7 @@ export class NeDBClient {
       console.log('[git] setting workspace parent to be that of the active project', { original: doc.parentId, new: this._projectId });
       // Whenever we write a workspace into nedb we should set the parentId to be that of the current project
       // This is because the parentId (or a project) is not synced into git, so it will be cleared whenever git writes the workspace into the db, thereby removing it from the project on the client
-      // In order to reproduce this bug, comment out the following line, then clone a repository into a local project, then open the workspace, you'll notice it will have moved into the base project
+      // In order to reproduce this bug, comment out the following line, then clone a repository into a local project, then open the workspace, you'll notice it will have moved into the default project
       doc.parentId = this._projectId;
     }
 

--- a/packages/insomnia-app/app/sync/vcs/__tests__/migrate-collections.test.ts
+++ b/packages/insomnia-app/app/sync/vcs/__tests__/migrate-collections.test.ts
@@ -5,7 +5,7 @@ import { globalBeforeEach } from '../../../__jest__/before-each';
 import { isLoggedIn as _isLoggedIn } from '../../../account/session';
 import { database } from '../../../common/database';
 import * as models from '../../../models';
-import { BASE_PROJECT_ID } from '../../../models/project';
+import { DEFAULT_PROJECT_ID } from '../../../models/project';
 import { backendProjectWithTeamSchema, teamSchema } from '../../__schemas__/type-schemas';
 import MemoryDriver from '../../store/drivers/memory-driver';
 import { initializeProjectFromTeam } from '../initialize-model-from';
@@ -49,8 +49,8 @@ describe('migrateCollectionsIntoRemoteProject', () => {
     // Arrange
     const vcs = newMockedVcs();
 
-    const baseProject = await models.project.getById(BASE_PROJECT_ID);
-    const workspaceInBase = await models.workspace.create({ parentId: baseProject?._id });
+    const defaultProject = await models.project.getById(DEFAULT_PROJECT_ID);
+    const workspaceInBase = await models.workspace.create({ parentId: defaultProject?._id });
 
     const localProject = await models.project.create();
     const workspaceInLocal = await models.workspace.create({ parentId: localProject._id });

--- a/packages/insomnia-app/app/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/project-dropdown.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import { strings } from '../../../common/strings';
-import { isBaseProject, isNotBaseProject, isRemoteProject, Project, projectHasSettings } from '../../../models/project';
+import { isDefaultProject, isNotDefaultProject, isRemoteProject, Project, projectHasSettings } from '../../../models/project';
 import { VCS } from '../../../sync/vcs/vcs';
 import { useRemoteProjects } from '../../hooks/project';
 import { setActiveProject } from '../../redux/modules/global';
@@ -39,7 +39,7 @@ const TooltipIcon = ({ message, icon }: { message: string, icon: SvgIconProps['i
 );
 
 const spinner = <i className="fa fa-spin fa-refresh" />;
-const home = <TooltipIcon message={`${strings.baseProject.singular} ${strings.project.singular} (Always ${strings.localProject.singular})`} icon="home" />;
+const home = <TooltipIcon message={`${strings.defaultProject.singular} ${strings.project.singular} (Always ${strings.localProject.singular})`} icon="home" />;
 const remoteProject = <TooltipIcon message={`${strings.remoteProject.singular} ${strings.project.singular}`} icon="globe" />;
 const localProject = <TooltipIcon message={`${strings.localProject.singular} ${strings.project.singular}`} icon="laptop" />;
 
@@ -53,7 +53,7 @@ const ProjectDropdownItem: FC<{
   setActive: (projectId: string) => void;
 }> = ({ isActive, project, setActive }) => {
   const { _id, name } = project;
-  const isBase = isBaseProject(project);
+  const isBase = isDefaultProject(project);
   const isRemote = isRemoteProject(project);
 
   return (
@@ -100,9 +100,9 @@ export const ProjectDropdown: FC<Props> = ({ vcs }) => {
 
   return (
     <Dropdown renderButton={button} onOpen={refresh}>
-      {projects.filter(isBaseProject).map(renderProject)}
+      {projects.filter(isDefaultProject).map(renderProject)}
       <DropdownDivider>All {strings.project.plural.toLowerCase()}{' '}{loading && spinner}</DropdownDivider>
-      {projects.filter(isNotBaseProject).map(renderProject)}
+      {projects.filter(isNotDefaultProject).map(renderProject)}
       {projectHasSettings(activeProject) && <>
         <DropdownDivider />
         <DropdownItem icon={<StyledSvgIcon icon="gear" />} onClick={showSettings}>

--- a/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
@@ -6,6 +6,7 @@ import { AUTOBIND_CFG } from '../../../common/constants';
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
 import { decompressObject } from '../../../common/misc';
+import { strings } from '../../../common/strings';
 import type { Environment } from '../../../models/environment';
 import type { RequestVersion } from '../../../models/request-version';
 import type { Response } from '../../../models/response';
@@ -158,7 +159,7 @@ class ResponseHistoryDropdown extends PureComponent<Props> {
       activeEnvironment,
       ...extraProps
     } = this.props;
-    const environmentName = activeEnvironment ? activeEnvironment.name : 'Base';
+    const environmentName = activeEnvironment ? activeEnvironment.name : strings.defaultProject.singular;
     const isLatestResponseActive = !responses.length || activeResponse._id === responses[0]._id;
     return (
       <KeydownBinder onKeydown={this._handleKeydown}>

--- a/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/response-history-dropdown.tsx
@@ -6,7 +6,6 @@ import { AUTOBIND_CFG } from '../../../common/constants';
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
 import { decompressObject } from '../../../common/misc';
-import { strings } from '../../../common/strings';
 import type { Environment } from '../../../models/environment';
 import type { RequestVersion } from '../../../models/request-version';
 import type { Response } from '../../../models/response';
@@ -159,7 +158,7 @@ class ResponseHistoryDropdown extends PureComponent<Props> {
       activeEnvironment,
       ...extraProps
     } = this.props;
-    const environmentName = activeEnvironment ? activeEnvironment.name : strings.defaultProject.singular;
+    const environmentName = activeEnvironment ? activeEnvironment.name : 'Base';
     const isLatestResponseActive = !responses.length || activeResponse._id === responses[0]._id;
     return (
       <KeydownBinder onKeydown={this._handleKeydown}>

--- a/packages/insomnia-app/app/ui/components/modals/workspace-duplicate-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-duplicate-modal.tsx
@@ -11,7 +11,7 @@ import * as models from '../../../models';
 import { ApiSpec } from '../../../models/api-spec';
 import getWorkspaceName from '../../../models/helpers/get-workspace-name';
 import * as workspaceOperations from '../../../models/helpers/workspace-operations';
-import { isBaseProject, isLocalProject, isRemoteProject, Project } from '../../../models/project';
+import { isDefaultProject, isLocalProject, isRemoteProject, Project } from '../../../models/project';
 import { Workspace } from '../../../models/workspace';
 import { initializeLocalBackendProjectAndMarkForSync } from '../../../sync/vcs/initialize-backend-project';
 import { VCS } from '../../../sync/vcs/vcs';
@@ -40,7 +40,7 @@ interface InnerProps extends Options, Props {
 
 const ProjectOption: FC<Project> = project => (
   <option key={project._id} value={project._id}>
-    {project.name} ({isBaseProject(project) ? strings.baseProject.singular : isLocalProject(project) ? strings.localProject.singular : strings.remoteProject.singular})
+    {project.name} ({isDefaultProject(project) ? strings.defaultProject.singular : isLocalProject(project) ? strings.localProject.singular : strings.remoteProject.singular})
   </option>
 );
 

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -48,7 +48,7 @@ import { isEnvironment } from '../../models/environment';
 import { GrpcRequest, isGrpcRequest, isGrpcRequestId } from '../../models/grpc-request';
 import { GrpcRequestMeta } from '../../models/grpc-request-meta';
 import * as requestOperations from '../../models/helpers/request-operations';
-import { isNotBaseProject } from '../../models/project';
+import { isNotDefaultProject } from '../../models/project';
 import { Request, updateMimeType } from '../../models/request';
 import { isRequestGroup, RequestGroup } from '../../models/request-group';
 import { RequestMeta } from '../../models/request-meta';
@@ -1339,7 +1339,7 @@ class App extends PureComponent<AppProps, State> {
               console.log(`[developer] clearing all "${type}" entities`);
               const allEntities = await db.all(type);
               const filteredEntites = allEntities
-                .filter(isNotBaseProject); // don't clear the base project
+                .filter(isNotDefaultProject); // don't clear the default project
               await db.batchModifyDocs({ remove: filteredEntites });
               db.flushChanges(bufferId);
             }
@@ -1363,7 +1363,7 @@ class App extends PureComponent<AppProps, State> {
                   console.log(`[developer] clearing all "${type}" entities`);
                   const allEntities = await db.all(type);
                   const filteredEntites = allEntities
-                    .filter(isNotBaseProject); // don't clear the base project
+                    .filter(isNotDefaultProject); // don't clear the default project
                   await db.batchModifyDocs({ remove: filteredEntites });
                 });
               await Promise.all(promises);

--- a/packages/insomnia-app/app/ui/hooks/__tests__/project.test.ts
+++ b/packages/insomnia-app/app/ui/hooks/__tests__/project.test.ts
@@ -8,7 +8,7 @@ import { globalBeforeEach } from '../../../__jest__/before-each';
 import { reduxStateForTest } from '../../../__jest__/redux-state-for-test';
 import { withReduxStore } from '../../../__jest__/with-redux-store';
 import * as models from '../../../models';
-import { BASE_PROJECT_ID, Project } from '../../../models/project';
+import { DEFAULT_PROJECT_ID, Project } from '../../../models/project';
 import MemoryDriver from '../../../sync/store/drivers/memory-driver';
 import { VCS } from '../../../sync/vcs/vcs';
 import { RootState } from '../../redux/modules';
@@ -74,7 +74,7 @@ describe('useRemoteProjects', () => {
     expect(allProjects).toHaveLength(3);
     expect(allProjects).toEqual(expect.arrayContaining([
       expect.objectContaining<Partial<Project>>({
-        _id: BASE_PROJECT_ID,
+        _id: DEFAULT_PROJECT_ID,
       }),
       expect.objectContaining<Partial<Project>>({
         remoteId: team1.id,
@@ -116,7 +116,7 @@ describe('useRemoteProjects', () => {
     expect(allProjects).toHaveLength(3);
     expect(allProjects).toEqual(expect.arrayContaining([
       expect.objectContaining<Partial<Project>>({
-        _id: BASE_PROJECT_ID,
+        _id: DEFAULT_PROJECT_ID,
       }),
       expect.objectContaining<Partial<Project>>({
         remoteId: team1.id,

--- a/packages/insomnia-app/app/ui/redux/__tests__/selectors.test.ts
+++ b/packages/insomnia-app/app/ui/redux/__tests__/selectors.test.ts
@@ -37,7 +37,7 @@ describe('selectors', () => {
       await models.project.create();
       await models.project.create();
 
-      // select the default project
+      // set nothing as active
       const state = await reduxStateForTest({ activeProjectId: undefined });
 
       const project = selectActiveProject(state);

--- a/packages/insomnia-app/app/ui/redux/__tests__/selectors.test.ts
+++ b/packages/insomnia-app/app/ui/redux/__tests__/selectors.test.ts
@@ -1,7 +1,7 @@
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import { reduxStateForTest } from '../../../__jest__/redux-state-for-test';
 import * as models from '../../../models';
-import { BASE_PROJECT_ID, Project } from '../../../models/project';
+import { DEFAULT_PROJECT_ID, Project } from '../../../models/project';
 import { selectActiveProject } from '../selectors';
 
 describe('selectors', () => {
@@ -20,7 +20,7 @@ describe('selectors', () => {
       expect(project).toStrictEqual(projectA);
     });
 
-    it('should return base project if active project not found', async () => {
+    it('should return default project if active project not found', async () => {
       // create two projects
       await models.project.create();
       await models.project.create();
@@ -29,19 +29,19 @@ describe('selectors', () => {
       const state = await reduxStateForTest({ activeProjectId: 'some-other-project' });
 
       const project = selectActiveProject(state);
-      expect(project).toStrictEqual(expect.objectContaining<Partial<Project>>({ _id: BASE_PROJECT_ID }));
+      expect(project).toStrictEqual(expect.objectContaining<Partial<Project>>({ _id: DEFAULT_PROJECT_ID }));
     });
 
-    it('should return base project if no active project', async () => {
+    it('should return default project if no active project', async () => {
       // create two projects
       await models.project.create();
       await models.project.create();
 
-      // set base as selected
+      // select the default project
       const state = await reduxStateForTest({ activeProjectId: undefined });
 
       const project = selectActiveProject(state);
-      expect(project).toStrictEqual(expect.objectContaining<Partial<Project>>({ _id: BASE_PROJECT_ID }));
+      expect(project).toStrictEqual(expect.objectContaining<Partial<Project>>({ _id: DEFAULT_PROJECT_ID }));
     });
   });
 });

--- a/packages/insomnia-app/app/ui/redux/modules/__tests__/git.test.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/__tests__/git.test.tsx
@@ -12,7 +12,7 @@ import { SegmentEvent, trackEvent, trackSegmentEvent } from '../../../../common/
 import { ACTIVITY_SPEC } from '../../../../common/constants';
 import * as models from '../../../../models';
 import { gitRepositorySchema } from '../../../../models/__schemas__/model-schemas';
-import { BASE_PROJECT_ID } from '../../../../models/project';
+import { DEFAULT_PROJECT_ID } from '../../../../models/project';
 import { Workspace, WorkspaceScopeKeys } from '../../../../models/workspace';
 import { GIT_INSOMNIA_DIR } from '../../../../sync/git/git-vcs';
 import { MemClient } from '../../../../sync/git/mem-client';
@@ -122,7 +122,7 @@ describe('git', () => {
         },
         {
           type: SET_ACTIVE_PROJECT,
-          projectId: BASE_PROJECT_ID,
+          projectId: DEFAULT_PROJECT_ID,
         },
         {
           type: SET_ACTIVE_WORKSPACE,

--- a/packages/insomnia-app/app/ui/redux/modules/__tests__/global.test.ts
+++ b/packages/insomnia-app/app/ui/redux/modules/__tests__/global.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../../common/constants';
 import { getDesignerDataDir } from '../../../../common/electron-helpers';
 import * as models from '../../../../models';
-import { BASE_PROJECT_ID } from '../../../../models/project';
+import { DEFAULT_PROJECT_ID } from '../../../../models/project';
 import {
   goToNextActivity,
   initActiveActivity,
@@ -266,10 +266,10 @@ describe('global', () => {
       expect(initActiveProject()).toStrictEqual(expectedEvent);
     });
 
-    it('should default to base project if not exist', () => {
+    it('should default to default project if not exist', () => {
       const expectedEvent = {
         type: SET_ACTIVE_PROJECT,
-        projectId: BASE_PROJECT_ID,
+        projectId: DEFAULT_PROJECT_ID,
       };
       expect(initActiveProject()).toStrictEqual(expectedEvent);
     });

--- a/packages/insomnia-app/app/ui/redux/modules/__tests__/project.test.ts
+++ b/packages/insomnia-app/app/ui/redux/modules/__tests__/project.test.ts
@@ -6,7 +6,7 @@ import { reduxStateForTest } from '../../../../__jest__/redux-state-for-test';
 import { SegmentEvent, trackEvent, trackSegmentEvent } from '../../../../common/analytics';
 import { ACTIVITY_HOME } from '../../../../common/constants';
 import * as models from '../../../../models';
-import { BASE_PROJECT_ID } from '../../../../models/project';
+import { DEFAULT_PROJECT_ID } from '../../../../models/project';
 import { getAndClearShowAlertMockArgs, getAndClearShowPromptMockArgs } from '../../../../test-utils';
 import { SET_ACTIVE_ACTIVITY, SET_ACTIVE_PROJECT } from '../global';
 import { createProject, removeProject } from '../project';
@@ -97,7 +97,7 @@ describe('project', () => {
       expect(store.getActions()).toEqual([
         {
           type: SET_ACTIVE_PROJECT,
-          projectId: BASE_PROJECT_ID,
+          projectId: DEFAULT_PROJECT_ID,
         },
         {
           type: SET_ACTIVE_ACTIVITY,

--- a/packages/insomnia-app/app/ui/redux/modules/__tests__/workspace.test.ts
+++ b/packages/insomnia-app/app/ui/redux/modules/__tests__/workspace.test.ts
@@ -10,7 +10,7 @@ import * as models from '../../../../models';
 import { ApiSpec } from '../../../../models/api-spec';
 import { CookieJar } from '../../../../models/cookie-jar';
 import { Environment } from '../../../../models/environment';
-import { BASE_PROJECT_ID } from '../../../../models/project';
+import { DEFAULT_PROJECT_ID } from '../../../../models/project';
 import { Workspace, WorkspaceScope, WorkspaceScopeKeys } from '../../../../models/workspace';
 import { WorkspaceMeta } from '../../../../models/workspace-meta';
 import { getAndClearShowPromptMockArgs } from '../../../../test-utils';
@@ -46,7 +46,7 @@ describe('workspace', () => {
   beforeEach(globalBeforeEach);
   describe('createWorkspace', () => {
     it('should create document', async () => {
-      const projectId = BASE_PROJECT_ID;
+      const projectId = DEFAULT_PROJECT_ID;
       const store = mockStore(await reduxStateForTest({ activeProjectId: projectId }));
 
       // @ts-expect-error redux-thunk types
@@ -66,7 +66,7 @@ describe('workspace', () => {
       expect(store.getActions()).toEqual([
         {
           type: SET_ACTIVE_PROJECT,
-          projectId: BASE_PROJECT_ID,
+          projectId: DEFAULT_PROJECT_ID,
         },
         {
           type: SET_ACTIVE_WORKSPACE,
@@ -80,7 +80,7 @@ describe('workspace', () => {
     });
 
     it('should create collection', async () => {
-      const projectId = BASE_PROJECT_ID;
+      const projectId = DEFAULT_PROJECT_ID;
       const store = mockStore(await reduxStateForTest({ activeProjectId: projectId }));
 
       // @ts-expect-error redux-thunk types
@@ -100,7 +100,7 @@ describe('workspace', () => {
       expect(store.getActions()).toEqual([
         {
           type: SET_ACTIVE_PROJECT,
-          projectId: BASE_PROJECT_ID,
+          projectId: DEFAULT_PROJECT_ID,
         },
         {
           type: SET_ACTIVE_WORKSPACE,

--- a/packages/insomnia-app/app/ui/redux/modules/global.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/global.tsx
@@ -30,7 +30,7 @@ import * as models from '../../../models';
 import { Environment, isEnvironment } from '../../../models/environment';
 import { GrpcRequest } from '../../../models/grpc-request';
 import * as requestOperations from '../../../models/helpers/request-operations';
-import { BASE_PROJECT_ID } from '../../../models/project';
+import { DEFAULT_PROJECT_ID } from '../../../models/project';
 import { Request } from '../../../models/request';
 import { Settings } from '../../../models/settings';
 import { isWorkspace } from '../../../models/workspace';
@@ -81,7 +81,7 @@ function activeActivityReducer(state: string | null = null, action) {
   }
 }
 
-function activeProjectReducer(state: string = BASE_PROJECT_ID, action) {
+function activeProjectReducer(state: string = DEFAULT_PROJECT_ID, action) {
   switch (action.type) {
     case SET_ACTIVE_PROJECT:
       return action.projectId;
@@ -669,7 +669,7 @@ export function initActiveProject() {
     // Nothing here...
   }
 
-  return setActiveProject(projectId || BASE_PROJECT_ID);
+  return setActiveProject(projectId || DEFAULT_PROJECT_ID);
 }
 
 export function initDashboardSortOrder() {

--- a/packages/insomnia-app/app/ui/redux/modules/project.ts
+++ b/packages/insomnia-app/app/ui/redux/modules/project.ts
@@ -2,7 +2,7 @@ import { SegmentEvent, trackEvent, trackSegmentEvent } from '../../../common/ana
 import { ACTIVITY_HOME } from '../../../common/constants';
 import { strings } from '../../../common/strings';
 import * as models from '../../../models';
-import { BASE_PROJECT_ID, isRemoteProject, Project } from '../../../models/project';
+import { DEFAULT_PROJECT_ID, isRemoteProject, Project } from '../../../models/project';
 import { showAlert, showPrompt } from '../../components/modals';
 import { setActiveActivity, setActiveProject } from './global';
 
@@ -40,8 +40,8 @@ export const removeProject = (project: Project) => dispatch => {
       await models.stats.incrementDeletedRequestsForDescendents(project);
       await models.project.remove(project);
       trackEvent('Project', 'Delete');
-      // Show base project
-      dispatch(setActiveProject(BASE_PROJECT_ID));
+      // Show default project
+      dispatch(setActiveProject(DEFAULT_PROJECT_ID));
       // Show home in case not already on home
       dispatch(setActiveActivity(ACTIVITY_HOME));
       trackSegmentEvent(SegmentEvent.projectLocalDelete);

--- a/packages/insomnia-app/app/ui/redux/selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/selectors.ts
@@ -5,7 +5,7 @@ import { isWorkspaceActivity } from '../../common/constants';
 import * as models from '../../models';
 import { BaseModel } from '../../models';
 import { getStatusCandidates } from '../../models/helpers/get-status-candidates';
-import { BASE_PROJECT_ID, isRemoteProject } from '../../models/project';
+import { DEFAULT_PROJECT_ID, isRemoteProject } from '../../models/project';
 import { isRequest, Request } from '../../models/request';
 import { isRequestGroup, RequestGroup } from '../../models/request-group';
 import { UnitTestResult } from '../../models/unit-test-result';
@@ -85,7 +85,7 @@ export const selectActiveProject = createSelector(
   selectEntities,
   (state: RootState) => state.global.activeProjectId,
   (entities, activeProjectId) => {
-    return entities.projects[activeProjectId] || entities.projects[BASE_PROJECT_ID];
+    return entities.projects[activeProjectId] || entities.projects[DEFAULT_PROJECT_ID];
   },
 );
 


### PR DESCRIPTION
During standup today we discussed renaming the "base project" to "default project" to be more clear to users what it is and what it does.  This PR makes that change.  Individual commit notes are in the commit descriptions.

The main places this changes for users are in the tooltip over the icon for the default space.

before:
![Screenshot_20210824_171348](https://user-images.githubusercontent.com/15232461/130690991-821c3daa-64ce-4b3a-bf80-77b856d3064a.png)

after:
![Screenshot_20210824_171248](https://user-images.githubusercontent.com/15232461/130690997-60a5cf52-c222-43da-ab30-ccb546150e42.png)
