### PR TITLE
preload remote modules

### DIFF
--- a/packages/insomnia-app/app/__jest__/before-each.ts
+++ b/packages/insomnia-app/app/__jest__/before-each.ts
@@ -1,5 +1,3 @@
-import electron from 'electron';
-
 import * as fetch from '../account/fetch';
 import { database as db } from '../common/database';
 import * as models from '../models';
@@ -7,7 +5,6 @@ import * as models from '../models';
 export async function globalBeforeEach() {
   // Setup the local database in case it's used
   fetch.setup('insomnia-tests', 'http://localhost:8000');
-  window.app = electron.app;
   await db.init(
     models.types(),
     {

--- a/packages/insomnia-app/app/__jest__/before-each.ts
+++ b/packages/insomnia-app/app/__jest__/before-each.ts
@@ -1,3 +1,5 @@
+import electron from 'electron';
+
 import * as fetch from '../account/fetch';
 import { database as db } from '../common/database';
 import * as models from '../models';
@@ -5,6 +7,7 @@ import * as models from '../models';
 export async function globalBeforeEach() {
   // Setup the local database in case it's used
   fetch.setup('insomnia-tests', 'http://localhost:8000');
+  window.app = electron.app;
   await db.init(
     models.types(),
     {

--- a/packages/insomnia-app/app/common/__tests__/analytics.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/analytics.test.ts
@@ -14,6 +14,10 @@ import {
   getGoogleAnalyticsLocation,
 } from '../constants';
 
+window.main = {
+  analytics: { viewportSize: '1900x1060', screenResolution: '1920x1080', locale: 'en-US' },
+};
+
 describe('init()', () => {
   beforeEach(async () => {
     await globalBeforeEach();

--- a/packages/insomnia-app/app/common/analytics.ts
+++ b/packages/insomnia-app/app/common/analytics.ts
@@ -279,11 +279,11 @@ async function _getDefaultParams(): Promise<RequestParameter[]> {
     },
     {
       name: KEY_SCREEN_RESOLUTION,
-      value: window.main.getAnalytics().screenResolution,
+      value: window.main.analytics.screenResolution,
     },
     {
       name: KEY_USER_LANGUAGE,
-      value: window.main.getAnalytics().locale,
+      value: window.main.analytics.locale,
     },
     {
       name: KEY_TITLE,
@@ -314,7 +314,7 @@ async function _getDefaultParams(): Promise<RequestParameter[]> {
       value: getAppVersion(),
     },
   ];
-  const viewport = window.main.getAnalytics().viewportSize;
+  const viewport = window.main.analytics.viewportSize;
   viewport &&
     params.push({
       name: KEY_VIEWPORT_SIZE,

--- a/packages/insomnia-app/app/common/analytics.ts
+++ b/packages/insomnia-app/app/common/analytics.ts
@@ -18,7 +18,6 @@ import {
   getSegmentWriteKey,
   isDevelopment,
 } from './constants';
-import { getScreenResolution, getUserLanguage, getViewportSize } from './electron-helpers';
 
 const DIMENSION_PLATFORM = 1;
 const DIMENSION_VERSION = 2;
@@ -280,11 +279,11 @@ async function _getDefaultParams(): Promise<RequestParameter[]> {
     },
     {
       name: KEY_SCREEN_RESOLUTION,
-      value: getScreenResolution(),
+      value: window.main.getAnalytics().screenResolution,
     },
     {
       name: KEY_USER_LANGUAGE,
-      value: getUserLanguage(),
+      value: window.main.getAnalytics().locale,
     },
     {
       name: KEY_TITLE,
@@ -315,7 +314,7 @@ async function _getDefaultParams(): Promise<RequestParameter[]> {
       value: getAppVersion(),
     },
   ];
-  const viewport = getViewportSize();
+  const viewport = window.main.getAnalytics().viewportSize;
   viewport &&
     params.push({
       name: KEY_VIEWPORT_SIZE,

--- a/packages/insomnia-app/app/common/analytics.ts
+++ b/packages/insomnia-app/app/common/analytics.ts
@@ -1,5 +1,4 @@
 import Analytics from 'analytics-node';
-import * as electron from 'electron';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
 import * as uuid from 'uuid';
 
@@ -363,8 +362,7 @@ async function _sendToGoogle(params: RequestParameter, queueable: boolean) {
     ? 'https://www.google-analytics.com/debug/collect'
     : 'https://www.google-analytics.com/collect';
   const url = joinUrlAndQueryString(baseUrl, qs);
-  const net = (process.type === 'renderer' ? window : electron).net;
-  const res = net.request(url);
+  const res = window.net.request(url);
   if (res.error)
     console.warn('[ga] Network error', res.error);
 

--- a/packages/insomnia-app/app/common/electron-helpers.ts
+++ b/packages/insomnia-app/app/common/electron-helpers.ts
@@ -42,11 +42,6 @@ export function restartApp() {
   app.exit();
 }
 
-export const exitAppFailure = () => {
-  const { app } = electron.remote || electron;
-  app.exit(1);
-};
-
 /**
  * There's no option that prevents Electron from fetching spellcheck dictionaries from Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from fetching.
  * see: https://github.com/electron/electron/issues/22995

--- a/packages/insomnia-app/app/common/electron-helpers.ts
+++ b/packages/insomnia-app/app/common/electron-helpers.ts
@@ -13,7 +13,7 @@ export function clickLink(href: string) {
 }
 
 export function getDesignerDataDir() {
-  const { app } = electron.remote || electron;
+  const { app } = process.type === 'renderer' ? window : electron;
   return process.env.DESIGNER_DATA_PATH || join(app.getPath('appData'), 'Insomnia Designer');
 }
 
@@ -24,7 +24,7 @@ export function getDesignerDataDir() {
 export const getPortableExecutableDir = () => process.env.PORTABLE_EXECUTABLE_DIR;
 
 export function getDataDirectory() {
-  const { app } = electron.remote || electron;
+  const { app } = process.type === 'renderer' ? window : electron;
   return process.env.INSOMNIA_DATA_PATH || app.getPath('userData');
 }
 
@@ -54,7 +54,7 @@ export function getUserLanguage() {
 
 export function getTempDir() {
   // NOTE: Using a fairly unique name here because "insomnia" is a common word
-  const { app } = electron.remote || electron;
+  const { app } = process.type === 'renderer' ? window : electron;
   const dir = join(app.getPath('temp'), `insomnia_${appConfig.version}`);
   mkdirp.sync(dir);
   return dir;

--- a/packages/insomnia-app/app/common/electron-helpers.ts
+++ b/packages/insomnia-app/app/common/electron-helpers.ts
@@ -36,12 +36,6 @@ export function getTempDir() {
   return dir;
 }
 
-export function restartApp() {
-  const { app } = electron.remote || electron;
-  app.relaunch();
-  app.exit();
-}
-
 /**
  * There's no option that prevents Electron from fetching spellcheck dictionaries from Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from fetching.
  * see: https://github.com/electron/electron/issues/22995

--- a/packages/insomnia-app/app/common/electron-helpers.ts
+++ b/packages/insomnia-app/app/common/electron-helpers.ts
@@ -28,30 +28,6 @@ export function getDataDirectory() {
   return process.env.INSOMNIA_DATA_PATH || app.getPath('userData');
 }
 
-export function getViewportSize(): string | null {
-  const { BrowserWindow } = electron.remote || electron;
-  const browserWindow = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
-
-  if (browserWindow) {
-    const { width, height } = browserWindow.getContentBounds();
-    return `${width}x${height}`;
-  } else {
-    // No windows open
-    return null;
-  }
-}
-
-export function getScreenResolution() {
-  const { screen } = electron.remote || electron;
-  const { width, height } = screen.getPrimaryDisplay().workAreaSize;
-  return `${width}x${height}`;
-}
-
-export function getUserLanguage() {
-  const { app } = electron.remote || electron;
-  return app.getLocale();
-}
-
 export function getTempDir() {
   // NOTE: Using a fairly unique name here because "insomnia" is a common word
   const { app } = process.type === 'renderer' ? window : electron;
@@ -69,19 +45,6 @@ export function restartApp() {
 export const exitAppFailure = () => {
   const { app } = electron.remote || electron;
   app.exit(1);
-};
-
-export const setMenuBarVisibility = (visible: boolean) => {
-  const { BrowserWindow } = electron.remote || electron;
-  BrowserWindow.getAllWindows()
-    .forEach(window => {
-      // the `setMenuBarVisibility` signature uses `visible` semantics
-      window.setMenuBarVisibility(visible);
-
-      // the `setAutoHideMenu` signature uses `hide` semantics
-      const hide = !visible;
-      window.setAutoHideMenuBar(hide);
-    });
 };
 
 /**

--- a/packages/insomnia-app/app/common/select-file-or-folder.ts
+++ b/packages/insomnia-app/app/common/select-file-or-folder.ts
@@ -1,4 +1,4 @@
-import { OpenDialogOptions, remote } from 'electron';
+import { OpenDialogOptions } from 'electron';
 import { unreachableCase } from 'ts-assert-unreachable';
 
 interface Options {
@@ -48,8 +48,11 @@ export const selectFileOrFolder = async ({ itemTypes, extensions }: Options) => 
       extensions: (extensions?.length ? extensions : ['*']),
     }],
   };
+  console.log('test');
 
-  const { canceled, filePaths } = await remote.dialog.showOpenDialog(options);
+  const { canceled, filePaths } = await window.dialog.showOpenDialog(options);
+  console.log('test2', filePaths);
+
   const fileSelection: FileSelection = {
     filePath: filePaths[0],
     canceled,

--- a/packages/insomnia-app/app/common/select-file-or-folder.ts
+++ b/packages/insomnia-app/app/common/select-file-or-folder.ts
@@ -48,10 +48,8 @@ export const selectFileOrFolder = async ({ itemTypes, extensions }: Options) => 
       extensions: (extensions?.length ? extensions : ['*']),
     }],
   };
-  console.log('test');
 
   const { canceled, filePaths } = await window.dialog.showOpenDialog(options);
-  console.log('test2', filePaths);
 
   const fileSelection: FileSelection = {
     filePath: filePaths[0],

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -38,9 +38,13 @@ interface Window {
   };
   app: {
     getPath: (name: string) => string;
+    getAppPath: () => string;
   };
   shell: {
     showItemInFolder: (fullPath: string) => void;
+  };
+  net: {
+    request: (options: AxiosRequestConfig) => AxiosResponse;
   };
 }
 

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -35,6 +35,9 @@ interface Window {
   app: {
     getPath: (name: string) => string;
   };
+  shell: {
+    showItemInFolder: (fullPath: string) => void;
+  };
 }
 
 // needed for @hot-loader/react-dom in order for TypeScript to build

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -28,6 +28,7 @@ interface Font {
 interface Window {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
   main: { getAvailableFonts: () => Promise<Font[]> };
+  dialog: { showOpenDialog: (options: Electron.OpenDialogOptions) => Promise<Electron.OpenDialogReturnValue> };
 }
 
 // needed for @hot-loader/react-dom in order for TypeScript to build

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -32,6 +32,9 @@ interface Window {
     showOpenDialog: (options: Electron.OpenDialogOptions) => Promise<Electron.OpenDialogReturnValue>;
     showSaveDialog: (options: Electron.SaveDialogOptions) => Promise<Electron.SaveDialogReturnValue>;
   };
+  app: {
+    getPath: (name: string) => string;
+  };
 }
 
 // needed for @hot-loader/react-dom in order for TypeScript to build

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -30,7 +30,7 @@ interface Window {
   main: {
     getAvailableFonts: () => Promise<Font[]>;
     setMenuBarVisibility: (visible: boolean) => void;
-    getAnalytics: () => {viewportSize: string; screenResolution: string; locale: string};
+    analytics: {viewportSize: string; screenResolution: string; locale: string};
   };
   dialog: {
     showOpenDialog: (options: Electron.OpenDialogOptions) => Promise<Electron.OpenDialogReturnValue>;

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -15,9 +15,19 @@ declare namespace NodeJS {
     __DEV__: boolean;
   }
 }
-
+interface Font {
+  family: string;
+  italic: boolean;
+  monospace: boolean;
+  path: string;
+  postscriptName: string;
+  style: string;
+  weight: number;
+  width: numbe;
+}
 interface Window {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
+  main: { getAvailableFonts: () => Promise<Font[]> };
 }
 
 // needed for @hot-loader/react-dom in order for TypeScript to build

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -28,7 +28,10 @@ interface Font {
 interface Window {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
   main: { getAvailableFonts: () => Promise<Font[]> };
-  dialog: { showOpenDialog: (options: Electron.OpenDialogOptions) => Promise<Electron.OpenDialogReturnValue> };
+  dialog: {
+    showOpenDialog: (options: Electron.OpenDialogOptions) => Promise<Electron.OpenDialogReturnValue>;
+    showSaveDialog: (options: Electron.SaveDialogOptions) => Promise<Electron.SaveDialogReturnValue>;
+  };
 }
 
 // needed for @hot-loader/react-dom in order for TypeScript to build

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -29,7 +29,7 @@ interface Window {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
   main: {
     restart: () => void;
-    authorizeUserInWindow: (options: { url: string; urlSuccessRegex: RegExp; urlFailureRegex: RegExp; sessionId: string }) => Promise<string>;
+    authorizeUserInWindow: (options: { url: string; urlSuccessRegex?: RegExp; urlFailureRegex?: RegExp; sessionId?: string }) => Promise<string>;
     getAvailableFonts: () => Promise<Font[]>;
     setMenuBarVisibility: (visible: boolean) => void;
     analytics: {viewportSize: string; screenResolution: string; locale: string};

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -27,7 +27,11 @@ interface Font {
 }
 interface Window {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
-  main: { getAvailableFonts: () => Promise<Font[]> };
+  main: {
+    getAvailableFonts: () => Promise<Font[]>;
+    setMenuBarVisibility: (visible: boolean) => void;
+    getAnalytics: () => {viewportSize: string; screenResolution: string; locale: string};
+  };
   dialog: {
     showOpenDialog: (options: Electron.OpenDialogOptions) => Promise<Electron.OpenDialogReturnValue>;
     showSaveDialog: (options: Electron.SaveDialogOptions) => Promise<Electron.SaveDialogReturnValue>;

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -28,6 +28,7 @@ interface Font {
 interface Window {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
   main: {
+    restart: () => void;
     getAvailableFonts: () => Promise<Font[]>;
     setMenuBarVisibility: (visible: boolean) => void;
     analytics: {viewportSize: string; screenResolution: string; locale: string};

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -29,7 +29,7 @@ interface Window {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
   main: {
     restart: () => void;
-    authorizeUserInWindow: (options: { url: string; urlSuccessRegex: RegExp; urlFailureRegex: RegExp }) => Promise<string>;
+    authorizeUserInWindow: (options: { url: string; urlSuccessRegex: RegExp; urlFailureRegex: RegExp; sessionId: string }) => Promise<string>;
     getAvailableFonts: () => Promise<Font[]>;
     setMenuBarVisibility: (visible: boolean) => void;
     analytics: {viewportSize: string; screenResolution: string; locale: string};

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -29,6 +29,7 @@ interface Window {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
   main: {
     restart: () => void;
+    authorizeUserInWindow: (options: { url: string; urlSuccessRegex: RegExp; urlFailureRegex: RegExp }) => Promise<string>;
     getAvailableFonts: () => Promise<Font[]>;
     setMenuBarVisibility: (visible: boolean) => void;
     analytics: {viewportSize: string; screenResolution: string; locale: string};

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -249,6 +249,11 @@ async function _trackStats() {
     electron.shell.showItemInFolder(name);
   });
 
+  ipcMain.on('restart', () => {
+    app.relaunch();
+    app.exit();
+  });
+
   ipcMain.handle('setMenuBarVisibility', (_, visible) => {
     electron.BrowserWindow.getAllWindows()
       .forEach(window => {

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -11,7 +11,7 @@ import appConfig from '../config/config.json';
 import { trackNonInteractiveEventQueueable } from './common/analytics';
 import { changelogUrl, getAppVersion, isDevelopment, isMac } from './common/constants';
 import { database } from './common/database';
-import { disableSpellcheckerDownload, exitAppFailure } from './common/electron-helpers';
+import { disableSpellcheckerDownload } from './common/electron-helpers';
 import log, { initializeLogging } from './common/log';
 import { validateInsomniaConfig } from './common/validate-insomnia-config';
 import * as errorHandling from './main/error-handling';

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -224,6 +224,11 @@ async function _trackStats() {
 
   ipcMain.handle('getAvailableFonts', () => fontScanner.getAvailableFonts());
 
+  ipcMain.handle('showOpenDialog', async (_, options) => {
+    const { filePaths, canceled } = await electron.dialog.showOpenDialog(options);
+    return { filePaths, canceled };
+  });
+
   ipcMain.once('window-ready', () => {
     const { currentVersion } = stats;
 

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -224,9 +224,14 @@ async function _trackStats() {
 
   ipcMain.handle('getAvailableFonts', () => fontScanner.getAvailableFonts());
 
-  ipcMain.handle('showOpenDialog', async (_, options) => {
+  ipcMain.handle('showOpenDialog', async (_, options: Electron.OpenDialogOptions) => {
     const { filePaths, canceled } = await electron.dialog.showOpenDialog(options);
     return { filePaths, canceled };
+  });
+
+  ipcMain.handle('showSaveDialog', async (_, options: Electron.SaveDialogOptions) => {
+    const { filePath, canceled } = await electron.dialog.showSaveDialog(options);
+    return { filePath, canceled };
   });
 
   ipcMain.once('window-ready', () => {

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -22,6 +22,7 @@ import * as windowUtils from './main/window-utils';
 import * as models from './models/index';
 import type { Stats } from './models/stats';
 import { axiosRequest } from './network/axios-request';
+import { authorizeUserInWindow } from './network/o-auth-2/misc';
 import type { ToastNotification } from './ui/components/toast';
 
 // Handle potential auto-update
@@ -282,6 +283,11 @@ async function _trackStats() {
 
   ipcMain.on('getAppPath', event => {
     event.returnValue = electron.app.getAppPath();
+  });
+
+  ipcMain.handle('authorizeUserInWindow', (_, options) => {
+    const { url, urlSuccessRegex, urlFailureRegex } = options;
+    return authorizeUserInWindow({ url, urlSuccessRegex, urlFailureRegex });
   });
 
   ipcMain.once('window-ready', () => {

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -286,8 +286,8 @@ async function _trackStats() {
   });
 
   ipcMain.handle('authorizeUserInWindow', (_, options) => {
-    const { url, urlSuccessRegex, urlFailureRegex } = options;
-    return authorizeUserInWindow({ url, urlSuccessRegex, urlFailureRegex });
+    const { url, urlSuccessRegex, urlFailureRegex, sessionId } = options;
+    return authorizeUserInWindow({ url, urlSuccessRegex, urlFailureRegex, sessionId });
   });
 
   ipcMain.once('window-ready', () => {

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -234,8 +234,12 @@ async function _trackStats() {
     return { filePath, canceled };
   });
 
-  ipcMain.handle('getPath', (_, name) => {
-    return electron.app.getPath(name);
+  ipcMain.handle('showItemInFolder', (_, name) => {
+    electron.shell.showItemInFolder(name);
+  });
+
+  ipcMain.on('getPath', (event, name) => {
+    return event.returnValue = electron.app.getPath(name);
   });
 
   ipcMain.once('window-ready', () => {

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -234,6 +234,10 @@ async function _trackStats() {
     return { filePath, canceled };
   });
 
+  ipcMain.handle('getPath', (_, name) => {
+    return electron.app.getPath(name);
+  });
+
   ipcMain.once('window-ready', () => {
     const { currentVersion } = stats;
 

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -3,6 +3,7 @@ import 'regenerator-runtime/runtime';
 
 import * as electron from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer';
+import fontScanner from 'font-scanner';
 import path from 'path';
 
 import appConfig from '../config/config.json';
@@ -220,6 +221,8 @@ async function _trackStats() {
   } else {
     trackNonInteractiveEventQueueable('General', 'Launched', stats.currentVersion);
   }
+
+  ipcMain.handle('getAvailableFonts', () => fontScanner.getAvailableFonts());
 
   ipcMain.once('window-ready', () => {
     const { currentVersion } = stats;

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -249,7 +249,7 @@ async function _trackStats() {
       });
   });
 
-  ipcMain.on('getAnalytics', event => {
+  ipcMain.on('analytics', event => {
     const { BrowserWindow, screen, app } = electron;
     const browserWindow = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
 

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -238,6 +238,28 @@ async function _trackStats() {
     electron.shell.showItemInFolder(name);
   });
 
+  ipcMain.handle('setMenuBarVisibility', (_, visible) => {
+    electron.BrowserWindow.getAllWindows()
+      .forEach(window => {
+        // the `setMenuBarVisibility` signature uses `visible` semantics
+        window.setMenuBarVisibility(visible);
+        // the `setAutoHideMenu` signature uses `hide` semantics
+        const hide = !visible;
+        window.setAutoHideMenuBar(hide);
+      });
+  });
+
+  ipcMain.on('getAnalytics', event => {
+    const { BrowserWindow, screen, app } = electron;
+    const browserWindow = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
+
+    return event.returnValue = {
+      viewportSize: !browserWindow ? null : `${browserWindow.getContentBounds().width}x${browserWindow.getContentBounds().height}`,
+      screenResolution: `${screen.getPrimaryDisplay().workAreaSize.width}x${screen.getPrimaryDisplay().workAreaSize.height}`,
+      locale: app.getLocale(),
+    };
+  });
+
   ipcMain.on('getPath', (event, name) => {
     return event.returnValue = electron.app.getPath(name);
   });

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -53,7 +53,7 @@ app.on('ready', async () => {
   if (error) {
     electron.dialog.showErrorBox(error.title, error.message);
     console.log('[config] Insomnia config is invalid, preventing app initialization');
-    exitAppFailure();
+    app.exit(1);
     return;
   }
 

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -89,7 +89,8 @@ export function createWindow() {
       zoomFactor: zoomFactor,
       nodeIntegration: true,
       webviewTag: true,
-      enableRemoteModule: false,
+      // TODO: required to be true by spectron
+      enableRemoteModule: true,
       // TODO: enable context isolation
       contextIsolation: false,
       disableBlinkFeatures: 'Auxclick',

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -89,7 +89,7 @@ export function createWindow() {
       zoomFactor: zoomFactor,
       nodeIntegration: true,
       webviewTag: true,
-      enableRemoteModule: true,
+      enableRemoteModule: false,
       // TODO: enable context isolation
       contextIsolation: false,
       disableBlinkFeatures: 'Auxclick',

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -85,6 +85,7 @@ export function createWindow() {
     acceptFirstMouse: true,
     icon: path.resolve(__dirname, appLogo),
     webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
       zoomFactor: zoomFactor,
       nodeIntegration: true,
       webviewTag: true,

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -16,7 +16,7 @@ import {
   MNEMONIC_SYM,
 } from '../common/constants';
 import { docsBase } from '../common/documentation';
-import { clickLink, getDataDirectory, restartApp } from '../common/electron-helpers';
+import { clickLink, getDataDirectory } from '../common/electron-helpers';
 import * as log from '../common/log';
 import LocalStorage from './local-storage';
 
@@ -473,7 +473,7 @@ export function createWindow() {
       },
       {
         label: `R${MNEMONIC_SYM}estart`,
-        click: restartApp,
+        click: window.main.restart,
       },
     ],
   };

--- a/packages/insomnia-app/app/network/__tests__/multipart.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/multipart.test.ts
@@ -1,9 +1,10 @@
+import electron from 'electron';
 import fs from 'fs';
 import path from 'path';
 
 import { globalBeforeEach } from '../../__jest__/before-each';
 import { buildMultipart, DEFAULT_BOUNDARY } from '../multipart';
-
+window.app = electron.app;
 describe('buildMultipart()', () => {
   beforeEach(globalBeforeEach);
 

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -1,3 +1,4 @@
+import electron from 'electron';
 import fs from 'fs';
 import { HttpVersions } from 'insomnia-common';
 import { join as pathJoin, resolve as pathResolve } from 'path';
@@ -18,6 +19,7 @@ import * as models from '../../models';
 import { DEFAULT_BOUNDARY } from '../multipart';
 import * as networkUtils from '../network';
 const CONTEXT = {};
+window.app = electron.app;
 
 const getRenderedRequest = async (args: Parameters<typeof getRenderedRequestAndContext>[0]) => (await getRenderedRequestAndContext(args)).request;
 

--- a/packages/insomnia-app/app/network/multipart.ts
+++ b/packages/insomnia-app/app/network/multipart.ts
@@ -1,4 +1,3 @@
-import * as electron from 'electron';
 import fs from 'fs';
 import mimes from 'mime-types';
 import path from 'path';
@@ -15,7 +14,7 @@ interface Multipart {
 
 export async function buildMultipart(params: RequestBodyParameter[]) {
   return new Promise<Multipart>(async (resolve, reject) => {
-    const filePath = path.join(electron.remote.app.getPath('temp'), Math.random() + '.body');
+    const filePath = path.join(window.app.getPath('temp'), Math.random() + '.body');
     const writeStream = fs.createWriteStream(filePath);
     const lineBreak = '\r\n';
     let totalSize = 0;

--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-authorization-code.test.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-authorization-code.test.ts
@@ -5,7 +5,6 @@ import { globalBeforeEach } from '../../../__jest__/before-each';
 import { getTempDir } from '../../../common/electron-helpers';
 import * as network from '../../network';
 import getToken from '../grant-authorization-code';
-import { createBWRedirectMock } from './helpers';
 
 // Mock some test things
 const AUTHORIZE_URL = 'https://foo.com/authorizeAuthCode';
@@ -22,7 +21,7 @@ describe('authorization_code', () => {
   beforeEach(globalBeforeEach);
 
   it('gets token with JSON and basic auth', async () => {
-    createBWRedirectMock({ redirectTo: `${REDIRECT_URI}?code=code_123&state=${STATE}` });
+    window.main = { authorizeUserInWindow: () => Promise.resolve(`${REDIRECT_URI}?code=code_123&state=${STATE}`) };
     const bodyPath = path.join(getTempDir(), 'foo.response');
     fs.writeFileSync(
       bodyPath,
@@ -130,7 +129,7 @@ describe('authorization_code', () => {
   });
 
   it('gets token with urlencoded and body auth', async () => {
-    createBWRedirectMock({ redirectTo:  `${REDIRECT_URI}?code=code_123&state=${STATE}` });
+    window.main = { authorizeUserInWindow: () => Promise.resolve(`${REDIRECT_URI}?code=code_123&state=${STATE}`) };
     const bodyPath = path.join(getTempDir(), 'foo.response');
     fs.writeFileSync(
       bodyPath,
@@ -242,7 +241,7 @@ describe('authorization_code', () => {
   });
 
   it('uses PKCE', async () => {
-    createBWRedirectMock({ redirectTo: `${REDIRECT_URI}?code=code_123&state=${STATE}` });
+    window.main = { authorizeUserInWindow: () => Promise.resolve(`${REDIRECT_URI}?code=code_123&state=${STATE}`) };
     const bodyPath = path.join(getTempDir(), 'foo.response');
     fs.writeFileSync(
       bodyPath,

--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-implicit.test.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/grant-implicit.test.ts
@@ -1,6 +1,5 @@
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import getToken from '../grant-implicit';
-import { createBWRedirectMock } from './helpers';
 // Mock some test things
 const AUTHORIZE_URL = 'https://foo.com/authorizeAuthCode';
 const CLIENT_ID = 'client_123';
@@ -13,7 +12,8 @@ describe('implicit', () => {
   beforeEach(globalBeforeEach);
 
   it('works in default case', async () => {
-    createBWRedirectMock({ redirectTo: `${REDIRECT_URI}#access_token=token_123&state=${STATE}&foo=bar` });
+    window.main = { authorizeUserInWindow: () => Promise.resolve(`${REDIRECT_URI}#access_token=token_123&state=${STATE}&foo=bar`) };
+
     const result = await getToken(AUTHORIZE_URL, CLIENT_ID, REDIRECT_URI, SCOPE, STATE, AUDIENCE);
     expect(result).toEqual({
       access_token: 'token_123',

--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/helpers.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/helpers.ts
@@ -10,7 +10,7 @@ export function createBWRedirectMock({
   redirectTo,
   setCertificateVerifyProc = () => {},
 }: Options) {
-  electron.remote.BrowserWindow = jest.fn(function() {
+  electron.BrowserWindow = jest.fn(function() {
     this._emitter = new EventEmitter();
 
     this.loadURL = () => this.webContents.emit('did-navigate');

--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/misc.test.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/misc.test.ts
@@ -64,6 +64,8 @@ describe('authorizeUserInWindow()', () => {
 
   const getCertificateVerifyCallbackMock = () => {
     const mockCallback = mocked<(verificationResult: number) => void>(jest.fn());
+    window.main = { authorizeUserInWindow: () => Promise.resolve(MOCK_AUTHORIZATION_URL) };
+
     createBWRedirectMock({
       redirectTo: MOCK_AUTHORIZATION_URL,
       setCertificateVerifyProc: proc => {
@@ -86,7 +88,7 @@ describe('authorizeUserInWindow()', () => {
 
     // Act
     // We don't really care about the result here, since we're only testing an event handler.
-    await authorizeUserInWindow(MOCK_AUTHORIZATION_URL, /.*/);
+    await authorizeUserInWindow({ url: MOCK_AUTHORIZATION_URL, urlSuccessRegex: /.*/ });
 
     // Assert
     expect(mockCallback).toHaveBeenCalledWith(ChromiumVerificationResult.USE_CHROMIUM_RESULT);
@@ -103,7 +105,7 @@ describe('authorizeUserInWindow()', () => {
 
     // Act
     // We don't really care about the result here, since we're only testing an event handler.
-    await authorizeUserInWindow(MOCK_AUTHORIZATION_URL, /.*/);
+    await authorizeUserInWindow({ url: MOCK_AUTHORIZATION_URL, urlSuccessRegex: /.*/ });
 
     // Assert
     expect(mockCallback).toHaveBeenCalledWith(ChromiumVerificationResult.BLIND_TRUST);

--- a/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
@@ -7,7 +7,7 @@ import * as models from '../../models/index';
 import { getBasicAuthHeader } from '../basic-auth/get-header';
 import { sendWithSettings } from '../network';
 import * as c from './constants';
-import { authorizeUserInWindow, responseToObject } from './misc';
+import { authorizeUserInWindow, getOAuthSession, responseToObject } from './misc';
 
 export default async function(
   requestId: string,
@@ -147,9 +147,11 @@ async function _authorize(
   // Add query params to URL
   const qs = buildQueryStringFromParams(params);
   const finalUrl = joinUrlAndQueryString(url, qs);
-  const successRegex = new RegExp(`${escapeRegex(redirectUri)}.*(code=)`, 'i');
-  const failureRegex = new RegExp(`${escapeRegex(redirectUri)}.*(error=)`, 'i');
-  const redirectedTo = await authorizeUserInWindow(finalUrl, successRegex, failureRegex);
+  const urlSuccessRegex = new RegExp(`${escapeRegex(redirectUri)}.*(code=)`, 'i');
+  const urlFailureRegex = new RegExp(`${escapeRegex(redirectUri)}.*(error=)`, 'i');
+  const sessionId = getOAuthSession();
+
+  const redirectedTo = await window.main.authorizeUserInWindow({ url: finalUrl, urlSuccessRegex, urlFailureRegex, sessionId });
   console.log('[oauth2] Detected redirect ' + redirectedTo);
   const { query } = urlParse(redirectedTo);
   return responseToObject(query, [

--- a/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
@@ -7,8 +7,7 @@ import * as models from '../../models/index';
 import { getBasicAuthHeader } from '../basic-auth/get-header';
 import { sendWithSettings } from '../network';
 import * as c from './constants';
-import { authorizeUserInWindow, getOAuthSession, responseToObject } from './misc';
-
+import { getOAuthSession, responseToObject } from './misc';
 export default async function(
   requestId: string,
   authorizeUrl: string,

--- a/packages/insomnia-app/app/network/o-auth-2/grant-implicit.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-implicit.ts
@@ -1,7 +1,7 @@
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
 
 import * as c from './constants';
-import { authorizeUserInWindow, responseToObject } from './misc';
+import { authorizeUserInWindow, getOAuthSession, responseToObject } from './misc';
 
 export default async function(
   _requestId: string,
@@ -60,11 +60,11 @@ export default async function(
   // Add query params to URL
   const qs = buildQueryStringFromParams(params);
   const finalUrl = joinUrlAndQueryString(authorizationUrl, qs);
-  const redirectedTo = await authorizeUserInWindow(
-    finalUrl,
-    /(access_token=|id_token=)/,
-    /(error=)/,
-  );
+  const urlSuccessRegex = /(access_token=|id_token=)/;
+  const urlFailureRegex = /(error=)/;
+  const sessionId = getOAuthSession();
+  const redirectedTo = await window.main.authorizeUserInWindow({ url: finalUrl, urlSuccessRegex, urlFailureRegex, sessionId });
+
   const fragment = redirectedTo.split('#')[1];
 
   if (fragment) {

--- a/packages/insomnia-app/app/network/o-auth-2/grant-implicit.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-implicit.ts
@@ -1,7 +1,7 @@
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
 
 import * as c from './constants';
-import { authorizeUserInWindow, getOAuthSession, responseToObject } from './misc';
+import { getOAuthSession, responseToObject } from './misc';
 
 export default async function(
   _requestId: string,

--- a/packages/insomnia-app/app/network/o-auth-2/misc.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/misc.ts
@@ -9,20 +9,20 @@ export enum ChromiumVerificationResult {
   USE_CHROMIUM_RESULT = -3
 }
 
-const LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
-let authWindowSessionId;
-
-if (window.localStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID)) {
-  authWindowSessionId = window.localStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID);
-} else {
-  initNewOAuthSession();
+export const LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
+export function getOAuthSession() {
+  if (window.localStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID)) {
+    return window.localStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID);
+  } else {
+    return initNewOAuthSession();
+  }
 }
-
 export function initNewOAuthSession() {
   // the value of this variable needs to start with 'persist:'
   // otherwise sessions won't be persisted over application-restarts
-  authWindowSessionId = `persist:oauth2_${uuid.v4()}`;
+  const authWindowSessionId = `persist:oauth2_${uuid.v4()}`;
   window.localStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, authWindowSessionId);
+  return authWindowSessionId;
 }
 
 export function responseToObject(body, keys, defaults = {}) {
@@ -60,11 +60,12 @@ export function responseToObject(body, keys, defaults = {}) {
   return results;
 }
 
-export function authorizeUserInWindow(
+export function authorizeUserInWindow({
   url,
   urlSuccessRegex = /(code=).*/,
   urlFailureRegex = /(error=).*/,
-) {
+  sessionId,
+}) {
   return new Promise<string>(async (resolve, reject) => {
     let finalUrl: string | null = null;
 
@@ -74,10 +75,10 @@ export function authorizeUserInWindow(
     } = await models.settings.getOrCreate();
 
     // Create a child window
-    const child = new electron.remote.BrowserWindow({
+    const child = new electron.BrowserWindow({
       webPreferences: {
         nodeIntegration: false,
-        partition: authWindowSessionId,
+        partition: sessionId,
       },
       show: false,
     });

--- a/packages/insomnia-app/app/network/o-auth-2/misc.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/misc.ts
@@ -1,4 +1,4 @@
-import electron from 'electron';
+import electron, { BrowserWindow } from 'electron';
 import querystring from 'querystring';
 import * as uuid from 'uuid';
 
@@ -75,7 +75,7 @@ export function authorizeUserInWindow({
     } = await models.settings.getOrCreate();
 
     // Create a child window
-    const child = new electron.BrowserWindow({
+    const child = new BrowserWindow({
       webPreferences: {
         nodeIntegration: false,
         partition: sessionId,

--- a/packages/insomnia-app/app/plugins/context/app.tsx
+++ b/packages/insomnia-app/app/plugins/context/app.tsx
@@ -172,7 +172,7 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): {
           buttonLabel: 'Save',
           defaultPath: options.defaultPath,
         };
-        const { filePath } = await electron.remote.dialog.showSaveDialog(
+        const { filePath } = await window.dialog.showSaveDialog(
           saveOptions
         );
         return filePath || null;

--- a/packages/insomnia-app/app/plugins/context/app.tsx
+++ b/packages/insomnia-app/app/plugins/context/app.tsx
@@ -146,7 +146,7 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): {
       getPath(name: string) {
         switch (name.toLowerCase()) {
           case 'desktop':
-            return electron.remote.app.getPath('desktop');
+            return window.app.getPath('desktop');
 
           default:
             throw new Error(`Unknown path name ${name}`);

--- a/packages/insomnia-app/app/plugins/install.ts
+++ b/packages/insomnia-app/app/plugins/install.ts
@@ -56,10 +56,10 @@ export default async function(lookupName: string) {
       mkdirp.sync(pluginDir);
 
       // Download the module
-      const request = electron.remote.net.request(info.dist.tarball);
-      request.on('error', err => {
-        reject(new Error(`Failed to make plugin request ${info?.dist.tarball}: ${err.message}`));
-      });
+      const request = window.net.request(info.dist.tarball);
+      if (request.error) {
+        reject(new Error(`Failed to make plugin request ${info?.dist.tarball}: ${request.error.message}`));
+      }
       const { tmpDir } = await _installPluginToTmpDir(lookupName);
       console.log(`[plugins] Moving plugin from ${tmpDir} to ${pluginDir}`);
 
@@ -247,7 +247,7 @@ export function isDeprecatedDependencies(str: string) {
 }
 
 function _getYarnPath() {
-  const { app } = electron.remote || electron;
+  const { app } = process.type === 'renderer' ? window : electron;
 
   // TODO: This is brittle. Make finding this more robust.
   if (isDevelopment()) {

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -7,6 +7,7 @@ try {
   });
   contextBridge.exposeInMainWorld('dialog', {
     showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),
+    showSaveDialog: options => ipcRenderer.invoke('showSaveDialog', options),
   });
 
 } catch (e) {}
@@ -16,3 +17,4 @@ window.main = window.main || {};
 window.main.getAvailableFonts = () => ipcRenderer.invoke('getAvailableFonts');
 window.dialog = window.dialog || {};
 window.dialog.showOpenDialog = options => ipcRenderer.invoke('showOpenDialog', options);
+window.dialog.showSaveDialog = options => ipcRenderer.invoke('showSaveDialog', options);

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -5,6 +5,8 @@ try {
   // assume contextIsolation=true
   contextBridge.exposeInMainWorld('main', {
     getAvailableFonts: () => ipcRenderer.invoke('getAvailableFonts'),
+    setMenuBarVisibility: options => ipcRenderer.send('setMenuBarVisibility', options),
+    analytics: ipcRenderer.sendSync('analytics'),
   });
   contextBridge.exposeInMainWorld('dialog', {
     showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),
@@ -22,8 +24,8 @@ try {
 // expose for other preload scripts to use, this also covers contextIsolation=false
 window.main = window.main || {};
 window.main.getAvailableFonts = () => ipcRenderer.invoke('getAvailableFonts');
-window.main.getAnalytics = () => ipcRenderer.sendSync('getAnalytics');
 window.main.setMenuBarVisibility = options => ipcRenderer.send('setMenuBarVisibility', options);
+window.main.analytics = ipcRenderer.sendSync('analytics');
 window.dialog = window.dialog || {};
 window.dialog.showOpenDialog = options => ipcRenderer.invoke('showOpenDialog', options);
 window.dialog.showSaveDialog = options => ipcRenderer.invoke('showSaveDialog', options);

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -5,6 +5,7 @@ try {
   // assume contextIsolation=true
   contextBridge.exposeInMainWorld('main', {
     restart: () => ipcRenderer.send('restart'),
+    authorizeUserInWindow: options => ipcRenderer.invoke('authorizeUserInWindow', options),
     getAvailableFonts: () => ipcRenderer.invoke('getAvailableFonts'),
     setMenuBarVisibility: options => ipcRenderer.send('setMenuBarVisibility', options),
     analytics: ipcRenderer.sendSync('analytics'),
@@ -29,6 +30,7 @@ try {
 // expose for other preload scripts to use, this also covers contextIsolation=false
 window.main = window.main || {};
 window.main.restart = () => ipcRenderer.send('restart');
+window.main.authorizeUserInWindow = options => ipcRenderer.invoke('authorizeUserInWindow', options);
 window.main.getAvailableFonts = () => ipcRenderer.invoke('getAvailableFonts');
 window.main.setMenuBarVisibility = options => ipcRenderer.send('setMenuBarVisibility', options);
 window.main.analytics = ipcRenderer.sendSync('analytics');

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -14,9 +14,13 @@ try {
   });
   contextBridge.exposeInMainWorld('app', {
     getPath: options => ipcRenderer.sendSync('getPath', options),
+    getAppPath: options => ipcRenderer.sendSync('getAppPath', options),
   });
   contextBridge.exposeInMainWorld('shell', {
     showItemInFolder: options => ipcRenderer.send('showItemInFolder', options),
+  });
+  contextBridge.exposeInMainWorld('net', {
+    request: options => ipcRenderer.send('request', options),
   });
 
 } catch (e) {}
@@ -31,5 +35,8 @@ window.dialog.showOpenDialog = options => ipcRenderer.invoke('showOpenDialog', o
 window.dialog.showSaveDialog = options => ipcRenderer.invoke('showSaveDialog', options);
 window.app = window.app || {};
 window.app.getPath = options => ipcRenderer.sendSync('getPath', options);
+window.app.getAppPath = () => ipcRenderer.sendSync('getAppPath');
 window.shell = window.shell || {};
 window.shell.showItemInFolder = options => ipcRenderer.send('showItemInFolder', options);
+window.net = window.net || {};
+window.net.request = options => ipcRenderer.invoke('request', options);

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -12,6 +12,9 @@ try {
   contextBridge.exposeInMainWorld('app', {
     getPath: options => ipcRenderer.sendSync('getPath', options),
   });
+  contextBridge.exposeInMainWorld('shell', {
+    showItemInFolder: options => ipcRenderer.invoke('showItemInFolder', options),
+  });
 
 } catch (e) {}
 
@@ -23,3 +26,5 @@ window.dialog.showOpenDialog = options => ipcRenderer.invoke('showOpenDialog', o
 window.dialog.showSaveDialog = options => ipcRenderer.invoke('showSaveDialog', options);
 window.app = window.app || {};
 window.app.getPath = options => ipcRenderer.sendSync('getPath', options);
+window.shell = window.shell || {};
+window.shell.showItemInFolder = options => ipcRenderer.invoke('showItemInFolder', options);

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -22,6 +22,8 @@ try {
 // expose for other preload scripts to use, this also covers contextIsolation=false
 window.main = window.main || {};
 window.main.getAvailableFonts = () => ipcRenderer.invoke('getAvailableFonts');
+window.main.getAnalytics = () => ipcRenderer.sendSync('getAnalytics');
+window.main.setMenuBarVisibility = options => ipcRenderer.send('setMenuBarVisibility', options);
 window.dialog = window.dialog || {};
 window.dialog.showOpenDialog = options => ipcRenderer.invoke('showOpenDialog', options);
 window.dialog.showSaveDialog = options => ipcRenderer.invoke('showSaveDialog', options);

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -1,4 +1,5 @@
 const { contextBridge, ipcRenderer } = require('electron');
+process.env.ELECTRON_IS_DEV = '1';
 
 try {
   // assume contextIsolation=true

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -13,7 +13,7 @@ try {
     getPath: options => ipcRenderer.sendSync('getPath', options),
   });
   contextBridge.exposeInMainWorld('shell', {
-    showItemInFolder: options => ipcRenderer.invoke('showItemInFolder', options),
+    showItemInFolder: options => ipcRenderer.send('showItemInFolder', options),
   });
 
 } catch (e) {}
@@ -27,4 +27,4 @@ window.dialog.showSaveDialog = options => ipcRenderer.invoke('showSaveDialog', o
 window.app = window.app || {};
 window.app.getPath = options => ipcRenderer.sendSync('getPath', options);
 window.shell = window.shell || {};
-window.shell.showItemInFolder = options => ipcRenderer.invoke('showItemInFolder', options);
+window.shell.showItemInFolder = options => ipcRenderer.send('showItemInFolder', options);

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -5,9 +5,14 @@ try {
   contextBridge.exposeInMainWorld('main', {
     getAvailableFonts: () => ipcRenderer.invoke('getAvailableFonts'),
   });
+  contextBridge.exposeInMainWorld('dialog', {
+    showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),
+  });
 
 } catch (e) {}
 
 // expose for other preload scripts to use, this also covers contextIsolation=false
 window.main = window.main || {};
 window.main.getAvailableFonts = () => ipcRenderer.invoke('getAvailableFonts');
+window.dialog = window.dialog || {};
+window.dialog.showOpenDialog = options => ipcRenderer.invoke('showOpenDialog', options);

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -9,6 +9,9 @@ try {
     showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),
     showSaveDialog: options => ipcRenderer.invoke('showSaveDialog', options),
   });
+  contextBridge.exposeInMainWorld('app', {
+    getPath: options => ipcRenderer.sendSync('getPath', options),
+  });
 
 } catch (e) {}
 
@@ -18,3 +21,5 @@ window.main.getAvailableFonts = () => ipcRenderer.invoke('getAvailableFonts');
 window.dialog = window.dialog || {};
 window.dialog.showOpenDialog = options => ipcRenderer.invoke('showOpenDialog', options);
 window.dialog.showSaveDialog = options => ipcRenderer.invoke('showSaveDialog', options);
+window.app = window.app || {};
+window.app.getPath = options => ipcRenderer.sendSync('getPath', options);

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -4,6 +4,7 @@ process.env.ELECTRON_IS_DEV = '1';
 try {
   // assume contextIsolation=true
   contextBridge.exposeInMainWorld('main', {
+    restart: () => ipcRenderer.send('restart'),
     getAvailableFonts: () => ipcRenderer.invoke('getAvailableFonts'),
     setMenuBarVisibility: options => ipcRenderer.send('setMenuBarVisibility', options),
     analytics: ipcRenderer.sendSync('analytics'),
@@ -27,6 +28,7 @@ try {
 
 // expose for other preload scripts to use, this also covers contextIsolation=false
 window.main = window.main || {};
+window.main.restart = () => ipcRenderer.send('restart');
 window.main.getAvailableFonts = () => ipcRenderer.invoke('getAvailableFonts');
 window.main.setMenuBarVisibility = options => ipcRenderer.send('setMenuBarVisibility', options);
 window.main.analytics = ipcRenderer.sendSync('analytics');

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -1,0 +1,13 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+try {
+  // assume contextIsolation=true
+  contextBridge.exposeInMainWorld('main', {
+    getAvailableFonts: () => ipcRenderer.invoke('getAvailableFonts'),
+  });
+
+} catch (e) {}
+
+// expose for other preload scripts to use, this also covers contextIsolation=false
+window.main = window.main || {};
+window.main.getAvailableFonts = () => ipcRenderer.invoke('getAvailableFonts');

--- a/packages/insomnia-app/app/ui/components/editors/body/file-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/file-editor.tsx
@@ -26,7 +26,7 @@ export class FileEditor extends PureComponent<Props> {
   render() {
     const { path } = this.props;
     // Replace home path with ~/ to make the path shorter
-    const homeDirectory = electron.remote.app.getPath('home');
+    const homeDirectory = window.app.getPath('home');
     const pathDescription = path.replace(homeDirectory, '~');
     let sizeDescription = '';
 

--- a/packages/insomnia-app/app/ui/components/editors/body/file-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/file-editor.tsx
@@ -1,5 +1,4 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import electron from 'electron';
 import fs from 'fs';
 import React, { PureComponent } from 'react';
 

--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import { EditorFromTextArea, LintOptions, ShowHintOptions, TextMarker } from 'codemirror';
 import { GraphQLInfoOptions } from 'codemirror-graphql/info';
 import { ModifiedGraphQLJumpOptions } from 'codemirror-graphql/jump';
-import electron, { OpenDialogOptions } from 'electron';
+import { OpenDialogOptions } from 'electron';
 import { readFileSync } from 'fs';
 import { DefinitionNode, DocumentNode, GraphQLNonNull, GraphQLSchema, NonNullTypeNode, OperationDefinitionNode } from 'graphql';
 import { parse, typeFromAST } from 'graphql';
@@ -353,7 +353,7 @@ export class GraphQLEditor extends PureComponent<Props, State> {
       ],
     };
 
-    const { canceled, filePaths } = await electron.remote.dialog.showOpenDialog(options);
+    const { canceled, filePaths } = await window.dialog.showOpenDialog(options);
 
     if (canceled) {
       return;

--- a/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
-import { clipboard, remote } from 'electron';
+import { clipboard } from 'electron';
 import fs from 'fs';
 import { HotKeyRegistry } from 'insomnia-common';
 import { json as jsonPrettify } from 'insomnia-prettify';
@@ -89,7 +89,7 @@ export class ResponsePane extends PureComponent<Props> {
 
     const { contentType } = response;
     const extension = mime.extension(contentType) || 'unknown';
-    const { canceled, filePath: outputPath } = await remote.dialog.showSaveDialog({
+    const { canceled, filePath: outputPath } = await window.dialog.showSaveDialog({
       title: 'Save Response Body',
       buttonLabel: 'Save',
       defaultPath: `${request.name.replace(/ +/g, '_')}-${Date.now()}.${extension}`,
@@ -144,7 +144,7 @@ export class ResponsePane extends PureComponent<Props> {
       .map(v => v.value)
       .join('');
 
-    const { canceled, filePath } = await remote.dialog.showSaveDialog({
+    const { canceled, filePath } = await window.dialog.showSaveDialog({
       title: 'Save Full Response',
       buttonLabel: 'Save',
       defaultPath: `${request.name.replace(/ +/g, '_')}-${Date.now()}.txt`,
@@ -196,7 +196,7 @@ export class ResponsePane extends PureComponent<Props> {
     const data = await exportHarCurrentRequest(request, response);
     const har = JSON.stringify(data, null, '\t');
 
-    const { filePath } = await remote.dialog.showSaveDialog({
+    const { filePath } = await window.dialog.showSaveDialog({
       title: 'Export As HAR',
       buttonLabel: 'Save',
       defaultPath: `${request.name.replace(/ +/g, '_')}-${Date.now()}.har`,

--- a/packages/insomnia-app/app/ui/components/request-url-bar.tsx
+++ b/packages/insomnia-app/app/ui/components/request-url-bar.tsx
@@ -1,5 +1,5 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { OpenDialogOptions, remote } from 'electron';
+import { OpenDialogOptions } from 'electron';
 import { HotKeyRegistry } from 'insomnia-common';
 import React, { PureComponent, ReactNode } from 'react';
 
@@ -127,7 +127,7 @@ export class RequestUrlBar extends PureComponent<Props, State> {
       buttonLabel: 'Select',
       properties: ['openDirectory'],
     };
-    const { canceled, filePaths } = await remote.dialog.showOpenDialog(options);
+    const { canceled, filePaths } = await window.dialog.showOpenDialog(options);
 
     if (canceled) {
       return;

--- a/packages/insomnia-app/app/ui/components/settings/general.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/general.tsx
@@ -1,5 +1,4 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import * as fontScanner from 'font-scanner';
 import { HttpVersion, HttpVersions } from 'insomnia-common';
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -67,7 +66,7 @@ class General extends PureComponent<Props, State> {
   };
 
   async componentDidMount() {
-    const allFonts = await fontScanner.getAvailableFonts();
+    const allFonts = await window.main.getAvailableFonts();
     // Find regular fonts
     const fonts = allFonts
       .filter(i => ['regular', 'book'].includes(i.style.toLowerCase()) && !i.italic)

--- a/packages/insomnia-app/app/ui/components/settings/general.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/general.tsx
@@ -23,7 +23,6 @@ import {
   updatesSupported,
 } from '../../../common/constants';
 import { docsKeyMaps } from '../../../common/documentation';
-import { restartApp } from '../../../common/electron-helpers';
 import { snapNumberToLimits } from '../../../common/misc';
 import { strings } from '../../../common/strings';
 import type { Settings } from '../../../models/settings';
@@ -105,7 +104,7 @@ class General extends PureComponent<Props, State> {
 
   async _handleUpdateSettingAndRestart(e: React.SyntheticEvent<HTMLInputElement>) {
     await this._handleUpdateSetting(e);
-    restartApp();
+    window.main.restart();
   }
 
   async _handleFontChange(el: React.SyntheticEvent<HTMLInputElement>) {

--- a/packages/insomnia-app/app/ui/components/settings/plugins.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/plugins.tsx
@@ -1,5 +1,4 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import * as electron from 'electron';
 import { PluginConfig } from 'insomnia-common';
 import { Button, ToggleSwitch } from 'insomnia-components';
 import * as path from 'path';
@@ -88,7 +87,7 @@ export class Plugins extends PureComponent<Props, State> {
   }
 
   static _handleOpenDirectory(directory: string) {
-    electron.remote.shell.showItemInFolder(directory);
+    window.shell.showItemInFolder(directory);
   }
 
   async _handleRefreshPlugins() {
@@ -116,7 +115,7 @@ export class Plugins extends PureComponent<Props, State> {
   }
 
   static _handleClickShowPluginsFolder() {
-    electron.remote.shell.showItemInFolder(PLUGIN_PATH);
+    window.shell.showItemInFolder(PLUGIN_PATH);
   }
 
   _handleCreatePlugin() {

--- a/packages/insomnia-app/app/ui/components/viewers/response-multipart-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-multipart-viewer.tsx
@@ -149,7 +149,7 @@ export class ResponseMultipartViewer extends PureComponent<Props, State> {
         },
       ],
     };
-    const { canceled, filePath } = await electron.remote.dialog.showSaveDialog(options);
+    const { canceled, filePath } = await window.dialog.showSaveDialog(options);
 
     if (canceled) {
       return;

--- a/packages/insomnia-app/app/ui/components/viewers/response-multipart-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-multipart-viewer.tsx
@@ -1,5 +1,5 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import electron, { SaveDialogOptions } from 'electron';
+import { SaveDialogOptions } from 'electron';
 import fs from 'fs';
 import mimes from 'mime-types';
 import moment from 'moment';
@@ -135,7 +135,7 @@ export class ResponseMultipartViewer extends PureComponent<Props, State> {
     const contentType = getContentTypeFromHeaders(part.headers, 'text/plain');
     const extension = mimes.extension(contentType) || '.txt';
     const lastDir = window.localStorage.getItem('insomnia.lastExportPath');
-    const dir = lastDir || electron.remote.app.getPath('desktop');
+    const dir = lastDir || window.app.getPath('desktop');
     const date = moment().format('YYYY-MM-DD');
     const filename = part.filename || `${part.name}_${date}`;
     const options: SaveDialogOptions = {

--- a/packages/insomnia-app/app/ui/components/wrapper-migration.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-migration.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, useCallback, useMemo, useState } from 'react'
 import { useDispatch } from 'react-redux';
 
 import { trackEvent } from '../../common/analytics';
-import { getDataDirectory, getDesignerDataDir, restartApp } from '../../common/electron-helpers';
+import { getDataDirectory, getDesignerDataDir } from '../../common/electron-helpers';
 import type { MigrationOptions } from '../../common/migrate-from-designer';
 import migrateFromDesigner, { existsAndIsDirectory } from '../../common/migrate-from-designer';
 import { goToNextActivity } from '../redux/modules/global';
@@ -198,7 +198,7 @@ const Migrating = () => (
 );
 
 const RestartButton = () => (
-  <button key="restart" className="btn btn--clicky" onClick={restartApp}>
+  <button key="restart" className="btn btn--clicky" onClick={window.main.restart}>
     Restart Now
   </button>
 );

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -743,7 +743,7 @@ class App extends PureComponent<AppProps, State> {
       options.defaultPath = defaultPath;
     }
 
-    const { filePath } = await remote.dialog.showSaveDialog(options);
+    const { filePath } = await window.dialog.showSaveDialog(options);
     // @ts-expect-error -- TSCONVERSION don't set item if filePath is undefined
     window.localStorage.setItem('insomnia.sendAndDownloadLocation', filePath);
     return filePath || null;

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -1,5 +1,5 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { clipboard, ipcRenderer, remote, SaveDialogOptions } from 'electron';
+import { clipboard, ipcRenderer, SaveDialogOptions } from 'electron';
 import fs from 'fs';
 import HTTPSnippet from 'httpsnippet';
 import * as mime from 'mime-types';

--- a/packages/insomnia-app/app/ui/hooks/settings-hooks.ts
+++ b/packages/insomnia-app/app/ui/hooks/settings-hooks.ts
@@ -1,13 +1,12 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { setMenuBarVisibility } from '../../common/electron-helpers';
 import { selectSettings } from '../redux/selectors';
 
 export const useMenuBarVisibility = () => {
   const { autoHideMenuBar } = useSelector(selectSettings);
 
   useEffect(() => {
-    setMenuBarVisibility(!autoHideMenuBar);
+    window.main.setMenuBarVisibility(!autoHideMenuBar);
   }, [autoHideMenuBar]);
 };

--- a/packages/insomnia-app/app/ui/redux/modules/global.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/global.tsx
@@ -475,7 +475,7 @@ const showSaveExportedFileDialog = async ({
     buttonLabel: 'Export',
     defaultPath: `${path.join(dir, `${name}_${date}`)}.${selectedFormat}`,
   };
-  const { filePath } = await electron.remote.dialog.showSaveDialog(options);
+  const { filePath } = await window.dialog.showSaveDialog(options);
   return filePath || null;
 };
 

--- a/packages/insomnia-app/app/ui/redux/modules/global.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/global.tsx
@@ -1,4 +1,3 @@
-import electron from 'electron';
 import fs, { NoParamCallback } from 'fs';
 import moment from 'moment';
 import path from 'path';
@@ -469,7 +468,7 @@ const showSaveExportedFileDialog = async ({
   const date = moment().format('YYYY-MM-DD');
   const name = exportedFileNamePrefix.replace(/ /g, '-');
   const lastDir = window.localStorage.getItem('insomnia.lastExportPath');
-  const dir = lastDir || electron.remote.app.getPath('desktop');
+  const dir = lastDir || window.app.getPath('desktop');
   const options = {
     title: 'Export Insomnia Data',
     buttonLabel: 'Export',

--- a/packages/insomnia-app/app/ui/redux/modules/import.ts
+++ b/packages/insomnia-app/app/ui/redux/modules/import.ts
@@ -88,7 +88,7 @@ export const importFile = (
       },
     ],
   };
-  const { canceled, filePaths } = await electron.remote.dialog.showOpenDialog(openDialogOptions);
+  const { canceled, filePaths } = await window.dialog.showOpenDialog(openDialogOptions);
 
   if (canceled) {
     // It was cancelled, so let's bail out

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -8702,9 +8702,9 @@
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
@@ -8717,21 +8717,21 @@
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
 				"string-width": {
-					"version": "4.2.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 					"requires": {
 						"emoji-regex": "^8.0.0",
 						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
+						"strip-ansi": "^6.0.1"
 					}
 				},
 				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 					"requires": {
-						"ansi-regex": "^5.0.0"
+						"ansi-regex": "^5.0.1"
 					}
 				}
 			}
@@ -10510,13 +10510,13 @@
 			}
 		},
 		"electron-context-menu": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-2.5.2.tgz",
-			"integrity": "sha512-1cEQR6fA9ktFsRBc+eXPwvrOgAPytUD7rUV4iBAA5zTrLAPKokJ23xeMjcK2fjrDPrlFRBxcLz0KP+GUhMrSCQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-3.1.1.tgz",
+			"integrity": "sha512-LJhwaKf6XHwk2LQ5SdwoGNODoA8lRwks9bbEeAqqMf4e3hsrT7pZtX6MaHKYNFZKxF14JjI/VR+VRjGvxmaQoA==",
 			"requires": {
 				"cli-truncate": "^2.1.0",
-				"electron-dl": "^3.1.0",
-				"electron-is-dev": "^1.2.0"
+				"electron-dl": "^3.2.1",
+				"electron-is-dev": "^2.0.0"
 			}
 		},
 		"electron-devtools-installer": {
@@ -10559,9 +10559,9 @@
 			}
 		},
 		"electron-is-dev": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
-			"integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
+			"integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA=="
 		},
 		"electron-log": {
 			"version": "4.3.5",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -89,7 +89,7 @@
     "codemirror": "^5.62.3",
     "codemirror-graphql": "^1.0.2",
     "color": "^3.1.2",
-    "electron-context-menu": "^2.2.0",
+    "electron-context-menu": "^3.1.1",
     "electron-log": "^4.3.5",
     "electron-updater": "^4.3.9",
     "font-scanner": "^0.1.2",

--- a/packages/insomnia-app/webpack/webpack.config.electron.ts
+++ b/packages/insomnia-app/webpack/webpack.config.electron.ts
@@ -30,7 +30,7 @@ if (process.env.NODE_ENV === 'development') {
   plugins = productionConfig.plugins;
 }
 
-const configuration: Configuration = {
+const configuration: Configuration[] = [{
   ...productionConfig,
   devtool,
   entry: ['./main.development.ts'],
@@ -40,6 +40,14 @@ const configuration: Configuration = {
   },
   target: 'electron-main',
   plugins,
-};
+},
+{
+  entry: './app/preload.js',
+  target: 'electron-preload',
+  output: {
+    path: path.join(__dirname, '../build'),
+    filename: 'preload.js',
+  },
+}];
 
 export default configuration;

--- a/packages/insomnia-smoke-test/modules/application.ts
+++ b/packages/insomnia-smoke-test/modules/application.ts
@@ -72,24 +72,22 @@ const launch = async config => {
     waitTimeout: 10000,
   });
   const promise = app.start();
-  if (isWindows()){
-    promise.then(async () => {
+  promise.then(async () => {
     // Windows spawns two terminal windows when running spectron, and the only workaround
     // is to focus the window on start.
     // https://github.com/electron-userland/spectron/issues/60
-      await app.browserWindow.focus();
-      await app.browserWindow.setAlwaysOnTop(true);
+    await app.browserWindow.focus();
+    await app.browserWindow.setAlwaysOnTop(true);
 
-      // Set the implicit wait timeout to 0 (webdriver default)
-      //  https://webdriver.io/docs/timeouts.html#session-implicit-wait-timeout
-      // Spectron overrides it to an unreasonable value, as per the issue
-      //  https://github.com/electron-userland/spectron/issues/763
-      await app.client.setTimeout({ implicit: 0 });
+    // Set the implicit wait timeout to 0 (webdriver default)
+    //  https://webdriver.io/docs/timeouts.html#session-implicit-wait-timeout
+    // Spectron overrides it to an unreasonable value, as per the issue
+    //  https://github.com/electron-userland/spectron/issues/763
+    await app.client.setTimeout({ implicit: 0 });
 
-      // Set bounds to default size
-      await app.browserWindow.setSize(1280, 700);
-    });
-  }
+    // Set bounds to default size
+    await app.browserWindow.setSize(1280, 700);
+  });
   return promise;
 };
 

--- a/packages/insomnia-smoke-test/modules/debug.ts
+++ b/packages/insomnia-smoke-test/modules/debug.ts
@@ -92,7 +92,7 @@ export const clickSendRequest = async (app: Application) => {
   await spinner.waitForDisplayed();
 
   // Wait for spinner to hide
-  await spinner.waitForDisplayed({ reverse: true });
+  await spinner.waitForDisplayed({ reverse: true, timeout: 20000 });
 };
 
 export const expect200 = async (app: Application) => {


### PR DESCRIPTION
Moves electron interactions from renderer to main thread

Effectively prepares font-scanner binary for `contextIsolation: true`

Disables the `enableRemoteModule` feature to aid with future contextIsolation

closes INS-1130

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Fixes warning:
```
(node:63354) Electron: Loading non-context-aware native module in renderer: '~/git/insomnia/packages/insomnia-app/node_modules/font-scanner/build/Release/fontmanager.node'. This is deprecated, see https://github.com/electron/electron/issues/18397.
```


Notes:

- preload should/can only expose serializable main thread function or listener outputs, should/can not require modules or unserializable structures. invoke for promises, send for fire and forget, sendSync for instance response(will likely block)
- electron-is-dev could be bumped because it also depends on remote, can be cut from this work, since we still need remote for electron as can the `ELECTRON_IS_DEV='1'` stuff
- in tests, stubbing window.main or whatever still not sure the best approach is
- moved from electron.net.request to axios meaning refactoring from listeners to a promise. used for sending analytics and installing plugins. tested but not exhaustively
- git-sync uses axios too but with proxy and cert validation overrides from preferences, should these have the same behaviour?
- oauth2 child window instance needs a session id currently stored in localstorage, should this be here or elsewhere, how to test?