### PR TITLE
[regression] reverts sort order callback behavior

### DIFF
--- a/packages/insomnia-app/app/common/constants.ts
+++ b/packages/insomnia-app/app/common/constants.ts
@@ -305,7 +305,7 @@ export const SORT_ORDERS = [
   SORT_HTTP_METHOD,
   SORT_TYPE_DESC,
   SORT_TYPE_ASC,
-];
+] as const;
 export const sortOrderName: Record<SortOrder, string> = {
   [SORT_NAME_ASC]: 'Name Ascending (A-Z)',
   [SORT_NAME_DESC]: 'Name Descending (Z-A)',

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar-sort-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar-sort-dropdown.tsx
@@ -15,7 +15,7 @@ export const SidebarSortDropdown: FunctionComponent<Props> = ({ handleSort }) =>
       <i className="fa fa-sort" />
     </DropdownButton>
     {SORT_ORDERS.map(order => (
-      <DropdownItem value={order} onClick={handleSort} key={order}>
+      <DropdownItem value={order} onClick={() => { handleSort(order); }} key={order}>
         {sortOrderName[order]}
       </DropdownItem>
     ))}


### PR DESCRIPTION
closes INS-1107
closes #4191

see: https://www.loom.com/share/c422ef5cd42d4d899668105c572b931f

Unfortunately, we were bitten by the Dropdown family yet again.  Except this time, it's that and the combination of very extensive prop drilling.

There are a few things that happened.  This PR reverts to the original behavior since day one:

https://github.com/Kong/insomnia/commit/c50bc1f965eba7c1ad9514840c2bea588e7f4a47#diff-916959cd385131affe2abf2f190250982a3df3c5819020ba515eec08fdeb6577R19

___

What happened here is that the the logic for the sorting lives in `App.tsx` in a function called `_sortSidebar`

here's the implementation.  note the signature and what it does with the 2nd argument:
```ts
  async _sortSidebar(order: SortOrder, parentId?: string) {
    let flushId: number | undefined;

    if (!this.props.activeWorkspace) {
      return;
    }

    if (!parentId) {
      parentId = this.props.activeWorkspace._id;
      flushId = await db.bufferChanges();
    }

    const docs = [
      ...(await models.requestGroup.findByParentId(parentId)),
      ...(await models.request.findByParentId(parentId)),
      ...(await models.grpcRequest.findByParentId(parentId)),
    ].sort(sortMethodMap[order]);
    await this._recalculateMetaSortKey(docs);
    // sort RequestGroups recursively
    await Promise.all(docs.filter(isRequestGroup).map(g => this._sortSidebar(order, g._id)));

    if (flushId) {
      await db.flushChanges(flushId);
    }
  }
```

### Prop Drill 1

Then `App` passes a reference to `_sortSidebar` to `Wrapper` in a prop, `handleSidebarSort`

### Prop Drill 2

Take note that the signature changes at the level of Wrapper, it's hardcoded like this:
```ts
interface WrapperProps {
  ...
  handleSidebarSort: (sortOrder: SortOrder) => void;
}
```

Then `Wrapper` passes it to `WrapperDebug` without modification

### Prop Drill 3

Note that in `WrapperDebug` it's hardcoded again (also wrong)

`WrapperDebug` then passes it's prop `handleSidebarSort` to `SidebarFilter` unchanged, but it renames it to the prop `sidebarSort` just for fun.

### Prop Drill 4

`SidebarFilter` again, for the 3rd time, hardcodes the signature (wrongly) and `sidebarSort` is passed to `SidebarSortDropdown` unchanged

### Prop Drill 5

`SidebarSortDropdown` hardcodes the signature a 4th time (wrong, again), then it passes this reference to `DropdownItem` as `onClick`

### Prop Drill 6

We've finally reached our destination.  Internally, `DropdownItem` uses `_handleClick`, which is implemented like this:

```ts
  _handleClick(e) {
    const { stayOpenAfterClick, onClick, disabled } = this.props;

    if (stayOpenAfterClick) {
      e.stopPropagation();
    }

    if (!onClick || disabled) {
      return;
    }

    if (this.props.hasOwnProperty('value')) {
      onClick(this.props.value, e);
    } else {
      onClick(e);
    }
  }
```

See the issue?  It passes `e` as the second argument.  Well, if you look back at the second argument above, you'll see that we do `findByParentId(parentId)`.   This means we're going to be passing an event here, and not a string of a parentId.  :)
