### PR TITLE
Show HTTP response string in Error modal

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/error-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/error-modal.tsx
@@ -7,9 +7,12 @@ import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
 
+interface HTTPError extends Error {
+  data?: {statusCode: number;statusMessage: string;response: string};
+}
 export interface ErrorModalOptions {
   title?: string;
-  error?: Error | null;
+  error?: HTTPError | null;
   addCancel?: boolean;
   message?: string;
 }
@@ -59,7 +62,12 @@ export class ErrorModal extends PureComponent<{}, ErrorModalOptions> {
 
   render() {
     const { error, title, addCancel } = this.state;
-    const message = this.state.message || error?.message;
+    let message = this.state.message || error?.message;
+    if (error?.data?.response) {
+      message = `HTTP Error: ${error?.data?.statusCode} ${error?.data?.statusMessage}
+${error?.data?.response}`;
+    }
+
     return (
       <Modal ref={this._setModalRef}>
         <ModalHeader>{title || 'Uh Oh!'}</ModalHeader>


### PR DESCRIPTION
This is just a first pass at getting more information about 401 and 403 error codes from the github API.
Since isometric-git adds a data structure to the thrown Error I've duplicated that in the ErrorModel component.

![image](https://user-images.githubusercontent.com/3679927/136808736-a2f78810-ef79-47cc-9928-f3db8c57d616.png)
