### PR TITLE
Handle human readable errors correctly

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/__snapshots__/validate-insomnia-config.test.ts.snap
+++ b/packages/insomnia-app/app/common/__tests__/__snapshots__/validate-insomnia-config.test.ts.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`validateInsomniaConfig should return error if there is a config error 1`] = `"{\\"error\\":{\\"errors\\":[],\\"humanReadableErrors\\":[],\\"insomniaConfig\\":\\"{ \\\\\\"mock\\\\\\": [\\\\\\"insomnia\\\\\\", \\\\\\"config\\\\\\"] }\\",\\"configPath\\":\\"/mock/insomnia/config/path\\"}}"`;
-
 exports[`validateInsomniaConfig should return error if there is a parse error 1`] = `
 "Failed to parse JSON file for Insomnia Config.
 
@@ -10,4 +8,17 @@ exports[`validateInsomniaConfig should return error if there is a parse error 1`
 
 [Syntax Error]
 mock syntax error"
+`;
+
+exports[`validateInsomniaConfig should return error if there is an unexpected error 1`] = `"{\\"error\\":{\\"errors\\":[],\\"humanReadableErrors\\":[],\\"insomniaConfig\\":\\"{ \\\\\\"mock\\\\\\": [\\\\\\"insomnia\\\\\\", \\\\\\"config\\\\\\"] }\\",\\"configPath\\":\\"/mock/insomnia/config/path\\"}}"`;
+
+exports[`validateInsomniaConfig should show error box and exit if there is a config error 1`] = `
+"Your Insomnia Config was found to be invalid.  Please check the path below for the following error:
+
+[Path]
+/mock/insomnia/config/path
+
+[Error 1]
+Path: path
+message.  suggestion"
 `;

--- a/packages/insomnia-app/app/common/__tests__/__snapshots__/validate-insomnia-config.test.ts.snap
+++ b/packages/insomnia-app/app/common/__tests__/__snapshots__/validate-insomnia-config.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`validateInsomniaConfig should return error if there is a config error 1`] = `
+"Your Insomnia Config was found to be invalid.  Please check the path below for the following error:
+
+[Path]
+/mock/insomnia/config/path
+
+[Error 1]
+Path: path
+message.  suggestion"
+`;
+
 exports[`validateInsomniaConfig should return error if there is a parse error 1`] = `
 "Failed to parse JSON file for Insomnia Config.
 
@@ -11,14 +22,3 @@ mock syntax error"
 `;
 
 exports[`validateInsomniaConfig should return error if there is an unexpected error 1`] = `"{\\"error\\":{\\"errors\\":[],\\"humanReadableErrors\\":[],\\"insomniaConfig\\":\\"{ \\\\\\"mock\\\\\\": [\\\\\\"insomnia\\\\\\", \\\\\\"config\\\\\\"] }\\",\\"configPath\\":\\"/mock/insomnia/config/path\\"}}"`;
-
-exports[`validateInsomniaConfig should show error box and exit if there is a config error 1`] = `
-"Your Insomnia Config was found to be invalid.  Please check the path below for the following error:
-
-[Path]
-/mock/insomnia/config/path
-
-[Error 1]
-Path: path
-message.  suggestion"
-`;

--- a/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
@@ -8,7 +8,7 @@ const getConfigSettings = mocked(_getConfigSettings);
 
 describe('validateInsomniaConfig', () => {
   it('should return error if there is a parse error', () => {
-  // Arrange
+    // Arrange
     const errorReturn = {
       error: {
         syntaxError: new SyntaxError('mock syntax error'),
@@ -27,7 +27,7 @@ describe('validateInsomniaConfig', () => {
   });
 
   it('should return error if there is a config error', () => {
-  // Arrange
+    // Arrange
     const errorReturn: ConfigError = {
       error: {
         errors: [],
@@ -52,7 +52,7 @@ describe('validateInsomniaConfig', () => {
   });
 
   it('should return error if there is an unexpected error', () => {
-  // Arrange
+    // Arrange
     const errorReturn = {
       error: {
         errors: [],
@@ -72,7 +72,7 @@ describe('validateInsomniaConfig', () => {
   });
 
   it('should not return any errors', () => {
-  // Arrange
+    // Arrange
     const validReturn = { enableAnalytics: true };
     getConfigSettings.mockReturnValue(validReturn);
 

--- a/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
@@ -26,7 +26,7 @@ describe('validateInsomniaConfig', () => {
     expect(result.error?.message).toMatchSnapshot();
   });
 
-  it('should show error box and exit if there is a config error', () => {
+  it('should return error if there is a config error', () => {
   // Arrange
     const errorReturn: ConfigError = {
       error: {

--- a/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/validate-insomnia-config.test.ts
@@ -1,6 +1,6 @@
 import { mocked } from 'ts-jest/utils';
 
-import { getConfigSettings as _getConfigSettings  } from '../../models/helpers/settings';
+import { ConfigError, getConfigSettings as _getConfigSettings  } from '../../models/helpers/settings';
 import { validateInsomniaConfig } from '../validate-insomnia-config';
 
 jest.mock('../../models/helpers/settings');
@@ -8,7 +8,7 @@ const getConfigSettings = mocked(_getConfigSettings);
 
 describe('validateInsomniaConfig', () => {
   it('should return error if there is a parse error', () => {
-    // Arrange
+  // Arrange
     const errorReturn = {
       error: {
         syntaxError: new SyntaxError('mock syntax error'),
@@ -26,8 +26,33 @@ describe('validateInsomniaConfig', () => {
     expect(result.error?.message).toMatchSnapshot();
   });
 
-  it('should return error if there is a config error', () => {
-    // Arrange
+  it('should show error box and exit if there is a config error', () => {
+  // Arrange
+    const errorReturn: ConfigError = {
+      error: {
+        errors: [],
+        humanReadableErrors: [{
+          message: 'message',
+          path: 'path',
+          suggestion: 'suggestion',
+          context: { errorType: 'const' },
+        }],
+        insomniaConfig: '{ "mock": ["insomnia", "config"] }',
+        configPath: '/mock/insomnia/config/path',
+      },
+    };
+    getConfigSettings.mockReturnValue(errorReturn);
+
+    // Act
+    const result = validateInsomniaConfig();
+
+    // Assert
+    expect(result.error?.title).toBe('Invalid Insomnia Config');
+    expect(result.error?.message).toMatchSnapshot();
+  });
+
+  it('should return error if there is an unexpected error', () => {
+  // Arrange
     const errorReturn = {
       error: {
         errors: [],
@@ -47,7 +72,7 @@ describe('validateInsomniaConfig', () => {
   });
 
   it('should not return any errors', () => {
-    // Arrange
+  // Arrange
     const validReturn = { enableAnalytics: true };
     getConfigSettings.mockReturnValue(validReturn);
 

--- a/packages/insomnia-app/app/models/helpers/settings.ts
+++ b/packages/insomnia-app/app/models/helpers/settings.ts
@@ -15,9 +15,13 @@ interface FailedParseResult {
   configPath: string;
 }
 
-const isFailedParseResult = (input: any): input is FailedParseResult => (
-  input ? input.syntaxError instanceof SyntaxError : false
-);
+const isFailedParseResult = (input: any): input is FailedParseResult => {
+  const typesafeInput = input as FailedParseResult;
+
+  return (
+    typesafeInput ? typesafeInput.syntaxError instanceof SyntaxError : false
+  );
+};
 
 /** takes an unresolved (or resolved will work fine too) filePath of the insomnia config and reads the insomniaConfig from disk */
 export const readConfigFile = (configPath?: string): unknown | FailedParseResult | undefined => {
@@ -96,7 +100,7 @@ export const getConfigFile = () => {
   };
 };
 
-interface ConfigError {
+export interface ConfigError {
   error: {
     configPath?: string;
     insomniaConfig: unknown;
@@ -105,16 +109,17 @@ interface ConfigError {
   };
 }
 
-export const isConfigError = (input: any): input is ConfigError => (
-  input ? input.humanErrors?.length > 0 : false
+export const isConfigError = (input: ConfigError | ParseError): input is ConfigError => (
+  // Cast for typesafety
+  (input as ConfigError).error?.humanReadableErrors?.length > 0
 );
 
-interface ParseError {
+export interface ParseError {
   error: FailedParseResult;
 }
 
-export const isParseError = (input: any): input is ParseError => (
-  input ? isFailedParseResult(input.error) : false
+export const isParseError = (input: ConfigError | ParseError): input is ParseError => (
+  isFailedParseResult(input.error)
 );
 
 /**


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

There exists an underlying bug with isConfigError, where it was checking for a field that does not exist, because of `any` types. This causes a false positive with the unit tests, and means the fallback `json.stringify` error message is shown, rather than the humanReadable one (see snapshot change).

Using the following config file, 

```json
{
  "insomniaConfig": "1.0.0",
  "settings": {
    "abc": 123
  }
}
```

2021.6.0-alpha.6 shows
<img width="372" alt="image" src="https://user-images.githubusercontent.com/4312346/138530565-7ab3746b-d942-4555-8f3e-7288503d1297.png">

This PR shows
<img width="372" alt="image" src="https://user-images.githubusercontent.com/4312346/138530576-28a33965-4f2b-4238-8d09-885fb2023785.png">


Follow-up to https://github.com/Kong/insomnia/pull/4134. Closes INS-1092.