### PR TITLE
Fix OAuth2 security schemes for OpenAPI importer

### DIFF
--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/dereferenced-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/dereferenced-output.json
@@ -27,6 +27,8 @@
         "apiKey": "apiKey",
         "base_path": "/v2",
         "host": "petstore.swagger.io",
+        "oauth2ClientId": "clientId",
+        "oauth2RedirectUrl": "http://localhost/",
         "scheme": "http"
       },
       "name": "OpenAPI env",
@@ -35,7 +37,14 @@
     {
       "_id": "req___WORKSPACE_ID__23acbe44",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -50,7 +59,14 @@
     {
       "_id": "req___WORKSPACE_ID__74a7a059",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -65,7 +81,14 @@
     {
       "_id": "req___WORKSPACE_ID__80ab0d08",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [],
       "method": "GET",
@@ -83,7 +106,14 @@
     {
       "_id": "req___WORKSPACE_ID__42a17980",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [],
       "method": "GET",
@@ -119,7 +149,14 @@
     {
       "_id": "req___WORKSPACE_ID__a4608701",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
@@ -133,7 +170,14 @@
     {
       "_id": "req___WORKSPACE_ID__e804bd05",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [
         {
@@ -151,7 +195,14 @@
     {
       "_id": "req___WORKSPACE_ID__8081fb6f",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "multipart/form-data"
       },

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/dereferenced-with-tags-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/dereferenced-with-tags-output.json
@@ -27,6 +27,8 @@
         "apiKey": "apiKey",
         "base_path": "/v2",
         "host": "petstore.swagger.io",
+        "oauth2ClientId": "clientId",
+        "oauth2RedirectUrl": "http://localhost/",
         "scheme": "http"
       },
       "name": "OpenAPI env",
@@ -59,7 +61,14 @@
     {
       "_id": "req___WORKSPACE_ID__23acbe44",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -74,7 +83,14 @@
     {
       "_id": "req___WORKSPACE_ID__74a7a059",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -89,7 +105,14 @@
     {
       "_id": "req___WORKSPACE_ID__80ab0d08",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [],
       "method": "GET",
@@ -107,7 +130,14 @@
     {
       "_id": "req___WORKSPACE_ID__42a17980",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [],
       "method": "GET",
@@ -143,7 +173,14 @@
     {
       "_id": "req___WORKSPACE_ID__a4608701",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
@@ -157,7 +194,14 @@
     {
       "_id": "req___WORKSPACE_ID__e804bd05",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [
         {
@@ -175,7 +219,14 @@
     {
       "_id": "req___WORKSPACE_ID__8081fb6f",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "multipart/form-data"
       },

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/endpoint-security-input.yaml
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/endpoint-security-input.yaml
@@ -39,7 +39,6 @@ components:
       in: query
     OAuth2-AuthorizationCode:
       type: oauth2
-      scheme: bearer
       flows:
         authorizationCode:
           authorizationUrl: https://api.server.test/v1/auth
@@ -49,7 +48,6 @@ components:
             write:something: Write all the data
     OAuth2-Implicit:
       type: oauth2
-      scheme: bearer
       flows:
         implicit:
           authorizationUrl: https://api.server.test/v1/auth
@@ -58,7 +56,6 @@ components:
             write:something: Write all the data
     OAuth2-ClientCredentials:
       type: oauth2
-      scheme: bearer
       flows:
         clientCredentials:
           tokenUrl: https://api.server.test/v1/token
@@ -67,7 +64,6 @@ components:
             write:something: Write all the data
     OAuth2-Password:
       type: oauth2
-      scheme: bearer
       flows:
         password:
           tokenUrl: https://api.server.test/v1/token

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/endpoint-security-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/endpoint-security-output.json
@@ -34,6 +34,7 @@
         "httpUsername": "username",
         "oauth2ClientId": "clientId",
         "oauth2ClientSecret": "clientSecret",
+        "oauth2RedirectUrl": "http://localhost/",
         "oauth2Username": "username",
         "oauth2Password": "password",
         "key": "key",
@@ -174,6 +175,7 @@
       "authentication": {
           "clientId": "{{ oauth2ClientId }}",
           "clientSecret": "{{ oauth2ClientSecret }}",
+          "redirectUrl": "{{ oauth2RedirectUrl }}",
           "accessTokenUrl": "https://api.server.test/v1/token",
           "authorizationUrl": "https://api.server.test/v1/auth",
           "grantType": "authorization_code",
@@ -193,6 +195,7 @@
       "_type": "request",
       "authentication": {
           "clientId": "{{ oauth2ClientId }}",
+          "redirectUrl": "{{ oauth2RedirectUrl }}",
           "authorizationUrl": "https://api.server.test/v1/auth",
           "grantType": "implicit",
           "scope": "read:something write:something",

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/oauth2-input.yaml
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/oauth2-input.yaml
@@ -1,0 +1,27 @@
+openapi: '3.0.2'
+info:
+  title: Endpoint Security
+  version: '1.2'
+servers:
+  - url: https://api.server.test/v1
+
+components:
+  securitySchemes:
+    OAuth2-AuthorizationCode:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://api.server.test/v1/auth
+          tokenUrl: https://api.server.test/v1/token
+          scopes:
+            read:something: Read all the data
+            write:something: Write all the data
+
+paths:
+  /oauth2/authorization-code:
+    get:
+      security:
+        - OAuth2-AuthorizationCode: []
+      responses:
+        '200':
+          description: OK

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/oauth2-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/oauth2-output.json
@@ -1,0 +1,59 @@
+{
+  "__export_date": "2020-05-13T23:55:24.712Z",
+  "__export_format": 4,
+  "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
+  "resources": [
+    {
+      "_id": "__WORKSPACE_ID__",
+      "_type": "workspace",
+      "description": "",
+      "name": "Endpoint Security 1.2",
+      "parentId": null
+    },
+    {
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
+      "data": {
+        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+      },
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_ID__"
+    },
+    {
+      "_id": "env___BASE_ENVIRONMENT_ID___sub",
+      "_type": "environment",
+      "data": {
+        "base_path": "/v1",
+        "host": "api.server.test",
+        "oauth2ClientId": "clientId",
+        "oauth2ClientSecret": "clientSecret",
+        "oauth2RedirectUrl": "http://localhost/",
+        "scheme": "https"
+      },
+      "name": "OpenAPI env",
+      "parentId": "__BASE_ENVIRONMENT_ID__"
+    },
+    {
+      "_id": "req___WORKSPACE_ID__028b5fb7",
+      "_type": "request",
+      "authentication": {
+          "clientId": "{{ oauth2ClientId }}",
+          "clientSecret": "{{ oauth2ClientSecret }}",
+          "accessTokenUrl": "https://api.server.test/v1/token",
+          "authorizationUrl": "https://api.server.test/v1/auth",
+          "grantType": "authorization_code",
+          "redirectUrl": "{{ oauth2RedirectUrl }}",
+          "scope": "read:something write:something",
+          "type": "oauth2"
+      },
+      "body": {},
+      "headers": [],
+      "method": "GET",
+      "name": "/oauth2/authorization-code",
+      "parameters": [],
+      "parentId": "__WORKSPACE_ID__",
+      "url": "{{ base_url }}/oauth2/authorization-code"
+    }
+  ]
+}

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/petstore-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/petstore-output.json
@@ -27,6 +27,8 @@
         "apiKey": "apiKey",
         "base_path": "/v2",
         "host": "petstore.swagger.io",
+        "oauth2ClientId": "clientId",
+        "oauth2RedirectUrl": "http://localhost/",
         "scheme": "http"
       },
       "name": "OpenAPI env",
@@ -35,7 +37,14 @@
     {
       "_id": "req___WORKSPACE_ID__23acbe44",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -50,7 +59,14 @@
     {
       "_id": "req___WORKSPACE_ID__74a7a059",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -65,7 +81,14 @@
     {
       "_id": "req___WORKSPACE_ID__80ab0d08",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [],
       "method": "GET",
@@ -83,7 +106,14 @@
     {
       "_id": "req___WORKSPACE_ID__42a17980",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [],
       "method": "GET",
@@ -119,7 +149,14 @@
     {
       "_id": "req___WORKSPACE_ID__a4608701",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
@@ -133,7 +170,14 @@
     {
       "_id": "req___WORKSPACE_ID__e804bd05",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [
         {
@@ -151,7 +195,14 @@
     {
       "_id": "req___WORKSPACE_ID__8081fb6f",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "multipart/form-data"
       },

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/petstore-with-tags-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/petstore-with-tags-output.json
@@ -27,6 +27,8 @@
         "apiKey": "apiKey",
         "base_path": "/v2",
         "host": "petstore.swagger.io",
+        "oauth2ClientId": "clientId",
+        "oauth2RedirectUrl": "http://localhost/",
         "scheme": "http"
       },
       "name": "OpenAPI env",
@@ -59,7 +61,14 @@
     {
       "_id": "req___WORKSPACE_ID__23acbe44",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -74,7 +83,14 @@
     {
       "_id": "req___WORKSPACE_ID__74a7a059",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -89,7 +105,14 @@
     {
       "_id": "req___WORKSPACE_ID__80ab0d08",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [],
       "method": "GET",
@@ -107,7 +130,14 @@
     {
       "_id": "req___WORKSPACE_ID__42a17980",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [],
       "method": "GET",
@@ -143,7 +173,14 @@
     {
       "_id": "req___WORKSPACE_ID__a4608701",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
@@ -157,7 +194,14 @@
     {
       "_id": "req___WORKSPACE_ID__e804bd05",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {},
       "headers": [
         {
@@ -175,7 +219,14 @@
     {
       "_id": "req___WORKSPACE_ID__8081fb6f",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+        "clientId": "{{ oauth2ClientId }}",
+        "grantType": "implicit",
+        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "scope": "write:pets read:pets",
+        "type": "oauth2"
+      },
       "body": {
         "mimeType": "multipart/form-data"
       },


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Closes #3093
Closes #4095

The existing importer for OpenAPI requires specifying `scheme: bearer` for OAuth2 security schemes, but unfortunately this violates the OpenAPI specification (and Insomnia will show warnings when using the schema editor). In this PR:

* Fixes importing OpenAPI specs for OAuth2 security schemes
* Updates the test fixtures to comply with the OpenAPI specification for OAuth2
* Updates the test result fixtures for Petstore tests (these previously didn't import correctly due to the above issue)
* Sets the Redirect URL for OAuth2 requests to a variable - this is a required parameter for Amazon Cognito/Okta and most/all IdPs, so being able to set it easily for all requests (as is possible for Client ID/secret) simplifies using Insomnia

changelog(Fixes): For OpenAPI documents, OAuth2 security scheme components no longer require the scheme to be set to `bearer`