### PR TITLE
chore: smoke test resiliance

### DIFF
--- a/packages/insomnia-smoke-test/modules/application.ts
+++ b/packages/insomnia-smoke-test/modules/application.ts
@@ -71,7 +71,8 @@ const launch = async config => {
     waitTimeout: 10000,
   });
 
-  await app.start().then(async () => {
+  const promise = app.start();
+  promise.then(async () => {
     // Windows spawns two terminal windows when running spectron, and the only workaround
     // is to focus the window on start.
     // https://github.com/electron-userland/spectron/issues/60
@@ -87,7 +88,7 @@ const launch = async config => {
     // Set bounds to default size
     await app.browserWindow.setSize(1280, 700);
   });
-  return app;
+  return promise;
 };
 
 export const stop = async app => {

--- a/packages/insomnia-smoke-test/modules/debug.ts
+++ b/packages/insomnia-smoke-test/modules/debug.ts
@@ -92,7 +92,7 @@ export const clickSendRequest = async (app: Application) => {
   await spinner.waitForDisplayed();
 
   // Wait for spinner to hide
-  await spinner.waitForDisplayed({ reverse: true });
+  await spinner.waitForDisplayed({ reverse: true, timeout: 30000 });
 };
 
 export const expect200 = async (app: Application) => {


### PR DESCRIPTION
the promise change appears to help with the below in my local windows env
```
[app]     Received promise rejected instead of resolved
[app]     Rejected to value: [invalid session id: invalid session id]
```
although its very hard to tell without running it mutliple times on CI...

the timeout also helped in my local experiments to avoid the timeout after send request, feels a bit arbitrary though :shrug:

planning to just keep hitting update branch for the next couple weeks to see if it ever breaks.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
