### PR TITLE
fix(workspace-card-dropdown): restore the use the get-workspace-name …

### DIFF
--- a/packages/insomnia-app/app/models/helpers/__tests__/get-workspace-name.test.ts
+++ b/packages/insomnia-app/app/models/helpers/__tests__/get-workspace-name.test.ts
@@ -1,0 +1,19 @@
+import * as models from '../../../models';
+import { WorkspaceScopeKeys } from '../../workspace';
+import getWorkspaceName from '../get-workspace-name';
+
+describe('getWorkspaceName', () => {
+  it('returns workspace name', () => {
+    const w = models.workspace.init();
+    const s = models.apiSpec.init();
+    w.scope = WorkspaceScopeKeys.collection;
+    expect(getWorkspaceName(w, s)).toBe(w.name);
+  });
+
+  it('returns api spec name', () => {
+    const w = models.workspace.init();
+    const s = models.apiSpec.init();
+    w.scope = WorkspaceScopeKeys.design;
+    expect(getWorkspaceName(w, s)).toBe(s.fileName);
+  });
+});

--- a/packages/insomnia-app/app/models/helpers/get-workspace-name.ts
+++ b/packages/insomnia-app/app/models/helpers/get-workspace-name.ts
@@ -1,0 +1,6 @@
+import type { ApiSpec } from '../api-spec';
+import { isDesign, Workspace } from '../workspace';
+
+export default function getWorkspaceName(w: Workspace, s: ApiSpec) {
+  return isDesign(w) ? s.fileName : w.name;
+}

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -1,12 +1,12 @@
 import { SvgIcon } from 'insomnia-components';
 import React, { FC, useCallback, useState } from 'react';
-import { useSelector } from 'react-redux';
 
 import { parseApiSpec } from '../../../common/api-specs';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
 import { RENDER_PURPOSE_NO_RENDER } from '../../../common/render';
 import * as models from '../../../models';
 import type { ApiSpec } from '../../../models/api-spec';
+import getWorkspaceName from '../../../models/helpers/get-workspace-name';
 import * as workspaceOperations from '../../../models/helpers/workspace-operations';
 import { Project } from '../../../models/project';
 import type { Workspace } from '../../../models/workspace';
@@ -15,7 +15,6 @@ import type { DocumentAction } from '../../../plugins';
 import { getDocumentActions } from '../../../plugins';
 import * as pluginContexts from '../../../plugins/context';
 import { useLoadingRecord } from '../../hooks/use-loading-record';
-import { selectActiveWorkspaceName } from '../../redux/selectors';
 import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -34,15 +33,15 @@ const spinner = <i className="fa fa-refresh fa-spin" />;
 
 const useWorkspaceHandlers = ({ workspace, apiSpec }: Props) => {
   const handleDuplicate = useCallback(() => {
-    showWorkspaceDuplicateModal({ workspace });
-  }, [workspace]);
+    showWorkspaceDuplicateModal({ workspace, apiSpec });
+  }, [workspace, apiSpec]);
 
-  const activeWorkspaceName = useSelector(selectActiveWorkspaceName);
+  const workspaceName = getWorkspaceName(workspace, apiSpec);
 
   const handleRename = useCallback(() => {
     showPrompt({
       title: `Rename ${getWorkspaceLabel(workspace).singular}`,
-      defaultValue: activeWorkspaceName,
+      defaultValue: workspaceName,
       submitName: 'Rename',
       selectText: true,
       label: 'Name',
@@ -50,13 +49,13 @@ const useWorkspaceHandlers = ({ workspace, apiSpec }: Props) => {
         await workspaceOperations.rename(workspace, apiSpec, name);
       },
     });
-  }, [apiSpec, workspace, activeWorkspaceName]);
+  }, [apiSpec, workspace, workspaceName]);
 
   const handleDelete = useCallback(() => {
     const label = getWorkspaceLabel(workspace);
     showModal(AskModal, {
       title: `Delete ${label.singular}`,
-      message: `Do you really want to delete "${activeWorkspaceName}"?`,
+      message: `Do you really want to delete "${workspaceName}"?`,
       yesText: 'Yes',
       noText: 'Cancel',
       onDone: async (isYes: boolean) => {
@@ -68,7 +67,7 @@ const useWorkspaceHandlers = ({ workspace, apiSpec }: Props) => {
         await models.workspace.remove(workspace);
       },
     });
-  }, [workspace, activeWorkspaceName]);
+  }, [workspace, workspaceName]);
 
   return { handleDelete, handleDuplicate, handleRename };
 };

--- a/packages/insomnia-app/app/ui/components/modals/workspace-duplicate-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-duplicate-modal.tsx
@@ -8,13 +8,15 @@ import { AUTOBIND_CFG } from '../../../common/constants';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
 import { strings } from '../../../common/strings';
 import * as models from '../../../models';
+import { ApiSpec } from '../../../models/api-spec';
+import getWorkspaceName from '../../../models/helpers/get-workspace-name';
 import * as workspaceOperations from '../../../models/helpers/workspace-operations';
 import { isDefaultProject, isLocalProject, isRemoteProject, Project } from '../../../models/project';
 import { Workspace } from '../../../models/workspace';
 import { initializeLocalBackendProjectAndMarkForSync } from '../../../sync/vcs/initialize-backend-project';
 import { VCS } from '../../../sync/vcs/vcs';
 import { activateWorkspace } from '../../redux/modules/workspace';
-import { selectActiveProject, selectActiveWorkspaceName, selectIsLoggedIn, selectProjects } from '../../redux/selectors';
+import { selectActiveProject, selectIsLoggedIn, selectProjects } from '../../redux/selectors';
 import { Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
@@ -23,6 +25,7 @@ import { showModal } from '.';
 
 interface Options {
   workspace: Workspace;
+  apiSpec: ApiSpec;
   onDone?: () => void;
 }
 
@@ -41,7 +44,7 @@ const ProjectOption: FC<Project> = project => (
   </option>
 );
 
-const WorkspaceDuplicateModalInternalWithRef: ForwardRefRenderFunction<Modal, InnerProps> = ({ workspace, onDone, hide, vcs }, ref) => {
+const WorkspaceDuplicateModalInternalWithRef: ForwardRefRenderFunction<Modal, InnerProps> = ({ workspace, apiSpec, onDone, hide, vcs }, ref) => {
   const dispatch = useDispatch();
 
   const projects = useSelector(selectProjects);
@@ -49,7 +52,7 @@ const WorkspaceDuplicateModalInternalWithRef: ForwardRefRenderFunction<Modal, In
   const isLoggedIn = useSelector(selectIsLoggedIn);
 
   const title = `Duplicate ${getWorkspaceLabel(workspace).singular}`;
-  const activeWorkspaceName = useSelector(selectActiveWorkspaceName);
+  const defaultWorkspaceName = getWorkspaceName(workspace, apiSpec);
 
   const {
     register,
@@ -59,7 +62,7 @@ const WorkspaceDuplicateModalInternalWithRef: ForwardRefRenderFunction<Modal, In
       errors,
     } } = useForm<FormFields>({
       defaultValues: {
-        newName: activeWorkspaceName,
+        newName: defaultWorkspaceName,
         projectId: activeProject._id,
       },
     });

--- a/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
@@ -131,8 +131,8 @@ export class UnconnectedWorkspaceSettingsModal extends PureComponent<Props, Stat
   }
 
   _handleDuplicateWorkspace() {
-    const { workspace } = this.props;
-    showWorkspaceDuplicateModal({ workspace, onDone: this.hide });
+    const { workspace, apiSpec } = this.props;
+    showWorkspaceDuplicateModal({ workspace, apiSpec, onDone: this.hide });
   }
 
   _handleToggleCertificateForm() {


### PR DESCRIPTION
Fixes a regression where the workspace name would not be displayed in the dashboard view in various places:
- [x] Renaming a workspace should have  the workspace name as default value
- [x] Duplicating should have the workspace name as default value
- [x] Deleting a workspace should show the correct workspace name

### Current
![workspace-name-before](https://user-images.githubusercontent.com/12115431/138725398-ddc7b8b2-d80d-4f47-bed8-27ad969f204d.gif)

### After
![workspace-name](https://user-images.githubusercontent.com/12115431/138724141-c4c911d3-57f0-42be-8915-2029f01bf2d1.gif)

This was introduced when we created the `activeWorkspaceName` selector.
There are places where there isn't an `active workspace` and instead we need to check for the name of a specific workspace. I brought back the previous utility to get the name and double checked the places where the selector and utility are used.

Closes INS-1069