### PR TITLE
Allow specifying a custom version for Inso

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,22 @@ on:
       - synchronize
 
 jobs:
+  get_version:
+    name: Get version
+    runs-on: ubuntu-latest
+    outputs:
+      inso-version: ${{ steps.get-package-version.outputs.current-version }}
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v1
+      - name: Get version
+        id: get-package-version
+        uses: martinbeentjes/npm-get-version-action@master
+        with:
+          path: packages/insomnia-inso
+    
   OS:
+    needs: [ get_version ]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -42,18 +57,22 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Package Inso CLI
-        run: npm run inso-package
-
       - name: Set Inso Variables
         id: inso-variables
         shell: bash
         run: |
           PKG_NAME="${{ matrix.os }}-inso-${{ github.run_number }}"
           BUNDLE_ID="com.insomnia.inso.app"
+          INSO_VERSION=${{ needs.get_version.outputs.inso-version }}-run.${{ github.run_number }}
 
           echo ::set-output name=pkg-name::$PKG_NAME
           echo ::set-output name=bundle-id::$BUNDLE_ID
+          echo ::set-output name=inso-version::$INSO_VERSION
+
+      - name: Package Inso CLI
+        run: npm run inso-package
+        env:
+          VERSION: ${{ steps.inso-variables.outputs.inso-version }}
 
       - name: Create macOS installer package
         if: matrix.os == 'macos-latest'
@@ -69,8 +88,7 @@ jobs:
           PKG_NAME: ${{ steps.inso-variables.outputs.pkg-name }}
           BUNDLE_ID: ${{ steps.inso-variables.outputs.bundle-id }}
           ARTIFACT_LOCATION: compressed
-          # Hardcoded here, configured in https://github.com/Kong/insomnia/pull/4086
-          VERSION: "2.3.2"
+          VERSION: ${{ steps.inso-variables.outputs.inso-version }}
 
       # We don't need to notarize and staple on every commit
       # - name: Notarize installer package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,9 +61,9 @@ jobs:
         id: inso-variables
         shell: bash
         run: |
-          PKG_NAME="${{ matrix.os }}-inso-${{ github.run_number }}"
+          INSO_VERSION="${{ needs.get_version.outputs.inso-version }}-run.${{ github.run_number }}"
+          PKG_NAME="inso-${{ matrix.os }}-$INSO_VERSION"
           BUNDLE_ID="com.insomnia.inso.app"
-          INSO_VERSION=${{ needs.get_version.outputs.inso-version }}-run.${{ github.run_number }}
 
           echo ::set-output name=pkg-name::$PKG_NAME
           echo ::set-output name=bundle-id::$BUNDLE_ID

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,8 @@ jobs:
 
       - name: Create Inso CLI artifacts
         run: npm run inso-package:compress
+        env:
+          VERSION: ${{ steps.inso-variables.outputs.inso-version }}
 
       - name: Upload Inso CLI artifacts
         uses: actions/upload-artifact@v2

--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -66,15 +66,6 @@ describe('cli', () => {
       logger.restoreAll();
     });
 
-    it.each(['-v', '--version'])('inso %s should print "dev" if running in development', args => {
-      const oldNodeEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'development';
-      logger.wrapAll();
-      expect(() => inso(args)).toThrowError('dev');
-      logger.restoreAll();
-      process.env.NODE_ENV = oldNodeEnv;
-    });
-
     it('should print options', () => {
       inso('generate config file.yaml -t declarative --printOptions --verbose');
 

--- a/packages/insomnia-inso/src/util.test.ts
+++ b/packages/insomnia-inso/src/util.test.ts
@@ -1,8 +1,7 @@
-import * as packageJson from '../package.json';
 import { InsoError } from './errors';
 import { globalBeforeAll, globalBeforeEach } from './jest/before';
 import { logger } from './logger';
-import { exit, getDefaultAppName, getVersion, isDevelopment, logErrorExit1, noop } from './util';
+import { exit, getDefaultAppName, getVersion, logErrorExit1, noop } from './util';
 
 describe('exit()', () => {
   beforeAll(() => {
@@ -122,31 +121,11 @@ describe('getDefaultAppName()', () => {
 });
 
 describe('getVersion()', () => {
-  it('should return version from packageJson', () => {
-    expect(getVersion()).toBe(packageJson.version);
-  });
-
-  it('should return dev if running in development', () => {
-    const oldNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
-    expect(getVersion()).toBe('dev');
-    process.env.NODE_ENV = oldNodeEnv;
-  });
-});
-
-describe('isDevelopment()', () => {
-  it('should return true if NODE_ENV is development', () => {
-    const oldNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'development';
-    expect(isDevelopment()).toBe(true);
-    process.env.NODE_ENV = oldNodeEnv;
-  });
-
-  it('should return false if NODE_ENV is not development', () => {
-    const oldNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
-    expect(isDevelopment()).toBe(false);
-    process.env.NODE_ENV = oldNodeEnv;
+  it('should get version from env variable', () => {
+    const oldVersion = process.env.VERSION;
+    process.env.VERSION = '2.3.3-canary.1234';
+    expect(getVersion()).toBe('2.3.3-canary.1234');
+    process.env.VERSION = oldVersion;
   });
 });
 

--- a/packages/insomnia-inso/src/util.test.ts
+++ b/packages/insomnia-inso/src/util.test.ts
@@ -1,3 +1,4 @@
+import * as packageJson from '../package.json';
 import { InsoError } from './errors';
 import { globalBeforeAll, globalBeforeEach } from './jest/before';
 import { logger } from './logger';
@@ -121,6 +122,10 @@ describe('getDefaultAppName()', () => {
 });
 
 describe('getVersion()', () => {
+  it('should return version from packageJson', () => {
+    expect(getVersion()).toBe(packageJson.version);
+  });
+
   it('should get version from env variable', () => {
     const oldVersion = process.env.VERSION;
     process.env.VERSION = '2.3.3-canary.1234';

--- a/packages/insomnia-inso/src/util.ts
+++ b/packages/insomnia-inso/src/util.ts
@@ -1,7 +1,8 @@
+import packageJson from '../package.json';
 import { handleError } from './errors';
 
 export const getVersion = () => {
-  return process.env.VERSION;
+  return process.env.VERSION || packageJson.version;
 };
 
 export const logErrorExit1 = (err?: Error) => {

--- a/packages/insomnia-inso/src/util.ts
+++ b/packages/insomnia-inso/src/util.ts
@@ -1,12 +1,7 @@
-import packageJson from '../package.json';
 import { handleError } from './errors';
 
 export const getVersion = () => {
-  return isDevelopment() ? 'dev' : packageJson.version;
-};
-
-export const isDevelopment = () => {
-  return process.env.NODE_ENV === 'development';
+  return process.env.VERSION;
 };
 
 export const logErrorExit1 = (err?: Error) => {

--- a/packages/insomnia-inso/webpack/webpack.config.development.js
+++ b/packages/insomnia-inso/webpack/webpack.config.development.js
@@ -9,6 +9,7 @@ module.exports = merge(base, {
     new webpack.DefinePlugin({
       __DEV__: true,
       'process.env.DEFAULT_APP_NAME': JSON.stringify('insomnia-app'),
+      'process.env.VERSION': JSON.stringify('dev'),
     }),
   ],
 });

--- a/packages/insomnia-inso/webpack/webpack.config.production.js
+++ b/packages/insomnia-inso/webpack/webpack.config.production.js
@@ -1,7 +1,6 @@
 const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const base = require('./webpack.config.base');
-const packageJson = require('../package.json');
 
 /** @type { import('webpack').Configuration } */
 module.exports = merge(base, {
@@ -12,7 +11,7 @@ module.exports = merge(base, {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.DEFAULT_APP_NAME': JSON.stringify('Insomnia'),
-      'process.env.VERSION': JSON.stringify(process.env.VERSION || packageJson.version),
+      'process.env.VERSION': JSON.stringify(process.env.VERSION),
     }),
   ],
 });

--- a/packages/insomnia-inso/webpack/webpack.config.production.js
+++ b/packages/insomnia-inso/webpack/webpack.config.production.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const base = require('./webpack.config.base');
+const packageJson = require('../package.json');
 
 /** @type { import('webpack').Configuration } */
 module.exports = merge(base, {
@@ -11,6 +12,7 @@ module.exports = merge(base, {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.DEFAULT_APP_NAME': JSON.stringify('Insomnia'),
+      'process.env.VERSION': JSON.stringify(process.env.VERSION || packageJson.version),
     }),
   ],
 });


### PR DESCRIPTION
This PR is a follow up to #4082.

This allows a user (and the macos `pkgbuild` command) to differentiate between versions of inso. Currently it is only used in the test workflow for build artifacts, but part of this will be necessary in the release workflow as well.

<img width="510" alt="image" src="https://user-images.githubusercontent.com/4312346/136487447-da16cd68-520b-4f02-8447-858c5da9edd7.png">

<img width="542" alt="image" src="https://user-images.githubusercontent.com/4312346/136487311-c71e4ae4-7bba-43ce-a263-121f60100d1e.png">
