### PR TITLE
add error-cause polyfill

### DIFF
--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -1,5 +1,6 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+import 'error-cause/auto';
 
 import * as electron from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer';

--- a/packages/insomnia-app/app/renderer.ts
+++ b/packages/insomnia-app/app/renderer.ts
@@ -1,3 +1,4 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+import 'error-cause/auto';
 import './ui';

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -8460,6 +8460,15 @@
 				}
 			}
 		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			}
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -9714,7 +9723,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -10897,6 +10905,110 @@
 				"prr": "~1.0.1"
 			}
 		},
+		"error-cause": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/error-cause/-/error-cause-1.0.1.tgz",
+			"integrity": "sha512-OostWQuSeSH/hHu4AtcjVVab2xpZzYqSHpNbFPek1xxkgeUwV9e610RRv0ynE8s55q4GK0IteD3NRZPRWn7+mw==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.1",
+				"es-aggregate-error": "^1.0.7",
+				"evalmd": "^0.0.19",
+				"get-intrinsic": "^1.1.1",
+				"globalthis": "^1.0.2"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+					"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"get-symbol-description": "^1.0.0",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.4",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.1",
+						"is-string": "^1.0.7",
+						"is-weakref": "^1.0.1",
+						"object-inspect": "^1.11.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					}
+				},
+				"globalthis": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+					"integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+					"requires": {
+						"define-properties": "^1.1.3"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+				},
+				"is-callable": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+				},
+				"is-regex": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"object-inspect": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+					"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
+			}
+		},
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -10941,6 +11053,119 @@
 				"string.prototype.trimstart": "^1.0.1"
 			}
 		},
+		"es-aggregate-error": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.7.tgz",
+			"integrity": "sha512-Zob/KUAOQUTvCzqgL2FEgtqNLPX5rYW3VhlldZ6La4W2mJUv3J8DmD0/sPxuD+kSAKF6nuceJ3uOSvCaaTLUyQ==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0",
+				"function-bind": "^1.1.1",
+				"functions-have-names": "^1.2.2",
+				"get-intrinsic": "^1.1.1",
+				"globalthis": "^1.0.2"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.19.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+					"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"get-symbol-description": "^1.0.0",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.4",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.4",
+						"is-shared-array-buffer": "^1.0.1",
+						"is-string": "^1.0.7",
+						"is-weakref": "^1.0.1",
+						"object-inspect": "^1.11.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					}
+				},
+				"globalthis": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+					"integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+					"requires": {
+						"define-properties": "^1.1.3"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+				},
+				"is-callable": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+					"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+				},
+				"is-regex": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+					"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-tostringtag": "^1.0.0"
+					}
+				},
+				"object-inspect": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+					"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
+			}
+		},
+		"es-lookup-scope": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-lookup-scope/-/es-lookup-scope-1.0.1.tgz",
+			"integrity": "sha1-6e0Rvy+gjZgm4/nQgP52fd00gBI=",
+			"requires": {
+				"es6-collections": "^0.5.1",
+				"escope": "^1.0.3",
+				"lodash.findlast": "^3.2.0"
+			}
+		},
 		"es-module-lexer": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
@@ -10951,7 +11176,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
 			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -10974,6 +11198,11 @@
 					"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
 				}
 			}
+		},
+		"es6-collections": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/es6-collections/-/es6-collections-0.5.6.tgz",
+			"integrity": "sha1-VVLoAK0SwYIM2ivUp5rn27A9iaI="
 		},
 		"es6-error": {
 			"version": "4.1.1",
@@ -11053,6 +11282,21 @@
 				}
 			}
 		},
+		"escope": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escope/-/escope-1.0.3.tgz",
+			"integrity": "sha1-dZ3OhJbEJI/sLQyq9BCLzz8af10=",
+			"requires": {
+				"estraverse": "^2.0.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz",
+					"integrity": "sha1-WuRpYyQ2ACBmdMyySgnhZnT83KE="
+				}
+			}
+		},
 		"eslint-scope": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -11092,6 +11336,179 @@
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
 			"dev": true
+		},
+		"evalmd": {
+			"version": "0.0.19",
+			"resolved": "https://registry.npmjs.org/evalmd/-/evalmd-0.0.19.tgz",
+			"integrity": "sha512-HXsgNnwsJ0ZYmwQNvwoFsCaPTOieUT4dNkCFYQWq6fTVE0N1tDBsvRcAkQ3mSqnt80geisP4zctZQnYn0HhsgQ==",
+			"requires": {
+				"acorn": "^7.0.0",
+				"bluebird": "^2.9.34",
+				"chalk": "^1.1.0",
+				"es-lookup-scope": "^1.0.1",
+				"estraverse": "^4.3.0",
+				"fs-extra": "github:reggi/node-fs-extra#enhanced",
+				"lodash": "^4.17.15",
+				"markdown-it": "github:markdown-it/markdown-it#255d62d39122694872ddce840e2141379ac3deca",
+				"os-tmpdir": "^1.0.1",
+				"underscore.string": "^3.1.1",
+				"yargs": "^3.19.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"bluebird": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+					"integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+				},
+				"camelcase": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
+					}
+				},
+				"entities": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+					"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+				},
+				"fs-extra": {
+					"version": "github:reggi/node-fs-extra#796dea19db2d82e80aa0d1b450a9c0b4a9c0d80b",
+					"from": "github:reggi/node-fs-extra#enhanced",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^2.1.0",
+						"path-is-absolute": "^1.0.0",
+						"rimraf": "^2.2.8"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				},
+				"linkify-it": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.4.tgz",
+					"integrity": "sha1-B3NSbDF8j9E71TTuHRgP+Iq/iBo=",
+					"requires": {
+						"uc.micro": "^1.0.1"
+					}
+				},
+				"markdown-it": {
+					"version": "github:markdown-it/markdown-it#255d62d39122694872ddce840e2141379ac3deca",
+					"from": "github:markdown-it/markdown-it#255d62d39122694872ddce840e2141379ac3deca",
+					"requires": {
+						"argparse": "~1.0.2",
+						"entities": "~1.1.1",
+						"linkify-it": "~1.2.0",
+						"mdurl": "~1.0.0",
+						"uc.micro": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				},
+				"window-size": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+					"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					}
+				},
+				"y18n": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+					"integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
+				},
+				"yargs": {
+					"version": "3.32.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+					"requires": {
+						"camelcase": "^2.0.1",
+						"cliui": "^3.0.3",
+						"decamelize": "^1.1.1",
+						"os-locale": "^1.4.0",
+						"string-width": "^1.0.1",
+						"window-size": "^0.1.4",
+						"y18n": "^3.2.0"
+					}
+				}
+			}
 		},
 		"event-emitter": {
 			"version": "0.3.5",
@@ -12174,8 +12591,12 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"functions-have-names": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
+			"integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA=="
 		},
 		"fuzzysort": {
 			"version": "1.1.4",
@@ -12331,6 +12752,16 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
 		},
+		"get-intrinsic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
+		},
 		"get-own-enumerable-property-symbols": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -12349,6 +12780,15 @@
 			"dev": true,
 			"requires": {
 				"pump": "^3.0.0"
+			}
+		},
+		"get-symbol-description": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.1"
 			}
 		},
 		"get-uri": {
@@ -12825,7 +13265,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -12845,6 +13284,11 @@
 				}
 			}
 		},
+		"has-bigints": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+		},
 		"has-color": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
@@ -12858,8 +13302,22 @@
 		"has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+		},
+		"has-tostringtag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"requires": {
+				"has-symbols": "^1.0.2"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+				}
+			}
 		},
 		"has-unicode": {
 			"version": "2.0.1",
@@ -13532,6 +13990,16 @@
 				"ipaddr.js": "^1.9.0"
 			}
 		},
+		"internal-slot": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+			"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+			"requires": {
+				"get-intrinsic": "^1.1.0",
+				"has": "^1.0.3",
+				"side-channel": "^1.0.4"
+			}
+		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -13539,6 +14007,11 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"ip": {
 			"version": "1.1.5",
@@ -13608,6 +14081,14 @@
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
 			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
 		},
+		"is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"requires": {
+				"has-bigints": "^1.0.1"
+			}
+		},
 		"is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -13615,6 +14096,15 @@
 			"optional": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
+			}
+		},
+		"is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
 			}
 		},
 		"is-buffer": {
@@ -13625,8 +14115,7 @@
 		"is-callable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-			"dev": true
+			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -13669,8 +14158,7 @@
 		"is-date-object": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-			"dev": true
+			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
 		},
 		"is-decimal": {
 			"version": "1.0.4",
@@ -13772,6 +14260,11 @@
 				"is-path-inside": "^3.0.1"
 			}
 		},
+		"is-negative-zero": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+		},
 		"is-npm": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
@@ -13782,6 +14275,14 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+		},
+		"is-number-object": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+			"integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
 		},
 		"is-obj": {
 			"version": "1.0.1",
@@ -13878,17 +14379,29 @@
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
 			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
+		"is-shared-array-buffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 			"dev": true
 		},
+		"is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
 		"is-symbol": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
 			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.1"
 			}
@@ -13897,6 +14410,14 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"is-weakref": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"requires": {
+				"call-bind": "^1.0.0"
+			}
 		},
 		"is-what": {
 			"version": "3.14.1",
@@ -16232,6 +16753,14 @@
 				"readable-stream": "^2.0.5"
 			}
 		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"requires": {
+				"invert-kv": "^1.0.0"
+			}
+		},
 		"less": {
 			"version": "3.12.2",
 			"resolved": "https://registry.npmjs.org/less/-/less-3.12.2.tgz",
@@ -16429,17 +16958,61 @@
 				"lodash.keys": "^3.0.0"
 			}
 		},
+		"lodash._basecallback": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+			"integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
+			"requires": {
+				"lodash._baseisequal": "^3.0.0",
+				"lodash._bindcallback": "^3.0.0",
+				"lodash.isarray": "^3.0.0",
+				"lodash.pairs": "^3.0.0"
+			}
+		},
 		"lodash._basecopy": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
 			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
 			"dev": true
 		},
+		"lodash._baseeachright": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash._baseeachright/-/lodash._baseeachright-3.0.3.tgz",
+			"integrity": "sha1-mFSiDNSonphTMK0fbRy6m9gDvQo=",
+			"requires": {
+				"lodash._baseforright": "^3.0.0",
+				"lodash.keys": "^3.0.0"
+			}
+		},
+		"lodash._basefind": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basefind/-/lodash._basefind-3.0.0.tgz",
+			"integrity": "sha1-srugXMZF+XLeLPkl+iv2Og9gyK4="
+		},
+		"lodash._basefindindex": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/lodash._basefindindex/-/lodash._basefindindex-3.6.0.tgz",
+			"integrity": "sha1-8IM2ChsCJBjtgbyJm+sxLiHnSk8="
+		},
+		"lodash._baseforright": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/lodash._baseforright/-/lodash._baseforright-3.0.2.tgz",
+			"integrity": "sha1-U1qIrK8G0E1sMwZJ0CG9LOaYc68="
+		},
+		"lodash._baseisequal": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+			"integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+			"requires": {
+				"lodash.isarray": "^3.0.0",
+				"lodash.istypedarray": "^3.0.0",
+				"lodash.keys": "^3.0.0"
+			}
+		},
 		"lodash._bindcallback": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-			"dev": true
+			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
 		},
 		"lodash._createassigner": {
 			"version": "3.1.1",
@@ -16455,8 +17028,7 @@
 		"lodash._getnative": {
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-			"dev": true
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
 		},
 		"lodash._isiterateecall": {
 			"version": "3.0.9",
@@ -16508,6 +17080,19 @@
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
 		},
+		"lodash.findlast": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.findlast/-/lodash.findlast-3.2.1.tgz",
+			"integrity": "sha1-YbcAcJP+GQ5XPuHD0Sl1miReAV8=",
+			"requires": {
+				"lodash._basecallback": "^3.0.0",
+				"lodash._baseeachright": "^3.0.0",
+				"lodash._basefind": "^3.0.0",
+				"lodash._basefindindex": "^3.0.0",
+				"lodash.isarray": "^3.0.0",
+				"lodash.keys": "^3.0.0"
+			}
+		},
 		"lodash.flatten": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -16522,14 +17107,12 @@
 		"lodash.isarguments": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-			"dev": true
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
 		},
 		"lodash.isarray": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-			"dev": true
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
@@ -16547,15 +17130,27 @@
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
 			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
 		},
+		"lodash.istypedarray": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+			"integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
+		},
 		"lodash.keys": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"dev": true,
 			"requires": {
 				"lodash._getnative": "^3.0.0",
 				"lodash.isarguments": "^3.0.0",
 				"lodash.isarray": "^3.0.0"
+			}
+		},
+		"lodash.pairs": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+			"integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
+			"requires": {
+				"lodash.keys": "^3.0.0"
 			}
 		},
 		"lodash.restparam": {
@@ -17837,8 +18432,7 @@
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -17998,6 +18592,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		},
+		"os-locale": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"requires": {
+				"lcid": "^1.0.0"
+			}
 		},
 		"os-name": {
 			"version": "3.1.0",
@@ -20499,6 +21101,23 @@
 			"dev": true,
 			"optional": true
 		},
+		"side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"requires": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			},
+			"dependencies": {
+				"object-inspect": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+					"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+				}
+			}
+		},
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -22138,10 +22757,37 @@
 				"random-bytes": "~1.0.0"
 			}
 		},
+		"unbox-primitive": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has-bigints": "^1.0.1",
+				"has-symbols": "^1.0.2",
+				"which-boxed-primitive": "^1.0.2"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+				}
+			}
+		},
 		"underscore": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
 			"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+		},
+		"underscore.string": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+			"integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+			"requires": {
+				"sprintf-js": "^1.0.3",
+				"util-deprecate": "^1.0.2"
+			}
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.0",
@@ -24414,6 +25060,18 @@
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"requires": {
 				"isexe": "^2.0.0"
+			}
+		},
+		"which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"requires": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
 			}
 		},
 		"which-module": {

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -5400,6 +5400,12 @@
 			"integrity": "sha512-mMUu4nWHLBlHtxXY17Fg6+ucS/MnndyOWyOe7MmwkoMYxvfQU2ajtRaEvqSUv+aVkMqH/C0NCI8UoVfRNQ10yg==",
 			"dev": true
 		},
+		"@types/error-cause": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/error-cause/-/error-cause-1.0.1.tgz",
+			"integrity": "sha512-+jboV83Oc3rUWnlZEXq2L6GU7qc8Gd5uI1nN2O5QE54goJapuYGWQpKXnj/s57BXlvohRgcICgQ99AB6RqxvXA==",
+			"dev": true
+		},
 		"@types/eslint": {
 			"version": "7.2.10",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -92,6 +92,7 @@
     "electron-context-menu": "^2.2.0",
     "electron-log": "^4.3.5",
     "electron-updater": "^4.3.9",
+    "error-cause": "1.0.1",
     "font-scanner": "^0.1.2",
     "framer-motion": "^1.11.1",
     "fs-extra": "^5.0.0",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -196,6 +196,7 @@
     "@types/color": "^3.0.1",
     "@types/concurrently": "^6.0.1",
     "@types/deep-equal": "^1.0.1",
+    "@types/error-cause": "1.0.1",
     "@types/events": "^1.2.0",
     "@types/file-loader": "^5.0.0",
     "@types/fs-extra": "^5.1.0",

--- a/packages/insomnia-app/send-request/index.ts
+++ b/packages/insomnia-app/send-request/index.ts
@@ -1,3 +1,4 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+import 'error-cause/auto';
 export { getSendRequestCallbackMemDb, getSendRequestCallback } from '../app/common/send-request';


### PR DESCRIPTION
adds this polyfill https://github.com/es-shims/error-cause

TODO:
- [ ] fix `~/git/insomnia/packages/insomnia-app/node_modules/depd/index.js:252 Uncaught TypeError: callSite.getFileName is not a function`
- [ ] screen grab the two error modals to show how nested errors would look


Note: not currently supported by jest but in progress over here  https://github.com/facebook/jest/issues/11935
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
