### PR TITLE
Prevent app initialization logic if config is invalid

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/__snapshots__/validate-insomnia-config.test.ts.snap
+++ b/packages/insomnia-app/app/common/__tests__/__snapshots__/validate-insomnia-config.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validateInsomniaConfig should show error box and exit if there is a config error 1`] = `
+"Your Insomnia Config was found to be invalid.  Please check the path below for the following error:
+
+[Path]
+/mock/insomnia/config/path
+
+[Error 1]
+Path: path
+message.  suggestion"
+`;
+
+exports[`validateInsomniaConfig should show error box and exit if there is a parse error 1`] = `
+"Failed to parse JSON file for Insomnia Config.
+
+[Path]
+/mock/insomnia/config/path
+
+[Syntax Error]
+mock syntax error"
+`;
+
+exports[`validateInsomniaConfig should show error box and exit if there is an unexpected error return 1`] = `"{\\"error\\":{\\"errors\\":[],\\"humanReadableErrors\\":[],\\"insomniaConfig\\":\\"{ \\\\\\"mock\\\\\\": [\\\\\\"insomnia\\\\\\", \\\\\\"config\\\\\\"] }\\",\\"configPath\\":\\"/mock/insomnia/config/path\\"}}"`;

--- a/packages/insomnia-app/app/common/__tests__/__snapshots__/validate-insomnia-config.test.ts.snap
+++ b/packages/insomnia-app/app/common/__tests__/__snapshots__/validate-insomnia-config.test.ts.snap
@@ -1,17 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`validateInsomniaConfig should show error box and exit if there is a config error 1`] = `
-"Your Insomnia Config was found to be invalid.  Please check the path below for the following error:
+exports[`validateInsomniaConfig should return error if there is a config error 1`] = `"{\\"error\\":{\\"errors\\":[],\\"humanReadableErrors\\":[],\\"insomniaConfig\\":\\"{ \\\\\\"mock\\\\\\": [\\\\\\"insomnia\\\\\\", \\\\\\"config\\\\\\"] }\\",\\"configPath\\":\\"/mock/insomnia/config/path\\"}}"`;
 
-[Path]
-/mock/insomnia/config/path
-
-[Error 1]
-Path: path
-message.  suggestion"
-`;
-
-exports[`validateInsomniaConfig should show error box and exit if there is a parse error 1`] = `
+exports[`validateInsomniaConfig should return error if there is a parse error 1`] = `
 "Failed to parse JSON file for Insomnia Config.
 
 [Path]
@@ -20,5 +11,3 @@ exports[`validateInsomniaConfig should show error box and exit if there is a par
 [Syntax Error]
 mock syntax error"
 `;
-
-exports[`validateInsomniaConfig should show error box and exit if there is an unexpected error return 1`] = `"{\\"error\\":{\\"errors\\":[],\\"humanReadableErrors\\":[],\\"insomniaConfig\\":\\"{ \\\\\\"mock\\\\\\": [\\\\\\"insomnia\\\\\\", \\\\\\"config\\\\\\"] }\\",\\"configPath\\":\\"/mock/insomnia/config/path\\"}}"`;

--- a/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
@@ -1,15 +1,15 @@
 import { mocked } from 'ts-jest/utils';
 
-import { ConfigError, getConfigSettings as _getConfigSettings, ParseError  } from '../../models/helpers/settings';
+import { getConfigSettings as _getConfigSettings  } from '../../models/helpers/settings';
 import { validateInsomniaConfig } from '../validate-insomnia-config';
 
 jest.mock('../../models/helpers/settings');
 const getConfigSettings = mocked(_getConfigSettings);
 
 describe('validateInsomniaConfig', () => {
-  it('should show error box and exit if there is a parse error', () => {
+  it('should return error if there is a parse error', () => {
     // Arrange
-    const errorReturn: ParseError = {
+    const errorReturn = {
       error: {
         syntaxError: new SyntaxError('mock syntax error'),
         fileContents: '{ "mock": ["insomnia", "config"] }',
@@ -26,34 +26,9 @@ describe('validateInsomniaConfig', () => {
     expect(result.error?.message).toMatchSnapshot();
   });
 
-  it('should show error box and exit if there is a config error', () => {
+  it('should return error if there is a config error', () => {
     // Arrange
-    const errorReturn: ConfigError = {
-      error: {
-        errors: [],
-        humanReadableErrors: [{
-          message: 'message',
-          path: 'path',
-          suggestion: 'suggestion',
-          context: { errorType: 'const' },
-        }],
-        insomniaConfig: '{ "mock": ["insomnia", "config"] }',
-        configPath: '/mock/insomnia/config/path',
-      },
-    };
-    getConfigSettings.mockReturnValue(errorReturn);
-
-    // Act
-    const result = validateInsomniaConfig();
-
-    // Assert
-    expect(result.error?.title).toBe('Invalid Insomnia Config');
-    expect(result.error?.message).toMatchSnapshot();
-  });
-
-  it('should show error box and exit if there is an unexpected error return', () => {
-    // Arrange
-    const errorReturn: ConfigError = {
+    const errorReturn = {
       error: {
         errors: [],
         humanReadableErrors: [],
@@ -71,7 +46,7 @@ describe('validateInsomniaConfig', () => {
     expect(result.error?.message).toMatchSnapshot();
   });
 
-  it('should not exit if there are no errors', () => {
+  it('should not return any errors', () => {
     // Arrange
     const validReturn = { enableAnalytics: true };
     getConfigSettings.mockReturnValue(validReturn);

--- a/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
@@ -43,9 +43,10 @@ describe('validateInsomniaConfig', () => {
     getConfigSettings.mockReturnValue(errorReturn);
 
     // Act
-    validateInsomniaConfig();
+    const result = validateInsomniaConfig();
 
     // Assert
+    expect(result).toBe(false);
     expect(electronShowErrorBox).toHaveBeenCalled();
     expect(electronAppExit).toHaveBeenCalled();
   });
@@ -56,9 +57,10 @@ describe('validateInsomniaConfig', () => {
     getConfigSettings.mockReturnValue(validReturn);
 
     // Act
-    validateInsomniaConfig();
+    const result = validateInsomniaConfig();
 
     // Assert
+    expect(result).toBe(true);
     expect(electronShowErrorBox).not.toHaveBeenCalled();
     expect(electronAppExit).not.toHaveBeenCalled();
   });

--- a/packages/insomnia-app/app/common/validate-insomnia-config.ts
+++ b/packages/insomnia-app/app/common/validate-insomnia-config.ts
@@ -1,13 +1,12 @@
 import electron from 'electron';
 
 import { getConfigSettings, isConfigError, isParseError } from '../models/helpers/settings';
-import { exitApp } from './electron-helpers';
 
 export const validateInsomniaConfig = () => {
   const configSettings = getConfigSettings();
 
   if (!('error' in configSettings)) {
-    return;
+    return true;
   }
 
   if (isParseError(configSettings)) {
@@ -44,5 +43,5 @@ export const validateInsomniaConfig = () => {
     );
   }
 
-  exitApp();
+  return false;
 };

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -6,7 +6,7 @@ import appConfig from '../config/config.json';
 import { trackNonInteractiveEventQueueable } from './common/analytics';
 import { changelogUrl, getAppVersion, isDevelopment, isMac } from './common/constants';
 import { database } from './common/database';
-import { disableSpellcheckerDownload } from './common/electron-helpers';
+import { disableSpellcheckerDownload, exitApp } from './common/electron-helpers';
 import log, { initializeLogging } from './common/log';
 import { validateInsomniaConfig } from './common/validate-insomnia-config';
 import * as errorHandling from './main/error-handling';
@@ -42,7 +42,12 @@ global.window = global.window || undefined;
 
 // When the app is first launched
 app.on('ready', async () => {
-  validateInsomniaConfig();
+  if (!validateInsomniaConfig()) {
+    exitApp();
+    console.log('[config] Insomnia config is invalid, preventing app initialization');
+    return;
+  }
+
   disableSpellcheckerDownload();
 
   if (isDevelopment()) {

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -42,9 +42,12 @@ global.window = global.window || undefined;
 
 // When the app is first launched
 app.on('ready', async () => {
-  if (!validateInsomniaConfig()) {
-    exitApp();
+  const { error } = validateInsomniaConfig();
+
+  if (error) {
+    electron.dialog.showErrorBox(error.title, error.message);
     console.log('[config] Insomnia config is invalid, preventing app initialization');
+    exitApp();
     return;
   }
 

--- a/packages/insomnia-app/app/models/helpers/settings.ts
+++ b/packages/insomnia-app/app/models/helpers/settings.ts
@@ -15,9 +15,13 @@ interface FailedParseResult {
   configPath: string;
 }
 
-const isFailedParseResult = (input: any): input is FailedParseResult => (
-  input ? input.syntaxError instanceof SyntaxError : false
-);
+const isFailedParseResult = (input: any): input is FailedParseResult => {
+  const typesafeInput = input as FailedParseResult;
+
+  return (
+    typesafeInput ? typesafeInput.syntaxError instanceof SyntaxError : false
+  );
+};
 
 /** takes an unresolved (or resolved will work fine too) filePath of the insomnia config and reads the insomniaConfig from disk */
 export const readConfigFile = (configPath?: string): unknown | FailedParseResult | undefined => {
@@ -96,7 +100,7 @@ export const getConfigFile = () => {
   };
 };
 
-interface ConfigError {
+export interface ConfigError {
   error: {
     configPath?: string;
     insomniaConfig: unknown;
@@ -105,16 +109,17 @@ interface ConfigError {
   };
 }
 
-export const isConfigError = (input: any): input is ConfigError => (
-  input ? input.humanErrors?.length > 0 : false
+export const isConfigError = (input: ConfigError | ParseError): input is ConfigError => (
+  // Cast for typesafety
+  (input as ConfigError).error?.humanReadableErrors?.length > 0
 );
 
-interface ParseError {
+export interface ParseError {
   error: FailedParseResult;
 }
 
-export const isParseError = (input: any): input is ParseError => (
-  input ? isFailedParseResult(input.error) : false
+export const isParseError = (input: ConfigError | ParseError): input is ParseError => (
+  isFailedParseResult(input.error)
 );
 
 /**

--- a/packages/insomnia-app/app/models/helpers/settings.ts
+++ b/packages/insomnia-app/app/models/helpers/settings.ts
@@ -15,13 +15,9 @@ interface FailedParseResult {
   configPath: string;
 }
 
-const isFailedParseResult = (input: any): input is FailedParseResult => {
-  const typesafeInput = input as FailedParseResult;
-
-  return (
-    typesafeInput ? typesafeInput.syntaxError instanceof SyntaxError : false
-  );
-};
+const isFailedParseResult = (input: any): input is FailedParseResult => (
+  input ? input.syntaxError instanceof SyntaxError : false
+);
 
 /** takes an unresolved (or resolved will work fine too) filePath of the insomnia config and reads the insomniaConfig from disk */
 export const readConfigFile = (configPath?: string): unknown | FailedParseResult | undefined => {
@@ -100,7 +96,7 @@ export const getConfigFile = () => {
   };
 };
 
-export interface ConfigError {
+interface ConfigError {
   error: {
     configPath?: string;
     insomniaConfig: unknown;
@@ -109,17 +105,16 @@ export interface ConfigError {
   };
 }
 
-export const isConfigError = (input: ConfigError | ParseError): input is ConfigError => (
-  // Cast for typesafety
-  (input as ConfigError).error?.humanReadableErrors?.length > 0
+export const isConfigError = (input: any): input is ConfigError => (
+  input ? input.humanErrors?.length > 0 : false
 );
 
-export interface ParseError {
+interface ParseError {
   error: FailedParseResult;
 }
 
-export const isParseError = (input: ConfigError | ParseError): input is ParseError => (
-  isFailedParseResult(input.error)
+export const isParseError = (input: any): input is ParseError => (
+  input ? isFailedParseResult(input.error) : false
 );
 
 /**


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

Notice the last few lines, especially the database fixing logic that runs. We need to exit the app.ready event handler, in addition to exiting the app

| Before | After |
| - | - |
| ![Screen Shot 2021-10-20 at 6 41 37 PM](https://user-images.githubusercontent.com/4312346/138035086-c2519e94-6dc3-4311-b958-d3c732399062.png)  |  ![image](https://user-images.githubusercontent.com/4312346/138035208-41ad694b-a1f4-4492-9751-c036928b3707.png) |