### PR TITLE
remove electron augmentation and use current API

### DIFF
--- a/packages/insomnia-app/app/electron.d.ts
+++ b/packages/insomnia-app/app/electron.d.ts
@@ -1,6 +1,0 @@
-declare module 'electron' {
-  export interface MenuItemConstructorOptions {
-    // see: https://github.com/electron/electron/issues/30719 for why this module augmentation is necessary.
-    selector?: string;
-  }
-}

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -186,12 +186,12 @@ export function createWindow() {
       {
         label: `${MNEMONIC_SYM}Undo`,
         accelerator: 'CmdOrCtrl+Z',
-        selector: 'undo:',
+        role: 'undo',
       },
       {
         label: `${MNEMONIC_SYM}Redo`,
         accelerator: 'Shift+CmdOrCtrl+Z',
-        selector: 'redo:',
+        role: 'redo',
       },
       {
         type: 'separator',
@@ -199,22 +199,22 @@ export function createWindow() {
       {
         label: `Cu${MNEMONIC_SYM}t`,
         accelerator: 'CmdOrCtrl+X',
-        selector: 'cut:',
+        role: 'cut',
       },
       {
         label: `${MNEMONIC_SYM}Copy`,
         accelerator: 'CmdOrCtrl+C',
-        selector: 'copy:',
+        role: 'copy',
       },
       {
         label: `${MNEMONIC_SYM}Paste`,
         accelerator: 'CmdOrCtrl+V',
-        selector: 'paste:',
+        role: 'paste',
       },
       {
         label: `Select ${MNEMONIC_SYM}All`,
         accelerator: 'CmdOrCtrl+A',
-        selector: 'selectAll:',
+        role: 'selectAll',
       },
     ],
   };


### PR DESCRIPTION
see: https://github.com/electron/electron/issues/30719#issuecomment-947006165

We were using something that was removed from electron 6 years ago.  I had inquired about it to the electron folks, and they clarified what we should be doing.
closes INS-1071

## What effect does this fix have for users?
Roles allow menu items to have predefined behaviors.

It is best to specify role for any menu item that matches a standard role, rather than trying to manually implement the behavior in a click function. The built-in role behavior will give the best native experience.

The label and accelerator values are optional when using a role and will default to appropriate values for each platform.