### PR TITLE
Attach sync button and button from component library to themes properly

### DIFF
--- a/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/sync-dropdown.tsx
@@ -430,7 +430,7 @@ class UnconnectedSyncDropdown extends PureComponent<Props, State> {
 
     return (
       <DropdownButton
-        className="btn--clicky-small btn-sync btn-utility wide text-left overflow-hidden row-spaced"
+        className="btn--clicky-small btn-sync wide text-left overflow-hidden row-spaced"
         disabled={initializing}
       >
         <div className="ellipsis">

--- a/packages/insomnia-app/app/ui/components/wrapper.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper.tsx
@@ -504,14 +504,12 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
         <GitSyncDropdown
           className="margin-left"
           workspace={activeWorkspace}
-          // @ts-expect-error -- TSCONVERSION this prop is unused
-          dropdownButtonClassName="btn--clicky-small btn-sync btn-utility"
           gitRepository={activeGitRepository}
           vcs={gitVCS}
           handleInitializeEntities={handleInitializeEntities}
           handleGitBranchChanged={this._handleGitBranchChanged}
           renderDropdownButton={children => (
-            <DropdownButton className="btn--clicky-small btn-sync btn-utility">
+            <DropdownButton className="btn--clicky-small btn-sync">
               {children}
             </DropdownButton>
           )}

--- a/packages/insomnia-app/app/ui/css/components/wrapper.less
+++ b/packages/insomnia-app/app/ui/css/components/wrapper.less
@@ -17,7 +17,7 @@
   }
 
   .btn-utility {
-    color: #fff;
+    color: var(--color-font-surprise);
     background-color: var(--color-surprise);
   }
 

--- a/packages/insomnia-app/app/ui/css/components/wrapper.less
+++ b/packages/insomnia-app/app/ui/css/components/wrapper.less
@@ -16,26 +16,8 @@
     color: var(--hl-xl);
   }
 
-  .btn-utility {
-    color: var(--color-font-surprise);
-    background-color: var(--color-surprise);
-  }
-
   .btn-create {
     padding: var(--padding-sm) var(--padding-md);
-  }
-
-  .btn-utility-reverse {
-    color: var(--color-text);
-    background-color: var(--hl-xs);
-    border: none;
-  }
-
-  .btn-utility,
-  .btn-utility-reverse {
-    &:hover {
-      filter: brightness(0.8);
-    }
   }
 
   .btn-sync {
@@ -49,6 +31,13 @@
     align-items: center !important;
     padding-left: var(--padding-md);
     padding-right: var(--padding-md);
+
+    color: var(--color-font-surprise);
+    background-color: var(--color-surprise);
+
+    &:hover {
+      filter: brightness(0.8);
+    }
   }
 
   height: 100%;

--- a/packages/insomnia-components/src/button/button.tsx
+++ b/packages/insomnia-components/src/button/button.tsx
@@ -37,16 +37,16 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   margin?: string;
 }
 
-const getColorVar = (bg?: ValueOf<typeof ButtonThemeEnum>) => {
-  if (bg === ButtonThemeEnum.Default) {
+const getColorVar = (theme?: ValueOf<typeof ButtonThemeEnum>) => {
+  if (!theme || theme === ButtonThemeEnum.Default) {
     return 'var(--color-font)';
   }
 
-  return `var(--color-${bg})`;
+  return `var(--color-${theme})`;
 };
 
 const getFontColorVar = (theme?: ValueOf<typeof ButtonThemeEnum>) => {
-  if (theme && theme === ButtonThemeEnum.Default) {
+  if (!theme || theme === ButtonThemeEnum.Default) {
     return 'var(--color-font)';
   }
 

--- a/packages/insomnia-components/src/button/button.tsx
+++ b/packages/insomnia-components/src/button/button.tsx
@@ -37,8 +37,24 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   margin?: string;
 }
 
+const getColorVar = (bg?: ValueOf<typeof ButtonThemeEnum>) => {
+  if (bg === ButtonThemeEnum.Default) {
+    return 'var(--color-font)';
+  }
+
+  return `var(--color-${bg})`;
+};
+
+const getFontColorVar = (theme?: ValueOf<typeof ButtonThemeEnum>) => {
+  if (theme && theme === ButtonThemeEnum.Default) {
+    return 'var(--color-font)';
+  }
+
+  return `var(--color-font-${theme})`;
+};
+
 const StyledButton = styled.button<ButtonProps>`
-  color: ${({ bg }) => (bg ? `var(--color-${bg})` : 'var(--color-font)')};
+  color: ${({ bg }) => getColorVar(bg)};
   margin: ${({ margin }) => (margin || 0)};
   text-align: center;
   font-size: var(--font-size-sm);
@@ -99,7 +115,7 @@ const StyledButton = styled.button<ButtonProps>`
       return 'background-color: var(--hl-xs)';
     }
 
-    return `background: var(--color-${bg}); color: var(--color-font-${bg})`;
+    return `background: var(--color-${bg}); color: ${getFontColorVar(bg)}`;
   }}}
 
   &:focus,


### PR DESCRIPTION
The sync button background is `--color-surprise`, but the foreground was hard-coded to `#fff`. This PR updates it to use `--color-font-surprise`.

Validate this using the following example theme plugin (generate one and paste this into `main.js`)

```js
module.exports.themes = [{
	name: 'Change Sync Button Color',
	displayName: 'Change Sync Button Color',
	theme: {
		background: {
			default: '#000',
			surprise: '#FFC20A',
		},
		foreground: {
			default: '#fff',
			surprise: '#000', // should be black
		},
	}
}]
```

The effect of the above plugin (which sets the foreground color to black) on this PR and on Production

| Before (Production) | After (this PR) |
| - | - |
| <img width="907" alt="image" src="https://user-images.githubusercontent.com/4312346/135778614-636bdd4c-1f8f-4e20-8468-b356e251444c.png"> |  <img width="908" alt="image" src="https://user-images.githubusercontent.com/4312346/135778583-1febca60-5910-4d11-8574-1786c1040057.png"> |

This PR also removes the `btn-utility` CSS class; it's only used by the sync button. In addition, this PR fixes a bug in the button in `insomnia-components`, where it would use `--color-default` or `--color-font-default` for the default theme, but should use `--color-bg` or `--color-font` (as appropriate). This has no material change, but means we aren't working "just because" a class can't be found. (This component is very messy and needs a cleanup, but, this is an initial fix to attach to themes properly).

| Before (Production) | After (this PR) |
| - | - |
| <img width="1081" alt="image" src="https://user-images.githubusercontent.com/4312346/135778458-72c3b99b-27fe-4661-9ae5-96bd83e5518f.png"> | <img width="1081" alt="image" src="https://user-images.githubusercontent.com/4312346/135778440-29dd8642-9e78-491d-96a0-158989b16ea3.png"> |
| <img width="1081" alt="image" src="https://user-images.githubusercontent.com/4312346/135778480-c4d42520-feef-48db-b755-2e7db0dff627.png">| <img width="1081" alt="image" src="https://user-images.githubusercontent.com/4312346/135778473-ca7058b8-a688-46fc-90f8-3c88cf36d8f8.png"> |