### PR TITLE
Version env variable for inso artifact name in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,8 @@ jobs:
 
       - name: Create Inso CLI artifacts
         run: npm run inso-package:artifacts
+        env:
+          VERSION: ${{ steps.inso-variables.outputs.inso-version }}
 
       - name: Upload Inso CLI artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
The test workflow creating run artifacts should suffix the run number onto artifacts, but that wasn't happening because the environment variable was not correctly set. Previously, the `inso-package` and `inso-package:artifacts` steps were combined, but on separation this was missed.

This screenshot is current behavior. The zip file should also have the `-run.1234` suffix.

![image](https://user-images.githubusercontent.com/4312346/137077195-60ef3f76-a18e-487b-9e3d-1eece3b81275.png)