### PR TITLE
feat: add format option to inso generate config

### DIFF
--- a/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
+++ b/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
@@ -94,11 +94,13 @@ exports[`Snapshot for "inso generate config -h" 1`] = `
 Generate configuration from an api spec.
 
 Options:
-  -t, --type <value>   type of configuration to generate, options are
-                       [declarative, kubernetes] (default: declarative)
-  --tags <tags>        comma separated list of tags to apply to each entity
-  -o, --output <path>  save the generated config to a file
-  -h, --help           display help for command"
+  -t, --type <value>    type of configuration to generate, options are
+                        [declarative, kubernetes] (default: declarative)
+  -f, --format <value>  format of configuration to generate, options are [yaml,
+                        json] (default: yaml)
+  --tags <tags>         comma separated list of tags to apply to each entity
+  -o, --output <path>   save the generated config to a file
+  -h, --help            display help for command"
 `;
 
 exports[`Snapshot for "inso help" 1`] = `

--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -73,6 +73,7 @@ describe('cli', () => {
 
       expect(logs.log?.[0]).toContainEqual({
         type: 'declarative',
+        format: 'yaml',
         printOptions: true,
         verbose: true,
       });
@@ -84,6 +85,7 @@ describe('cli', () => {
       inso('generate config');
       expect(generateConfig).toHaveBeenCalledWith(undefined, {
         type: 'declarative',
+        format: 'yaml',
       });
     });
 
@@ -103,6 +105,7 @@ describe('cli', () => {
       inso('generate config -t declarative file.yaml');
       expect(generateConfig).toHaveBeenCalledWith('file.yaml', {
         type: 'declarative',
+        format: 'yaml',
       });
     });
 

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -3,7 +3,7 @@ import { parseArgsStringToArgv } from 'string-argv';
 
 import type { ExportSpecificationOptions } from './commands/export-specification';
 import { exportSpecification } from './commands/export-specification';
-import type { GenerateConfigOptions } from './commands/generate-config';
+import { FormatOption, formatOptions, GenerateConfigOptions } from './commands/generate-config';
 import { ConversionOption, conversionOptions, generateConfig } from './commands/generate-config';
 import type { LintSpecificationOptions } from './commands/lint-specification';
 import { lintSpecification } from './commands/lint-specification';
@@ -26,6 +26,7 @@ const makeGenerateCommand = (commandCreator: CreateCommand) => {
   // inso generate
   const command = commandCreator('generate').description('Code generation utilities');
   const defaultType: ConversionOption = 'declarative';
+  const defaultFormat: FormatOption = 'yaml';
 
   // inso generate config -t kubernetes config.yaml
   command
@@ -35,11 +36,16 @@ const makeGenerateCommand = (commandCreator: CreateCommand) => {
       '-t, --type <value>',
       `type of configuration to generate, options are [${conversionOptions.join(', ')}] (default: ${defaultType})`,
     )
+    .option(
+      '-f, --format <value>',
+      `format of configuration to generate, options are [${formatOptions.join(', ')}] (default: ${defaultFormat})`,
+    )
     .option('--tags <tags>', 'comma separated list of tags to apply to each entity')
     .option('-o, --output <path>', 'save the generated config to a file')
     .action((identifier, cmd) => {
       let options = getOptions<GenerateConfigOptions>(cmd, {
         type: defaultType,
+        format: defaultFormat,
       });
       options = prepareCommand(options);
       return exit(generateConfig(identifier, options));

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -3,8 +3,14 @@ import { parseArgsStringToArgv } from 'string-argv';
 
 import type { ExportSpecificationOptions } from './commands/export-specification';
 import { exportSpecification } from './commands/export-specification';
-import { FormatOption, formatOptions, GenerateConfigOptions } from './commands/generate-config';
-import { ConversionOption, conversionOptions, generateConfig } from './commands/generate-config';
+import {
+  ConversionOption,
+  conversionOptions,
+  FormatOption,
+  formatOptions,
+  generateConfig,
+  GenerateConfigOptions,
+} from './commands/generate-config';
 import type { LintSpecificationOptions } from './commands/lint-specification';
 import { lintSpecification } from './commands/lint-specification';
 import type { RunTestsOptions } from './commands/run-tests';

--- a/packages/insomnia-inso/src/commands/generate-config.test.ts
+++ b/packages/insomnia-inso/src/commands/generate-config.test.ts
@@ -191,6 +191,22 @@ describe('generateConfig()', () => {
     );
     expect(result).toBe(true);
     expect(logger.__getLogs().log).toEqual([
+      `_format_version: \"1.1\"
+services: []
+upstreams: []
+`,
+    ]);
+  });
+
+  it('when format is json should generate declarative config as json', async () => {
+    generate.mockResolvedValue(mockDeclarativeConversionResult);
+
+    const result = await generateConfig(
+      filePath,
+      { type: 'declarative', format: 'json' }
+    );
+    expect(result).toBe(true);
+    expect(logger.__getLogs().log).toEqual([
       '{"_format_version":"1.1","services":[],"upstreams":[]}',
     ]);
   });

--- a/packages/insomnia-inso/src/commands/generate-config.test.ts
+++ b/packages/insomnia-inso/src/commands/generate-config.test.ts
@@ -198,7 +198,7 @@ upstreams: []
     ]);
   });
 
-  it('when format is json should generate declarative config as json', async () => {
+  it('should generate declarative config as json when format is set to json', async () => {
     generate.mockResolvedValue(mockDeclarativeConversionResult);
 
     const result = await generateConfig(

--- a/packages/insomnia-inso/src/commands/generate-config.ts
+++ b/packages/insomnia-inso/src/commands/generate-config.ts
@@ -16,6 +16,13 @@ export const conversionOptions: ConversionOption[] = [
   'kubernetes',
 ];
 
+export type FormatOption = 'yaml' | 'json';
+
+export const formatOptions: FormatOption[] = [
+  'yaml',
+  'json',
+];
+
 export const conversionTypeMap: Record<ConversionOption, ConversionResultType> = {
   kubernetes: 'kong-for-kubernetes',
   declarative: 'kong-declarative-config',
@@ -24,6 +31,7 @@ export const conversionTypeMap: Record<ConversionOption, ConversionResultType> =
 export type GenerateConfigOptions = GlobalOptions & {
   type: ConversionOption;
   output?: string;
+  format?: string;
 
   /** a comma-separated list of tags */
   tags?: string;
@@ -49,7 +57,7 @@ export const generateConfig = async (
     return false;
   }
 
-  const { type, output, tags, appDataDir, workingDir, ci, src } = options;
+  const { type, output, tags, appDataDir, workingDir, ci, src, format } = options;
   const db = await loadDb({
     workingDir,
     appDataDir,
@@ -94,7 +102,8 @@ export const generateConfig = async (
   let document = '';
   if (isListOfDeclarativeConfigs(result.documents)){
     // We know for certain the result.documents has only one entry for declarative config: packages/openapi-2-kong/src/declarative-config/generate.ts#L20
-    document = JSON.stringify(result.documents?.[0]);
+    const declarativeConfig = result.documents?.[0];
+    document = format?.toLocaleLowerCase() === 'json' ? JSON.stringify(declarativeConfig) : YAML.stringify(declarativeConfig);
   } else {
     const yamlDocs = result.documents.map((document: K8sManifest) => YAML.stringify(document));
     // Join the YAML docs with "---" and strip any extra newlines surrounding them

--- a/packages/insomnia-inso/src/commands/generate-config.ts
+++ b/packages/insomnia-inso/src/commands/generate-config.ts
@@ -31,7 +31,7 @@ export const conversionTypeMap: Record<ConversionOption, ConversionResultType> =
 export type GenerateConfigOptions = GlobalOptions & {
   type: ConversionOption;
   output?: string;
-  format?: string;
+  format?: FormatOption;
 
   /** a comma-separated list of tags */
   tags?: string;


### PR DESCRIPTION
Closes INS-1081

Adds argument to support JSON format to inso cli

inso default output remains YAML
add --format=json to override output format

related: https://github.com/Kong/insomnia/issues/3938

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
