### PR TITLE
Refactor/choose-openapi-over-generic-spec-format

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/api-specs.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/api-specs.test.ts
@@ -16,8 +16,7 @@ describe('parseApiSpec()', () => {
     const yamlSpec = YAML.stringify(objSpec);
     const jsonSpec = JSON.stringify(objSpec);
     const expected = {
-      format: 'openapi',
-      formatVersion: '3.0.0',
+      openapiVersion: '3.0.0',
       contents: objSpec,
     };
     expect(parseApiSpec(yamlSpec)).toEqual({ ...expected, rawContents: yamlSpec });
@@ -32,8 +31,7 @@ describe('parseApiSpec()', () => {
       },
     };
     const expected = {
-      format: 'swagger',
-      formatVersion: '2.0.0',
+      openapiVersion: '2.0.0',
       contents: objSpec,
     };
     const yamlSpec = YAML.stringify(objSpec);
@@ -50,8 +48,7 @@ describe('parseApiSpec()', () => {
       },
     };
     const expected = {
-      format: null,
-      formatVersion: null,
+      openapiVersion: null,
       contents: objSpec,
     };
     const yamlSpec = YAML.stringify(objSpec);
@@ -62,8 +59,7 @@ describe('parseApiSpec()', () => {
 
   it('returns the default result if empty document', () => {
     const expected = {
-      format: null,
-      formatVersion: null,
+      openapiVersion: null,
       contents: null,
       rawContents: '',
     };

--- a/packages/insomnia-app/app/common/api-specs.ts
+++ b/packages/insomnia-app/app/common/api-specs.ts
@@ -3,8 +3,7 @@ import YAML from 'yaml';
 export interface ParsedApiSpec {
   contents: Record<string, any> | null;
   rawContents: string;
-  format: 'openapi' | 'swagger' | null;
-  formatVersion: string | null;
+  openapiVersion: string | null;
 }
 
 export function parseApiSpec(
@@ -13,8 +12,7 @@ export function parseApiSpec(
   const result: ParsedApiSpec = {
     contents: null,
     rawContents: rawDocument,
-    format: null,
-    formatVersion: null,
+    openapiVersion: null,
   };
 
   // NOTE: JSON is valid YAML so we only need to parse YAML
@@ -27,12 +25,10 @@ export function parseApiSpec(
   if (result.contents) {
     if (result.contents.openapi) {
       // Check if it's OpenAPI
-      result.format = 'openapi';
-      result.formatVersion = result.contents.openapi;
+      result.openapiVersion = result.contents.openapi;
     } else if (result.contents.swagger) {
       // Check if it's Swagger
-      result.format = 'swagger';
-      result.formatVersion = result.contents.swagger;
+      result.openapiVersion = result.contents.swagger;
     } else {
       // Not sure what format it is
     }

--- a/packages/insomnia-app/app/plugins/index.ts
+++ b/packages/insomnia-app/app/plugins/index.ts
@@ -84,8 +84,7 @@ export interface WorkspaceAction extends InternalProperties {
 export interface SpecInfo {
   contents: Record<string, any>;
   rawContents: string;
-  format: string;
-  formatVersion: string;
+  openapiVersion: string;
 }
 
 export interface ConfigGenerator extends InternalProperties {

--- a/packages/insomnia-app/app/ui/components/workspace-card.tsx
+++ b/packages/insomnia-app/app/ui/components/workspace-card.tsx
@@ -27,8 +27,7 @@ export interface WorkspaceCardProps {
   lastCommitAuthor?: string | null;
   modifiedLocally?: number;
   spec: Record<string, any> | null;
-  specFormat: 'openapi' | 'swagger' | null;
-  specFormatVersion: string | null;
+  openapiVersion: string | null;
   hasUnsavedChanges: boolean;
   onSelect: (workspaceId: string, activity: GlobalActivity) => void;
 }
@@ -44,8 +43,7 @@ export const WorkspaceCard: FC<WorkspaceCardProps> = ({
   modifiedLocally,
   lastCommitAuthor,
   spec,
-  specFormat,
-  specFormatVersion,
+  openapiVersion,
   hasUnsavedChanges,
   onSelect,
 }) => {
@@ -96,12 +94,7 @@ export const WorkspaceCard: FC<WorkspaceCardProps> = ({
     label = strings.document.singular;
     labelIcon = <i className="fa fa-file-o" />;
 
-    if (specFormat === 'openapi') {
-      format = `OpenAPI ${specFormatVersion}`;
-    } else if (specFormat === 'swagger') {
-      // NOTE: This is not a typo, we're labeling Swagger as OpenAPI also
-      format = `OpenAPI ${specFormatVersion}`;
-    }
+    format = `OpenAPI ${openapiVersion}`;
 
     defaultActivity = ACTIVITY_SPEC;
     title = apiSpec.fileName || title;

--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -90,14 +90,12 @@ const mapWorkspaceToWorkspaceCard = ({
   }
 
   let spec: ParsedApiSpec['contents'] = null;
-  let specFormat: ParsedApiSpec['format'] = null;
-  let specFormatVersion: ParsedApiSpec['formatVersion'] = null;
+  let openapiVersion: ParsedApiSpec['openapiVersion'] = null;
 
   try {
     const result = parseApiSpec(apiSpec.contents);
     spec = result.contents;
-    specFormat = result.format;
-    specFormatVersion = result.formatVersion;
+    openapiVersion = result.openapiVersion;
   } catch (err) {
     // Assume there is no spec
     // TODO: Check for parse errors if it's an invalid spec
@@ -143,9 +141,8 @@ const mapWorkspaceToWorkspaceCard = ({
     lastCommitAuthor,
     lastActiveBranch,
     spec,
-    specFormat,
     apiSpec,
-    specFormatVersion,
+    openapiVersion,
     workspace,
   };
 };

--- a/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
@@ -3,14 +3,14 @@ const o2k = require('openapi-2-kong');
 
 module.exports = {
   label: 'Declarative Config',
-  generate: async ({ contents, format, formatVersion }) => {
-    const isSupported = format === 'openapi' && formatVersion.match(/^3./);
+  generate: async ({ contents, openapiVersion }) => {
+    const isSupported = openapiVersion && openapiVersion.match(/^3./);
 
     // Return to signify that it's not supported
     if (!isSupported) {
       return {
         document: null,
-        error: `Unsupported spec format ${format} ${formatVersion}`,
+        error: `Unsupported OpenAPI spec format ${openapiVersion}`,
       };
     }
 

--- a/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-kubernetes-config/src/generate.js
@@ -3,14 +3,14 @@ const o2k = require('openapi-2-kong');
 
 module.exports = {
   label: 'Kong for Kubernetes',
-  generate: async ({ contents, format, formatVersion }) => {
-    const isSupported = format === 'openapi' && formatVersion.match(/^3./);
+  generate: async ({ contents, openapiVersion }) => {
+    const isSupported = openapiVersion && openapiVersion.match(/^3./);
 
     // Return to signify that it's not supported
     if (!isSupported) {
       return {
         document: null,
-        error: `Unsupported spec format ${format} ${formatVersion}`,
+        error: `Unsupported OpenAPI spec format ${openapiVersion}`,
       };
     }
 

--- a/plugins/insomnia-plugin-kong-portal/src/deploy-to-portal.js
+++ b/plugins/insomnia-plugin-kong-portal/src/deploy-to-portal.js
@@ -21,8 +21,7 @@ type Props = {
   spec: {
     contents: Object,
     rawContents: string,
-    format: string,
-    formatVersion: string,
+    openapiVersion: string,
   },
 };
 


### PR DESCRIPTION
Follow up from #4204
https://en.wikipedia.org/wiki/OpenAPI_Specification 
OpenAPI is the name for Swagger version >2, this can be calculated in code by checking the version, this PR eliminates specFormat. Need to confirm this doesn't break deploy to dev portal.
- renames specFormatVersion+formatVersion -> openapiVersion
- removes specFormat
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
