### PR TITLE
remove autobind from insomnia-components

### DIFF
--- a/packages/insomnia-components/package-lock.json
+++ b/packages/insomnia-components/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/styled-components": "^5.1.23",
-				"class-autobind-decorator": "^3.0.1",
 				"classnames": "^2.3.1",
 				"framer-motion": "4.1.17",
 				"fuzzysort": "^1.2.1",
@@ -4846,11 +4845,6 @@
 			"engines": {
 				"node": ">=0.8.0"
 			}
-		},
-		"node_modules/class-autobind-decorator": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/class-autobind-decorator/-/class-autobind-decorator-3.0.1.tgz",
-			"integrity": "sha512-/5QCUe6KYGIMDDFEI/UrVc3egWVTVhuK00ppY/8sS/9f0KapY5Y2TirBbM1qICRq0p0WafuTaMfEGL2GKHcN0Q=="
 		},
 		"node_modules/class-utils": {
 			"version": "0.3.6",
@@ -19288,11 +19282,6 @@
 					"dev": true
 				}
 			}
-		},
-		"class-autobind-decorator": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/class-autobind-decorator/-/class-autobind-decorator-3.0.1.tgz",
-			"integrity": "sha512-/5QCUe6KYGIMDDFEI/UrVc3egWVTVhuK00ppY/8sS/9f0KapY5Y2TirBbM1qICRq0p0WafuTaMfEGL2GKHcN0Q=="
 		},
 		"class-utils": {
 			"version": "0.3.6",

--- a/packages/insomnia-components/package.json
+++ b/packages/insomnia-components/package.json
@@ -66,7 +66,6 @@
   },
   "dependencies": {
     "@types/styled-components": "^5.1.23",
-    "class-autobind-decorator": "^3.0.1",
     "classnames": "^2.3.1",
     "framer-motion": "4.1.17",
     "fuzzysort": "^1.2.1",

--- a/packages/insomnia-components/src/dropdown/dropdown.tsx
+++ b/packages/insomnia-components/src/dropdown/dropdown.tsx
@@ -1,4 +1,3 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import fuzzySort from 'fuzzysort';
 import { any, equals } from 'ramda';
@@ -155,7 +154,6 @@ const isComponent = (match: string) => (child: ReactNode) => any(equals(match), 
 const isDropdownItem = isComponent(DropdownItem.name);
 const isDropdownDivider = isComponent(DropdownDivider.name);
 
-@autoBindMethodsForReact
 export class Dropdown extends PureComponent<DropdownProps, State> {
   // Save body overflow so we can revert it when needed
   defaultBodyOverflow = document.body.style.overflow;
@@ -200,15 +198,15 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
     }
   }
 
-  _handleCheckFilterSubmit(e: React.KeyboardEvent<HTMLInputElement>) {
+  _handleCheckFilterSubmit = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       // Listen for the Enter key and "click" on the active list item
       const selector = `li[data-filter-index="${this.state.filterActiveIndex}"] button`;
       this._dropdownList?.querySelector<HTMLButtonElement>(selector)?.click();
     }
-  }
+  };
 
-  _handleChangeFilter(event: React.ChangeEvent<HTMLInputElement>) {
+  _handleChangeFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newFilter = event.target.value;
 
     // Nothing to do if the filter didn't change
@@ -239,9 +237,9 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
       filterActiveIndex: filterItems[0] || -1,
       filterVisible: this.state.filterVisible ? true : newFilter.length > 0,
     });
-  }
+  };
 
-  _handleDropdownNavigation(event: React.KeyboardEvent<HTMLDivElement>) {
+  _handleDropdownNavigation = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const { key, shiftKey } = event;
     // Handle tab and arrows to move up and down dropdown entries
     const { filterItems, filterActiveIndex } = this.state;
@@ -274,9 +272,9 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
     }
 
     this._filter?.focus();
-  }
+  };
 
-  _handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+  _handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (!this.state.open) {
       return;
     }
@@ -289,9 +287,9 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
     if (event.key === 'Escape') {
       this.hide();
     }
-  }
+  };
 
-  _checkSizeAndPosition() {
+  _checkSizeAndPosition = () => {
     if (!this.state.open || !this._dropdownList) {
       return;
     }
@@ -381,20 +379,20 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
       this._dropdownList.style.top = `${bottom}px`;
       this._dropdownList.style.maxHeight = `${bodyRect.height - bottom - screenMargin}px`;
     }
-  }
+  };
 
-  _handleClick(event: React.MouseEvent<HTMLDivElement>) {
+  _handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
     event.stopPropagation();
     this.toggle();
-  }
+  };
 
-  static _handleMouseDown(event: React.MouseEvent<HTMLDivElement>) {
+  _handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
     // Intercept mouse down so that clicks don't trigger things like drag and drop.
     event.preventDefault();
-  }
+  };
 
-  _getFlattenedChildren(children: ReactNode) {
+  _getFlattenedChildren = (children: ReactNode) => {
     let newChildren: (ReactChild | ReactFragment | ReactPortal)[] = [];
 
     for (const child of React.Children.toArray(children)) {
@@ -421,13 +419,13 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
     }
 
     return newChildren;
-  }
+  };
 
   componentDidUpdate() {
     this._checkSizeAndPosition();
   }
 
-  hide() {
+  hide = () => {
     // Focus the dropdown button after hiding
     if (this._node) {
       const button = this._node.querySelector('button');
@@ -439,9 +437,9 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
       open: false,
     });
     this.props.onHide?.();
-  }
+  };
 
-  show(filterVisible = false, forcedPosition = null) {
+  show = (filterVisible = false, forcedPosition = null) => {
     const bodyHeight = document.body.getBoundingClientRect().height;
 
     const dropdownTop = this._node?.getBoundingClientRect().top || 0;
@@ -458,9 +456,9 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
       uniquenessKey: this.state.uniquenessKey + 1,
     });
     this.props.onOpen?.();
-  }
+  };
 
-  toggle(filterVisible = false) {
+  toggle = (filterVisible = false) => {
     if (this.state.open) {
       this.hide();
       document.body.style.overflow = this.defaultBodyOverflow;
@@ -469,7 +467,7 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
       // Prevent body from scrolling when dropdown is open
       document.body.style.overflow = 'hidden';
     }
-  }
+  };
 
   render() {
     const { className, style, children, renderButton } = this.props;
@@ -541,7 +539,7 @@ export class Dropdown extends PureComponent<DropdownProps, State> {
         onClick={this._handleClick}
         onKeyDown={this._handleKeyDown}
         tabIndex={-1}
-        onMouseDown={Dropdown._handleMouseDown}
+        onMouseDown={this._handleMouseDown}
       >
         <Fragment key="button">{button}</Fragment>
         {this.dropdownsContainer && ReactDOM.createPortal(

--- a/packages/insomnia-components/src/help-tooltip.tsx
+++ b/packages/insomnia-components/src/help-tooltip.tsx
@@ -1,5 +1,4 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import React, { CSSProperties, PureComponent, ReactNode } from 'react';
+import React, { CSSProperties, FC, ReactNode } from 'react';
 
 import { SvgIcon } from './svg-icon';
 import { Tooltip } from './tooltip';
@@ -12,21 +11,14 @@ interface Props {
   style?: CSSProperties;
   info?: boolean;
 }
-
-@autoBindMethodsForReact
-export class HelpTooltip extends PureComponent<Props> {
-  render() {
-    const { children, className, style, info, position, delay } = this.props;
-    return (
-      <Tooltip
-        position={position}
-        delay={delay}
-        className={className}
-        message={children}
-        style={style}
-      >
-        {info ? <SvgIcon icon="info" /> : <SvgIcon icon="question" />}
-      </Tooltip>
-    );
-  }
-}
+export const HelpTooltip: FC<Props> = ({ children, className, style, info, position, delay }) => (
+  <Tooltip
+    position={position}
+    delay={delay}
+    className={className}
+    message={children}
+    style={style}
+  >
+    {info ? <SvgIcon icon="info" /> : <SvgIcon icon="question" />}
+  </Tooltip>
+);

--- a/packages/insomnia-components/src/tooltip.tsx
+++ b/packages/insomnia-components/src/tooltip.tsx
@@ -1,4 +1,3 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import React, { CSSProperties, MouseEvent, PureComponent, ReactNode } from 'react';
 import ReactDOM from 'react-dom';
@@ -57,7 +56,6 @@ const StyledTooltipBubble = styled.div`
   }
 `;
 
-@autoBindMethodsForReact
 export class Tooltip extends PureComponent<TooltipProps, State> {
   _showTimeout: NodeJS.Timeout | null = null;
   _hideTimeout: NodeJS.Timeout | null = null;
@@ -71,11 +69,11 @@ export class Tooltip extends PureComponent<TooltipProps, State> {
     movedToBody: false,
   };
 
-  _handleStopClick(e: MouseEvent) {
+  _handleStopClick = (e: MouseEvent) => {
     e.stopPropagation();
-  }
+  };
 
-  _handleMouseEnter() {
+  _handleMouseEnter = () => {
     if (this._showTimeout !== null) {
       clearTimeout(this._showTimeout);
     }
@@ -129,9 +127,9 @@ export class Tooltip extends PureComponent<TooltipProps, State> {
         visible: true,
       });
     }, this.props.delay || 400);
-  }
+  };
 
-  _handleMouseLeave(): void {
+  _handleMouseLeave = (): void => {
     if (this._showTimeout !== null) {
       clearTimeout(this._showTimeout);
     }
@@ -154,9 +152,9 @@ export class Tooltip extends PureComponent<TooltipProps, State> {
       bubble.style.bottom = '';
       bubble.style.right = '';
     }, 100);
-  }
+  };
 
-  _getContainer() {
+  _getContainer = () => {
     let container = document.querySelector<HTMLElement>('#tooltips-container');
 
     if (!container) {
@@ -168,9 +166,9 @@ export class Tooltip extends PureComponent<TooltipProps, State> {
     }
 
     return container;
-  }
+  };
 
-  _moveBubbleToBody() {
+  _moveBubbleToBody = () => {
     if (this._bubble) {
       const el = ReactDOM.findDOMNode(this._bubble);
       el && this._getContainer().appendChild(el);
@@ -178,9 +176,9 @@ export class Tooltip extends PureComponent<TooltipProps, State> {
         movedToBody: true,
       });
     }
-  }
+  };
 
-  _removeBubbleFromBody() {
+  _removeBubbleFromBody = () => {
     if (this._bubble) {
       const el = ReactDOM.findDOMNode(this._bubble);
       el && this._getContainer().removeChild(el);
@@ -188,7 +186,7 @@ export class Tooltip extends PureComponent<TooltipProps, State> {
         movedToBody: false,
       });
     }
-  }
+  };
 
   componentDidMount() {
     // Move the element to the body so we can position absolutely


### PR DESCRIPTION
This PR may or may not be a candidate for merging, my primary goal is to drive discussion about the appropriate first pass for refactoring out autobinding decorator from the 143 files its currently in in order to eliminate some of the magic that makes components harder to refactor to more modern react conventions and ideally also support react-fast-refresh.

There are a few things on the table in this PR
- Removal of the import and decorator and transformation of class methods to arrow functions
- Refactoring class components to function components
- Using more contemporary react features like hooks
- Simplifying components

Since all of these could be applied to the 143 files the PR scope would be too large to reasonable review with any quality. So how can we scope one or more PRs to mitigate regression risks?

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
