### PR TITLE
Allow overriding "coreAnnotations" on Kubernetes Ingress objects

### DIFF
--- a/packages/openapi-2-kong/src/kubernetes/generate.ts
+++ b/packages/openapi-2-kong/src/kubernetes/generate.ts
@@ -139,9 +139,9 @@ export const generateMetadataAnnotations = (
 
     const originalAnnotations = metadata?.annotations || {};
     return {
+      ...coreAnnotations,
       ...originalAnnotations,
       ...customAnnotations,
-      ...coreAnnotations,
     };
   }
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

The return value appender for the Ingress object annotations map is set up in the wrong order.

I would like to override the default `kubernetes.io/ingress.class: 'kong'` in an API Spec, like this:

```
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Customers MDM API
  x-kubernetes-ingress-metadata:
    annotations:
      kubernetes.io/ingress.class: 'mdm-workspace-ingress-class'
```

but I can't, because when `coreAnnotations` is appended to the map, it clobbers my value from the OAS.

changelog(Inso CLI): You can now override annotations on Kubernetes Ingress objects