### PR TITLE
Remove unused core plugin metadata option

### DIFF
--- a/packages/insomnia-app/app/plugins/install.ts
+++ b/packages/insomnia-app/app/plugins/install.ts
@@ -24,6 +24,8 @@ interface InsomniaPlugin {
       cover?: string;
     };
 
+    unlisted?: boolean;
+
     publisher?: {
       name: string;
       // absolute URL

--- a/plugins/insomnia-plugin-base64/package.json
+++ b/plugins/insomnia-plugin-base64/package.json
@@ -14,7 +14,6 @@
   },
   "main": "index.js",
   "insomnia": {
-    "core": true,
     "unlisted": true,
     "name": "base64",
     "description": "Encode/Decode base64 strings"

--- a/plugins/insomnia-plugin-cookie-jar/package.json
+++ b/plugins/insomnia-plugin-cookie-jar/package.json
@@ -21,7 +21,6 @@
   "main": "index.js",
   "insomnia": {
     "name": "cookieJar",
-    "core": true,
     "unlisted": true
   },
   "scripts": {

--- a/plugins/insomnia-plugin-core-themes/package.json
+++ b/plugins/insomnia-plugin-core-themes/package.json
@@ -15,7 +15,6 @@
   "main": "index.js",
   "insomnia": {
     "name": "core-themes",
-    "core": true,
     "unlisted": true
   },
   "scripts": {

--- a/plugins/insomnia-plugin-file/package.json
+++ b/plugins/insomnia-plugin-file/package.json
@@ -15,7 +15,6 @@
   "main": "index.js",
   "insomnia": {
     "name": "file",
-    "core": true,
     "unlisted": true
   },
   "scripts": {

--- a/plugins/insomnia-plugin-hash/package.json
+++ b/plugins/insomnia-plugin-hash/package.json
@@ -15,7 +15,6 @@
   "main": "index.js",
   "insomnia": {
     "name": "hash",
-    "core": true,
     "unlisted": true
   },
   "scripts": {

--- a/plugins/insomnia-plugin-jsonpath/package.json
+++ b/plugins/insomnia-plugin-jsonpath/package.json
@@ -16,7 +16,6 @@
   "insomnia": {
     "name": "json-path",
     "description": "Template tag to pull data out of JSON strings",
-    "core": true,
     "unlisted": true
   },
   "dependencies": {

--- a/plugins/insomnia-plugin-now/package.json
+++ b/plugins/insomnia-plugin-now/package.json
@@ -15,7 +15,6 @@
   "main": "index.js",
   "insomnia": {
     "name": "now",
-    "core": true,
     "unlisted": true
   },
   "scripts": {

--- a/plugins/insomnia-plugin-prompt/package.json
+++ b/plugins/insomnia-plugin-prompt/package.json
@@ -15,7 +15,6 @@
   "main": "index.js",
   "insomnia": {
     "name": "prompt",
-    "core": true,
     "unlisted": true
   },
   "scripts": {

--- a/plugins/insomnia-plugin-request/package.json
+++ b/plugins/insomnia-plugin-request/package.json
@@ -15,7 +15,6 @@
   "main": "index.js",
   "insomnia": {
     "name": "request",
-    "core": true,
     "unlisted": true
   },
   "scripts": {

--- a/plugins/insomnia-plugin-response/package.json
+++ b/plugins/insomnia-plugin-response/package.json
@@ -15,7 +15,6 @@
   "main": "index.js",
   "insomnia": {
     "name": "response",
-    "core": true,
     "unlisted": true
   },
   "scripts": {

--- a/plugins/insomnia-plugin-uuid/package.json
+++ b/plugins/insomnia-plugin-uuid/package.json
@@ -15,7 +15,6 @@
   "main": "index.js",
   "insomnia": {
     "name": "uuid",
-    "core": true,
     "unlisted": true
   },
   "scripts": {


### PR DESCRIPTION
Core plugins are listed here, and according to https://github.com/Kong/insomnia-website/pull/17  the option isn't used by anything, therefore it is redundant.

https://github.com/Kong/insomnia/blob/841df1cff4221bba381c82ac3b1a3b595f4320f3/packages/insomnia-app/config/config.json#L24-L39