### PR TITLE
updates settings to include final newline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,4 +4,5 @@
     "*.jsonl": "ndjson",
     "*.njson": "ndjson"
   },
+  "files.insertFinalNewline": true,
 }


### PR DESCRIPTION
It's happened a few times recently in PRs ([example](https://github.com/Kong/insomnia/pull/4043/files/e87bee58f7390eb5222e8873c451192c7ccf1ebd#r713422156), [example](https://github.com/Kong/insomnia/pull/4056#pullrequestreview-766682765)) that we missed a (required) final newline when modifying or adding new files (mostly, it's been JSON files).  Although what's implemented in this PR isn't a perfect solution, it would at least have caught both of the two examples and prevented at least some unnecessary churn.  I see no downsides to including this as all text files in our project (so far as I'm aware) need final newlines.
