### PR TITLE
block starting the app if there's an invalid config

### DIFF
--- a/packages/insomnia-app/app/__mocks__/electron.ts
+++ b/packages/insomnia-app/app/__mocks__/electron.ts
@@ -16,6 +16,8 @@ const remote = {
     getLocale() {
       return 'en-US';
     },
+
+    exit: jest.fn(),
   },
   net: {
     request() {
@@ -55,9 +57,14 @@ const remote = {
   },
 };
 
+const dialog = {
+  showErrorBox: jest.fn(),
+};
+
 const electron = {
   ...remote,
   remote,
+  dialog,
   ipcMain: {
     on: jest.fn(),
 

--- a/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
@@ -39,6 +39,7 @@ describe('validateInsomniaConfig', () => {
     validateInsomniaConfig();
 
     // Assert
-    expect(electronAppExit).not.toHaveBeenCalledWith();
+    expect(electronShowErrorBox).not.toHaveBeenCalled();
+    expect(electronAppExit).not.toHaveBeenCalled();
   });
 });

--- a/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
@@ -1,0 +1,44 @@
+import electron from 'electron';
+import { mocked } from 'ts-jest/utils';
+
+import { getConfigSettings as _getConfigSettings  } from '../../models/helpers/settings';
+import { validateInsomniaConfig } from '../validate-insomnia-config';
+
+jest.mock('electron');
+jest.mock('../models/helpers/settings');
+const electronAppExit = mocked(electron.app.exit);
+const electronShowErrorBox = mocked(electron.dialog.showErrorBox);
+const getConfigSettings = mocked(_getConfigSettings);
+
+describe('validateInsomniaConfig', () => {
+  it('should show error box and exit if there is an error', () => {
+    // Arrange
+    const errorReturn = {
+      error: {
+        errors: [],
+        insomniaConfig: 'abc',
+        configPath: 'configPath',
+      },
+    };
+    getConfigSettings.mockReturnValue(errorReturn);
+
+    // Act
+    validateInsomniaConfig();
+
+    // Assert
+    expect(electronShowErrorBox).toHaveBeenCalled();
+    expect(electronAppExit).toHaveBeenCalled();
+  });
+
+  it('should not exit if there are no errors', () => {
+    // Arrange
+    const validReturn = { enableAnalytics: true };
+    getConfigSettings.mockReturnValue(validReturn);
+
+    // Act
+    validateInsomniaConfig();
+
+    // Assert
+    expect(electronAppExit).not.toHaveBeenCalledWith();
+  });
+});

--- a/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
@@ -5,7 +5,7 @@ import { getConfigSettings as _getConfigSettings  } from '../../models/helpers/s
 import { validateInsomniaConfig } from '../validate-insomnia-config';
 
 jest.mock('electron');
-jest.mock('../models/helpers/settings');
+jest.mock('../../models/helpers/settings');
 const electronAppExit = mocked(electron.app.exit);
 const electronShowErrorBox = mocked(electron.dialog.showErrorBox);
 const getConfigSettings = mocked(_getConfigSettings);

--- a/packages/insomnia-app/app/common/electron-helpers.ts
+++ b/packages/insomnia-app/app/common/electron-helpers.ts
@@ -66,6 +66,11 @@ export function restartApp() {
   app.exit();
 }
 
+export const exitApp = () => {
+  const { app } = electron.remote || electron;
+  app.exit();
+};
+
 export const setMenuBarVisibility = (visible: boolean) => {
   const { BrowserWindow } = electron.remote || electron;
   BrowserWindow.getAllWindows()

--- a/packages/insomnia-app/app/common/validate-insomnia-config.ts
+++ b/packages/insomnia-app/app/common/validate-insomnia-config.ts
@@ -1,0 +1,23 @@
+import electron from 'electron';
+import { omit } from 'ramda';
+
+import { getConfigSettings } from '../models/helpers/settings';
+import { exitApp } from './electron-helpers';
+
+export const validateInsomniaConfig = () => {
+  const configSettings = getConfigSettings();
+  if ('error' in configSettings) {
+    const errors = configSettings.error.errors?.map(omit(['parentSchema', 'data']));
+
+    electron.dialog.showErrorBox('Invalid Insomnia Config',
+      [
+        `Invalid Insomnia Config found at "${configSettings.error.configPath}"`,
+        '',
+        'errors:',
+        `${JSON.stringify(errors, null, 2)}`,
+      ].join('\n'),
+    );
+
+    exitApp();
+  }
+};

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -1,18 +1,20 @@
 import * as electron from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer';
 import path from 'path';
+import { omit } from 'ramda';
 
 import appConfig from '../config/config.json';
 import { trackNonInteractiveEventQueueable } from './common/analytics';
 import { changelogUrl, getAppVersion, isDevelopment, isMac } from './common/constants';
 import { database } from './common/database';
-import { disableSpellcheckerDownload } from './common/electron-helpers';
+import { disableSpellcheckerDownload, exitApp } from './common/electron-helpers';
 import log, { initializeLogging } from './common/log';
 import * as errorHandling from './main/error-handling';
 import * as grpcIpcMain from './main/grpc-ipc-main';
 import { checkIfRestartNeeded } from './main/squirrel-startup';
 import * as updates from './main/updates';
 import * as windowUtils from './main/window-utils';
+import { getConfigSettings } from './models/helpers/settings';
 import * as models from './models/index';
 import type { Stats } from './models/stats';
 import type { ToastNotification } from './ui/components/toast';
@@ -38,8 +40,28 @@ if (!isDevelopment()) {
 
 // So if (window) checks don't throw
 global.window = global.window || undefined;
+
+export const validateInsomniaConfig = () => {
+  const configSettings = getConfigSettings();
+  if ('error' in configSettings) {
+    const errors = configSettings.error.errors?.map(omit(['parentSchema', 'data']));
+
+    electron.dialog.showErrorBox('Invalid Insomnia Config',
+      [
+        `Invalid Insomnia Config found at "${configSettings.error.configPath}"`,
+        '',
+        'errors:',
+        `${JSON.stringify(errors, null, 2)}`,
+      ].join('\n'),
+    );
+
+    exitApp();
+  }
+};
+
 // When the app is first launched
 app.on('ready', async () => {
+  validateInsomniaConfig();
   disableSpellcheckerDownload();
 
   if (isDevelopment()) {
@@ -62,6 +84,7 @@ app.on('ready', async () => {
   const updatedStats = await _trackStats();
   await _updateFlags(updatedStats);
   await _launchApp();
+
   // Init the rest
   await updates.init();
   grpcIpcMain.init();

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -1,20 +1,19 @@
 import * as electron from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer';
 import path from 'path';
-import { omit } from 'ramda';
 
 import appConfig from '../config/config.json';
 import { trackNonInteractiveEventQueueable } from './common/analytics';
 import { changelogUrl, getAppVersion, isDevelopment, isMac } from './common/constants';
 import { database } from './common/database';
-import { disableSpellcheckerDownload, exitApp } from './common/electron-helpers';
+import { disableSpellcheckerDownload } from './common/electron-helpers';
 import log, { initializeLogging } from './common/log';
+import { validateInsomniaConfig } from './common/validate-insomnia-config';
 import * as errorHandling from './main/error-handling';
 import * as grpcIpcMain from './main/grpc-ipc-main';
 import { checkIfRestartNeeded } from './main/squirrel-startup';
 import * as updates from './main/updates';
 import * as windowUtils from './main/window-utils';
-import { getConfigSettings } from './models/helpers/settings';
 import * as models from './models/index';
 import type { Stats } from './models/stats';
 import type { ToastNotification } from './ui/components/toast';
@@ -40,24 +39,6 @@ if (!isDevelopment()) {
 
 // So if (window) checks don't throw
 global.window = global.window || undefined;
-
-export const validateInsomniaConfig = () => {
-  const configSettings = getConfigSettings();
-  if ('error' in configSettings) {
-    const errors = configSettings.error.errors?.map(omit(['parentSchema', 'data']));
-
-    electron.dialog.showErrorBox('Invalid Insomnia Config',
-      [
-        `Invalid Insomnia Config found at "${configSettings.error.configPath}"`,
-        '',
-        'errors:',
-        `${JSON.stringify(errors, null, 2)}`,
-      ].join('\n'),
-    );
-
-    exitApp();
-  }
-};
 
 // When the app is first launched
 app.on('ready', async () => {

--- a/packages/insomnia-app/app/models/helpers/__tests__/get-config-settings-error.test.ts
+++ b/packages/insomnia-app/app/models/helpers/__tests__/get-config-settings-error.test.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+
+import { getConfigSettings } from '../settings';
+
+describe('getConfigSettings error', () => {
+  it('returns an error if validation result has errors', () => {
+    // Arrange
+    const invalidConfig = {
+      insomniaConfig: '1.0.0',
+      settings: {
+        random: 'abcd',
+      },
+    };
+
+    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(invalidConfig));
+    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
+
+    // Act
+    const result = getConfigSettings();
+
+    // Assert
+    expect(result).toHaveProperty('error');
+    if ('error' in result) {
+      expect(consoleErrorMock).toHaveBeenCalledWith('invalid insomnia config', result.error);
+    }
+
+    // Cleanup
+    readFileSyncSpy.mockRestore();
+    consoleErrorMock.mockRestore();
+  });
+});

--- a/packages/insomnia-app/app/models/helpers/__tests__/get-config-settings-once.test.ts
+++ b/packages/insomnia-app/app/models/helpers/__tests__/get-config-settings-once.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { getConfigSettings } from '../settings';
 
 // This test exists outside of settings.test.ts because we need an unmocked `../settings` module
-describe('getConfigSettings', () => {
+describe('getConfigSettings once', () => {
   it('only reads the config once on startup and then never again', () => {
     // Arrange
     const configOne = {
@@ -19,7 +19,8 @@ describe('getConfigSettings', () => {
       },
     };
 
-    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(configOne));
+    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+    readFileSyncSpy.mockReturnValue(JSON.stringify(configOne));
 
     // Act
     const settingsFirstLoad = getConfigSettings();
@@ -43,6 +44,9 @@ describe('getConfigSettings', () => {
     // Cleanup
     readFileSyncSpy.mockRestore();
   });
+});
+
+describe('abc', () => {
 
   it('returns an error if validation result has errors', () => {
     // Arrange

--- a/packages/insomnia-app/app/models/helpers/__tests__/get-config-settings-once.test.ts
+++ b/packages/insomnia-app/app/models/helpers/__tests__/get-config-settings-once.test.ts
@@ -19,8 +19,7 @@ describe('getConfigSettings once', () => {
       },
     };
 
-    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
-    readFileSyncSpy.mockReturnValue(JSON.stringify(configOne));
+    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(configOne));
 
     // Act
     const settingsFirstLoad = getConfigSettings();

--- a/packages/insomnia-app/app/models/helpers/__tests__/get-config-settings-once.test.ts
+++ b/packages/insomnia-app/app/models/helpers/__tests__/get-config-settings-once.test.ts
@@ -45,32 +45,3 @@ describe('getConfigSettings once', () => {
     readFileSyncSpy.mockRestore();
   });
 });
-
-describe('abc', () => {
-
-  it('returns an error if validation result has errors', () => {
-    // Arrange
-    const invalidConfig = {
-      insomniaConfig: '1.0.0',
-      settings: {
-        random: 'abcd',
-      },
-    };
-
-    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(invalidConfig));
-    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
-
-    // Act
-    const result = getConfigSettings();
-
-    // Assert
-    expect(result).toHaveProperty('error');
-    if ('error' in result) {
-      expect(consoleErrorMock).toHaveBeenCalledWith('invalid insomnia config', result.error);
-    }
-
-    // Cleanup
-    readFileSyncSpy.mockRestore();
-    consoleErrorMock.mockRestore();
-  });
-});

--- a/packages/insomnia-app/app/models/helpers/__tests__/get-config-settings.test.ts
+++ b/packages/insomnia-app/app/models/helpers/__tests__/get-config-settings.test.ts
@@ -43,4 +43,30 @@ describe('getConfigSettings', () => {
     // Cleanup
     readFileSyncSpy.mockRestore();
   });
+
+  it('returns an error if validation result has errors', () => {
+    // Arrange
+    const invalidConfig = {
+      insomniaConfig: '1.0.0',
+      settings: {
+        random: 'abcd',
+      },
+    };
+
+    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(invalidConfig));
+    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
+
+    // Act
+    const result = getConfigSettings();
+
+    // Assert
+    expect(result).toHaveProperty('error');
+    if ('error' in result) {
+      expect(consoleErrorMock).toHaveBeenCalledWith('invalid insomnia config', result.error);
+    }
+
+    // Cleanup
+    readFileSyncSpy.mockRestore();
+    consoleErrorMock.mockRestore();
+  });
 });

--- a/packages/insomnia-app/app/models/helpers/settings.ts
+++ b/packages/insomnia-app/app/models/helpers/settings.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'fs';
 import { Settings } from 'insomnia-common';
-import { InsomniaConfig, validate } from 'insomnia-config';
-import { ValidationResult } from 'insomnia-config/dist/validate';
+import { InsomniaConfig, validate, ValidationResult } from 'insomnia-config';
 import { resolve } from 'path';
 import { mapObjIndexed, once } from 'ramda';
 import { omitBy } from 'ramda-adjunct';

--- a/packages/insomnia-app/app/models/helpers/settings.ts
+++ b/packages/insomnia-app/app/models/helpers/settings.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { Settings } from 'insomnia-common';
-import { InsomniaConfig, validate, ValidationResult } from 'insomnia-config';
+import { InsomniaConfig, validate, ValidationResult } from 'insomnia-config/dist';
 import { resolve } from 'path';
 import { mapObjIndexed, once } from 'ramda';
 import { omitBy } from 'ramda-adjunct';

--- a/packages/insomnia-config/src/entities.ts
+++ b/packages/insomnia-config/src/entities.ts
@@ -1,8 +1,8 @@
 import { Settings } from 'insomnia-common';
 
-type ConfigVersion = '1.0.0';
+export type ConfigVersion = '1.0.0';
 
-type AllowedSettings = Partial<Pick<Settings,
+export type AllowedSettings = Partial<Pick<Settings,
   | 'allowNotificationRequests'
   | 'disableUpdateNotification'
   | 'enableAnalytics'

--- a/packages/insomnia-config/src/index.ts
+++ b/packages/insomnia-config/src/index.ts
@@ -1,2 +1,12 @@
-export { validate } from './validate';
-export { InsomniaConfig } from './entities';
+export {
+  validate,
+  ErrorResult,
+  ValidResult,
+  ValidationResult,
+} from './validate';
+
+export {
+  InsomniaConfig,
+  AllowedSettings,
+  ConfigVersion,
+} from './entities';


### PR DESCRIPTION
closes INS-1030

This PR will block starting the app if there's an invalid insomnia config, and report the raw error (and file location) to the user.

Before this PR, the app would happily start up, despite an invalid config.  After this PR, it shows a message like this to the user:

<img src="https://user-images.githubusercontent.com/15232461/137991917-3f0dc874-24cd-438c-9db6-8a0529bff7a8.png" height="500" />


for a config like

```json
{
  "insomniaConfig": "1.0.0",
  "settings": {
    "allowNotificationRequests": 1,
    "disablePaidFeatureAdz": false
  }
}
```

and then kills the app process.