### PR TITLE
deprecate electron.remote and use @electron/remote

### DIFF
--- a/packages/insomnia-app/app/common/analytics.ts
+++ b/packages/insomnia-app/app/common/analytics.ts
@@ -1,5 +1,4 @@
 import Analytics from 'analytics-node';
-import * as electron from 'electron';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
 import * as uuid from 'uuid';
 
@@ -18,6 +17,7 @@ import {
   getSegmentWriteKey,
   isDevelopment,
 } from './constants';
+import electron from './electron-everywhere';
 import { getScreenResolution, getUserLanguage, getViewportSize } from './electron-helpers';
 
 const DIMENSION_PLATFORM = 1;

--- a/packages/insomnia-app/app/common/electron-everywhere.ts
+++ b/packages/insomnia-app/app/common/electron-everywhere.ts
@@ -1,0 +1,7 @@
+import electron from 'electron';
+const isTest = process.env.NODE_ENV === 'test';
+// const isNodeProcess = !process.versions.electron
+const isRenderProcess = process.type === 'renderer';
+const shouldOverrideRemote = isRenderProcess && !isTest;
+
+export default shouldOverrideRemote ? { ...electron, remote: require('@electron/remote') } : electron;

--- a/packages/insomnia-app/app/common/electron-helpers.ts
+++ b/packages/insomnia-app/app/common/electron-helpers.ts
@@ -1,8 +1,8 @@
-import * as electron from 'electron';
 import mkdirp from 'mkdirp';
 import { join } from 'path';
 
 import appConfig from '../../config/config.json';
+import electron from './electron-everywhere';
 
 export function clickLink(href: string) {
   const { protocol } = new URL(href);

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+require('@electron/remote/main').initialize();
 import * as electron from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer';
 import path from 'path';

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -94,7 +94,8 @@ export function createWindow() {
       disableBlinkFeatures: 'Auxclick',
     },
   });
-
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('@electron/remote/main').enable(mainWindow.webContents);
   // BrowserWindow doesn't have an option for this, so we have to do it manually :(
   if (maximize) {
     mainWindow?.maximize();

--- a/packages/insomnia-app/app/network/multipart.ts
+++ b/packages/insomnia-app/app/network/multipart.ts
@@ -1,8 +1,8 @@
-import * as electron from 'electron';
 import fs from 'fs';
 import mimes from 'mime-types';
 import path from 'path';
 
+import electron from '../common/electron-everywhere';
 import type { RequestBodyParameter } from '../models/request';
 
 export const DEFAULT_BOUNDARY = 'X-INSOMNIA-BOUNDARY';

--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/helpers.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/helpers.ts
@@ -1,6 +1,6 @@
-import electron from 'electron';
 import EventEmitter from 'events';
 
+import electron from '../../../common/electron-everywhere';
 interface Options {
   redirectTo?: string;
   setCertificateVerifyProc?: Electron.Session['setCertificateVerifyProc'];

--- a/packages/insomnia-app/app/network/o-auth-2/misc.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/misc.ts
@@ -1,7 +1,7 @@
-import electron from 'electron';
 import querystring from 'querystring';
 import * as uuid from 'uuid';
 
+import electron from '../../common/electron-everywhere';
 import * as models from '../../models/index';
 
 export enum ChromiumVerificationResult {

--- a/packages/insomnia-app/app/plugins/context/app.tsx
+++ b/packages/insomnia-app/app/plugins/context/app.tsx
@@ -1,9 +1,9 @@
-import * as electron from 'electron';
 import React from 'react';
 
 import * as analytics from '../../../app/common/analytics';
 import { axiosRequest as axios } from '../../../app/network/axios-request';
 import { getAppPlatform, getAppVersion } from '../../common/constants';
+import electron from '../../common/electron-everywhere';
 import type { RenderPurpose } from '../../common/render';
 import {
   RENDER_PURPOSE_GENERAL,

--- a/packages/insomnia-app/app/plugins/install.ts
+++ b/packages/insomnia-app/app/plugins/install.ts
@@ -1,11 +1,11 @@
 import childProcess from 'child_process';
-import * as electron from 'electron';
 import fs from 'fs';
 import fsx from 'fs-extra';
 import mkdirp from 'mkdirp';
 import path from 'path';
 
 import { isDevelopment, isWindows, PLUGIN_PATH } from '../common/constants';
+import electron from '../common/electron-everywhere';
 import { getTempDir } from '../common/electron-helpers';
 
 const YARN_DEPRECATED_WARN = /(?<keyword>warning)(?<dependencies>[^>:].+[>:])(?<issue>.+)/;

--- a/packages/insomnia-app/app/ui/components/editors/body/file-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/file-editor.tsx
@@ -1,9 +1,9 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import electron from 'electron';
 import fs from 'fs';
 import React, { PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../../common/constants';
+import electron from '../../../../common/electron-everywhere';
 import * as misc from '../../../../common/misc';
 import { FileInputButton } from '../../base/file-input-button';
 import { PromptButton } from '../../base/prompt-button';

--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import { EditorFromTextArea, LintOptions, ShowHintOptions, TextMarker } from 'codemirror';
 import { GraphQLInfoOptions } from 'codemirror-graphql/info';
 import { ModifiedGraphQLJumpOptions } from 'codemirror-graphql/jump';
-import electron, { OpenDialogOptions } from 'electron';
+import { OpenDialogOptions } from 'electron';
 import { readFileSync } from 'fs';
 import { DefinitionNode, DocumentNode, GraphQLNonNull, GraphQLSchema, NonNullTypeNode, OperationDefinitionNode } from 'graphql';
 import { parse, typeFromAST } from 'graphql';
@@ -16,6 +16,7 @@ import ReactDOM from 'react-dom';
 
 import { AUTOBIND_CFG, CONTENT_TYPE_JSON, DEBOUNCE_MILLIS } from '../../../../common/constants';
 import { database as db } from '../../../../common/database';
+import electron from '../../../../common/electron-everywhere';
 import { markdownToHTML } from '../../../../common/markdown-to-html';
 import { isNotNullOrUndefined, jsonParseOr } from '../../../../common/misc';
 import { HandleGetRenderContext, HandleRender } from '../../../../common/render';

--- a/packages/insomnia-app/app/ui/components/settings/plugins.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.tsx
@@ -1,5 +1,4 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import * as electron from 'electron';
 import { PluginConfig } from 'insomnia-common';
 import { Button, ToggleSwitch } from 'insomnia-components';
 import * as path from 'path';
@@ -12,6 +11,7 @@ import {
   PLUGIN_PATH,
 } from '../../../common/constants';
 import { docsPlugins } from '../../../common/documentation';
+import electron from '../../../common/electron-everywhere';
 import { delay } from '../../../common/misc';
 import type { Settings } from '../../../models/settings';
 import { createPlugin } from '../../../plugins/create';

--- a/packages/insomnia-app/app/ui/components/viewers/response-multipart-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-multipart-viewer.tsx
@@ -1,5 +1,5 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import electron, { SaveDialogOptions } from 'electron';
+import { SaveDialogOptions } from 'electron';
 import fs from 'fs';
 import mimes from 'mime-types';
 import moment from 'moment';
@@ -13,6 +13,7 @@ import {
   getContentTypeFromHeaders,
   PREVIEW_MODE_FRIENDLY,
 } from '../../../common/constants';
+import electron from '../../../common/electron-everywhere';
 import type { ResponseHeader } from '../../../models/response';
 import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
@@ -160,7 +161,6 @@ export class ResponseMultipartViewer extends PureComponent<Props, State> {
 
     // Save the file
     try {
-      // @ts-expect-error -- TSCONVERSION if filePath is undefined, don't try to write anything
       await fs.promises.writeFile(filePath, part.value);
     } catch (err) {
       console.warn('Failed to save multipart to file', err);

--- a/packages/insomnia-app/app/ui/redux/modules/global.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/global.tsx
@@ -1,4 +1,3 @@
-import electron from 'electron';
 import fs, { NoParamCallback } from 'fs';
 import moment from 'moment';
 import path from 'path';
@@ -18,6 +17,7 @@ import {
   isValidActivity,
 } from '../../../common/constants';
 import { database } from '../../../common/database';
+import electron from '../../../common/electron-everywhere';
 import { getDesignerDataDir } from '../../../common/electron-helpers';
 import {
   exportRequestsData,

--- a/packages/insomnia-app/app/ui/redux/modules/import.ts
+++ b/packages/insomnia-app/app/ui/redux/modules/import.ts
@@ -1,7 +1,8 @@
-import electron, { OpenDialogOptions } from 'electron';
+import { OpenDialogOptions } from 'electron';
 import { AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 
+import electron from '../../../common/electron-everywhere';
 import {
   importRaw,
   ImportRawConfig,

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -473,6 +473,11 @@
 				}
 			}
 		},
+		"@electron/remote": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.0.1.tgz",
+			"integrity": "sha512-bGX4/yB2bPZwXm1DsxgoABgH0Cz7oFtXJgkerB8VrStYdTyvhGAULzNLRn9rVmeAuC3VUDXaXpZIlZAZHpsLIA=="
+		},
 		"@emotion/is-prop-valid": {
 			"version": "0.8.8",
 			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -75,6 +75,7 @@
     "zprint-clj"
   ],
   "dependencies": {
+    "@electron/remote": "^2.0.1",
     "@hot-loader/react-dom": "^16.8.6",
     "@stoplight/spectral": "^5.9.0",
     "analytics-node": "^4.0.1",


### PR DESCRIPTION
Working increment of electron.remote to require('@electron/remote') refactor required for electron 12.0.0 upgrade

The ideal solution would separate functions which act on the main thread from those that operate on the renderer. This just helps us get to 12 with a minimal diff.

Motivation: https://www.electronjs.org/blog/electron-12-0/#breaking-changes
![image](https://user-images.githubusercontent.com/3679927/139071476-612e48b1-7625-4d86-8075-72f4d112ac9c.png)

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

https://medium.com/@nornagon/electrons-remote-module-considered-harmful-70d69500f31

closes INS-1122