### PR TITLE
fixes styling regression for autocomplete

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/extensions/autocomplete.ts
+++ b/packages/insomnia-app/app/ui/components/codemirror/extensions/autocomplete.ts
@@ -108,8 +108,9 @@ CodeMirror.defineOption('environmentAutocomplete', null, (cm, options) => {
           widget.close();
           return CodeMirror.Pass;
         },
-      }, // Good for debugging
-      // ,closeOnUnfocus: false
+      },
+      // Good for debugging
+      // closeOnUnfocus: false,
     });
   }
 

--- a/packages/insomnia-app/app/ui/css/editor/hints.less
+++ b/packages/insomnia-app/app/ui/css/editor/hints.less
@@ -16,7 +16,7 @@
     padding: 0 !important; // ugh
     border-radius: 0;
     display: grid;
-    grid-template-columns: var(--line-height-xxs) auto minmax(0, 1fr);
+    grid-template-columns: var(--line-height-xxs) auto minmax(0, 0);
     background: var(--color-bg);
     font-size: var(--font-size-xs);
 


### PR DESCRIPTION
I noticed that the styling for the autocomplete has broken.  The background doesn't fill all the way across (and, it should).

## Before

https://user-images.githubusercontent.com/15232461/131869557-f2d948b7-c8ca-4722-a2df-ce01c5e3c043.mp4

## After

https://user-images.githubusercontent.com/15232461/131869780-cd272977-04b8-4a90-983d-623b95d73e29.mp4

There's a way in which, I guess, this isn't a regression, but it seems to have been uncovered after https://github.com/Kong/insomnia/pull/3983.  Visually, though, it is a regression.