### PR TITLE
reorders github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,13 @@ name: Bug Report
 description: Report an Insomnia bug
 labels: [B-bug, S-unverified]
 body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+      - label: I have searched the [issue tracker](https://www.github.com/Kong/insomnia/issues) for a bug that matches the one I want to file, without success.
+        required: true
 - type: textarea
   attributes:
     label: Expected Behavior
@@ -30,13 +37,6 @@ body:
       If your problem needs further explanation, please add more information here.
 
       Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
-- type: checkboxes
-  attributes:
-    label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the bug you encountered.
-    options:
-      - label: I have searched the [issue tracker](https://www.github.com/Kong/insomnia/issues) for a bug that matches the one I want to file, without success.
-        required: true
 - type: input
   attributes:
     label: Insomnia Version

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,34 @@ name: Bug Report
 description: Report an Insomnia bug
 labels: [B-bug, S-unverified]
 body:
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A clear and concise description of what you expected to happen.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Actual Behavior
+    description: A clear description of what actually happens.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Reproduction Steps
+    description: Provide steps to reproduce the behavior
+    placeholder: |
+      1. Go to '...'
+      2. Click on '....'
+      3. Scroll down to '....'
+      4. See error
+- type: textarea
+  attributes:
+    label: Additional Information
+    description: |
+      If your problem needs further explanation, please add more information here.
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?
@@ -50,31 +78,3 @@ body:
     label: Last Known Working Insomnia version
     description: What is the last version of Insomnia this worked in, if applicable?
     placeholder: "2021.4.0"
-- type: textarea
-  attributes:
-    label: Expected Behavior
-    description: A clear and concise description of what you expected to happen.
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Actual Behavior
-    description: A clear description of what actually happens.
-  validations:
-    required: true
-- type: textarea
-  attributes:
-    label: Reproduction Steps
-    description: Provide steps to reproduce the behavior
-    placeholder: |
-      1. Go to '...'
-      2. Click on '....'
-      3. Scroll down to '....'
-      4. See error
-- type: textarea
-  attributes:
-    label: Additional Information
-    description: |
-      If your problem needs further explanation, please add more information here.
-
-      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,10 +4,8 @@ labels: [B-bug, S-unverified]
 body:
 - type: checkboxes
   attributes:
-    label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the bug you encountered.
     options:
-      - label: I have searched the [issue tracker](https://www.github.com/Kong/insomnia/issues) for a bug that matches the one I want to file, without success.
+      - label: I have searched the [issue tracker](https://www.github.com/Kong/insomnia/issues) for this problem.
         required: true
 - type: textarea
   attributes:
@@ -15,6 +13,9 @@ body:
     description: A clear and concise description of what you expected to happen.
   validations:
     required: true
+- type: markdown
+  attributes:
+    value: '> **Tip**: You can attach images or log files to textareas by clicking to highlight and then dragging files in.'
 - type: textarea
   attributes:
     label: Actual Behavior
@@ -33,10 +34,7 @@ body:
 - type: textarea
   attributes:
     label: Additional Information
-    description: |
-      If your problem needs further explanation, please add more information here.
-
-      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    description: If your problem needs further explanation, please add more information here.
 - type: input
   attributes:
     label: Insomnia Version


### PR DESCRIPTION
closes INS-1160

The goal of this ticket is just to rearrange ~(but not modify)~* the things in the GitHub issue template to make the final output easier to read for developers and contributors.

I added b66c244479c3d1ea244897fac41a945fea8089a8 as a separate commit so we can drop it individually if we decide we don't want to have the "duplicate issue check" at the top.  Seems like there's good reason to do it both ways.

*in https://github.com/Kong/insomnia/pull/4190#discussion_r745144302 there was one other very minor change made