### PR TITLE
fonts settings UI changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,6 @@ sudo apt-get update
 
 # Install font configuration library & support
 sudo apt-get install libfontconfig-dev
-sudo apt-get install font-manager
-
-# Build capability for required font-scanner package
-sudo apt-get install build-essential
 ```
 
 </details>
@@ -76,16 +72,6 @@ sudo apt-get install build-essential
 <summary>Fedora</summary>
 
 ```shell
-# Enable FontManager Copr (https://github.com/FontManager/font-manager#fedora-copr)
-sudo dnf copr enable jerrycasiano/FontManager
-
-# Install font configuration library & support
-sudo dnf install font-manager
-sudo dnf install fontconfig-devel
-
-# Build capability for required font-scanner package
-sudo dnf install make automake gcc gcc-c++ kernel-devel
-
 # Install libcurl for node-libcurl
 sudo dnf install libcurl-devel
 ```

--- a/packages/insomnia-app/app/ui/components/settings/general.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/general.tsx
@@ -182,21 +182,8 @@ class General extends PureComponent<Props, State> {
     return this.renderTextSetting(label, name, help, { ...props, type: 'number' });
   }
 
-  formFontstring(fonts:{family:string}[]):string {
-    let fontsList = '';
-    for (const font of fonts){
-      fontsList += (font.family.includes(' ')) ? `\'${font.family}\'` : font.family;
-      fontsList += ' , ';
-    }
-    return fontsList;
-  }
-
   render() {
     const { settings } = this.props;
-    const { fontsMono } = this.state;
-
-    const fontsMonoString:string | null = (fontsMono) ? this.formFontstring(fontsMono) : null;
-
     return (
       <div className="pad-bottom">
         <div className="row-fill row-fill--top">
@@ -284,14 +271,13 @@ class General extends PureComponent<Props, State> {
 
         <div className="form-row pad-top-sm">
           <div className="form-row">
-
             {this.renderTextSetting(
               'Interface Font',
               'fontInterface',
-              'Comma-separated list of fonts. if empty - takes system defaults',
+              'Comma-separated list of fonts. If left empty, takes system defaults.',
               {
                 placeholder: '-- System Default --',
-                onChange:this._handleFontChange,
+                onChange: this._handleFontChange,
               },
             )}
             {this.renderNumberSetting('Interface Font Size (px)', 'fontSize', '', {
@@ -303,14 +289,13 @@ class General extends PureComponent<Props, State> {
         </div>
 
         <div className="form-row">
-
           {this.renderTextSetting(
             'Text Editor Font',
             'fontMonospace',
-            `Comma-separated list of monospase fonts. if empty - takes system defaults. There is list of Monospace fonts in your system: ${fontsMonoString}`,
+            'Comma-separated list of monospace fonts. If left empty, takes system defaults.',
             {
               placeholder: '-- System Default --',
-              onChange:this._handleFontChange,
+              onChange: this._handleFontChange,
             },
           )}
           {this.renderNumberSetting('Editor Font Size (px)', 'editorFontSize', '', {

--- a/packages/insomnia-app/app/ui/components/settings/general.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/general.tsx
@@ -181,9 +181,21 @@ class General extends PureComponent<Props, State> {
     return this.renderTextSetting(label, name, help, { ...props, type: 'number' });
   }
 
+  formFontstring(fonts:{family:string}[]):string {
+    let fontsList = '';
+    for (const font of fonts){
+      fontsList += (font.family.includes(' ')) ? `\'${font.family}\'` : font.family;
+      fontsList += ' , ';
+    }
+    return fontsList;
+  }
+
   render() {
     const { settings } = this.props;
-    const { fonts, fontsMono } = this.state;
+    const { fontsMono } = this.state;
+
+    const fontsMonoString:string | null = (fontsMono) ? this.formFontstring(fontsMono) : null;
+
     return (
       <div className="pad-bottom">
         <div className="row-fill row-fill--top">
@@ -270,62 +282,36 @@ class General extends PureComponent<Props, State> {
         </div>
 
         <div className="form-row pad-top-sm">
-          <div className="form-control form-control--outlined">
-            <label>
-              Interface Font
-              {fonts ? (
-                <select
-                  name="fontInterface"
-                  value={settings.fontInterface || '__NULL__'}
-                  // @ts-expect-error -- TSCONVERSION
-                  onChange={this._handleFontChange}
-                >
-                  <option value="__NULL__">-- System Default --</option>
-                  {fonts.map((item, index) => (
-                    <option key={index} value={item.family}>
-                      {item.family}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <select disabled>
-                  <option value="__NULL__">-- Unsupported Platform --</option>
-                </select>
-              )}
-            </label>
+          <div className="form-row">
+
+            {this.renderTextSetting(
+              'Interface Font',
+              'fontInterface',
+              'Comma-separated list of fonts. if empty - takes system defaults',
+              {
+                placeholder: '-- System Default --',
+                onChange:this._handleFontChange,
+              },
+            )}
+            {this.renderNumberSetting('Interface Font Size (px)', 'fontSize', '', {
+              min: MIN_INTERFACE_FONT_SIZE,
+              max: MAX_INTERFACE_FONT_SIZE,
+              onBlur: this._handleFontChange,
+            })}
           </div>
-          {this.renderNumberSetting('Interface Font Size (px)', 'fontSize', '', {
-            min: MIN_INTERFACE_FONT_SIZE,
-            max: MAX_INTERFACE_FONT_SIZE,
-            onBlur: this._handleFontChange,
-          })}
         </div>
 
         <div className="form-row">
-          <div className="form-control form-control--outlined">
-            <label>
-              Text Editor Font
-              {fontsMono ? (
-                <select
-                  name="fontMonospace"
-                  value={settings.fontMonospace || '__NULL__'}
-                  // @ts-expect-error -- TSCONVERSION
-                  onChange={this._handleFontChange}
-                >
-                  <option value="__NULL__">-- System Default --</option>
-                  {fontsMono.map((item, index) => (
-                    <option key={index} value={item.family}>
-                      {item.family}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <select disabled>
-                  <option value="__NULL__">-- Unsupported Platform --</option>
-                </select>
-              )}
-            </label>
-          </div>
+
+          {this.renderTextSetting(
+            'Text Editor Font',
+            'fontMonospace',
+            `Comma-separated list of monospase fonts. if empty - takes system defaults. There is list of Monospace fonts in your system: ${fontsMonoString}`,
+            {
+              placeholder: '-- System Default --',
+              onChange:this._handleFontChange,
+            },
+          )}
           {this.renderNumberSetting('Editor Font Size (px)', 'editorFontSize', '', {
             min: MIN_EDITOR_FONT_SIZE,
             max: MAX_EDITOR_FONT_SIZE,

--- a/packages/insomnia-app/app/ui/components/settings/general.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/general.tsx
@@ -1,5 +1,4 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import * as fontScanner from 'font-scanner';
 import { HttpVersion, HttpVersions } from 'insomnia-common';
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -37,11 +36,6 @@ import { HelpTooltip } from '../help-tooltip';
 import { BooleanSetting } from './boolean-setting';
 import { MaskedSetting } from './masked-setting';
 
-// Font family regex to match certain monospace fonts that don't get
-// recognized as monospace
-
-const FORCED_MONO_FONT_REGEX = /^fixedsys /i;
-
 interface Props {
   settings: Settings;
   hideModal: () => void;
@@ -49,39 +43,8 @@ interface Props {
   handleSetActiveActivity: (activity?: GlobalActivity) => void;
 }
 
-interface State {
-  fonts: {
-    family: string;
-    monospace: boolean;
-  }[] | null;
-  fontsMono: {
-    family: string;
-    monospace: boolean;
-  }[] | null;
-}
-
 @autoBindMethodsForReact(AUTOBIND_CFG)
-class General extends PureComponent<Props, State> {
-  state: State = {
-    fonts: null,
-    fontsMono: null,
-  };
-
-  async componentDidMount() {
-    const allFonts = await fontScanner.getAvailableFonts();
-    // Find regular fonts
-    const fonts = allFonts
-      .filter(i => ['regular', 'book'].includes(i.style.toLowerCase()) && !i.italic)
-      .sort((a, b) => (a.family > b.family ? 1 : -1));
-    // Find monospaced fonts
-    // NOTE: Also include some others:
-    //  - https://github.com/Kong/insomnia/issues/1835
-    const fontsMono = fonts.filter(i => i.monospace || i.family.match(FORCED_MONO_FONT_REGEX));
-    this.setState({
-      fonts,
-      fontsMono,
-    });
-  }
+class General extends PureComponent<Props> {
 
   async _handleUpdateSetting(e: React.SyntheticEvent<HTMLInputElement>) {
     const el = e.currentTarget;

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -11956,14 +11956,6 @@
 				}
 			}
 		},
-		"font-scanner": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/font-scanner/-/font-scanner-0.1.2.tgz",
-			"integrity": "sha512-60XIPuzqeTey3P8wo/3t2mvKnjeeKl3O9QFzwk2cypQgJaqYF4Q/eOMSCro3YxCzTDzcGA5q5TtDRZXkI3tx0g==",
-			"requires": {
-				"nan": "^2.14.0"
-			}
-		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -92,7 +92,6 @@
     "electron-context-menu": "^2.2.0",
     "electron-log": "^4.3.5",
     "electron-updater": "^4.3.9",
-    "font-scanner": "^0.1.2",
     "framer-motion": "^1.11.1",
     "fs-extra": "^5.0.0",
     "fuzzysort": "^1.1.1",


### PR DESCRIPTION
This PR Closes #2279. It was changed UI element to set Interface and Editor fonts from Dropdown to Text Input. Help texts were added for both.

|Before |After   |
|-------|-------|
| <img width="761" alt="Screenshot before" src="https://user-images.githubusercontent.com/31065254/140984896-83e7fa0f-2870-4f82-86c3-326732c1be6a.png"> | <img width="830" alt="Screenshot after" src="https://user-images.githubusercontent.com/31065254/140985897-e3b16ccc-e128-4b4d-be6e-838066434d6d.png"> |

