### PR TITLE
Don't resolve plugin prompt promise until modal has closed, to avoid a race condition

### DIFF
--- a/packages/insomnia-app/app/plugins/context/__tests__/app.test.ts
+++ b/packages/insomnia-app/app/plugins/context/__tests__/app.test.ts
@@ -80,6 +80,7 @@ describe('app.prompt()', () => {
           title: 'Title',
           onComplete: expect.any(Function),
           onCancel: expect.any(Function),
+          onHide: expect.any(Function),
         },
       ],
       [
@@ -88,6 +89,7 @@ describe('app.prompt()', () => {
           label: 'Label',
           onComplete: expect.any(Function),
           onCancel: expect.any(Function),
+          onHide: expect.any(Function),
         },
       ],
     ]);

--- a/packages/insomnia-app/app/plugins/context/app.tsx
+++ b/packages/insomnia-app/app/plugins/context/app.tsx
@@ -69,7 +69,11 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): {
           return Promise.resolve(options.defaultValue || '');
         }
 
+        // This custom promise converts the prompt modal from being callback-based to reject when the modal is cancelled and resolve when the modal is submitted
         return new Promise((resolve, reject) => {
+          let shouldResolve = false;
+          let resolveWith: string;
+
           showPrompt({
             title,
             ...(options || ({} as Record<string, any>)),
@@ -79,7 +83,15 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): {
             },
 
             onComplete(value: string) {
-              resolve(value);
+              shouldResolve = true;
+              resolveWith = value;
+            },
+
+            // don't resolve the overall promise until the modal has hidden after clicking submit
+            onHide() {
+              if (shouldResolve){
+                resolve(resolveWith);
+              }
             },
           });
         });

--- a/packages/insomnia-app/app/plugins/context/app.tsx
+++ b/packages/insomnia-app/app/plugins/context/app.tsx
@@ -89,7 +89,7 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): {
 
             // don't resolve the overall promise until the modal has hidden after clicking submit
             onHide() {
-              if (shouldResolve){
+              if (shouldResolve) {
                 resolve(resolveWith);
               }
             },

--- a/packages/insomnia-app/app/plugins/context/app.tsx
+++ b/packages/insomnia-app/app/plugins/context/app.tsx
@@ -69,10 +69,10 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): {
           return Promise.resolve(options.defaultValue || '');
         }
 
-        // This custom promise converts the prompt modal from being callback-based to reject when the modal is cancelled and resolve when the modal is submitted
-        return new Promise((resolve, reject) => {
+        // This custom promise converts the prompt modal from being callback-based to reject when the modal is cancelled and resolve when the modal is submitted and hidden
+        return new Promise<string>((resolve, reject) => {
           let shouldResolve = false;
-          let resolveWith: string;
+          let resolveWith: string | null = null;
 
           showPrompt({
             title,
@@ -89,7 +89,7 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): {
 
             // don't resolve the overall promise until the modal has hidden after clicking submit
             onHide() {
-              if (shouldResolve) {
+              if (shouldResolve && resolveWith !== null) {
                 resolve(resolveWith);
               }
             },

--- a/packages/insomnia-app/app/ui/components/modals/prompt-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/prompt-modal.tsx
@@ -25,6 +25,7 @@ interface State {
   cancelable?: boolean | null;
   onComplete?: (arg0: string) => Promise<void> | void;
   onCancel?: (() => void) | null;
+  onHide?: () => void,
   onDeleteHint?: ((arg0: string) => void) | null;
   currentValue: string;
   loading: boolean;
@@ -44,6 +45,7 @@ export interface PromptModalOptions {
   label?: string;
   hints?: string[];
   onComplete?: (arg0: string) => Promise<void> | void;
+  onHide?: () => void,
   onDeleteHint?: (arg0: string) => void;
   onCancel?: () => void;
 }
@@ -69,6 +71,7 @@ class PromptModal extends PureComponent<{}, State> {
     onComplete: undefined,
     onCancel: undefined,
     onDeleteHint: undefined,
+    onHide: undefined,
     currentValue: '',
     loading: false,
   }
@@ -162,6 +165,7 @@ class PromptModal extends PureComponent<{}, State> {
     onCancel,
     validate,
     onDeleteHint,
+    onHide,
   }: PromptModalOptions) {
     this.setState({
       currentValue: '',
@@ -181,6 +185,7 @@ class PromptModal extends PureComponent<{}, State> {
       validate,
       hints: hints || [],
       loading: false,
+      onHide,
     });
     this.modal?.show();
 
@@ -276,7 +281,7 @@ class PromptModal extends PureComponent<{}, State> {
       'form-control--outlined': inputType !== 'checkbox',
     });
     return (
-      <Modal ref={this._setModalRef} noEscape={!cancelable || loading} onCancel={this._handleCancel}>
+      <Modal ref={this._setModalRef} noEscape={!cancelable || loading} onCancel={this._handleCancel} onHide={this.state.onHide}>
         <ModalHeader>{title}</ModalHeader>
         <ModalBody className="wide">
           <form onSubmit={this._handleSubmit} className="wide pad">

--- a/packages/insomnia-app/app/ui/components/modals/the-plan-for-modals.md
+++ b/packages/insomnia-app/app/ui/components/modals/the-plan-for-modals.md
@@ -5,13 +5,14 @@
 1. We're trying to move the entire codebase to hooks.  With the possible exception of one component (ErrorBoundary) there should be no component in the codebase that must be a class.
 1. Right now, all modals are classes.  One core reason for this is that `showModal` in `app/ui/components/modals/index.ts` directly calls `show` on the modal instance of a registered modal.
 
-## Where we're going
+## Where we're going (TBC, but this is an initial plan)
 
 1. Modal lifecycle state (hiding, showing, loading) will be managed with redux actions.  This will eliminate the current blocker for moving to hooks.
 1. All modals will be hooks.
     1. Modals will thereby do their part in the larger mission of dropping the class-autobind-decorator dependency.
 1. Modals will use portals.
 1. Modals will not have to be singletons, making them more easily composable in the app's flows.
+    1. For an example of why singleton modals cause issues, see the regression that was resolved in https://github.com/Kong/insomnia/pull/3970
 1. Modals will not have to be loaded into the react tree at all times.
 
 ## How we're going to get there

--- a/packages/insomnia-app/app/ui/components/modals/the-plan-for-modals.md
+++ b/packages/insomnia-app/app/ui/components/modals/the-plan-for-modals.md
@@ -12,7 +12,7 @@
     1. Modals will thereby do their part in the larger mission of dropping the class-autobind-decorator dependency.
 1. Modals will use portals.
 1. Modals will not have to be singletons, making them more easily composable in the app's flows.
-    1. For an example of why singleton modals cause issues, see the regression that was resolved in https://github.com/Kong/insomnia/pull/3970
+    1. For an example of why singleton modals cause issues, see the regression that was resolved in [#3970](https://github.com/Kong/insomnia/pull/3970)
 1. Modals will not have to be loaded into the react tree at all times.
 
 ## How we're going to get there


### PR DESCRIPTION
### The background

All modals in this codebase are callback based. That is, to process the result of a modal, you need to send an `onComplete` or `onCancel` callback into the `modal.show()` method.

The plugin API which exposes the prompt modal (`context.app.prompt`) _is not_ callback based, it is promise based. That is, if the prompt was cancelled, `context.app.prompt` should reject with an error, and if the prompt was submitted, `context.app.prompt` should resolve with the prompt value.

The callback-based prompt is converted to a promise-based helper in `packages/insomnia-app/app/plugins/context/app.tsx`.

> The alert modal "attempts" to make itself be both callback-based and promise-based, which is additional confusion, so this (and modals in general) do need a cleanup which is not done in this PR.

### The change

The `onComplete` callback for a prompt was previously synchronous, however an update in https://github.com/Kong/insomnia/pull/3474 introduced asynchronous handlers, adding a loading state and not closing the modal until the `onComplete` handler was finished.

### The race condition

This change introduced a race condition with the plugin API implementation translation. On clicking submit and triggering the `onComplete` callback, the plugin API (which resolves the wrapped promise - see previous implementation) would resolve the promise and tell a plugin that "the prompt is complete", while at the same time the application would be in the process of closing the modal. If the plugin immediately opened another prompt (while the application was still trying to close the first, because of a race condition), the _second_ prompt would close.

### The fix

> We already know that the modal APIs need to be improved, and ideally an attempt made to remove the difference in API (callback-based vs promise-based) to avoid mistakes in translation such as this one. This PR only makes a minimal fix for `context.app.prompt`. One approach to make this plugin stable would be to decouple the `PromptModal` used within the app from the plugin API and have a minimal `PromptModal` specifically for plugins with a restricted implementation matching the API available the plugin developers.

In this PR, when translating from the callback-based prompt modal to a promise-based helper for plugins, we only resolve the promise if:
1. the user pressed submit
1. after the modal has hidden

### The demo

This demo uses the example plugin in #3959 and also https://github.com/Vyoam/insomnia-plugin-postman-export, both of which were impacted by this race condition.

![2021-08-30 17 27 56](https://user-images.githubusercontent.com/4312346/131289684-3a5e5881-dee4-44fd-ab9e-44c3e1c20db2.gif)

Closes #3959