### PR TITLE
Move prompt hide function before the async onComplete handler

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.tsx
@@ -76,8 +76,8 @@ class PromptModal extends PureComponent<{}, State> {
   async _done(rawValue: string) {
     const { onComplete, upperCase } = this.state;
     const value = upperCase ? rawValue.toUpperCase() : rawValue;
-    await onComplete?.(value);
     this.hide();
+    await onComplete?.(value);
   }
 
   _handleCancel() {


### PR DESCRIPTION
Fixes an issue where opening consecutive prompts only displays the first one.

Since the _done function in the prompt-modal became async, it is now possible for the onComplete function to trigger some logic that opens a new prompt before the old one gets hidden.

You can test that the fix works by generating a new plugin in Insomnia > Preferences > Plugins, and using the code provided in #3959 as an example.

**Before:**

![before3959](https://user-images.githubusercontent.com/12115431/131155397-2dd7d95b-ec09-4493-8478-53fb8cc1138f.gif)

**After:**

![3959after](https://user-images.githubusercontent.com/12115431/131155088-58116a7b-3ed5-46b0-9aee-df4c9e48063c.gif)

Closes #3959