### PR TITLE
fixes nunjucks-tag pointer

### DIFF
--- a/packages/insomnia-app/app/ui/css/editor/nunjucks-tag.less
+++ b/packages/insomnia-app/app/ui/css/editor/nunjucks-tag.less
@@ -7,7 +7,7 @@
     position: relative;
     font-size: 0.9em;
     line-height: 1em; // Need this for CodeMirror line-height math
-    cursor: default;
+    cursor: pointer;
     white-space: nowrap;
     text-shadow: 0 0 0.1em rgba(0, 0, 0, 0.4);
 


### PR DESCRIPTION
I noticed while working on https://github.com/Kong/insomnia/issues/3990 that this bit of UI doesn't use the correct pointer.  If you don't know that this needs to be clicked for the UX flow to continue, the cursor can go a long way towards hinting that this but of UI needs to be clicked on.

| BEFORE | AFTER |
| - | - |
| ![image](https://user-images.githubusercontent.com/15232461/131871806-1f2016e6-56e9-457d-b575-77fbae66fa1d.png) | ![image](https://user-images.githubusercontent.com/15232461/131872153-30a8f475-4d17-4e2d-818a-2722ea8e6da4.png)
|
