### PR TITLE
fix font-scanner warning

### DIFF
--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -15,9 +15,21 @@ declare namespace NodeJS {
     __DEV__: boolean;
   }
 }
-
+interface Font {
+  family: string;
+  italic: boolean;
+  monospace: boolean;
+  path: string;
+  postscriptName: string;
+  style: string;
+  weight: number;
+  width: numbe;
+}
 interface Window {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
+  api: {
+    getAvailableFonts: () => Promise<Font[]>;
+  };
 }
 
 // needed for @hot-loader/react-dom in order for TypeScript to build

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -3,6 +3,7 @@ import 'regenerator-runtime/runtime';
 
 import * as electron from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer';
+import fontScanner from 'font-scanner';
 import path from 'path';
 
 import appConfig from '../config/config.json';
@@ -220,6 +221,8 @@ async function _trackStats() {
   } else {
     trackNonInteractiveEventQueueable('General', 'Launched', stats.currentVersion);
   }
+
+  ipcMain.handle('getAvailableFonts', () => fontScanner.getAvailableFonts());
 
   ipcMain.once('window-ready', () => {
     const { currentVersion } = stats;

--- a/packages/insomnia-app/app/preload.ts
+++ b/packages/insomnia-app/app/preload.ts
@@ -1,0 +1,15 @@
+import { contextBridge, ipcRenderer } from 'electron';
+const api = {
+  getAvailableFonts: () => ipcRenderer.invoke('getAvailableFonts'),
+};
+
+// contextIsolationEnabled should be true in a dev and prod env, can use process.contextIsolated in electron 13
+const { internalContextBridge } = contextBridge as any;
+const { contextIsolationEnabled } = internalContextBridge;
+
+if (contextIsolationEnabled) {
+  contextBridge.exposeInMainWorld('api', api);
+} else {
+  // contextIsolationEnabled should be at false in a testing environment (spectron still relies on node integration and remote module, this else should be removed in the future)
+  window.api = api;
+}

--- a/packages/insomnia-app/app/ui/components/settings/general.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/general.tsx
@@ -1,5 +1,4 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import * as fontScanner from 'font-scanner';
 import { HttpVersion, HttpVersions } from 'insomnia-common';
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
@@ -68,7 +67,7 @@ class General extends PureComponent<Props, State> {
   };
 
   async componentDidMount() {
-    const allFonts = await fontScanner.getAvailableFonts();
+    const allFonts = await window.api.getAvailableFonts();
     // Find regular fonts
     const fonts = allFonts
       .filter(i => ['regular', 'book'].includes(i.style.toLowerCase()) && !i.italic)

--- a/packages/insomnia-app/webpack/webpack.config.electron.ts
+++ b/packages/insomnia-app/webpack/webpack.config.electron.ts
@@ -13,7 +13,9 @@ const output: Configuration['output'] = {
   filename: 'main.min.js',
 };
 
-if (process.env.NODE_ENV === 'development') {
+const isDev = process.env.NODE_ENV === 'development';
+
+if (isDev) {
   output.path = path.join(__dirname, '../app');
   devtool = 'eval-source-map';
   plugins = [
@@ -30,7 +32,7 @@ if (process.env.NODE_ENV === 'development') {
   plugins = productionConfig.plugins;
 }
 
-const configuration: Configuration = {
+const configuration: Configuration[] = [{
   ...productionConfig,
   devtool,
   entry: ['./main.development.ts'],
@@ -40,6 +42,24 @@ const configuration: Configuration = {
   },
   target: 'electron-main',
   plugins,
-};
+},
+{
+  mode: isDev ? 'development' : 'production',
+  devtool: isDev ? 'source-map' : false,
+  entry: path.join(__dirname, '../app/preload.ts'),
+  stats: 'minimal',
+  target: 'electron-preload',
+  output: {
+    path: path.join(__dirname, '../build'),
+    filename: 'preload.ts',
+  },
+  module: {
+    rules: [{
+      test: /\.tsx?$/,
+      exclude: /node_modules/,
+      loader: 'babel-loader',
+    }],
+  },
+}];
 
 export default configuration;


### PR DESCRIPTION
when running `npm run app-start` the following warning is shown

This fixes `[app] (node:50073) Electron: Loading non-context-aware native module in renderer: '~/git/insomnia/packages/insomnia-app/node_modules/font-scanner/build/Release/fontmanager.node'. This is deprecated, see https://github.com/electron/electron/issues/18397.`

Solution:
- create preload.ts and webpack resolver
- create api object for preloading things in mixed and isolated context
- add types

Note: the other node-libcurl warning can also be resolved but harder to untangle than font-scanner.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Closes INS-1179