### PR TITLE
Update response-timeline-viewer to show response body.

### DIFF
--- a/packages/insomnia-app/app/common/misc.ts
+++ b/packages/insomnia-app/app/common/misc.ts
@@ -466,3 +466,14 @@ export function isNotNullOrUndefined<ValueType>(
 }
 
 export const kebabCase = (value: string) => value.replace(/ /g, '-');
+
+// Because node-libcurl changed some names that we used in the timeline
+export const LIBCURL_DEBUG_MIGRATION_MAP = {
+  HeaderIn: 'HEADER_IN',
+  DataIn: 'DATA_IN',
+  SslDataIn: 'SSL_DATA_IN',
+  HeaderOut: 'HEADER_OUT',
+  DataOut: 'DATA_OUT',
+  SslDataOut: 'SSL_DATA_OUT',
+  Text: 'TEXT',
+} as const;

--- a/packages/insomnia-app/app/models/response.ts
+++ b/packages/insomnia-app/app/models/response.ts
@@ -240,22 +240,15 @@ export function getTimeline(response: Response, showBody?: boolean) {
 
   try {
     const rawBuffer = fs.readFileSync(timelinePath);
-    const timeline = JSON.parse(rawBuffer.toString());
-    let body: ResponseTimelineEntry[] = [];
-    if (showBody) {
-      const name = LIBCURL_DEBUG_MIGRATION_MAP.DataOut;
-      body = [
-        {
-          name,
-          timestamp: Date.now(),
-          value: fs.readFileSync(bodyPath).toString(),
-        },
-      ];
-    }
-    const output = [
-      ...timeline,
-      ...body,
-    ] as ResponseTimelineEntry[];
+    const timeline = JSON.parse(rawBuffer.toString()) as ResponseTimelineEntry[];
+    const body: ResponseTimelineEntry[] = showBody ? [
+      {
+        name: LIBCURL_DEBUG_MIGRATION_MAP.DataOut,
+        timestamp: Date.now(),
+        value: fs.readFileSync(bodyPath).toString(),
+      },
+    ] : [];
+    const output = [...timeline, ...body];
     return output;
   } catch (err) {
     console.warn('Failed to read response body', err.message);

--- a/packages/insomnia-app/app/models/response.ts
+++ b/packages/insomnia-app/app/models/response.ts
@@ -3,11 +3,12 @@ import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
 import { Readable } from 'stream';
+import { ValueOf } from 'type-fest';
 import zlib from 'zlib';
 
 import { database as db, Query } from '../common/database';
 import { getDataDirectory } from '../common/electron-helpers';
-import { LIBCURL_DEBUG_MIGRATION_MAP } from '../network/network';
+import { LIBCURL_DEBUG_MIGRATION_MAP } from '../common/misc';
 import type { BaseModel } from './index';
 import * as models from './index';
 
@@ -27,7 +28,7 @@ export interface ResponseHeader {
 }
 
 export interface ResponseTimelineEntry {
-  name: string;
+  name: ValueOf<typeof LIBCURL_DEBUG_MIGRATION_MAP>;
   timestamp: number;
   value: string;
 }

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -48,6 +48,7 @@ import {
   hasAuthHeader,
   hasContentTypeHeader,
   hasUserAgentHeader,
+  LIBCURL_DEBUG_MIGRATION_MAP,
   waitForStreamToFinish,
 } from '../common/misc';
 import type { ExtraRenderInfo, RenderedRequest } from '../common/render';
@@ -95,17 +96,6 @@ const MAX_DELAY_TIME = 1000;
 
 // Special header value that will prevent the header being sent
 const DISABLE_HEADER_VALUE = '__Di$aB13d__';
-
-// Because node-libcurl changed some names that we used in the timeline
-export const LIBCURL_DEBUG_MIGRATION_MAP = {
-  HeaderIn: 'HEADER_IN',
-  DataIn: 'DATA_IN',
-  SslDataIn: 'SSL_DATA_IN',
-  HeaderOut: 'HEADER_OUT',
-  DataOut: 'DATA_OUT',
-  SslDataOut: 'SSL_DATA_OUT',
-  Text: 'TEXT',
-} as const;
 
 const cancelRequestFunctionMap = {};
 

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -97,7 +97,7 @@ const MAX_DELAY_TIME = 1000;
 const DISABLE_HEADER_VALUE = '__Di$aB13d__';
 
 // Because node-libcurl changed some names that we used in the timeline
-const LIBCURL_DEBUG_MIGRATION_MAP = {
+export const LIBCURL_DEBUG_MIGRATION_MAP = {
   HeaderIn: 'HEADER_IN',
   DataIn: 'DATA_IN',
   SslDataIn: 'SSL_DATA_IN',

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -378,6 +378,7 @@ const OAuth2Error: FC = () => {
 
     showModal(ResponseDebugModal, {
       responseId: token.xResponseId,
+      showBody: true,
     });
   };
 

--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -1,3 +1,4 @@
+import { Button } from 'insomnia-components';
 import React, { ChangeEvent, FC, ReactNode, useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -383,13 +384,13 @@ const OAuth2Error: FC = () => {
   };
 
   const debugButton = token?.xResponseId ? (
-    <button
+    <Button
       onClick={debug}
-      className="icon icon--success space-left"
+      className="margin-top-sm"
       title="View response timeline"
     >
-      <i className="fa fa-bug" />
-    </button>
+      <i className="fa fa-bug space-right" /> Response Timeline
+    </Button>
   ) : null;
 
   const errorUriButton = token?.errorUri ? (
@@ -408,8 +409,8 @@ const OAuth2Error: FC = () => {
         <p>
           {errorDescription || 'no description provided'}
           {errorUriButton}
-          {debugButton}
         </p>
+        {debugButton}
       </div>
     );
   }

--- a/packages/insomnia-app/app/ui/components/modals/response-debug-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/response-debug-modal.tsx
@@ -11,6 +11,7 @@ import { ModalHeader } from '../base/modal-header';
 
 interface State {
   response: Response | null;
+  showBody?: boolean;
   title: string | null;
 }
 
@@ -20,6 +21,7 @@ export class ResponseDebugModal extends PureComponent<{}, State> {
 
   state: State = {
     response: null,
+    showBody: false,
     title: '',
   };
 
@@ -31,19 +33,20 @@ export class ResponseDebugModal extends PureComponent<{}, State> {
     this.modal?.hide();
   }
 
-  async show(options: { responseId?: string; response?: Response; title?: string }) {
+  async show(options: { responseId?: string; response?: Response; title?: string; showBody?: boolean }) {
     const response = options.response
       ? options.response
       : await models.response.getById(options.responseId || 'n/a');
     this.setState({
       response,
       title: options.title || null,
+      showBody: options.showBody,
     });
     this.modal?.show();
   }
 
   render() {
-    const { response, title } = this.state;
+    const { response, title, showBody } = this.state;
     return (
       <Modal ref={this._setModalRef} tall>
         <ModalHeader>{title || 'Response Timeline'}</ModalHeader>
@@ -57,6 +60,7 @@ export class ResponseDebugModal extends PureComponent<{}, State> {
             {response ? (
               <ResponseTimelineViewer
                 response={response}
+                showBody={showBody}
               />
             ) : (
               <div>No response found</div>

--- a/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/response-pane.tsx
@@ -134,7 +134,7 @@ export class ResponsePane extends PureComponent<Props> {
       return;
     }
 
-    const timeline = await models.response.getTimeline(response);
+    const timeline = models.response.getTimeline(response);
     const headers = timeline
       .filter(v => v.name === 'HEADER_IN')
       .map(v => v.value)

--- a/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 
 import { clickLink } from '../../../common/electron-helpers';
+import { LIBCURL_DEBUG_MIGRATION_MAP } from '../../../common/misc';
 import * as models from '../../../models';
 import { Response, ResponseTimelineEntry } from '../../../models/response';
-import { LIBCURL_DEBUG_MIGRATION_MAP } from '../../../network/network';
 import { CodeEditor } from '../codemirror/code-editor';
 
 interface Props {

--- a/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 import { clickLink } from '../../../common/electron-helpers';
 import * as models from '../../../models';
 import { Response, ResponseTimelineEntry } from '../../../models/response';
+import { LIBCURL_DEBUG_MIGRATION_MAP } from '../../../network/network';
 import { CodeEditor } from '../codemirror/code-editor';
 
 interface Props {
@@ -49,31 +50,31 @@ export class ResponseTimelineViewer extends PureComponent<Props, State> {
     let prefix: string | null = null;
 
     switch (name) {
-      case 'HEADER_IN':
+      case LIBCURL_DEBUG_MIGRATION_MAP.HeaderIn:
         prefix = '< ';
         break;
 
-      case 'DATA_IN':
+      case LIBCURL_DEBUG_MIGRATION_MAP.DataIn:
         prefix = '| ';
         break;
 
-      case 'SSL_DATA_IN':
+      case LIBCURL_DEBUG_MIGRATION_MAP.SslDataIn:
         prefix = '<< ';
         break;
 
-      case 'HEADER_OUT':
+      case LIBCURL_DEBUG_MIGRATION_MAP.HeaderOut:
         prefix = '> ';
         break;
 
-      case 'DATA_OUT':
+      case LIBCURL_DEBUG_MIGRATION_MAP.DataOut:
         prefix = '| ';
         break;
 
-      case 'SSL_DATA_OUT':
+      case LIBCURL_DEBUG_MIGRATION_MAP.SslDataOut:
         prefix = '>> ';
         break;
 
-      case 'TEXT':
+      case LIBCURL_DEBUG_MIGRATION_MAP.Text:
         prefix = '* ';
         break;
 

--- a/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
@@ -19,7 +19,7 @@ export class ResponseTimelineViewer extends PureComponent<Props, State> {
   state: State = {
     timeline: [],
     timelineKey: '',
-    body: ''
+    body: '',
   };
 
   componentDidMount() {
@@ -37,12 +37,12 @@ export class ResponseTimelineViewer extends PureComponent<Props, State> {
   async refreshTimeline() {
     const { response } = this.props;
     const timeline = await models.response.getTimeline(response);
-    const body = await models.response.getBodyBuffer(response)!.toString('utf8')
+    const body = await models.response.getBodyBuffer(response)?.toString('utf8') || '';
 
     this.setState({
       timeline,
       timelineKey: response._id,
-      body: body
+      body: body,
     });
   }
 
@@ -99,11 +99,11 @@ export class ResponseTimelineViewer extends PureComponent<Props, State> {
 
   render() {
     const { timeline, timelineKey } = this.state;
-    let rows = timeline
+    const rows = timeline
       .map(this.renderRow)
       .filter(r => r !== null);
 
-    rows.push(`\n| ${this.state.body}`);
+    rows.push(`\n|\n${this.state.body}`);
 
     const value = rows
       .join('\n')

--- a/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-timeline-viewer.tsx
@@ -12,12 +12,14 @@ interface Props {
 interface State {
   timeline: any[];
   timelineKey: string;
+  body: string;
 }
 
 export class ResponseTimelineViewer extends PureComponent<Props, State> {
   state: State = {
     timeline: [],
     timelineKey: '',
+    body: ''
   };
 
   componentDidMount() {
@@ -35,9 +37,12 @@ export class ResponseTimelineViewer extends PureComponent<Props, State> {
   async refreshTimeline() {
     const { response } = this.props;
     const timeline = await models.response.getTimeline(response);
+    const body = await models.response.getBodyBuffer(response)!.toString('utf8')
+
     this.setState({
       timeline,
       timelineKey: response._id,
+      body: body
     });
   }
 
@@ -94,18 +99,23 @@ export class ResponseTimelineViewer extends PureComponent<Props, State> {
 
   render() {
     const { timeline, timelineKey } = this.state;
-    const rows = timeline
+    let rows = timeline
       .map(this.renderRow)
-      .filter(r => r !== null)
+      .filter(r => r !== null);
+
+    rows.push(`\n| ${this.state.body}`);
+
+    const value = rows
       .join('\n')
       .trim();
+
     return (
       <CodeEditor
         key={timelineKey}
         hideLineNumbers
         readOnly
         onClickLink={clickLink}
-        defaultValue={rows}
+        defaultValue={value}
         className="pad-left"
         mode="curl"
       />


### PR DESCRIPTION
Whenever I have an issue with oauth in insomnia it takes an awful lot of effort to work out what has actually gone wrong.

Have to make use of debugging proxies, or add breakpoints in dev tools.

Adding the following (or similar if this isn't appropriate) would make life a lot easier for me.

![image](https://user-images.githubusercontent.com/2056399/148594418-118a3316-9bfc-49a8-917a-7efc48f6df56.png)

![image](https://user-images.githubusercontent.com/2056399/148594288-7050490a-db00-4e73-90e4-4ef3027f4b46.png)

changelog(Improvements): Insomnia will now show the response body for OAuth2 requests when there's an error