### PR TITLE
Update axios-request to respect the validateSSL app setting

### DIFF
--- a/packages/insomnia-app/app/network/axios-request.ts
+++ b/packages/insomnia-app/app/network/axios-request.ts
@@ -1,13 +1,14 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
+import * as https from 'https';
 import { setDefaultProtocol } from 'insomnia-url';
 import { parse as urlParse } from 'url';
 
 import { isDevelopment } from '../common/constants';
 import * as models from '../models';
 
-export async function axiosRequest(config) {
+export async function axiosRequest(config: AxiosRequestConfig) {
   const settings = await models.settings.getOrCreate();
-  const isHttps = config.url.indexOf('https:') === 0;
+  const isHttps = config.url?.indexOf('https:') === 0;
   let proxyUrl: string | null = null;
 
   if (isHttps && settings.httpsProxy) {
@@ -16,14 +17,23 @@ export async function axiosRequest(config) {
     proxyUrl = settings.httpProxy;
   }
 
-  const finalConfig = { ...config, adapter: global.require('axios/lib/adapters/http') };
+  const finalConfig: AxiosRequestConfig = {
+    ...config,
+    adapter: global.require('axios/lib/adapters/http'),
+    httpsAgent: new https.Agent({
+      rejectUnauthorized: settings.validateSSL,
+    }),
+  };
 
   if (proxyUrl) {
     const { hostname, port } = urlParse(setDefaultProtocol(proxyUrl));
-    finalConfig.proxy = {
-      host: hostname,
-      port,
-    };
+
+    if (hostname && port) {
+      finalConfig.proxy = {
+        host: hostname,
+        port: parseInt(port, 10),
+      };
+    }
   }
 
   const response = await axios(finalConfig);


### PR DESCRIPTION
The plugin api exposes the __private.axios method to allow plugins to send requests outside of the insomnia request lifecycle.
This PR checks the `validateSSL` app setting in order to skip validating certificates.

Tested using the `insomnia-plugin-kong-deploy` which uses the axios module to login to the kong-portal and upload the configuration:

![deploy-to-portal](https://user-images.githubusercontent.com/12115431/134178883-39ab3e14-0d00-4767-bbbb-6f978e393502.gif)


Closes INS-941