### PR TITLE
rm version divider from Collection dropdown

### DIFF
--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
@@ -164,9 +164,7 @@ export class WorkspaceDropdown extends PureComponent<Props, State> {
             <i className="fa fa-caret-down space-left" />
             {isLoading ? <i className="fa fa-refresh fa-spin space-left" /> : null}
           </DropdownButton>
-          <DropdownDivider>
-            {getAppName()} v{getAppVersion()}
-          </DropdownDivider>
+          
           <DropdownItem onClick={WorkspaceDropdown._handleShowWorkspaceSettings}>
             <i className="fa fa-wrench" /> {getWorkspaceLabel(activeWorkspace).singular} Settings
             <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.WORKSPACE_SHOW_SETTINGS.id]} />

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import { HotKeyRegistry } from 'insomnia-common';
 import React, { PureComponent } from 'react';
 
-import { AUTOBIND_CFG, getAppName, getAppVersion } from '../../../common/constants';
+import { AUTOBIND_CFG } from '../../../common/constants';
 import { database as db } from '../../../common/database';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
 import { hotKeyRefs } from '../../../common/hotkeys';
@@ -164,7 +164,6 @@ export class WorkspaceDropdown extends PureComponent<Props, State> {
             <i className="fa fa-caret-down space-left" />
             {isLoading ? <i className="fa fa-refresh fa-spin space-left" /> : null}
           </DropdownButton>
-          
           <DropdownItem onClick={WorkspaceDropdown._handleShowWorkspaceSettings}>
             <i className="fa fa-wrench" /> {getWorkspaceLabel(activeWorkspace).singular} Settings
             <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.WORKSPACE_SHOW_SETTINGS.id]} />


### PR DESCRIPTION
Remove the version top divider on the Collection dropdown menu as the information is already available under settings. 

**Before**
![Screen Shot 2021-11-22 at 4 49 45 PM](https://user-images.githubusercontent.com/22301405/142956193-91716f83-e356-4643-9353-004a13da5601.png)

**After**

<img width="431" alt="Screen Shot 2021-11-22 at 4 46 56 PM" src="https://user-images.githubusercontent.com/22301405/142956167-f244125d-ea56-48f7-a723-54bb8fd102be.png">

Closes [INS-1020](https://linear.app/insomnia/issue/INS-1020/remove-insomnia-version-from-workspace-dropdown)
