### PR TITLE
Don't encode if string is empty in the tag editor

### DIFF
--- a/packages/insomnia-app/app/templating/__tests__/utils.test.ts
+++ b/packages/insomnia-app/app/templating/__tests__/utils.test.ts
@@ -303,6 +303,7 @@ describe('encodeEncoding()', () => {
     expect(utils.encodeEncoding('hello', 'unknown')).toBe('hello');
     expect(utils.encodeEncoding('hello')).toBe('hello');
     expect(utils.encodeEncoding('hello', 'utf8')).toBe('hello');
+    expect(utils.encodeEncoding('', 'base64')).toBe('');
   });
 });
 
@@ -314,5 +315,6 @@ describe('decodeEncoding()', () => {
     expect(utils.decodeEncoding('aGVsbG8=')).toBe('aGVsbG8=');
     expect(utils.decodeEncoding('hello')).toBe('hello');
     expect(utils.decodeEncoding(null)).toBe(null);
+    expect(utils.decodeEncoding('')).toBe('');
   });
 });

--- a/packages/insomnia-app/app/templating/__tests__/utils.test.ts
+++ b/packages/insomnia-app/app/templating/__tests__/utils.test.ts
@@ -300,9 +300,7 @@ describe('encodeEncoding()', () => {
   it('encodes things', () => {
     expect(utils.encodeEncoding('hello', 'base64')).toBe('b64::aGVsbG8=::46b');
     expect(utils.encodeEncoding(null, 'base64')).toBe(null);
-    expect(utils.encodeEncoding('hello', 'unknown')).toBe('hello');
     expect(utils.encodeEncoding('hello')).toBe('hello');
-    expect(utils.encodeEncoding('hello', 'utf8')).toBe('hello');
     expect(utils.encodeEncoding('', 'base64')).toBe('');
   });
 });

--- a/packages/insomnia-app/app/templating/utils.ts
+++ b/packages/insomnia-app/app/templating/utils.ts
@@ -246,8 +246,12 @@ export function getDefaultFill(name: string, args: NunjucksParsedTagArg[]) {
   return `${name} ${stringArgs.join(', ')}`;
 }
 
-export function encodeEncoding(value: string, encoding: 'base64') {
+export function encodeEncoding<T>(value: T, encoding?: 'base64' | 'unknown' | 'utf8') {
   if (typeof value !== 'string') {
+    return value;
+  }
+
+  if (value.length === 0) {
     return value;
   }
 
@@ -259,7 +263,7 @@ export function encodeEncoding(value: string, encoding: 'base64') {
   return value;
 }
 
-export function decodeEncoding(value: string) {
+export function decodeEncoding<T>(value: T) {
   if (typeof value !== 'string') {
     return value;
   }

--- a/packages/insomnia-app/app/templating/utils.ts
+++ b/packages/insomnia-app/app/templating/utils.ts
@@ -246,7 +246,7 @@ export function getDefaultFill(name: string, args: NunjucksParsedTagArg[]) {
   return `${name} ${stringArgs.join(', ')}`;
 }
 
-export function encodeEncoding<T>(value: T, encoding?: 'base64' | 'unknown' | 'utf8') {
+export function encodeEncoding<T>(value: T, encoding?: 'base64') {
   if (typeof value !== 'string') {
     return value;
   }


### PR DESCRIPTION
When using a template tag string argument with encoding enabled (as per the [response => body attribute template tag](https://github.com/Kong/insomnia/blob/6a60e2bbbca6214270653be3bd235eec4a6d7e79/plugins/insomnia-plugin-response/index.js#L50-L50)), Insomnia encodes the filter value, but if the filter value is empty it should not attempt to encode and leave it blank.

In the following demo video, the first example is live, and second is this PR. This fix was inspired by this comment (https://github.com/Kong/insomnia/issues/2050#issuecomment-908826203), noticed while exploring XPath issues.

https://www.loom.com/share/7a3bbf3c52b048ce902e634be0bd9198

Closes INS-947