### PR TITLE
prevent fetching spellcheck Dictionary

### DIFF
--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -26,9 +26,8 @@ const { app, Menu, shell, dialog, clipboard, session } = electron;
 app.allowRendererProcessReuse = false;
 
 app.on('ready', () => {
-  // There's no option that prevents Electron from fetching spellcheck dictionaries from
-  // Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from
-  // fetching.  https://github.com/electron/electron/issues/22995
+  // There's no option that prevents Electron from fetching spellcheck dictionaries from Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from fetching.
+  // see: https://github.com/electron/electron/issues/22995
   // On macOS the OS spellchecker is used and therefore we do not download any dictionary files.
   // This API is a no-op on macOS.
   session.defaultSession.setSpellCheckerDictionaryDownloadURL('https://00.00/');

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -20,10 +20,19 @@ import { clickLink, getDataDirectory, restartApp } from '../common/electron-help
 import * as log from '../common/log';
 import LocalStorage from './local-storage';
 
-const { app, Menu, shell, dialog, clipboard } = electron;
+const { app, Menu, shell, dialog, clipboard, session } = electron;
 // So we can use native modules in renderer
 // NOTE: This was (deprecated in Electron 10)[https://github.com/electron/electron/issues/18397] and (removed in Electron 14)[https://github.com/electron/electron/pull/26874]
 app.allowRendererProcessReuse = false;
+
+app.on('ready', () => {
+  // There's no option that prevents Electron from fetching spellcheck dictionaries from
+  // Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from
+  // fetching.  https://github.com/electron/electron/issues/22995
+  // On macOS the OS spellchecker is used and therefore we do not download any dictionary files.
+  // This API is a no-op on macOS.
+  session.defaultSession.setSpellCheckerDictionaryDownloadURL('https://00.00/');
+});
 
 const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 700;
@@ -85,6 +94,7 @@ export function createWindow() {
     acceptFirstMouse: true,
     icon: path.resolve(__dirname, appLogo),
     webPreferences: {
+      spellcheck: false,
       zoomFactor: zoomFactor,
       nodeIntegration: true,
       webviewTag: true,
@@ -107,6 +117,7 @@ export function createWindow() {
   mainWindow?.on('unresponsive', () => {
     showUnresponsiveModal();
   });
+
   // Open generic links (<a .../>) in default browser
   mainWindow?.webContents.on('will-navigate', (e, url) => {
     if (url === appUrl) {

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -93,7 +93,6 @@ export function createWindow() {
     acceptFirstMouse: true,
     icon: path.resolve(__dirname, appLogo),
     webPreferences: {
-      spellcheck: false,
       zoomFactor: zoomFactor,
       nodeIntegration: true,
       webviewTag: true,


### PR DESCRIPTION
Disables spellchecking in electron and sets the dictionary download URL to `https://00.00/` as a way to prevent fetching anything from Chromium's CDN.


TODO:
- [x] Validate the behaviour in Linux/Windows

Closes INS-891