### PR TITLE
Fix cookie modal

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/cookies-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/cookies-modal.tsx
@@ -14,6 +14,7 @@ import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
 import { CookieList, CookieListProps } from '../cookie-list';
+import { showModal } from '.';
 
 interface Props extends ModalProps {
   handleShowModifyCookieModal: CookieListProps['handleShowModifyCookieModal'];
@@ -28,7 +29,7 @@ interface State {
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-class CookiesModalInternal extends PureComponent<Props, State> {
+class CookiesModal extends PureComponent<Props, State> {
   modal: Modal | null = null;
   filterInput: HTMLInputElement | null = null;
 
@@ -206,10 +207,12 @@ class CookiesModalInternal extends PureComponent<Props, State> {
   }
 }
 
-const CookiesModalFCRF: ForwardRefRenderFunction<CookiesModalInternal, Omit<Props, 'handleRender'>> = (props, ref) => {
+const CookiesModalFCRF: ForwardRefRenderFunction<CookiesModal, Omit<Props, 'handleRender'>> = (props, ref) => {
   const { handleRender } = useNunjucks();
-  return <CookiesModalInternal ref={ref} {...props} handleRender={handleRender} />;
+  return <CookiesModal ref={ref} {...props} handleRender={handleRender} />;
 
 };
 
-export const CookiesModal = forwardRef(CookiesModalFCRF);
+export const CookiesModalFC = forwardRef(CookiesModalFCRF);
+
+export const showCookiesModal = () => showModal(CookiesModal);

--- a/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
@@ -36,7 +36,6 @@ import { PlaceholderResponsePane } from './placeholder-response-pane';
 
 interface Props {
   handleSetFilter: (filter: string) => void;
-  showCookiesModal: Function;
   handleSetPreviewMode: Function;
   handleSetActiveResponse: Function;
   handleDeleteResponses: Function;
@@ -242,7 +241,6 @@ export class ResponsePane extends PureComponent<Props> {
       requestVersions,
       response,
       responses,
-      showCookiesModal,
     } = this.props;
 
     if (!request) {
@@ -353,7 +351,6 @@ export class ResponsePane extends PureComponent<Props> {
                   handleShowRequestSettings={handleShowRequestSettings}
                   cookiesSent={response.settingSendCookies}
                   cookiesStored={response.settingStoreCookies}
-                  showCookiesModal={showCookiesModal}
                   headers={cookieHeaders}
                 />
               </ErrorBoundary>

--- a/packages/insomnia-app/app/ui/components/viewers/response-cookies-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-cookies-viewer.tsx
@@ -3,9 +3,9 @@ import React, { PureComponent } from 'react';
 import { Cookie } from 'tough-cookie';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
+import { showCookiesModal } from '../modals/cookies-modal';
 
 interface Props {
-  showCookiesModal: Function;
   cookiesSent?: boolean | null;
   cookiesStored?: boolean | null;
   headers: any[];
@@ -33,7 +33,7 @@ export class ResponseCookiesViewer extends PureComponent<Props> {
   }
 
   render() {
-    const { headers, showCookiesModal, cookiesSent, cookiesStored } = this.props;
+    const { headers, cookiesSent, cookiesStored } = this.props;
     const notifyNotStored = !cookiesStored && headers.length;
     let noticeMessage: string | null = null;
 
@@ -65,7 +65,7 @@ export class ResponseCookiesViewer extends PureComponent<Props> {
           <tbody>{!headers.length ? this.renderRow(null, -1) : headers.map(this.renderRow)}</tbody>
         </table>
         <p className="pad-top">
-          <button className="pull-right btn btn--clicky" onClick={() => showCookiesModal()}>
+          <button className="pull-right btn btn--clicky" onClick={showCookiesModal}>
             Manage Cookies
           </button>
         </p>

--- a/packages/insomnia-app/app/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-debug.tsx
@@ -10,6 +10,7 @@ import { isCollection, isDesign } from '../../models/workspace';
 import { EnvironmentsDropdown } from './dropdowns/environments-dropdown';
 import { SyncDropdown } from './dropdowns/sync-dropdown';
 import { ErrorBoundary } from './error-boundary';
+import { showCookiesModal } from './modals/cookies-modal';
 import { PageLayout } from './page-layout';
 import { GrpcRequestPane } from './panes/grpc-request-pane';
 import { GrpcResponsePane } from './panes/grpc-response-pane';
@@ -37,7 +38,6 @@ interface Props {
   handleSetActiveResponse: Function;
   handleSetPreviewMode: Function;
   handleSetResponseFilter: (filter: string) => void;
-  handleShowCookiesModal: Function;
   handleShowRequestSettingsModal: Function;
   handleSidebarSort: (sortOrder: SortOrder) => void;
   handleUpdateRequestAuthentication: (r: Request, auth: RequestAuthentication) => Promise<Request>;
@@ -94,7 +94,6 @@ export class WrapperDebug extends PureComponent<Props> {
       handleChangeEnvironment,
       handleRequestCreate,
       handleRequestGroupCreate,
-      handleShowCookiesModal,
       handleSidebarSort,
     } = this.props;
     const {
@@ -131,8 +130,7 @@ export class WrapperDebug extends PureComponent<Props> {
             environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
             hotKeyRegistry={settings.hotKeyRegistry}
           />
-          {/* @ts-expect-error -- TSCONVERSION onClick event doesn't matter */}
-          <button className="btn btn--super-compact" onClick={handleShowCookiesModal}>
+          <button className="btn btn--super-compact" onClick={showCookiesModal}>
             <div className="sidebar__menu__thing">
               <span>Cookies</span>
             </div>
@@ -264,7 +262,6 @@ export class WrapperDebug extends PureComponent<Props> {
       handleSetActiveResponse,
       handleSetPreviewMode,
       handleSetResponseFilter,
-      handleShowCookiesModal,
       handleShowRequestSettingsModal,
     } = this.props;
     const {
@@ -309,7 +306,6 @@ export class WrapperDebug extends PureComponent<Props> {
           handleSetFilter={handleSetResponseFilter}
           handleSetPreviewMode={handleSetPreviewMode}
           handleShowRequestSettings={handleShowRequestSettingsModal}
-          showCookiesModal={handleShowCookiesModal}
           hotKeyRegistry={settings.hotKeyRegistry}
           loadStartTime={loadStartTime}
           previewMode={responsePreviewMode}

--- a/packages/insomnia-app/app/ui/components/wrapper.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper.tsx
@@ -43,7 +43,7 @@ import { AddKeyCombinationModal } from './modals/add-key-combination-modal';
 import { AlertModal } from './modals/alert-modal';
 import { AskModal } from './modals/ask-modal';
 import { CodePromptModal } from './modals/code-prompt-modal';
-import { CookiesModal } from './modals/cookies-modal';
+import { CookiesModalFC } from './modals/cookies-modal';
 import { EnvironmentEditModal } from './modals/environment-edit-modal';
 import { ErrorModal } from './modals/error-modal';
 import { ExportRequestsModal } from './modals/export-requests-modal';
@@ -313,10 +313,6 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
     showModal(WorkspaceEnvironmentsEditModal, this.props.activeWorkspace);
   }
 
-  _handleShowCookiesModal() {
-    showModal(CookiesModal, this.props.activeWorkspace);
-  }
-
   static _handleShowModifyCookieModal(cookie: Cookie) {
     showModal(CookieModifyModal, cookie);
   }
@@ -552,7 +548,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
             {activeWorkspace ? <>
               {/* TODO: Figure out why cookieJar is sometimes null */}
               {activeCookieJar ? <>
-                <CookiesModal
+                <CookiesModalFC
                   ref={registerModal}
                   handleShowModifyCookieModal={Wrapper._handleShowModifyCookieModal}
                   workspace={activeWorkspace}
@@ -720,7 +716,6 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
               handleSetActiveResponse={this._handleSetActiveResponse}
               handleSetPreviewMode={this._handleSetPreviewMode}
               handleSetResponseFilter={this._handleSetResponseFilter}
-              handleShowCookiesModal={this._handleShowCookiesModal}
               handleShowRequestSettingsModal={this._handleShowRequestSettingsModal}
               handleSidebarSort={handleSidebarSort}
               handleUpdateRequestAuthentication={Wrapper._handleUpdateRequestAuthentication}

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -65,7 +65,7 @@ import * as templating from '../../templating/index';
 import { ErrorBoundary } from '../components/error-boundary';
 import { KeydownBinder } from '../components/keydown-binder';
 import { AskModal } from '../components/modals/ask-modal';
-import { CookiesModal } from '../components/modals/cookies-modal';
+import { showCookiesModal } from '../components/modals/cookies-modal';
 import { GenerateCodeModal } from '../components/modals/generate-code-modal';
 import { showAlert, showModal, showPrompt } from '../components/modals/index';
 import { RequestCreateModal } from '../components/modals/request-create-modal';
@@ -251,13 +251,7 @@ class App extends PureComponent<AppProps, State> {
           showModal(WorkspaceEnvironmentsEditModal, activeWorkspace);
         },
       ],
-      [
-        hotKeyRefs.SHOW_COOKIES_EDITOR,
-        () => {
-          const { activeWorkspace } = this.props;
-          showModal(CookiesModal, activeWorkspace);
-        },
-      ],
+      [hotKeyRefs.SHOW_COOKIES_EDITOR, showCookiesModal],
       [
         hotKeyRefs.REQUEST_QUICK_CREATE,
         async () => {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->

Demo: https://www.loom.com/share/141ec94e03174613b69cf4fec2d6fa2e

* Had to deviate from the `*Internal` pattern for modals, because otherwise the event logged would change from `[ga] Event Modals, Show, CookiesModal` to `[ga] Event Modals, Show, CookiesModalInternal`.
* I used the pattern we've started to use for modals; actually exporting a `showCookiesModal` helper from the modal file itself. This way we can type the options, which are lost using the generic approach. That helped to identify the fact that we were sending extraneous data to the `showModal` function before
* Removed prop drilling 🎉 