### PR TITLE
remove noisy cookie test

### DIFF
--- a/packages/insomnia-cookies/src/cookies.test.ts
+++ b/packages/insomnia-cookies/src/cookies.test.ts
@@ -56,16 +56,4 @@ describe('cookiesFromJar()', () => {
     expect(cookies[0].creation).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/);
     expect(cookies[0].expires).toEqual(d.toISOString());
   });
-
-  it('handles bad jar', async () => {
-    const jar = CookieJar.fromJSON({ cookies: [] });
-
-    // MemoryStore never actually throws errors, so lets mock the function to force it to this time.
-    // @ts-expect-error intentionally invalid value
-    jar.store.getAllCookies = cb => cb(new Error('Dummy Error'));
-    const cookies = await cookiesFromJar(jar);
-
-    // Cookies failed to parse
-    expect(cookies.length).toBe(0);
-  });
 });

--- a/packages/insomnia-cookies/src/cookies.test.ts
+++ b/packages/insomnia-cookies/src/cookies.test.ts
@@ -24,6 +24,7 @@ describe('jarFromCookies()', () => {
   });
 
   it('handles malformed JSON', () => {
+    jest.spyOn(console, 'log').mockImplementationOnce(() => {});
     // @ts-expect-error this test is verifying that an invalid input is handled appropriately
     const jar = jarFromCookies('not a jar');
     expect(jar.constructor.name).toBe('CookieJar');
@@ -59,11 +60,10 @@ describe('cookiesFromJar()', () => {
 
   it('handles bad jar', async () => {
     const jar = CookieJar.fromJSON({ cookies: [] });
-
+    jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
     // MemoryStore never actually throws errors, so lets mock the function to force it to this time.
     // @ts-expect-error intentionally invalid value
     jar.store.getAllCookies = cb => cb(new Error('Dummy Error'));
-    jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
     const cookies = await cookiesFromJar(jar);
     // Cookies failed to parse
     expect(cookies.length).toBe(0);

--- a/packages/insomnia-cookies/src/cookies.test.ts
+++ b/packages/insomnia-cookies/src/cookies.test.ts
@@ -56,4 +56,16 @@ describe('cookiesFromJar()', () => {
     expect(cookies[0].creation).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/);
     expect(cookies[0].expires).toEqual(d.toISOString());
   });
+
+  it('handles bad jar', async () => {
+    const jar = CookieJar.fromJSON({ cookies: [] });
+
+    // MemoryStore never actually throws errors, so lets mock the function to force it to this time.
+    // @ts-expect-error intentionally invalid value
+    jar.store.getAllCookies = cb => cb(new Error('Dummy Error'));
+    jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
+    const cookies = await cookiesFromJar(jar);
+    // Cookies failed to parse
+    expect(cookies.length).toBe(0);
+  });
 });


### PR DESCRIPTION
Closes INS-1067

Test was creating distracting noise in the logs, giving poor test ROI

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
