### PR TITLE
change mocha timeout to be 1 minute

### DIFF
--- a/packages/insomnia-testing/src/run/run.ts
+++ b/packages/insomnia-testing/src/run/run.ts
@@ -32,7 +32,8 @@ const runInternal = async <TReturn, TNetworkResponse>(
   global.chai = chai;
 
   const mocha: Mocha = new Mocha({
-    timeout: 5000,
+    //       ms   * sec * min
+    timeout: 1000 * 60  * 1,
     globals: ['insomnia', 'chai'],
     bail,
     reporter,


### PR DESCRIPTION
closes INS-898

> 5s is not reasonable for a network test and often causes timeouts. Use 1 minute.