### PR TITLE
fails validation if the config has a parse error

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
@@ -11,7 +11,26 @@ const electronShowErrorBox = mocked(electron.dialog.showErrorBox);
 const getConfigSettings = mocked(_getConfigSettings);
 
 describe('validateInsomniaConfig', () => {
-  it('should show error box and exit if there is an error', () => {
+  it('should show error box and exit if there is a parse error', () => {
+    // Arrange
+    const errorReturn = {
+      error: {
+        syntaxError: new SyntaxError('mock syntax error'),
+        fileContents: '{ "mock": ["insomnia", "config"] }',
+        configPath: '/mock/insomnia/config/path',
+      },
+    };
+    getConfigSettings.mockReturnValue(errorReturn);
+
+    // Act
+    validateInsomniaConfig();
+
+    // Assert
+    expect(electronShowErrorBox).toHaveBeenCalled();
+    expect(electronAppExit).toHaveBeenCalled();
+  });
+
+  it('should show error box and exit if there is a config error', () => {
     // Arrange
     const errorReturn = {
       error: {

--- a/packages/insomnia-app/app/common/validate-insomnia-config.ts
+++ b/packages/insomnia-app/app/common/validate-insomnia-config.ts
@@ -1,27 +1,48 @@
 import electron from 'electron';
 
-import { getConfigSettings } from '../models/helpers/settings';
+import { getConfigSettings, isConfigError, isParseError } from '../models/helpers/settings';
 import { exitApp } from './electron-helpers';
 
 export const validateInsomniaConfig = () => {
   const configSettings = getConfigSettings();
-  if ('error' in configSettings) {
-    const errors = configSettings.error.humanReadableErrors?.map(({ message, path, suggestion }, index) => ([
+
+  if (!('error' in configSettings)) {
+    return;
+  }
+
+  if (isParseError(configSettings)) {
+    const { syntaxError, configPath } = configSettings.error;
+    electron.dialog.showErrorBox('Invalid Insomnia Config', [
+      'Failed to parse JSON file for Insomnia Config.',
+      '',
+      '[Path]',
+      configPath,
+      '',
+      '[Syntax Error]',
+      syntaxError.message,
+    ].join('\n'));
+  } else if (isConfigError(configSettings)) {
+    const { humanReadableErrors, configPath } = configSettings.error;
+    const errors = humanReadableErrors.map(({ message, path, suggestion }, index) => ([
       `[Error ${index + 1}]`,
       `Path: ${path}`,
       `${message}.${suggestion ? `  ${suggestion}` : ''}`,
     ]).join('\n')).join('\n\n');
 
-    electron.dialog.showErrorBox('Invalid Insomnia Config',
-      [
-        `Your Insomnia Config was found to be invalid.  Please check the path below for the following error${configSettings.error.humanReadableErrors?.length > 1 ? 's' : ''}:`,
-        '',
-        '[Path]',
-        configSettings.error.configPath,
-        '',
-        errors,
-      ].join('\n'),
+    electron.dialog.showErrorBox('Invalid Insomnia Config', [
+      `Your Insomnia Config was found to be invalid.  Please check the path below for the following error${configSettings.error.humanReadableErrors?.length > 1 ? 's' : ''}:`,
+      '',
+      '[Path]',
+      configPath,
+      '',
+      errors,
+    ].join('\n'));
+  } else {
+    electron.dialog.showErrorBox(
+      'An unexpected error occured while parsing Insomnia Config',
+      JSON.stringify(configSettings),
     );
-    exitApp();
   }
+
+  exitApp();
 };


### PR DESCRIPTION
closes INS-1046

this will present an error to the user if the config

Before this PR, invalid JSON was just skipped.

After this PR, users are presented with a message like this:
<img src="https://user-images.githubusercontent.com/15232461/138148326-c60c8081-ea19-493b-a599-04a218fe105d.png" height="200" />

and then the app exits.

The above can be tested with a bad insomnia config, e.g.
```json
{
  "insomniaConfig": "1.0.0",
  settings": {}
}
```