### PR TITLE
add vscode launch config for debugging inso

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,6 +46,56 @@
       },
       "webRoot": "${workspaceFolder}/packages/insomnia-app/app",
       "timeout": 60000
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "protocol": "inspector",
+      "smartStep": true,
+      "name": "Inso",
+      "cwd": "${workspaceFolder}/packages/insomnia-inso",
+      "program": "${workspaceFolder}/packages/insomnia-inso/bin/debug_inso",
+      "sourceMaps": true,
+      "autoAttachChildProcesses": true,
+      "trace": true,
+      "preLaunchTask": "Inso: Compile (Watch)",
+      "sourceMapPathOverrides": {
+        "webpack://insomniacli/./*": "${workspaceFolder}/packages/insomnia-inso/*"
+      },
+      "args": ["${input:insoCommand}", "${input:insoCommandArgs}"],
+      "console": "integratedTerminal"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "insoCommandArgs",
+      "description": "Add an additional argument to inso",
+      "type": "promptString"
+    },
+    {
+      "id": "insoCommand",
+      "description": "Pick an inso command to run",
+      "type": "pickString",
+      "options": [
+        {
+          "value": "generate config"
+        },
+        {
+          "value": "run test"
+        },
+        {
+          "value": "lint spec"
+        },
+        {
+          "value": "export spec"
+        },
+        {
+          "value": "script"
+        },
+        {
+          "value": "help"
+        },
+      ]
     }
   ],
   "compounds": [
@@ -59,8 +109,8 @@
       "preLaunchTask": "Insomnia: Compile (Watch)",
       "configurations": [
         "Electron: main",
-        "Electron: renderer",
-      ],
+        "Electron: renderer"
+      ]
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -60,8 +60,7 @@
       "detail": "Compile Renderer (Watch) | Compile Main",
       "dependsOn": [
         "Insomnia: Compile Renderer (Watch)",
-        "Insomnia: Compile Main",
-        "Components: Compile (Watch)"
+        "Insomnia: Compile Main"
       ]
     },
     {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -51,7 +51,7 @@
           "endsPattern": {
             "regexp": "Compiled"
           }
-        },
+        }
       },
       "command": "${workspaceRoot}/packages/insomnia-app/node_modules/.bin/webpack-dev-server --config webpack/webpack.config.development.ts"
     },
@@ -61,7 +61,50 @@
       "dependsOn": [
         "Insomnia: Compile Renderer (Watch)",
         "Insomnia: Compile Main",
+        "Components: Compile (Watch)"
       ]
+    },
+    {
+      "label": "Inso: Compile (Watch)",
+      "detail": "npm start",
+      "type": "shell",
+      "promptOnClose": false,
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "webpack",
+        "severity": "error",
+        "fileLocation": "absolute",
+        "pattern": [
+          {
+            "regexp": "ERROR in (.*)",
+            "file": 1
+          },
+          {
+            "regexp": "\\((\\d+),(\\d+)\\):(.*)",
+            "line": 1,
+            "column": 2,
+            "message": 3
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": {
+            "regexp": "watching"
+          },
+          "endsPattern": {
+            "regexp": "Built at\\:"
+          }
+        }
+      },
+      "command": "npm run inso-start"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "inso_args",
+      "type": "promptString",
+      "description": "Arguments to pass to inso",
+      "default": "-v"
     }
   ]
 }

--- a/packages/insomnia-inso/bin/debug_inso
+++ b/packages/insomnia-inso/bin/debug_inso
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+/**
+ * This file is only used by the vscode launch config.
+ * It allows us to provide a free text prompt to the user to pass any inso extra arguments.
+ * https://github.com/microsoft/vscode/issues/83678
+ */
+let args = process.argv;
+
+if (args.length >= 2 && require('inspector').url()) {
+  args = process.argv.reduce((allArgs, arg) => [...allArgs, ...arg.split(/\s/)], []);
+}
+
+// This should always be the same as bin/inso
+global.require = require;
+const insomniacli = require('../dist/index.js');
+insomniacli.go(args);

--- a/packages/insomnia-inso/webpack/webpack.config.development.js
+++ b/packages/insomnia-inso/webpack/webpack.config.development.js
@@ -5,6 +5,7 @@ const base = require('./webpack.config.base');
 /** @type { import('webpack').Configuration } */
 module.exports = merge(base, {
   mode: 'development',
+  devtool: 'inline-source-map',
   plugins: [
     new webpack.DefinePlugin({
       __DEV__: true,


### PR DESCRIPTION
Adds a vscode launch configuration for inso making it easy to debug from the editor.

![inso_debug](https://user-images.githubusercontent.com/12115431/139459150-3e4b7cad-a7cf-44e5-8fbd-04dd98fa1f07.gif)
