### PR TITLE
adds hotkey support to graphql editor for prettifying

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
@@ -18,6 +18,8 @@ import { SetRequired } from 'type-fest';
 
 import { AUTOBIND_CFG, CONTENT_TYPE_JSON, DEBOUNCE_MILLIS } from '../../../../common/constants';
 import { database as db } from '../../../../common/database';
+import { hotKeyRefs } from '../../../../common/hotkeys';
+import { executeHotKey } from '../../../../common/hotkeys-listener';
 import { markdownToHTML } from '../../../../common/markdown-to-html';
 import { jsonParseOr } from '../../../../common/misc';
 import { HandleGetRenderContext, HandleRender } from '../../../../common/render';
@@ -36,6 +38,7 @@ import { CodeEditor } from '../../codemirror/code-editor';
 import { GraphQLExplorer } from '../../graph-ql-explorer/graph-ql-explorer';
 import { ActiveReference } from '../../graph-ql-explorer/graph-ql-types';
 import { HelpTooltip } from '../../help-tooltip';
+import { KeydownBinder } from '../../keydown-binder';
 import { showModal } from '../../modals';
 import { ResponseDebugModal } from '../../modals/response-debug-modal';
 import { TimeFromNow } from '../../time-from-now';
@@ -190,6 +193,10 @@ export class GraphQLEditor extends PureComponent<Props, State> {
     this.setState({
       explorerVisible: false,
     });
+  }
+
+  _handleKeyDown(event: KeyboardEvent) {
+    executeHotKey(event, hotKeyRefs.BEAUTIFY_REQUEST_BODY, this._handlePrettify);
   }
 
   _handleClickReference(reference: Maybe<ActiveReference>, event: MouseEvent) {
@@ -726,6 +733,7 @@ export class GraphQLEditor extends PureComponent<Props, State> {
 
     return (
       <div className="graphql-editor">
+        <KeydownBinder onKeydown={this._handleKeyDown} />
         <Dropdown right className="graphql-editor__schema-dropdown margin-bottom-xs">
 
           <DropdownButton className="space-left btn btn--micro btn--outlined">


### PR DESCRIPTION
Closes: INS-1100

In https://github.com/Kong/insomnia/pull/2733 support for a hotkey for prettifying was added, but it did not add support for the expected hotkey functionality for GraphQL bodies, specifically.  This PR adds that functionality.

Steps to test:
1. create a new POST request with a GraphQL request body type
2. enter a graphql body that is malformatted, for example
    ```graphql
    query {
      characters(filter: { name: "rick"}) {
        results {
          id
          name
            status
        }
      }
    }
    ```
3. Press the beautify hotkey shortcut (e.g. `Ctrl + Shift + I` on Windows/Linux or `Alt + Shift + I` on Mac).
4. Observe that the body is formatted, for example:
    ```diff
     query {
    -  characters(filter: { name: "rick"}) {
    +  characters(filter: { name: "rick" }) {
         results {
           id
           name
    -        status
    +      status
         }
       }
    }
    ```