### PR TITLE
adds ndjson language support extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
     "yzhang.markdown-all-in-one",
     "DavidAnson.vscode-markdownlint",
     "dbaeumer.vscode-eslint",
+    "adrieankhisbe.vscode-ndjson",
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "files.associations": {
+    "*.db": "ndjson",
+    "*.jsonl": "ndjson",
+    "*.njson": "ndjson"
+  },
+}


### PR DESCRIPTION
When providing an answer in https://github.com/Kong/insomnia/issues/3786#issuecomment-924236677 I realized that we'd benefit from just including this extension.

Our database files are newline-delimited JSON (http://ndjson.org/), the [native format of NeDB](https://github.com/louischatriot/nedb/issues/518#issuecomment-322640935).


| BEFORE | AFTER |
| - | - |
| annoying prompt: <br />![Screenshot_20210921_141455](https://user-images.githubusercontent.com/15232461/134225775-e2bad519-303d-4adc-b675-31b36b24d585.png) | \~no annoying prompt\~ |
| no language support: <br /> ![Screenshot_20210921_141618](https://user-images.githubusercontent.com/15232461/134225766-ca782e6e-cccc-4580-bdcb-5d8ba7611415.png) | language support: <br /> ![Screenshot_20210921_141546](https://user-images.githubusercontent.com/15232461/134225806-1e081f99-457a-4689-93ba-1f4bb574cee3.png) |

It's often enough, at least for me, that I look at a data file, so I thought this would be useful to others as well.
 