### PR TITLE
[Docs] Add devel docs for package installation on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ npm test
 npm run app-start
 ```
 
+### Linux
+
 If you are on Linux, you may need to install the following supporting packages:
 
 <details>
@@ -85,13 +87,15 @@ sudo dnf install libcurl-devel
 ```
 
 </details>
-
+<br/>
 Also on Linux, if Electron is failing during the bootstrap process, run the following
 
 ```shell
 # Clear Electron install conflicts
 rm -rf ~/.cache/electron
 ```
+
+### Windows
 
 If you are on Windows and have problems, you may need to install [Windows Build Tools](https://github.com/felixrieseberg/windows-build-tools)
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ sudo dnf install libcurl-devel
 ```
 
 </details>
-<br/>
+
 Also on Linux, if Electron is failing during the bootstrap process, run the following
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ npm test
 npm run app-start
 ```
 
-If you are on Linux, you may need to install the following supporting packages
+If you are on Linux, you may need to install the following supporting packages:
+
+<details>
+<summary>Ubuntu/Debian</summary>
 
 ```shell
 # Update library
@@ -60,6 +63,28 @@ sudo apt-get install font-manager
 # Build capability for required font-scanner package
 sudo apt-get install build-essential
 ```
+
+</details>
+
+<details>
+<summary>Fedora</summary>
+
+```shell
+# Enable FontManager Copr (https://github.com/FontManager/font-manager#fedora-copr)
+sudo dnf copr enable jerrycasiano/FontManager
+
+# Install font configuration library & support
+sudo dnf install font-manager
+sudo dnf install fontconfig-devel
+
+# Build capability for required font-scanner package
+sudo dnf install make automake gcc gcc-c++ kernel-devel
+
+# Install libcurl for node-libcurl
+sudo dnf install libcurl-devel
+```
+
+</details>
 
 Also on Linux, if Electron is failing during the bootstrap process, run the following
 


### PR DESCRIPTION
- Initial Dev Setup only included installing OS dependencies for Linux distributions that use apt-get (Ubuntu/Debian)
- This adds instructions for what deps are needed on Fedora using dnf
- Added OS headers for clearer separation of OS reqs/troubleshooting