### PR TITLE
fixes hotkey ux (and ui bugs)

### DIFF
--- a/packages/insomnia-app/app/common/constants.ts
+++ b/packages/insomnia-app/app/common/constants.ts
@@ -101,10 +101,22 @@ export const displayModifierKey = (key: keyof Omit<KeyCombination, 'keyCode'>) =
       return mac ? '⇧' : 'Shift';
 
     case 'meta':
-      return mac ? '⌘' : 'Super';
+      if (mac) {
+        return '⌘';
+      }
+
+      if (isWindows()) {
+        // Note: Although this unicode character for the Windows doesn't exist, the the Unicode character U+229E ⊞ SQUARED PLUS is very commonly used for this purpose. For example, Wikipedia uses it as a simulation of the windows logo.  Though, Windows itself uses `Windows` or `Win`, so we'll go with `Win` here.
+        // see: https://en.wikipedia.org/wiki/Windows_key
+        return 'Win';
+      }
+
+      // Note: To avoid using a Microsoft trademark, much Linux documentation refers to the key as "Super". This can confuse some users who still consider it a "Windows key". In KDE Plasma documentation it is called the Meta key even though the X11 "Super" shift bit is used.
+      // see: https://en.wikipedia.org/wiki/Super_key_(keyboard_button)
+      return 'Super';
 
     default:
-      unreachableCase(key, 'unrecognized key');
+      return unreachableCase(key, 'unrecognized key');
   }
 };
 

--- a/packages/insomnia-app/app/common/constants.ts
+++ b/packages/insomnia-app/app/common/constants.ts
@@ -1,9 +1,9 @@
+import { KeyCombination } from 'insomnia-common';
 import path from 'path';
 import { unreachableCase } from 'ts-assert-unreachable';
 
 import appConfig from '../../config/config.json';
 import { getDataDirectory, getPortableExecutableDir } from './electron-helpers';
-import { KeyCombination } from './hotkeys';
 
 // App Stuff
 export const getAppVersion = () => appConfig.version;

--- a/packages/insomnia-app/app/common/constants.ts
+++ b/packages/insomnia-app/app/common/constants.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import { unreachableCase } from 'ts-assert-unreachable';
-import { ValueOf } from 'type-fest';
 
 import appConfig from '../../config/config.json';
 import { getDataDirectory, getPortableExecutableDir } from './electron-helpers';

--- a/packages/insomnia-app/app/common/constants.ts
+++ b/packages/insomnia-app/app/common/constants.ts
@@ -1,7 +1,10 @@
 import path from 'path';
+import { unreachableCase } from 'ts-assert-unreachable';
+import { ValueOf } from 'type-fest';
 
 import appConfig from '../../config/config.json';
 import { getDataDirectory, getPortableExecutableDir } from './electron-helpers';
+import { KeyCombination } from './hotkeys';
 
 // App Stuff
 export const getAppVersion = () => appConfig.version;
@@ -84,10 +87,26 @@ export const EDITOR_KEY_MAP_VIM = 'vim';
 // Hotkey
 // For an explanation of mnemonics on linux and windows see https://github.com/Kong/insomnia/pull/1221#issuecomment-443543435 & https://docs.microsoft.com/en-us/cpp/windows/defining-mnemonics-access-keys?view=msvc-160#mnemonics-access-keys
 export const MNEMONIC_SYM = isMac() ? '' : '&';
-export const CTRL_SYM = isMac() ? '⌃' : 'Ctrl';
-export const ALT_SYM = isMac() ? '⌥' : 'Alt';
-export const SHIFT_SYM = isMac() ? '⇧' : 'Shift';
-export const META_SYM = isMac() ? '⌘' : 'Super';
+
+export const displayModifierKey = (key: keyof Omit<KeyCombination, 'keyCode'>) => {
+  const mac = isMac();
+  switch (key) {
+    case 'ctrl':
+      return mac ? '⌃' : 'Ctrl';
+
+    case 'alt':
+      return mac ? '⌥' : 'Alt';
+
+    case 'shift':
+      return mac ? '⇧' : 'Shift';
+
+    case 'meta':
+      return mac ? '⌘' : 'Super';
+
+    default:
+      unreachableCase(key, 'unrecognized key');
+  }
+};
 
 // Update
 export const UPDATE_CHANNEL_STABLE = 'stable';

--- a/packages/insomnia-app/app/common/hotkeys.ts
+++ b/packages/insomnia-app/app/common/hotkeys.ts
@@ -406,7 +406,7 @@ function joinHotKeys(mustUsePlus: boolean, keys: string[]) {
     return keys.join('');
   }
 
-  return keys.join('+');
+  return keys.join(' + ');
 }
 
 /**
@@ -430,10 +430,10 @@ export function isModifierKeyCode(keyCode: number) {
  * For example, the display of alt in Windows or Linux would be "Alt";
  * while in Mac would be "⌥".
  * @param keyComb
- * @param mustUsePlus if true will join the characters with "+" for all platforms;
+ * @param mustUsePlus if true will join the characters with " + " for all platforms;
  * otherwise if the platform is Mac, the characters will be next to each other.
- * @returns the constructed string, if keyCode is null and the characters are joint with "+",
- * it will have a dangling "+" as the last character, e.g., "Alt+Ctrl+".
+ * @returns the constructed string, if keyCode is null and the characters are joined with " + ",
+ * it will have a dangling "+" as the last character, e.g., "Alt + Ctrl +".
  */
 export function constructKeyCombinationDisplay(
   keyComb: KeyCombination,
@@ -453,7 +453,7 @@ export function constructKeyCombinationDisplay(
   let joint = joinHotKeys(mustUsePlus, chars);
 
   if (mustUsePlus && isModifierKeyCode(keyCode)) {
-    joint += '+';
+    joint += ' +';
   }
 
   return joint;

--- a/packages/insomnia-app/app/common/hotkeys.ts
+++ b/packages/insomnia-app/app/common/hotkeys.ts
@@ -404,7 +404,7 @@ export function getChar(keyCode: number) {
 
 function joinHotKeys(mustUsePlus: boolean, keys: string[]) {
   if (!mustUsePlus && isMac()) {
-    return keys.join('');
+    return keys.join(' ');
   }
 
   return keys.join(' + ');

--- a/packages/insomnia-app/app/ui/components/hotkey.tsx
+++ b/packages/insomnia-app/app/ui/components/hotkey.tsx
@@ -50,7 +50,14 @@ export const Hotkey: FC<Props> = memo(({ keyCombination, keyBindings, className,
     italic: isFallback,
   };
 
-  return <span className={classnames(className, classes)}>{display}</span>;
+  return (
+    <span
+      className={classnames(className, classes)}
+      style={{ verticalAlign: 'middle' }}
+    >
+      {display}
+    </span>
+  );
 });
 
 Hotkey.displayName = 'Hotkey';

--- a/packages/insomnia-app/app/ui/components/modals/add-key-combination-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/add-key-combination-modal.tsx
@@ -114,7 +114,7 @@ export class AddKeyCombinationModal extends PureComponent<{}, State> {
     let isDuplicate = false;
 
     if (pressedKeyCombination != null) {
-      keyCombDisplay = constructKeyCombinationDisplay(pressedKeyCombination, true).toLowerCase();
+      keyCombDisplay = constructKeyCombinationDisplay(pressedKeyCombination, true);
       isDuplicate = checkKeyCombinationDuplicate(pressedKeyCombination);
     }
 

--- a/packages/insomnia-app/app/ui/components/panes/placeholder-response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/placeholder-response-pane.tsx
@@ -31,7 +31,7 @@ export const PlaceholderResponsePane: FunctionComponent<Props> = ({ hotKeyRegist
                 keyBindings: hotKeyRegistry[hotKeyRefs.SHOW_COOKIES_EDITOR.id],
               },
               {
-                name: 'Edit Environment',
+                name: 'Edit Environments',
                 keyBindings: hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id],
               },
             ].map(({ name, keyBindings }) => (

--- a/packages/insomnia-app/app/ui/components/panes/placeholder-response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/placeholder-response-pane.tsx
@@ -17,50 +17,36 @@ export const PlaceholderResponsePane: FunctionComponent<Props> = ({ hotKeyRegist
       <div>
         <table className="table--fancy">
           <tbody>
-            <tr>
-              <td>Send Request</td>
-              <td className="text-right">
-                <code>
-                  <Hotkey
-                    keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SEND.id]}
-                    useFallbackMessage
-                  />
-                </code>
-              </td>
-            </tr>
-            <tr>
-              <td>Focus Url Bar</td>
-              <td className="text-right">
-                <code>
-                  <Hotkey
-                    keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_FOCUS_URL.id]}
-                    useFallbackMessage
-                  />
-                </code>
-              </td>
-            </tr>
-            <tr>
-              <td>Manage Cookies</td>
-              <td className="text-right">
-                <code>
-                  <Hotkey
-                    keyBindings={hotKeyRegistry[hotKeyRefs.SHOW_COOKIES_EDITOR.id]}
-                    useFallbackMessage
-                  />
-                </code>
-              </td>
-            </tr>
-            <tr>
-              <td>Edit Environments</td>
-              <td className="text-right">
-                <code>
-                  <Hotkey
-                    keyBindings={hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]}
-                    useFallbackMessage
-                  />
-                </code>
-              </td>
-            </tr>
+            {[
+              {
+                name: 'Send Request',
+                keyBindings: hotKeyRegistry[hotKeyRefs.REQUEST_SEND.id],
+              },
+              {
+                name: 'Focus Url Bar',
+                keyBindings: hotKeyRegistry[hotKeyRefs.REQUEST_FOCUS_URL.id],
+              },
+              {
+                name: 'Manage Cookies',
+                keyBindings: hotKeyRegistry[hotKeyRefs.SHOW_COOKIES_EDITOR.id],
+              },
+              {
+                name: 'Edit Environment',
+                keyBindings: hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id],
+              },
+            ].map(({ name, keyBindings }) => (
+              <tr key={name} style={{ lineHeight: '1em' }}>
+                <td style={{ verticalAlign: 'middle' }}>{name}</td>
+                <td className="text-right">
+                  <code>
+                    <Hotkey
+                      keyBindings={keyBindings}
+                      useFallbackMessage
+                    />
+                  </code>
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>

--- a/packages/insomnia-app/app/ui/components/panes/placeholder-response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/placeholder-response-pane.tsx
@@ -36,7 +36,7 @@ export const PlaceholderResponsePane: FunctionComponent<Props> = ({ hotKeyRegist
               },
             ].map(({ name, keyBindings }) => (
               <tr key={name} style={{ lineHeight: '1em' }}>
-                <td style={{ verticalAlign: 'middle' }}>{name}</td>
+                <td className="valign-middle">{name}</td>
                 <td className="text-right">
                   <code>
                     <Hotkey

--- a/packages/insomnia-app/app/ui/components/settings/shortcuts.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/shortcuts.tsx
@@ -112,17 +112,17 @@ export class Shortcuts extends PureComponent<Props> {
     const hasResetItems = !areKeyBindingsSameAsDefault(def.id, keyBindings);
     return (
       <tr key={index}>
-        <td>{def.description}</td>
+        <td style={{ verticalAlign: 'middle' }}>{def.description}</td>
         <td className="text-right">
           {keyCombinations.map((keyComb: KeyCombination, index: number) => {
             return (
-              <code key={index} className="margin-left-sm">
+              <code key={index} className="margin-left-sm" style={{ lineHeight: '1.25em' }}>
                 <Hotkey keyCombination={keyComb} />
               </code>
             );
           })}
         </td>
-        <td className="text-right options">
+        <td className="text-right options" style={{ verticalAlign: 'middle' }}>
           <Dropdown outline>
             <DropdownButton className="btn btn--clicky-small">
               <i className="fa fa-gear" />

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -2908,6 +2908,19 @@
 				}
 			}
 		},
+		"ts-assert-unreachable": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/ts-assert-unreachable/-/ts-assert-unreachable-0.0.9.tgz",
+			"integrity": "sha512-8tpQLahyZSNTSxKS8QPIO0AAxF8VB02tLPNqcMF638gNDOrhr8uGx9SFP1C/Vtbib2Xc/u12hiXnwmqD7pn+2A==",
+			"requires": {
+				"ts-tiny-invariant": "0.0.3"
+			}
+		},
+		"ts-tiny-invariant": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/ts-tiny-invariant/-/ts-tiny-invariant-0.0.3.tgz",
+			"integrity": "sha512-EiaBUsUta7PPzVKpvZurcSDgaSkymxwiUc2rhX6Wu30bws2maipT6ihbEY072dU9lz6/FoFWEc6psXdlo0xqtg=="
+		},
 		"tslib": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -39,6 +39,7 @@
     "ramda": "^0.27.1",
     "ramda-adjunct": "^2.33.0",
     "tough-cookie": "^4.0.0",
+    "ts-assert-unreachable": "^0.0.9",
     "url-join": "^4.0.1",
     "uuid": "^8.2.0",
     "whatwg-fetch": "^3.1.0",


### PR DESCRIPTION
closes INS-1024 

This is a pretty minor change or two, but it has a comparatively larger UX impact.  Please read commit by commit to see the changes.

- there was previously no space between the hotkeys (including plus signs) which made it feel crammed and hard to read (for me)
- when you enter a new keyboard shortcut it was strangely lowercased, despite that nowhere else has it like this
- the order of the keyboard shortcuts was wrong - this one was the one that I notice all the time and I find confusing
- we call the windows key "super" on windows, despite that we can detect that the user is on windows and call it the right thing
- the styling was very out of alignment, but for mac it was the worst of all, in part because the line height for the rows was significantly different due to the mac shortcut unicode characters (meaning, that if you have a row without a modifier key it'd be a different height than the rest).

Oh, and regarding styling, I tried very very hard to restrict this scope of this PR down as far as possible, so I didn't create a bunch of new styles (e.g. `--line-height-xxs`) when I could do it simply with an inline style.  Ultimately, the styling approach used here needs a total overhaul, but I don't want to get into that now, I just want it to be less visually broken.

## Styling / alignment example
| BEFORE | AFTER |
| - | - |
| mac: ![Screenshot_20210922_144318](https://user-images.githubusercontent.com/15232461/134416107-c545b0ac-e3e6-48c4-baf2-3b905f922d04.png) | mac: ![Screenshot_20210922_144109](https://user-images.githubusercontent.com/15232461/134415854-d7daa1f1-5d0f-4c09-8ccf-de971174280b.png) |

*note that in the before the rows are different heights, as well.

## Preferences window
| BEFORE | AFTER |
| - | - |
| linux:<br />![before - pref - linux](https://user-images.githubusercontent.com/15232461/134417626-3fc8810c-b8f7-432c-8b98-2d7dff95fb4b.png) | linux:<br />![after - pref - linux](https://user-images.githubusercontent.com/15232461/134414186-6739df89-9b5f-4ec4-bdef-ff00495031bd.png) |
| mac:<br />![before - pref - mac](https://user-images.githubusercontent.com/15232461/134414358-9da4f423-26bb-43ca-a7cb-27a7dc2427d8.png) | mac:<br />![after - pref - mac](https://user-images.githubusercontent.com/15232461/134414370-1aaf10a4-e47b-4bfd-ad43-c538f85bb682.png) |
| win:<br />![before - pref - linux](https://user-images.githubusercontent.com/15232461/134417626-3fc8810c-b8f7-432c-8b98-2d7dff95fb4b.png) | win:<br />![after - pref - win](https://user-images.githubusercontent.com/15232461/134414456-5b16df5d-7e86-4c4e-ba7b-fdb369c2e200.png) |



## In-app shortcuts
| BEFORE | AFTER |
| - | - |
| linux:<br />![before - req - linux](https://user-images.githubusercontent.com/15232461/134418474-4b7b77e3-fbac-4553-b3c2-b1dc537a08d1.png) | linux:<br />![after - req - linux](https://user-images.githubusercontent.com/15232461/134414538-f3c5c4b9-e61b-40d3-b03c-bc87d51e7ff3.png) |
| mac:<br />![before - req - mac](https://user-images.githubusercontent.com/15232461/134414570-6c710204-a8cf-4eb4-8d70-4ca054e84199.png) | mac:<br />![after - req - mac](https://user-images.githubusercontent.com/15232461/134414586-15343eed-86ce-4012-b896-8df8d6d44a6c.png) |
| win:<br />![before - req - linux](https://user-images.githubusercontent.com/15232461/134418474-4b7b77e3-fbac-4553-b3c2-b1dc537a08d1.png) | win:<br />![after - req - win](https://user-images.githubusercontent.com/15232461/134414608-35a14e18-f14b-4671-b1a1-ba48ee8c35cd.png) |

## Shortcut creation
| BEFORE | AFTER |
| - | - |
| linux:<br />![before - enter - linux](https://user-images.githubusercontent.com/15232461/134418680-b2039297-8a4a-4c6f-864f-6f81246796b9.png) | linux:<br />![after - enter - linux](https://user-images.githubusercontent.com/15232461/134414695-581b5ced-1d51-41ba-b145-71b1907c9d81.png) |