### PR TITLE
Extend config generator plugin API and modal to handle documentation links

### DIFF
--- a/packages/insomnia-app/app/plugins/index.ts
+++ b/packages/insomnia-app/app/plugins/index.ts
@@ -90,7 +90,7 @@ export interface SpecInfo {
 
 export interface ConfigGenerator extends InternalProperties {
   label: string;
-  docsLink: string;
+  docsLink?: string;
   generate: (
     info: SpecInfo,
   ) => Promise<{

--- a/packages/insomnia-app/app/plugins/index.ts
+++ b/packages/insomnia-app/app/plugins/index.ts
@@ -90,6 +90,7 @@ export interface SpecInfo {
 
 export interface ConfigGenerator extends InternalProperties {
   label: string;
+  docsLink: string;
   generate: (
     info: SpecInfo,
   ) => Promise<{

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
@@ -99,7 +99,7 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
         <TabPanel key={config.label}>
           <Notice color="error" className="margin-md">
             {config.error}
-            {!!config.docsLink && <><br /><Link href={config.docsLink}>Documentation {linkIcon}</Link></>}
+            {!!config.docsLink ? <><br /><Link href={config.docsLink}>Documentation {linkIcon}</Link></> : null}
           </Notice>
         </TabPanel>
       );
@@ -134,15 +134,15 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
       <Tab key={config.label} tabIndex="-1">
         <button>
           {config.label}
-          {!!config.docsLink &&
-          <>
-            {' '}
-            <HelpTooltip>
-              To learn more about {config.label}
-              <br />
-              <Link href={config.docsLink}>Documentation {linkIcon}</Link>
-            </HelpTooltip>
-          </>}
+          {!!config.docsLink ?
+            <>
+              {' '}
+              <HelpTooltip>
+                To learn more about {config.label}
+                <br />
+                <Link href={config.docsLink}>Documentation {linkIcon}</Link>
+              </HelpTooltip>
+            </> : null}
         </button>
       </Tab>
     );

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
@@ -55,26 +55,30 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
   }
 
   async _generate(generatePlugin: ConfigGenerator, apiSpec: ApiSpec) {
-    const config: Config = {
-      content: '',
-      mimeType: 'text/yaml',
-      label: generatePlugin.label,
-      docsLink: generatePlugin.docsLink,
-      error: null,
-    };
-    let result;
-
     try {
-      // @ts-expect-error -- TSCONVERSION
-      result = await generatePlugin.generate(parseApiSpec(apiSpec.contents));
+      const spec = parseApiSpec(apiSpec.contents);
+      const result = await generatePlugin.generate({
+        format: spec.format || 'openapi',
+        formatVersion: spec.formatVersion || '',
+        contents: spec.contents || {},
+        rawContents: spec.rawContents,
+      });
+      return {
+        mimeType: 'text/yaml',
+        label: generatePlugin.label,
+        docsLink: generatePlugin.docsLink,
+        content: result.document || '',
+        error: result.error || null,
+      };
     } catch (err) {
-      config.error = err.message;
-      return config;
+      return {
+        mimeType: 'text/yaml',
+        label: generatePlugin.label,
+        docsLink: generatePlugin.docsLink,
+        content: '',
+        error: err.message,
+      };
     }
-
-    config.content = result.document || null;
-    config.error = result.error || null;
-    return config;
   }
 
   async show({ activeTabLabel, apiSpec }: ShowOptions) {

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
@@ -4,7 +4,6 @@ import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
 import { parseApiSpec } from '../../../common/api-specs';
 import { AUTOBIND_CFG } from '../../../common/constants';
-import { docsImportExport } from '../../../common/documentation';
 import type { ApiSpec } from '../../../models/api-spec';
 import type { Settings } from '../../../models/settings';
 import type { ConfigGenerator } from '../../../plugins';
@@ -26,6 +25,7 @@ interface Props {
 
 interface Config {
   label: string;
+  docsLink?: string;
   content: string;
   mimeType: string;
   error: string | null;
@@ -99,8 +99,7 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
         <TabPanel key={config.label}>
           <Notice color="error" className="margin-md">
             {config.error}
-            <br />
-            <Link href={docsImportExport}>Documentation {linkIcon}</Link>
+            {!!config.docsLink && <><br /><Link href={config.docsLink}>Documentation {linkIcon}</Link></>}
           </Notice>
         </TabPanel>
       );
@@ -133,12 +132,17 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
     const linkIcon = <i className="fa fa-external-link-square" />;
     return (
       <Tab key={config.label} tabIndex="-1">
-        <button>{config.label + ' '}
-          <HelpTooltip>
-            To learn more about {config.label}
-            <br />
-            <Link href={docsImportExport}>Documentation {linkIcon}</Link>
-          </HelpTooltip>
+        <button>
+          {config.label}
+          {!!config.docsLink &&
+          <>
+            {' '}
+            <HelpTooltip>
+              To learn more about {config.label}
+              <br />
+              <Link href={config.docsLink}>Documentation {linkIcon}</Link>
+            </HelpTooltip>
+          </>}
         </button>
       </Tab>
     );

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
@@ -59,6 +59,7 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
       content: '',
       mimeType: 'text/yaml',
       label: generatePlugin.label,
+      docsLink: generatePlugin.docsLink,
       error: null,
     };
     let result;
@@ -130,6 +131,7 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
 
   renderConfigTab(config: Config) {
     const linkIcon = <i className="fa fa-external-link-square" />;
+    console.log(config);
     return (
       <Tab key={config.label} tabIndex="-1">
         <button>

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
@@ -59,6 +59,7 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
       content: '',
       mimeType: 'text/yaml',
       label: generatePlugin.label,
+      docsLink: generatePlugin.docsLink,
       error: null,
     };
     let result;

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
@@ -104,7 +104,7 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
         <TabPanel key={config.label}>
           <Notice color="error" className="margin-md">
             {config.error}
-            {!!config.docsLink ? <><br /><Link href={config.docsLink}>Documentation {linkIcon}</Link></> : null}
+            {config.docsLink ? <><br /><Link href={config.docsLink}>Documentation {linkIcon}</Link></> : null}
           </Notice>
         </TabPanel>
       );
@@ -135,12 +135,11 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
 
   renderConfigTab(config: Config) {
     const linkIcon = <i className="fa fa-external-link-square" />;
-    console.log(config);
     return (
       <Tab key={config.label} tabIndex="-1">
         <button>
           {config.label}
-          {!!config.docsLink ?
+          {config.docsLink ?
             <>
               {' '}
               <HelpTooltip>

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
@@ -4,16 +4,19 @@ import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
 import { parseApiSpec } from '../../../common/api-specs';
 import { AUTOBIND_CFG } from '../../../common/constants';
+import { docsImportExport } from '../../../common/documentation';
 import type { ApiSpec } from '../../../models/api-spec';
 import type { Settings } from '../../../models/settings';
 import type { ConfigGenerator } from '../../../plugins';
 import * as plugins from '../../../plugins';
 import { CopyButton } from '../base/copy-button';
+import { Link } from '../base/link';
 import { Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
 import { CodeEditor } from '../codemirror/code-editor';
+import { HelpTooltip } from '../help-tooltip';
 import { Notice } from '../notice';
 import { showModal } from './index';
 
@@ -90,12 +93,14 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
 
   renderConfigTabPanel(config: Config) {
     const { settings } = this.props;
-
+    const linkIcon = <i className="fa fa-external-link-square" />;
     if (config.error) {
       return (
         <TabPanel key={config.label}>
           <Notice color="error" className="margin-md">
             {config.error}
+            <br />
+            <Link href={docsImportExport}>Documentation {linkIcon}</Link>
           </Notice>
         </TabPanel>
       );
@@ -125,9 +130,16 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
   }
 
   renderConfigTab(config: Config) {
+    const linkIcon = <i className="fa fa-external-link-square" />;
     return (
       <Tab key={config.label} tabIndex="-1">
-        <button>{config.label}</button>
+        <button>{config.label + ' '}
+          <HelpTooltip>
+            To learn more about {config.label}
+            <br />
+            <Link href={docsImportExport}>Documentation {linkIcon}</Link>
+          </HelpTooltip>
+        </button>
       </Tab>
     );
   }

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
@@ -55,30 +55,25 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
   }
 
   async _generate(generatePlugin: ConfigGenerator, apiSpec: ApiSpec) {
+    const config: Config = {
+      content: '',
+      mimeType: 'text/yaml',
+      label: generatePlugin.label,
+      error: null,
+    };
+    let result;
+
     try {
-      const spec = parseApiSpec(apiSpec.contents);
-      const result = await generatePlugin.generate({
-        format: spec.format || 'openapi',
-        formatVersion: spec.formatVersion || '',
-        contents: spec.contents || {},
-        rawContents: spec.rawContents,
-      });
-      return {
-        mimeType: 'text/yaml',
-        label: generatePlugin.label,
-        docsLink: generatePlugin.docsLink,
-        content: result.document || '',
-        error: result.error || null,
-      };
+      // @ts-expect-error -- TSCONVERSION
+      result = await generatePlugin.generate(parseApiSpec(apiSpec.contents));
     } catch (err) {
-      return {
-        mimeType: 'text/yaml',
-        label: generatePlugin.label,
-        docsLink: generatePlugin.docsLink,
-        content: '',
-        error: err.message,
-      };
+      config.error = err.message;
+      return config;
     }
+
+    config.content = result.document || null;
+    config.error = result.error || null;
+    return config;
   }
 
   async show({ activeTabLabel, apiSpec }: ShowOptions) {

--- a/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
@@ -1,38 +1,31 @@
-const YAML = require('yaml');
 const o2k = require('openapi-2-kong');
 
 module.exports = {
   label: 'Declarative Config',
-  docsLink: 'https://docs.insomnia.rest/insomnia/kong-for-kubernetes',
-  generate: async ({ contents, format, formatVersion }) => {
-    const isSupported = format === 'openapi' && formatVersion.match(/^3./);
-    const capitalisedInitial = format?.replace(/^\w/, c => c.toUpperCase());
-    const capitalisedFormat = format === 'openapi' ? 'OpenAPI' : capitalisedInitial;
-    // Return to signify that it's not supported
+  docsLink: 'https://docs.insomnia.rest/insomnia/declarative-config',
+  generate: async ({ contents, formatVersion }) => {
+    const isSupported = formatVersion && formatVersion.match(/^3./);
+
     if (!isSupported) {
       return {
         document: null,
-        error: `Unsupported spec format ${capitalisedFormat} ${formatVersion}`,
+        error: `Unsupported OpenAPI spec format ${formatVersion}`,
       };
     }
 
-    let result;
-
     try {
-      result = await o2k.generateFromString(contents, 'kong-declarative-config');
+      const result = await o2k.generateFromString(contents, 'kong-declarative-config');
+      // We know for certain the result.documents has only one entry for declarative config: packages/openapi-2-kong/src/declarative-config/generate.ts#L20
+      const declarativeConfig = result.documents?.[0]
+      return {
+        document: JSON.stringify(declarativeConfig, null, '\t'),
+        error: null,
+      };
     } catch (err) {
       return {
         document: null,
         error: err.message,
       };
     }
-    
-    // We know for certain the result.documents has only one entry for declarative config: packages/openapi-2-kong/src/declarative-config/generate.ts#L20
-    const document = JSON.stringify(result.documents?.[0], null, '\t');
-
-    return {
-      document,
-      error: null,
-    };
   },
 };

--- a/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
@@ -3,6 +3,7 @@ const o2k = require('openapi-2-kong');
 
 module.exports = {
   label: 'Declarative Config',
+  docsLink: 'https://docs.insomnia.rest/insomnia/kong-for-kubernetes',
   generate: async ({ contents, format, formatVersion }) => {
     const isSupported = format === 'openapi' && formatVersion.match(/^3./);
     const capitalisedFormat = format === 'openapi' ? 'OpenAPI' : format?.replace(/^\w/, c => c.toUpperCase())

--- a/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
@@ -6,7 +6,8 @@ module.exports = {
   docsLink: 'https://docs.insomnia.rest/insomnia/kong-for-kubernetes',
   generate: async ({ contents, format, formatVersion }) => {
     const isSupported = format === 'openapi' && formatVersion.match(/^3./);
-    const capitalisedFormat = format === 'openapi' ? 'OpenAPI' : format?.replace(/^\w/, c => c.toUpperCase())
+    const capitalisedInitial = format?.replace(/^\w/, c => c.toUpperCase());
+    const capitalisedFormat = format === 'openapi' ? 'OpenAPI' : capitalisedInitial;
     // Return to signify that it's not supported
     if (!isSupported) {
       return {

--- a/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
@@ -5,12 +5,12 @@ module.exports = {
   label: 'Declarative Config',
   generate: async ({ contents, format, formatVersion }) => {
     const isSupported = format === 'openapi' && formatVersion.match(/^3./);
-
+    const capitalisedFormat = format === 'openapi' ? 'OpenAPI' : format?.replace(/^\w/, c => c.toUpperCase())
     // Return to signify that it's not supported
     if (!isSupported) {
       return {
         document: null,
-        error: `Unsupported spec format ${format} ${formatVersion}`,
+        error: `Unsupported spec format ${capitalisedFormat} ${formatVersion}`,
       };
     }
 

--- a/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
@@ -3,39 +3,31 @@ const o2k = require('openapi-2-kong');
 
 module.exports = {
   label: 'Kong for Kubernetes',
-  docsLink: 'https://docs.insomnia.rest/insomnia/declarative-config',
-  generate: async ({ contents, format, formatVersion }) => {
-    const isSupported = format === 'openapi' && formatVersion.match(/^3./);
-    const capitalisedInitial = format?.replace(/^\w/, c => c.toUpperCase());
-    const capitalisedFormat = format === 'openapi' ? 'OpenAPI' : capitalisedInitial;
+  docsLink: 'https://docs.insomnia.rest/insomnia/kong-for-kubernetes',
+  generate: async ({ contents, formatVersion }) => {
+    const isSupported = formatVersion && formatVersion.match(/^3./);
 
-    // Return to signify that it's not supported
     if (!isSupported) {
       return {
         document: null,
-        error: `Unsupported spec format ${capitalisedFormat} ${formatVersion}`,
+        error: `Unsupported OpenAPI spec format ${formatVersion}`,
       };
     }
 
-    let result;
-
     try {
-      result = await o2k.generateFromString(contents, 'kong-for-kubernetes');
+      const result = await o2k.generateFromString(contents, 'kong-for-kubernetes');
+      const yamlDocs = result.documents.map(d => YAML.stringify(d));
+
+      return {
+        // Join the YAML docs with "---" and strip any extra newlines surrounding them
+        document: yamlDocs.join('\n---\n').replace(/\n+---\n+/g, '\n---\n'),
+        error: null,
+      };
     } catch (err) {
       return {
         document: null,
         error: err.message,
       };
     }
-
-    const yamlDocs = result.documents.map(d => YAML.stringify(d));
-
-    // Join the YAML docs with "---" and strip any extra newlines surrounding them
-    const document = yamlDocs.join('\n---\n').replace(/\n+---\n+/g, '\n---\n');
-
-    return {
-      document,
-      error: null,
-    };
   },
 };

--- a/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
@@ -3,14 +3,16 @@ const o2k = require('openapi-2-kong');
 
 module.exports = {
   label: 'Kong for Kubernetes',
+  docsLink: 'https://docs.insomnia.rest/insomnia/declarative-config',
   generate: async ({ contents, format, formatVersion }) => {
     const isSupported = format === 'openapi' && formatVersion.match(/^3./);
+    const capitalisedFormat = format === 'openapi' ? 'OpenAPI' : format?.replace(/^\w/, c => c.toUpperCase())
 
     // Return to signify that it's not supported
     if (!isSupported) {
       return {
         document: null,
-        error: `Unsupported spec format ${format} ${formatVersion}`,
+        error: `Unsupported spec format ${capitalisedFormat} ${formatVersion}`,
       };
     }
 

--- a/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
@@ -6,7 +6,8 @@ module.exports = {
   docsLink: 'https://docs.insomnia.rest/insomnia/declarative-config',
   generate: async ({ contents, format, formatVersion }) => {
     const isSupported = format === 'openapi' && formatVersion.match(/^3./);
-    const capitalisedFormat = format === 'openapi' ? 'OpenAPI' : format?.replace(/^\w/, c => c.toUpperCase())
+    const capitalisedInitial = format?.replace(/^\w/, c => c.toUpperCase());
+    const capitalisedFormat = format === 'openapi' ? 'OpenAPI' : capitalisedInitial;
 
     // Return to signify that it's not supported
     if (!isSupported) {


### PR DESCRIPTION
Closes INS-1063

Adds a link to Documentation in the declarative kong config and k8s config tabs and error messages

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
