### PR TITLE
Move OAuth session id to database

### DIFF
--- a/packages/insomnia-app/app/models/settings.ts
+++ b/packages/insomnia-app/app/models/settings.ts
@@ -69,6 +69,7 @@ export function init(): BaseSettings {
     maxTimelineDataSizeKB: 10,
     noProxy: '',
     nunjucksPowerUserMode: false,
+    oAuthSessionId: '',
     pluginConfig: {},
     pluginPath: '',
     preferredHttpVersion: HttpVersions.default,

--- a/packages/insomnia-app/app/network/o-auth-2/__tests__/misc.test.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/__tests__/misc.test.ts
@@ -2,7 +2,7 @@ import { mocked } from 'ts-jest/utils';
 
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import * as models from '../../../models';
-import { authorizeUserInWindow, ChromiumVerificationResult, createNewOAuthSession, initOAuthSession, responseToObject } from '../misc';
+import { authorizeUserInWindow, ChromiumVerificationResult, createNewOAuthSession, initOAuthSession, LEGACY_LOCALSTORAGE_KEY_SESSION_ID, responseToObject } from '../misc';
 import { createBWRedirectMock } from './helpers';
 
 const MOCK_AUTHORIZATION_URL = 'https://foo.com';
@@ -142,10 +142,9 @@ describe('initOAuthSession()', () => {
     // Arrange
     const settingsBefore = await models.settings.patch({ clearOAuth2SessionOnRestart: false });
 
-    const key = 'insomnia::current-oauth-session-id';
     const value = 'abc';
-    global.localStorage.setItem(key, value);
-    expect(global.localStorage.getItem(key)).not.toBe(null);
+    global.localStorage.setItem(LEGACY_LOCALSTORAGE_KEY_SESSION_ID, value);
+    expect(global.localStorage.getItem(LEGACY_LOCALSTORAGE_KEY_SESSION_ID)).not.toBe(null);
 
     // Act
     await initOAuthSession();
@@ -156,7 +155,7 @@ describe('initOAuthSession()', () => {
     expect(settingsAfter.oAuthSessionId).toBe(value);
 
     // Ensure local storage key has been removed
-    expect(global.localStorage.getItem(key)).toBe(null);
+    expect(global.localStorage.getItem(LEGACY_LOCALSTORAGE_KEY_SESSION_ID)).toBe(null);
   });
 
   it('should create a new OAuth session', async () => {
@@ -176,9 +175,8 @@ describe('initOAuthSession()', () => {
     // Arrange
     const settingsBefore = await models.settings.patch({ clearOAuth2SessionOnRestart: true });
 
-    const key = 'insomnia::current-oauth-session-id';
     const value = 'abc';
-    global.localStorage.setItem(key, value);
+    global.localStorage.setItem(LEGACY_LOCALSTORAGE_KEY_SESSION_ID, value);
 
     // Act
     await initOAuthSession();

--- a/packages/insomnia-app/app/network/o-auth-2/misc.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/misc.ts
@@ -91,7 +91,8 @@ export function authorizeUserInWindow(
     const authWindowSessionId = oAuthSessionId || await createNewOAuthSession();
 
     // Create a child window
-    const child = new electron.remote.BrowserWindow({
+    const { BrowserWindow } = electron.remote || electron;
+    const child = new BrowserWindow({
       webPreferences: {
         nodeIntegration: false,
         partition: authWindowSessionId,

--- a/packages/insomnia-app/app/network/o-auth-2/misc.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/misc.ts
@@ -10,7 +10,7 @@ export enum ChromiumVerificationResult {
 }
 
 /**
- * @deprecated oauth session ids no longer stored in the database. This key is kept for migration purposes and unit tests.
+ * @deprecated oauth session ids no longer stored in the localstorage. This key is kept for migration purposes and unit tests.
  */
 export const LEGACY_LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
 

--- a/packages/insomnia-app/app/network/o-auth-2/misc.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/misc.ts
@@ -9,17 +9,17 @@ export enum ChromiumVerificationResult {
   USE_CHROMIUM_RESULT = -3
 }
 
-async function migrateOAuthSessionIntoDatabase() {
-  /**
-   * @deprecated oauth session ids no longer stored in the database. This key is kept for migration purposes.
-   */
-  const LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
+/**
+ * @deprecated oauth session ids no longer stored in the database. This key is kept for migration purposes and unit tests.
+ */
+export const LEGACY_LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
 
-  const fromLocalStorage = window.localStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID);
+async function migrateOAuthSessionIntoDatabase() {
+  const fromLocalStorage = window.localStorage.getItem(LEGACY_LOCALSTORAGE_KEY_SESSION_ID);
 
   if (fromLocalStorage) {
     await models.settings.patch({ oAuthSessionId: fromLocalStorage });
-    window.localStorage.removeItem(LOCALSTORAGE_KEY_SESSION_ID);
+    window.localStorage.removeItem(LEGACY_LOCALSTORAGE_KEY_SESSION_ID);
   }
 }
 

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -23,7 +23,7 @@ import {
   RESPONSE_TYPE_TOKEN,
 } from '../../../../network/o-auth-2/constants';
 import getAccessToken from '../../../../network/o-auth-2/get-token';
-import { initNewOAuthSession } from '../../../../network/o-auth-2/misc';
+import { createNewOAuthSession } from '../../../../network/o-auth-2/misc';
 import { useNunjucks } from '../../../context/nunjucks/use-nunjucks';
 import { Button } from '../../base/button';
 import { Link } from '../../base/link';
@@ -685,7 +685,7 @@ class OAuth2AuthInternal extends PureComponent<Props, State> {
         </table>
         {showAdvanced ? (
           <div className="pad-top text-right">
-            <button className="btn btn--clicky" onClick={initNewOAuthSession}>
+            <button className="btn btn--clicky" onClick={createNewOAuthSession}>
               Clear OAuth 2 session
             </button>
           </div>

--- a/packages/insomnia-app/app/ui/components/settings/general.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/general.tsx
@@ -27,7 +27,7 @@ import { restartApp } from '../../../common/electron-helpers';
 import { snapNumberToLimits } from '../../../common/misc';
 import { strings } from '../../../common/strings';
 import type { Settings } from '../../../models/settings';
-import { initNewOAuthSession } from '../../../network/o-auth-2/misc';
+import { createNewOAuthSession } from '../../../network/o-auth-2/misc';
 import { setFont } from '../../../plugins/misc';
 import * as globalActions from '../../redux/modules/global';
 import { Link } from '../base/link';
@@ -407,7 +407,7 @@ class General extends PureComponent<Props> {
             style={{
               padding: 0,
             }}
-            onClick={initNewOAuthSession}
+            onClick={createNewOAuthSession}
           >
             Clear OAuth 2 session
           </button>

--- a/packages/insomnia-app/app/ui/index.tsx
+++ b/packages/insomnia-app/app/ui/index.tsx
@@ -11,7 +11,7 @@ import { getAppLongName, isDevelopment } from '../common/constants';
 import { database as db } from '../common/database';
 import { initializeLogging } from '../common/log';
 import * as models from '../models';
-import { initNewOAuthSession } from '../network/o-auth-2/misc';
+import { initOAuthSession } from '../network/o-auth-2/misc';
 import { init as initPlugins } from '../plugins';
 import { applyColorScheme, setFont } from '../plugins/misc';
 import App from './containers/app';
@@ -29,10 +29,7 @@ document.title = getAppLongName();
   await initPlugins();
   const settings = await models.settings.getOrCreate();
 
-  if (settings.clearOAuth2SessionOnRestart) {
-    initNewOAuthSession();
-  }
-
+  await initOAuthSession();
   await applyColorScheme(settings);
   await setFont(settings);
   // Create Redux store

--- a/packages/insomnia-common/src/entities/settings.ts
+++ b/packages/insomnia-common/src/entities/settings.ts
@@ -14,6 +14,7 @@ export interface Settings {
   autoHideMenuBar: boolean;
   autocompleteDelay: number;
   clearOAuth2SessionOnRestart: boolean;
+  oAuthSessionId: string;
   darkTheme: string;
   deviceId: string | null;
   disableHtmlPreviewJs: boolean;


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Demo of manually clearing the session: https://www.loom.com/share/b76b2fee8c624f90bdcb18f7353c4a3b

The oauth session id was previously stored in local storage, and the process of sending a request would sometimes trigger the OAuth workflow. Given we have moved the sending of requests into the main process, Insomnia can no longer access local storage to access the cached oauth session id. This PR moves the session id from local storage into the database, and includes a one-time migration step to take the existing session id and store that in the database as well.

Closes INS-1274