### PR TITLE
fixes direct import for insomnia-config

### DIFF
--- a/packages/insomnia-app/app/models/helpers/settings.ts
+++ b/packages/insomnia-app/app/models/helpers/settings.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { Settings } from 'insomnia-common';
-import { ErrorResult, INSOMNIA_CONFIG_FILENAME, InsomniaConfig, isErrorResult, validate } from 'insomnia-config/dist';
+import { ErrorResult, INSOMNIA_CONFIG_FILENAME, InsomniaConfig, isErrorResult, validate } from 'insomnia-config';
 import { resolve } from 'path';
 import { mapObjIndexed, once } from 'ramda';
 import { omitBy } from 'ramda-adjunct';


### PR DESCRIPTION
closes: INS-1158

We had to do this prior to the release of the insomnia-config package because it wasn't published to NPM yet, but now that it is release we can fix the import.