### PR TITLE
[Feature/Plugin API] Add clipboard wrapper methods to context app

### DIFF
--- a/packages/insomnia-app/app/__mocks__/electron.ts
+++ b/packages/insomnia-app/app/__mocks__/electron.ts
@@ -74,6 +74,11 @@ const electron = {
   shell: {
     openExternal: jest.fn(),
   },
+  clipboard: {
+    writeText: jest.fn(),
+    readText: jest.fn(),
+    clear: jest.fn(),
+  },
 };
 
 // WARNING: changing this to `export default` will break the mock and be incredibly hard to debug. Ask me how I know.

--- a/packages/insomnia-app/app/plugins/context/__tests__/app.test.ts
+++ b/packages/insomnia-app/app/plugins/context/__tests__/app.test.ts
@@ -20,7 +20,7 @@ describe('init()', () => {
       'prompt',
       'showGenericModalDialog',
       'showSaveDialog',
-    ]);
+    ].sort());
     expect(Object.keys(result.app.clipboard).sort()).toEqual([
       'clear',
       'readText',

--- a/packages/insomnia-app/app/plugins/context/__tests__/app.test.ts
+++ b/packages/insomnia-app/app/plugins/context/__tests__/app.test.ts
@@ -25,7 +25,7 @@ describe('init()', () => {
       'clear',
       'readText',
       'writeText',
-    ]);
+    ].sort());
   });
 });
 

--- a/packages/insomnia-app/app/plugins/context/__tests__/app.test.ts
+++ b/packages/insomnia-app/app/plugins/context/__tests__/app.test.ts
@@ -1,3 +1,6 @@
+import electron from 'electron';
+import { mocked } from 'ts-jest/utils';
+
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import { RENDER_PURPOSE_SEND } from '../../../common/render';
 import * as modals from '../../../ui/components/modals';
@@ -11,12 +14,17 @@ describe('init()', () => {
     expect(Object.keys(result)).toEqual(['app', '__private']);
     expect(Object.keys(result.app).sort()).toEqual([
       'alert',
+      'clipboard',
       'dialog',
       'getPath',
       'prompt',
       'showGenericModalDialog',
       'showSaveDialog',
-      'clipboard',
+    ]);
+    expect(Object.keys(result.app.clipboard).sort()).toEqual([
+      'clear',
+      'readText',
+      'writeText',
     ]);
   });
 });
@@ -94,5 +102,47 @@ describe('app.prompt()', () => {
         },
       ],
     ]);
+  });
+});
+
+describe('app.clipboard', () => {
+  it('writes to clipboard', () => {
+    // Arrange
+    const mockedClipboard = mocked(electron.clipboard);
+    const context = plugin.init();
+    const text = 'abc';
+
+    // Act
+    context.app.clipboard.writeText(text);
+
+    // Assert
+    expect(mockedClipboard.writeText).toHaveBeenCalledWith(text);
+  });
+
+  it('reads from clipboard', () => {
+    // Arrange
+    const text = 'abc';
+    const mockedClipboard = mocked(electron.clipboard);
+    mockedClipboard.readText.mockReturnValue(text);
+    const context = plugin.init();
+
+    // Act
+    const outputText = context.app.clipboard.readText();
+
+    // Assert
+    expect(outputText).toBe(text);
+    expect(mockedClipboard.readText).toHaveBeenCalled();
+  });
+
+  it('clears clipboard', () => {
+    // Arrange
+    const mockedClipboard = mocked(electron.clipboard);
+    const context = plugin.init();
+
+    // Act
+    context.app.clipboard.clear();
+
+    // Assert
+    expect(mockedClipboard.clear).toHaveBeenCalled();
   });
 });

--- a/packages/insomnia-app/app/plugins/context/__tests__/app.test.ts
+++ b/packages/insomnia-app/app/plugins/context/__tests__/app.test.ts
@@ -16,6 +16,7 @@ describe('init()', () => {
       'prompt',
       'showGenericModalDialog',
       'showSaveDialog',
+      'clipboard',
     ]);
   });
 });

--- a/packages/insomnia-app/app/plugins/context/app.tsx
+++ b/packages/insomnia-app/app/plugins/context/app.tsx
@@ -125,6 +125,20 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): {
         return filePath || null;
       },
 
+      clipboard: {
+        readText(): string {
+          return electron.clipboard.readText();
+        },
+
+        writeText(text: string): void {
+          electron.clipboard.writeText(text);
+        },
+
+        clear(): void {
+          electron.clipboard.clear();
+        },
+      },
+
       // ~~~~~~~~~~~~~~~~~~ //
       // Deprecated Methods //
       // ~~~~~~~~~~~~~~~~~~ //


### PR DESCRIPTION
- Adds clipboard object with `.readText` and `.writeText` methods using
underlying electorn clipboard methods

Closes INS-919