### PR TITLE
fixes bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,11 +2,6 @@ name: Bug Report
 description: Report an Insomnia bug
 labels: [B-bug, S-unverified]
 body:
-- type: checkboxes
-  attributes:
-    options:
-      - label: I have searched the [issue tracker](https://www.github.com/Kong/insomnia/issues) for this problem.
-        required: true
 - type: textarea
   attributes:
     label: Expected Behavior
@@ -31,6 +26,12 @@ body:
       2. Click on '....'
       3. Scroll down to '....'
       4. See error
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    options:
+      - label: I have searched the [issue tracker](https://www.github.com/Kong/insomnia/issues) for this problem.
+        required: true
 - type: textarea
   attributes:
     label: Additional Information


### PR DESCRIPTION
GitHub's documentation for issue templates _and_ validation for this entity is wrong.

Worse, I tested exactly what broke here before the insomnia PR merged (see https://github.com/dimitropoulos/insomnia-test/issues/3) and it absolutely _did_ work, just a few hours prior.

On their docs https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#checkboxes
<img height=400 src="https://user-images.githubusercontent.com/15232461/141183917-1985b2af-7351-4076-ad24-146da9472958.png" />

They say that the `label` field is optional.

This same message is communicated on the help text in a side panel when you edit a template:
<img height=300 src="https://user-images.githubusercontent.com/15232461/141184108-b90229c4-8618-4ef1-8884-77f2c20bf107.png" />

> NOTE: it says the `label` field is optional.

Mind you, there is validation for issue templates.  Here's what happens when there is a validation error in the config:

<img height=300 src="https://user-images.githubusercontent.com/15232461/141184570-1966ba5e-347f-4bb9-9639-5c8cd6b743aa.png" />

However... no such validation exists for this field.

Not providing `label` to a `checkboxes` type in the issue template causes the user a failed submission and a 400 error:

<img height=300 src="https://user-images.githubusercontent.com/15232461/141185611-c62a7459-4994-4d58-b993-9d00fb9a006e.png" />

You can see this exact config in https://github.com/dimitropoulos/insomnia-test and you can see the result of submitting this exact config in https://github.com/dimitropoulos/insomnia-test/issues/13