### PR TITLE
Add gRPC Headers (INS-362) (#3667)

### DIFF
--- a/packages/insomnia-app/app/__mocks__/@grpc/grpc-js.ts
+++ b/packages/insomnia-app/app/__mocks__/@grpc/grpc-js.ts
@@ -79,10 +79,20 @@ class MockGrpcClient {
     makeMockCall();
     return getMockCall();
   }
+
 }
 
 export function makeGenericClientConstructor() {
   return MockGrpcClient;
+}
+
+export class Metadata {
+  /**
+   * Mock Metadata class to avoid TypeError: grpc.Metadata is not a constructor
+   */
+  constructor() {
+    // Do nothing
+  }
 }
 
 export const credentials = {

--- a/packages/insomnia-app/app/common/__tests__/common-headers.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/common-headers.test.ts
@@ -1,0 +1,53 @@
+import allCharsets from '../../datasets/charsets';
+import allMimeTypes from '../../datasets/content-types';
+import allEncodings from '../../datasets/encodings';
+import allHeaderNames from '../../datasets/header-names';
+import { getCommonHeaderNames, getCommonHeaderValues } from '../common-headers';
+
+describe('getCommonHeaderNames', () => {
+  it('should return common header names', () => {
+    expect(getCommonHeaderNames()).toBe(allHeaderNames);
+  });
+});
+
+describe('getCommonHeaderValues', () => {
+  it('should return mime types for accept', () => {
+    const header = {
+      name: 'Accept',
+      value: 'test',
+    };
+    expect(getCommonHeaderValues(header)).toEqual(expect.arrayContaining(allMimeTypes));
+  });
+
+  it('should return mime types for content-type', () => {
+    const header = {
+      name: 'Content-Type',
+      value: 'test',
+    };
+    expect(getCommonHeaderValues(header)).toEqual(expect.arrayContaining(allMimeTypes));
+  });
+
+  it('should return charsets for accept-charset', () => {
+    const header = {
+      name: 'Accept-Charset',
+      value: 'test',
+    };
+    expect(getCommonHeaderValues(header)).toEqual(expect.arrayContaining(allCharsets));
+  });
+
+  it('should return encodings for accept-encoding', () => {
+    const header = {
+      name: 'Accept-Encoding',
+      value: 'test',
+    };
+    expect(getCommonHeaderValues(header)).toEqual(expect.arrayContaining(allEncodings));
+  });
+
+  it('should return empty array for unknown header name', () => {
+    const header = {
+      name: 'Some-Header-Name',
+      value: 'test',
+    };
+    expect(getCommonHeaderValues(header)).toEqual(expect.arrayContaining([]));
+  });
+});

--- a/packages/insomnia-app/app/common/common-headers.ts
+++ b/packages/insomnia-app/app/common/common-headers.ts
@@ -1,0 +1,27 @@
+
+import allCharsets from '../datasets/charsets';
+import allMimeTypes from '../datasets/content-types';
+import allEncodings from '../datasets/encodings';
+import allHeaderNames from '../datasets/header-names';
+import { RequestHeader } from '../models/request';
+
+export const _getCommonHeaderValues = (pair: RequestHeader): any[] => {
+  switch (pair.name.toLowerCase()) {
+    case 'content-type':
+    case 'accept':
+      return allMimeTypes;
+
+    case 'accept-charset':
+      return allCharsets;
+
+    case 'accept-encoding':
+      return allEncodings;
+
+    default:
+      return [];
+  }
+};
+
+export const _getCommonHeaderNames = (): any[] => {
+  return allHeaderNames;
+};

--- a/packages/insomnia-app/app/common/common-headers.ts
+++ b/packages/insomnia-app/app/common/common-headers.ts
@@ -5,7 +5,7 @@ import allEncodings from '../datasets/encodings';
 import allHeaderNames from '../datasets/header-names';
 import { RequestHeader } from '../models/request';
 
-export const _getCommonHeaderValues = (pair: RequestHeader): any[] => {
+export const getCommonHeaderValues = (pair: RequestHeader): any[] => {
   switch (pair.name.toLowerCase()) {
     case 'content-type':
     case 'accept':
@@ -22,6 +22,6 @@ export const _getCommonHeaderValues = (pair: RequestHeader): any[] => {
   }
 };
 
-export const _getCommonHeaderNames = (): any[] => {
+export const getCommonHeaderNames = (): any[] => {
   return allHeaderNames;
 };

--- a/packages/insomnia-app/app/models/__tests__/grpc-request.test.ts
+++ b/packages/insomnia-app/app/models/__tests__/grpc-request.test.ts
@@ -12,6 +12,7 @@ describe('init()', () => {
       description: '',
       protoFileId: '',
       protoMethodName: '',
+      metadata: [],
       body: {
         text: '{}',
       },
@@ -40,6 +41,7 @@ describe('create()', () => {
       url: '',
       protoFileId: '',
       protoMethodName: '',
+      metadata: [],
       body: {
         text: '{}',
       },

--- a/packages/insomnia-app/app/models/grpc-request.ts
+++ b/packages/insomnia-app/app/models/grpc-request.ts
@@ -11,6 +11,13 @@ export interface GrpcRequestBody {
   text?: string;
 }
 
+export interface GrpcRequestHeader {
+  name: string;
+  value: string;
+  description?: string;
+  disabled?: boolean;
+}
+
 interface BaseGrpcRequest {
   name: string;
   url: string;
@@ -18,6 +25,7 @@ interface BaseGrpcRequest {
   protoFileId?: string;
   protoMethodName?: string;
   body: GrpcRequestBody;
+  metadata: GrpcRequestHeader[];
   metaSortKey: number;
   isPrivate: boolean;
 }
@@ -39,6 +47,7 @@ export function init(): BaseGrpcRequest {
     description: '',
     protoFileId: '',
     protoMethodName: '',
+    metadata: [],
     body: {
       text: '{}',
     },

--- a/packages/insomnia-app/app/network/grpc/__tests__/index.test.ts
+++ b/packages/insomnia-app/app/network/grpc/__tests__/index.test.ts
@@ -173,6 +173,7 @@ describe('grpc', () => {
             body: {
               text: '{}',
             },
+            metadata: [],
           })
           .build();
         const unaryMethod = methodBuilder.requestStream(false).responseStream(false).build();
@@ -209,6 +210,7 @@ describe('grpc', () => {
             body: {
               text: '{}',
             },
+            metadata: [],
           })
           .build();
         const unaryMethod = methodBuilder.requestStream(false).responseStream(false).build();
@@ -247,6 +249,7 @@ describe('grpc', () => {
             body: {
               text: undefined,
             },
+            metadata: [],
           })
           .build();
         const serverMethod = methodBuilder.requestStream(false).responseStream(true).build();
@@ -271,6 +274,7 @@ describe('grpc', () => {
             body: {
               text: '{}',
             },
+            metadata: [],
           })
           .build();
         const serverMethod = methodBuilder.requestStream(false).responseStream(true).build();

--- a/packages/insomnia-app/app/network/grpc/__tests__/index.test.ts
+++ b/packages/insomnia-app/app/network/grpc/__tests__/index.test.ts
@@ -188,13 +188,14 @@ describe('grpc', () => {
           unaryMethod.responseDeserialize,
           {},
           expect.anything(),
+          expect.anything(),
         );
         // Trigger response
         const err = {
           code: grpcJs.status.DATA_LOSS,
         };
         const val = undefined;
-        grpcMocks.mockMakeUnaryRequest.mock.calls[0][4](err, val);
+        grpcMocks.mockMakeUnaryRequest.mock.calls[0][5](err, val);
         // Assert
         expect(respond.sendData).not.toHaveBeenCalled();
         expect(respond.sendError).toHaveBeenCalledWith(params.request._id, err);
@@ -225,13 +226,14 @@ describe('grpc', () => {
           unaryMethod.responseDeserialize,
           {},
           expect.anything(),
+          expect.anything(),
         );
         // Trigger response
         const err = undefined;
         const val = {
           foo: 'bar',
         };
-        grpcMocks.mockMakeUnaryRequest.mock.calls[0][4](err, val);
+        grpcMocks.mockMakeUnaryRequest.mock.calls[0][5](err, val);
         // Assert
         expect(respond.sendError).not.toHaveBeenCalled();
         expect(respond.sendData).toHaveBeenCalledWith(params.request._id, val);
@@ -288,6 +290,7 @@ describe('grpc', () => {
           serverMethod.requestSerialize,
           serverMethod.responseDeserialize,
           {},
+          expect.anything(),
         );
         // Trigger valid response
         const val = {
@@ -329,13 +332,14 @@ describe('grpc', () => {
           clientMethod.requestSerialize,
           clientMethod.responseDeserialize,
           expect.anything(),
+          expect.anything(),
         );
         // Trigger response
         const err = {
           code: grpcJs.status.DATA_LOSS,
         };
         const val = undefined;
-        grpcMocks.mockMakeClientStreamRequest.mock.calls[0][3](err, val);
+        grpcMocks.mockMakeClientStreamRequest.mock.calls[0][4](err, val);
         // Assert
         expect(respond.sendData).not.toHaveBeenCalled();
         expect(respond.sendError).toHaveBeenCalledWith(params.request._id, err);
@@ -361,13 +365,14 @@ describe('grpc', () => {
           clientMethod.requestSerialize,
           clientMethod.responseDeserialize,
           expect.anything(),
+          expect.anything(),
         );
         // Trigger response
         const err = undefined;
         const val = {
           foo: 'bar',
         };
-        grpcMocks.mockMakeClientStreamRequest.mock.calls[0][3](err, val);
+        grpcMocks.mockMakeClientStreamRequest.mock.calls[0][4](err, val);
         // Assert
         expect(respond.sendError).not.toHaveBeenCalled();
         expect(respond.sendData).toHaveBeenCalledWith(params.request._id, val);
@@ -394,6 +399,7 @@ describe('grpc', () => {
           bidiMethod.path,
           bidiMethod.requestSerialize,
           bidiMethod.responseDeserialize,
+          expect.anything()
         );
         // Trigger valid response
         const val = {

--- a/packages/insomnia-app/app/network/grpc/__tests__/index.test.ts
+++ b/packages/insomnia-app/app/network/grpc/__tests__/index.test.ts
@@ -41,6 +41,7 @@ describe('grpc', () => {
         .request({
           _id: 'id',
           protoMethodName: 'SayHi',
+          metadata: [],
         })
         .build();
       protoLoader.getSelectedMethod.mockResolvedValue(null);
@@ -60,6 +61,7 @@ describe('grpc', () => {
         .request({
           _id: 'id',
           url: '',
+          metadata: [],
         })
         .build();
       protoLoader.getSelectedMethod.mockResolvedValue(methodBuilder.build());
@@ -79,6 +81,7 @@ describe('grpc', () => {
         .request({
           _id: 'id',
           url: 'grpcb.in:9000',
+          metadata: [],
         })
         .build();
       const bidiMethod = methodBuilder.requestStream(true).responseStream(true).build();
@@ -100,6 +103,7 @@ describe('grpc', () => {
         .request({
           _id: 'id',
           url: 'grpcs://grpcb.in:9000',
+          metadata: [],
         })
         .build();
       const bidiMethod = methodBuilder.requestStream(true).responseStream(true).build();
@@ -121,6 +125,7 @@ describe('grpc', () => {
         .request({
           _id: 'id',
           url: 'grpcb.in:9000',
+          metadata: [],
         })
         .build();
       const bidiMethod = methodBuilder.requestStream(true).responseStream(true).build();
@@ -319,6 +324,7 @@ describe('grpc', () => {
           .request({
             _id: 'id',
             url: 'grpcb.in:9000',
+            metadata: [],
           })
           .build();
         const clientMethod = methodBuilder.requestStream(true).responseStream(false).build();
@@ -352,6 +358,7 @@ describe('grpc', () => {
           .request({
             _id: 'id',
             url: 'grpcb.in:9000',
+            metadata: [],
           })
           .build();
         const clientMethod = methodBuilder.requestStream(true).responseStream(false).build();
@@ -387,6 +394,7 @@ describe('grpc', () => {
           .request({
             _id: 'id',
             url: 'grpcb.in:9000',
+            metadata: [],
           })
           .build();
         const bidiMethod = methodBuilder.requestStream(true).responseStream(true).build();
@@ -428,6 +436,7 @@ describe('grpc', () => {
         .request({
           _id: 'id',
           url: 'grpcb.in:9000',
+          metadata: [],
         })
         .build();
       const clientMethod = methodBuilder.requestStream(true).responseStream(false).build();
@@ -489,6 +498,7 @@ describe('grpc', () => {
         .request({
           _id: 'id',
           url: 'grpcb.in:9000',
+          metadata: [],
         })
         .build();
       const clientMethod = methodBuilder.requestStream(true).responseStream(false).build();
@@ -520,6 +530,7 @@ describe('grpc', () => {
         .request({
           _id: 'id',
           url: 'grpcb.in:9000',
+          metadata: [],
         })
         .build();
       const clientMethod = methodBuilder.requestStream(true).responseStream(false).build();

--- a/packages/insomnia-app/app/network/grpc/index.ts
+++ b/packages/insomnia-app/app/network/grpc/index.ts
@@ -69,12 +69,15 @@ const _makeClientStreamRequest = ({
   method: { path, requestSerialize, responseDeserialize },
   client,
   respond,
+  metadata,
 }: RequestData): Call | undefined => {
   // Create callback
   const callback = _createUnaryCallback(requestId, respond);
 
+  const grpcMetadata = _parseMetadata(metadata);
+
   // Make call
-  return client.makeClientStreamRequest(path, requestSerialize, responseDeserialize, callback);
+  return client.makeClientStreamRequest(path, requestSerialize, responseDeserialize, grpcMetadata, callback);
 };
 
 const _makeServerStreamRequest = (
@@ -83,6 +86,7 @@ const _makeServerStreamRequest = (
     method: { path, requestSerialize, responseDeserialize },
     client,
     respond,
+    metadata,
   }: RequestData,
   bodyText: string,
 ): Call | undefined => {
@@ -93,16 +97,20 @@ const _makeServerStreamRequest = (
     return;
   }
 
+  const grpcMetadata = _parseMetadata(metadata);
+
   // Make call
   const call = client.makeServerStreamRequest(
     path,
     requestSerialize,
     responseDeserialize,
     messageBody,
+    grpcMetadata,
   );
 
   _setupServerStreamListeners(call, requestId, respond);
 
+  // eslint-disable-next-line consistent-return
   return call;
 };
 
@@ -111,9 +119,12 @@ const _makeBidiStreamRequest = ({
   method: { path, requestSerialize, responseDeserialize },
   client,
   respond,
+  metadata,
 }: RequestData): Call | undefined => {
+  const grpcMetadata = _parseMetadata(metadata);
+
   // Make call
-  const call = client.makeBidiStreamRequest(path, requestSerialize, responseDeserialize);
+  const call = client.makeBidiStreamRequest(path, requestSerialize, responseDeserialize, grpcMetadata);
 
   _setupServerStreamListeners(call, requestId, respond);
 

--- a/packages/insomnia-app/app/network/grpc/index.ts
+++ b/packages/insomnia-app/app/network/grpc/index.ts
@@ -301,12 +301,10 @@ const _parseMessage = (
 const _parseMetadata = (
   metadata: GrpcRequestHeader[]
 ): grpc.Metadata => {
-  const grpcMetadata = new grpc.Metadata({});
-  if (metadata) {
-    for (const entry of metadata) {
-      if (!entry.disabled) {
-        grpcMetadata.add(entry.name, entry.value);
-      }
+  const grpcMetadata = new grpc.Metadata();
+  for (const entry of metadata) {
+    if (!entry.disabled) {
+      grpcMetadata.add(entry.name, entry.value);
     }
   }
   return grpcMetadata;

--- a/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
@@ -1,12 +1,9 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import React, { PureComponent } from 'react';
+import { _getCommonHeaderNames, _getCommonHeaderValues } from '../../../common/common-headers';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { HandleGetRenderContext, HandleRender } from '../../../common/render';
-import allCharsets from '../../../datasets/charsets';
-import allMimeTypes from '../../../datasets/content-types';
-import allEncodings from '../../../datasets/encodings';
-import allHeaderNames from '../../../datasets/header-names';
 import type { Request, RequestHeader } from '../../../models/request';
 import { CodeEditor } from '../codemirror/code-editor';
 import { KeyValueEditor } from '../key-value-editor/key-value-editor';
@@ -78,27 +75,6 @@ export class RequestHeadersEditor extends PureComponent<Props> {
     return headersString;
   }
 
-  static _getCommonHeaderValues(pair: RequestHeader) {
-    switch (pair.name.toLowerCase()) {
-      case 'content-type':
-      case 'accept':
-        return allMimeTypes;
-
-      case 'accept-charset':
-        return allCharsets;
-
-      case 'accept-encoding':
-        return allEncodings;
-
-      default:
-        return [];
-    }
-  }
-
-  static _getCommonHeaderNames() {
-    return allHeaderNames;
-  }
-
   render() {
     const {
       bulk,
@@ -129,8 +105,8 @@ export class RequestHeadersEditor extends PureComponent<Props> {
             isVariableUncovered={isVariableUncovered}
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
-            handleGetAutocompleteNameConstants={RequestHeadersEditor._getCommonHeaderNames}
-            handleGetAutocompleteValueConstants={RequestHeadersEditor._getCommonHeaderValues}
+            handleGetAutocompleteNameConstants={_getCommonHeaderNames}
+            handleGetAutocompleteValueConstants={_getCommonHeaderValues}
             onChange={this._handleKeyValueUpdate}
           />
         </div>

--- a/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
@@ -1,7 +1,7 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import React, { PureComponent } from 'react';
-import { _getCommonHeaderNames, _getCommonHeaderValues } from '../../../common/common-headers';
 
+import { _getCommonHeaderNames, _getCommonHeaderValues } from '../../../common/common-headers';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { HandleGetRenderContext, HandleRender } from '../../../common/render';
 import type { Request, RequestHeader } from '../../../models/request';

--- a/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
@@ -1,7 +1,7 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import React, { PureComponent } from 'react';
 
-import { _getCommonHeaderNames, _getCommonHeaderValues } from '../../../common/common-headers';
+import { getCommonHeaderNames, getCommonHeaderValues } from '../../../common/common-headers';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { HandleGetRenderContext, HandleRender } from '../../../common/render';
 import type { Request, RequestHeader } from '../../../models/request';
@@ -105,8 +105,8 @@ export class RequestHeadersEditor extends PureComponent<Props> {
             isVariableUncovered={isVariableUncovered}
             handleRender={handleRender}
             handleGetRenderContext={handleGetRenderContext}
-            handleGetAutocompleteNameConstants={_getCommonHeaderNames}
-            handleGetAutocompleteValueConstants={_getCommonHeaderValues}
+            handleGetAutocompleteNameConstants={getCommonHeaderNames}
+            handleGetAutocompleteValueConstants={getCommonHeaderValues}
             onChange={this._handleKeyValueUpdate}
           />
         </div>

--- a/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/request-headers-editor.tsx
@@ -3,15 +3,15 @@ import React, { PureComponent } from 'react';
 
 import { getCommonHeaderNames, getCommonHeaderValues } from '../../../common/common-headers';
 import { AUTOBIND_CFG } from '../../../common/constants';
-import type * as request from '../../../models/request';
+import type { Request, RequestHeader } from '../../../models/request';
 import { CodeEditor } from '../codemirror/code-editor';
 import { KeyValueEditor } from '../key-value-editor/key-value-editor';
 
 interface Props {
-  onChange: (r: request.Request, headers: request.RequestHeader[]) => Promise<request.Request>;
+  onChange: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   bulk: boolean;
   isVariableUncovered: boolean;
-  request: request.Request;
+  request: Request;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -24,7 +24,7 @@ export class RequestHeadersEditor extends PureComponent<Props> {
     onChange(request, headers);
   }
 
-  _handleKeyValueUpdate(headers: request.RequestHeader[]) {
+  _handleKeyValueUpdate(headers: RequestHeader[]) {
     const { onChange, request } = this.props;
     onChange(request, headers);
   }

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
@@ -135,21 +135,25 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
               />
             </TabPanel>
             <TabPanel className="react-tabs__tab-panel">
-              <ErrorBoundary key={uniquenessKey} errorClassName="font-error pad text-center">
-                <KeyValueEditor
-                  sortable
-                  namePlaceholder="header"
-                  valuePlaceholder="value"
-                  descriptionPlaceholder="description"
-                  pairs={activeRequest.metadata}
-                  isVariableUncovered={isVariableUncovered}
-                  handleRender={handleRender}
-                  handleGetRenderContext={handleGetRenderContext}
-                  handleGetAutocompleteNameConstants={_getCommonHeaderNames}
-                  handleGetAutocompleteValueConstants={_getCommonHeaderValues}
-                  onChange={handleChange.metadata}
-                />
-              </ErrorBoundary>
+              <div className="tall wide scrollable-container">
+                <div className="scrollable">
+                  <ErrorBoundary key={uniquenessKey} errorClassName="font-error pad text-center">
+                    <KeyValueEditor
+                      sortable
+                      namePlaceholder="header"
+                      valuePlaceholder="value"
+                      descriptionPlaceholder="description"
+                      pairs={activeRequest.metadata}
+                      isVariableUncovered={isVariableUncovered}
+                      handleRender={handleRender}
+                      handleGetRenderContext={handleGetRenderContext}
+                      handleGetAutocompleteNameConstants={_getCommonHeaderNames}
+                      handleGetAutocompleteValueConstants={_getCommonHeaderValues}
+                      onChange={handleChange.metadata}
+                    />
+                  </ErrorBoundary>
+                </div>
+              </div>
             </TabPanel>
           </Tabs>
         )}

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
@@ -142,7 +142,6 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                   valuePlaceholder="value"
                   descriptionPlaceholder="description"
                   pairs={activeRequest.metadata}
-                  nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
                   isVariableUncovered={isVariableUncovered}
                   handleRender={handleRender}
                   handleGetRenderContext={handleGetRenderContext}

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import styled from 'styled-components';
-
+import { _getCommonHeaderNames, _getCommonHeaderValues } from '../../../../common/common-headers';
 import { HandleGetRenderContext, HandleRender } from '../../../../common/render';
 import type { GrpcRequest } from '../../../../models/grpc-request';
 import type { Settings } from '../../../../models/settings';
@@ -9,7 +9,6 @@ import { useGrpc } from '../../../context/grpc';
 import { GrpcSendButton } from '../../buttons/grpc-send-button';
 import { OneLineEditor } from '../../codemirror/one-line-editor';
 import { GrpcMethodDropdown } from '../../dropdowns/grpc-method-dropdown/grpc-method-dropdown';
-import { RequestHeadersEditor } from '../../editors/request-headers-editor';
 import { ErrorBoundary } from '../../error-boundary';
 import { KeyValueEditor } from '../../key-value-editor/key-value-editor';
 import { GrpcTabbedMessages } from '../../viewers/grpc-tabbed-messages';
@@ -145,8 +144,8 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                   isVariableUncovered={isVariableUncovered}
                   handleRender={handleRender}
                   handleGetRenderContext={handleGetRenderContext}
-                  handleGetAutocompleteNameConstants={RequestHeadersEditor._getCommonHeaderNames}
-                  handleGetAutocompleteValueConstants={RequestHeadersEditor._getCommonHeaderValues}
+                  handleGetAutocompleteNameConstants={_getCommonHeaderNames}
+                  handleGetAutocompleteValueConstants={_getCommonHeaderValues}
                   onChange={handleChange.metadata}
                 />
               </ErrorBoundary>

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import styled from 'styled-components';
+
 import { _getCommonHeaderNames, _getCommonHeaderValues } from '../../../../common/common-headers';
 import { HandleGetRenderContext, HandleRender } from '../../../../common/render';
 import type { GrpcRequest } from '../../../../models/grpc-request';

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import styled from 'styled-components';
 
-import { _getCommonHeaderNames, _getCommonHeaderValues } from '../../../../common/common-headers';
+import { getCommonHeaderNames, getCommonHeaderValues } from '../../../../common/common-headers';
 import { HandleGetRenderContext, HandleRender } from '../../../../common/render';
 import type { GrpcRequest } from '../../../../models/grpc-request';
 import type { Settings } from '../../../../models/settings';
@@ -147,8 +147,8 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                       isVariableUncovered={isVariableUncovered}
                       handleRender={handleRender}
                       handleGetRenderContext={handleGetRenderContext}
-                      handleGetAutocompleteNameConstants={_getCommonHeaderNames}
-                      handleGetAutocompleteValueConstants={_getCommonHeaderValues}
+                      handleGetAutocompleteNameConstants={getCommonHeaderNames}
+                      handleGetAutocompleteValueConstants={getCommonHeaderValues}
                       onChange={handleChange.metadata}
                     />
                   </ErrorBoundary>

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/index.tsx
@@ -9,6 +9,9 @@ import { useGrpc } from '../../../context/grpc';
 import { GrpcSendButton } from '../../buttons/grpc-send-button';
 import { OneLineEditor } from '../../codemirror/one-line-editor';
 import { GrpcMethodDropdown } from '../../dropdowns/grpc-method-dropdown/grpc-method-dropdown';
+import { RequestHeadersEditor } from '../../editors/request-headers-editor';
+import { ErrorBoundary } from '../../error-boundary';
+import { KeyValueEditor } from '../../key-value-editor/key-value-editor';
 import { GrpcTabbedMessages } from '../../viewers/grpc-tabbed-messages';
 import { Pane, PaneBody, PaneHeader } from '../pane';
 import useActionHandlers from './use-action-handlers';
@@ -135,7 +138,22 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
               />
             </TabPanel>
             <TabPanel className="react-tabs__tab-panel">
-              <h4 className="pad">Coming soon! 😊</h4>
+              <ErrorBoundary key={uniquenessKey} errorClassName="font-error pad text-center">
+                <KeyValueEditor
+                  sortable
+                  namePlaceholder="header"
+                  valuePlaceholder="value"
+                  descriptionPlaceholder="description"
+                  pairs={activeRequest.metadata}
+                  nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
+                  isVariableUncovered={isVariableUncovered}
+                  handleRender={handleRender}
+                  handleGetRenderContext={handleGetRenderContext}
+                  handleGetAutocompleteNameConstants={RequestHeadersEditor._getCommonHeaderNames}
+                  handleGetAutocompleteValueConstants={RequestHeadersEditor._getCommonHeaderValues}
+                  onChange={handleChange.metadata}
+                />
+              </ErrorBoundary>
             </TabPanel>
           </Tabs>
         )}

--- a/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-change-handlers.ts
+++ b/packages/insomnia-app/app/ui/components/panes/grpc-request-pane/use-change-handlers.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import * as models from '../../../../models';
-import type { GrpcRequest } from '../../../../models/grpc-request';
+import type { GrpcRequest, GrpcRequestHeader } from '../../../../models/grpc-request';
 import type { GrpcDispatch } from '../../../context/grpc';
 import { grpcActions } from '../../../context/grpc';
 import { showModal } from '../../modals';
@@ -11,6 +11,7 @@ interface ChangeHandlers {
   url: (arg0: string) => Promise<void>;
   body: (arg0: string) => Promise<void>;
   method: (arg0: string) => Promise<void>;
+  metadata: (arg0: GrpcRequestHeader[]) => Promise<void>;
   protoFile: (arg0: string) => Promise<void>;
 }
 
@@ -36,6 +37,12 @@ const useChangeHandlers = (request: GrpcRequest, dispatch: GrpcDispatch): Change
       dispatch(grpcActions.clear(request._id));
     };
 
+    const metadata = async (values: GrpcRequestHeader[]) => {
+      await models.grpcRequest.update(request, {
+        metadata: values,
+      });
+    };
+
     const protoFile = async () => {
       showModal(ProtoFilesModal, {
         preselectProtoFileId: request.protoFileId,
@@ -58,6 +65,7 @@ const useChangeHandlers = (request: GrpcRequest, dispatch: GrpcDispatch): Change
       url,
       body,
       method,
+      metadata,
       protoFile,
     };
   }, [request, dispatch]);


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

Closes #3667 and [INS-362](https://linear.app/insomnia/issue/INS-362/grpc-headersmetadata)

This PR adds initial support for gRPC "Headers" (aka. Metadata).

### How to test

1. Checkout this branch 
2. Run `npm run bootstrap && npm run app-start`
3. Clone https://github.com/filfreire/grpc-example-python and follow instructions to build/run
4. Import this [Insomnia collection](https://raw.githubusercontent.com/filfreire/grpc-example-python/main/grpc_insomnia.json) (URL is `https://raw.githubusercontent.com/filfreire/grpc-example-python/main/grpc_insomnia.json`) (<a href="insomnia://app/import?uri=https://raw.githubusercontent.com/filfreire/grpc-example-python/main/grpc_insomnia.json">Open in Insomnia</a>)

5. (In case you need) you can find the [proto file here](https://github.com/filfreire/grpc-example-python/blob/main/proto/helloworld.proto)
6. For testing client, server and bidi streams, use this [other proto file instead](https://github.com/filfreire/grpc-example-python/blob/main/route_example/route_guide.proto) and use the [route_guide example](https://github.com/filfreire/grpc-example-python#build-and-run-route_guide-example).

### Example recording

https://user-images.githubusercontent.com/11976836/143292010-52b29127-bf8c-458f-b76b-584286ad8ed7.mp4


### Problems

- ~~Only tested unary gRPC requests. Still need to add support and test metadata for server, client and bidirectional streams.~~ **UPDATE**: All types of requests are supported now. 
- ~~There's a tiny UI bug, that I suspect might be general to wherever `KeyValueEditor` is used - if the user switches between environments - and is using (and disabling) variables from two environments, the value field stops being in an error state, but the color stays red (check the video above near the end).~~ UPDATE: Bug has been reported on Linear, see [INS-1245](https://linear.app/insomnia/issue/INS-1245/error-state-styling-issues-in-header-keyvalueeditor)
- ~~There's 2 tests failing, not sure yet how to fix them just yet (maybe @dimitropoulos or @develohpanda you can help me in this case). More details:~~ **UPDATE**: this has been fixed, we had to mock `grpc.Metadata` class similarly to how we mocked other `grpc` lib calls.

## UPDATE, 30 Nov 2021

- Added support to all types of gRPC comms that we support, not just unary streams, but client, server and bidirectional as well.

https://user-images.githubusercontent.com/11976836/144087183-810adcb8-edad-46dd-b401-91364792912e.mp4



