### PR TITLE
feat(plugin) install from markdown link

### DIFF
--- a/packages/insomnia-app/app/common/electron-helpers.ts
+++ b/packages/insomnia-app/app/common/electron-helpers.ts
@@ -3,12 +3,17 @@ import mkdirp from 'mkdirp';
 import { join } from 'path';
 
 import appConfig from '../../config/config.json';
+import install from '../plugins/install';
 
 export function clickLink(href: string) {
-  const { protocol } = new URL(href);
+  const { protocol, searchParams } = new URL(href);
   if (protocol === 'http:' || protocol === 'https:') {
     // eslint-disable-next-line no-restricted-properties -- this is, other than tests, what _should be_ the one and only place in this project where this is called.
     electron.shell.openExternal(href);
+  }
+  const name = searchParams.get('name');
+  if (protocol === 'insomnia:' && name !== null) {
+    install(name);
   }
 }
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
You can now install a plugin from clicking a link in markdown, this helps docs point at required plugins.

![image](https://user-images.githubusercontent.com/3679927/131123311-dca7e400-4d19-40f5-a6ce-a6a7a58795a5.png)

Such cool, much wowo!