### PR TITLE
fixes defaultTabBehavior for OneLineEditor

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -39,7 +39,6 @@ import { FilterHelpModal } from '../modals/filter-help-modal';
 import { showModal } from '../modals/index';
 import { normalizeIrregularWhitespace } from './normalizeIrregularWhitespace';
 
-const TAB_KEY = 9;
 const TAB_SIZE = 4;
 const MAX_SIZE_FOR_LINTING = 1000000; // Around 1MB
 
@@ -956,7 +955,7 @@ export class UnconnectedCodeEditor extends Component<Props, State> {
 
   async _codemirrorKeyDown(doc: CodeMirror.EditorFromTextArea, e: KeyboardEvent & {codemirrorIgnore: boolean}) {
     // Use default tab behaviour if we're told
-    if (this.props.defaultTabBehavior && e.code === TAB_KEY.toString()) {
+    if (this.props.defaultTabBehavior && e.code === 'Tab') {
       e.codemirrorIgnore = true;
     }
 


### PR DESCRIPTION
closes: #4206
closes: INS-1170

Pressing the tab key on a OneLineEditor was inserting tabs (if no selection) or indent (if selection) when instead it should shift tabIndex.  This was because the change in [this commit](https://github.com/Kong/insomnia/pull/3993/commits/39a4a0286f9b9398d856905e38f04b0e2fc18629#diff-111d80360a042255b5795cbbd547911cd7ffe089a551617a57ba92e2a4daaa9aL921).  The change was motivated because `keyCode` is deprecated.  The event was typed implicitly as `any` before, so when adding the type it looked like this:

![Screenshot_20211115_111458](https://user-images.githubusercontent.com/15232461/141815939-5a0766c0-9d90-42f4-b4aa-50e38196b6f8.png)

Unfortunately, the constant `TAB_KEY` sortof obscures the fact that it was a number.  Based on that, instead of updating the constant I just removed it and pulled it into the condition.  I would wager that if this line had read `e.keyCode === 9` that this bug would never have been able to fly under the radar like it did.

It's a bit tricky, as it was before, and perhaps less so now.