### PR TITLE
spike: use axios rather than node-libcurl

### DIFF
--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -1,6 +1,7 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 
+import axios from 'axios';
 import * as electron from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer';
 import path from 'path';
@@ -220,6 +221,11 @@ async function _trackStats() {
   } else {
     trackNonInteractiveEventQueueable('General', 'Launched', stats.currentVersion);
   }
+  ipcMain.handle('request', async (_, axios_request) => {
+    const { data, status, statusText, headers } = await axios(axios_request);
+
+    return { data, status, statusText, headers };
+  });
 
   ipcMain.once('window-ready', () => {
     const { currentVersion } = stats;

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -222,7 +222,7 @@ async function _trackStats() {
     trackNonInteractiveEventQueueable('General', 'Launched', stats.currentVersion);
   }
   ipcMain.handle('request', async (_, axios_request) => {
-    const { data, status, statusText, headers } = await axios(axios_request);
+    const { data, status, statusText, headers } = await axios({ ...axios_request, validateStatus:() => true });
 
     return { data, status, statusText, headers };
   });

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -1,3 +1,4 @@
+import { AxiosResponse } from 'axios';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import crypto from 'crypto';
 import { clipboard, ipcRenderer, remote, SaveDialogOptions } from 'electron';
@@ -856,6 +857,7 @@ class App extends PureComponent<AppProps, State> {
       const responsesDir = path.join(getDataDirectory(), 'responses');
       mkdirp.sync(responsesDir);
       const responseBodyPath = path.join(responsesDir, uuid.v4() + '.response');
+      // TODO get some debug logging
       const timeline = ['some logs'];
       const timelineStr = JSON.stringify(timeline, null, '\t');
       const timelineHash = crypto.createHash('sha1').update(timelineStr).digest('hex');
@@ -864,9 +866,7 @@ class App extends PureComponent<AppProps, State> {
       console.log(request);
       // TODO transform and check request options
       // TODO handle large files
-      // TODO get some debug logging
-
-      const response = await ipcRenderer.invoke('request', { url: request.url, method: request.method });
+      const response: AxiosResponse = await ipcRenderer.invoke('request', { url: request.url, method: request.method });
       console.log('response', response);
       fs.writeFile(responseBodyPath,
         response.data, function(err) {
@@ -890,7 +890,7 @@ class App extends PureComponent<AppProps, State> {
         elapsedTime: endTime - startTime,
         environmentId,
         headers,
-        httpVersion: response.httpVersion,
+        httpVersion: 'HTTP/2', // TODO
         parentId: requestId,
         settingSendCookies: request.settingSendCookies,
         settingStoreCookies: request.settingStoreCookies,
@@ -899,7 +899,8 @@ class App extends PureComponent<AppProps, State> {
         timelinePath,
         url: request.url,
       };
-
+      console.log(responsePatch);
+      // const responsePatch = await network.send(requestId, environmentId);
       models.response.create(responsePatch, settings.maxHistoryResponses);
 
     } catch (err) {

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -850,34 +850,10 @@ class App extends PureComponent<AppProps, State> {
     handleStartLoading(requestId);
 
     try {
+      const responsePatch = await ipcRenderer.invoke('request', request);
 
-      console.log(request);
-      // TODO transform and check request options https://axios-http.com/docs/req_config
-      // headers, params, timeout
-      const response = await ipcRenderer.invoke('request', { url: request.url, method: request.method, auth: request.authentication, data: request.body });
-
-      const headers = Object.entries(response.headers).map(([key, value]) => ({ name: key, value })) as [];
-      const responsePatch: network.ResponsePatch = {
-        bodyCompression: null,
-        bodyPath: response.bodyPath,
-        bytesContent: 169, // TODO
-        bytesRead: 169, // TODO
-        contentType: response.headers['content-type'],
-        elapsedTime: response.elapsedTime,
-        environmentId,
-        headers,
-        httpVersion: 'HTTP/2', // TODO
-        parentId: requestId,
-        settingSendCookies: request.settingSendCookies,
-        settingStoreCookies: request.settingStoreCookies,
-        statusCode: response.status,
-        statusMessage: response.statusText,
-        timelinePath: response.timelinePath,
-        url: request.url,
-      };
-      console.log(responsePatch);
       // const responsePatch = await network.send(requestId, environmentId);
-      models.response.create(responsePatch, settings.maxHistoryResponses);
+      models.response.create({ ...responsePatch, environmentId }, settings.maxHistoryResponses);
 
     } catch (err) {
       if (err.type === 'render') {

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -862,58 +862,46 @@ class App extends PureComponent<AppProps, State> {
       const timelinePath = path.join(responsesDir, timelineHash + '.timeline');
       const startTime = performance.now();
       console.log(request);
-      // TODO evaluate other request libs, this one has content length 0 and no content type in the header
-      const req = remote.net.request({ url: request.url, method: request.method });
-      req.on('response', response => {
-        const headers = Object.entries(response.headers).map(([key, value]) => ({ name: key, value })) as [];
-        console.log(response.headers, headers);
-        response.on('data', chunk => {
-          console.log(`BODY: ${chunk}`);
+      // TODO transform and check request options
+      // TODO handle large files
+      // TODO get some debug logging
 
-          fs.writeFile(responseBodyPath,
-            chunk, function(err) {
-              if (err) throw err;
-              console.log('Saved!');
-            });
-
-          fs.writeFile(timelinePath,
-            timelineStr, function(err) {
-              if (err) throw err;
-              console.log('Saved!');
-            });
-          const endTime = performance.now();
-          const responsePatch: network.ResponsePatch = {
-            bodyCompression: null,
-            bodyPath: responseBodyPath,
-            bytesContent: 169, // TODO
-            bytesRead: 169, // TODO
-            contentType: response.headers['content-type'] as string || 'application/json; charset=utf-8',
-            elapsedTime: endTime - startTime,
-            environmentId,
-            headers,
-            httpVersion: response.httpVersion,
-            parentId: requestId,
-            settingSendCookies: request.settingSendCookies,
-            settingStoreCookies: request.settingStoreCookies,
-            statusCode: response.statusCode,
-            statusMessage: response.statusMessage,
-            timelinePath,
-            url: request.url,
-          };
-          console.log('responsePatch:', responsePatch, headers, response.httpVersion, response.httpVersionMajor, response.httpVersionMinor, response.statusMessage);
-
-          models.response.create(responsePatch, settings.maxHistoryResponses);
+      const response = await ipcRenderer.invoke('request', { url: request.url, method: request.method });
+      console.log('response', response);
+      fs.writeFile(responseBodyPath,
+        response.data, function(err) {
+          if (err) throw err;
+          console.log('Saved!');
         });
-        response.on('end', test => {
-          console.log('No more data in response.', test);
+
+      fs.writeFile(timelinePath,
+        timelineStr, function(err) {
+          if (err) throw err;
+          console.log('Saved!');
         });
-      });
-      req.end();
+      const endTime = performance.now();
+      const headers = Object.entries(response.headers).map(([key, value]) => ({ name: key, value })) as [];
+      const responsePatch: network.ResponsePatch = {
+        bodyCompression: null,
+        bodyPath: responseBodyPath,
+        bytesContent: 169, // TODO
+        bytesRead: 169, // TODO
+        contentType: response.headers['content-type'],
+        elapsedTime: endTime - startTime,
+        environmentId,
+        headers,
+        httpVersion: response.httpVersion,
+        parentId: requestId,
+        settingSendCookies: request.settingSendCookies,
+        settingStoreCookies: request.settingStoreCookies,
+        statusCode: response.status,
+        statusMessage: response.statusText,
+        timelinePath,
+        url: request.url,
+      };
 
-      // const responsePatch = await network.send(requestId, environmentId);
-      // console.log(responsePatch);
+      models.response.create(responsePatch, settings.maxHistoryResponses);
 
-      // await models.response.create(responsePatch, settings.maxHistoryResponses);
     } catch (err) {
       if (err.type === 'render') {
         showModal(RequestRenderErrorModal, {

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -851,7 +851,6 @@ class App extends PureComponent<AppProps, State> {
 
     try {
       const responsePatch = await ipcRenderer.invoke('request', request);
-
       // const responsePatch = await network.send(requestId, environmentId);
       models.response.create({ ...responsePatch, environmentId }, settings.maxHistoryResponses);
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Aiming to see what would be missing if we use axios instead of node-libcurl

TODO
- [x] poc with electron.remote.net.request and fs
- [x] use ipcMain to call axios
- [x] move fs to main
- [x] chunked response
- [x] response transform
- [x] request transform
- [x] timeline
- [ ] interpolate environment json "nunjucks"
- [ ] timeline axios interceptor https://github.com/nuxt-community/axios-module/blob/a99b56c11166cc1b0cde89fe5982c853ced17c57/lib/plugin.js#L81
- [ ] cancellation
- [ ] request chaining

Notes
- axios can't set http version directly, but can take a http agent with configuration which may still provide this

Takeaways
- solving event based to promise based request handling is to large a problem to solve along side anything else
- the domain logic for setting options should be decoupled and unit tested away from the request event handles
- we could switch out curl event handlers for nodejs http library event handlers
