### PR TITLE
[Feature] Introducing un-safe plugin installation

### DIFF
--- a/packages/insomnia-app/app/ui/redux/modules/global.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/global.tsx
@@ -222,9 +222,8 @@ export const newCommand = (command: string, args: any) => async (dispatch: Dispa
           if (!isYes) {
             return;
           }
-
           try {
-            await install(args.name);
+            await install(args.name, args.skipStdErrOutputCheck);
             showModal(SettingsModal, TAB_INDEX_PLUGINS);
           } catch (err) {
             showError({


### PR DESCRIPTION
**Issue**
Yarn prints warnings messages (e.g deprecated dependencies, custom library messages) on the stderr and Insomnia erroneously treat them as installation errors.

**What this PR aims for**
Resolve the **edge cases** which may prevent a plugin to be installed just for a couple of warnings.

**What is this "unsafe" mode all about**
Insomnia executes its own plugin installation as always ... but _skips_ the stderr check on its last step.

 **Implementation**
The user can only install un-safely when he gets an installation failure **that failed when the plugin reached the stderr check.**

**Showcase**
![showcase](https://user-images.githubusercontent.com/20780192/133908520-69b8cbaf-414b-4c8d-a3b5-8705cdc7cddd.gif)

As always feedback are welcome.