### PR TITLE
Use explicit filename with tar

### DIFF
--- a/packages/insomnia-inso/src/scripts/artifacts.ts
+++ b/packages/insomnia-inso/src/scripts/artifacts.ts
@@ -11,7 +11,7 @@ const isMac = () => platform === 'darwin';
 const isLinux = () => platform === 'linux';
 const isWindows = () => platform === 'win32';
 
-const getName = () => {
+const getArchiveName = () => {
   const version = getVersion();
   if (isMac()) {
     return `inso-macos-${version}.zip`;
@@ -29,7 +29,7 @@ const getName = () => {
 };
 
 const startProcess = (cwd: ProcessEnvOptions['cwd']) => {
-  const name = getName();
+  const name = getArchiveName();
 
   if (isMac()) {
     return spawn('ditto',
@@ -52,7 +52,7 @@ const startProcess = (cwd: ProcessEnvOptions['cwd']) => {
         '../binaries',
         isWindows() ? '-a -cf' : '-cJf',
         name,
-        '.',
+        isWindows() ? 'inso.exe' : 'inso',
       ], {
         cwd,
         shell: true,


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

A couple of issues with using tar on Windows...

* I cannot find documentation for what the `-a` flag does, and the archive cannot be opened by Windows Explorer if we archive _without_ the `-a` flag.
* `tar -C ../binaries -a -cf output.zip inso.exe` can be extracted fine by Windows Explorer, but replace `inso.exe` with `.` and the archive fails to extract via Windows Explorer. Is there some different syntax I should be using to say "archive everything in this directory" on Windows?

In any case, this should work fine now. Needs to be validated using the build artifacts created from CI.

Archiving can use a revisit: we use `ditto` on macOS and `tar` for Windows and Linux. We currently produce a zip archive for Windows and macOS, and a `tar.xz` for Linux. We don't need to change any of this until the need for it arises.

Closes INS-1056
