### PR TITLE
Update response headers viewer to FC

### DIFF
--- a/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
@@ -27,7 +27,7 @@ import SizeTag from '../tags/size-tag';
 import StatusTag from '../tags/status-tag';
 import TimeTag from '../tags/time-tag';
 import ResponseCookiesViewer from '../viewers/response-cookies-viewer';
-import ResponseHeadersViewer from '../viewers/response-headers-viewer';
+import { ResponseHeadersViewer } from '../viewers/response-headers-viewer';
 import ResponseTimelineViewer from '../viewers/response-timeline-viewer';
 import ResponseViewer from '../viewers/response-viewer';
 import BlankPane from './blank-pane';

--- a/packages/insomnia-app/app/ui/components/viewers/response-headers-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-headers-viewer.tsx
@@ -1,4 +1,5 @@
-import React, { Fragment, PureComponent } from 'react';
+import React, { FC, Fragment, useMemo } from 'react';
+import styled from 'styled-components';
 import { URL } from 'url';
 
 import type { ResponseHeader } from '../../../models/response';
@@ -9,58 +10,51 @@ interface Props {
   headers: ResponseHeader[];
 }
 
-function validateURL(urlString) {
+const validateURL = ({ value }: ResponseHeader) => {
   try {
-    const parsedUrl = new URL(urlString);
-    if (!parsedUrl.hostname) return false;
-    return true;
-  } catch (error) {
+    const parsedUrl = new URL(value);
+    return Boolean(parsedUrl.hostname);
+  } catch {
     return false;
   }
-}
+};
 
-class ResponseHeadersViewer extends PureComponent<Props> {
-  render() {
-    const { headers } = this.props;
-    const headersString = headers.map(h => `${h.name}: ${h.value}`).join('\n');
-    return (
-      <Fragment>
-        <table className="table--fancy table--striped table--compact">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Value</th>
+const headerAsString = (header: ResponseHeader) => `${header.name}: ${header.value}`;
+
+const StyledTableDataCell = styled.td.attrs({
+  className: 'force-wrap',
+})({
+  width: '50%',
+});
+
+export const ResponseHeadersViewer: FC<Props> = ({ headers }) => {
+  const headersString = useMemo(() => headers.map(headerAsString).join('\n'), [headers]);
+
+  return (
+    <Fragment>
+      <table className="table--fancy table--striped table--compact">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {headers.map(header => (
+            <tr className="selectable" key={headerAsString(header)}>
+              <StyledTableDataCell>
+                {header.name}
+              </StyledTableDataCell>
+              <StyledTableDataCell>
+                {validateURL(header) ? <Link href={header.value}>{header.value}</Link> : header.value}
+              </StyledTableDataCell>
             </tr>
-          </thead>
-          <tbody>
-            {headers.map((h, i) => (
-              <tr className="selectable" key={i}>
-                <td
-                  style={{
-                    width: '50%',
-                  }}
-                  className="force-wrap"
-                >
-                  {h.name}
-                </td>
-                <td
-                  style={{
-                    width: '50%',
-                  }}
-                  className="force-wrap"
-                >
-                  {validateURL(h.value) ? <Link href={h.value}>{h.value}</Link> : h.value}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        <p key="copy" className="pad-top">
-          <CopyButton className="pull-right" content={headersString} />
-        </p>
-      </Fragment>
-    );
-  }
-}
-
-export default ResponseHeadersViewer;
+          ))}
+        </tbody>
+      </table>
+      <p key="copy" className="pad-top">
+        <CopyButton className="pull-right" content={headersString} />
+      </p>
+    </Fragment>
+  );
+};

--- a/packages/insomnia-app/app/ui/components/viewers/response-multipart.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-multipart.tsx
@@ -17,7 +17,7 @@ import type { ResponseHeader } from '../../../models/response';
 import { Dropdown, DropdownButton, DropdownItem } from '../base/dropdown/index';
 import { showModal } from '../modals/index';
 import WrapperModal from '../modals/wrapper-modal';
-import ResponseHeadersViewer from './response-headers-viewer';
+import { ResponseHeadersViewer } from './response-headers-viewer';
 import ResponseViewer from './response-viewer';
 
 interface Part {


### PR DESCRIPTION
Resolves an ES Lint warning, removes inline repetitive styling in favor of `styled-components` (but still using named CSS classes that exist), and removes index as key.

This is general cleanup and should have no behavior change.

<img width="1393" alt="image" src="https://user-images.githubusercontent.com/4312346/131952181-8a9496e2-6488-4eb3-a47a-a396fd1d54ff.png">
