### PR TITLE
Update release workflow to sign, notarize and staple macos inso binary

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -179,6 +179,8 @@ jobs:
 
       - name: Create Inso CLI artifacts
         run: npm run inso-package:compress
+        env:
+          VERSION: ${{ needs.inso_release_info.outputs.inso-version }}
 
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -11,6 +11,7 @@ env:
   GITHUB_SHA: ${{ github.sha }}
 
 jobs:
+  # Run unit tests (excl smoke tests)
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -23,13 +24,16 @@ jobs:
       - name: Read Node version from .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
-      - uses: actions/setup-node@v1
+      - name: Setup Node
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - name: Bootstrap packages
         run: npm run bootstrap
       - name: Run tests
         run: npm test
+  
+  # Publish to NPM
   npm:
     needs: [ test ]
     name: npm
@@ -40,7 +44,8 @@ jobs:
       - name: Read Node version from .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
-      - uses: actions/setup-node@v1
+      - name: Setup Node
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - name: Bootstrap packages
@@ -51,6 +56,8 @@ jobs:
           npm run release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  
+  # Check if a GitHub Release for Inso already exists
   inso_release_info:
     needs: [ npm ]
     name: Does Inso release exist?
@@ -81,6 +88,8 @@ jobs:
       - name: Check release exists
         id: check-release
         run: echo "::set-output name=should-create-release::${{ steps.find-release.outcome == 'failure' }}"
+  
+  # Create GitHub Release for Inso
   create_inso_release:
     needs: [ inso_release_info ]
     if: needs.inso_release_info.outputs.should-create-release == 'true'
@@ -96,6 +105,8 @@ jobs:
           body: Full changelog ⇒ https://insomnia.rest/changelog
           draft: false
           prerelease: true
+  
+  # Package and upload Inso release artifacts
   upload_inso:
     needs: [ inso_release_info, create_inso_release ]
     name: Package & release Inso
@@ -110,7 +121,8 @@ jobs:
       - name: Read Node version from .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
-      - uses: actions/setup-node@v1
+      - name: Setup Node
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - name: Bootstrap packages
@@ -125,6 +137,8 @@ jobs:
           tag_name: ${{ needs.inso_release_info.outputs.tag-name }}
           files: packages/insomnia-inso/compressed/*
           fail_on_unmatched_files: true
+  
+  # Package and upload Insomnia Windows release artifacts
   windows_app:
     needs: [ npm ]
     name: Windows
@@ -139,7 +153,8 @@ jobs:
       - name: Read Node version from .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
-      - uses: actions/setup-node@v1
+      - name: Setup Node
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - name: Bootstrap packages
@@ -149,6 +164,8 @@ jobs:
         env:
           CSC_LINK: ${{ secrets.DESIGNER_WINDOWS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.DESIGNER_WINDOWS_CSC_KEY_PASSWORD }}
+  
+  # Package and upload Insomnia MacOS release artifacts
   mac_app:
     needs: [ npm ]
     name: Mac
@@ -163,7 +180,8 @@ jobs:
       - name: Read Node version from .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
-      - uses: actions/setup-node@v1
+      - name: Setup Node
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - name: Bootstrap packages
@@ -175,6 +193,8 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.DESIGNER_APPLE_ID_PASSWORD }}
           CSC_LINK: ${{ secrets.DESIGNER_MAC_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.DESIGNER_MAC_CSC_KEY_PASSWORD }}
+  
+  # Package and upload Insomnia Linux release artifacts
   linux_app:
     needs: [ npm ]
     name: Linux
@@ -193,7 +213,8 @@ jobs:
       - name: Read Node version from .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
-      - uses: actions/setup-node@v1
+      - name: Setup Node
+        uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - name: Bootstrap packages

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -63,7 +63,7 @@ jobs:
     name: Does Inso release exist?
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.get-package-version.outputs.current-version }}
+      inso-version: ${{ steps.get-package-version.outputs.current-version }}
       tag-name: ${{ steps.get-tag.outputs.tag-name }}
       should-create-release: ${{ steps.check-release.outputs.should-create-release }}
     steps:
@@ -101,7 +101,7 @@ jobs:
         with:
           tag_name: ${{ needs.inso_release_info.outputs.tag-name }}
           # The following is all taken from packages/insomnia-app/scripts/release.ts
-          name: "Inso CLI ${{ needs.inso_release_info.outputs.version }} 📦"
+          name: "Inso CLI ${{ needs.inso_release_info.outputs.inso-version }} 📦"
           body: Full changelog ⇒ https://insomnia.rest/changelog
           draft: false
           prerelease: true
@@ -127,10 +127,59 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
       - name: Bootstrap packages
         run: npm run bootstrap
+
+      - name: Set Inso Variables
+        id: inso-variables
+        shell: bash
+        run: |
+          PKG_NAME="inso-${{ matrix.os }}-${{ needs.inso_release_info.outputs.inso-version }}"
+          BUNDLE_ID="com.insomnia.inso.app"
+
+          echo ::set-output name=pkg-name::$PKG_NAME
+          echo ::set-output name=bundle-id::$BUNDLE_ID
+
       - name: Package Inso CLI
         run: npm run inso-package
+        env:
+          VERSION: ${{ needs.inso_release_info.outputs.inso-version }}
+
       - name: Run CLI smoke tests
         run: npm run test:smoke:cli
+
+      - name: Create macOS installer package
+        if: matrix.os == 'macos-latest'
+        run: |
+          chmod +x ./src/scripts/macos-pkg.sh
+          ./src/scripts/macos-pkg.sh
+        shell: bash
+        working-directory: packages/insomnia-inso
+        continue-on-error: true
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.DESIGNER_MAC_CSC_LINK }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.DESIGNER_MAC_CSC_KEY_PASSWORD }}
+          PKG_NAME: ${{ steps.inso-variables.outputs.pkg-name }}
+          BUNDLE_ID: ${{ steps.inso-variables.outputs.bundle-id }}
+          ARTIFACT_LOCATION: compressed
+          VERSION: ${{ needs.inso_release_info.outputs.inso-version }}
+
+      - name: Notarize installer package
+        if: matrix.os == 'macos-latest'
+        uses: devbotsxyz/xcode-notarize@v1
+        with:
+          product-path: packages/insomnia-inso/compressed/${{ steps.inso-variables.outputs.pkg-name }}.pkg
+          primary-bundle-id: ${{ steps.inso-variables.outputs.bundle-id }}
+          appstore-connect-username: ${{ secrets.DESIGNER_APPLE_ID }}
+          appstore-connect-password: ${{ secrets.DESIGNER_APPLE_ID_PASSWORD }}
+
+      - name: Staple installer package
+        if: matrix.os == 'macos-latest'
+        uses: devbotsxyz/xcode-staple@v1
+        with:
+          product-path: packages/insomnia-inso/compressed/${{ steps.inso-variables.outputs.pkg-name }}.pkg
+
+      - name: Create Inso CLI artifacts
+        run: npm run inso-package:compress
+
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
![](https://media0.giphy.com/media/mC22LcC2sIXzJp765b/giphy.gif)

(Basically a copy-pasta from the test workflow)

Example run showing this working: https://github.com/Kong/insomnia/runs/3865499880 from https://github.com/Kong/insomnia/pull/4096