### PR TITLE
Move all app.on('ready') calls in one place

### DIFF
--- a/packages/insomnia-app/app/common/electron-helpers.ts
+++ b/packages/insomnia-app/app/common/electron-helpers.ts
@@ -72,3 +72,15 @@ export const setMenuBarVisibility = (visible: boolean) => {
       window.setAutoHideMenuBar(hide);
     });
 };
+
+/**
+ * There's no option that prevents Electron from fetching spellcheck dictionaries from Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from fetching.
+ * see: https://github.com/electron/electron/issues/22995
+ * On macOS the OS spellchecker is used and therefore we do not download any dictionary files.
+ * This API is a no-op on macOS.
+ */
+export const disableSpellcheckerDownload = () => {
+  electron.session.defaultSession.setSpellCheckerDictionaryDownloadURL(
+    'https://00.00/'
+  );
+};

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -39,6 +39,12 @@ if (!isDevelopment()) {
 global.window = global.window || undefined;
 // When the app is first launched
 app.on('ready', async () => {
+  // There's no option that prevents Electron from fetching spellcheck dictionaries from Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from fetching.
+  // see: https://github.com/electron/electron/issues/22995
+  // On macOS the OS spellchecker is used and therefore we do not download any dictionary files.
+  // This API is a no-op on macOS.
+  session.defaultSession.setSpellCheckerDictionaryDownloadURL('https://00.00/');
+
   if (isDevelopment()) {
     try {
       const extensions = [REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS];

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -6,6 +6,7 @@ import appConfig from '../config/config.json';
 import { trackNonInteractiveEventQueueable } from './common/analytics';
 import { changelogUrl, getAppVersion, isDevelopment, isMac } from './common/constants';
 import { database } from './common/database';
+import { disableSpellcheckerDownload } from './common/electron-helpers';
 import log, { initializeLogging } from './common/log';
 import * as errorHandling from './main/error-handling';
 import * as grpcIpcMain from './main/grpc-ipc-main';
@@ -39,11 +40,7 @@ if (!isDevelopment()) {
 global.window = global.window || undefined;
 // When the app is first launched
 app.on('ready', async () => {
-  // There's no option that prevents Electron from fetching spellcheck dictionaries from Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from fetching.
-  // see: https://github.com/electron/electron/issues/22995
-  // On macOS the OS spellchecker is used and therefore we do not download any dictionary files.
-  // This API is a no-op on macOS.
-  session.defaultSession.setSpellCheckerDictionaryDownloadURL('https://00.00/');
+  disableSpellcheckerDownload();
 
   if (isDevelopment()) {
     try {

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -20,18 +20,10 @@ import { clickLink, getDataDirectory, restartApp } from '../common/electron-help
 import * as log from '../common/log';
 import LocalStorage from './local-storage';
 
-const { app, Menu, shell, dialog, clipboard, session } = electron;
+const { app, Menu, shell, dialog, clipboard } = electron;
 // So we can use native modules in renderer
 // NOTE: This was (deprecated in Electron 10)[https://github.com/electron/electron/issues/18397] and (removed in Electron 14)[https://github.com/electron/electron/pull/26874]
 app.allowRendererProcessReuse = false;
-
-app.on('ready', () => {
-  // There's no option that prevents Electron from fetching spellcheck dictionaries from Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from fetching.
-  // see: https://github.com/electron/electron/issues/22995
-  // On macOS the OS spellchecker is used and therefore we do not download any dictionary files.
-  // This API is a no-op on macOS.
-  session.defaultSession.setSpellCheckerDictionaryDownloadURL('https://00.00/');
-});
 
 const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 700;


### PR DESCRIPTION
🧹 use one 'ready' listener in the app

Closes INS-1044