### PR TITLE
Use xz compression instead of bzip2

### DIFF
--- a/packages/insomnia-inso/src/scripts/artifacts.ts
+++ b/packages/insomnia-inso/src/scripts/artifacts.ts
@@ -50,7 +50,7 @@ const startProcess = (cwd: ProcessEnvOptions['cwd']) => {
       [
         '-C',
         '../binaries',
-        isWindows() ? '-a -cf' : '-cjf',
+        isWindows() ? '-a -cf' : '-cJf',
         name,
         '.',
       ], {


### PR DESCRIPTION
`tar -j` uses  bzip2 compression, while `tar -J` uses xz compression. The intention is to use xz compression and this was a typo during a recent refactor.

Validated the CI artifacts:

![image](https://user-images.githubusercontent.com/4312346/140857425-3012c0c4-1510-4b9a-9f18-daf4fcfbcf56.png)


Closes #4185, Closes INS-1162
