### PR TITLE
distinguish upstreams name in declarative config

### DIFF
--- a/packages/openapi-2-kong/src/declarative-config/fixtures/api-with-examples.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/api-with-examples.expected.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "protocol": "http",
-      "host": "Simple_API_overview",
+      "host": "Simple_API_overview.upstream",
       "port": 80,
       "path": "/path",
       "name": "Simple_API_overview",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/api-with-examples.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/api-with-examples.expected.json
@@ -33,7 +33,7 @@
   "upstreams": [
     {
       "tags": ["OAS3_import", "OAS3file_api-with-examples.yaml"],
-      "name": "Simple_API_overview",
+      "name": "Simple_API_overview.upstream",
       "hash_on": "ip",
       "healthchecks": {
         "passive": {

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/callback-example.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/callback-example.expected.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "protocol": "http",
-      "host": "Callback_Example",
+      "host": "Callback_Example.upstream",
       "port": 80,
       "path": "/path",
       "name": "Callback_Example",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/callback-example.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/callback-example.expected.json
@@ -22,7 +22,7 @@
   "upstreams": [
     {
       "tags": ["OAS3_import", "OAS3file_callback-example.yaml"],
-      "name": "Callback_Example",
+      "name": "Callback_Example.upstream",
       "targets": [
         {
           "target": "backend.com:80",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/httpbin.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/httpbin.expected.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "protocol": "https",
-      "host": "httpbin",
+      "host": "httpbin.upstream",
       "port": 443,
       "path": "/",
       "name": "httpbin",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/httpbin.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/httpbin.expected.json
@@ -246,7 +246,7 @@
   "upstreams": [
     {
       "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
-      "name": "httpbin",
+      "name": "httpbin.upstream",
       "targets": [
         {
           "target": "httpbin.org:443",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/link-example.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/link-example.expected.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "protocol": "http",
-      "host": "Link_Example",
+      "host": "Link_Example.upstream",
       "port": 80,
       "path": "/path",
       "name": "Link_Example",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/link-example.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/link-example.expected.json
@@ -65,7 +65,7 @@
   "upstreams": [
     {
       "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
-      "name": "Link_Example",
+      "name": "Link_Example.upstream",
       "targets": [
         {
           "target": "backend.com:80",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/no-targets-example.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/no-targets-example.expected.json
@@ -29,7 +29,7 @@
   "upstreams": [
     {
       "tags": ["OAS3_import", "OAS3file_no-targets-example.yaml"],
-      "name": "Simple_API_overview",
+      "name": "Simple_API_overview.upstream",
       "targets": []
     }
   ],

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/no-targets-example.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/no-targets-example.expected.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "protocol": "http",
-      "host": "Simple_API_overview",
+      "host": "Simple_API_overview.upstream",
       "port": 80,
       "path": "/path",
       "name": "Simple_API_overview",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/petstore-expanded.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/petstore-expanded.expected.json
@@ -43,7 +43,7 @@
   "upstreams": [
     {
       "tags": ["OAS3_import", "OAS3file_petstore-expanded.yaml"],
-      "name": "Swagger_Petstore",
+      "name": "Swagger_Petstore.upstream",
       "targets": [
         {
           "target": "petstore.swagger.io:80",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/petstore-expanded.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/petstore-expanded.expected.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "protocol": "http",
-      "host": "Swagger_Petstore",
+      "host": "Swagger_Petstore.upstream",
       "port": 80,
       "path": "/api",
       "name": "Swagger_Petstore",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/petstore.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/petstore.expected.json
@@ -36,7 +36,7 @@
   "upstreams": [
     {
       "tags": ["OAS3_import", "OAS3file_petstore.yaml"],
-      "name": "Swagger_Petstore",
+      "name": "Swagger_Petstore.upstream",
       "targets": [
         {
           "target": "petstore.swagger.io:80",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/petstore.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/petstore.expected.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "protocol": "http",
-      "host": "Swagger_Petstore",
+      "host": "Swagger_Petstore.upstream",
       "port": 80,
       "path": "/v1",
       "name": "Swagger_Petstore",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/request-validator-plugin.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/request-validator-plugin.expected.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "protocol": "http",
-      "host": "Example",
+      "host": "Example.upstream",
       "port": 80,
       "path": "/path",
       "name": "Example",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/request-validator-plugin.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/request-validator-plugin.expected.json
@@ -114,7 +114,7 @@
   ],
   "upstreams": [
     {
-      "name": "Example",
+      "name": "Example.upstream",
       "tags": ["OAS3_import", "OAS3file_request-validator-plugin.yaml"],
       "targets": [
         {

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/security.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/security.expected.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "protocol": "http",
-      "host": "Security_Example",
+      "host": "Security_Example.upstream",
       "port": 80,
       "path": "/path",
       "name": "Security_Example",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/security.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/security.expected.json
@@ -102,7 +102,7 @@
   "upstreams": [
     {
       "tags": ["OAS3_import", "OAS3file_security.yaml"],
-      "name": "Security_Example",
+      "name": "Security_Example.upstream",
       "targets": [
         {
           "target": "backend.com:80",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/uspto.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/uspto.expected.json
@@ -36,7 +36,7 @@
   "upstreams": [
     {
       "tags": ["OAS3_import", "OAS3file_uspto.yaml"],
-      "name": "USPTO_Data_Set_API",
+      "name": "USPTO_Data_Set_API.upstream",
       "targets": [
         {
           "target": "developer.uspto.gov:443",

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/uspto.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/uspto.expected.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "protocol": "https",
-      "host": "USPTO_Data_Set_API",
+      "host": "USPTO_Data_Set_API.upstream",
       "port": 443,
       "path": "/ds-api",
       "name": "USPTO_Data_Set_API",

--- a/packages/openapi-2-kong/src/declarative-config/services.test.ts
+++ b/packages/openapi-2-kong/src/declarative-config/services.test.ts
@@ -8,7 +8,7 @@ import { generateServices } from './services';
 const getSpecResult = (): DCService =>
   JSON.parse(
     JSON.stringify({
-      host: 'My_API',
+      host: 'My_API.upstream',
       name: 'My_API',
       plugins: [],
       path: '/path',

--- a/packages/openapi-2-kong/src/declarative-config/services.ts
+++ b/packages/openapi-2-kong/src/declarative-config/services.ts
@@ -47,7 +47,7 @@ export function generateService(server: OA3Server, api: OpenApi3Spec, tags: stri
     name,
     // remove semicolon i.e. convert `https:` to `https`
     protocol: parsedUrl?.protocol?.substring(0, parsedUrl.protocol.length - 1),
-    host: name,
+    host: `${name}.upstream`,
     // not a hostname, but the Upstream name
     port: Number(parsedUrl.port || '80'),
     path: parsedUrl.pathname,

--- a/packages/openapi-2-kong/src/declarative-config/upstreams.test.ts
+++ b/packages/openapi-2-kong/src/declarative-config/upstreams.test.ts
@@ -7,7 +7,7 @@ import { generateUpstreams } from './upstreams';
 const getSpecResult = (): DCUpstream =>
   JSON.parse(
     JSON.stringify({
-      name: 'My_API',
+      name: 'My_API.upstream',
       targets: [
         {
           target: 'server1.com:443',

--- a/packages/openapi-2-kong/src/declarative-config/upstreams.ts
+++ b/packages/openapi-2-kong/src/declarative-config/upstreams.ts
@@ -20,7 +20,7 @@ export function generateUpstreams(api: OpenApi3Spec, tags: string[]) {
 
   const upstream: DCUpstream = {
     ...upstreamDefaults,
-    name: getName(api) + '.upstream',
+    name: `${getName(api)}.upstream`,
     targets: [],
     tags,
   };

--- a/packages/openapi-2-kong/src/declarative-config/upstreams.ts
+++ b/packages/openapi-2-kong/src/declarative-config/upstreams.ts
@@ -20,7 +20,7 @@ export function generateUpstreams(api: OpenApi3Spec, tags: string[]) {
 
   const upstream: DCUpstream = {
     ...upstreamDefaults,
-    name: getName(api),
+    name: getName(api) + '.upstream',
     targets: [],
     tags,
   };


### PR DESCRIPTION
Closes INS-894

upstreams node name matched services node name confusingly, this change adds .upstream to it for clarification.

**Before:**
```
upstreams:
  - name: CAS
```
**After:**
```
upstreams:
  - name: CAS.upstream
```
![image](https://user-images.githubusercontent.com/3679927/137022773-177bd7d2-b85b-424b-a407-bf486261ede7.png)
