### PR TITLE
fix: consistently use `index`

### DIFF
--- a/packages/insomnia-app/app/common/render.ts
+++ b/packages/insomnia-app/app/common/render.ts
@@ -356,8 +356,8 @@ export async function getRenderContext(
 
   // Get Keys from ancestors (e.g. Folders)
   if (ancestors) {
-    for (let idx = 0; idx < ancestors.length; idx++) {
-      const ancestor: any = ancestors[idx] || {};
+    for (let index = 0; index < ancestors.length; index++) {
+      const ancestor: any = ancestors[index] || {};
 
       if (
         isRequestGroup(ancestor) &&

--- a/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -362,9 +362,9 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
     // Do this last so we don't block the sorting
     db.bufferChanges();
 
-    Promise.all(newSubEnvironments.map((environment, idx) => this._updateEnvironment(
+    Promise.all(newSubEnvironments.map((environment, index) => this._updateEnvironment(
       environment,
-      { metaSortKey: idx },
+      { metaSortKey: index },
       false,
     ))).then(() => {
       db.flushChanges();

--- a/packages/insomnia-app/app/ui/components/settings/shortcuts.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/shortcuts.tsx
@@ -82,9 +82,9 @@ export class Shortcuts extends PureComponent<Props> {
     const { hotKeyRegistry, handleUpdateKeyBindings } = this.props;
     const keyCombs = getPlatformKeyCombinations(hotKeyRegistry[hotKeyRefId]);
     let toBeRemovedIndex = -1;
-    keyCombs.forEach((existingKeyComb, idx) => {
+    keyCombs.forEach((existingKeyComb, index) => {
       if (areSameKeyCombinations(existingKeyComb, keyComb)) {
-        toBeRemovedIndex = idx;
+        toBeRemovedIndex = index;
       }
     });
 
@@ -105,18 +105,18 @@ export class Shortcuts extends PureComponent<Props> {
     handleUpdateKeyBindings(newDefaultRegistry());
   }
 
-  renderHotKey(def: HotKeyDefinition, i: number) {
+  renderHotKey(def: HotKeyDefinition, index: number) {
     const keyBindings = this.props.hotKeyRegistry[def.id];
     const keyCombinations = getPlatformKeyCombinations(keyBindings);
     const hasRemoveItems = keyCombinations.length > 0;
     const hasResetItems = !areKeyBindingsSameAsDefault(def.id, keyBindings);
     return (
-      <tr key={i}>
+      <tr key={index}>
         <td>{def.description}</td>
         <td className="text-right">
-          {keyCombinations.map((keyComb: KeyCombination, idx: number) => {
+          {keyCombinations.map((keyComb: KeyCombination, index: number) => {
             return (
-              <code key={idx} className="margin-left-sm">
+              <code key={index} className="margin-left-sm">
                 <Hotkey keyCombination={keyComb} />
               </code>
             );
@@ -181,8 +181,8 @@ export class Shortcuts extends PureComponent<Props> {
         </div>
         <table className="table--fancy">
           <tbody>
-            {HOT_KEY_DEFS.map((def: HotKeyDefinition, idx: number) => {
-              return this.renderHotKey(def, idx);
+            {HOT_KEY_DEFS.map((def: HotKeyDefinition, index: number) => {
+              return this.renderHotKey(def, index);
             })}
           </tbody>
         </table>


### PR DESCRIPTION
closes: INS-1049

just a simple copy/consistency change we noticed in the context of other work.  looping back to update.