### PR TITLE
Add note that Kong Plugin Bundle is auto bundled

### DIFF
--- a/plugins/insomnia-plugin-kong-bundle/README.md
+++ b/plugins/insomnia-plugin-kong-bundle/README.md
@@ -2,7 +2,7 @@
 
 [![Npm Version](https://img.shields.io/npm/v/insomnia-plugin-kong-bundle.svg)](https://www.npmjs.com/package/insomnia-plugin-kong-bundle)
 
-This plugin that bundles Kong-specific Insomnia plugins into a single plugin.
+This plugin bundles Kong-specific Insomnia plugins into a single plugin.
 
 **Note**: The functionality that this plugin offers is now bundled automatically with Insomnia. If you are on the latest version of Insomnia, you can delete this plugin entirely from Preferences > Plugins.
 

--- a/plugins/insomnia-plugin-kong-bundle/README.md
+++ b/plugins/insomnia-plugin-kong-bundle/README.md
@@ -2,7 +2,9 @@
 
 [![Npm Version](https://img.shields.io/npm/v/insomnia-plugin-kong-bundle.svg)](https://www.npmjs.com/package/insomnia-plugin-kong-bundle)
 
-This is a plugin that bundles Kong-specific Insomnia plugins into a single plugin.
+This plugin that bundles Kong-specific Insomnia plugins into a single plugin.
+
+**Note**: The functionality that this plugin offers is now bundled automatically with Insomnia. If you are on the latest version of Insomnia, you can delete this plugin entirely from Preferences > Plugins.
 
 ## Installation
 


### PR DESCRIPTION
I added a note that [Kong Plugin Bundle](https://insomnia.rest/plugins/insomnia-plugin-kong-bundle) is now auto-bundled with Insomnia. 

Users can delete the plugin if they are on latest. 