### PR TITLE
Add DEFAULT-HEADER-IGNORE to ignore headers

### DIFF
--- a/plugins/insomnia-plugin-default-headers/src/default-headers.js
+++ b/plugins/insomnia-plugin-default-headers/src/default-headers.js
@@ -11,6 +11,10 @@ module.exports = function(context) {
       console.log(`[header] Skip setting default header ${name}. Already set to ${value}`);
       continue;
     }
+    else if (context.request.hasHeader("DEFAULT-HEADER-IGNORE")) {
+      console.log(`[header] Skip setting default header ${name}. DEFAULT-HEADER-IGNORE found`);
+      continue;
+    }
 
     if (value==="null") {
       context.request.removeHeader(name);


### PR DESCRIPTION

This fix resolves the problem of recursive attempt to add headers to requests that are the request used to generate the header being added. I face a problem with this issue when doing: 
![image](https://user-images.githubusercontent.com/62527567/140245997-745b4600-afd9-4f49-9978-65d3e285417b.png)
Add the header DEFAULT-HEADER-IGNRORE with any value to the request that will be not be added the DEFAULT_HEADERS.