### PR TITLE
removes DEPRECATED_ACTIVITY_INSOMNIA

### DIFF
--- a/packages/insomnia-app/app/common/constants.ts
+++ b/packages/insomnia-app/app/common/constants.ts
@@ -166,7 +166,6 @@ export const ACTIVITY_DEBUG: GlobalActivity = 'debug';
 export const ACTIVITY_UNIT_TEST: GlobalActivity = 'unittest';
 export const ACTIVITY_HOME: GlobalActivity = 'home';
 export const ACTIVITY_MIGRATION: GlobalActivity = 'migration';
-export const DEPRECATED_ACTIVITY_INSOMNIA = 'insomnia';
 
 export const isWorkspaceActivity = (activity?: string): activity is GlobalActivity =>
   isDesignActivity(activity) || isCollectionActivity(activity);

--- a/packages/insomnia-app/app/models/workspace-meta.ts
+++ b/packages/insomnia-app/app/models/workspace-meta.ts
@@ -1,9 +1,7 @@
 import {
-  ACTIVITY_DEBUG,
   DEFAULT_PANE_HEIGHT,
   DEFAULT_PANE_WIDTH,
   DEFAULT_SIDEBAR_WIDTH,
-  DEPRECATED_ACTIVITY_INSOMNIA,
 } from '../common/constants';
 import { database as db } from '../common/database';
 import type { BaseModel } from './index';
@@ -63,15 +61,6 @@ export function init(): BaseWorkspaceMeta {
 }
 
 export function migrate(doc: WorkspaceMeta) {
-  doc = _migrateInsomniaActivity(doc);
-  return doc;
-}
-
-function _migrateInsomniaActivity(doc: WorkspaceMeta) {
-  if (doc.activeActivity === DEPRECATED_ACTIVITY_INSOMNIA) {
-    doc.activeActivity = ACTIVITY_DEBUG;
-  }
-
   return doc;
 }
 

--- a/packages/insomnia-app/app/ui/redux/modules/__tests__/global.test.ts
+++ b/packages/insomnia-app/app/ui/redux/modules/__tests__/global.test.ts
@@ -10,7 +10,6 @@ import {
   ACTIVITY_MIGRATION,
   ACTIVITY_SPEC,
   ACTIVITY_UNIT_TEST,
-  DEPRECATED_ACTIVITY_INSOMNIA,
   GlobalActivity,
   SORT_MODIFIED_DESC,
 } from '../../../../common/constants';
@@ -191,24 +190,6 @@ describe('global', () => {
       const expectedEvent = {
         type: SET_ACTIVE_ACTIVITY,
         activity,
-      };
-      store.dispatch(initActiveActivity());
-      expect(store.getActions()).toEqual([expectedEvent]);
-    });
-
-    it('should initialize from local storage and migrate deprecated activity', async () => {
-      const settings = createSettings(true, true);
-      const store = mockStore({
-        global: {},
-        entities: {
-          settings: [settings],
-        },
-      });
-      const activity = DEPRECATED_ACTIVITY_INSOMNIA;
-      global.localStorage.setItem(`${LOCALSTORAGE_PREFIX}::activity`, JSON.stringify(activity));
-      const expectedEvent = {
-        type: SET_ACTIVE_ACTIVITY,
-        activity: ACTIVITY_DEBUG,
       };
       store.dispatch(initActiveActivity());
       expect(store.getActions()).toEqual([expectedEvent]);

--- a/packages/insomnia-app/app/ui/redux/modules/global.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/global.tsx
@@ -12,7 +12,6 @@ import {
   ACTIVITY_DEBUG,
   ACTIVITY_HOME,
   ACTIVITY_MIGRATION,
-  DEPRECATED_ACTIVITY_INSOMNIA,
   isValidActivity,
 } from '../../../common/constants';
 import { database } from '../../../common/database';
@@ -652,14 +651,7 @@ export function initActiveWorkspace() {
   return setActiveWorkspace(workspaceId);
 }
 
-function _migrateDeprecatedActivity(activity: GlobalActivity): GlobalActivity {
-  // @ts-expect-error -- TSCONVERSION
-  return activity === DEPRECATED_ACTIVITY_INSOMNIA ? ACTIVITY_DEBUG : activity;
-}
-
 function _normalizeActivity(activity: GlobalActivity): GlobalActivity {
-  activity = _migrateDeprecatedActivity(activity);
-
   if (isValidActivity(activity)) {
     return activity;
   }


### PR DESCRIPTION
closes: INS-1314

per the existing tests for activity fallback, the usual fallbacks will apply if the app is booted with this activity, which was deprecated a year ago (https://github.com/Kong/insomnia/commit/26fb78ab99f3d16858fd4afe76d9ca3ba8fe7d92#diff-a5ade3251e8fc7740bbb8bdf5c47676cf76d7d066e76d4f56de0cd9763bd4cb7R159)