### PR TITLE
Remove prop drilling to code-editor

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -164,6 +164,7 @@ interface Props extends ReduxProps {
   infoOptions?: GraphQLInfoOptions;
   jumpOptions?: ModifiedGraphQLJumpOptions;
   uniquenessKey?: string;
+  // TODO: I think this prop can actually be removed entirely
   isVariableUncovered?: boolean;
   raw?: boolean;
 }

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -95,16 +95,30 @@ export type CodeEditorOnChange = (value: string) => void;
 type ReduxProps = ReturnType<typeof mapStateToProps>;
 
 const mapStateToProps = (state: RootState) => {
-  const { hotKeyRegistry, autocompleteDelay } = selectSettings(state);
+  const {
+    hotKeyRegistry,
+    autocompleteDelay,
+    editorFontSize,
+    editorIndentSize,
+    editorKeyMap,
+    editorLineWrapping,
+    editorIndentWithTabs,
+    nunjucksPowerUserMode,
+  } = selectSettings(state);
 
   return {
     hotKeyRegistry,
     autocompleteDelay,
+    fontSize: editorFontSize,
+    indentSize: editorIndentSize,
+    keyMap: editorKeyMap,
+    lineWrapping: editorLineWrapping,
+    indentWithTabs: editorIndentWithTabs,
+    nunjucksPowerUserMode,
   };
 };
 
 interface Props extends ReduxProps {
-  indentWithTabs?: boolean;
   onChange?: CodeEditorOnChange;
   onCursorActivity?: (cm: CodeMirror.EditorFromTextArea) => void;
   onFocus?: (e: FocusEvent) => void;
@@ -116,21 +130,16 @@ interface Props extends ReduxProps {
   onPaste?: (e: ClipboardEvent) => void;
   onCodeMirrorInit?: (editor: CodeMirror.EditorFromTextArea) => void;
   render?: HandleRender;
-  nunjucksPowerUserMode?: boolean;
   getRenderContext?: HandleGetRenderContext;
   getAutocompleteConstants?: () => string[] | PromiseLike<string[]>;
   getAutocompleteSnippets?: () => CodeMirror.Snippet[];
-  keyMap?: string;
   mode?: string;
   id?: string;
   placeholder?: string;
-  lineWrapping?: boolean;
   hideLineNumbers?: boolean;
   hideGutters?: boolean;
   noMatchBrackets?: boolean;
   hideScrollbars?: boolean;
-  fontSize?: number;
-  indentSize?: number;
   defaultValue?: string;
   tabIndex?: number;
   autoPrettify?: boolean;

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -94,7 +94,11 @@ export type CodeEditorOnChange = (value: string) => void;
 
 type ReduxProps = ReturnType<typeof mapStateToProps>;
 
-const mapStateToProps = (state: RootState) => {
+interface OwnProps {
+  ignoreEditorFontSettings?: boolean;
+}
+
+const mapStateToProps = (state: RootState, { ignoreEditorFontSettings }: OwnProps) => {
   const {
     hotKeyRegistry,
     autocompleteDelay,
@@ -109,11 +113,11 @@ const mapStateToProps = (state: RootState) => {
   return {
     hotKeyRegistry,
     autocompleteDelay,
-    fontSize: editorFontSize,
-    indentSize: editorIndentSize,
+    fontSize: ignoreEditorFontSettings ? undefined : editorFontSize,
+    indentSize: ignoreEditorFontSettings ? undefined : editorIndentSize,
     keyMap: editorKeyMap,
-    lineWrapping: editorLineWrapping,
-    indentWithTabs: editorIndentWithTabs,
+    lineWrapping: ignoreEditorFontSettings ? undefined : editorLineWrapping,
+    indentWithTabs: ignoreEditorFontSettings ? undefined : editorIndentWithTabs,
     nunjucksPowerUserMode,
   };
 };

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -590,6 +590,7 @@ export class UnconnectedCodeEditor extends Component<Props, State> {
       this.codeMirror?.clearHistory();
 
       // Setup nunjucks listeners
+      // TODO: we shouldn't need to set setup nunjucks if we're in readonly mode
       if (this.props.render && !this.props.nunjucksPowerUserMode) {
         this.codeMirror?.enableNunjucksTags(
           this.props.render,

--- a/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
@@ -24,7 +24,6 @@ interface Props {
   onPaste?: (e: ClipboardEvent) => void;
   render?: HandleRender;
   getRenderContext?: HandleGetRenderContext;
-  nunjucksPowerUserMode?: boolean;
   getAutocompleteConstants?: () => string[] | PromiseLike<string[]>;
   placeholder?: string;
   className?: string;
@@ -352,7 +351,6 @@ export class OneLineEditor extends PureComponent<Props, State> {
       render,
       onPaste,
       getRenderContext,
-      nunjucksPowerUserMode,
       getAutocompleteConstants,
       isVariableUncovered,
       mode: syntaxMode,
@@ -388,7 +386,6 @@ export class OneLineEditor extends PureComponent<Props, State> {
             onChange={onChange}
             render={render}
             getRenderContext={getRenderContext}
-            nunjucksPowerUserMode={nunjucksPowerUserMode}
             getAutocompleteConstants={getAutocompleteConstants}
             className={classnames('editor--single-line', className)}
             defaultValue={defaultValue}

--- a/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/one-line-editor.tsx
@@ -372,6 +372,7 @@ export class OneLineEditor extends PureComponent<Props, State> {
             noStyleActiveLine
             noLint
             singleLine
+            ignoreEditorFontSettings
             autoCloseBrackets={false}
             tabIndex={0}
             id={id}

--- a/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/asap-auth.tsx
@@ -28,7 +28,6 @@ interface Props {
   request: Request;
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   onChange: (arg0: Request, arg1: RequestAuthentication) => Promise<Request>;
 }
@@ -83,7 +82,6 @@ export class AsapAuth extends PureComponent<Props> {
       handleRender,
       handleGetRenderContext,
       request,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     const { authentication } = request;
@@ -106,7 +104,6 @@ export class AsapAuth extends PureComponent<Props> {
               mode={mode}
               onChange={onChange}
               defaultValue={authentication[property] || ''}
-              nunjucksPowerUserMode={nunjucksPowerUserMode}
               render={handleRender}
               getRenderContext={handleGetRenderContext}
               isVariableUncovered={isVariableUncovered}

--- a/packages/insomnia-app/app/ui/components/editors/auth/auth-wrapper.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/auth-wrapper.tsx
@@ -33,7 +33,6 @@ interface Props {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
   handleUpdateSettingsShowPasswords: (showPasswords: boolean) => Promise<Settings>;
-  nunjucksPowerUserMode: boolean;
   onChange: (arg0: Request, arg1: RequestAuthentication) => Promise<Request>;
   request: Request;
   showPasswords: boolean;
@@ -49,7 +48,6 @@ export class AuthWrapper extends PureComponent<Props> {
       request,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       handleUpdateSettingsShowPasswords,
       onChange,
       showPasswords,
@@ -64,7 +62,6 @@ export class AuthWrapper extends PureComponent<Props> {
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
           handleUpdateSettingsShowPasswords={handleUpdateSettingsShowPasswords}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={onChange}
           showPasswords={showPasswords}
           isVariableUncovered={isVariableUncovered}
@@ -77,7 +74,6 @@ export class AuthWrapper extends PureComponent<Props> {
           request={request}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           handleUpdateSettingsShowPasswords={handleUpdateSettingsShowPasswords}
           onChange={onChange}
           showPasswords={showPasswords}
@@ -90,7 +86,6 @@ export class AuthWrapper extends PureComponent<Props> {
           request={request}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={onChange}
           isVariableUncovered={isVariableUncovered}
         />
@@ -101,7 +96,6 @@ export class AuthWrapper extends PureComponent<Props> {
           request={request}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           showPasswords={showPasswords}
           onChange={onChange}
           isVariableUncovered={isVariableUncovered}
@@ -114,7 +108,6 @@ export class AuthWrapper extends PureComponent<Props> {
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
           handleUpdateSettingsShowPasswords={handleUpdateSettingsShowPasswords}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={onChange}
           showPasswords={showPasswords}
           isVariableUncovered={isVariableUncovered}
@@ -126,7 +119,6 @@ export class AuthWrapper extends PureComponent<Props> {
           request={request}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           handleUpdateSettingsShowPasswords={handleUpdateSettingsShowPasswords}
           onChange={onChange}
           showPasswords={showPasswords}
@@ -139,7 +131,6 @@ export class AuthWrapper extends PureComponent<Props> {
           request={request}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={onChange}
           isVariableUncovered={isVariableUncovered}
         />
@@ -151,7 +142,6 @@ export class AuthWrapper extends PureComponent<Props> {
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
           handleUpdateSettingsShowPasswords={handleUpdateSettingsShowPasswords}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={onChange}
           showPasswords={showPasswords}
           isVariableUncovered={isVariableUncovered}
@@ -165,7 +155,6 @@ export class AuthWrapper extends PureComponent<Props> {
           request={request}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           onChange={onChange}
           isVariableUncovered={isVariableUncovered}
         />

--- a/packages/insomnia-app/app/ui/components/editors/auth/aws-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/aws-auth.tsx
@@ -12,7 +12,6 @@ import { HelpTooltip } from '../../help-tooltip';
 
 interface Props {
   request: Request;
-  nunjucksPowerUserMode: boolean;
   showPasswords: boolean;
   isVariableUncovered: boolean;
   onChange: (arg0: Request, arg1: RequestAuthentication) => Promise<Request>;
@@ -56,7 +55,6 @@ export class AWSAuth extends PureComponent<Props> {
   renderRow(key: string, label: string, onChange: (...args: any[]) => any, help?: string) {
     const {
       request,
-      nunjucksPowerUserMode,
       handleRender,
       handleGetRenderContext,
       isVariableUncovered,
@@ -79,7 +77,6 @@ export class AWSAuth extends PureComponent<Props> {
               id={key}
               onChange={onChange}
               defaultValue={request.authentication[key] || ''}
-              nunjucksPowerUserMode={nunjucksPowerUserMode}
               render={handleRender}
               getRenderContext={handleGetRenderContext}
               isVariableUncovered={isVariableUncovered}

--- a/packages/insomnia-app/app/ui/components/editors/auth/basic-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/basic-auth.tsx
@@ -15,7 +15,6 @@ interface Props {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
   handleUpdateSettingsShowPasswords: (arg0: boolean) => Promise<Settings>;
-  nunjucksPowerUserMode: boolean;
   onChange: (arg0: Request, arg1: RequestAuthentication) => Promise<Request>;
   request: Request;
   showPasswords: boolean;
@@ -53,7 +52,6 @@ export class BasicAuth extends PureComponent<Props> {
       showPasswords,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     const { authentication } = request;
@@ -79,7 +77,6 @@ export class BasicAuth extends PureComponent<Props> {
                     disabled={authentication.disabled}
                     onChange={this._handleChangeUsername}
                     defaultValue={authentication.username || ''}
-                    nunjucksPowerUserMode={nunjucksPowerUserMode}
                     render={handleRender}
                     getRenderContext={handleGetRenderContext}
                     isVariableUncovered={isVariableUncovered}
@@ -99,7 +96,6 @@ export class BasicAuth extends PureComponent<Props> {
                   disabled={authentication.disabled}
                   password={authentication.password}
                   onChange={this._handleChangePassword}
-                  nunjucksPowerUserMode={nunjucksPowerUserMode}
                   handleRender={handleRender}
                   handleGetRenderContext={handleGetRenderContext}
                   isVariableUncovered={isVariableUncovered}

--- a/packages/insomnia-app/app/ui/components/editors/auth/bearer-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/bearer-auth.tsx
@@ -12,7 +12,6 @@ import { HelpTooltip } from '../../help-tooltip';
 interface Props {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
-  nunjucksPowerUserMode: boolean;
   request: Request;
   onChange: (arg0: Request, arg1: RequestAuthentication) => Promise<Request>;
   isVariableUncovered: boolean;
@@ -40,7 +39,6 @@ export class BearerAuth extends PureComponent<Props> {
       request,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     const { authentication } = request;
@@ -66,7 +64,6 @@ export class BearerAuth extends PureComponent<Props> {
                     disabled={authentication.disabled}
                     onChange={this._handleChangeToken}
                     defaultValue={authentication.token || ''}
-                    nunjucksPowerUserMode={nunjucksPowerUserMode}
                     render={handleRender}
                     getRenderContext={handleGetRenderContext}
                     isVariableUncovered={isVariableUncovered}
@@ -95,7 +92,6 @@ export class BearerAuth extends PureComponent<Props> {
                     disabled={authentication.disabled}
                     onChange={this._handleChangePrefix}
                     defaultValue={authentication.prefix || ''}
-                    nunjucksPowerUserMode={nunjucksPowerUserMode}
                     render={handleRender}
                     getRenderContext={handleGetRenderContext}
                     isVariableUncovered={isVariableUncovered}

--- a/packages/insomnia-app/app/ui/components/editors/auth/digest-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/digest-auth.tsx
@@ -14,7 +14,6 @@ interface Props {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
   handleUpdateSettingsShowPasswords: (arg0: boolean) => Promise<Settings>;
-  nunjucksPowerUserMode: boolean;
   onChange: (arg0: Request, arg1: RequestAuthentication) => Promise<Request>;
   request: Request;
   showPasswords: boolean;
@@ -43,7 +42,6 @@ export class DigestAuth extends PureComponent<Props> {
       request,
       showPasswords,
       handleRender,
-      nunjucksPowerUserMode,
       handleGetRenderContext,
       isVariableUncovered,
     } = this.props;
@@ -70,7 +68,6 @@ export class DigestAuth extends PureComponent<Props> {
                     disabled={authentication.disabled}
                     onChange={this._handleChangeUsername}
                     defaultValue={authentication.username || ''}
-                    nunjucksPowerUserMode={nunjucksPowerUserMode}
                     render={handleRender}
                     getRenderContext={handleGetRenderContext}
                     isVariableUncovered={isVariableUncovered}
@@ -90,7 +87,6 @@ export class DigestAuth extends PureComponent<Props> {
                   disabled={authentication.disabled}
                   password={authentication.password}
                   onChange={this._handleChangePassword}
-                  nunjucksPowerUserMode={nunjucksPowerUserMode}
                   handleRender={handleRender}
                   handleGetRenderContext={handleGetRenderContext}
                   isVariableUncovered={isVariableUncovered}

--- a/packages/insomnia-app/app/ui/components/editors/auth/hawk-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/hawk-auth.tsx
@@ -17,7 +17,6 @@ interface Props {
   request: Request;
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   onChange: (arg0: Request, arg1: RequestAuthentication) => Promise<Request>;
 }
@@ -133,7 +132,6 @@ export class HawkAuth extends PureComponent<Props> {
       handleRender,
       handleGetRenderContext,
       request,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     const { authentication } = request;
@@ -156,7 +154,6 @@ export class HawkAuth extends PureComponent<Props> {
               type="text"
               onChange={onChange}
               defaultValue={authentication[property] || ''}
-              nunjucksPowerUserMode={nunjucksPowerUserMode}
               render={handleRender}
               getRenderContext={handleGetRenderContext}
               isVariableUncovered={isVariableUncovered}

--- a/packages/insomnia-app/app/ui/components/editors/auth/ntlm-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/ntlm-auth.tsx
@@ -14,7 +14,6 @@ interface Props {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
   handleUpdateSettingsShowPasswords: (arg0: boolean) => Promise<Settings>;
-  nunjucksPowerUserMode: boolean;
   onChange: (arg0: Request, arg1: RequestAuthentication) => Promise<Request>;
   request: Request;
   showPasswords: boolean;
@@ -44,7 +43,6 @@ export class NTLMAuth extends PureComponent<Props> {
       showPasswords,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     const { authentication } = request;
@@ -70,7 +68,6 @@ export class NTLMAuth extends PureComponent<Props> {
                     disabled={authentication.disabled}
                     onChange={this._handleChangeUsername}
                     defaultValue={authentication.username || ''}
-                    nunjucksPowerUserMode={nunjucksPowerUserMode}
                     render={handleRender}
                     getRenderContext={handleGetRenderContext}
                     isVariableUncovered={isVariableUncovered}
@@ -90,7 +87,6 @@ export class NTLMAuth extends PureComponent<Props> {
                   disabled={authentication.disabled}
                   password={authentication.password}
                   onChange={this._handleChangePassword}
-                  nunjucksPowerUserMode={nunjucksPowerUserMode}
                   handleRender={handleRender}
                   handleGetRenderContext={handleGetRenderContext}
                   isVariableUncovered={isVariableUncovered}

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-1-auth.tsx
@@ -33,7 +33,6 @@ cJV+wRTs/Szp6LXAgMmTkKMJ+9XXErUIUgwbl27Y3Rv/9ox1p5VRg+A=
 interface Props {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
-  nunjucksPowerUserMode: boolean;
   showPasswords: boolean;
   isVariableUncovered: boolean;
   onChange: (arg0: Request, arg1: RequestAuthentication) => Promise<Request>;
@@ -199,7 +198,6 @@ export class OAuth1Auth extends PureComponent<Props> {
       handleRender,
       handleGetRenderContext,
       request,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     const { authentication } = request;
@@ -225,7 +223,6 @@ export class OAuth1Auth extends PureComponent<Props> {
               onChange={onChange}
               defaultValue={request.authentication[property] || ''}
               render={handleRender}
-              nunjucksPowerUserMode={nunjucksPowerUserMode}
               getAutocompleteConstants={handleAutocomplete}
               getRenderContext={handleGetRenderContext}
               isVariableUncovered={isVariableUncovered}

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -37,7 +37,6 @@ interface Props {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
   handleUpdateSettingsShowPasswords: (arg0: boolean) => Promise<Settings>;
-  nunjucksPowerUserMode: boolean;
   onChange: (arg0: Request, arg1: RequestAuthentication) => Promise<Request>;
   request: Request;
   showPasswords: boolean;
@@ -326,7 +325,6 @@ export class OAuth2Auth extends PureComponent<Props, State> {
       handleRender,
       handleGetRenderContext,
       request,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     const { authentication } = request;
@@ -352,7 +350,6 @@ export class OAuth2Auth extends PureComponent<Props, State> {
               onChange={onChange}
               defaultValue={request.authentication[property] || ''}
               render={handleRender}
-              nunjucksPowerUserMode={nunjucksPowerUserMode}
               getAutocompleteConstants={handleAutocomplete}
               getRenderContext={handleGetRenderContext}
               isVariableUncovered={isVariableUncovered}

--- a/packages/insomnia-app/app/ui/components/editors/body/body-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/body-editor.tsx
@@ -138,7 +138,6 @@ export class BodyEditor extends PureComponent<Props> {
           onChange={this._handleFormUrlEncodedChange}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
-          nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
           isVariableUncovered={isVariableUncovered}
           parameters={request.body.params || []}
         />
@@ -150,7 +149,6 @@ export class BodyEditor extends PureComponent<Props> {
           onChange={this._handleFormChange}
           handleRender={handleRender}
           handleGetRenderContext={handleGetRenderContext}
-          nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
           isVariableUncovered={isVariableUncovered}
           parameters={request.body.params || []}
         />
@@ -178,16 +176,10 @@ export class BodyEditor extends PureComponent<Props> {
       return (
         <RawEditor
           uniquenessKey={uniqueKey}
-          fontSize={settings.editorFontSize}
-          indentSize={settings.editorIndentSize}
-          keyMap={settings.editorKeyMap}
-          lineWrapping={settings.editorLineWrapping}
-          indentWithTabs={settings.editorIndentWithTabs}
           contentType={contentType || 'text/plain'}
           content={request.body.text || ''}
           render={handleRender}
           getRenderContext={handleGetRenderContext}
-          nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
           isVariableUncovered={isVariableUncovered}
           onChange={this._handleRawChange}
         />

--- a/packages/insomnia-app/app/ui/components/editors/body/form-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/form-editor.tsx
@@ -8,7 +8,6 @@ import { KeyValueEditor } from '../../key-value-editor/key-value-editor';
 interface Props {
   onChange: Function;
   parameters: any[];
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   handleRender?: HandleRender;
   handleGetRenderContext?: HandleGetRenderContext;
@@ -22,7 +21,6 @@ export class FormEditor extends PureComponent<Props> {
       onChange,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     return (
@@ -37,7 +35,6 @@ export class FormEditor extends PureComponent<Props> {
             descriptionPlaceholder="description"
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
-            nunjucksPowerUserMode={nunjucksPowerUserMode}
             isVariableUncovered={isVariableUncovered}
             onChange={onChange}
             pairs={parameters}

--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
@@ -771,9 +771,6 @@ export class GraphQLEditor extends PureComponent<Props, State> {
             dynamicHeight
             manualPrettify
             uniquenessKey={uniquenessKey ? uniquenessKey + '::query' : undefined}
-            fontSize={settings.editorFontSize}
-            indentSize={settings.editorIndentSize}
-            keyMap={settings.editorKeyMap}
             defaultValue={query}
             className={className}
             onChange={this._handleQueryChange}
@@ -781,7 +778,6 @@ export class GraphQLEditor extends PureComponent<Props, State> {
             onCursorActivity={this._handleQueryUserActivity}
             onFocus={this._handleQueryFocus}
             mode="graphql"
-            lineWrapping={settings.editorLineWrapping}
             placeholder=""
             {...graphqlOptions}
           />
@@ -824,9 +820,6 @@ export class GraphQLEditor extends PureComponent<Props, State> {
             uniquenessKey={uniquenessKey ? uniquenessKey + '::variables' : undefined}
             debounceMillis={DEBOUNCE_MILLIS * 4}
             manualPrettify={false}
-            fontSize={settings.editorFontSize}
-            indentSize={settings.editorIndentSize}
-            keyMap={settings.editorKeyMap}
             defaultValue={variables}
             className={className}
             render={render}
@@ -836,11 +829,9 @@ export class GraphQLEditor extends PureComponent<Props, State> {
               variableToType: variableTypes,
             }}
             noLint={!variableTypes}
-            nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             isVariableUncovered={isVariableUncovered}
             onChange={this._handleVariablesChange}
             mode="graphql-variables"
-            lineWrapping={settings.editorLineWrapping}
             placeholder=""
           />
         </div>

--- a/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/graph-ql-editor.tsx
@@ -665,7 +665,6 @@ export class GraphQLEditor extends PureComponent<Props, State> {
       content,
       render,
       getRenderContext,
-      settings,
       className,
       uniquenessKey,
       isVariableUncovered,

--- a/packages/insomnia-app/app/ui/components/editors/body/raw-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/raw-editor.tsx
@@ -9,17 +9,11 @@ interface Props {
   onChange: CodeEditorOnChange;
   content: string;
   contentType: string;
-  fontSize: number;
-  indentSize: number;
-  keyMap: string;
-  lineWrapping: boolean;
-  nunjucksPowerUserMode: boolean;
   uniquenessKey: string;
   isVariableUncovered: boolean;
   className?: string;
   render?: HandleRender;
   getRenderContext?: HandleGetRenderContext;
-  indentWithTabs?: boolean;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -29,13 +23,7 @@ export class RawEditor extends PureComponent<Props> {
       className,
       content,
       contentType,
-      fontSize,
       getRenderContext,
-      indentSize,
-      keyMap,
-      lineWrapping,
-      indentWithTabs,
-      nunjucksPowerUserMode,
       isVariableUncovered,
       onChange,
       render,
@@ -46,19 +34,13 @@ export class RawEditor extends PureComponent<Props> {
         <CodeEditor
           manualPrettify
           uniquenessKey={uniquenessKey}
-          fontSize={fontSize}
-          indentSize={indentSize}
-          indentWithTabs={indentWithTabs}
-          keyMap={keyMap}
           defaultValue={content}
           className={className}
           render={render}
           getRenderContext={getRenderContext}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           isVariableUncovered={isVariableUncovered}
           onChange={onChange}
           mode={contentType}
-          lineWrapping={lineWrapping}
           placeholder="..."
         />
       </Fragment>

--- a/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/body/url-encoded-editor.tsx
@@ -8,7 +8,6 @@ import { KeyValueEditor } from '../../key-value-editor/key-value-editor';
 interface Props {
   onChange: Function;
   parameters: any[];
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   handleRender?: HandleRender;
   handleGetRenderContext?: HandleGetRenderContext;
@@ -22,7 +21,6 @@ export class UrlEncodedEditor extends PureComponent<Props> {
       onChange,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     return (
@@ -37,7 +35,6 @@ export class UrlEncodedEditor extends PureComponent<Props> {
             onChange={onChange}
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
-            nunjucksPowerUserMode={nunjucksPowerUserMode}
             isVariableUncovered={isVariableUncovered}
             pairs={parameters}
           />

--- a/packages/insomnia-app/app/ui/components/editors/environment-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/environment-editor.tsx
@@ -59,14 +59,9 @@ export interface EnvironmentInfo {
 interface Props {
   environmentInfo: EnvironmentInfo;
   didChange: (...args: any[]) => any;
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorKeyMap: string;
   render: (...args: any[]) => any;
   getRenderContext: (...args: any[]) => any;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
-  lineWrapping: boolean;
 }
 
 // There was existing logic to also handle warnings, but it was removed in PR#2601 as there were no more warnings
@@ -145,14 +140,9 @@ export class EnvironmentEditor extends PureComponent<Props, State> {
   render() {
     const {
       environmentInfo,
-      editorFontSize,
-      editorIndentSize,
-      editorKeyMap,
       render,
       getRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
-      lineWrapping,
       ...props
     } = this.props;
     const { error } = this.state;
@@ -166,13 +156,8 @@ export class EnvironmentEditor extends PureComponent<Props, State> {
         <CodeEditor
           ref={this._setEditorRef}
           autoPrettify
-          fontSize={editorFontSize}
-          indentSize={editorIndentSize}
-          lineWrapping={lineWrapping}
-          keyMap={editorKeyMap}
           onChange={this._handleChange}
           defaultValue={defaultValue}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           isVariableUncovered={isVariableUncovered}
           render={render}
           getRenderContext={getRenderContext}

--- a/packages/insomnia-app/app/ui/components/editors/grpc-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/grpc-editor.tsx
@@ -1,13 +1,11 @@
 import React, { FunctionComponent } from 'react';
 
 import { HandleGetRenderContext, HandleRender } from '../../../common/render';
-import type { Settings } from '../../../models/settings';
 import { CodeEditor } from '../codemirror/code-editor';
 
 interface Props {
   content?: string;
   handleChange?: (arg0: string) => void;
-  settings: Settings;
   readOnly?: boolean;
   handleRender?: HandleRender;
   isVariableUncovered?: boolean;
@@ -18,17 +16,11 @@ export const GRPCEditor: FunctionComponent<Props> = ({
   content,
   handleChange,
   readOnly,
-  settings,
   handleGetRenderContext,
   handleRender,
   isVariableUncovered,
 }) => (
   <CodeEditor
-    fontSize={settings.editorFontSize}
-    indentSize={settings.editorIndentSize}
-    indentWithTabs={settings.editorIndentWithTabs}
-    keyMap={settings.editorKeyMap}
-    lineWrapping={settings.editorLineWrapping}
     defaultValue={content}
     onChange={handleChange}
     mode="application/json"
@@ -38,6 +30,5 @@ export const GRPCEditor: FunctionComponent<Props> = ({
     render={handleRender}
     getRenderContext={handleGetRenderContext}
     isVariableUncovered={isVariableUncovered}
-    nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
   />
 );

--- a/packages/insomnia-app/app/ui/components/editors/password-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/password-editor.tsx
@@ -10,7 +10,6 @@ import { OneLineEditor } from '../codemirror/one-line-editor';
 interface Props {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
-  nunjucksPowerUserMode: boolean;
   onChange: (...args: any[]) => any;
   password: string;
   disabled: boolean;
@@ -42,7 +41,6 @@ export class PasswordEditor extends PureComponent<Props, State> {
       showAllPasswords,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
       onChange,
     } = this.props;
@@ -58,7 +56,6 @@ export class PasswordEditor extends PureComponent<Props, State> {
             id="password"
             onChange={onChange}
             defaultValue={password || ''}
-            nunjucksPowerUserMode={nunjucksPowerUserMode}
             render={handleRender}
             getRenderContext={handleGetRenderContext}
             isVariableUncovered={isVariableUncovered}

--- a/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
@@ -14,10 +14,6 @@ import { KeyValueEditor } from '../key-value-editor/key-value-editor';
 interface Props {
   onChange: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   bulk: boolean;
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorLineWrapping: boolean;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
@@ -107,12 +103,8 @@ export class RequestHeadersEditor extends PureComponent<Props> {
     const {
       bulk,
       request,
-      editorFontSize,
-      editorIndentSize,
-      editorLineWrapping,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     return bulk ? (
@@ -120,11 +112,7 @@ export class RequestHeadersEditor extends PureComponent<Props> {
         <CodeEditor
           getRenderContext={handleGetRenderContext}
           render={handleRender}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           isVariableUncovered={isVariableUncovered}
-          fontSize={editorFontSize}
-          indentSize={editorIndentSize}
-          lineWrapping={editorLineWrapping}
           onChange={this._handleBulkUpdate}
           defaultValue={this._getHeadersString()}
         />
@@ -138,7 +126,6 @@ export class RequestHeadersEditor extends PureComponent<Props> {
             valuePlaceholder="value"
             descriptionPlaceholder="description"
             pairs={request.headers}
-            nunjucksPowerUserMode={nunjucksPowerUserMode}
             isVariableUncovered={isVariableUncovered}
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}

--- a/packages/insomnia-app/app/ui/components/editors/request-parameters-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/request-parameters-editor.tsx
@@ -10,10 +10,6 @@ import { KeyValueEditor } from '../key-value-editor/key-value-editor';
 interface Props {
   onChange: (r: Request, parameters: RequestParameter[]) => Promise<Request>;
   bulk: boolean;
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorLineWrapping: boolean;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
@@ -82,23 +78,15 @@ export class RequestParametersEditor extends PureComponent<Props> {
     const {
       bulk,
       request,
-      editorFontSize,
-      editorIndentSize,
-      editorLineWrapping,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     return bulk ? (
       <CodeEditor
         getRenderContext={handleGetRenderContext}
         render={handleRender}
-        nunjucksPowerUserMode={nunjucksPowerUserMode}
         isVariableUncovered={isVariableUncovered}
-        fontSize={editorFontSize}
-        indentSize={editorIndentSize}
-        lineWrapping={editorLineWrapping}
         onChange={this._handleBulkUpdate}
         defaultValue={this._getQueriesString()}
       />
@@ -110,7 +98,6 @@ export class RequestParametersEditor extends PureComponent<Props> {
         valuePlaceholder="value"
         descriptionPlaceholder="description"
         pairs={request.parameters}
-        nunjucksPowerUserMode={nunjucksPowerUserMode}
         isVariableUncovered={isVariableUncovered}
         handleRender={handleRender}
         handleGetRenderContext={handleGetRenderContext}

--- a/packages/insomnia-app/app/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/key-value-editor.tsx
@@ -27,7 +27,6 @@ interface Props {
   pairs: any[];
   handleRender?: HandleRender;
   handleGetRenderContext?: HandleGetRenderContext;
-  nunjucksPowerUserMode?: boolean;
   isVariableUncovered?: boolean;
   handleGetAutocompleteNameConstants?: Function;
   handleGetAutocompleteValueConstants?: Function;
@@ -433,7 +432,6 @@ export class KeyValueEditor extends PureComponent<Props, State> {
       descriptionPlaceholder,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
       handleGetAutocompleteNameConstants,
       handleGetAutocompleteValueConstants,
@@ -469,7 +467,6 @@ export class KeyValueEditor extends PureComponent<Props, State> {
               onBlurValue={this._handleBlurValue}
               onBlurDescription={this._handleBlurDescription}
               onMove={this._handleMove}
-              nunjucksPowerUserMode={nunjucksPowerUserMode}
               isVariableUncovered={isVariableUncovered}
               handleRender={handleRender}
               handleGetRenderContext={handleGetRenderContext}

--- a/packages/insomnia-app/app/ui/components/key-value-editor/row.tsx
+++ b/packages/insomnia-app/app/ui/components/key-value-editor/row.tsx
@@ -43,7 +43,6 @@ interface Props {
   onBlurDescription?: Function;
   handleRender?: HandleRender;
   handleGetRenderContext?: HandleGetRenderContext;
-  nunjucksPowerUserMode?: boolean;
   isVariableUncovered?: boolean;
   handleGetAutocompleteNameConstants?: Function;
   handleGetAutocompleteValueConstants?: Function;
@@ -278,7 +277,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
       pair,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     return displayDescription ? (
@@ -302,7 +300,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
           onFocus={this._handleFocusDescription}
           render={handleRender}
           getRenderContext={handleGetRenderContext}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           isVariableUncovered={isVariableUncovered}
         />
       </div>
@@ -318,7 +315,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
       valuePlaceholder,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
 
@@ -361,7 +357,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
           onFocus={this._handleFocusValue}
           render={handleRender}
           getRenderContext={handleGetRenderContext}
-          nunjucksPowerUserMode={nunjucksPowerUserMode}
           isVariableUncovered={isVariableUncovered}
           getAutocompleteConstants={this._handleAutocompleteValues}
         />
@@ -435,7 +430,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
       namePlaceholder,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
       sortable,
       noDropZone,
@@ -489,7 +483,6 @@ class KeyValueEditorRow extends PureComponent<Props, State> {
               defaultValue={pair.name}
               render={handleRender}
               getRenderContext={handleGetRenderContext}
-              nunjucksPowerUserMode={nunjucksPowerUserMode}
               isVariableUncovered={isVariableUncovered}
               getAutocompleteConstants={this._handleAutocompleteNames}
               forceInput={forceInput}

--- a/packages/insomnia-app/app/ui/components/markdown-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/markdown-editor.tsx
@@ -12,13 +12,8 @@ import { MarkdownPreview } from './markdown-preview';
 interface Props {
   onChange: Function;
   defaultValue: string;
-  fontSize: number;
-  indentSize: number;
-  keyMap: string;
-  lineWrapping: boolean;
   handleRender?: HandleRender;
   handleGetRenderContext?: HandleGetRenderContext;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   placeholder?: string;
   defaultPreviewMode?: boolean;
@@ -63,10 +58,6 @@ export class MarkdownEditor extends PureComponent<Props, State> {
 
   render() {
     const {
-      fontSize,
-      lineWrapping,
-      indentSize,
-      keyMap,
       mode,
       placeholder,
       defaultPreviewMode,
@@ -74,7 +65,6 @@ export class MarkdownEditor extends PureComponent<Props, State> {
       tall,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     const { markdown } = this.state;
@@ -103,14 +93,9 @@ export class MarkdownEditor extends PureComponent<Props, State> {
               mode={mode || 'text/x-markdown'}
               placeholder={placeholder}
               debounceMillis={300}
-              keyMap={keyMap}
-              fontSize={fontSize}
-              lineWrapping={lineWrapping}
-              indentSize={indentSize}
               defaultValue={markdown}
               render={handleRender}
               getRenderContext={handleGetRenderContext}
-              nunjucksPowerUserMode={nunjucksPowerUserMode}
               isVariableUncovered={isVariableUncovered}
               onChange={this._handleChange}
             />

--- a/packages/insomnia-app/app/ui/components/modals/code-prompt-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/code-prompt-modal.tsx
@@ -25,11 +25,6 @@ const MODES = {
 };
 
 interface Props {
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorKeyMap: string;
-  editorLineWrapping: boolean;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   handleGetRenderContext?: HandleGetRenderContext;
   handleRender?: HandleRender;
@@ -117,13 +112,8 @@ export class CodePromptModal extends PureComponent<Props, State> {
   render() {
     const {
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
       handleRender,
-      editorKeyMap,
-      editorIndentSize,
-      editorFontSize,
-      editorLineWrapping,
     } = this.props;
     const {
       submitName,
@@ -170,11 +160,6 @@ export class CodePromptModal extends PureComponent<Props, State> {
                 handleGetRenderContext={enableRender ? handleGetRenderContext : undefined}
                 handleRender={enableRender ? handleRender : undefined}
                 mode={mode}
-                keyMap={editorKeyMap}
-                indentSize={editorIndentSize}
-                fontSize={editorFontSize}
-                lineWrapping={editorLineWrapping}
-                nunjucksPowerUserMode={nunjucksPowerUserMode}
                 isVariableUncovered={isVariableUncovered}
               />
             </div>
@@ -188,15 +173,10 @@ export class CodePromptModal extends PureComponent<Props, State> {
                   defaultValue={defaultValue}
                   placeholder={placeholder}
                   onChange={this._handleChange}
-                  nunjucksPowerUserMode={nunjucksPowerUserMode}
                   isVariableUncovered={isVariableUncovered}
                   getRenderContext={handleGetRenderContext}
                   render={handleRender}
                   mode={mode}
-                  keyMap={editorKeyMap}
-                  indentSize={editorIndentSize}
-                  fontSize={editorFontSize}
-                  lineWrapping={editorLineWrapping}
                 />
               </div>
             </div>

--- a/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/cookie-modify-modal.tsx
@@ -19,7 +19,6 @@ import { OneLineEditor } from '../codemirror/one-line-editor';
 interface Props extends ModalProps {
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   workspace: Workspace;
   cookieJar: CookieJar;
@@ -188,7 +187,6 @@ export class CookieModifyModal extends PureComponent<Props, State> {
     const {
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
 
@@ -204,7 +202,6 @@ export class CookieModifyModal extends PureComponent<Props, State> {
           <OneLineEditor
             render={handleRender}
             getRenderContext={handleGetRenderContext}
-            nunjucksPowerUserMode={nunjucksPowerUserMode}
             isVariableUncovered={isVariableUncovered}
             defaultValue={val || ''}
             onChange={value => this._handleChange(field, value)}

--- a/packages/insomnia-app/app/ui/components/modals/environment-edit-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/environment-edit-modal.tsx
@@ -12,14 +12,9 @@ import { EnvironmentEditor } from '../editors/environment-editor';
 
 interface Props {
   onChange: Function;
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorKeyMap: string;
   render: HandleRender;
   getRenderContext: HandleGetRenderContext;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
-  lineWrapping: boolean;
 }
 
 interface State {
@@ -89,13 +84,8 @@ export class EnvironmentEditModal extends PureComponent<Props, State> {
 
   render() {
     const {
-      editorKeyMap,
-      editorFontSize,
-      editorIndentSize,
-      lineWrapping,
       render,
       getRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
       ...extraProps
     } = this.props;
@@ -109,17 +99,12 @@ export class EnvironmentEditModal extends PureComponent<Props, State> {
         <ModalHeader>Environment Overrides (JSON Format)</ModalHeader>
         <ModalBody noScroll className="pad-top-sm">
           <EnvironmentEditor
-            editorFontSize={editorFontSize}
-            editorIndentSize={editorIndentSize}
-            editorKeyMap={editorKeyMap}
             ref={this._setEditorRef}
             key={requestGroup ? requestGroup._id : 'n/a'}
-            lineWrapping={lineWrapping}
             environmentInfo={environmentInfo}
             didChange={this._didChange}
             render={render}
             getRenderContext={getRenderContext}
-            nunjucksPowerUserMode={nunjucksPowerUserMode}
             isVariableUncovered={isVariableUncovered}
           />
         </ModalBody>

--- a/packages/insomnia-app/app/ui/components/modals/generate-code-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-code-modal.tsx
@@ -32,9 +32,6 @@ const TO_ADD_CONTENT_LENGTH = {
 
 interface Props {
   environmentId: string;
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorKeyMap: string;
 }
 
 interface State {
@@ -138,7 +135,6 @@ export class GenerateCodeModal extends PureComponent<Props, State> {
 
   render() {
     const { cmd, target, client } = this.state;
-    const { editorFontSize, editorIndentSize, editorKeyMap } = this.props;
     const targets = HTTPSnippet.availableTargets();
     // NOTE: Just some extra precautions in case the target is messed up
     let clients: HTTPSnippetClient[] = [];
@@ -192,15 +188,11 @@ export class GenerateCodeModal extends PureComponent<Props, State> {
             <CopyButton content={cmd} className="pull-right" />
           </div>
           <CodeEditor
-            lineWrapping
             placeholder="Generating code snippet..."
             className="border-top"
             key={Date.now()}
             mode={MODE_MAP[target.key] || target.key}
             ref={this._setEditorRef}
-            fontSize={editorFontSize}
-            indentSize={editorIndentSize}
-            keyMap={editorKeyMap}
             defaultValue={cmd}
           />
         </ModalBody>

--- a/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/generate-config-modal.tsx
@@ -5,7 +5,6 @@ import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import { parseApiSpec } from '../../../common/api-specs';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import type { ApiSpec } from '../../../models/api-spec';
-import type { Settings } from '../../../models/settings';
 import type { ConfigGenerator } from '../../../plugins';
 import * as plugins from '../../../plugins';
 import { CopyButton } from '../base/copy-button';
@@ -18,10 +17,6 @@ import { CodeEditor } from '../codemirror/code-editor';
 import { HelpTooltip } from '../help-tooltip';
 import { Notice } from '../notice';
 import { showModal } from './index';
-
-interface Props {
-  settings: Settings;
-}
 
 interface Config {
   label: string;
@@ -42,7 +37,7 @@ interface ShowOptions {
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-export class GenerateConfigModal extends PureComponent<Props, State> {
+export class GenerateConfigModal extends PureComponent<{}, State> {
   modal: Modal | null = null;
 
   state: State = {
@@ -93,7 +88,6 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
   }
 
   renderConfigTabPanel(config: Config) {
-    const { settings } = this.props;
     const linkIcon = <i className="fa fa-external-link-square" />;
     if (config.error) {
       return (
@@ -111,12 +105,7 @@ export class GenerateConfigModal extends PureComponent<Props, State> {
         <CodeEditor
           className="tall pad-top-sm"
           defaultValue={config.content}
-          fontSize={settings.editorFontSize}
-          indentSize={settings.editorIndentSize}
-          keyMap={settings.editorKeyMap}
-          lineWrapping={settings.editorLineWrapping}
           mode={config.mimeType}
-          nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
           readOnly
         />
       </TabPanel>

--- a/packages/insomnia-app/app/ui/components/modals/request-group-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-group-settings-modal.tsx
@@ -15,11 +15,6 @@ import { HelpTooltip } from '../help-tooltip';
 import { MarkdownEditor } from '../markdown-editor';
 
 interface Props {
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorKeyMap: string;
-  editorLineWrapping: boolean;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
@@ -199,13 +194,8 @@ export class RequestGroupSettingsModal extends React.PureComponent<Props, State>
 
   _renderDescription() {
     const {
-      editorLineWrapping,
-      editorFontSize,
-      editorIndentSize,
-      editorKeyMap,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
 
@@ -220,14 +210,9 @@ export class RequestGroupSettingsModal extends React.PureComponent<Props, State>
         ref={this._setEditorRef}
         className="margin-top"
         defaultPreviewMode={defaultPreviewMode}
-        fontSize={editorFontSize}
-        indentSize={editorIndentSize}
-        keyMap={editorKeyMap}
         placeholder="Write a description"
-        lineWrapping={editorLineWrapping}
         handleRender={handleRender}
         handleGetRenderContext={handleGetRenderContext}
-        nunjucksPowerUserMode={nunjucksPowerUserMode}
         isVariableUncovered={isVariableUncovered}
         defaultValue={requestGroup.description}
         onChange={this._handleDescriptionChange}

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
@@ -17,11 +17,6 @@ import { HelpTooltip } from '../help-tooltip';
 import { MarkdownEditor } from '../markdown-editor';
 
 interface Props {
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorKeyMap: string;
-  editorLineWrapping: boolean;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
@@ -325,13 +320,8 @@ export class RequestSettingsModal extends PureComponent<Props, State> {
 
   _renderDescription() {
     const {
-      editorLineWrapping,
-      editorFontSize,
-      editorIndentSize,
-      editorKeyMap,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     const { showDescription, defaultPreviewMode, request } = this.state;
@@ -346,14 +336,9 @@ export class RequestSettingsModal extends PureComponent<Props, State> {
         ref={this._setEditorRef}
         className="margin-top"
         defaultPreviewMode={defaultPreviewMode}
-        fontSize={editorFontSize}
-        indentSize={editorIndentSize}
-        keyMap={editorKeyMap}
         placeholder="Write a description"
-        lineWrapping={editorLineWrapping}
         handleRender={handleRender}
         handleGetRenderContext={handleGetRenderContext}
-        nunjucksPowerUserMode={nunjucksPowerUserMode}
         isVariableUncovered={isVariableUncovered}
         defaultValue={request.description}
         onChange={this._handleDescriptionChange}

--- a/packages/insomnia-app/app/ui/components/modals/response-debug-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/response-debug-modal.tsx
@@ -4,15 +4,10 @@ import React, { PureComponent } from 'react';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import * as models from '../../../models/index';
 import type { Response } from '../../../models/response';
-import type { Settings } from '../../../models/settings';
 import { ResponseTimelineViewer } from '../../components/viewers/response-timeline-viewer';
 import { Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
-
-interface Props {
-  settings: Settings;
-}
 
 interface State {
   response: Response | null;
@@ -20,7 +15,7 @@ interface State {
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-export class ResponseDebugModal extends PureComponent<Props, State> {
+export class ResponseDebugModal extends PureComponent<{}, State> {
   modal: Modal | null = null;
 
   state: State = {
@@ -48,7 +43,6 @@ export class ResponseDebugModal extends PureComponent<Props, State> {
   }
 
   render() {
-    const { settings } = this.props;
     const { response, title } = this.state;
     return (
       <Modal ref={this._setModalRef} tall>
@@ -62,9 +56,6 @@ export class ResponseDebugModal extends PureComponent<Props, State> {
           >
             {response ? (
               <ResponseTimelineViewer
-                editorFontSize={settings.editorFontSize}
-                editorIndentSize={settings.editorIndentSize}
-                editorLineWrapping={settings.editorLineWrapping}
                 response={response}
               />
             ) : (

--- a/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -29,13 +29,8 @@ const ROOT_ENVIRONMENT_NAME = 'Base Environment';
 interface Props extends ModalProps {
   handleChangeEnvironment: (id: string | null) => void;
   activeEnvironmentId: string | null;
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorKeyMap: string;
-  lineWrapping: boolean;
   render: HandleRender;
   getRenderContext: HandleGetRenderContext;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
 }
 
@@ -433,13 +428,8 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
   render() {
     const {
       activeEnvironmentId,
-      editorFontSize,
-      editorIndentSize,
-      editorKeyMap,
       getRenderContext,
       isVariableUncovered,
-      lineWrapping,
-      nunjucksPowerUserMode,
       render,
     } = this.props;
     const { subEnvironments, rootEnvironment, isValid } = this.state;
@@ -587,17 +577,12 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
             </div>
             <div className="env-modal__editor">
               <EnvironmentEditor
-                editorFontSize={editorFontSize}
-                editorIndentSize={editorIndentSize}
-                editorKeyMap={editorKeyMap}
-                lineWrapping={lineWrapping}
                 ref={this._setEditorRef}
                 key={`${this.editorKey}::${selectedEnvironment ? selectedEnvironment._id : 'n/a'}`}
                 environmentInfo={environmentInfo}
                 didChange={this._didChange}
                 render={render}
                 getRenderContext={getRenderContext}
-                nunjucksPowerUserMode={nunjucksPowerUserMode}
                 isVariableUncovered={isVariableUncovered}
               />
             </div>

--- a/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/workspace-settings-modal.tsx
@@ -66,11 +66,6 @@ interface Props extends ReduxProps {
   clientCertificates: ClientCertificate[];
   workspace: Workspace;
   apiSpec: ApiSpec;
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorKeyMap: string;
-  editorLineWrapping: boolean;
-  nunjucksPowerUserMode: boolean;
   isVariableUncovered: boolean;
   handleRender: HandleRender;
   handleGetRenderContext: HandleGetRenderContext;
@@ -297,13 +292,8 @@ export class UnconnectedWorkspaceSettingsModal extends PureComponent<Props, Stat
       clientCertificates,
       workspace,
       activeWorkspaceName,
-      editorLineWrapping,
-      editorFontSize,
-      editorIndentSize,
-      editorKeyMap,
       handleRender,
       handleGetRenderContext,
-      nunjucksPowerUserMode,
       isVariableUncovered,
     } = this.props;
     const publicCertificates = clientCertificates.filter(c => !c.isPrivate);
@@ -347,14 +337,9 @@ export class UnconnectedWorkspaceSettingsModal extends PureComponent<Props, Stat
                 <MarkdownEditor
                   className="margin-top"
                   defaultPreviewMode={defaultPreviewMode}
-                  fontSize={editorFontSize}
-                  indentSize={editorIndentSize}
-                  keyMap={editorKeyMap}
                   placeholder="Write a description"
-                  lineWrapping={editorLineWrapping}
                   handleRender={handleRender}
                   handleGetRenderContext={handleGetRenderContext}
-                  nunjucksPowerUserMode={nunjucksPowerUserMode}
                   isVariableUncovered={isVariableUncovered}
                   defaultValue={workspace.description}
                   onChange={this._handleDescriptionChange}

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
@@ -52,7 +52,6 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
   environmentId,
   workspaceId,
   forceRefreshKey,
-  settings,
   handleRender,
   handleGetRenderContext,
   isVariableUncovered,
@@ -83,7 +82,6 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
               placeholder="grpcb.in:9000"
               onChange={handleChange.url}
               render={handleRender}
-              nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
               isVariableUncovered={isVariableUncovered}
               getAutocompleteConstants={getExistingGrpcUrls}
               getRenderContext={handleGetRenderContext}
@@ -121,7 +119,6 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
             <TabPanel className="react-tabs__tab-panel">
               <GrpcTabbedMessages
                 uniquenessKey={uniquenessKey}
-                settings={settings}
                 tabNamePrefix="Stream"
                 messages={requestMessages}
                 bodyText={activeRequest.body.text}

--- a/packages/insomnia-app/app/ui/components/panes/grpc-response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-response-pane.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from 'react';
 
 import type { GrpcRequest } from '../../../models/grpc-request';
-import type { Settings } from '../../../models/settings';
 import { useGrpcRequestState } from '../../context/grpc';
 import { GrpcSpinner } from '../grpc-spinner';
 import { GrpcStatusTag } from '../tags/grpc-status-tag';
@@ -11,10 +10,9 @@ import { Pane, PaneBody, PaneHeader } from './pane';
 interface Props {
   forceRefreshKey: number;
   activeRequest: GrpcRequest;
-  settings: Settings;
 }
 
-export const GrpcResponsePane: FunctionComponent<Props> = ({ settings, activeRequest, forceRefreshKey }) => {
+export const GrpcResponsePane: FunctionComponent<Props> = ({ activeRequest, forceRefreshKey }) => {
   // Used to refresh input fields to their default value when switching between requests.
   // This is a common pattern in this codebase.
   const uniquenessKey = `${forceRefreshKey}::${activeRequest._id}`;
@@ -32,7 +30,6 @@ export const GrpcResponsePane: FunctionComponent<Props> = ({ settings, activeReq
         {!!responseMessages.length && (
           <GrpcTabbedMessages
             uniquenessKey={uniquenessKey}
-            settings={settings}
             tabNamePrefix="Response"
             messages={responseMessages}
           />

--- a/packages/insomnia-app/app/ui/components/panes/placeholder-response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/placeholder-response-pane.tsx
@@ -9,6 +9,7 @@ interface Props {
   hotKeyRegistry: HotKeyRegistry;
 }
 
+// TODO: get hotKeyRegistry from redux
 export const PlaceholderResponsePane: FunctionComponent<Props> = ({ hotKeyRegistry, children }) => (
   <Pane type="response">
     <PaneHeader />

--- a/packages/insomnia-app/app/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/request-pane.tsx
@@ -272,7 +272,6 @@ export class RequestPane extends PureComponent<Props> {
                   handleUpdateSettingsShowPasswords={updateSettingsShowPasswords}
                   handleRender={handleRender}
                   handleGetRenderContext={handleGetRenderContext}
-                  nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
                   isVariableUncovered={isVariableUncovered}
                   onChange={updateRequestAuthentication}
                 />
@@ -300,11 +299,7 @@ export class RequestPane extends PureComponent<Props> {
                   key={headerEditorKey}
                   handleRender={handleRender}
                   handleGetRenderContext={handleGetRenderContext}
-                  nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
                   isVariableUncovered={isVariableUncovered}
-                  editorFontSize={settings.editorFontSize}
-                  editorIndentSize={settings.editorIndentSize}
-                  editorLineWrapping={settings.editorLineWrapping}
                   onChange={updateRequestParameters}
                   request={request}
                   bulk={settings.useBulkParametersEditor}
@@ -333,11 +328,7 @@ export class RequestPane extends PureComponent<Props> {
                 key={headerEditorKey}
                 handleRender={handleRender}
                 handleGetRenderContext={handleGetRenderContext}
-                nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
                 isVariableUncovered={isVariableUncovered}
-                editorFontSize={settings.editorFontSize}
-                editorIndentSize={settings.editorIndentSize}
-                editorLineWrapping={settings.editorLineWrapping}
                 onChange={updateRequestHeaders}
                 request={request}
                 bulk={settings.useBulkHeaderEditor}

--- a/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
@@ -48,9 +48,6 @@ interface Props {
   filterHistory: string[];
   disableHtmlPreviewJs: boolean;
   editorFontSize: number;
-  editorIndentSize: number;
-  editorKeyMap: string;
-  editorLineWrapping: boolean;
   loadStartTime: number;
   responses: Response[];
   hotKeyRegistry: HotKeyRegistry;
@@ -229,9 +226,6 @@ export class ResponsePane extends PureComponent<Props> {
     const {
       disableHtmlPreviewJs,
       editorFontSize,
-      editorIndentSize,
-      editorKeyMap,
-      editorLineWrapping,
       environment,
       filter,
       disableResponsePreviewLinks,
@@ -336,9 +330,6 @@ export class ResponsePane extends PureComponent<Props> {
               disablePreviewLinks={disableResponsePreviewLinks}
               download={this._handleDownloadResponseBody}
               editorFontSize={editorFontSize}
-              editorIndentSize={editorIndentSize}
-              editorKeyMap={editorKeyMap}
-              editorLineWrapping={editorLineWrapping}
               error={response.error}
               filter={filter}
               filterHistory={filterHistory}
@@ -373,9 +364,6 @@ export class ResponsePane extends PureComponent<Props> {
             <ErrorBoundary key={response._id} errorClassName="font-error pad text-center">
               <ResponseTimelineViewer
                 response={response}
-                editorLineWrapping={editorLineWrapping}
-                editorFontSize={editorFontSize}
-                editorIndentSize={editorIndentSize}
               />
             </ErrorBoundary>
           </TabPanel>

--- a/packages/insomnia-app/app/ui/components/request-url-bar.tsx
+++ b/packages/insomnia-app/app/ui/components/request-url-bar.tsx
@@ -353,7 +353,6 @@ export class RequestUrlBar extends PureComponent<Props, State> {
     const {
       request,
       handleRender,
-      nunjucksPowerUserMode,
       isVariableUncovered,
       handleGetRenderContext,
       handleAutocompleteUrls,
@@ -378,7 +377,6 @@ export class RequestUrlBar extends PureComponent<Props, State> {
               forceEditor
               type="text"
               render={handleRender}
-              nunjucksPowerUserMode={nunjucksPowerUserMode}
               isVariableUncovered={isVariableUncovered}
               getAutocompleteConstants={handleAutocompleteUrls}
               getRenderContext={handleGetRenderContext}

--- a/packages/insomnia-app/app/ui/components/viewers/grpc-tabbed-messages.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/grpc-tabbed-messages.tsx
@@ -3,7 +3,6 @@ import React, { FunctionComponent } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
 import { HandleGetRenderContext, HandleRender } from '../../../common/render';
-import { Settings } from '../../../models/settings';
 import { Button } from '../base/button';
 import { GRPCEditor } from '../editors/grpc-editor';
 
@@ -14,7 +13,6 @@ interface Message {
 }
 
 interface Props {
-  settings: Settings;
   messages?: Message[];
   tabNamePrefix: 'Stream' | 'Response';
   bodyText?: string;
@@ -29,7 +27,6 @@ interface Props {
 }
 
 export const GrpcTabbedMessages: FunctionComponent<Props> = ({
-  settings,
   showActions,
   bodyText,
   messages,
@@ -88,7 +85,6 @@ export const GrpcTabbedMessages: FunctionComponent<Props> = ({
         <TabPanel className="react-tabs__tab-panel editor-wrapper">
           <GRPCEditor
             content={bodyText}
-            settings={settings}
             handleChange={handleBodyChange}
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
@@ -98,7 +94,7 @@ export const GrpcTabbedMessages: FunctionComponent<Props> = ({
       )}
       {orderedMessages.map(m => (
         <TabPanel key={m.id} className="react-tabs__tab-panel editor-wrapper">
-          <GRPCEditor content={m.text} settings={settings} readOnly />
+          <GRPCEditor content={m.text} readOnly />
         </TabPanel>
       ))}
     </Tabs>

--- a/packages/insomnia-app/app/ui/components/viewers/response-error-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-error-viewer.tsx
@@ -1,5 +1,7 @@
 import React, { FC, memo } from 'react';
+import { useSelector } from 'react-redux';
 
+import { selectSettings } from '../../redux/selectors';
 import { Link } from '../base/link';
 import { showModal } from '../modals/index';
 import { SettingsModal } from '../modals/settings-modal';
@@ -7,10 +9,10 @@ import { SettingsModal } from '../modals/settings-modal';
 interface Props {
   error: string;
   url: string;
-  fontSize: number;
 }
-export const ResponseErrorViewer: FC<Props> = memo(({ error, fontSize }) => {
+export const ResponseErrorViewer: FC<Props> = memo(({ error }) => {
   let msg: React.ReactNode = null;
+  const { editorFontSize } = useSelector(selectSettings);
 
   if (error?.toLowerCase().indexOf('certificate') !== -1) {
     msg = (
@@ -37,7 +39,7 @@ export const ResponseErrorViewer: FC<Props> = memo(({ error, fontSize }) => {
       <pre
         className="selectable pad force-pre-wrap"
         style={{
-          fontSize: `${fontSize}px`,
+          fontSize: `${editorFontSize}px`,
         }}
       >
         {error}

--- a/packages/insomnia-app/app/ui/components/viewers/response-multipart-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-multipart-viewer.tsx
@@ -40,9 +40,6 @@ interface Props {
   filter: string;
   filterHistory: string[];
   editorFontSize: number;
-  editorIndentSize: number;
-  editorKeyMap: string;
-  editorLineWrapping: boolean;
   url: string;
 }
 
@@ -222,9 +219,6 @@ export class ResponseMultipartViewer extends PureComponent<Props, State> {
       disableHtmlPreviewJs,
       disablePreviewLinks,
       editorFontSize,
-      editorIndentSize,
-      editorKeyMap,
-      editorLineWrapping,
       filter,
       filterHistory,
       responseId,
@@ -302,10 +296,6 @@ export class ResponseMultipartViewer extends PureComponent<Props, State> {
               disableHtmlPreviewJs={disableHtmlPreviewJs}
               disablePreviewLinks={disablePreviewLinks}
               download={download}
-              editorFontSize={editorFontSize}
-              editorIndentSize={editorIndentSize}
-              editorKeyMap={editorKeyMap}
-              editorLineWrapping={editorLineWrapping}
               error={null}
               filter={filter}
               filterHistory={filterHistory}

--- a/packages/insomnia-app/app/ui/components/viewers/response-multipart-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-multipart-viewer.tsx
@@ -296,6 +296,7 @@ export class ResponseMultipartViewer extends PureComponent<Props, State> {
               disableHtmlPreviewJs={disableHtmlPreviewJs}
               disablePreviewLinks={disablePreviewLinks}
               download={download}
+              editorFontSize={editorFontSize}
               error={null}
               filter={filter}
               filterHistory={filterHistory}

--- a/packages/insomnia-app/app/ui/components/viewers/response-raw-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-raw-viewer.tsx
@@ -6,7 +6,6 @@ import { CodeEditor,  UnconnectedCodeEditor } from '../codemirror/code-editor';
 
 interface Props {
   value: string;
-  fontSize?: number;
   responseId?: string;
 }
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -30,14 +29,12 @@ export class ResponseRawViewer extends PureComponent<Props> {
   }
 
   render() {
-    const { fontSize, responseId, value } = this.props;
+    const { responseId, value } = this.props;
     return (
       <CodeEditor
         ref={this._setCodeEditorRef}
         defaultValue={value}
-        fontSize={fontSize}
         hideLineNumbers
-        lineWrapping
         mode="text/plain"
         noMatchBrackets
         placeholder="..."

--- a/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
@@ -7,9 +7,6 @@ import { CodeEditor } from '../codemirror/code-editor';
 
 interface Props {
   response: Response;
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorLineWrapping: boolean;
 }
 
 interface State {
@@ -96,7 +93,6 @@ export class ResponseTimelineViewer extends PureComponent<Props, State> {
   }
 
   render() {
-    const { editorFontSize, editorIndentSize, editorLineWrapping } = this.props;
     const { timeline, timelineKey } = this.state;
     const rows = timeline
       .map(this.renderRow)
@@ -110,9 +106,6 @@ export class ResponseTimelineViewer extends PureComponent<Props, State> {
         readOnly
         onClickLink={clickLink}
         defaultValue={rows}
-        fontSize={editorFontSize}
-        indentSize={editorIndentSize}
-        lineWrapping={editorLineWrapping}
         className="pad-left"
         mode="curl"
       />

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
@@ -30,6 +30,7 @@ export interface ResponseViewerProps {
   disableHtmlPreviewJs: boolean;
   disablePreviewLinks: boolean;
   download: (...args: any[]) => any;
+  editorFontSize: number;
   filter: string;
   filterHistory: string[];
   getBody: (...args: any[]) => any;
@@ -279,6 +280,7 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
       disableHtmlPreviewJs,
       disablePreviewLinks,
       download,
+      editorFontSize,
       error: responseError,
       filter,
       filterHistory,
@@ -406,6 +408,7 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
           disableHtmlPreviewJs={disableHtmlPreviewJs}
           disablePreviewLinks={disablePreviewLinks}
           download={download}
+          editorFontSize={editorFontSize}
           filter={filter}
           filterHistory={filterHistory}
           key={responseId}

--- a/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-viewer.tsx
@@ -30,10 +30,6 @@ export interface ResponseViewerProps {
   disableHtmlPreviewJs: boolean;
   disablePreviewLinks: boolean;
   download: (...args: any[]) => any;
-  editorFontSize: number;
-  editorIndentSize: number;
-  editorKeyMap: string;
-  editorLineWrapping: boolean;
   filter: string;
   filterHistory: string[];
   getBody: (...args: any[]) => any;
@@ -283,10 +279,6 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
       disableHtmlPreviewJs,
       disablePreviewLinks,
       download,
-      editorFontSize,
-      editorIndentSize,
-      editorKeyMap,
-      editorLineWrapping,
       error: responseError,
       filter,
       filterHistory,
@@ -301,7 +293,7 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
     if (error) {
       return (
         <div className="scrollable tall">
-          <ResponseErrorViewer url={url} error={error} fontSize={editorFontSize} />
+          <ResponseErrorViewer url={url} error={error} />
         </div>
       );
     }
@@ -414,10 +406,6 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
           disableHtmlPreviewJs={disableHtmlPreviewJs}
           disablePreviewLinks={disablePreviewLinks}
           download={download}
-          editorFontSize={editorFontSize}
-          editorIndentSize={editorIndentSize}
-          editorKeyMap={editorKeyMap}
-          editorLineWrapping={editorLineWrapping}
           filter={filter}
           filterHistory={filterHistory}
           key={responseId}
@@ -446,7 +434,6 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
           responseId={responseId}
           ref={this._setSelectableViewRef}
           value={this._getBody()}
-          fontSize={editorFontSize}
         />
       );
     }
@@ -460,10 +447,6 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
         defaultValue={this._getBody()}
         filter={filter}
         filterHistory={filterHistory}
-        fontSize={editorFontSize}
-        indentSize={editorIndentSize}
-        keyMap={editorKeyMap}
-        lineWrapping={editorLineWrapping}
         mode={this._getMode()}
         noMatchBrackets
         onClickLink={disablePreviewLinks ? undefined : this._handleClickLink}

--- a/packages/insomnia-app/app/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-debug.tsx
@@ -297,7 +297,6 @@ export class WrapperDebug extends PureComponent<Props> {
           <GrpcResponsePane
             activeRequest={activeRequest}
             forceRefreshKey={forceRefreshKey}
-            settings={settings}
           />
         </ErrorBoundary>
       );
@@ -309,9 +308,6 @@ export class WrapperDebug extends PureComponent<Props> {
           disableHtmlPreviewJs={settings.disableHtmlPreviewJs}
           disableResponsePreviewLinks={settings.disableResponsePreviewLinks}
           editorFontSize={settings.editorFontSize}
-          editorIndentSize={settings.editorIndentSize}
-          editorKeyMap={settings.editorKeyMap}
-          editorLineWrapping={settings.editorLineWrapping}
           environment={activeEnvironment}
           filter={responseFilter}
           filterHistory={responseFilterHistory}

--- a/packages/insomnia-app/app/ui/components/wrapper-design.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.tsx
@@ -146,7 +146,7 @@ export class WrapperDesign extends PureComponent<Props, State> {
   }
 
   _renderEditor() {
-    const { activeApiSpec, settings } = this.props.wrapperProps;
+    const { activeApiSpec } = this.props.wrapperProps;
     const { lintMessages } = this.state;
 
     if (!activeApiSpec) {
@@ -159,10 +159,6 @@ export class WrapperDesign extends PureComponent<Props, State> {
           <CodeEditor
             manualPrettify
             ref={this._setEditorRef}
-            fontSize={settings.editorFontSize}
-            indentSize={settings.editorIndentSize}
-            lineWrapping={settings.lineWrapping}
-            keyMap={settings.editorKeyMap}
             lintOptions={WrapperDesign.lintOptions}
             mode="openapi"
             defaultValue={activeApiSpec.contents}

--- a/packages/insomnia-app/app/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-unit-test.tsx
@@ -428,18 +428,12 @@ export class WrapperUnitTest extends PureComponent<Props, State> {
         <CodeEditor
           dynamicHeight
           manualPrettify
-          fontSize={settings.editorFontSize}
-          indentSize={settings.editorIndentSize}
-          indentWithTabs={settings.editorIndentWithTabs}
-          keyMap={settings.editorKeyMap}
           defaultValue={unitTest ? unitTest.code : ''}
           getAutocompleteSnippets={() => this.autocompleteSnippets(unitTest)}
           lintOptions={WrapperUnitTest.lintOptions}
           onChange={this._handleUnitTestCodeChange.bind(this, unitTest)}
-          nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
           isVariableUncovered={settings.isVariableUncovered}
           mode="javascript"
-          lineWrapping={settings.editorLineWrapping}
           placeholder=""
         />
       </UnitTestItem>

--- a/packages/insomnia-app/app/ui/components/wrapper.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper.tsx
@@ -533,7 +533,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
             <PaymentNotificationModal ref={registerModal} />
             <FilterHelpModal ref={registerModal} />
             <RequestRenderErrorModal ref={registerModal} />
-            <GenerateConfigModal ref={registerModal} settings={settings} />
+            <GenerateConfigModal ref={registerModal} />
             <ProjectSettingsModal ref={registerModal} />
             <WorkspaceDuplicateModal ref={registerModal} vcs={vcs || undefined} />
 
@@ -541,36 +541,21 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
               ref={registerModal}
               handleRender={handleRender}
               handleGetRenderContext={handleGetRenderContext}
-              nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
-              editorFontSize={settings.editorFontSize}
-              editorIndentSize={settings.editorIndentSize}
-              editorKeyMap={settings.editorKeyMap}
-              editorLineWrapping={settings.editorLineWrapping}
               isVariableUncovered={isVariableUncovered}
             />
 
             <RequestSettingsModal
               ref={registerModal}
-              editorFontSize={settings.editorFontSize}
-              editorIndentSize={settings.editorIndentSize}
-              editorKeyMap={settings.editorKeyMap}
-              editorLineWrapping={settings.editorLineWrapping}
               handleRender={handleRender}
               handleGetRenderContext={handleGetRenderContext}
-              nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
               workspaces={workspaces}
               isVariableUncovered={isVariableUncovered}
             />
 
             <RequestGroupSettingsModal
               ref={registerModal}
-              editorFontSize={settings.editorFontSize}
-              editorIndentSize={settings.editorIndentSize}
-              editorKeyMap={settings.editorKeyMap}
-              editorLineWrapping={settings.editorLineWrapping}
               handleRender={handleRender}
               handleGetRenderContext={handleGetRenderContext}
-              nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
               workspaces={workspaces}
               isVariableUncovered={isVariableUncovered}
             />
@@ -588,7 +573,6 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
                 <CookieModifyModal
                   handleRender={handleRender}
                   handleGetRenderContext={handleGetRenderContext}
-                  nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
                   ref={registerModal}
                   cookieJar={activeCookieJar}
                   workspace={activeWorkspace}
@@ -609,13 +593,8 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
                 clientCertificates={activeWorkspaceClientCertificates}
                 workspace={activeWorkspace}
                 apiSpec={activeApiSpec}
-                editorFontSize={settings.editorFontSize}
-                editorIndentSize={settings.editorIndentSize}
-                editorKeyMap={settings.editorKeyMap}
-                editorLineWrapping={settings.editorLineWrapping}
                 handleRender={handleRender}
                 handleGetRenderContext={handleGetRenderContext}
-                nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
                 handleRemoveWorkspace={this._handleRemoveActiveWorkspace}
                 handleClearAllResponses={this._handleActiveWorkspaceClearAllResponses}
                 isVariableUncovered={isVariableUncovered}
@@ -625,9 +604,6 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
             <GenerateCodeModal
               ref={registerModal}
               environmentId={activeEnvironment ? activeEnvironment._id : 'n/a'}
-              editorFontSize={settings.editorFontSize}
-              editorIndentSize={settings.editorIndentSize}
-              editorKeyMap={settings.editorKeyMap}
             />
 
             <SettingsModal
@@ -635,7 +611,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
               settings={settings}
             />
 
-            <ResponseDebugModal ref={registerModal} settings={settings} />
+            <ResponseDebugModal ref={registerModal} />
 
             <RequestSwitcherModal
               ref={registerModal}
@@ -644,14 +620,9 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
 
             <EnvironmentEditModal
               ref={registerModal}
-              editorFontSize={settings.editorFontSize}
-              editorIndentSize={settings.editorIndentSize}
-              editorKeyMap={settings.editorKeyMap}
-              lineWrapping={settings.editorLineWrapping}
               onChange={models.requestGroup.update}
               render={handleRender}
               getRenderContext={handleGetRenderContext}
-              nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
               isVariableUncovered={isVariableUncovered}
             />
 
@@ -702,14 +673,9 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
             <WorkspaceEnvironmentsEditModal
               ref={registerModal}
               handleChangeEnvironment={this._handleChangeEnvironment}
-              lineWrapping={settings.editorLineWrapping}
-              editorFontSize={settings.editorFontSize}
-              editorIndentSize={settings.editorIndentSize}
-              editorKeyMap={settings.editorKeyMap}
               activeEnvironmentId={activeEnvironment ? activeEnvironment._id : null}
               render={handleRender}
               getRenderContext={handleGetRenderContext}
-              nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
               isVariableUncovered={isVariableUncovered}
             />
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

Moved `editorFontSize`, `editorIndentSize`, `editorKeyMap`, `editorLineWrapping`, `editorIndentWithTabs` and `nunjucksPowerUserMode` into `mapStateToProps` in `CodeEditor`.

The `OneLineEditor` previously didn't use the `editor*` properties, and this PR introduces an `ignoreEditorFontSettings` prop, used only by the `OneLineEditor`, to preserve existing behavior.

If the `OneLineEditor` doesn't send this prop, we see the following behavior when the `editorFontSide` and `interfaceFontSize` differ, because of how the component works. In a future PR, we could look to remove this.

![2021-11-24 13 46 49](https://user-images.githubusercontent.com/4312346/143151333-8d016525-e1bc-43bf-aa92-ac82b74e8e12.gif)

