### PR TITLE
INS-975 workaround: add immer directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9673,6 +9673,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "immer": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "ts-jest": "^26.5.6",
     "type-fest": "^1.0.2",
     "typescript": "^4.2.3"
+  },
+  "dependencies": {
+    "immer": "^9.0.6"
   }
 }


### PR DESCRIPTION
This PR is an alternative solution to https://github.com/Kong/insomnia/pull/4047.  See the previous PR for discussion and description.

This approach, while hacky, postpones the topic of needing to update spectral (or extract spectral configs).  My hope is that we will be able to, in the future (and less in a hurry) update spectral (while continuing to use the default rulesets) while _at the same time_ giving users the ability to specify rules.  That way, if we do make a change that happens to break for a user (since, as the previous PR's discussion establishes, spectral will make a change that they don't consider breaking but we do), the user will have some way to get back to a working state quickly and easily (and, perhaps, permanently (at least for that one rule)).