### PR TITLE
updates support.insomnia.rest to docs.insomnia.rest

### DIFF
--- a/packages/insomnia-app/app/common/documentation.ts
+++ b/packages/insomnia-app/app/common/documentation.ts
@@ -1,12 +1,12 @@
 const insomniaDocs = (slug: string) => `https://docs.insomnia.rest${slug}`;
 
 export const docsBase = insomniaDocs('/');
-export const docsGitSync = insomniaDocs('/article/193-git-sync');
-export const docsTemplateTags = insomniaDocs('/article/171-template-tags');
-export const docsVersionControl = insomniaDocs('/article/165-version-control-sync');
-export const docsPlugins = insomniaDocs('/article/173-plugins');
-export const docsImportExport = insomniaDocs('/article/172-importing-and-exporting-data');
-export const docsKeyMaps = insomniaDocs('/article/203-key-maps');
+export const docsGitSync = insomniaDocs('/insomnia/git-sync');
+export const docsTemplateTags = insomniaDocs('/insomnia/template-tags');
+export const docsVersionControl = insomniaDocs('/insomnia/version-control-sync');
+export const docsPlugins = insomniaDocs('/insomnia/introduction-to-plugins');
+export const docsImportExport = insomniaDocs('/insomnia/import-export-data');
+export const docsKeyMaps = insomniaDocs('/insomnia/key-maps');
 export const docsIntroductionInsomnia = insomniaDocs('/insomnia/get-started');
 export const docsWorkingWithDesignDocs = insomniaDocs('/insomnia/design-documents');
 

--- a/packages/insomnia-app/app/common/documentation.ts
+++ b/packages/insomnia-app/app/common/documentation.ts
@@ -1,4 +1,4 @@
-const insomniaDocs = (slug: string) => `https://support.insomnia.rest${slug}`;
+const insomniaDocs = (slug: string) => `https://docs.insomnia.rest${slug}`;
 
 export const docsBase = insomniaDocs('/');
 export const docsGitSync = insomniaDocs('/article/193-git-sync');

--- a/packages/insomnia-app/app/ui/components/viewers/response-error-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-error-viewer.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo } from 'react';
 import { useSelector } from 'react-redux';
 
+import { docsBase } from '../../../common/documentation';
 import { selectSettings } from '../../redux/selectors';
 import { Link } from '../base/link';
 import { showModal } from '../modals/index';
@@ -28,7 +29,7 @@ export const ResponseErrorViewer: FC<Props> = memo(({ error }) => {
     );
   } else {
     msg = (
-      <Link button className="btn btn--clicky" href="https://support.insomnia.rest">
+      <Link button className="btn btn--clicky" href={docsBase}>
         Documentation
       </Link>
     );


### PR DESCRIPTION
closes INS-1351

It appears that this URL was updated, so we can point all links in the app to the right thing by just changing the factory.