### PR TITLE
allow for an empty string as a workspace name in the header

### DIFF
--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
@@ -32,7 +32,7 @@ import { WorkspaceSettingsModal } from '../modals/workspace-settings-modal';
 interface Props {
   activeEnvironment: Environment | null;
   activeWorkspace: Workspace;
-  activeWorkspaceName: string;
+  activeWorkspaceName?: string;
   activeApiSpec: ApiSpec;
   activeProject: Project;
   hotKeyRegistry: HotKeyRegistry;

--- a/packages/insomnia-app/app/ui/components/workspace-page-header.tsx
+++ b/packages/insomnia-app/app/ui/components/workspace-page-header.tsx
@@ -35,7 +35,7 @@ export const WorkspacePageHeader: FunctionComponent<Props> = ({
   );
   const activeProjectName = useSelector(selectActiveProjectName);
 
-  if (!activeWorkspace || !activeWorkspaceName || !activeApiSpec || !activity) {
+  if (!activeWorkspace || !activeApiSpec || !activity) {
     return null;
   }
 


### PR DESCRIPTION
Currently when creating/updating a workspace with an empty name the application ends up in the document view and the navigation disappears.

![empty-workspace-name](https://user-images.githubusercontent.com/12115431/141022096-b1c17ff3-244c-4fe8-85fb-b58bbca9af0f.gif)

Initially I thought there was something happening in the database but it turns out that the header is expecting a name otherwise it doesn't get rendered. I also tested how empty names get handled in a remote project so I ended up allowing an empty name in the page header!

With this fix:

![empty-wrk-name-fix](https://user-images.githubusercontent.com/12115431/141022407-9df94adc-e937-4053-8e90-3b47abcaba9e.gif)

How workspaces with empty names are displayed in a remote project:
![RemoteWorkspaceEmpty](https://user-images.githubusercontent.com/12115431/141021968-9bb464fc-2730-454c-a53f-8c4315f04b56.gif)

Closes INS-1150