### PR TITLE
fix: show JSON preview if content type is text/plain but body is valid json

### DIFF
--- a/packages/insomnia-app/app/__jest__/mock-component.tsx
+++ b/packages/insomnia-app/app/__jest__/mock-component.tsx
@@ -1,0 +1,12 @@
+import React, { forwardRef, ForwardRefRenderFunction } from 'react';
+
+export const mockRenderWithProps = jest.fn();
+
+export const MockComponentTestId = 'MockComponent';
+
+const MockComponentWithRef: ForwardRefRenderFunction<any, any> = (props, ref) => {
+  mockRenderWithProps(props);
+  return <div ref={ref} data-testid={MockComponentTestId} />;
+};
+
+export const MockComponent = forwardRef(MockComponentWithRef);

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -1269,7 +1269,13 @@ export class UnconnectedCodeEditor extends Component<Props, State> {
     }
 
     return (
-      <div className={classes} style={style} data-editor-type={type}>
+      <div
+        className={classes}
+        style={style}
+        data-editor-type={type}
+        data-mode={mode}
+        data-testid="CodeEditor"
+      >
         <KeydownBinder onKeydown={this._handleKeyDown} />
         <div
           className={classnames('editor__container', 'input', className)}

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -1273,7 +1273,6 @@ export class UnconnectedCodeEditor extends Component<Props, State> {
         className={classes}
         style={style}
         data-editor-type={type}
-        data-mode={mode}
         data-testid="CodeEditor"
       >
         <KeydownBinder onKeydown={this._handleKeyDown} />

--- a/packages/insomnia-app/app/ui/components/viewers/__tests__/response-viewer.test.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/__tests__/response-viewer.test.tsx
@@ -1,0 +1,92 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import { globalBeforeEach } from '../../../../__jest__/before-each';
+import { reduxStateForTest } from '../../../../__jest__/redux-state-for-test';
+import { withReduxStore } from '../../../../__jest__/with-redux-store';
+import { RootState } from '../../../redux/modules';
+import { ResponseViewer, ResponseViewerProps } from '../response-viewer';
+
+const defaultProps: ResponseViewerProps = {
+  bytes: 2,
+  contentType: 'application/json',
+  disableHtmlPreviewJs: false,
+  disablePreviewLinks: false,
+  download: jest.fn,
+  editorFontSize: 11,
+  editorIndentSize: 2,
+  editorKeyMap: 'default',
+  editorLineWrapping: true,
+  filter: '',
+  filterHistory: [],
+  getBody: () => Buffer.from('{}'),
+  previewMode: 'friendly',
+  responseId: 'res_<UUID>',
+  url: 'http://mockbin.org/echo',
+};
+
+/**
+ * Unfortunately, without this code, many of the tests in this file will all fail due to an implementation detail of CodeMirror.
+ * see: https://github.com/jsdom/jsdom/issues/3002
+ */
+document.createRange = () => {
+  const range = new Range();
+  range.getBoundingClientRect = jest.fn();
+  range.getClientRects = jest.fn(() => ({
+    [Symbol.iterator]: jest.fn(),
+    item: () => null,
+    length: 0,
+  }));
+  return range;
+};
+
+const middlewares = [thunk];
+const mockStore = configureMockStore<RootState>(middlewares);
+const getResponseViewerChild = async (overrideProps:  Partial<ResponseViewerProps>, selector: string) => {
+  const store = mockStore(await reduxStateForTest());
+  const responseViewer = <ResponseViewer {...defaultProps} {...overrideProps} />;
+  const { getByTestId } = render(responseViewer, { wrapper: withReduxStore(store) });
+  return getByTestId(selector);
+};
+
+describe('<ResponseViewer />', () => {
+  beforeEach(globalBeforeEach);
+  it('should use plain text mode for a text/plain Content-Type with plain text body', async () => {
+    const codeEditor = await getResponseViewerChild({
+      contentType: 'text/plain',
+      getBody: () => Buffer.from('plain text'),
+    }, 'CodeEditor');
+
+    expect(codeEditor).toBeInTheDocument();
+    expect(codeEditor).toHaveAttribute('data-mode', 'text/plain');
+  });
+
+  it('should use JSON mode for a JSON Content-Type with valid JSON body', async () => {
+    const codeEditor = await getResponseViewerChild({
+      contentType: 'application/json',
+      getBody: () => Buffer.from('{"validJSON":true}'),
+    }, 'CodeEditor');
+
+    expect(codeEditor).toBeInTheDocument();
+    expect(codeEditor).toHaveAttribute('data-mode', 'application/json');
+  });
+
+  it('should use JSON mode for text/plain Content-Type when the body is valid JSON', async () => {
+    const codeEditor = await getResponseViewerChild({
+      contentType: 'text/plain',
+      getBody: () => Buffer.from('{"validJSON":true}'),
+    }, 'CodeEditor');
+    expect(codeEditor).toBeInTheDocument();
+    expect(codeEditor).toHaveAttribute('data-mode', 'application/json');
+  });
+
+  it('should use HTML mode for text/plain Content-Type that contains a doctype declaration', async () => {
+    const responseWebView = await getResponseViewerChild({
+      contentType: 'text/plain',
+      getBody: () => Buffer.from('<!DOCTYPE html><html></html>'),
+    }, 'ResponseWebView');
+    expect(responseWebView).toBeInTheDocument();
+  });
+});

--- a/packages/insomnia-app/app/ui/components/viewers/__tests__/response-viewer.test.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/__tests__/response-viewer.test.tsx
@@ -4,10 +4,15 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { globalBeforeEach } from '../../../../__jest__/before-each';
+import { MockComponent, MockComponentTestId, mockRenderWithProps } from '../../../../__jest__/mock-component';
 import { reduxStateForTest } from '../../../../__jest__/redux-state-for-test';
 import { withReduxStore } from '../../../../__jest__/with-redux-store';
 import { RootState } from '../../../redux/modules';
 import { ResponseViewer, ResponseViewerProps } from '../response-viewer';
+
+jest.mock('../../codemirror/code-editor', () => ({
+  CodeEditor: MockComponent,
+}));
 
 const defaultProps: ResponseViewerProps = {
   bytes: 2,
@@ -27,23 +32,9 @@ const defaultProps: ResponseViewerProps = {
   url: 'http://mockbin.org/echo',
 };
 
-/**
- * Unfortunately, without this code, many of the tests in this file will all fail due to an implementation detail of CodeMirror.
- * see: https://github.com/jsdom/jsdom/issues/3002
- */
-document.createRange = () => {
-  const range = new Range();
-  range.getBoundingClientRect = jest.fn();
-  range.getClientRects = jest.fn(() => ({
-    [Symbol.iterator]: jest.fn(),
-    item: () => null,
-    length: 0,
-  }));
-  return range;
-};
-
 const middlewares = [thunk];
 const mockStore = configureMockStore<RootState>(middlewares);
+
 const getResponseViewerChild = async (overrideProps:  Partial<ResponseViewerProps>, selector: string) => {
   const store = mockStore(await reduxStateForTest());
   const responseViewer = <ResponseViewer {...defaultProps} {...overrideProps} />;
@@ -53,33 +44,35 @@ const getResponseViewerChild = async (overrideProps:  Partial<ResponseViewerProp
 
 describe('<ResponseViewer />', () => {
   beforeEach(globalBeforeEach);
+
   it('should use plain text mode for a text/plain Content-Type with plain text body', async () => {
     const codeEditor = await getResponseViewerChild({
       contentType: 'text/plain',
       getBody: () => Buffer.from('plain text'),
-    }, 'CodeEditor');
+    }, MockComponentTestId);
 
     expect(codeEditor).toBeInTheDocument();
-    expect(codeEditor).toHaveAttribute('data-mode', 'text/plain');
+    expect(mockRenderWithProps).toHaveBeenCalledWith(expect.objectContaining({ mode: 'text/plain' }));
   });
 
   it('should use JSON mode for a JSON Content-Type with valid JSON body', async () => {
     const codeEditor = await getResponseViewerChild({
       contentType: 'application/json',
       getBody: () => Buffer.from('{"validJSON":true}'),
-    }, 'CodeEditor');
+    }, MockComponentTestId);
 
     expect(codeEditor).toBeInTheDocument();
-    expect(codeEditor).toHaveAttribute('data-mode', 'application/json');
+    expect(mockRenderWithProps).toHaveBeenCalledWith(expect.objectContaining({ mode: 'application/json' }));
   });
 
   it('should use JSON mode for text/plain Content-Type when the body is valid JSON', async () => {
     const codeEditor = await getResponseViewerChild({
       contentType: 'text/plain',
       getBody: () => Buffer.from('{"validJSON":true}'),
-    }, 'CodeEditor');
+    }, MockComponentTestId);
+
     expect(codeEditor).toBeInTheDocument();
-    expect(codeEditor).toHaveAttribute('data-mode', 'application/json');
+    expect(mockRenderWithProps).toHaveBeenCalledWith(expect.objectContaining({ mode: 'application/json' }));
   });
 
   it('should use HTML mode for text/plain Content-Type that contains a doctype declaration', async () => {
@@ -87,6 +80,8 @@ describe('<ResponseViewer />', () => {
       contentType: 'text/plain',
       getBody: () => Buffer.from('<!DOCTYPE html><html></html>'),
     }, 'ResponseWebView');
+
     expect(responseWebView).toBeInTheDocument();
+    expect(mockRenderWithProps).not.toHaveBeenCalledWith();
   });
 });

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
@@ -197,9 +197,50 @@ export class ResponseViewer extends Component<Props, State> {
     });
   }
 
+  _getContentType() {
+    const { contentType: originalContentType } = this.props;
+    const { bodyBuffer } = this.state;
+
+    const lowercasedOriginalContentType = originalContentType.toLowerCase();
+
+    if (!bodyBuffer || bodyBuffer.length === 0) {
+      return lowercasedOriginalContentType;
+    }
+
+    // Try to detect JSON in all cases (even if a different header is set).
+    // Apparently users often send JSON with weird content-types like text/plain.
+    try {
+      if (bodyBuffer && bodyBuffer.length > 0) {
+        JSON.parse(bodyBuffer.toString('utf8'));
+        return 'application/json';
+      }
+    } catch (e) {
+      // Nothing
+    }
+
+    // Try to detect HTML in all cases (even if header is set).
+    // It is fairly common for webservers to send errors in HTML by default.
+    // NOTE: This will probably never throw but I'm not 100% so wrap anyway
+    try {
+      const isProbablyHTML = bodyBuffer
+        .slice(0, 100)
+        .toString()
+        .trim()
+        .match(/^<!doctype html.*>/i);
+
+      if (lowercasedOriginalContentType.indexOf('text/html') !== 0 && isProbablyHTML) {
+        return 'text/html';
+      }
+    } catch (e) {
+      // Nothing
+    }
+
+    return lowercasedOriginalContentType;
+  }
+
   _getBody() {
     const { bodyBuffer } = this.state;
-    const { contentType } = this.props;
+    const contentType = this._getContentType();
 
     if (!bodyBuffer) {
       return '';
@@ -220,7 +261,7 @@ export class ResponseViewer extends Component<Props, State> {
 
   /** Try to detect content-types if there isn't one */
   _getMode() {
-    const { contentType } = this.props;
+    const contentType = this._getContentType();
     const body = this._getBody();
     if (body?.match(/^\s*<\?xml [^?]*\?>/)) {
       return 'application/xml';
@@ -257,8 +298,7 @@ export class ResponseViewer extends Component<Props, State> {
       updateFilter,
       url,
     } = this.props;
-    // WARNING: props should never be overwritten!
-    let { contentType } = this.props;
+    const contentType = this._getContentType();
     const { bodyBuffer, error: parseError } = this.state;
     const error = responseError || parseError;
 
@@ -321,35 +361,7 @@ export class ResponseViewer extends Component<Props, State> {
       return <div className="pad faint">No body returned for response</div>;
     }
 
-    // Try to detect JSON in all cases (even if header is set). Apparently users
-    // often send JSON with weird content-types like text/plain
-    try {
-      JSON.parse(bodyBuffer.toString('utf8'));
-      contentType = 'application/json';
-    } catch (e) {
-      // Nothing
-    }
-
-    // Try to detect HTML in all cases (even if header is set). It is fairly
-    // common for webservers to send errors in HTML by default.
-    // NOTE: This will probably never throw but I'm not 100% so wrap anyway
-    try {
-      const isProbablyHTML = bodyBuffer
-        .slice(0, 100)
-        .toString()
-        .trim()
-        .match(/^<!doctype html.*>/i);
-
-      if (contentType.indexOf('text/html') !== 0 && isProbablyHTML) {
-        contentType = 'text/html';
-      }
-    } catch (e) {
-      // Nothing
-    }
-
-    const ct = contentType.toLowerCase();
-
-    if (previewMode === PREVIEW_MODE_FRIENDLY && ct.indexOf('image/') === 0) {
+    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('image/') === 0) {
       const justContentType = contentType.split(';')[0];
       const base64Body = bodyBuffer.toString('base64');
       return (
@@ -369,7 +381,7 @@ export class ResponseViewer extends Component<Props, State> {
       );
     }
 
-    if (previewMode === PREVIEW_MODE_FRIENDLY && ct.includes('html')) {
+    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.includes('html')) {
       return (
         <ResponseWebView
           body={this._getBody()}
@@ -381,7 +393,7 @@ export class ResponseViewer extends Component<Props, State> {
       );
     }
 
-    if (previewMode === PREVIEW_MODE_FRIENDLY && ct.indexOf('application/pdf') === 0) {
+    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('application/pdf') === 0) {
       return (
         <div className="tall wide scrollable">
           <ResponsePDFViewer body={bodyBuffer} uniqueKey={responseId} />
@@ -389,7 +401,7 @@ export class ResponseViewer extends Component<Props, State> {
       );
     }
 
-    if (previewMode === PREVIEW_MODE_FRIENDLY && ct.indexOf('text/csv') === 0) {
+    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('text/csv') === 0) {
       return (
         <div className="tall wide scrollable">
           <ResponseCSVViewer body={bodyBuffer} key={responseId} />
@@ -397,7 +409,7 @@ export class ResponseViewer extends Component<Props, State> {
       );
     }
 
-    if (previewMode === PREVIEW_MODE_FRIENDLY && ct.indexOf('multipart/') === 0) {
+    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('multipart/') === 0) {
       return (
         <ResponseMultipartViewer
           bodyBuffer={bodyBuffer}
@@ -418,7 +430,7 @@ export class ResponseViewer extends Component<Props, State> {
       );
     }
 
-    if (previewMode === PREVIEW_MODE_FRIENDLY && ct.indexOf('audio/') === 0) {
+    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('audio/') === 0) {
       const justContentType = contentType.split(';')[0];
       const base64Body = bodyBuffer.toString('base64');
       return (

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
@@ -240,13 +240,12 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
 
   _getBody() {
     const { bodyBuffer } = this.state;
-    const contentType = this._getContentType();
-
     if (!bodyBuffer) {
       return '';
     }
 
     // Show everything else as "source"
+    const contentType = this._getContentType();
     const match = contentType.match(/charset=([\w-]+)/);
     const charset = match && match.length >= 2 ? match[1] : 'utf-8';
 

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
@@ -261,13 +261,11 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
 
   /** Try to detect content-types if there isn't one */
   _getMode() {
-    const contentType = this._getContentType();
-    const body = this._getBody();
-    if (body?.match(/^\s*<\?xml [^?]*\?>/)) {
+    if (this._getBody()?.match(/^\s*<\?xml [^?]*\?>/)) {
       return 'application/xml';
-    } else {
-      return contentType;
     }
+
+    return this._getContentType();
   }
 
   _handleClickLink(url: string) {

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
@@ -24,7 +24,7 @@ import { ResponseWebView } from './response-web-view';
 
 let alwaysShowLargeResponses = false;
 
-interface Props {
+export interface ResponseViewerProps {
   bytes: number;
   contentType: string;
   disableHtmlPreviewJs: boolean;
@@ -53,7 +53,7 @@ interface State {
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-export class ResponseViewer extends Component<Props, State> {
+export class ResponseViewer extends Component<ResponseViewerProps, State> {
   _selectableView: ResponseRawViewer | UnconnectedCodeEditor | null;
 
   state: State = {
@@ -86,7 +86,7 @@ export class ResponseViewer extends Component<Props, State> {
     this._handleDismissBlocker();
   }
 
-  _maybeLoadResponseBody(props: Props, forceShow?: boolean) {
+  _maybeLoadResponseBody(props: ResponseViewerProps, forceShow?: boolean) {
     const { bytes } = props;
     const largeResponse = bytes > LARGE_RESPONSE_MB * 1024 * 1024;
     const hugeResponse = bytes > HUGE_RESPONSE_MB * 1024 * 1024;
@@ -117,11 +117,11 @@ export class ResponseViewer extends Component<Props, State> {
   }
 
   // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: ResponseViewerProps) {
     this._maybeLoadResponseBody(nextProps);
   }
 
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
+  shouldComponentUpdate(nextProps: ResponseViewerProps, nextState: State) {
     for (const k of Object.keys(nextProps)) {
       const next = nextProps[k];
       const current = this.props[k];

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
@@ -296,7 +296,6 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
       updateFilter,
       url,
     } = this.props;
-    const contentType = this._getContentType();
     const { bodyBuffer, error: parseError } = this.state;
     const error = responseError || parseError;
 
@@ -359,6 +358,7 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
       return <div className="pad faint">No body returned for response</div>;
     }
 
+    const contentType = this._getContentType();
     if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('image/') === 0) {
       const justContentType = contentType.split(';')[0];
       const base64Body = bodyBuffer.toString('base64');

--- a/packages/insomnia-app/app/ui/components/viewers/response-web-view.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-web-view.tsx
@@ -76,6 +76,7 @@ export class ResponseWebView extends PureComponent<Props> {
     const { webpreferences } = this.props;
     return (
       <webview
+        data-testid="ResponseWebView"
         ref={this.webview}
         src="about:blank"
         webpreferences={webpreferences}


### PR DESCRIPTION
closes: https://github.com/Kong/insomnia/issues/4163
closes: https://github.com/Kong/insomnia/issues/4168
closes: INS-1133

| BEFORE | AFTER |
| - | - |
| ![Screenshot_20211101_161431](https://user-images.githubusercontent.com/15232461/139735642-84b83b36-32ac-478e-a3d2-fada638f8534.png)  | ![Screenshot_20211101_161349](https://user-images.githubusercontent.com/15232461/139735536-af88084b-a1d3-4cd1-9efe-ace497bcab54.png) |
| ![Screenshot_20211101_161502](https://user-images.githubusercontent.com/15232461/139735701-0b38a9a9-35bc-4337-8fc4-2eea10acd662.png) | ![Screenshot_20211101_161516](https://user-images.githubusercontent.com/15232461/139735736-5afc7c89-99bd-45c7-a03f-bdf705799e42.png) |

This was introduced in [`ac9303b` (#2725)](https://github.com/Kong/insomnia/pull/2725/commits/ac9303bf44756e38bc1bb87517a5d9ff57e22520).  I noticed that there was high potential for a bug in this area from the moment I looked at it, but I didn't want to scope creep so I just left a comment [`c3bfad5` (#2725)](https://github.com/Kong/insomnia/pull/2725/commits/c3bfad5a6a9d55ad95d68186a9cb6eef4d05f307#diff-528e429aed8939bdb16dc6931cf82fca3b07559c278ada0be2759eefacfd4ecaR260) with a warning that I noticed that we were playing with fire.  I gotta take responsibility for this one.  In retrospect I probably should have just fixed it once I saw it had broken behavior, perhaps just in a new PR.

Ultimately, what's going on is that there was overwriting of the prop happening [in one place](https://github.com/Kong/insomnia/pull/2725/commits/ac9303bf44756e38bc1bb87517a5d9ff57e22520#diff-528e429aed8939bdb16dc6931cf82fca3b07559c278ada0be2759eefacfd4ecaR325-R330) that wasn't happening elsewhere, and and extraction, while done correctly (the code that was extracted was character-for-character copied around the file) the mutation of `contentType` _one hundred lines (and 7 return statements!) above_ created a different behavior than what was extracted since the extraction didn't have this same fix.

You may be thinking, well, were there other places that used contentType that should have, then, had this change but didn't?  The answer is yes, there were two other places where it was out of sync, and those are fixed now as well (since, it's the same bug in play).

## Testing

As for the tests, it was quite tricky to find something that works since we don't want to assert on low-level implementation details of CodeMirror.  I'm satisfied with what we (thanks @gatzjames for the help!) came up with, but would love to improve it further if there's a way to do so!

And, in case you're wondering "why not make a function that calculates the CodeMirror mode given the original content type and the body?", the answer is, simply, because those unit tests would still pass if, in the future, we mistakenly forget to calculate the content type within the code of `ResponseViewer`.  We know this is a high danger, because it already happened in the very bug that this PR fixes.  We want to test that CodeMirror is sent the right prop.  How CodeMirror represents that mode is completely outside of the concern of `ResponseViewer`.  We just want to test that it makes the right outputs for it's own inputs.

## What this PR does not do

There's quite a lot that this area of the codebase could use in the way of refactoring.  This PR tries to avoid doing so.  This is a bug fix for a regression, and hopefully not much else.

The prior behavior was to always parse the entire body as JSON on every render unconditionally (!!!) for all responses.  That ain't good.  I know.  Although that behavior is closely tied to the kind of preview that CodeMirror shows (since, a successful parse will override the Content-Type header for the purposes of what get's sent to CodeMirror), it's not in scope to change this behavior which has existed for years (see above).