### PR TITLE
Chore/consolidate request libs

### DIFF
--- a/packages/insomnia-app/app/account/fetch.ts
+++ b/packages/insomnia-app/app/account/fetch.ts
@@ -66,7 +66,12 @@ async function _fetch(method, path, obj, sessionId, compressBody = false, retrie
   const url = _getUrl(path);
 
   try {
-    response = await axiosRequest({ url, headers: config.headers, data: config.body, method: config.method });
+    response = await axiosRequest({
+      url,
+      method: config.method,
+      headers: config.headers,
+      data: config.body,
+    });
 
     // Exponential backoff for 502 errors
     if (response.status === 502 && retries < 5) {

--- a/packages/insomnia-app/app/account/fetch.ts
+++ b/packages/insomnia-app/app/account/fetch.ts
@@ -1,7 +1,9 @@
+import { Method } from 'axios';
 import { parse as urlParse } from 'url';
 import zlib from 'zlib';
 
 import { delay } from '../common/misc';
+import { axiosRequest } from '../network/axios-request';
 let _userAgent = '';
 let _baseUrl = '';
 const _commandListeners: Function[] = [];
@@ -33,7 +35,7 @@ async function _fetch(method, path, obj, sessionId, compressBody = false, retrie
   }
 
   const config: {
-    method: string;
+    method: Method | undefined;
     headers: HeadersInit;
     body?: string | Buffer;
   } = {
@@ -64,7 +66,7 @@ async function _fetch(method, path, obj, sessionId, compressBody = false, retrie
   const url = _getUrl(path);
 
   try {
-    response = await window.fetch(url, config);
+    response = await axiosRequest({ url, headers: config.headers, data: config.body, method: config.method });
 
     // Exponential backoff for 502 errors
     if (response.status === 502 && retries < 5) {

--- a/packages/insomnia-app/app/account/fetch.ts
+++ b/packages/insomnia-app/app/account/fetch.ts
@@ -35,7 +35,7 @@ async function _fetch(method, path, obj, sessionId, compressBody = false, retrie
   }
 
   const config: {
-    method: Method | undefined;
+    method?: Method;
     headers: HeadersInit;
     body?: string | Buffer;
   } = {

--- a/packages/insomnia-app/app/account/fetch.ts
+++ b/packages/insomnia-app/app/account/fetch.ts
@@ -66,6 +66,7 @@ async function _fetch(method, path, obj, sessionId, compressBody = false, retrie
   const url = _getUrl(path);
 
   try {
+    // NOTE: does not respect user preferences
     response = await axiosRequest({
       url,
       method: config.method,

--- a/packages/insomnia-app/app/common/__tests__/analytics.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/analytics.test.ts
@@ -147,7 +147,7 @@ describe('init()', () => {
       value: 'val',
     });
     expect(axiosRequest.mock.calls).toEqual([
-      [
+      [{ url:
         'https://www.google-analytics.com/collect?' +
         'v=1&' +
         `tid=${getGoogleAnalyticsId()}&` +

--- a/packages/insomnia-app/app/common/__tests__/analytics.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/analytics.test.ts
@@ -17,7 +17,6 @@ describe('init()', () => {
   beforeEach(async () => {
     await globalBeforeEach();
     axiosRequest.mockResolvedValue({ data:{}, headers:{} });
-    // console.log(axiosRequest);
     jest.useFakeTimers();
   });
 

--- a/packages/insomnia-app/app/common/__tests__/analytics.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/analytics.test.ts
@@ -1,8 +1,6 @@
-import * as electron from 'electron';
-import { EventEmitter } from 'events';
-
 import { globalBeforeEach } from '../../__jest__/before-each';
 import * as models from '../../models/index';
+import * as axiosModule from '../../network/axios-request';
 import { _trackEvent, _trackPageView } from '../analytics';
 import {
   getAppId,
@@ -14,16 +12,12 @@ import {
   getGoogleAnalyticsLocation,
 } from '../constants';
 
+const axiosRequest = jest.spyOn(axiosModule, 'axiosRequest');
 describe('init()', () => {
   beforeEach(async () => {
     await globalBeforeEach();
-    electron.net.request = jest.fn(() => {
-      const req = new EventEmitter();
-
-      req.end = function() {};
-
-      return req;
-    });
+    axiosRequest.mockResolvedValue({ data:{}, headers:{} });
+    // console.log(axiosRequest);
     jest.useFakeTimers();
   });
 
@@ -33,10 +27,10 @@ describe('init()', () => {
       deviceId: 'device',
     });
     expect(settings.enableAnalytics).toBe(false);
-    expect(electron.net.request.mock.calls).toEqual([]);
+    expect(axiosRequest.mock.calls).toEqual([]);
     await _trackEvent({ interactive: true, category: 'Foo', action: 'Bar' });
     jest.runAllTimers();
-    expect(electron.net.request.mock.calls).toEqual([]);
+    expect(axiosRequest.mock.calls).toEqual([]);
   });
 
   it('works with tracking enabled', async () => {
@@ -45,32 +39,32 @@ describe('init()', () => {
       deviceId: 'device',
     });
     expect(settings.enableAnalytics).toBe(true);
-    expect(electron.net.request.mock.calls).toEqual([]);
+    expect(axiosRequest.mock.calls).toEqual([]);
     await _trackEvent({ interactive: true, category: 'Foo', action: 'Bar' });
     jest.runAllTimers();
-    expect(electron.net.request.mock.calls).toEqual([
-      [
+    expect(axiosRequest.mock.calls).toEqual([
+      [{ url:
         'https://www.google-analytics.com/collect?' +
-          'v=1&' +
-          `tid=${getGoogleAnalyticsId()}&` +
-          'cid=device&' +
-          `ua=${getBrowserUserAgent()}&` +
-          `dl=${encodeURIComponent(getGoogleAnalyticsLocation())}%2F&` +
-          'sr=1920x1080&' +
-          'ul=en-US&' +
-          `dt=${getAppId()}%3A${getAppVersion()}&` +
-          `cd1=${getAppPlatform()}&` +
-          `cd2=${getAppVersion()}&` +
-          'aip=1&' +
-          `an=${encodeURI(getAppName())}&` +
-          `aid=${getAppId()}&` +
-          `av=${getAppVersion()}&` +
-          'vp=1900x1060&' +
-          'de=UTF-8&' +
-          't=event&' +
-          'ec=Foo&' +
-          'ea=Bar',
-      ],
+        'v=1&' +
+        `tid=${getGoogleAnalyticsId()}&` +
+        'cid=device&' +
+        `ua=${getBrowserUserAgent()}&` +
+        `dl=${encodeURIComponent(getGoogleAnalyticsLocation())}%2F&` +
+        'sr=1920x1080&' +
+        'ul=en-US&' +
+        `dt=${getAppId()}%3A${getAppVersion()}&` +
+        `cd1=${getAppPlatform()}&` +
+        `cd2=${getAppVersion()}&` +
+        'aip=1&' +
+        `an=${encodeURI(getAppName())}&` +
+        `aid=${getAppId()}&` +
+        `av=${getAppVersion()}&` +
+        'vp=1900x1060&' +
+        'de=UTF-8&' +
+        't=event&' +
+        'ec=Foo&' +
+        'ea=Bar',
+      }],
     ]);
   });
 
@@ -81,30 +75,30 @@ describe('init()', () => {
     });
     await _trackEvent({ interactive: false, category: 'Foo', action: 'Bar' });
     jest.runAllTimers();
-    expect(electron.net.request.mock.calls).toEqual([
-      [
+    expect(axiosRequest.mock.calls).toEqual([
+      [{ url:
         'https://www.google-analytics.com/collect?' +
-          'v=1&' +
-          `tid=${getGoogleAnalyticsId()}&` +
-          'cid=device&' +
-          `ua=${getBrowserUserAgent()}&` +
-          `dl=${encodeURIComponent(getGoogleAnalyticsLocation())}%2F&` +
-          'sr=1920x1080&' +
-          'ul=en-US&' +
-          `dt=${getAppId()}%3A${getAppVersion()}&` +
-          `cd1=${getAppPlatform()}&` +
-          `cd2=${getAppVersion()}&` +
-          'aip=1&' +
-          `an=${encodeURI(getAppName())}&` +
-          `aid=${getAppId()}&` +
-          `av=${getAppVersion()}&` +
-          'vp=1900x1060&' +
-          'de=UTF-8&' +
-          't=event&' +
-          'ec=Foo&' +
-          'ea=Bar&' +
-          'ni=1',
-      ],
+        'v=1&' +
+        `tid=${getGoogleAnalyticsId()}&` +
+        'cid=device&' +
+        `ua=${getBrowserUserAgent()}&` +
+        `dl=${encodeURIComponent(getGoogleAnalyticsLocation())}%2F&` +
+        'sr=1920x1080&' +
+        'ul=en-US&' +
+        `dt=${getAppId()}%3A${getAppVersion()}&` +
+        `cd1=${getAppPlatform()}&` +
+        `cd2=${getAppVersion()}&` +
+        'aip=1&' +
+        `an=${encodeURI(getAppName())}&` +
+        `aid=${getAppId()}&` +
+        `av=${getAppVersion()}&` +
+        'vp=1900x1060&' +
+        'de=UTF-8&' +
+        't=event&' +
+        'ec=Foo&' +
+        'ea=Bar&' +
+        'ni=1',
+      }],
     ]);
   });
 
@@ -115,27 +109,27 @@ describe('init()', () => {
     });
     await _trackPageView('/my/path');
     jest.runAllTimers();
-    expect(electron.net.request.mock.calls).toEqual([
-      [
+    expect(axiosRequest.mock.calls).toEqual([
+      [{ url:
         'https://www.google-analytics.com/collect?' +
-          'v=1&' +
-          `tid=${getGoogleAnalyticsId()}&` +
-          'cid=device&' +
-          `ua=${getBrowserUserAgent()}&` +
-          `dl=${encodeURIComponent(getGoogleAnalyticsLocation())}%2Fmy%2Fpath&` +
-          'sr=1920x1080&' +
-          'ul=en-US&' +
-          `dt=${getAppId()}%3A${getAppVersion()}&` +
-          `cd1=${getAppPlatform()}&` +
-          `cd2=${getAppVersion()}&` +
-          'aip=1&' +
-          `an=${encodeURI(getAppName())}&` +
-          `aid=${getAppId()}&` +
-          `av=${getAppVersion()}&` +
-          'vp=1900x1060&' +
-          'de=UTF-8&' +
-          't=pageview',
-      ],
+        'v=1&' +
+        `tid=${getGoogleAnalyticsId()}&` +
+        'cid=device&' +
+        `ua=${getBrowserUserAgent()}&` +
+        `dl=${encodeURIComponent(getGoogleAnalyticsLocation())}%2Fmy%2Fpath&` +
+        'sr=1920x1080&' +
+        'ul=en-US&' +
+        `dt=${getAppId()}%3A${getAppVersion()}&` +
+        `cd1=${getAppPlatform()}&` +
+        `cd2=${getAppVersion()}&` +
+        'aip=1&' +
+        `an=${encodeURI(getAppName())}&` +
+        `aid=${getAppId()}&` +
+        `av=${getAppVersion()}&` +
+        'vp=1900x1060&' +
+        'de=UTF-8&' +
+        't=pageview',
+      }],
     ]);
   });
 
@@ -153,51 +147,51 @@ describe('init()', () => {
       label: 'lab',
       value: 'val',
     });
-    expect(electron.net.request.mock.calls).toEqual([
+    expect(axiosRequest.mock.calls).toEqual([
       [
         'https://www.google-analytics.com/collect?' +
-          'v=1&' +
-          `tid=${getGoogleAnalyticsId()}&` +
-          'cid=device&' +
-          `ua=${getBrowserUserAgent()}&` +
-          `dl=${encodeURIComponent(getGoogleAnalyticsLocation())}%2Fmy%2Fpath&` +
-          'sr=1920x1080&' +
-          'ul=en-US&' +
-          `dt=${getAppId()}%3A${getAppVersion()}&` +
-          `cd1=${getAppPlatform()}&` +
-          `cd2=${getAppVersion()}&` +
-          'aip=1&' +
-          `an=${encodeURI(getAppName())}&` +
-          `aid=${getAppId()}&` +
-          `av=${getAppVersion()}&` +
-          'vp=1900x1060&' +
-          'de=UTF-8&' +
-          't=pageview',
-      ],
-      [
+        'v=1&' +
+        `tid=${getGoogleAnalyticsId()}&` +
+        'cid=device&' +
+        `ua=${getBrowserUserAgent()}&` +
+        `dl=${encodeURIComponent(getGoogleAnalyticsLocation())}%2Fmy%2Fpath&` +
+        'sr=1920x1080&' +
+        'ul=en-US&' +
+        `dt=${getAppId()}%3A${getAppVersion()}&` +
+        `cd1=${getAppPlatform()}&` +
+        `cd2=${getAppVersion()}&` +
+        'aip=1&' +
+        `an=${encodeURI(getAppName())}&` +
+        `aid=${getAppId()}&` +
+        `av=${getAppVersion()}&` +
+        'vp=1900x1060&' +
+        'de=UTF-8&' +
+        't=pageview',
+      }],
+      [{ url:
         'https://www.google-analytics.com/collect?' +
-          'v=1&' +
-          `tid=${getGoogleAnalyticsId()}&` +
-          'cid=device&' +
-          `ua=${getBrowserUserAgent()}&` +
-          `dl=${encodeURIComponent(getGoogleAnalyticsLocation())}%2Fmy%2Fpath&` +
-          'sr=1920x1080&' +
-          'ul=en-US&' +
-          `dt=${getAppId()}%3A${getAppVersion()}&` +
-          `cd1=${getAppPlatform()}&` +
-          `cd2=${getAppVersion()}&` +
-          'aip=1&' +
-          `an=${encodeURI(getAppName())}&` +
-          `aid=${getAppId()}&` +
-          `av=${getAppVersion()}&` +
-          'vp=1900x1060&' +
-          'de=UTF-8&' +
-          't=event&' +
-          'ec=cat&' +
-          'ea=act&' +
-          'el=lab&' +
-          'ev=val',
-      ],
+        'v=1&' +
+        `tid=${getGoogleAnalyticsId()}&` +
+        'cid=device&' +
+        `ua=${getBrowserUserAgent()}&` +
+        `dl=${encodeURIComponent(getGoogleAnalyticsLocation())}%2Fmy%2Fpath&` +
+        'sr=1920x1080&' +
+        'ul=en-US&' +
+        `dt=${getAppId()}%3A${getAppVersion()}&` +
+        `cd1=${getAppPlatform()}&` +
+        `cd2=${getAppVersion()}&` +
+        'aip=1&' +
+        `an=${encodeURI(getAppName())}&` +
+        `aid=${getAppId()}&` +
+        `av=${getAppVersion()}&` +
+        'vp=1900x1060&' +
+        'de=UTF-8&' +
+        't=event&' +
+        'ec=cat&' +
+        'ea=act&' +
+        'el=lab&' +
+        'ev=val',
+      }],
     ]);
   });
 });

--- a/packages/insomnia-app/app/common/analytics.ts
+++ b/packages/insomnia-app/app/common/analytics.ts
@@ -410,30 +410,24 @@ async function _sendToGoogle({ params }: { params: RequestParameter[] }) {
   try {
     res = await axiosRequest({ url });
   } catch (err) {
-    res.error = err;
+    console.warn('[ga] Network error', err);
   }
-  if (res.error)
-    console.warn('[ga] Network error', res.error);
-  if (res.status < 200 && res.status >= 300) {
-    console.warn('[ga] Bad status code ' + res.status);
-  }
-  const [contentType] = res.headers['content-type'] || [];
+
+  const [contentType] = res?.headers['content-type'] || [];
   if (contentType !== 'application/json') {
     // Production GA API returns a Gif to use for tracking
     return;
   }
   try {
-    const data = JSON.parse(res.data);
-    const { hitParsingResult } = data;
-    if (hitParsingResult.valid) {
+    const data = JSON.parse(res?.data);
+    if (data?.hitParsingResult?.valid) {
       return;
     }
 
-    for (const result of hitParsingResult || []) {
-      for (const msg of result.parserMessage || []) {
-        console.warn(`[ga] Error ${msg.description}`);
+    for (const result of data?.hitParsingResult || []) {
+      for (const msg of result?.parserMessage || []) {
+        console.warn(`[ga] Error ${msg?.description}`);
       }
-
     }
   } catch (err) {
     console.warn('[ga] Failed to parse response', err);

--- a/packages/insomnia-app/app/common/analytics.ts
+++ b/packages/insomnia-app/app/common/analytics.ts
@@ -1,5 +1,6 @@
 import Analytics from 'analytics-node';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
+import { map } from 'ramda';
 import * as uuid from 'uuid';
 
 import { getAccountId } from '../account/session';
@@ -414,11 +415,14 @@ async function _sendToGoogle({ params }: { params: RequestParameter[] }) {
       return;
     }
 
-    if (data?.hitParsingResult?.valid) {
+    if (data?.hitParsingResult?.find(r => r.valid)) {
       return;
     }
-    data?.hitParsingResult?.parserMessage?.map(msg =>
-      console.warn(`[ga] Error ${msg?.description}`));
+    data?.hitParsingResult?.map(r =>
+      r?.parserMessage?.map(msg =>
+        console.warn(`[ga] Error ${msg?.description}`)
+      )
+    );
 
   }).catch(err => console.warn('[ga] Network error', err));
 }

--- a/packages/insomnia-app/app/common/import.ts
+++ b/packages/insomnia-app/app/common/import.ts
@@ -6,6 +6,7 @@ import type { BaseModel } from '../models/index';
 import * as models from '../models/index';
 import { isRequest } from '../models/request';
 import { isWorkspace, Workspace } from '../models/workspace';
+import { axiosRequest } from '../network/axios-request';
 import { AlertModal } from '../ui/components/modals/alert-modal';
 import { showError, showModal } from '../ui/components/modals/index';
 import { ImportToWorkspacePrompt, SetWorkspaceScopePrompt } from '../ui/redux/modules/helpers';
@@ -62,8 +63,8 @@ export async function importUri(uri: string, importConfig: ImportRawConfig) {
   }
 
   if (uri.match(/^(http|https):\/\//)) {
-    const response = await window.fetch(uri);
-    rawText = await response.text();
+    const response = await axiosRequest({ url: uri });
+    rawText = await response.data;
   } else if (uri.match(/^(file):\/\//)) {
     const path = uri.replace(/^(file):\/\//, '');
     rawText = fs.readFileSync(path, 'utf8');

--- a/packages/insomnia-app/app/common/import.ts
+++ b/packages/insomnia-app/app/common/import.ts
@@ -64,6 +64,7 @@ export async function importUri(uri: string, importConfig: ImportRawConfig) {
 
   if (uri.match(/^(http|https):\/\//)) {
     // NOTE: disabled axios default JSON parse by overriding transformResponse
+    // NOTE: does not respect user preferences
     const response = await axiosRequest({ url: uri, transformResponse: _ => _ });
     rawText = await response.data;
   } else if (uri.match(/^(file):\/\//)) {

--- a/packages/insomnia-app/app/common/import.ts
+++ b/packages/insomnia-app/app/common/import.ts
@@ -63,7 +63,8 @@ export async function importUri(uri: string, importConfig: ImportRawConfig) {
   }
 
   if (uri.match(/^(http|https):\/\//)) {
-    const response = await axiosRequest({ url: uri });
+    // NOTE: disabled axios default JSON parse by overriding transformResponse
+    const response = await axiosRequest({ url: uri, transformResponse: _ => _ });
     rawText = await response.data;
   } else if (uri.match(/^(file):\/\//)) {
     const path = uri.replace(/^(file):\/\//, '');

--- a/packages/insomnia-app/app/network/__tests__/axios-request.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/axios-request.test.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 import { globalBeforeEach } from '../../__jest__/before-each';
 import * as models from '../../models';
-import { axiosRequest } from '../axios-request';
+import { axiosRequestWithUserDefinedProxy } from '../axios-request';
 
 interface AxiosRequestMockUserSettings {
   // mocking only what we need to run axiosRequest
@@ -46,7 +46,7 @@ describe('axiosRequest used for git-sync', () => {
         validateSSL: false,
       };
       (models.settings.getOrCreate as unknown as jest.Mock).mockImplementation(() => mockInsomniaConfigPanelUserSettings);
-      const response = await axiosRequest({ url: 'https://git.acme.com/username/repo-name.git/git-upload-pack' });
+      const response = await axiosRequestWithUserDefinedProxy({ url: 'https://git.acme.com/username/repo-name.git/git-upload-pack' });
       expect(response.config.proxy).toBe(false);
     });
 
@@ -59,7 +59,7 @@ describe('axiosRequest used for git-sync', () => {
         validateSSL: false,
       };
       (models.settings.getOrCreate as unknown as jest.Mock).mockImplementation(() => mockInsomniaConfigPanelUserSettings);
-      const response = await axiosRequest({ url: 'http://git.acme.com/username/repo-name.git/git-upload-pack' });
+      const response = await axiosRequestWithUserDefinedProxy({ url: 'http://git.acme.com/username/repo-name.git/git-upload-pack' });
       expect(response.config.proxy).toEqual({ host: 'some.proxy.com', port: 8080 });
     });
 
@@ -72,7 +72,7 @@ describe('axiosRequest used for git-sync', () => {
         validateSSL: false,
       };
       (models.settings.getOrCreate as unknown as jest.Mock).mockImplementation(() => mockInsomniaConfigPanelUserSettings);
-      const response = await axiosRequest({ url: 'http://git.acme.com/username/repo-name.git/git-upload-pack' });
+      const response = await axiosRequestWithUserDefinedProxy({ url: 'http://git.acme.com/username/repo-name.git/git-upload-pack' });
       expect(response.config.proxy).toBe(false);
     });
 
@@ -85,7 +85,7 @@ describe('axiosRequest used for git-sync', () => {
         validateSSL: false,
       };
       (models.settings.getOrCreate as unknown as jest.Mock).mockImplementation(() => mockInsomniaConfigPanelUserSettings);
-      const response = await axiosRequest({ url: 'https://git.acme.com/username/repo-name.git/git-upload-pack' });
+      const response = await axiosRequestWithUserDefinedProxy({ url: 'https://git.acme.com/username/repo-name.git/git-upload-pack' });
       expect(response.config.proxy).toEqual({ host: 'some.proxy.com', port: 8080 });
     });
 
@@ -98,7 +98,7 @@ describe('axiosRequest used for git-sync', () => {
         validateSSL: false,
       };
       (models.settings.getOrCreate as unknown as jest.Mock).mockImplementation(() => mockInsomniaConfigPanelUserSettings);
-      const response = await axiosRequest({ url: 'http://git.acme.com/username/repo-name.git/git-upload-pack' });
+      const response = await axiosRequestWithUserDefinedProxy({ url: 'http://git.acme.com/username/repo-name.git/git-upload-pack' });
       expect(response.config.proxy).toEqual({ host: 'some.proxy.com', port: 8081 });
     });
 
@@ -111,7 +111,7 @@ describe('axiosRequest used for git-sync', () => {
         validateSSL: false,
       };
       (models.settings.getOrCreate as unknown as jest.Mock).mockImplementation(() => mockInsomniaConfigPanelUserSettings);
-      const response = await axiosRequest({ url: 'https://git.acme.com/username/repo-name.git/git-upload-pack' });
+      const response = await axiosRequestWithUserDefinedProxy({ url: 'https://git.acme.com/username/repo-name.git/git-upload-pack' });
       expect(response.config.proxy).toEqual({ host: 'some.proxy.com', port: 8080 });
     });
 

--- a/packages/insomnia-app/app/network/axios-request.ts
+++ b/packages/insomnia-app/app/network/axios-request.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosRequestConfig } from 'axios';
-import * as https from 'https';
 import { setDefaultProtocol } from 'insomnia-url';
 import { parse as urlParse } from 'url';
 
@@ -21,9 +20,6 @@ export async function axiosRequest(config: AxiosRequestConfig) {
   const finalConfig: AxiosRequestConfig = {
     ...config,
     adapter: global.require('axios/lib/adapters/http'),
-    httpsAgent: new https.Agent({
-      rejectUnauthorized: settings.validateSSL,
-    }),
   };
 
   // ignore HTTP_PROXY, HTTPS_PROXY, NO_PROXY environment variables

--- a/packages/insomnia-app/app/network/axios-request.ts
+++ b/packages/insomnia-app/app/network/axios-request.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig } from 'axios';
+import https from 'https';
 import { setDefaultProtocol } from 'insomnia-url';
 import { parse as urlParse } from 'url';
 
@@ -6,6 +7,15 @@ import { isDevelopment } from '../common/constants';
 import * as models from '../models';
 import { isUrlMatchedInNoProxyRule } from './is-url-matched-in-no-proxy-rule';
 
+export const axiosRequestWithOptionalSSLVerify = async (config: AxiosRequestConfig) => {
+  const settings = await models.settings.getOrCreate();
+  return axiosRequest({
+    ...config,
+    httpsAgent: new https.Agent({
+      rejectUnauthorized: settings.validateSSL,
+    }),
+  });
+};
 export async function axiosRequest(config: AxiosRequestConfig) {
   const settings = await models.settings.getOrCreate();
   const isHttps = config.url?.indexOf('https:') === 0;

--- a/packages/insomnia-app/app/plugins/context/app.tsx
+++ b/packages/insomnia-app/app/plugins/context/app.tsx
@@ -2,7 +2,7 @@ import * as electron from 'electron';
 import React from 'react';
 
 import * as analytics from '../../../app/common/analytics';
-import { axiosRequest as axios } from '../../../app/network/axios-request';
+import { axiosRequestWithOptionalSSLVerify as axios } from '../../../app/network/axios-request';
 import { getAppPlatform, getAppVersion } from '../../common/constants';
 import type { RenderPurpose } from '../../common/render';
 import {

--- a/packages/insomnia-app/app/plugins/install.ts
+++ b/packages/insomnia-app/app/plugins/install.ts
@@ -58,6 +58,7 @@ export default async function(lookupName: string) {
 
       // Download the module
       try {
+        // NOTE: does not respect user preferences
         await axiosRequest({ url: info.dist.tarball });
       } catch (err) {
         reject(new Error(`Failed to make plugin request ${info?.dist.tarball}: ${err.message}`));

--- a/packages/insomnia-app/app/plugins/install.ts
+++ b/packages/insomnia-app/app/plugins/install.ts
@@ -57,15 +57,12 @@ export default async function(lookupName: string) {
       mkdirp.sync(pluginDir);
 
       // Download the module
-      let request;
       try {
-        request = await axiosRequest({ url: info.dist.tarball });
+        await axiosRequest({ url: info.dist.tarball });
       } catch (err) {
-        request.error = err;
+        reject(new Error(`Failed to make plugin request ${info?.dist.tarball}: ${err.message}`));
       }
-      if (request.error) {
-        reject(new Error(`Failed to make plugin request ${info?.dist.tarball}: ${request.error.message}`));
-      }
+
       const { tmpDir } = await _installPluginToTmpDir(lookupName);
       console.log(`[plugins] Moving plugin from ${tmpDir} to ${pluginDir}`);
 

--- a/packages/insomnia-app/app/plugins/install.ts
+++ b/packages/insomnia-app/app/plugins/install.ts
@@ -5,9 +5,9 @@ import fsx from 'fs-extra';
 import mkdirp from 'mkdirp';
 import path from 'path';
 
-import { axiosRequest } from '../network/axios-request';
 import { isDevelopment, isWindows, PLUGIN_PATH } from '../common/constants';
 import { getTempDir } from '../common/electron-helpers';
+import { axiosRequest } from '../network/axios-request';
 
 const YARN_DEPRECATED_WARN = /(?<keyword>warning)(?<dependencies>[^>:].+[>:])(?<issue>.+)/;
 
@@ -43,7 +43,7 @@ interface InsomniaPlugin {
   };
 }
 
-export default async function (lookupName: string) {
+export default async function(lookupName: string) {
   return new Promise<void>(async (resolve, reject) => {
     let info: InsomniaPlugin | null = null;
 

--- a/packages/insomnia-app/app/sync/git/http-client.ts
+++ b/packages/insomnia-app/app/sync/git/http-client.ts
@@ -1,4 +1,4 @@
-import { axiosRequest } from '../../network/axios-request';
+import { axiosRequestWithOptionalSSLVerify } from '../../network/axios-request';
 
 /** This is a client for isomorphic-git {@link https://isomorphic-git.org/docs/en/http} */
 export const httpClient = {
@@ -11,7 +11,7 @@ export const httpClient = {
     }
 
     try {
-      response = await axiosRequest({
+      response = await axiosRequestWithOptionalSSLVerify({
         url: config.url,
         method: config.method,
         headers: config.headers,

--- a/packages/insomnia-app/app/ui/components/design-empty-state.tsx
+++ b/packages/insomnia-app/app/ui/components/design-empty-state.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { documentationLinks } from '../../common/documentation';
 import { selectFileOrFolder } from '../../common/select-file-or-folder';
 import * as models from '../../models';
+import { axiosRequest } from '../../network/axios-request';
 import { faint } from '../css/css-in-js';
 import { selectActiveApiSpec } from '../redux/selectors';
 import { showPrompt } from './modals';
@@ -78,11 +79,12 @@ const ImportSpecButton: FC<Props> = ({ onUpdateContents }) => {
       label: 'URL',
       placeholder: 'e.g. https://petstore.swagger.io/v2/swagger.json',
       onComplete: async (uri: string) => {
-        const response = await window.fetch(uri);
+        // NOTE: does not respect user preferences
+        const response = await axiosRequest({ url: uri, responseType: 'text', transformResponse: _ => _ });
         if (!response) {
           return;
         }
-        const contents = await response.text();
+        const contents = await response.data;
         await updateApiSpecContents(contents);
         onUpdateContents();
       },
@@ -119,11 +121,12 @@ const SecondaryAction: FC<Props> = ({ onUpdateContents }) => {
 
   const updateApiSpecContents = useUpdateApiSpecContents();
   const onClick = useCallback(async () => {
-    const response = await window.fetch(PETSTORE_EXAMPLE_URI);
+    // NOTE: does not respect user preferences
+    const response = await axiosRequest({ url: PETSTORE_EXAMPLE_URI, responseType: 'text', transformResponse: _ => _ });
     if (!response) {
       return;
     }
-    const contents = await response.text();
+    const contents = await response.data;
     await updateApiSpecContents(contents);
     onUpdateContents();
   }, [updateApiSpecContents, onUpdateContents]);


### PR DESCRIPTION
Problem: There are 4 ways to send a request in insomnia today and not all respect user preferences.

- whatwg-fetch: feat/sync to insomnia backend
- axios: feat/git-sync, segment analytics and deploy to dev portal
- electron.net.request: google analytics and plugin install
- node-libcurl: normal user requests, including oauth2 and graphql introspection

Solution: Remove 2 of them

- node-libcurl: normal user requests, including oauth2 and graphql introspection
- axios: everything else

NOTE: 
There is some expectation that validateCertificates in preferences can disable ssl verify for feat/git-sync, plugin api and deploy to dev portal, so I have created a new axiosRequest method to make that clearer named axiosRequestWithOptionalSSLVerify.

For other application request types, analytics, plugin install, and feat/sync SSL certificates must be valid.

As these changes remove whatwg-fetch and electron.net.request approaches those should be the only code paths that carry any risk of regression. Therefore cursory testing of feat/sync and plugin install should confirm a no-op refactor.


<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcommings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Closes INS-1302