### PR TITLE
no-libcurl

### DIFF
--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -1,4 +1,3 @@
-import { Curl } from '@getinsomnia/node-libcurl';
 import electron, { BrowserWindow, MenuItemConstructorOptions } from 'electron';
 import fs from 'fs';
 import * as os from 'os';
@@ -19,12 +18,10 @@ import {
 import { docsBase } from '../common/documentation';
 import { clickLink, getDataDirectory } from '../common/electron-helpers';
 import * as log from '../common/log';
+import { Curl } from '../network/curl-shim';
 import LocalStorage from './local-storage';
 
 const { app, Menu, shell, dialog, clipboard } = electron;
-// So we can use native modules in renderer
-// NOTE: This was (deprecated in Electron 10)[https://github.com/electron/electron/issues/18397] and (removed in Electron 14)[https://github.com/electron/electron/pull/26874]
-app.allowRendererProcessReuse = false;
 
 const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 700;

--- a/packages/insomnia-app/app/models/response.ts
+++ b/packages/insomnia-app/app/models/response.ts
@@ -270,7 +270,7 @@ function getBodyBufferFromPath<T>(
 
   try {
     const rawBuffer = fs.readFileSync(bodyPath);
-
+    console.log('suspiciously frequent file read', rawBuffer.length, bodyPath);
     if (compression === 'zip') {
       return zlib.gunzipSync(rawBuffer);
     } else {

--- a/packages/insomnia-app/app/network/__mocks__/curl-shim.ts
+++ b/packages/insomnia-app/app/network/__mocks__/curl-shim.ts
@@ -1,13 +1,10 @@
-// Note: we cannot import these from `node-libcurl` like normal because they come from the native library and it's not possible to load it while testing because it was built to run with Electron.
-// That applies to these Enum type imports, but also applies to the members of the class below.
-import { CurlAuth } from '@getinsomnia/node-libcurl/dist/enum/CurlAuth';
-import { CurlCode } from '@getinsomnia/node-libcurl/dist/enum/CurlCode';
-import { CurlFeature } from '@getinsomnia/node-libcurl/dist/enum/CurlFeature';
-import { CurlHttpVersion } from '@getinsomnia/node-libcurl/dist/enum/CurlHttpVersion';
-import { CurlInfoDebug } from '@getinsomnia/node-libcurl/dist/enum/CurlInfoDebug';
-import { CurlNetrc } from '@getinsomnia/node-libcurl/dist/enum/CurlNetrc';
+
 import { EventEmitter } from 'events';
 import fs from 'fs';
+
+// Note: we cannot import these from `node-libcurl` like normal because they come from the native library and it's not possible to load it while testing because it was built to run with Electron.
+// That applies to these Enum type imports, but also applies to the members of the class below.
+import { CurlAuth, CurlCode, CurlFeature, CurlHttpVersion, CurlInfoDebug, CurlNetrc } from '../../network/curl-enum/Curl';
 
 class Curl extends EventEmitter {
   _options = {};
@@ -153,12 +150,11 @@ class Curl extends EventEmitter {
           'end',
           'NOT_USED',
           'NOT_USED',
-          [
-            'HTTP/1.1 200 OK',
-            `Content-Length: ${data.length}`,
-            'Content-Type: application/json',
-            '',
-          ].join('\n'),
+          [{
+            version: 'HTTP/1.1',
+            code: '200',
+            reason: 'OK',
+          }]
         );
       });
     });

--- a/packages/insomnia-app/app/network/curl-enum/Curl.ts
+++ b/packages/insomnia-app/app/network/curl-enum/Curl.ts
@@ -1,0 +1,93 @@
+export class CurlEnums {
+  static info = {
+    COOKIELIST: 'COOKIELIST',
+    EFFECTIVE_URL: 'EFFECTIVE_URL',
+    SIZE_DOWNLOAD: 'SIZE_DOWNLOAD',
+    TOTAL_TIME: 'TOTAL_TIME',
+  };
+
+  static option = {
+    ACCEPT_ENCODING: 'ACCEPT_ENCODING',
+    CAINFO: 'CAINFO',
+    COOKIE: 'COOKIE',
+    COOKIEFILE: 'COOKIEFILE',
+    COOKIELIST: 'COOKIELIST',
+    CUSTOMREQUEST: 'CUSTOMREQUEST',
+    DEBUGFUNCTION: 'DEBUGFUNCTION',
+    FOLLOWLOCATION: 'FOLLOWLOCATION',
+    HTTPAUTH: 'HTTPAUTH',
+    HTTPGET: 'HTTPGET',
+    HTTPHEADER: 'HTTPHEADER',
+    HTTPPOST: 'HTTPPOST',
+    HTTP_VERSION: 'HTTP_VERSION',
+    INFILESIZE_LARGE: 'INFILESIZE_LARGE',
+    KEYPASSWD: 'KEYPASSWD',
+    MAXREDIRS: 'MAXREDIRS',
+    NETRC: 'NETRC',
+    NOBODY: 'NOBODY',
+    NOPROGRESS: 'NOPROGRESS',
+    NOPROXY: 'NOPROXY',
+    PASSWORD: 'PASSWORD',
+    POST: 'POST',
+    POSTFIELDS: 'POSTFIELDS',
+    PROXY: 'PROXY',
+    PROXYAUTH: 'PROXYAUTH',
+    READDATA: 'READDATA',
+    READFUNCTION: 'READFUNCTION',
+    SSLCERT: 'SSLCERT',
+    SSLCERTTYPE: 'SSLCERTTYPE',
+    SSLKEY: 'SSLKEY',
+    SSL_VERIFYHOST: 'SSL_VERIFYHOST',
+    SSL_VERIFYPEER: 'SSL_VERIFYPEER',
+    TIMEOUT_MS: 'TIMEOUT_MS',
+    UNIX_SOCKET_PATH: 'UNIX_SOCKET_PATH',
+    UPLOAD: 'UPLOAD',
+    URL: 'URL',
+    USERAGENT: 'USERAGENT',
+    USERNAME: 'USERNAME',
+    VERBOSE: 'VERBOSE',
+    WRITEFUNCTION: 'WRITEFUNCTION',
+  };
+}
+
+export enum CurlAuth {
+  Basic = 1 << 0,
+  Digest = 1 << 1,
+  Ntlm = 1 << 3,
+  DigestIe = 1 << 4,
+  Any = ~DigestIe,
+}
+
+export enum CurlCode {
+  CURLE_ABORTED_BY_CALLBACK = 42
+}
+
+export enum CurlHttpVersion {
+  None,
+  V1_0,
+  V1_1,
+  V2_0,
+  V2Tls,
+  V2PriorKnowledge,
+  v3,
+}
+
+export enum CurlInfoDebug {
+  Text,
+  HeaderIn,
+  HeaderOut,
+  DataIn,
+  DataOut,
+  SslDataIn,
+  SslDataOut,
+}
+export enum CurlNetrc {
+  Ignored,
+  Optional,
+  Required,
+}
+export enum CurlFeature {
+  NoDataParsing = 1 << 0,
+  NoHeaderParsing = 1 << 1,
+  Raw = NoDataParsing | NoHeaderParsing,
+}

--- a/packages/insomnia-app/app/network/curl-shim.ts
+++ b/packages/insomnia-app/app/network/curl-shim.ts
@@ -1,0 +1,205 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import { EventEmitter } from 'events';
+import fs from 'fs';
+import https from 'https';
+import { performance } from 'perf_hooks';
+
+import { CurlAuth, CurlEnums, CurlInfoDebug } from './curl-enum/Curl';
+
+class NotCurl extends EventEmitter {
+  reqOptions: AxiosRequestConfig;
+  writeListener: any;
+  debugListener: any;
+  // NOTE: these are for solving assignment ordering problems
+  sslVerify: boolean;
+  responseBodyBytes: number;
+  elapsedTime: number;
+  followRedirects: boolean;
+  caBundle: string | Buffer | (string | Buffer)[] | undefined;
+  username: any;
+  password: any;
+  httpAuth: any;
+  cookies: string[];
+
+  constructor() {
+    super();
+    this.reqOptions = { headers: {} };
+    this.sslVerify = true;
+    this.responseBodyBytes = 0;
+    this.elapsedTime = 0;
+    this.cookies = [];
+  }
+  static option = CurlEnums.option;
+  static info = CurlEnums.info;
+  static getVersion() {
+    return 'axios/0.21.1';
+  }
+
+  getInfo(opt) {
+    const name = Object.keys(CurlEnums.info).find(name => CurlEnums.info[name] === opt);
+    if (name === 'SIZE_DOWNLOAD') return this.responseBodyBytes;
+    if (name === 'TOTAL_TIME') return this.elapsedTime;
+    if (name === 'EFFECTIVE_URL') return this.reqOptions.url;
+
+    console.log('unhandled getInfo', opt, name);
+    return undefined;
+  }
+  setOpt(opt: any, val: any) {
+    const name = Object.keys(CurlEnums.option).find(name => CurlEnums.option[name] === opt);
+
+    switch (name) {
+      case 'MAXREDIRS':
+        this.reqOptions.maxRedirects = val;
+        break;
+      case 'FOLLOWLOCATION':
+        this.followRedirects = val;
+        break;
+      case 'PROXY':
+        // NOTE: explicitly ignore system env var HTTP/S_PROXY and NO_PROXY
+        if (val === '') this.reqOptions.proxy = false;
+        else {
+          const { hostname, port } = new URL(val);
+          this.reqOptions.proxy = {
+            host: hostname,
+            port: parseInt(port, 10),
+          };
+        }
+        break;
+      case 'HTTPAUTH':
+        this.httpAuth = val;
+        break;
+      case 'USERNAME':
+        this.username = val;
+        break;
+      case 'PASSWORD':
+        this.password = val;
+        break;
+      case 'NOBODY':
+        this.reqOptions.method = 'HEAD';
+        break;
+      case 'POST':
+        this.reqOptions.method = 'POST';
+        break;
+      case 'CUSTOMREQUEST':
+        this.reqOptions.method = val;
+        break;
+      case 'READDATA':
+        this.reqOptions.data = fs.readFileSync(val, 'utf8');
+        break;
+      case 'TIMEOUT_MS':
+        this.reqOptions.timeout = val;
+        break;
+      case 'SSL_VERIFYHOST':
+        this.sslVerify = !!val;
+        break;
+      case 'SSL_VERIFYPEER':
+        // NOTE: same as above in nodejs
+        break;
+      case 'CAINFO':
+        // NOTE: needs testing
+        this.caBundle = fs.readFileSync(val);
+        break;
+      case 'POSTFIELDS':
+        this.reqOptions.data = val;
+        break;
+      case 'URL':
+        this.reqOptions.url = val;
+        break;
+      case 'WRITEFUNCTION':
+        this.writeListener = val;
+        break;
+      case 'DEBUGFUNCTION':
+        this.debugListener = val;
+        break;
+      case 'HTTPHEADER':
+        val.map(x => {
+          const name = x.split(':')[0];
+          // NOTE: skip empty header values
+          if (x.split(':')[1]?.trim()) this.reqOptions.headers[name] = x.split(':')[1]?.trim();
+        });
+        break;
+      case 'USERAGENT':
+        this.reqOptions.headers['User-Agent'] = val;
+        break;
+      case 'COOKIELIST':
+        // this.reqOptions.headers['Set-Cookie'] = val;
+        console.log('cookielist', val);
+        break;
+      case 'COOKIEFILE':
+        // do nothing
+        break;
+      case 'COOKIE':
+        this.cookies.push(val);
+        break;
+      default:
+        console.log('unhandled option', opt, name, val);
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  enable(_) {
+    // ignore this, as its only used for disabling auto parsing of headers and body
+  }
+  perform() {
+
+    if (this.cookies.length) this.reqOptions.headers['Cookie'] = this.cookies.join(';');
+    // NOTE: disable follow redirects https://github.com/axios/axios/pull/307/files#diff-586c04c24
+    if (!this.followRedirects) this.reqOptions.maxRedirects = 0;
+    const agentConfig: https.AgentOptions = { rejectUnauthorized: this.sslVerify };
+    if (this.caBundle) {
+      agentConfig.ca = this.caBundle;
+    }
+
+    // TODO: digest, ntlm, netrc etc
+    if (this.httpAuth === CurlAuth.Basic) {
+      this.reqOptions.auth = { username: this.username, password: this.password };
+    }
+    this.reqOptions.httpsAgent = new https.Agent(agentConfig);
+    this.reqOptions.adapter = global.require('axios/lib/adapters/http'),
+    this.reqOptions.responseType = 'stream';
+    this.reqOptions.validateStatus = () => true;
+    const startTime = performance.now();
+    axios.request(this.reqOptions)
+      .then(({ data, status, statusText, headers, config, request }) => {
+        console.log('perform', { data, status, statusText, headers, config, request });
+        if (this.caBundle) this.debugListener(CurlInfoDebug.Text, `Found bundle for host ${request.host} (#1)`);
+
+        this.debugListener(CurlInfoDebug.Text, `Connected to ${request.host} (#1)`);
+
+        this.debugListener(CurlInfoDebug.HeaderOut, request._header);
+
+        if (this.reqOptions.data !== undefined) this.debugListener(CurlInfoDebug.DataOut, this.reqOptions.data);
+
+        // NOTE: axios chops HTTP/1.1 200 Success off the top of the raw header string
+        this.debugListener(CurlInfoDebug.HeaderIn, `HTTP/${data.httpVersion} ${status} ${statusText}`);
+        Object.entries(data.headers)
+          .map(([name, value]) => `${name}: ${value}`)
+          .map(h => this.debugListener(CurlInfoDebug.HeaderIn, h));
+
+        data.on('data', chunk => {
+          this.responseBodyBytes += chunk.length;
+          this.writeListener(chunk);
+          this.debugListener(CurlInfoDebug.DataIn, chunk);
+        });
+        data.on('end', () => {
+          this.elapsedTime = performance.now() - startTime;
+
+          this.emit('end', null, null, [{
+            version: 'HTTP/' + data.httpVersion,
+            code: status,
+            reason: statusText,
+            headers: Object.entries(headers).map(([name, value]) => ({ name, value })),
+          }]);
+          this.debugListener(CurlInfoDebug.Text, `Connection #1 to host ${request.host} left intact`);
+        });
+      }).catch(e => this.emit('error', e));
+  }
+  close() {
+    // TODO: maybe reset state here?
+    console.log('close');
+    this.removeAllListeners('end');
+    this.removeAllListeners('error');
+  }
+}
+
+export { NotCurl as Curl };
+export { CurlAuth, CurlCode, CurlFeature, CurlHttpVersion, CurlInfoDebug, CurlNetrc } from './curl-enum/Curl';

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -1,12 +1,3 @@
-import {
-  Curl,
-  CurlAuth,
-  CurlCode,
-  CurlFeature,
-  CurlHttpVersion,
-  CurlInfoDebug,
-  CurlNetrc,
-} from '@getinsomnia/node-libcurl';
 import aws4 from 'aws4';
 import clone from 'clone';
 import crypto from 'crypto';
@@ -66,6 +57,15 @@ import * as pluginContexts from '../plugins/context/index';
 import * as plugins from '../plugins/index';
 import { getAuthHeader } from './authentication';
 import caCerts from './ca-certs';
+import {
+  Curl,
+  CurlAuth,
+  CurlCode,
+  CurlFeature,
+  CurlHttpVersion,
+  CurlInfoDebug,
+  CurlNetrc,
+} from './curl-shim';
 import { buildMultipart } from './multipart';
 import { urlMatchesCertHost } from './url-matches-cert-host';
 
@@ -233,11 +233,9 @@ export async function _actuallySend(
       cancelRequestFunctionMap[renderedRequest._id] = async () => {
         await respond(
           {
-            elapsedTime: (curl.getInfo(Curl.info.TOTAL_TIME) as number || 0) * 1000,
-            // @ts-expect-error -- needs generic
-            bytesRead: curl.getInfo(Curl.info.SIZE_DOWNLOAD),
-            // @ts-expect-error -- needs generic
-            url: curl.getInfo(Curl.info.EFFECTIVE_URL),
+            elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number,
+            bytesRead: curl.getInfo(Curl.info.SIZE_DOWNLOAD) as number,
+            url: curl.getInfo(Curl.info.EFFECTIVE_URL) as string,
             statusMessage: 'Cancelled',
             error: 'Request was cancelled',
           },
@@ -248,16 +246,16 @@ export async function _actuallySend(
       };
 
       // Set all the basic options
-      setOpt(Curl.option.VERBOSE, true);
+      setOpt(Curl.option.VERBOSE, true); // NOTE: not needed for axios
 
       // True so debug function works\
-      setOpt(Curl.option.NOPROGRESS, true);
+      setOpt(Curl.option.NOPROGRESS, true); // NOTE: not needed for axios
 
       // True so curl doesn't print progress
-      setOpt(Curl.option.ACCEPT_ENCODING, '');
+      setOpt(Curl.option.ACCEPT_ENCODING, ''); // NOTE: not needed for axios
 
       // Auto decode everything
-      curl.enable(CurlFeature.Raw);
+      curl.enable(CurlFeature.Raw); // NOTE: not needed for axios
 
       // Set follow redirects setting
       switch (renderedRequest.settingFollowRedirects) {
@@ -283,7 +281,7 @@ export async function _actuallySend(
 
       // Don't rebuild dot sequences in path
       if (!renderedRequest.settingRebuildPath) {
-        setOpt(Curl.option.PATH_AS_IS, true);
+        // setOpt(Curl.option.PATH_AS_IS, true); // NOTE: not needed
       }
 
       // Only set CURLOPT_CUSTOMREQUEST if not HEAD or GET. This is because Curl
@@ -721,8 +719,8 @@ export async function _actuallySend(
         return buff.length;
       });
       // Handle the response ending
-      curl.on('end', async (_1, _2, rawHeaders: Buffer) => {
-        const allCurlHeadersObjects = _parseHeaders(rawHeaders);
+      curl.on('end', async (_1, _2, rawHeaders: any[]) => {
+        const allCurlHeadersObjects = rawHeaders;
 
         // Headers are an array (one for each redirect)
         const lastCurlHeadersObject = allCurlHeadersObjects[allCurlHeadersObjects.length - 1];
@@ -788,11 +786,9 @@ export async function _actuallySend(
           statusCode,
           statusMessage,
           bytesContent: responseBodyBytes,
-          // @ts-expect-error -- TSCONVERSION appears to be a genuine error
-          bytesRead: curl.getInfo(Curl.info.SIZE_DOWNLOAD),
-          elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000,
-          // @ts-expect-error -- TSCONVERSION appears to be a genuine error
-          url: curl.getInfo(Curl.info.EFFECTIVE_URL),
+          bytesRead: curl.getInfo(Curl.info.SIZE_DOWNLOAD) as number,
+          elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number,
+          url: curl.getInfo(Curl.info.EFFECTIVE_URL) as string,
         };
         // Close the request
         curl.close();
@@ -814,7 +810,7 @@ export async function _actuallySend(
           {
             statusMessage,
             error: error || 'Something went wrong',
-            elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000,
+            elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number,
           },
           null,
         );
@@ -1047,51 +1043,6 @@ async function _applyResponsePluginHooks(
     };
   }
 
-}
-
-interface HeaderResult {
-  headers: ResponseHeader[];
-  version: string;
-  code: number;
-  reason: string;
-}
-
-export function _parseHeaders(
-  buffer: Buffer,
-) {
-  const results: HeaderResult[] = [];
-  const lines = buffer.toString('utf8').split(/\r?\n|\r/g);
-
-  for (let i = 0, currentResult: HeaderResult | null = null; i < lines.length; i++) {
-    const line = lines[i];
-    const isEmptyLine = line.trim() === '';
-
-    // If we hit an empty line, start parsing the next response
-    if (isEmptyLine && currentResult) {
-      results.push(currentResult);
-      currentResult = null;
-      continue;
-    }
-
-    if (!currentResult) {
-      const [version, code, ...other] = line.split(/ +/g);
-      currentResult = {
-        version,
-        code: parseInt(code, 10),
-        reason: other.join(' '),
-        headers: [],
-      };
-    } else {
-      const [name, value] = line.split(/:\s(.+)/);
-      const header: ResponseHeader = {
-        name,
-        value: value || '',
-      };
-      currentResult.headers.push(header);
-    }
-  }
-
-  return results;
 }
 
 // exported for unit tests only

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
@@ -1,4 +1,3 @@
-import { Curl } from '@getinsomnia/node-libcurl';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { HotKeyRegistry } from 'insomnia-common';
 import React, { PureComponent } from 'react';
@@ -8,6 +7,7 @@ import * as session from '../../../account/session';
 import { AUTOBIND_CFG, getAppName, getAppVersion } from '../../../common/constants';
 import * as models from '../../../models/index';
 import { Settings } from '../../../models/settings';
+import { Curl } from '../../../network/curl-shim';
 import { Button } from '../base/button';
 import { Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';

--- a/packages/insomnia-app/app/ui/components/tags/url-tag.tsx
+++ b/packages/insomnia-app/app/ui/components/tags/url-tag.tsx
@@ -23,7 +23,7 @@ export const URLTag: FC<Props> = memo(({
   const max = maxLength || 30;
   let shortUrl = url;
 
-  if (url.length > max) {
+  if (url?.length > max) {
     shortUrl = url.slice(0, max - 3) + '…';
   }
 

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -3610,40 +3610,6 @@
 			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
 			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
 		},
-		"@getinsomnia/node-libcurl": {
-			"version": "2.3.4-1",
-			"resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.3.4-1.tgz",
-			"integrity": "sha512-DhP5Nk7Gy3DRJxTrhk9adnqnRFPppUklhh6YSXgWMjBu7mbWuKSSu384zLHbs6VV7+Sa0EW7mTogKZ5ALlaukg==",
-			"requires": {
-				"@mapbox/node-pre-gyp": "1.0.5",
-				"env-paths": "2.2.0",
-				"nan": "2.15.0",
-				"node-gyp": "7.1.2",
-				"npmlog": "4.1.2",
-				"rimraf": "^3.0.2",
-				"tslib": "2.0.1"
-			},
-			"dependencies": {
-				"nan": {
-					"version": "2.15.0",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-					"integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"tslib": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
-				}
-			}
-		},
 		"@grpc/grpc-js": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.1.8.tgz",
@@ -4620,103 +4586,6 @@
 					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
 					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
-				}
-			}
-		},
-		"@mapbox/node-pre-gyp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz",
-			"integrity": "sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==",
-			"requires": {
-				"detect-libc": "^1.0.3",
-				"https-proxy-agent": "^5.0.0",
-				"make-dir": "^3.1.0",
-				"node-fetch": "^2.6.1",
-				"nopt": "^5.0.0",
-				"npmlog": "^4.1.2",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.4",
-				"tar": "^6.1.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"requires": {
-						"semver": "^6.0.0"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "6.3.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-						}
-					}
-				},
-				"node-fetch": {
-					"version": "2.6.6",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-					"integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
-					"requires": {
-						"whatwg-url": "^5.0.0"
-					}
-				},
-				"nopt": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-					"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-					"requires": {
-						"abbrev": "1"
-					}
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"tr46": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-				},
-				"webidl-conversions": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-				},
-				"whatwg-url": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-					"requires": {
-						"tr46": "~0.0.3",
-						"webidl-conversions": "^3.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -7048,7 +6917,8 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
 		},
 		"abort-controller": {
 			"version": "3.0.0",
@@ -7281,7 +7151,8 @@
 		"ansi-regex": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -7454,7 +7325,8 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
 		},
 		"archiver": {
 			"version": "5.3.0",
@@ -7521,15 +7393,6 @@
 				"lodash.union": "^4.6.0",
 				"normalize-path": "^3.0.0",
 				"readable-stream": "^2.0.0"
-			}
-		},
-		"are-we-there-yet": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-			"integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
 			}
 		},
 		"arg": {
@@ -7643,6 +7506,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -7696,7 +7560,8 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -7775,7 +7640,8 @@
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.10.0",
@@ -8099,6 +7965,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -9060,7 +8927,8 @@
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"catharsis": {
 			"version": "0.8.11",
@@ -9137,11 +9005,6 @@
 				"normalize-path": "~3.0.0",
 				"readdirp": "~3.4.0"
 			}
-		},
-		"chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -9337,11 +9200,6 @@
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
-		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"codemirror": {
 			"version": "5.62.3",
@@ -9790,11 +9648,6 @@
 			"requires": {
 				"date-now": "^0.1.4"
 			}
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -10298,6 +10151,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -10552,11 +10406,6 @@
 			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
 			"optional": true
 		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -10594,11 +10443,6 @@
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
 			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
 			"dev": true
-		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
 		"detect-newline": {
 			"version": "3.1.0",
@@ -10946,6 +10790,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -11598,7 +11443,8 @@
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
 		},
 		"emojis-list": {
 			"version": "3.0.0",
@@ -11652,7 +11498,8 @@
 		"env-paths": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+			"dev": true
 		},
 		"eol": {
 			"version": "0.9.1",
@@ -12220,7 +12067,8 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -12366,7 +12214,8 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -12745,7 +12594,8 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "3.0.0",
@@ -12854,14 +12704,6 @@
 				}
 			}
 		},
-		"fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"requires": {
-				"minipass": "^3.0.0"
-			}
-		},
 		"fs-readfile-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fs-readfile-promise/-/fs-readfile-promise-2.0.1.tgz",
@@ -12944,54 +12786,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.1.4.tgz",
 			"integrity": "sha512-JzK/lHjVZ6joAg3OnCjylwYXYVjRiwTY6Yb25LvfpJHK8bjisfnZJ5bY8aVWwTwCXgxPNgLAtmHL+Hs5q1ddLQ=="
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
 		},
 		"gaxios": {
 			"version": "4.0.1",
@@ -13167,6 +12961,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -13637,11 +13432,6 @@
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
 			"dev": true
 		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -14057,6 +13847,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -14521,7 +14312,8 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-generator-fn": {
 			"version": "2.1.0",
@@ -14676,7 +14468,8 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-what": {
 			"version": "3.14.1",
@@ -14720,7 +14513,8 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isomorphic-form-data": {
 			"version": "2.0.0",
@@ -14788,7 +14582,8 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
@@ -16766,7 +16561,8 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -16776,7 +16572,8 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"json3": {
 			"version": "3.3.3",
@@ -16847,6 +16644,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -17802,37 +17600,6 @@
 				"minimist": "^1.2.5"
 			}
 		},
-		"minipass": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
-			"integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
-			"requires": {
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
-		"minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"requires": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
 		"mississippi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -18136,41 +17903,6 @@
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.0.0.tgz",
 			"integrity": "sha512-ShkiiAlzSsgH1IwGlA0jybk9vQTIOLyJ9nBd0JTuP+nzADJFLY0NoDijM2zvD/JaezooGu3G2p2FNxOAK6459g=="
 		},
-		"node-gyp": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
-			"integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
-			"requires": {
-				"env-paths": "^2.2.0",
-				"glob": "^7.1.4",
-				"graceful-fs": "^4.2.3",
-				"nopt": "^5.0.0",
-				"npmlog": "^4.1.2",
-				"request": "^2.88.2",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.2",
-				"tar": "^6.0.2",
-				"which": "^2.0.2"
-			},
-			"dependencies": {
-				"nopt": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-					"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-					"requires": {
-						"abbrev": "1"
-					}
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
-			}
-		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -18401,26 +18133,10 @@
 				"path-key": "^2.0.0"
 			}
 		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
 		"nullthrows": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
 			"integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nunjucks": {
 			"version": "3.2.2",
@@ -18454,7 +18170,8 @@
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -19247,7 +18964,8 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -19571,7 +19289,8 @@
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -20160,6 +19879,7 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -20173,12 +19893,14 @@
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -20437,6 +20159,7 @@
 			"version": "2.88.2",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -20464,6 +20187,7 @@
 					"version": "2.3.3",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
 						"combined-stream": "^1.0.6",
@@ -20980,7 +20704,8 @@
 		"semver": {
 			"version": "7.3.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+			"dev": true
 		},
 		"semver-compare": {
 			"version": "1.0.0",
@@ -21243,7 +20968,8 @@
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
 		},
 		"simple-concat": {
 			"version": "1.0.1",
@@ -21800,6 +21526,7 @@
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -22001,6 +21728,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+			"dev": true,
 			"requires": {
 				"emoji-regex": "^7.0.1",
 				"is-fullwidth-code-point": "^2.0.0",
@@ -22046,6 +21774,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^4.1.0"
 			}
@@ -22328,31 +22057,6 @@
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
 			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
 			"dev": true
-		},
-		"tar": {
-			"version": "6.1.11",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-			"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-			"requires": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^3.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
 		},
 		"tar-stream": {
 			"version": "2.2.0",
@@ -22756,6 +22460,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -22763,7 +22468,8 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
 		},
 		"type": {
 			"version": "1.2.0",
@@ -23418,6 +23124,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -25194,6 +24901,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -25202,14 +24910,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-		},
-		"wide-align": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-			"requires": {
-				"string-width": "^1.0.2 || 2 || 3 || 4"
-			}
 		},
 		"widest-line": {
 			"version": "3.1.0",

--- a/packages/insomnia-inso/src/jest/__mocks__/@getinsomnia/node-libcurl.ts
+++ b/packages/insomnia-inso/src/jest/__mocks__/@getinsomnia/node-libcurl.ts
@@ -1,3 +1,0 @@
-// Just do nothing for node-libcurl. It fails to import in CI because it will have been
-// built with Electron headers.
-export {};

--- a/packages/insomnia-inso/src/jest/setup.ts
+++ b/packages/insomnia-inso/src/jest/setup.ts
@@ -1,2 +1,1 @@
-jest.mock('@getinsomnia/node-libcurl');
 process.env.DEFAULT_APP_NAME = process.env.DEFAULT_APP_NAME || 'insomnia-app';

--- a/packages/insomnia-inso/webpack/webpack.config.base.js
+++ b/packages/insomnia-inso/webpack/webpack.config.base.js
@@ -28,7 +28,6 @@ module.exports = {
     extensions: ['.js', '.ts'],
   },
   externals: [
-    '@getinsomnia/node-libcurl',
     'mocha',
     nodeExternals(),
   ],

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -4,27 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@getinsomnia/node-libcurl": {
-			"version": "2.3.4-1",
-			"resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.3.4-1.tgz",
-			"integrity": "sha512-DhP5Nk7Gy3DRJxTrhk9adnqnRFPppUklhh6YSXgWMjBu7mbWuKSSu384zLHbs6VV7+Sa0EW7mTogKZ5ALlaukg==",
-			"requires": {
-				"@mapbox/node-pre-gyp": "1.0.5",
-				"env-paths": "2.2.0",
-				"nan": "2.15.0",
-				"node-gyp": "7.1.2",
-				"npmlog": "4.1.2",
-				"rimraf": "^3.0.2",
-				"tslib": "2.0.1"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
-				}
-			}
-		},
 		"@hapi/b64": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
@@ -90,22 +69,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-4.0.0.tgz",
 			"integrity": "sha512-V6xYOrr5aFv/IJqNPneaYCu8vuGTKisamqHVRS3JJnbZr18TrpXdsJOYk9pjPhFti+M2YETPebQLUr820N5NoQ=="
-		},
-		"@mapbox/node-pre-gyp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz",
-			"integrity": "sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==",
-			"requires": {
-				"detect-libc": "^1.0.3",
-				"https-proxy-agent": "^5.0.0",
-				"make-dir": "^3.1.0",
-				"node-fetch": "^2.6.1",
-				"nopt": "^5.0.0",
-				"npmlog": "^4.1.2",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.4",
-				"tar": "^6.1.0"
-			}
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.4",
@@ -320,11 +283,6 @@
 			"resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
 			"integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
 		},
-		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-		},
 		"abort-controller": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -423,37 +381,10 @@
 				"picomatch": "^2.0.4"
 			}
 		},
-		"aproba": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-		},
-		"are-we-there-yet": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-			"integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			}
-		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
-		"asn1": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"ast-types": {
 			"version": "0.13.4",
@@ -495,11 +426,6 @@
 			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
 			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
 		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-		},
 		"aws4": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
@@ -525,14 +451,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"requires": {
-				"tweetnacl": "^0.14.3"
-			}
 		},
 		"binary-extensions": {
 			"version": "2.1.0",
@@ -587,11 +505,6 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
 		"chalk": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -622,11 +535,6 @@
 				"readdirp": "~3.4.0"
 			}
 		},
-		"chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
-		},
 		"clean-git-ref": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
@@ -655,11 +563,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
 			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"color": {
 			"version": "3.1.2",
@@ -723,11 +626,6 @@
 				"date-now": "^0.1.4"
 			}
 		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -746,14 +644,6 @@
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
 			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
 		},
 		"data-uri-to-buffer": {
 			"version": "3.0.1",
@@ -811,11 +701,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -825,11 +710,6 @@
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.10.0.tgz",
 			"integrity": "sha512-c9amUgpgxSi1bE5/sbLwcs5diLD0ygCQYmhfM5H1s5VH1mCsYkcmAL3CcNdv4kdSw6JuMoHeDGzLgj/gAXdWVg=="
-		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
 		"diff3": {
 			"version": "0.0.3",
@@ -884,15 +764,6 @@
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
 		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -902,11 +773,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
 			"integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
-		},
-		"env-paths": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
 		},
 		"eol": {
 			"version": "0.9.1",
@@ -989,16 +855,6 @@
 				"jsep": "^0.3.0"
 			}
 		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1075,11 +931,6 @@
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
 			"integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
 		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-		},
 		"form-data": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
@@ -1104,14 +955,6 @@
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
-			}
-		},
-		"fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"requires": {
-				"minipass": "^3.0.0"
 			}
 		},
 		"fs-readfile-promise": {
@@ -1179,54 +1022,6 @@
 			"resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.1.4.tgz",
 			"integrity": "sha512-JzK/lHjVZ6joAg3OnCjylwYXYVjRiwTY6Yb25LvfpJHK8bjisfnZJ5bY8aVWwTwCXgxPNgLAtmHL+Hs5q1ddLQ=="
 		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
-		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1273,14 +1068,6 @@
 					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 				}
-			}
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"requires": {
-				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -1348,11 +1135,6 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-		},
 		"hkdf": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/hkdf/-/hkdf-0.0.2.tgz",
@@ -1408,16 +1190,6 @@
 				"@tootallnate/once": "1",
 				"agent-base": "6",
 				"debug": "4"
-			}
-		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
 			}
 		},
 		"https-proxy-agent": {
@@ -1595,20 +1367,10 @@
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
 			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-		},
 		"isarray": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isomorphic-git": {
 			"version": "1.10.2",
@@ -1653,20 +1415,10 @@
 				}
 			}
 		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-		},
 		"join-component": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
 			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
-		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"jsep": {
 			"version": "0.3.5",
@@ -1692,11 +1444,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"jsonc-parser": {
 			"version": "2.2.1",
@@ -1730,24 +1477,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
 			"integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
-		},
-		"jsprim": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.4.0",
-				"verror": "1.10.0"
-			},
-			"dependencies": {
-				"json-schema": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-					"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-				}
-			}
 		},
 		"leven": {
 			"version": "3.1.0",
@@ -1813,21 +1542,6 @@
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"requires": {
 				"yallist": "^3.0.2"
-			}
-		},
-		"make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"requires": {
-				"semver": "^6.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"map-stream": {
@@ -1910,37 +1624,6 @@
 				"minimist": "^1.2.5"
 			}
 		},
-		"minipass": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
-			"integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
-			"requires": {
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
-		"minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"requires": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
 		"mkdirp": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -1966,11 +1649,6 @@
 				"safe-buffer": "5.1.2",
 				"uid-safe": "2.1.5"
 			}
-		},
-		"nan": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-			"integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
 		},
 		"nanoid": {
 			"version": "2.1.11",
@@ -2028,23 +1706,6 @@
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.0.0.tgz",
 			"integrity": "sha512-ShkiiAlzSsgH1IwGlA0jybk9vQTIOLyJ9nBd0JTuP+nzADJFLY0NoDijM2zvD/JaezooGu3G2p2FNxOAK6459g=="
 		},
-		"node-gyp": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
-			"integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
-			"requires": {
-				"env-paths": "^2.2.0",
-				"glob": "^7.1.4",
-				"graceful-fs": "^4.2.3",
-				"nopt": "^5.0.0",
-				"npmlog": "^4.1.2",
-				"request": "^2.88.2",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.2",
-				"tar": "^6.0.2",
-				"which": "^2.0.2"
-			}
-		},
 		"nomnom": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
@@ -2076,35 +1737,11 @@
 				}
 			}
 		},
-		"nopt": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-			"requires": {
-				"abbrev": "1"
-			}
-		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"optional": true
-		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nunjucks": {
 			"version": "3.2.2",
@@ -2128,16 +1765,6 @@
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
 			"integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ=="
-		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"once": {
 			"version": "1.4.0",
@@ -2235,11 +1862,6 @@
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
 		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-		},
 		"picomatch": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -2280,11 +1902,6 @@
 			"resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
 			"integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
 		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-		},
 		"proxy-agent": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
@@ -2314,11 +1931,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-		},
-		"qs": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
 		},
 		"queue-microtask": {
 			"version": "1.2.3",
@@ -2351,35 +1963,6 @@
 				"unpipe": "1.0.0"
 			}
 		},
-		"readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
-		},
 		"readdirp": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
@@ -2393,59 +1976,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
 			"integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA=="
-		},
-		"request": {
-			"version": "2.88.2",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.5.0",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"form-data": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.6",
-						"mime-types": "^2.1.12"
-					}
-				},
-				"tough-cookie": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-					"requires": {
-						"psl": "^1.1.28",
-						"punycode": "^2.1.1"
-					}
-				},
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-				}
-			}
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -2461,14 +1991,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
-		},
-		"rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"requires": {
-				"glob": "^7.1.3"
-			}
 		},
 		"run-parallel": {
 			"version": "1.2.0",
@@ -2493,29 +2015,6 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
-		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-			"requires": {
-				"lru-cache": "^6.0.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -2539,11 +2038,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
 			"integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
-		},
-		"signal-exit": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-			"integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
 		},
 		"simple-concat": {
 			"version": "1.0.1",
@@ -2606,22 +2100,6 @@
 				"through": "2"
 			}
 		},
-		"sshpk": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
-		},
 		"statuses": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -2681,26 +2159,6 @@
 				"has-flag": "^4.0.0"
 			}
 		},
-		"tar": {
-			"version": "6.1.11",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-			"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-			"requires": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^3.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2758,19 +2216,6 @@
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
 			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -2836,41 +2281,15 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
-			}
-		},
 		"whatwg-fetch": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
 			"integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
 		},
-		"which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"requires": {
-				"isexe": "^2.0.0"
-			}
-		},
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-		},
-		"wide-align": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-			"requires": {
-				"string-width": "^1.0.2 || 2 || 3 || 4"
-			}
 		},
 		"wolfy87-eventemitter": {
 			"version": "5.2.9",


### PR DESCRIPTION
This PR removes `node-libcurl` and replaces it with a `curl-shim` which attempts to handle the use cases the libcurl binary was handling but using axios instead.

Closes INS-1408