### PR TITLE
decouple plugins from networking

### DIFF
--- a/packages/insomnia-app/app/common/har.ts
+++ b/packages/insomnia-app/app/common/har.ts
@@ -340,7 +340,7 @@ export async function exportHarWithRequest(
 async function _applyRequestPluginHooks(
   renderedRequest: RenderedRequest,
   renderedContext: Record<string, any>,
-) {
+): Promise<RenderedRequest> {
   let newRenderedRequest = renderedRequest;
 
   for (const { plugin, hook } of await plugins.getRequestHooks()) {

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -18,7 +18,6 @@ import { getRenderedRequestAndContext } from '../../common/render';
 import * as models from '../../models';
 import { DEFAULT_BOUNDARY } from '../multipart';
 import * as networkUtils from '../network';
-const CONTEXT = {};
 
 const getRenderedRequest = async (args: Parameters<typeof getRenderedRequestAndContext>[0]) => (await getRenderedRequestAndContext(args)).request;
 
@@ -97,7 +96,6 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      CONTEXT,
       workspace,
       settings,
     );
@@ -172,7 +170,6 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      CONTEXT,
       workspace,
       settings,
     );
@@ -272,7 +269,6 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      CONTEXT,
       workspace,
       settings,
     );
@@ -332,7 +328,6 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      CONTEXT,
       workspace,
       settings,
     );
@@ -412,7 +407,6 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      CONTEXT,
       workspace,
       settings,
     );
@@ -473,7 +467,6 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      CONTEXT,
       workspace,
       settings,
     );
@@ -513,7 +506,6 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      CONTEXT,
       workspace,
       settings,
     );
@@ -552,7 +544,6 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      CONTEXT,
       workspace,
       settings,
     );
@@ -592,7 +583,6 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      CONTEXT,
       workspace,
       settings,
     );
@@ -689,7 +679,6 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      CONTEXT,
       workspace,
       settings,
       null,
@@ -741,7 +730,7 @@ describe('actuallySend()', () => {
       parentId: workspace._id,
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const responseV1 = await networkUtils._actuallySend(renderedRequest, CONTEXT, workspace, {
+    const responseV1 = await networkUtils._actuallySend(renderedRequest, workspace, {
       ...settings,
       preferredHttpVersion: HttpVersions.V1_0,
     });
@@ -777,14 +766,12 @@ describe('actuallySend()', () => {
     // WHEN
     const response1Promise = networkUtils._actuallySend(
       renderedRequest1,
-      CONTEXT,
       workspace,
       settings,
     );
 
     const response2Promise = networkUtils._actuallySend(
       renderedRequest2,
-      CONTEXT,
       workspace,
       settings,
     );

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -155,7 +155,6 @@ export function hasCancelFunctionForId(requestId) {
 
 export async function _actuallySend(
   renderedRequest: RenderedRequest,
-  renderContext: Record<string, any>,
   workspace: Workspace,
   settings: Omit<Settings, 'validateSSL' | 'validateAuthSSL'>,
   environment?: Environment | null,
@@ -183,13 +182,12 @@ export async function _actuallySend(
     async function respond(
       patch: ResponsePatch,
       bodyPath: string | null,
-      noPlugins = false,
     ) {
       const timelinePath = await storeTimeline(timeline);
       // Tear Down the cancellation logic
       clearCancelFunctionForId(renderedRequest._id);
       const environmentId = environment ? environment._id : null;
-      const responsePatchBeforeHooks = Object.assign(
+      return resolve(Object.assign(
         {
           timelinePath,
           environmentId,
@@ -201,29 +199,7 @@ export async function _actuallySend(
           settingStoreCookies: renderedRequest.settingStoreCookies,
         } as ResponsePatch,
         patch,
-      );
-
-      if (noPlugins) {
-        resolve(responsePatchBeforeHooks);
-        return;
-      }
-
-      let responsePatch: ResponsePatch | null = null;
-
-      try {
-        responsePatch = await _applyResponsePluginHooks(
-          responsePatchBeforeHooks,
-          renderedRequest,
-          renderContext,
-        );
-      } catch (err) {
-        await handleError(
-          new Error(`[plugin] Response hook failed plugin=${err.plugin.name} err=${err.message}`),
-        );
-        return;
-      }
-
-      resolve(responsePatch);
+      ));
     }
 
     /** Helper function to respond with an error */
@@ -232,14 +208,13 @@ export async function _actuallySend(
         {
           url: renderedRequest.url,
           parentId: renderedRequest._id,
-          error: err.message,
+          error: err.message || 'Something went wrong',
           elapsedTime: 0, // 0 because this path is hit during plugin calls
           statusMessage: 'Error',
           settingSendCookies: renderedRequest.settingSendCookies,
           settingStoreCookies: renderedRequest.settingStoreCookies,
         },
         null,
-        true,
       );
     }
 
@@ -267,7 +242,6 @@ export async function _actuallySend(
             error: 'Request was cancelled',
           },
           null,
-          true,
         );
         // Kill it!
         curl.close();
@@ -839,11 +813,10 @@ export async function _actuallySend(
         await respond(
           {
             statusMessage,
-            error,
+            error: error || 'Something went wrong',
             elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000,
           },
           null,
-          true,
         );
       });
       curl.perform();
@@ -896,14 +869,33 @@ export async function sendWithSettings(
     throw new Error(`Failed to render request: ${requestId}`);
   }
 
-  return _actuallySend(
+  const response = await _actuallySend(
     renderResult.request,
-    renderResult.context,
     workspace,
     settings,
     environment,
     settings.validateAuthSSL,
   );
+  if (response.error){
+    return response;
+  }
+  try {
+    return _applyResponsePluginHooks(
+      response,
+      renderResult.request,
+      renderResult.context,
+    );
+  } catch (err) {
+    return {
+      url: renderResult.request.url,
+      parentId: renderResult.request._id,
+      error: `[plugin] Response hook failed plugin=${err.plugin.name} err=${err.message}`,
+      elapsedTime: 0, // 0 because this path is hit during plugin calls
+      statusMessage: 'Error',
+      settingSendCookies: renderResult.request.settingSendCookies,
+      settingStoreCookies: renderResult.request.settingStoreCookies,
+    };
+  }
 }
 
 export async function send(
@@ -969,7 +961,7 @@ export async function send(
   } catch (err) {
     return {
       environmentId: environmentId,
-      error: err.message,
+      error: err.message || 'Something went wrong',
       parentId: renderedRequestBeforePlugins._id,
       settingSendCookies: renderedRequestBeforePlugins.settingSendCookies,
       settingStoreCookies: renderedRequestBeforePlugins.settingStoreCookies,
@@ -981,7 +973,6 @@ export async function send(
 
   const response = await _actuallySend(
     renderedRequest,
-    renderedContextBeforePlugins,
     workspace,
     settings,
     environment,
@@ -992,7 +983,26 @@ export async function send(
       ? `[network] Response failed req=${requestId} err=${response.error || 'n/a'}`
       : `[network] Response succeeded req=${requestId} status=${response.statusCode || '?'}`,
   );
-  return response;
+  if (response.error){
+    return response;
+  }
+  try {
+    return _applyResponsePluginHooks(
+      response,
+      renderedRequest,
+      renderedContextBeforePlugins,
+    );
+  } catch (err) {
+    return {
+      url: renderedRequest.url,
+      parentId: renderedRequest._id,
+      error: `[plugin] Response hook failed plugin=${err.plugin.name} err=${err.message}`,
+      elapsedTime: 0, // 0 because this path is hit during plugin calls
+      statusMessage: 'Error',
+      settingSendCookies: renderedRequest.settingSendCookies,
+      settingStoreCookies: renderedRequest.settingStoreCookies,
+    };
+  }
 }
 
 async function _applyRequestPluginHooks(


### PR DESCRIPTION
Closes INS-1189

Makes `_actuallySend()`'s return error value significant rather than tracking `noPlugins` for error cases. Also ensures response and requests hooks happen in the same closure, separating concerns.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
