### PR TITLE
turns off consistent-return rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,7 +70,7 @@ module.exports = {
     'camelcase': [ERROR, { allow: ['__export_format', '__export_date', '__export_source'] }],
     'comma-dangle': [ERROR, 'always-multiline'],
     'comma-spacing': ERROR,
-    'consistent-return': WARN(UNKNOWN),
+    'consistent-return': OFF('found to be too many false positives'),
     'default-case': ERROR,
     'default-case-last': ERROR,
     'filenames/match-exported': [ERROR, 'kebab'],


### PR DESCRIPTION
closes INS-1218

after discussion on the team, we have decided this rule doesn't provide us enough value compared to the requisite work to identify all the false positives.