### PR TITLE
Fix: disabled native modules in the renderer

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/analytics.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/analytics.test.ts
@@ -9,10 +9,15 @@ import {
   getAppName,
   getAppPlatform,
   getAppVersion,
-  getBrowserUserAgent,
   getGoogleAnalyticsId,
   getGoogleAnalyticsLocation,
 } from '../constants';
+
+export const getBrowserUserAgent = () => encodeURIComponent(
+  String(window.navigator.userAgent)
+    .replace(new RegExp(`${getAppId()}\\/\\d+\\.\\d+\\.\\d+ `), '')
+    .replace(/Electron\/\d+\.\d+\.\d+ /, ''),
+).replace('%2C', ',');
 
 describe('init()', () => {
   beforeEach(async () => {

--- a/packages/insomnia-app/app/common/__tests__/analytics.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/analytics.test.ts
@@ -13,7 +13,7 @@ import {
   getGoogleAnalyticsLocation,
 } from '../constants';
 
-export const getBrowserUserAgent = () => encodeURIComponent(
+const getBrowserUserAgent = () => encodeURIComponent(
   String(window.navigator.userAgent)
     .replace(new RegExp(`${getAppId()}\\/\\d+\\.\\d+\\.\\d+ `), '')
     .replace(/Electron\/\d+\.\d+\.\d+ /, ''),

--- a/packages/insomnia-app/app/common/constants.ts
+++ b/packages/insomnia-app/app/common/constants.ts
@@ -23,12 +23,6 @@ export const isDevelopment = () => getAppEnvironment() === 'development';
 export const getSegmentWriteKey = () => appConfig.segmentWriteKeys[isDevelopment() ? 'development' : 'production'];
 export const getAppReleaseDate = () => new Date(process.env.RELEASE_DATE ?? '').toLocaleDateString();
 
-export const getBrowserUserAgent = () => encodeURIComponent(
-  String(window.navigator.userAgent)
-    .replace(new RegExp(`${getAppId()}\\/\\d+\\.\\d+\\.\\d+ `), '')
-    .replace(/Electron\/\d+\.\d+\.\d+ /, ''),
-).replace('%2C', ',');
-
 export function updatesSupported() {
   // Updates are not supported on Linux
   if (isLinux()) {

--- a/packages/insomnia-app/app/common/ipc-events.ts
+++ b/packages/insomnia-app/app/common/ipc-events.ts
@@ -19,3 +19,8 @@ export const GrpcResponseEventEnum = {
 } as const;
 
 export type GrpcResponseEvent = ValueOf<typeof GrpcResponseEventEnum>;
+
+export enum CurlRequestEvent {
+  send = 'SEND_REQUEST',
+  cancel = 'CANCEL_REQUEST'
+}

--- a/packages/insomnia-app/app/common/send-request.ts
+++ b/packages/insomnia-app/app/common/send-request.ts
@@ -1,37 +1,9 @@
 import { stats } from '../models';
-import { getBodyBuffer } from '../models/response';
-import { send } from '../network/network';
-import * as plugins from '../plugins';
+import { sendAndTransform } from '../network/network';
 
 export function getSendRequestCallback(environmentId?: string) {
   return async function sendRequest(requestId: string) {
     stats.incrementExecutedRequests();
     return sendAndTransform(requestId, environmentId);
   };
-}
-
-async function sendAndTransform(requestId: string, environmentId?: string) {
-  try {
-    plugins.ignorePlugin('insomnia-plugin-kong-declarative-config');
-    plugins.ignorePlugin('insomnia-plugin-kong-kubernetes-config');
-    plugins.ignorePlugin('insomnia-plugin-kong-portal');
-    const res = await send(requestId, environmentId);
-    const headersObj: Record<string, string> = {};
-
-    for (const h of res.headers || []) {
-      const name = h.name || '';
-      headersObj[name.toLowerCase()] = h.value || '';
-    }
-
-    const bodyBuffer = await getBodyBuffer(res) as Buffer;
-    return {
-      status: res.statusCode,
-      statusMessage: res.statusMessage,
-      data: bodyBuffer ? bodyBuffer.toString('utf8') : undefined,
-      headers: headersObj,
-      responseTime: res.elapsedTime,
-    };
-  } finally {
-    plugins.clearIgnores();
-  }
 }

--- a/packages/insomnia-app/app/common/send-request.ts
+++ b/packages/insomnia-app/app/common/send-request.ts
@@ -1,46 +1,7 @@
-import { BaseModel, stats, types as modelTypes } from '../models';
-import * as models from '../models';
+import { stats } from '../models';
 import { getBodyBuffer } from '../models/response';
-import { Settings } from '../models/settings';
 import { send } from '../network/network';
 import * as plugins from '../plugins';
-import { database } from './database';
-
-// The network layer uses settings from the settings model
-// We want to give consumers the ability to override certain settings
-type SettingsOverride = Pick<Settings, 'validateSSL'>;
-
-export async function getSendRequestCallbackMemDb(environmentId: string, memDB: any, settingsOverrides?: SettingsOverride) {
-  // Initialize the DB in-memory and fill it with data if we're given one
-  await database.init(
-    modelTypes(),
-    {
-      inMemoryOnly: true,
-    },
-    true,
-    () => { },
-  );
-  const docs: BaseModel[] = [];
-
-  const settings = await models.settings.getOrCreate();
-  docs.push({ ...settings, ...settingsOverrides });
-
-  for (const type of Object.keys(memDB)) {
-    for (const doc of memDB[type]) {
-      docs.push(doc);
-    }
-  }
-
-  await database.batchModifyDocs({
-    upsert: docs,
-    remove: [],
-  });
-
-  // Return callback helper to send requests
-  return async function sendRequest(requestId: string) {
-    return sendAndTransform(requestId, environmentId);
-  };
-}
 
 export function getSendRequestCallback(environmentId?: string) {
   return async function sendRequest(requestId: string) {

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -3,7 +3,6 @@ import 'regenerator-runtime/runtime';
 
 import * as electron from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer';
-import { Curl } from 'node-libcurl';
 import path from 'path';
 
 import appConfig from '../config/config.json';
@@ -12,19 +11,15 @@ import { changelogUrl, getAppVersion, isDevelopment, isMac } from './common/cons
 import { database } from './common/database';
 import { disableSpellcheckerDownload, exitAppFailure } from './common/electron-helpers';
 import log, { initializeLogging } from './common/log';
-import type { RenderedRequest } from './common/render';
 import { validateInsomniaConfig } from './common/validate-insomnia-config';
+import * as curlIpcMain from './main/curl-ipc-main';
 import * as errorHandling from './main/error-handling';
 import * as grpcIpcMain from './main/grpc-ipc-main';
 import { checkIfRestartNeeded } from './main/squirrel-startup';
 import * as updates from './main/updates';
 import * as windowUtils from './main/window-utils';
-import type { Environment } from './models/environment';
 import * as models from './models/index';
 import type { Stats } from './models/stats';
-import type { Workspace } from './models/workspace';
-import { _actuallySend, cancelRequestById } from './network/curl';
-import type { ResponsePatch } from './network/network';
 import type { ToastNotification } from './ui/components/toast';
 
 // Handle potential auto-update
@@ -85,6 +80,7 @@ app.on('ready', async () => {
 
   // Init the rest
   await updates.init();
+  curlIpcMain.init();
   grpcIpcMain.init();
 });
 
@@ -226,18 +222,6 @@ async function _trackStats() {
   } else {
     trackNonInteractiveEventQueueable('General', 'Launched', stats.currentVersion);
   }
-
-  ipcMain.handle('_actuallySend', async (_, renderedRequest: RenderedRequest, workspace: Workspace, settings, environment: Environment | null, validateSSL: boolean): Promise<ResponsePatch> => {
-    return _actuallySend(renderedRequest, workspace, settings, environment, validateSSL);
-  });
-
-  ipcMain.on('cancelRequestById', (_, requestId: string): void => {
-    cancelRequestById(requestId);
-  });
-
-  ipcMain.on('Curl.getVersion', event => {
-    event.returnValue = Curl.getVersion();
-  });
 
   ipcMain.once('window-ready', () => {
     const { currentVersion } = stats;

--- a/packages/insomnia-app/app/main/__tests__/grpc-ipc-main.test.ts
+++ b/packages/insomnia-app/app/main/__tests__/grpc-ipc-main.test.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 
-import { GrpcRequestEventEnum } from '../../common/grpc-events';
+import { GrpcRequestEventEnum } from '../../common/ipc-events';
 import * as grpc from '../../network/grpc';
 import { ResponseCallbacks } from '../../network/grpc/response-callbacks';
 import * as grpcIpcMain from '../grpc-ipc-main';

--- a/packages/insomnia-app/app/main/curl-ipc-main.ts
+++ b/packages/insomnia-app/app/main/curl-ipc-main.ts
@@ -1,0 +1,18 @@
+import { ipcMain } from 'electron';
+
+import { CurlRequestEvent } from '../common/ipc-events';
+import type { RenderedRequest } from '../common/render';
+import type { Environment } from '../models/environment';
+import type { Workspace } from '../models/workspace';
+import { _actuallySend, cancelRequestById } from '../network/curl';
+import type { ResponsePatch } from '../network/network';
+
+export function init() {
+  ipcMain.handle(CurlRequestEvent.send, async (_, renderedRequest: RenderedRequest, workspace: Workspace, settings, environment: Environment | null, validateSSL: boolean): Promise<ResponsePatch> => {
+    return _actuallySend(renderedRequest, workspace, settings, environment, validateSSL);
+  });
+
+  ipcMain.on(CurlRequestEvent.cancel, (_, requestId: string): void => {
+    cancelRequestById(requestId);
+  });
+}

--- a/packages/insomnia-app/app/main/grpc-ipc-main.ts
+++ b/packages/insomnia-app/app/main/grpc-ipc-main.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 
-import { GrpcRequestEventEnum } from '../common/grpc-events';
+import { GrpcRequestEventEnum } from '../common/ipc-events';
 import * as grpc from '../network/grpc';
 import { GrpcIpcRequestParams } from '../network/grpc/prepare';
 import { ResponseCallbacks } from '../network/grpc/response-callbacks';

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -21,9 +21,6 @@ import * as log from '../common/log';
 import LocalStorage from './local-storage';
 
 const { app, Menu, shell, dialog, clipboard } = electron;
-// So we can use native modules in renderer
-// NOTE: This was (deprecated in Electron 10)[https://github.com/electron/electron/issues/18397] and (removed in Electron 14)[https://github.com/electron/electron/pull/26874]
-app.allowRendererProcessReuse = false;
 
 const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 700;

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -16,8 +16,9 @@ import {
 import { filterHeaders } from '../../common/misc';
 import { getRenderedRequestAndContext } from '../../common/render';
 import * as models from '../../models';
+import * as networkUtils from '../curl';
 import { DEFAULT_BOUNDARY } from '../multipart';
-import * as networkUtils from '../network';
+import { _getAwsAuthHeaders, _parseHeaders } from '../network';
 
 const getRenderedRequest = async (args: Parameters<typeof getRenderedRequestAndContext>[0]) => (await getRenderedRequestAndContext(args)).request;
 
@@ -816,7 +817,7 @@ describe('_getAwsAuthHeaders', () => {
       sessionToken: req.authentication.sessionToken || '',
     };
 
-    const headers = networkUtils._getAwsAuthHeaders(
+    const headers = _getAwsAuthHeaders(
       credentials,
       req.headers,
       req.body.text,
@@ -850,7 +851,7 @@ describe('_getAwsAuthHeaders', () => {
       sessionToken: req.authentication.sessionToken || '',
     };
 
-    const headers = networkUtils._getAwsAuthHeaders(
+    const headers = _getAwsAuthHeaders(
       credentials,
       req.headers,
       null,
@@ -886,7 +887,7 @@ describe('_parseHeaders', () => {
   const minimalHeaders = ['HTTP/1.1 301', ''];
 
   it('Parses single response headers', () => {
-    expect(networkUtils._parseHeaders(Buffer.from(basicHeaders.join('\n')))).toEqual([
+    expect(_parseHeaders(Buffer.from(basicHeaders.join('\n')))).toEqual([
       {
         code: 301,
         version: 'HTTP/1.1',
@@ -934,7 +935,7 @@ describe('_parseHeaders', () => {
   });
 
   it('Parses Windows newlines', () => {
-    expect(networkUtils._parseHeaders(Buffer.from(basicHeaders.join('\r\n')))).toEqual([
+    expect(_parseHeaders(Buffer.from(basicHeaders.join('\r\n')))).toEqual([
       {
         code: 301,
         version: 'HTTP/1.1',
@@ -983,7 +984,7 @@ describe('_parseHeaders', () => {
 
   it('Parses multiple responses', () => {
     const blobs = basicHeaders.join('\r\n') + '\n' + minimalHeaders.join('\n');
-    expect(networkUtils._parseHeaders(Buffer.from(blobs))).toEqual([
+    expect(_parseHeaders(Buffer.from(blobs))).toEqual([
       {
         code: 301,
         version: 'HTTP/1.1',

--- a/packages/insomnia-app/app/network/curl.ts
+++ b/packages/insomnia-app/app/network/curl.ts
@@ -1,0 +1,806 @@
+import clone from 'clone';
+import crypto from 'crypto';
+import fs from 'fs';
+import { HttpVersions } from 'insomnia-common';
+import { cookiesFromJar, jarFromCookies } from 'insomnia-cookies';
+import {
+  buildQueryStringFromParams,
+  joinUrlAndQueryString,
+  setDefaultProtocol,
+  smartEncodeUrl,
+} from 'insomnia-url';
+import mkdirp from 'mkdirp';
+import {
+  Curl,
+  CurlAuth,
+  CurlCode,
+  CurlFeature,
+  CurlHttpVersion,
+  CurlInfoDebug,
+  CurlNetrc,
+} from 'node-libcurl';
+import { join as pathJoin } from 'path';
+import { parse as urlParse, resolve as urlResolve } from 'url';
+import * as uuid from 'uuid';
+
+import {
+  AUTH_AWS_IAM,
+  AUTH_DIGEST,
+  AUTH_NETRC,
+  AUTH_NTLM,
+  CONTENT_TYPE_FORM_DATA,
+  CONTENT_TYPE_FORM_URLENCODED,
+  getAppVersion,
+} from '../common/constants';
+import { getDataDirectory, getTempDir } from '../common/electron-helpers';
+import {
+  describeByteSize,
+  getContentTypeHeader,
+  getLocationHeader,
+  getSetCookieHeaders,
+  hasAcceptEncodingHeader,
+  hasAcceptHeader,
+  hasAuthHeader,
+  hasContentTypeHeader,
+  hasUserAgentHeader,
+  waitForStreamToFinish,
+} from '../common/misc';
+import { RenderedRequest } from '../common/render';
+import * as models from '../models';
+import { Environment } from '../models/environment';
+import { ResponseTimelineEntry } from '../models/response';
+import type { Settings } from '../models/settings';
+import { Workspace } from '../models/workspace';
+import { getAuthHeader } from '../network/authentication';
+import caCerts from '../network/ca-certs';
+import { buildMultipart } from '../network/multipart';
+import {  _getAwsAuthHeaders, _parseHeaders, ResponsePatch } from '../network/network';
+import { urlMatchesCertHost } from '../network/url-matches-cert-host';
+// Special header value that will prevent the header being sent
+const DISABLE_HEADER_VALUE = '__Di$aB13d__';
+
+// Because node-libcurl changed some names that we used in the timeline
+const LIBCURL_DEBUG_MIGRATION_MAP = {
+  HeaderIn: 'HEADER_IN',
+  DataIn: 'DATA_IN',
+  SslDataIn: 'SSL_DATA_IN',
+  HeaderOut: 'HEADER_OUT',
+  DataOut: 'DATA_OUT',
+  SslDataOut: 'SSL_DATA_OUT',
+  Text: 'TEXT',
+  '': '',
+};
+
+const cancelRequestFunctionMap = {};
+
+export const getHttpVersion = preferredHttpVersion => {
+  switch (preferredHttpVersion) {
+    case HttpVersions.V1_0:
+      return { log: 'Using HTTP 1.0', curlHttpVersion:CurlHttpVersion.V1_0 };
+    case HttpVersions.V1_1:
+      return { log: 'Using HTTP 1.1', curlHttpVersion:CurlHttpVersion.V1_1 };
+    case HttpVersions.V2PriorKnowledge:
+      return { log: 'Using HTTP/2 PriorKnowledge', curlHttpVersion:CurlHttpVersion.V2PriorKnowledge };
+    case HttpVersions.V2_0:
+      return { log: 'Using HTTP/2', curlHttpVersion:CurlHttpVersion.V2_0 };
+    case HttpVersions.v3:
+      return { log: 'Using HTTP/3', curlHttpVersion:CurlHttpVersion.v3 };
+    case HttpVersions.default:
+      return { log: 'Using default HTTP version' };
+    default:
+      return { log: `Unknown HTTP version specified ${preferredHttpVersion}`  };
+  }
+};
+
+export async function cancelRequestById(requestId) {
+  if (hasCancelFunctionForId(requestId)) {
+    const cancelRequestFunction = cancelRequestFunctionMap[requestId];
+
+    if (typeof cancelRequestFunction === 'function') {
+      return cancelRequestFunction();
+    }
+  }
+
+  console.log(`[network] Failed to cancel req=${requestId} because cancel function not found`);
+}
+
+function clearCancelFunctionForId(requestId) {
+  if (hasCancelFunctionForId(requestId)) {
+    delete cancelRequestFunctionMap[requestId];
+  }
+}
+
+export function hasCancelFunctionForId(requestId) {
+  return cancelRequestFunctionMap.hasOwnProperty(requestId);
+}
+
+export async function _actuallySend(
+  renderedRequest: RenderedRequest,
+  workspace: Workspace,
+  settings: Omit<Settings, 'validateSSL' | 'validateAuthSSL'>,
+  environment?: Environment | null,
+  validateSSL = true,
+) {
+  return new Promise<ResponsePatch>(async resolve => {
+    const timeline: ResponseTimelineEntry[] = [];
+
+    function addTimeline(name, value) {
+      timeline.push({
+        name,
+        value,
+        timestamp: Date.now(),
+      });
+    }
+
+    function addTimelineText(value) {
+      addTimeline('TEXT', value);
+    }
+
+    // Initialize the curl handle
+    const curl = new Curl();
+
+    /** Helper function to respond with a success */
+    async function respond(
+      patch: ResponsePatch,
+      bodyPath: string | null,
+    ) {
+      const timelinePath = await storeTimeline(timeline);
+      // Tear Down the cancellation logic
+      clearCancelFunctionForId(renderedRequest._id);
+      const environmentId = environment ? environment._id : null;
+      return resolve(Object.assign(
+        {
+          timelinePath,
+          environmentId,
+          parentId: renderedRequest._id,
+          bodyCompression: null,
+          // Will default to .zip otherwise
+          bodyPath: bodyPath || '',
+          settingSendCookies: renderedRequest.settingSendCookies,
+          settingStoreCookies: renderedRequest.settingStoreCookies,
+        } as ResponsePatch,
+        patch,
+      ));
+    }
+
+    /** Helper function to respond with an error */
+    async function handleError(err: Error) {
+      await respond(
+        {
+          url: renderedRequest.url,
+          parentId: renderedRequest._id,
+          error: err.message || 'Something went wrong',
+          elapsedTime: 0, // 0 because this path is hit during plugin calls
+          statusMessage: 'Error',
+          settingSendCookies: renderedRequest.settingSendCookies,
+          settingStoreCookies: renderedRequest.settingStoreCookies,
+        },
+        null,
+      );
+    }
+
+    /** Helper function to set Curl options */
+    const setOpt: typeof curl.setOpt = (opt: any, val: any) => {
+      try {
+        return curl.setOpt(opt, val);
+      } catch (err) {
+        const name = Object.keys(Curl.option).find(name => Curl.option[name] === opt);
+        throw new Error(`${err.message} (${opt} ${name || 'n/a'})`);
+      }
+    };
+
+    try {
+      // Setup the cancellation logic
+      cancelRequestFunctionMap[renderedRequest._id] = async () => {
+        await respond(
+          {
+            elapsedTime: (curl.getInfo(Curl.info.TOTAL_TIME) as number || 0) * 1000,
+            // @ts-expect-error -- needs generic
+            bytesRead: curl.getInfo(Curl.info.SIZE_DOWNLOAD),
+            // @ts-expect-error -- needs generic
+            url: curl.getInfo(Curl.info.EFFECTIVE_URL),
+            statusMessage: 'Cancelled',
+            error: 'Request was cancelled',
+          },
+          null,
+        );
+        // Kill it!
+        curl.close();
+      };
+
+      // Set all the basic options
+      setOpt(Curl.option.VERBOSE, true);
+
+      // True so debug function works\
+      setOpt(Curl.option.NOPROGRESS, true);
+
+      // True so curl doesn't print progress
+      setOpt(Curl.option.ACCEPT_ENCODING, '');
+
+      // Auto decode everything
+      curl.enable(CurlFeature.Raw);
+
+      // Set follow redirects setting
+      switch (renderedRequest.settingFollowRedirects) {
+        case 'off':
+          setOpt(Curl.option.FOLLOWLOCATION, false);
+          break;
+
+        case 'on':
+          setOpt(Curl.option.FOLLOWLOCATION, true);
+          break;
+
+        default:
+          // Set to global setting
+          setOpt(Curl.option.FOLLOWLOCATION, settings.followRedirects);
+          break;
+      }
+
+      // Set maximum amount of redirects allowed
+      // NOTE: Setting this to -1 breaks some versions of libcurl
+      if (settings.maxRedirects > 0) {
+        setOpt(Curl.option.MAXREDIRS, settings.maxRedirects);
+      }
+
+      // Don't rebuild dot sequences in path
+      if (!renderedRequest.settingRebuildPath) {
+        setOpt(Curl.option.PATH_AS_IS, true);
+      }
+
+      // Only set CURLOPT_CUSTOMREQUEST if not HEAD or GET. This is because Curl
+      // See https://curl.haxx.se/libcurl/c/CURLOPT_CUSTOMREQUEST.html
+      switch (renderedRequest.method.toUpperCase()) {
+        case 'HEAD':
+          // This is how you tell Curl to send a HEAD request
+          setOpt(Curl.option.NOBODY, 1);
+          break;
+
+        case 'POST':
+          // This is how you tell Curl to send a POST request
+          setOpt(Curl.option.POST, 1);
+          break;
+
+        default:
+          // IMPORTANT: Only use CUSTOMREQUEST for all but HEAD and POST
+          setOpt(Curl.option.CUSTOMREQUEST, renderedRequest.method);
+          break;
+      }
+
+      // Setup debug handler
+      setOpt(Curl.option.DEBUGFUNCTION, (infoType, contentBuffer) => {
+        const content = contentBuffer.toString('utf8');
+        const rawName = Object.keys(CurlInfoDebug).find(k => CurlInfoDebug[k] === infoType) || '';
+        const name = LIBCURL_DEBUG_MIGRATION_MAP[rawName] || rawName;
+
+        if (infoType === CurlInfoDebug.SslDataIn || infoType === CurlInfoDebug.SslDataOut) {
+          return 0;
+        }
+
+        // Ignore the possibly large data messages
+        if (infoType === CurlInfoDebug.DataOut) {
+          if (contentBuffer.length === 0) {
+            // Sometimes this happens, but I'm not sure why. Just ignore it.
+          } else if (contentBuffer.length / 1024 < settings.maxTimelineDataSizeKB) {
+            addTimeline(name, content);
+          } else {
+            addTimeline(name, `(${describeByteSize(contentBuffer.length)} hidden)`);
+          }
+
+          return 0;
+        }
+
+        if (infoType === CurlInfoDebug.DataIn) {
+          addTimelineText(`Received ${describeByteSize(contentBuffer.length)} chunk`);
+          return 0;
+        }
+
+        // Don't show cookie setting because this will display every domain in the jar
+        if (infoType === CurlInfoDebug.Text && content.indexOf('Added cookie') === 0) {
+          return 0;
+        }
+
+        addTimeline(name, content);
+        return 0; // Must be here
+      });
+      // Set the headers (to be modified as we go)
+      const headers = clone(renderedRequest.headers);
+      // Set the URL, including the query parameters
+      const qs = buildQueryStringFromParams(renderedRequest.parameters);
+      const url = joinUrlAndQueryString(renderedRequest.url, qs);
+      const isUnixSocket = url.match(/https?:\/\/unix:\//);
+      const finalUrl = smartEncodeUrl(url, renderedRequest.settingEncodeUrl);
+
+      if (isUnixSocket) {
+        // URL prep will convert "unix:/path" hostname to "unix/path"
+        const match = finalUrl.match(/(https?:)\/\/unix:?(\/[^:]+):\/(.+)/);
+        const protocol = (match && match[1]) || '';
+        const socketPath = (match && match[2]) || '';
+        const socketUrl = (match && match[3]) || '';
+        setOpt(Curl.option.URL, `${protocol}//${socketUrl}`);
+        setOpt(Curl.option.UNIX_SOCKET_PATH, socketPath);
+      } else {
+        setOpt(Curl.option.URL, finalUrl);
+      }
+
+      addTimelineText('Preparing request to ' + finalUrl);
+      addTimelineText('Current time is ' + new Date().toISOString());
+      addTimelineText(`Using ${Curl.getVersion()}`);
+
+      const httpVersion = getHttpVersion(settings.preferredHttpVersion);
+      addTimelineText(httpVersion.log);
+      if (httpVersion.curlHttpVersion){
+        // Set HTTP version
+        setOpt(Curl.option.HTTP_VERSION, httpVersion.curlHttpVersion);
+      }
+
+      // Set timeout
+      if (settings.timeout > 0) {
+        addTimelineText(`Enable timeout of ${settings.timeout}ms`);
+        setOpt(Curl.option.TIMEOUT_MS, settings.timeout);
+      } else {
+        addTimelineText('Disable timeout');
+        setOpt(Curl.option.TIMEOUT_MS, 0);
+      }
+
+      // log some things
+      if (renderedRequest.settingEncodeUrl) {
+        addTimelineText('Enable automatic URL encoding');
+      } else {
+        addTimelineText('Disable automatic URL encoding');
+      }
+
+      // SSL Validation
+      if (validateSSL) {
+        addTimelineText('Enable SSL validation');
+      } else {
+        setOpt(Curl.option.SSL_VERIFYHOST, 0);
+        setOpt(Curl.option.SSL_VERIFYPEER, 0);
+        addTimelineText('Disable SSL validation');
+      }
+
+      // Setup CA Root Certificates
+      const baseCAPath = getTempDir();
+      const fullCAPath = pathJoin(baseCAPath, 'ca-certs.pem');
+
+      try {
+        fs.statSync(fullCAPath);
+      } catch (err) {
+        // Doesn't exist yet, so write it
+        mkdirp.sync(baseCAPath);
+        // TODO: Should mock cacerts module for testing. This is literally
+        // coercing a function to string in tests due to lack of val-loader.
+        fs.writeFileSync(fullCAPath, String(caCerts));
+        console.log('[net] Set CA to', fullCAPath);
+      }
+
+      setOpt(Curl.option.CAINFO, fullCAPath);
+
+      // Set cookies from jar
+      if (renderedRequest.settingSendCookies) {
+        // Tell Curl to store cookies that it receives. This is only important if we receive
+        // a cookie on a redirect that needs to be sent on the next request in the chain.
+        setOpt(Curl.option.COOKIEFILE, '');
+        const cookies = renderedRequest.cookieJar.cookies || [];
+
+        for (const cookie of cookies) {
+          let expiresTimestamp = 0;
+
+          if (cookie.expires) {
+            const expiresDate = new Date(cookie.expires);
+            expiresTimestamp = Math.round(expiresDate.getTime() / 1000);
+          }
+
+          setOpt(
+            Curl.option.COOKIELIST,
+            [
+              cookie.httpOnly ? `#HttpOnly_${cookie.domain}` : cookie.domain,
+              cookie.hostOnly ? 'FALSE' : 'TRUE',
+              cookie.path,
+              cookie.secure ? 'TRUE' : 'FALSE',
+              expiresTimestamp,
+              cookie.key,
+              cookie.value,
+            ].join('\t'),
+          );
+        }
+
+        for (const { name, value } of renderedRequest.cookies) {
+          setOpt(Curl.option.COOKIE, `${name}=${value}`);
+        }
+
+        addTimelineText(
+          `Enable cookie sending with jar of ${cookies.length} cookie${
+            cookies.length !== 1 ? 's' : ''
+          }`,
+        );
+      } else {
+        addTimelineText('Disable cookie sending due to user setting');
+      }
+
+      // Set proxy settings if we have them
+      if (settings.proxyEnabled) {
+        const { protocol } = urlParse(renderedRequest.url);
+        const { httpProxy, httpsProxy, noProxy } = settings;
+        const proxyHost = protocol === 'https:' ? httpsProxy : httpProxy;
+        const proxy = proxyHost ? setDefaultProtocol(proxyHost) : null;
+        addTimelineText(`Enable network proxy for ${protocol || ''}`);
+
+        if (proxy) {
+          setOpt(Curl.option.PROXY, proxy);
+          setOpt(Curl.option.PROXYAUTH, CurlAuth.Any);
+        }
+
+        if (noProxy) {
+          setOpt(Curl.option.NOPROXY, noProxy);
+        }
+      } else {
+        setOpt(Curl.option.PROXY, '');
+      }
+
+      // Set client certs if needed
+      const clientCertificates = await models.clientCertificate.findByParentId(workspace._id);
+
+      for (const certificate of (clientCertificates || [])) {
+        if (certificate.disabled) {
+          continue;
+        }
+
+        const cHostWithProtocol = setDefaultProtocol(certificate.host, 'https:');
+
+        if (urlMatchesCertHost(cHostWithProtocol, renderedRequest.url)) {
+          const ensureFile = blobOrFilename => {
+            try {
+              fs.statSync(blobOrFilename);
+            } catch (err) {
+              // Certificate file not found!
+              // LEGACY: Certs used to be stored in blobs (not as paths), so let's write it to
+              // the temp directory first.
+              const fullBase = getTempDir();
+              const name = `${renderedRequest._id}_${renderedRequest.modified}`;
+              const fullPath = pathJoin(fullBase, name);
+              fs.writeFileSync(fullPath, Buffer.from(blobOrFilename, 'base64'));
+              // Set filename to the one we just saved
+              blobOrFilename = fullPath;
+            }
+
+            return blobOrFilename;
+          };
+
+          const { passphrase, cert, key, pfx } = certificate;
+
+          if (cert) {
+            setOpt(Curl.option.SSLCERT, ensureFile(cert));
+            setOpt(Curl.option.SSLCERTTYPE, 'PEM');
+            addTimelineText('Adding SSL PEM certificate');
+          }
+
+          if (pfx) {
+            setOpt(Curl.option.SSLCERT, ensureFile(pfx));
+            setOpt(Curl.option.SSLCERTTYPE, 'P12');
+            addTimelineText('Adding SSL P12 certificate');
+          }
+
+          if (key) {
+            setOpt(Curl.option.SSLKEY, ensureFile(key));
+            addTimelineText('Adding SSL KEY certificate');
+          }
+
+          if (passphrase) {
+            setOpt(Curl.option.KEYPASSWD, passphrase);
+          }
+        }
+      }
+
+      // Build the body
+      let noBody = false;
+      let requestBody: string | null = null;
+      const expectsBody = ['POST', 'PUT', 'PATCH'].includes(renderedRequest.method.toUpperCase());
+
+      if (renderedRequest.body.mimeType === CONTENT_TYPE_FORM_URLENCODED) {
+        requestBody = buildQueryStringFromParams(renderedRequest.body.params || [], false);
+      } else if (renderedRequest.body.mimeType === CONTENT_TYPE_FORM_DATA) {
+        const params = renderedRequest.body.params || [];
+        const { filePath: multipartBodyPath, boundary, contentLength } = await buildMultipart(
+          params,
+        );
+        // Extend the Content-Type header
+        const contentTypeHeader = getContentTypeHeader(headers);
+
+        if (contentTypeHeader) {
+          contentTypeHeader.value = `multipart/form-data; boundary=${boundary}`;
+        } else {
+          headers.push({
+            name: 'Content-Type',
+            value: `multipart/form-data; boundary=${boundary}`,
+          });
+        }
+
+        const fd = fs.openSync(multipartBodyPath, 'r');
+        setOpt(Curl.option.INFILESIZE_LARGE, contentLength);
+        setOpt(Curl.option.UPLOAD, 1);
+        setOpt(Curl.option.READDATA, fd);
+        // We need this, otherwise curl will send it as a PUT
+        setOpt(Curl.option.CUSTOMREQUEST, renderedRequest.method);
+
+        const fn = () => {
+          fs.closeSync(fd);
+          fs.unlink(multipartBodyPath, () => {
+            // Pass
+          });
+        };
+
+        curl.on('end', fn);
+        curl.on('error', fn);
+      } else if (renderedRequest.body.fileName) {
+        const { size } = fs.statSync(renderedRequest.body.fileName);
+        const fileName = renderedRequest.body.fileName || '';
+        const fd = fs.openSync(fileName, 'r');
+        setOpt(Curl.option.INFILESIZE_LARGE, size);
+        setOpt(Curl.option.UPLOAD, 1);
+        setOpt(Curl.option.READDATA, fd);
+        // We need this, otherwise curl will send it as a POST
+        setOpt(Curl.option.CUSTOMREQUEST, renderedRequest.method);
+
+        const fn = () => fs.closeSync(fd);
+
+        curl.on('end', fn);
+        curl.on('error', fn);
+      } else if (typeof renderedRequest.body.mimeType === 'string' || expectsBody) {
+        requestBody = renderedRequest.body.text || '';
+      } else {
+        // No body
+        noBody = true;
+      }
+
+      if (!noBody) {
+        // Don't chunk uploads
+        headers.push({
+          name: 'Expect',
+          value: DISABLE_HEADER_VALUE,
+        });
+        headers.push({
+          name: 'Transfer-Encoding',
+          value: DISABLE_HEADER_VALUE,
+        });
+      }
+
+      // If we calculated the body within Insomnia (ie. not computed by Curl)
+      if (requestBody !== null) {
+        setOpt(Curl.option.POSTFIELDS, requestBody);
+      }
+
+      // Handle Authorization header
+      if (!hasAuthHeader(headers) && !renderedRequest.authentication.disabled) {
+        if (renderedRequest.authentication.type === AUTH_DIGEST) {
+          const { username, password } = renderedRequest.authentication;
+          setOpt(Curl.option.HTTPAUTH, CurlAuth.Digest);
+          setOpt(Curl.option.USERNAME, username || '');
+          setOpt(Curl.option.PASSWORD, password || '');
+        } else if (renderedRequest.authentication.type === AUTH_NTLM) {
+          const { username, password } = renderedRequest.authentication;
+          setOpt(Curl.option.HTTPAUTH, CurlAuth.Ntlm);
+          setOpt(Curl.option.USERNAME, username || '');
+          setOpt(Curl.option.PASSWORD, password || '');
+        } else if (renderedRequest.authentication.type === AUTH_AWS_IAM) {
+          if (!noBody && !requestBody) {
+            return handleError(
+              new Error('AWS authentication not supported for provided body type'),
+            );
+          }
+
+          const { authentication } = renderedRequest;
+          const credentials = {
+            accessKeyId: authentication.accessKeyId || '',
+            secretAccessKey: authentication.secretAccessKey || '',
+            sessionToken: authentication.sessionToken || '',
+          };
+
+          const extraHeaders = _getAwsAuthHeaders(
+            credentials,
+            headers,
+            requestBody || '',
+            finalUrl,
+            renderedRequest.method,
+            authentication.region || '',
+            authentication.service || '',
+          );
+
+          for (const header of extraHeaders) {
+            headers.push(header);
+          }
+        } else if (renderedRequest.authentication.type === AUTH_NETRC) {
+          setOpt(Curl.option.NETRC, CurlNetrc.Required);
+        } else {
+          const authHeader = await getAuthHeader(renderedRequest, finalUrl);
+
+          if (authHeader) {
+            headers.push({
+              name: authHeader.name,
+              value: authHeader.value,
+            });
+          }
+        }
+      }
+
+      // Send a default Accept headers of anything
+      if (!hasAcceptHeader(headers)) {
+        headers.push({
+          name: 'Accept',
+          value: '*/*',
+        }); // Default to anything
+      }
+
+      // Don't auto-send Accept-Encoding header
+      if (!hasAcceptEncodingHeader(headers)) {
+        headers.push({
+          name: 'Accept-Encoding',
+          value: DISABLE_HEADER_VALUE,
+        });
+      }
+
+      // Set User-Agent if it's not already in headers
+      if (!hasUserAgentHeader(headers)) {
+        setOpt(Curl.option.USERAGENT, `insomnia/${getAppVersion()}`);
+      }
+
+      // Prevent curl from adding default content-type header
+      if (!hasContentTypeHeader(headers)) {
+        headers.push({
+          name: 'content-type',
+          value: DISABLE_HEADER_VALUE,
+        });
+      }
+
+      // NOTE: This is last because headers might be modified multiple times
+      const headerStrings = headers
+        .filter(h => h.name)
+        .map(h => {
+          const value = h.value || '';
+
+          if (value === '') {
+            // Curl needs a semicolon suffix to send empty header values
+            return `${h.name};`;
+          } else if (value === DISABLE_HEADER_VALUE) {
+            // Tell Curl NOT to send the header if value is null
+            return `${h.name}:`;
+          } else {
+            // Send normal header value
+            return `${h.name}: ${value}`;
+          }
+        });
+      setOpt(Curl.option.HTTPHEADER, headerStrings);
+      let responseBodyBytes = 0;
+      const responsesDir = pathJoin(getDataDirectory(), 'responses');
+      mkdirp.sync(responsesDir);
+      const responseBodyPath = pathJoin(responsesDir, uuid.v4() + '.response');
+      const responseBodyWriteStream = fs.createWriteStream(responseBodyPath);
+      curl.on('end', () => responseBodyWriteStream.end());
+      curl.on('error', () => responseBodyWriteStream.end());
+      setOpt(Curl.option.WRITEFUNCTION, buff => {
+        responseBodyBytes += buff.length;
+        responseBodyWriteStream.write(buff);
+        return buff.length;
+      });
+      // Handle the response ending
+      curl.on('end', async (_1, _2, rawHeaders: Buffer) => {
+        const allCurlHeadersObjects = _parseHeaders(rawHeaders);
+
+        // Headers are an array (one for each redirect)
+        const lastCurlHeadersObject = allCurlHeadersObjects[allCurlHeadersObjects.length - 1];
+        // Collect various things
+        const httpVersion = lastCurlHeadersObject.version || '';
+        const statusCode = lastCurlHeadersObject.code || -1;
+        const statusMessage = lastCurlHeadersObject.reason || '';
+        // Collect the headers
+        const headers = lastCurlHeadersObject.headers;
+        // Calculate the content type
+        const contentTypeHeader = getContentTypeHeader(headers);
+        const contentType = contentTypeHeader ? contentTypeHeader.value : '';
+        // Update Cookie Jar
+        let currentUrl = finalUrl;
+        let setCookieStrings: string[] = [];
+        const jar = jarFromCookies(renderedRequest.cookieJar.cookies);
+
+        for (const { headers } of allCurlHeadersObjects) {
+          // Collect Set-Cookie headers
+          const setCookieHeaders = getSetCookieHeaders(headers);
+          setCookieStrings = [...setCookieStrings, ...setCookieHeaders.map(h => h.value)];
+          // Pull out new URL if there is a redirect
+          const newLocation = getLocationHeader(headers);
+
+          if (newLocation !== null) {
+            currentUrl = urlResolve(currentUrl, newLocation.value);
+          }
+        }
+
+        // Update jar with Set-Cookie headers
+        for (const setCookieStr of setCookieStrings) {
+          try {
+            jar.setCookieSync(setCookieStr, currentUrl);
+          } catch (err) {
+            addTimelineText(`Rejected cookie: ${err.message}`);
+          }
+        }
+
+        // Update cookie jar if we need to and if we found any cookies
+        if (renderedRequest.settingStoreCookies && setCookieStrings.length) {
+          const cookies = await cookiesFromJar(jar);
+          await models.cookieJar.update(renderedRequest.cookieJar, {
+            cookies,
+          });
+        }
+
+        // Print informational message
+        if (setCookieStrings.length > 0) {
+          const n = setCookieStrings.length;
+
+          if (renderedRequest.settingStoreCookies) {
+            addTimelineText(`Saved ${n} cookie${n === 1 ? '' : 's'}`);
+          } else {
+            addTimelineText(`Ignored ${n} cookie${n === 1 ? '' : 's'}`);
+          }
+        }
+
+        // Return the response data
+        const responsePatch: ResponsePatch = {
+          contentType,
+          headers,
+          httpVersion,
+          statusCode,
+          statusMessage,
+          bytesContent: responseBodyBytes,
+          // @ts-expect-error -- TSCONVERSION appears to be a genuine error
+          bytesRead: curl.getInfo(Curl.info.SIZE_DOWNLOAD),
+          elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000,
+          // @ts-expect-error -- TSCONVERSION appears to be a genuine error
+          url: curl.getInfo(Curl.info.EFFECTIVE_URL),
+        };
+        // Close the request
+        curl.close();
+        // Make sure the response body has been fully written first
+        await waitForStreamToFinish(responseBodyWriteStream);
+        // Send response
+        await respond(responsePatch, responseBodyPath);
+      });
+      curl.on('error', async function(err, code) {
+        let error = err + '';
+        let statusMessage = 'Error';
+
+        if (code === CurlCode.CURLE_ABORTED_BY_CALLBACK) {
+          error = 'Request aborted';
+          statusMessage = 'Abort';
+        }
+
+        await respond(
+          {
+            statusMessage,
+            error: error || 'Something went wrong',
+            elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000,
+          },
+          null,
+        );
+      });
+      curl.perform();
+    } catch (err) {
+      console.log('[network] Error', err);
+      await handleError(err);
+    }
+  });
+}
+
+function storeTimeline(timeline: ResponseTimelineEntry[]) {
+  return new Promise<string>((resolve, reject) => {
+    const timelineStr = JSON.stringify(timeline, null, '\t');
+    const timelineHash = crypto.createHash('sha1').update(timelineStr).digest('hex');
+    const responsesDir = pathJoin(getDataDirectory(), 'responses');
+    mkdirp.sync(responsesDir);
+    const timelinePath = pathJoin(responsesDir, timelineHash + '.timeline');
+    fs.writeFile(timelinePath, timelineStr, err => {
+      if (err != null) {
+        reject(err);
+      } else {
+        resolve(timelinePath);
+      }
+    });
+  });
+}

--- a/packages/insomnia-app/app/network/grpc/__tests__/response-callbacks.test.ts
+++ b/packages/insomnia-app/app/network/grpc/__tests__/response-callbacks.test.ts
@@ -1,4 +1,4 @@
-import { GrpcResponseEventEnum } from '../../../common/grpc-events';
+import { GrpcResponseEventEnum } from '../../../common/ipc-events';
 import { ResponseCallbacks } from '../response-callbacks';
 
 describe('response-callbacks', () => {

--- a/packages/insomnia-app/app/network/grpc/response-callbacks.ts
+++ b/packages/insomnia-app/app/network/grpc/response-callbacks.ts
@@ -1,7 +1,7 @@
 import { ServiceError, StatusObject } from '@grpc/grpc-js';
 import { IpcMainEvent } from 'electron';
 
-import { GrpcResponseEventEnum } from '../../common/grpc-events';
+import { GrpcResponseEventEnum } from '../../common/ipc-events';
 interface IResponseCallbacks {
   sendData(requestId: string, val: Record<string, any> | undefined): void;
   sendError(requestId: string, err: ServiceError): void;

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -1,54 +1,15 @@
 import aws4 from 'aws4';
 import clone from 'clone';
-import crypto from 'crypto';
-import fs from 'fs';
-import { HttpVersions } from 'insomnia-common';
-import { cookiesFromJar, jarFromCookies } from 'insomnia-cookies';
-import {
-  buildQueryStringFromParams,
-  joinUrlAndQueryString,
-  setDefaultProtocol,
-  smartEncodeUrl,
-} from 'insomnia-url';
-import mkdirp from 'mkdirp';
-import {
-  Curl,
-  CurlAuth,
-  CurlCode,
-  CurlFeature,
-  CurlHttpVersion,
-  CurlInfoDebug,
-  CurlNetrc,
-} from 'node-libcurl';
-import { join as pathJoin } from 'path';
-import { parse as urlParse, resolve as urlResolve } from 'url';
-import * as uuid from 'uuid';
+import { parse as urlParse } from 'url';
 
 import {
-  AUTH_AWS_IAM,
-  AUTH_DIGEST,
-  AUTH_NETRC,
-  AUTH_NTLM,
-  CONTENT_TYPE_FORM_DATA,
-  CONTENT_TYPE_FORM_URLENCODED,
-  getAppVersion,
   STATUS_CODE_PLUGIN_ERROR,
 } from '../common/constants';
 import { database as db } from '../common/database';
-import { getDataDirectory, getTempDir } from '../common/electron-helpers';
 import {
   delay,
-  describeByteSize,
   getContentTypeHeader,
   getHostHeader,
-  getLocationHeader,
-  getSetCookieHeaders,
-  hasAcceptEncodingHeader,
-  hasAcceptHeader,
-  hasAuthHeader,
-  hasContentTypeHeader,
-  hasUserAgentHeader,
-  waitForStreamToFinish,
 } from '../common/misc';
 import type { ExtraRenderInfo, RenderedRequest } from '../common/render';
 import {
@@ -59,15 +20,12 @@ import {
 import * as models from '../models';
 import type { Environment } from '../models/environment';
 import type { Request, RequestHeader } from '../models/request';
-import type { ResponseHeader, ResponseTimelineEntry } from '../models/response';
+import type { ResponseHeader } from '../models/response';
 import type { Settings } from '../models/settings';
 import { isWorkspace, Workspace } from '../models/workspace';
 import * as pluginContexts from '../plugins/context/index';
 import * as plugins from '../plugins/index';
-import { getAuthHeader } from './authentication';
-import caCerts from './ca-certs';
-import { buildMultipart } from './multipart';
-import { urlMatchesCertHost } from './url-matches-cert-host';
+import { _actuallySend } from './curl';
 
 export interface ResponsePatch {
   bodyCompression?: 'zip' | null;
@@ -92,740 +50,7 @@ export interface ResponsePatch {
 
 // Time since user's last keypress to wait before making the request
 const MAX_DELAY_TIME = 1000;
-
-// Special header value that will prevent the header being sent
-const DISABLE_HEADER_VALUE = '__Di$aB13d__';
-
-// Because node-libcurl changed some names that we used in the timeline
-const LIBCURL_DEBUG_MIGRATION_MAP = {
-  HeaderIn: 'HEADER_IN',
-  DataIn: 'DATA_IN',
-  SslDataIn: 'SSL_DATA_IN',
-  HeaderOut: 'HEADER_OUT',
-  DataOut: 'DATA_OUT',
-  SslDataOut: 'SSL_DATA_OUT',
-  Text: 'TEXT',
-  '': '',
-};
-
-const cancelRequestFunctionMap = {};
-
 let lastUserInteraction = Date.now();
-
-export const getHttpVersion = preferredHttpVersion => {
-  switch (preferredHttpVersion) {
-    case HttpVersions.V1_0:
-      return { log: 'Using HTTP 1.0', curlHttpVersion:CurlHttpVersion.V1_0 };
-    case HttpVersions.V1_1:
-      return { log: 'Using HTTP 1.1', curlHttpVersion:CurlHttpVersion.V1_1 };
-    case HttpVersions.V2PriorKnowledge:
-      return { log: 'Using HTTP/2 PriorKnowledge', curlHttpVersion:CurlHttpVersion.V2PriorKnowledge };
-    case HttpVersions.V2_0:
-      return { log: 'Using HTTP/2', curlHttpVersion:CurlHttpVersion.V2_0 };
-    case HttpVersions.v3:
-      return { log: 'Using HTTP/3', curlHttpVersion:CurlHttpVersion.v3 };
-    case HttpVersions.default:
-      return { log: 'Using default HTTP version' };
-    default:
-      return { log: `Unknown HTTP version specified ${preferredHttpVersion}`  };
-  }
-};
-
-export async function cancelRequestById(requestId) {
-  if (hasCancelFunctionForId(requestId)) {
-    const cancelRequestFunction = cancelRequestFunctionMap[requestId];
-
-    if (typeof cancelRequestFunction === 'function') {
-      return cancelRequestFunction();
-    }
-  }
-
-  console.log(`[network] Failed to cancel req=${requestId} because cancel function not found`);
-}
-
-function clearCancelFunctionForId(requestId) {
-  if (hasCancelFunctionForId(requestId)) {
-    delete cancelRequestFunctionMap[requestId];
-  }
-}
-
-export function hasCancelFunctionForId(requestId) {
-  return cancelRequestFunctionMap.hasOwnProperty(requestId);
-}
-
-export async function _actuallySend(
-  renderedRequest: RenderedRequest,
-  workspace: Workspace,
-  settings: Omit<Settings, 'validateSSL' | 'validateAuthSSL'>,
-  environment?: Environment | null,
-  validateSSL = true,
-) {
-  return new Promise<ResponsePatch>(async resolve => {
-    const timeline: ResponseTimelineEntry[] = [];
-
-    function addTimeline(name, value) {
-      timeline.push({
-        name,
-        value,
-        timestamp: Date.now(),
-      });
-    }
-
-    function addTimelineText(value) {
-      addTimeline('TEXT', value);
-    }
-
-    // Initialize the curl handle
-    const curl = new Curl();
-
-    /** Helper function to respond with a success */
-    async function respond(
-      patch: ResponsePatch,
-      bodyPath: string | null,
-    ) {
-      const timelinePath = await storeTimeline(timeline);
-      // Tear Down the cancellation logic
-      clearCancelFunctionForId(renderedRequest._id);
-      const environmentId = environment ? environment._id : null;
-      return resolve(Object.assign(
-        {
-          timelinePath,
-          environmentId,
-          parentId: renderedRequest._id,
-          bodyCompression: null,
-          // Will default to .zip otherwise
-          bodyPath: bodyPath || '',
-          settingSendCookies: renderedRequest.settingSendCookies,
-          settingStoreCookies: renderedRequest.settingStoreCookies,
-        } as ResponsePatch,
-        patch,
-      ));
-    }
-
-    /** Helper function to respond with an error */
-    async function handleError(err: Error) {
-      await respond(
-        {
-          url: renderedRequest.url,
-          parentId: renderedRequest._id,
-          error: err.message || 'Something went wrong',
-          elapsedTime: 0, // 0 because this path is hit during plugin calls
-          statusMessage: 'Error',
-          settingSendCookies: renderedRequest.settingSendCookies,
-          settingStoreCookies: renderedRequest.settingStoreCookies,
-        },
-        null,
-      );
-    }
-
-    /** Helper function to set Curl options */
-    const setOpt: typeof curl.setOpt = (opt: any, val: any) => {
-      try {
-        return curl.setOpt(opt, val);
-      } catch (err) {
-        const name = Object.keys(Curl.option).find(name => Curl.option[name] === opt);
-        throw new Error(`${err.message} (${opt} ${name || 'n/a'})`);
-      }
-    };
-
-    try {
-      // Setup the cancellation logic
-      cancelRequestFunctionMap[renderedRequest._id] = async () => {
-        await respond(
-          {
-            elapsedTime: (curl.getInfo(Curl.info.TOTAL_TIME) as number || 0) * 1000,
-            // @ts-expect-error -- needs generic
-            bytesRead: curl.getInfo(Curl.info.SIZE_DOWNLOAD),
-            // @ts-expect-error -- needs generic
-            url: curl.getInfo(Curl.info.EFFECTIVE_URL),
-            statusMessage: 'Cancelled',
-            error: 'Request was cancelled',
-          },
-          null,
-        );
-        // Kill it!
-        curl.close();
-      };
-
-      // Set all the basic options
-      setOpt(Curl.option.VERBOSE, true);
-
-      // True so debug function works\
-      setOpt(Curl.option.NOPROGRESS, true);
-
-      // True so curl doesn't print progress
-      setOpt(Curl.option.ACCEPT_ENCODING, '');
-
-      // Auto decode everything
-      curl.enable(CurlFeature.Raw);
-
-      // Set follow redirects setting
-      switch (renderedRequest.settingFollowRedirects) {
-        case 'off':
-          setOpt(Curl.option.FOLLOWLOCATION, false);
-          break;
-
-        case 'on':
-          setOpt(Curl.option.FOLLOWLOCATION, true);
-          break;
-
-        default:
-          // Set to global setting
-          setOpt(Curl.option.FOLLOWLOCATION, settings.followRedirects);
-          break;
-      }
-
-      // Set maximum amount of redirects allowed
-      // NOTE: Setting this to -1 breaks some versions of libcurl
-      if (settings.maxRedirects > 0) {
-        setOpt(Curl.option.MAXREDIRS, settings.maxRedirects);
-      }
-
-      // Don't rebuild dot sequences in path
-      if (!renderedRequest.settingRebuildPath) {
-        setOpt(Curl.option.PATH_AS_IS, true);
-      }
-
-      // Only set CURLOPT_CUSTOMREQUEST if not HEAD or GET. This is because Curl
-      // See https://curl.haxx.se/libcurl/c/CURLOPT_CUSTOMREQUEST.html
-      switch (renderedRequest.method.toUpperCase()) {
-        case 'HEAD':
-          // This is how you tell Curl to send a HEAD request
-          setOpt(Curl.option.NOBODY, 1);
-          break;
-
-        case 'POST':
-          // This is how you tell Curl to send a POST request
-          setOpt(Curl.option.POST, 1);
-          break;
-
-        default:
-          // IMPORTANT: Only use CUSTOMREQUEST for all but HEAD and POST
-          setOpt(Curl.option.CUSTOMREQUEST, renderedRequest.method);
-          break;
-      }
-
-      // Setup debug handler
-      setOpt(Curl.option.DEBUGFUNCTION, (infoType, contentBuffer) => {
-        const content = contentBuffer.toString('utf8');
-        const rawName = Object.keys(CurlInfoDebug).find(k => CurlInfoDebug[k] === infoType) || '';
-        const name = LIBCURL_DEBUG_MIGRATION_MAP[rawName] || rawName;
-
-        if (infoType === CurlInfoDebug.SslDataIn || infoType === CurlInfoDebug.SslDataOut) {
-          return 0;
-        }
-
-        // Ignore the possibly large data messages
-        if (infoType === CurlInfoDebug.DataOut) {
-          if (contentBuffer.length === 0) {
-            // Sometimes this happens, but I'm not sure why. Just ignore it.
-          } else if (contentBuffer.length / 1024 < settings.maxTimelineDataSizeKB) {
-            addTimeline(name, content);
-          } else {
-            addTimeline(name, `(${describeByteSize(contentBuffer.length)} hidden)`);
-          }
-
-          return 0;
-        }
-
-        if (infoType === CurlInfoDebug.DataIn) {
-          addTimelineText(`Received ${describeByteSize(contentBuffer.length)} chunk`);
-          return 0;
-        }
-
-        // Don't show cookie setting because this will display every domain in the jar
-        if (infoType === CurlInfoDebug.Text && content.indexOf('Added cookie') === 0) {
-          return 0;
-        }
-
-        addTimeline(name, content);
-        return 0; // Must be here
-      });
-      // Set the headers (to be modified as we go)
-      const headers = clone(renderedRequest.headers);
-      // Set the URL, including the query parameters
-      const qs = buildQueryStringFromParams(renderedRequest.parameters);
-      const url = joinUrlAndQueryString(renderedRequest.url, qs);
-      const isUnixSocket = url.match(/https?:\/\/unix:\//);
-      const finalUrl = smartEncodeUrl(url, renderedRequest.settingEncodeUrl);
-
-      if (isUnixSocket) {
-        // URL prep will convert "unix:/path" hostname to "unix/path"
-        const match = finalUrl.match(/(https?:)\/\/unix:?(\/[^:]+):\/(.+)/);
-        const protocol = (match && match[1]) || '';
-        const socketPath = (match && match[2]) || '';
-        const socketUrl = (match && match[3]) || '';
-        setOpt(Curl.option.URL, `${protocol}//${socketUrl}`);
-        setOpt(Curl.option.UNIX_SOCKET_PATH, socketPath);
-      } else {
-        setOpt(Curl.option.URL, finalUrl);
-      }
-
-      addTimelineText('Preparing request to ' + finalUrl);
-      addTimelineText('Current time is ' + new Date().toISOString());
-      addTimelineText(`Using ${Curl.getVersion()}`);
-
-      const httpVersion = getHttpVersion(settings.preferredHttpVersion);
-      addTimelineText(httpVersion.log);
-      if (httpVersion.curlHttpVersion){
-        // Set HTTP version
-        setOpt(Curl.option.HTTP_VERSION, httpVersion.curlHttpVersion);
-      }
-
-      // Set timeout
-      if (settings.timeout > 0) {
-        addTimelineText(`Enable timeout of ${settings.timeout}ms`);
-        setOpt(Curl.option.TIMEOUT_MS, settings.timeout);
-      } else {
-        addTimelineText('Disable timeout');
-        setOpt(Curl.option.TIMEOUT_MS, 0);
-      }
-
-      // log some things
-      if (renderedRequest.settingEncodeUrl) {
-        addTimelineText('Enable automatic URL encoding');
-      } else {
-        addTimelineText('Disable automatic URL encoding');
-      }
-
-      // SSL Validation
-      if (validateSSL) {
-        addTimelineText('Enable SSL validation');
-      } else {
-        setOpt(Curl.option.SSL_VERIFYHOST, 0);
-        setOpt(Curl.option.SSL_VERIFYPEER, 0);
-        addTimelineText('Disable SSL validation');
-      }
-
-      // Setup CA Root Certificates
-      const baseCAPath = getTempDir();
-      const fullCAPath = pathJoin(baseCAPath, 'ca-certs.pem');
-
-      try {
-        fs.statSync(fullCAPath);
-      } catch (err) {
-        // Doesn't exist yet, so write it
-        mkdirp.sync(baseCAPath);
-        // TODO: Should mock cacerts module for testing. This is literally
-        // coercing a function to string in tests due to lack of val-loader.
-        fs.writeFileSync(fullCAPath, String(caCerts));
-        console.log('[net] Set CA to', fullCAPath);
-      }
-
-      setOpt(Curl.option.CAINFO, fullCAPath);
-
-      // Set cookies from jar
-      if (renderedRequest.settingSendCookies) {
-        // Tell Curl to store cookies that it receives. This is only important if we receive
-        // a cookie on a redirect that needs to be sent on the next request in the chain.
-        setOpt(Curl.option.COOKIEFILE, '');
-        const cookies = renderedRequest.cookieJar.cookies || [];
-
-        for (const cookie of cookies) {
-          let expiresTimestamp = 0;
-
-          if (cookie.expires) {
-            const expiresDate = new Date(cookie.expires);
-            expiresTimestamp = Math.round(expiresDate.getTime() / 1000);
-          }
-
-          setOpt(
-            Curl.option.COOKIELIST,
-            [
-              cookie.httpOnly ? `#HttpOnly_${cookie.domain}` : cookie.domain,
-              cookie.hostOnly ? 'FALSE' : 'TRUE',
-              cookie.path,
-              cookie.secure ? 'TRUE' : 'FALSE',
-              expiresTimestamp,
-              cookie.key,
-              cookie.value,
-            ].join('\t'),
-          );
-        }
-
-        for (const { name, value } of renderedRequest.cookies) {
-          setOpt(Curl.option.COOKIE, `${name}=${value}`);
-        }
-
-        addTimelineText(
-          `Enable cookie sending with jar of ${cookies.length} cookie${
-            cookies.length !== 1 ? 's' : ''
-          }`,
-        );
-      } else {
-        addTimelineText('Disable cookie sending due to user setting');
-      }
-
-      // Set proxy settings if we have them
-      if (settings.proxyEnabled) {
-        const { protocol } = urlParse(renderedRequest.url);
-        const { httpProxy, httpsProxy, noProxy } = settings;
-        const proxyHost = protocol === 'https:' ? httpsProxy : httpProxy;
-        const proxy = proxyHost ? setDefaultProtocol(proxyHost) : null;
-        addTimelineText(`Enable network proxy for ${protocol || ''}`);
-
-        if (proxy) {
-          setOpt(Curl.option.PROXY, proxy);
-          setOpt(Curl.option.PROXYAUTH, CurlAuth.Any);
-        }
-
-        if (noProxy) {
-          setOpt(Curl.option.NOPROXY, noProxy);
-        }
-      } else {
-        setOpt(Curl.option.PROXY, '');
-      }
-
-      // Set client certs if needed
-      const clientCertificates = await models.clientCertificate.findByParentId(workspace._id);
-
-      for (const certificate of (clientCertificates || [])) {
-        if (certificate.disabled) {
-          continue;
-        }
-
-        const cHostWithProtocol = setDefaultProtocol(certificate.host, 'https:');
-
-        if (urlMatchesCertHost(cHostWithProtocol, renderedRequest.url)) {
-          const ensureFile = blobOrFilename => {
-            try {
-              fs.statSync(blobOrFilename);
-            } catch (err) {
-              // Certificate file not found!
-              // LEGACY: Certs used to be stored in blobs (not as paths), so let's write it to
-              // the temp directory first.
-              const fullBase = getTempDir();
-              const name = `${renderedRequest._id}_${renderedRequest.modified}`;
-              const fullPath = pathJoin(fullBase, name);
-              fs.writeFileSync(fullPath, Buffer.from(blobOrFilename, 'base64'));
-              // Set filename to the one we just saved
-              blobOrFilename = fullPath;
-            }
-
-            return blobOrFilename;
-          };
-
-          const { passphrase, cert, key, pfx } = certificate;
-
-          if (cert) {
-            setOpt(Curl.option.SSLCERT, ensureFile(cert));
-            setOpt(Curl.option.SSLCERTTYPE, 'PEM');
-            addTimelineText('Adding SSL PEM certificate');
-          }
-
-          if (pfx) {
-            setOpt(Curl.option.SSLCERT, ensureFile(pfx));
-            setOpt(Curl.option.SSLCERTTYPE, 'P12');
-            addTimelineText('Adding SSL P12 certificate');
-          }
-
-          if (key) {
-            setOpt(Curl.option.SSLKEY, ensureFile(key));
-            addTimelineText('Adding SSL KEY certificate');
-          }
-
-          if (passphrase) {
-            setOpt(Curl.option.KEYPASSWD, passphrase);
-          }
-        }
-      }
-
-      // Build the body
-      let noBody = false;
-      let requestBody: string | null = null;
-      const expectsBody = ['POST', 'PUT', 'PATCH'].includes(renderedRequest.method.toUpperCase());
-
-      if (renderedRequest.body.mimeType === CONTENT_TYPE_FORM_URLENCODED) {
-        requestBody = buildQueryStringFromParams(renderedRequest.body.params || [], false);
-      } else if (renderedRequest.body.mimeType === CONTENT_TYPE_FORM_DATA) {
-        const params = renderedRequest.body.params || [];
-        const { filePath: multipartBodyPath, boundary, contentLength } = await buildMultipart(
-          params,
-        );
-        // Extend the Content-Type header
-        const contentTypeHeader = getContentTypeHeader(headers);
-
-        if (contentTypeHeader) {
-          contentTypeHeader.value = `multipart/form-data; boundary=${boundary}`;
-        } else {
-          headers.push({
-            name: 'Content-Type',
-            value: `multipart/form-data; boundary=${boundary}`,
-          });
-        }
-
-        const fd = fs.openSync(multipartBodyPath, 'r');
-        setOpt(Curl.option.INFILESIZE_LARGE, contentLength);
-        setOpt(Curl.option.UPLOAD, 1);
-        setOpt(Curl.option.READDATA, fd);
-        // We need this, otherwise curl will send it as a PUT
-        setOpt(Curl.option.CUSTOMREQUEST, renderedRequest.method);
-
-        const fn = () => {
-          fs.closeSync(fd);
-          fs.unlink(multipartBodyPath, () => {
-            // Pass
-          });
-        };
-
-        curl.on('end', fn);
-        curl.on('error', fn);
-      } else if (renderedRequest.body.fileName) {
-        const { size } = fs.statSync(renderedRequest.body.fileName);
-        const fileName = renderedRequest.body.fileName || '';
-        const fd = fs.openSync(fileName, 'r');
-        setOpt(Curl.option.INFILESIZE_LARGE, size);
-        setOpt(Curl.option.UPLOAD, 1);
-        setOpt(Curl.option.READDATA, fd);
-        // We need this, otherwise curl will send it as a POST
-        setOpt(Curl.option.CUSTOMREQUEST, renderedRequest.method);
-
-        const fn = () => fs.closeSync(fd);
-
-        curl.on('end', fn);
-        curl.on('error', fn);
-      } else if (typeof renderedRequest.body.mimeType === 'string' || expectsBody) {
-        requestBody = renderedRequest.body.text || '';
-      } else {
-        // No body
-        noBody = true;
-      }
-
-      if (!noBody) {
-        // Don't chunk uploads
-        headers.push({
-          name: 'Expect',
-          value: DISABLE_HEADER_VALUE,
-        });
-        headers.push({
-          name: 'Transfer-Encoding',
-          value: DISABLE_HEADER_VALUE,
-        });
-      }
-
-      // If we calculated the body within Insomnia (ie. not computed by Curl)
-      if (requestBody !== null) {
-        setOpt(Curl.option.POSTFIELDS, requestBody);
-      }
-
-      // Handle Authorization header
-      if (!hasAuthHeader(headers) && !renderedRequest.authentication.disabled) {
-        if (renderedRequest.authentication.type === AUTH_DIGEST) {
-          const { username, password } = renderedRequest.authentication;
-          setOpt(Curl.option.HTTPAUTH, CurlAuth.Digest);
-          setOpt(Curl.option.USERNAME, username || '');
-          setOpt(Curl.option.PASSWORD, password || '');
-        } else if (renderedRequest.authentication.type === AUTH_NTLM) {
-          const { username, password } = renderedRequest.authentication;
-          setOpt(Curl.option.HTTPAUTH, CurlAuth.Ntlm);
-          setOpt(Curl.option.USERNAME, username || '');
-          setOpt(Curl.option.PASSWORD, password || '');
-        } else if (renderedRequest.authentication.type === AUTH_AWS_IAM) {
-          if (!noBody && !requestBody) {
-            return handleError(
-              new Error('AWS authentication not supported for provided body type'),
-            );
-          }
-
-          const { authentication } = renderedRequest;
-          const credentials = {
-            accessKeyId: authentication.accessKeyId || '',
-            secretAccessKey: authentication.secretAccessKey || '',
-            sessionToken: authentication.sessionToken || '',
-          };
-
-          const extraHeaders = _getAwsAuthHeaders(
-            credentials,
-            headers,
-            requestBody || '',
-            finalUrl,
-            renderedRequest.method,
-            authentication.region || '',
-            authentication.service || '',
-          );
-
-          for (const header of extraHeaders) {
-            headers.push(header);
-          }
-        } else if (renderedRequest.authentication.type === AUTH_NETRC) {
-          setOpt(Curl.option.NETRC, CurlNetrc.Required);
-        } else {
-          const authHeader = await getAuthHeader(renderedRequest, finalUrl);
-
-          if (authHeader) {
-            headers.push({
-              name: authHeader.name,
-              value: authHeader.value,
-            });
-          }
-        }
-      }
-
-      // Send a default Accept headers of anything
-      if (!hasAcceptHeader(headers)) {
-        headers.push({
-          name: 'Accept',
-          value: '*/*',
-        }); // Default to anything
-      }
-
-      // Don't auto-send Accept-Encoding header
-      if (!hasAcceptEncodingHeader(headers)) {
-        headers.push({
-          name: 'Accept-Encoding',
-          value: DISABLE_HEADER_VALUE,
-        });
-      }
-
-      // Set User-Agent if it's not already in headers
-      if (!hasUserAgentHeader(headers)) {
-        setOpt(Curl.option.USERAGENT, `insomnia/${getAppVersion()}`);
-      }
-
-      // Prevent curl from adding default content-type header
-      if (!hasContentTypeHeader(headers)) {
-        headers.push({
-          name: 'content-type',
-          value: DISABLE_HEADER_VALUE,
-        });
-      }
-
-      // NOTE: This is last because headers might be modified multiple times
-      const headerStrings = headers
-        .filter(h => h.name)
-        .map(h => {
-          const value = h.value || '';
-
-          if (value === '') {
-            // Curl needs a semicolon suffix to send empty header values
-            return `${h.name};`;
-          } else if (value === DISABLE_HEADER_VALUE) {
-            // Tell Curl NOT to send the header if value is null
-            return `${h.name}:`;
-          } else {
-            // Send normal header value
-            return `${h.name}: ${value}`;
-          }
-        });
-      setOpt(Curl.option.HTTPHEADER, headerStrings);
-      let responseBodyBytes = 0;
-      const responsesDir = pathJoin(getDataDirectory(), 'responses');
-      mkdirp.sync(responsesDir);
-      const responseBodyPath = pathJoin(responsesDir, uuid.v4() + '.response');
-      const responseBodyWriteStream = fs.createWriteStream(responseBodyPath);
-      curl.on('end', () => responseBodyWriteStream.end());
-      curl.on('error', () => responseBodyWriteStream.end());
-      setOpt(Curl.option.WRITEFUNCTION, buff => {
-        responseBodyBytes += buff.length;
-        responseBodyWriteStream.write(buff);
-        return buff.length;
-      });
-      // Handle the response ending
-      curl.on('end', async (_1, _2, rawHeaders: Buffer) => {
-        const allCurlHeadersObjects = _parseHeaders(rawHeaders);
-
-        // Headers are an array (one for each redirect)
-        const lastCurlHeadersObject = allCurlHeadersObjects[allCurlHeadersObjects.length - 1];
-        // Collect various things
-        const httpVersion = lastCurlHeadersObject.version || '';
-        const statusCode = lastCurlHeadersObject.code || -1;
-        const statusMessage = lastCurlHeadersObject.reason || '';
-        // Collect the headers
-        const headers = lastCurlHeadersObject.headers;
-        // Calculate the content type
-        const contentTypeHeader = getContentTypeHeader(headers);
-        const contentType = contentTypeHeader ? contentTypeHeader.value : '';
-        // Update Cookie Jar
-        let currentUrl = finalUrl;
-        let setCookieStrings: string[] = [];
-        const jar = jarFromCookies(renderedRequest.cookieJar.cookies);
-
-        for (const { headers } of allCurlHeadersObjects) {
-          // Collect Set-Cookie headers
-          const setCookieHeaders = getSetCookieHeaders(headers);
-          setCookieStrings = [...setCookieStrings, ...setCookieHeaders.map(h => h.value)];
-          // Pull out new URL if there is a redirect
-          const newLocation = getLocationHeader(headers);
-
-          if (newLocation !== null) {
-            currentUrl = urlResolve(currentUrl, newLocation.value);
-          }
-        }
-
-        // Update jar with Set-Cookie headers
-        for (const setCookieStr of setCookieStrings) {
-          try {
-            jar.setCookieSync(setCookieStr, currentUrl);
-          } catch (err) {
-            addTimelineText(`Rejected cookie: ${err.message}`);
-          }
-        }
-
-        // Update cookie jar if we need to and if we found any cookies
-        if (renderedRequest.settingStoreCookies && setCookieStrings.length) {
-          const cookies = await cookiesFromJar(jar);
-          await models.cookieJar.update(renderedRequest.cookieJar, {
-            cookies,
-          });
-        }
-
-        // Print informational message
-        if (setCookieStrings.length > 0) {
-          const n = setCookieStrings.length;
-
-          if (renderedRequest.settingStoreCookies) {
-            addTimelineText(`Saved ${n} cookie${n === 1 ? '' : 's'}`);
-          } else {
-            addTimelineText(`Ignored ${n} cookie${n === 1 ? '' : 's'}`);
-          }
-        }
-
-        // Return the response data
-        const responsePatch: ResponsePatch = {
-          contentType,
-          headers,
-          httpVersion,
-          statusCode,
-          statusMessage,
-          bytesContent: responseBodyBytes,
-          // @ts-expect-error -- TSCONVERSION appears to be a genuine error
-          bytesRead: curl.getInfo(Curl.info.SIZE_DOWNLOAD),
-          elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000,
-          // @ts-expect-error -- TSCONVERSION appears to be a genuine error
-          url: curl.getInfo(Curl.info.EFFECTIVE_URL),
-        };
-        // Close the request
-        curl.close();
-        // Make sure the response body has been fully written first
-        await waitForStreamToFinish(responseBodyWriteStream);
-        // Send response
-        await respond(responsePatch, responseBodyPath);
-      });
-      curl.on('error', async function(err, code) {
-        let error = err + '';
-        let statusMessage = 'Error';
-
-        if (code === CurlCode.CURLE_ABORTED_BY_CALLBACK) {
-          error = 'Request aborted';
-          statusMessage = 'Abort';
-        }
-
-        await respond(
-          {
-            statusMessage,
-            error: error || 'Something went wrong',
-            elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000,
-          },
-          null,
-        );
-      });
-      curl.perform();
-    } catch (err) {
-      console.log('[network] Error', err);
-      await handleError(err);
-    }
-  });
-}
 
 export async function sendWithSettings(
   requestId: string,
@@ -868,14 +93,14 @@ export async function sendWithSettings(
   } catch (err) {
     throw new Error(`Failed to render request: ${requestId}`);
   }
-
-  const response = await _actuallySend(
+  const sendOptions: [RenderedRequest, Workspace, Omit<Settings, 'validateSSL' | 'validateAuthSSL'>, Environment | null, boolean?] = [
     renderResult.request,
     workspace,
     settings,
     environment,
     settings.validateAuthSSL,
-  );
+  ];
+  const response: ResponsePatch = await _actuallySend(...sendOptions);
   if (response.error){
     return response;
   }
@@ -890,7 +115,7 @@ export async function send(
   requestId: string,
   environmentId?: string,
   extraInfo?: ExtraRenderInfo,
-) {
+): Promise<ResponsePatch> {
   console.log(`[network] Sending req=${requestId} env=${environmentId || 'null'}`);
   // HACK: wait for all debounces to finish
 
@@ -953,19 +178,22 @@ export async function send(
       parentId: renderedRequestBeforePlugins._id,
       settingSendCookies: renderedRequestBeforePlugins.settingSendCookies,
       settingStoreCookies: renderedRequestBeforePlugins.settingStoreCookies,
+      elapsedTime: 0, // 0 because this path is hit during plugin calls
       statusCode: STATUS_CODE_PLUGIN_ERROR,
       statusMessage: err.plugin ? `Plugin ${err.plugin.name}` : 'Plugin',
       url: renderedRequestBeforePlugins.url,
-    } as ResponsePatch;
+    };
   }
 
-  const response = await _actuallySend(
+  const sendOptions: [RenderedRequest, Workspace, Omit<Settings, 'validateSSL' | 'validateAuthSSL'>, Environment | null, boolean?] = [
     renderedRequest,
     workspace,
     settings,
     environment,
     settings.validateSSL,
-  );
+  ];
+
+  const response: ResponsePatch = await _actuallySend(...sendOptions);
   console.log(
     response.error
       ? `[network] Response failed req=${requestId} err=${response.error || 'n/a'}`
@@ -1138,23 +366,6 @@ export function _getAwsAuthHeaders(
       name,
       value: signature.headers[name],
     }));
-}
-
-function storeTimeline(timeline: ResponseTimelineEntry[]) {
-  return new Promise<string>((resolve, reject) => {
-    const timelineStr = JSON.stringify(timeline, null, '\t');
-    const timelineHash = crypto.createHash('sha1').update(timelineStr).digest('hex');
-    const responsesDir = pathJoin(getDataDirectory(), 'responses');
-    mkdirp.sync(responsesDir);
-    const timelinePath = pathJoin(responsesDir, timelineHash + '.timeline');
-    fs.writeFile(timelinePath, timelineStr, err => {
-      if (err != null) {
-        reject(err);
-      } else {
-        resolve(timelinePath);
-      }
-    });
-  });
 }
 
 if (global.document) {

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -7,6 +7,7 @@ import {
   STATUS_CODE_PLUGIN_ERROR,
 } from '../common/constants';
 import { database as db } from '../common/database';
+import { CurlRequestEvent } from '../common/ipc-events';
 import {
   delay,
   getContentTypeHeader,
@@ -100,7 +101,7 @@ export async function sendWithSettings(
     environment,
     settings.validateAuthSSL,
   ];
-  const response: ResponsePatch = await ipcRenderer.invoke('_actuallySend', ...sendOptions);
+  const response: ResponsePatch = await ipcRenderer.invoke(CurlRequestEvent.send, ...sendOptions);
   if (response.error){
     return response;
   }
@@ -195,7 +196,7 @@ export async function send(
     settings.validateSSL,
   ];
 
-  const response: ResponsePatch = overrideSend ?  await overrideSend(...sendOptions) : await ipcRenderer.invoke('_actuallySend', ...sendOptions);
+  const response: ResponsePatch = overrideSend ?  await overrideSend(...sendOptions) : await ipcRenderer.invoke(CurlRequestEvent.send, ...sendOptions);
   console.log(
     response.error
       ? `[network] Response failed req=${requestId} err=${response.error || 'n/a'}`

--- a/packages/insomnia-app/app/network/o-auth-2/misc.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/misc.ts
@@ -10,19 +10,13 @@ export enum ChromiumVerificationResult {
 }
 
 const LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
-let authWindowSessionId;
-
-if (window.localStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID)) {
-  authWindowSessionId = window.localStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID);
-} else {
-  initNewOAuthSession();
-}
 
 export function initNewOAuthSession() {
   // the value of this variable needs to start with 'persist:'
   // otherwise sessions won't be persisted over application-restarts
-  authWindowSessionId = `persist:oauth2_${uuid.v4()}`;
-  window.localStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, authWindowSessionId);
+  const token = `persist:oauth2_${uuid.v4()}`;
+  window.localStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, token);
+  return token;
 }
 
 export function responseToObject(body, keys, defaults = {}) {
@@ -72,6 +66,9 @@ export function authorizeUserInWindow(
     const {
       validateAuthSSL,
     } = await models.settings.getOrCreate();
+
+    const authWindowSessionId = window.localStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID) || initNewOAuthSession();
+    window.localStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, authWindowSessionId);
 
     // Create a child window
     const child = new electron.remote.BrowserWindow({

--- a/packages/insomnia-app/app/ui/components/modals/proto-files-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/proto-files-modal.tsx
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
-import { GrpcRequestEventEnum } from '../../../common/grpc-events';
+import { GrpcRequestEventEnum } from '../../../common/ipc-events';
 import type { ProtoDirectory } from '../../../models/proto-directory';
 import type { ProtoFile } from '../../../models/proto-file';
 import * as protoManager from '../../../network/grpc/proto-manager';

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
@@ -1,5 +1,4 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { ipcRenderer } from 'electron';
 import { HotKeyRegistry } from 'insomnia-common';
 import React, { PureComponent } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
@@ -18,7 +17,6 @@ import { ImportExport } from '../settings/import-export';
 import { Plugins } from '../settings/plugins';
 import { Shortcuts } from '../settings/shortcuts';
 import { ThemePanel } from '../settings/theme-panel';
-import { Tooltip } from '../tooltip';
 import { showModal } from './index';
 
 export const TAB_INDEX_EXPORT = 1;

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
@@ -41,7 +41,6 @@ export class SettingsModal extends PureComponent<Props, State> {
   };
 
   modal: Modal | null = null;
-  curlVersion = ipcRenderer.sendSync('Curl.getVersion');
 
   _setModalRef(n: Modal) {
     this.modal = n;
@@ -84,9 +83,6 @@ export class SettingsModal extends PureComponent<Props, State> {
           {getAppName()} Preferences
           <span className="faint txt-sm">
             &nbsp;&nbsp;–&nbsp; v{getAppVersion()}
-            <Tooltip position="bottom" message={this.curlVersion}>
-              <i className="fa fa-info-circle" />
-            </Tooltip>
             {email ? ` – ${email}` : null}
           </span>
         </ModalHeader>

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
+import { ipcRenderer } from 'electron';
 import { HotKeyRegistry } from 'insomnia-common';
-import { Curl } from 'node-libcurl';
 import React, { PureComponent } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
@@ -41,6 +41,7 @@ export class SettingsModal extends PureComponent<Props, State> {
   };
 
   modal: Modal | null = null;
+  curlVersion = ipcRenderer.sendSync('Curl.getVersion');
 
   _setModalRef(n: Modal) {
     this.modal = n;
@@ -83,7 +84,7 @@ export class SettingsModal extends PureComponent<Props, State> {
           {getAppName()} Preferences
           <span className="faint txt-sm">
             &nbsp;&nbsp;–&nbsp; v{getAppVersion()}
-            <Tooltip position="bottom" message={Curl.getVersion()}>
+            <Tooltip position="bottom" message={this.curlVersion}>
               <i className="fa fa-info-circle" />
             </Tooltip>
             {email ? ` – ${email}` : null}

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-action-handlers.ts
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-action-handlers.ts
@@ -1,7 +1,7 @@
 import { ipcRenderer } from 'electron';
 import { useCallback } from 'react';
 
-import { GrpcRequestEventEnum } from '../../../../common/grpc-events';
+import { GrpcRequestEventEnum } from '../../../../common/ipc-events';
 import type { GrpcMethodType } from '../../../../network/grpc/method';
 import { prepareGrpcMessage, prepareGrpcRequest } from '../../../../network/grpc/prepare';
 import { grpcActions, GrpcDispatch } from '../../../context/grpc';

--- a/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
@@ -17,7 +17,7 @@ import type { Request } from '../../../models/request';
 import type { RequestVersion } from '../../../models/request-version';
 import type { Response } from '../../../models/response';
 import type { UnitTestResult } from '../../../models/unit-test-result';
-import { cancelRequestById } from '../../../network/network';
+import { cancelRequestById } from '../../../network/curl';
 import { Button } from '../base/button';
 import { PreviewModeDropdown } from '../dropdowns/preview-mode-dropdown';
 import { ResponseHistoryDropdown } from '../dropdowns/response-history-dropdown';

--- a/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
-import { clipboard, remote } from 'electron';
+import { clipboard, ipcRenderer, remote } from 'electron';
 import fs from 'fs';
 import { HotKeyRegistry } from 'insomnia-common';
 import { json as jsonPrettify } from 'insomnia-prettify';
@@ -17,7 +17,6 @@ import type { Request } from '../../../models/request';
 import type { RequestVersion } from '../../../models/request-version';
 import type { Response } from '../../../models/response';
 import type { UnitTestResult } from '../../../models/unit-test-result';
-import { cancelRequestById } from '../../../network/curl';
 import { Button } from '../base/button';
 import { PreviewModeDropdown } from '../dropdowns/preview-mode-dropdown';
 import { ResponseHistoryDropdown } from '../dropdowns/response-history-dropdown';
@@ -254,7 +253,7 @@ export class ResponsePane extends PureComponent<Props> {
       return (
         <PlaceholderResponsePane hotKeyRegistry={hotKeyRegistry}>
           <ResponseTimer
-            handleCancel={() => cancelRequestById(request._id)}
+            handleCancel={() => ipcRenderer.send('cancelRequestById', request._id)}
             loadStartTime={loadStartTime}
           />
         </PlaceholderResponsePane>
@@ -370,7 +369,7 @@ export class ResponsePane extends PureComponent<Props> {
         </Tabs>
         <ErrorBoundary errorClassName="font-error pad text-center">
           <ResponseTimer
-            handleCancel={() => cancelRequestById(request._id)}
+            handleCancel={() => ipcRenderer.send('cancelRequestById', request._id)}
             loadStartTime={loadStartTime}
           />
         </ErrorBoundary>

--- a/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-ipc-renderer.test.ts
+++ b/packages/insomnia-app/app/ui/context/grpc/__tests__/grpc-ipc-renderer.test.ts
@@ -1,7 +1,7 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
 import { ipcRenderer } from 'electron';
 
-import { GrpcRequestEventEnum, GrpcResponseEventEnum } from '../../../../common/grpc-events';
+import { GrpcRequestEventEnum, GrpcResponseEventEnum } from '../../../../common/ipc-events';
 import { grpcStatusObjectSchema } from '../__schemas__';
 import { grpcActions } from '../grpc-actions';
 import { grpcIpcRenderer, sendGrpcIpcMultiple } from '../grpc-ipc-renderer';

--- a/packages/insomnia-app/app/ui/context/grpc/grpc-ipc-renderer.ts
+++ b/packages/insomnia-app/app/ui/context/grpc/grpc-ipc-renderer.ts
@@ -1,7 +1,7 @@
 import { ipcRenderer } from 'electron';
 
-import type { GrpcRequestEvent } from '../../../common/grpc-events';
-import { GrpcResponseEventEnum } from '../../../common/grpc-events';
+import type { GrpcRequestEvent } from '../../../common/ipc-events';
+import { GrpcResponseEventEnum } from '../../../common/ipc-events';
 import type { GrpcDispatch } from './grpc-actions';
 import { grpcActions } from './grpc-actions';
 

--- a/packages/insomnia-app/send-request/index.ts
+++ b/packages/insomnia-app/send-request/index.ts
@@ -4,11 +4,9 @@ import 'regenerator-runtime/runtime';
 import { database } from '../app/common/database';
 import { BaseModel, types as modelTypes } from '../app/models';
 import * as models from '../app/models';
-import { getBodyBuffer } from '../app/models/response';
 import { Settings } from '../app/models/settings';
 import { _actuallySend } from '../app/network/curl';
-import { send } from '../app/network/network';
-import * as plugins from '../app/plugins';
+import { sendAndTransform } from '../app/network/network';
 
 // The network layer uses settings from the settings model
 // We want to give consumers the ability to override certain settings
@@ -42,31 +40,6 @@ export async function getSendRequestCallbackMemDb(environmentId: string, memDB: 
 
   // Return callback helper to send requests
   return async function sendRequest(requestId: string) {
-    return sendAndTransform(requestId, environmentId);
+    return sendAndTransform(requestId, environmentId, _actuallySend);
   };
-}
-async function sendAndTransform(requestId: string, environmentId?: string) {
-  try {
-    plugins.ignorePlugin('insomnia-plugin-kong-declarative-config');
-    plugins.ignorePlugin('insomnia-plugin-kong-kubernetes-config');
-    plugins.ignorePlugin('insomnia-plugin-kong-portal');
-    const res = await send(requestId, environmentId, undefined, _actuallySend);
-    const headersObj: Record<string, string> = {};
-
-    for (const h of res.headers || []) {
-      const name = h.name || '';
-      headersObj[name.toLowerCase()] = h.value || '';
-    }
-
-    const bodyBuffer = await getBodyBuffer(res) as Buffer;
-    return {
-      status: res.statusCode,
-      statusMessage: res.statusMessage,
-      data: bodyBuffer ? bodyBuffer.toString('utf8') : undefined,
-      headers: headersObj,
-      responseTime: res.elapsedTime,
-    };
-  } finally {
-    plugins.clearIgnores();
-  }
 }

--- a/packages/insomnia-app/send-request/index.ts
+++ b/packages/insomnia-app/send-request/index.ts
@@ -6,6 +6,7 @@ import { BaseModel, types as modelTypes } from '../app/models';
 import * as models from '../app/models';
 import { getBodyBuffer } from '../app/models/response';
 import { Settings } from '../app/models/settings';
+import { _actuallySend } from '../app/network/curl';
 import { send } from '../app/network/network';
 import * as plugins from '../app/plugins';
 
@@ -49,7 +50,7 @@ async function sendAndTransform(requestId: string, environmentId?: string) {
     plugins.ignorePlugin('insomnia-plugin-kong-declarative-config');
     plugins.ignorePlugin('insomnia-plugin-kong-kubernetes-config');
     plugins.ignorePlugin('insomnia-plugin-kong-portal');
-    const res = await send(requestId, environmentId);
+    const res = await send(requestId, environmentId, undefined, _actuallySend);
     const headersObj: Record<string, string> = {};
 
     for (const h of res.headers || []) {

--- a/packages/insomnia-app/send-request/index.ts
+++ b/packages/insomnia-app/send-request/index.ts
@@ -1,3 +1,71 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
-export { getSendRequestCallbackMemDb, getSendRequestCallback } from '../app/common/send-request';
+
+import { database } from '../app/common/database';
+import { BaseModel, types as modelTypes } from '../app/models';
+import * as models from '../app/models';
+import { getBodyBuffer } from '../app/models/response';
+import { Settings } from '../app/models/settings';
+import { send } from '../app/network/network';
+import * as plugins from '../app/plugins';
+
+// The network layer uses settings from the settings model
+// We want to give consumers the ability to override certain settings
+type SettingsOverride = Pick<Settings, 'validateSSL'>;
+
+export async function getSendRequestCallbackMemDb(environmentId: string, memDB: any, settingsOverrides?: SettingsOverride) {
+  // Initialize the DB in-memory and fill it with data if we're given one
+  await database.init(
+    modelTypes(),
+    {
+      inMemoryOnly: true,
+    },
+    true,
+    () => { },
+  );
+  const docs: BaseModel[] = [];
+
+  const settings = await models.settings.getOrCreate();
+  docs.push({ ...settings, ...settingsOverrides });
+
+  for (const type of Object.keys(memDB)) {
+    for (const doc of memDB[type]) {
+      docs.push(doc);
+    }
+  }
+
+  await database.batchModifyDocs({
+    upsert: docs,
+    remove: [],
+  });
+
+  // Return callback helper to send requests
+  return async function sendRequest(requestId: string) {
+    return sendAndTransform(requestId, environmentId);
+  };
+}
+async function sendAndTransform(requestId: string, environmentId?: string) {
+  try {
+    plugins.ignorePlugin('insomnia-plugin-kong-declarative-config');
+    plugins.ignorePlugin('insomnia-plugin-kong-kubernetes-config');
+    plugins.ignorePlugin('insomnia-plugin-kong-portal');
+    const res = await send(requestId, environmentId);
+    const headersObj: Record<string, string> = {};
+
+    for (const h of res.headers || []) {
+      const name = h.name || '';
+      headersObj[name.toLowerCase()] = h.value || '';
+    }
+
+    const bodyBuffer = await getBodyBuffer(res) as Buffer;
+    return {
+      status: res.statusCode,
+      statusMessage: res.statusMessage,
+      data: bodyBuffer ? bodyBuffer.toString('utf8') : undefined,
+      headers: headersObj,
+      responseTime: res.elapsedTime,
+    };
+  } finally {
+    plugins.clearIgnores();
+  }
+}


### PR DESCRIPTION
Follow up from #4223 

The goal of this PR is to move the action of sending curl requests to the electron main context to avoid circumstances where the renderer context becomes blocked and requests cannot be cancelled or sent. The same code is also used by inso-cli which should treat this change as a no-op.


- cancel also must be called in the main context since thats where the curl instance is.
- curl.ts must be extracted to another file to keep node-libcurl instances from being created in the renderer context
- inso-cli injects native module
- expose curl version checks
- remove `allowRendererProcessReuse` electron override

NOTES: 
Removing `allowRendererProcessReuse` electron override forces the renderer to fail if any native modules are imported into the renderer context. So this keeps us from worrying about regression.


Closes INS-973
Closes INS-1180
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
