### PR TITLE
removes analytics onboarding if incognito mode is (already) on

### DIFF
--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.tsx
@@ -8,7 +8,6 @@ import { bindActionCreators } from 'redux';
 import { AUTOBIND_CFG, getAppLongName, getAppName, getAppSynopsis } from '../../common/constants';
 import { database as db } from '../../common/database';
 import type { BaseModel } from '../../models';
-import { getControlledStatus } from '../../models/helpers/settings';
 import { isWorkspace, WorkspaceScopeKeys } from '../../models/workspace';
 import { ForceToWorkspace } from '../redux/modules/helpers';
 import { importFile, importUri } from '../redux/modules/import';
@@ -125,25 +124,20 @@ class WrapperOnboarding extends PureComponent<Props, State> {
       settings: { enableAnalytics },
     } = this.props.wrapperProps;
 
-    const isControlledByInsomniaConfig = (
-      getControlledStatus(this.props.wrapperProps.settings)('enableAnalytics')?.controller === 'incognitoMode'
-    );
-
-    const analyticsMessage = enableAnalytics
-      ? `Thanks for helping make ${getAppName()} better!`
-      : `Opted out of analytics${isControlledByInsomniaConfig ? ' by Incognito Mode' : ''}`;
+    const lastStep = this.hasStep1() ? (
+      <p className="notice success text-left margin-top margin-bottom">
+        <a href="#" className="pull-right" onClick={this._handleBackStep}>
+          Back
+        </a>
+        {enableAnalytics
+          ? `Thanks for helping make ${getAppName()} better!`
+          : 'Opted out of analytics'}
+      </p>
+    ) : null;
 
     return (
       <Fragment>
-        <p className="notice success text-left margin-top margin-bottom">
-          {this.hasStep1() ? (
-            <a href="#" className="pull-right" onClick={this._handleBackStep}>
-              Back
-            </a>
-          ) : null}
-
-          {analyticsMessage}
-        </p>
+        {lastStep}
         <p>Import an OpenAPI spec to get started:</p>
         <button key="file" className="btn btn--clicky" onClick={this._handleImportFile}>
           From File

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.tsx
@@ -8,6 +8,7 @@ import { bindActionCreators } from 'redux';
 import { AUTOBIND_CFG, getAppLongName, getAppName, getAppSynopsis } from '../../common/constants';
 import { database as db } from '../../common/database';
 import type { BaseModel } from '../../models';
+import { getControlledStatus } from '../../models/helpers/settings';
 import { isWorkspace, WorkspaceScopeKeys } from '../../models/workspace';
 import { ForceToWorkspace } from '../redux/modules/helpers';
 import { importFile, importUri } from '../redux/modules/import';
@@ -123,6 +124,15 @@ class WrapperOnboarding extends PureComponent<Props, State> {
     const {
       settings: { enableAnalytics },
     } = this.props.wrapperProps;
+
+    const isControlledByInsomniaConfig = (
+      getControlledStatus(this.props.wrapperProps.settings)('enableAnalytics')?.controller === 'incognitoMode'
+    );
+
+    const analyticsMessage = enableAnalytics
+      ? `Thanks for helping make ${getAppName()} better!`
+      : `Opted out of analytics${isControlledByInsomniaConfig ? ' by Incognito Mode' : ''}`;
+
     return (
       <Fragment>
         <p className="notice success text-left margin-top margin-bottom">
@@ -132,9 +142,7 @@ class WrapperOnboarding extends PureComponent<Props, State> {
             </a>
           ) : null}
 
-          {enableAnalytics
-            ? `Thanks for helping make ${getAppName()} better!`
-            : 'Opted out of analytics'}
+          {analyticsMessage}
         </p>
         <p>Import an OpenAPI spec to get started:</p>
         <button key="file" className="btn btn--clicky" onClick={this._handleImportFile}>

--- a/packages/insomnia-app/app/ui/components/wrapper-onboarding.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-onboarding.tsx
@@ -106,6 +106,10 @@ class WrapperOnboarding extends PureComponent<Props, State> {
     this.props.wrapperProps.handleGoToNextActivity();
   }
 
+  hasStep1() {
+    return this.props.wrapperProps.settings.incognitoMode === false;
+  }
+
   renderStep1() {
     return (
       <Analytics
@@ -122,9 +126,12 @@ class WrapperOnboarding extends PureComponent<Props, State> {
     return (
       <Fragment>
         <p className="notice success text-left margin-top margin-bottom">
-          <a href="#" className="pull-right" onClick={this._handleBackStep}>
-            Back
-          </a>
+          {this.hasStep1() ? (
+            <a href="#" className="pull-right" onClick={this._handleBackStep}>
+              Back
+            </a>
+          ) : null}
+
           {enableAnalytics
             ? `Thanks for helping make ${getAppName()} better!`
             : 'Opted out of analytics'}
@@ -147,7 +154,7 @@ class WrapperOnboarding extends PureComponent<Props, State> {
     const { step } = this.state;
     let stepBody;
 
-    if (step === 1) {
+    if (step === 1 && this.hasStep1()) {
       stepBody = this.renderStep1();
     } else {
       stepBody = this.renderStep2();


### PR DESCRIPTION
closes INS-962

This bypasses the "Share Usage Analytics with Kong Inc" portion of the onboarding if incognito mode is on and removes the mentions of the step from the 2nd step.

## To test

1. modify your `packages/insomnia-app/app/insomnia.config.json` as follows:
    ```diff
      {
        "insomniaConfig": "1.0.0",
        "settings": {
    +      "incognitoMode": true
        }
      }
    ```
1. run
    ```bash
    rm -rf ~/.config/insomnia-app && npm run app-start
    ```
1. observe that the app starts without showing you the analytics onboarding


## Results

| Onboarding Step | BEFORE | AFTER |
| - | - | - |
| Step 1 | ![0c6cc9b5-bf3a-44e1-8392-1a1d869a6a3f](https://user-images.githubusercontent.com/15232461/137361920-d4daecd2-296b-4665-87e6-6858ca7f20c7.png) | ![84-842915_delete-icon-png-red](https://user-images.githubusercontent.com/15232461/137362391-427b81ff-2f66-44fa-93f7-a5c327e1f023.png) |
| Step 2 | ![Screenshot_20211014_124909](https://user-images.githubusercontent.com/15232461/137361991-2c1d51fc-5e11-4278-97c5-7895f9127c0b.png) |  ![Screenshot_20211014_161108](https://user-images.githubusercontent.com/15232461/137388538-3d1cc801-31e2-41e3-83e9-a6f9f943454f.png) |


