### PR TITLE
adds missing smoke text fixture for Projects

### DIFF
--- a/packages/insomnia-smoke-test/.gitignore
+++ b/packages/insomnia-smoke-test/.gitignore
@@ -1,0 +1,2 @@
+fixtures/inso-nedb
+fixtures/basic-designer


### PR DESCRIPTION
Since we changed the name of this entity (from spaces to project), whenever I run these commands:

```
npm run app-build:smoke
npm run test:smoke:build
```

I added this file in https://github.com/Kong/insomnia/commit/c3f92d0603aeb82cd0de672974d8ad1465c2f26f during the initial conversion and @develohpanda removed it in https://github.com/Kong/insomnia/commit/ef8168bcef8c601a2afe8ff3682fef8ba1643ea3.  I can't see where that discussion happened but my recollection was that the thinking was that it doesn't matter since it'll just be created on the CI.  However, I frequently run the smoke tests locally and I'd like to not have to continually clean up this file after every run.