### PR TITLE
chore(url) fix node 11 deprecations

### DIFF
--- a/packages/insomnia-app/app/account/fetch.ts
+++ b/packages/insomnia-app/app/account/fetch.ts
@@ -1,4 +1,3 @@
-import { parse as urlParse } from 'url';
 import zlib from 'zlib';
 
 import { delay } from '../common/misc';
@@ -101,11 +100,10 @@ function _getUrl(path) {
 
   return `${_baseUrl}${path}`;
 }
-
 function _notifyCommandListeners(uri) {
-  const parsed = urlParse(uri, true);
+  const parsed = new URL(uri);
   const command = `${parsed.hostname}${parsed.pathname}`;
-  const args = JSON.parse(JSON.stringify(parsed.query));
+  const args = JSON.parse(JSON.stringify(parsed.searchParams.toString()));
 
   _commandListeners.map(fn => fn(command, args));
 }

--- a/packages/insomnia-app/app/account/fetch.ts
+++ b/packages/insomnia-app/app/account/fetch.ts
@@ -101,9 +101,9 @@ function _getUrl(path) {
   return `${_baseUrl}${path}`;
 }
 function _notifyCommandListeners(uri) {
-  const parsed = new URL(uri);
-  const command = `${parsed.hostname}${parsed.pathname}`;
-  const args = JSON.parse(JSON.stringify(parsed.searchParams.toString()));
+  const { hostname, pathname, search } = new URL(uri);
+  const command = `${hostname}${pathname}`;
+  const args = JSON.parse(JSON.stringify(search.substring(1)));
 
   _commandListeners.map(fn => fn(command, args));
 }

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -3,7 +3,7 @@ import electron, { BrowserWindow, MenuItemConstructorOptions } from 'electron';
 import fs from 'fs';
 import * as os from 'os';
 import path from 'path';
-import url from 'url';
+import { pathToFileURL } from 'url';
 
 import {
   changelogUrl,
@@ -125,7 +125,7 @@ export function createWindow() {
 
   // Load the html of the app.
   const appPath = path.resolve(__dirname, './renderer.html');
-  const appUrl = process.env.APP_RENDER_URL || url.pathToFileURL(appPath).href;
+  const appUrl = process.env.APP_RENDER_URL || pathToFileURL(appPath).href;
   console.log(`[main] Loading ${appUrl}`);
   mainWindow?.loadURL(appUrl);
   // Emitted when the window is closed.

--- a/packages/insomnia-app/app/network/__tests__/certificate-url-parse.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/certificate-url-parse.test.ts
@@ -1,5 +1,3 @@
-import { parse as urlParse } from 'url';
-
 import { globalBeforeEach } from '../../__jest__/before-each';
 import certificateUrlParse from '../certificate-url-parse';
 
@@ -8,7 +6,7 @@ describe('certificateUrlParse', () => {
 
   it('should return the result of url.parse if no wildcard paths are supplied', () => {
     const url = 'https://www.example.org:80/some/resources?query=1&other=2#myfragment';
-    const expected = urlParse(url);
+    const expected = new URL(url);
     expect(certificateUrlParse(url)).toEqual(expected);
   });
 
@@ -16,10 +14,10 @@ describe('certificateUrlParse', () => {
     const protocol = 'https';
     const host = 'www.exam*ple.org';
     const port = '123';
-    const path = '/some/resources';
-    const query = 'query=1&other=2';
+    const pathname = '/some/resources';
+    const search = '?query=1&other=2';
     const fragment = 'myfragment';
-    const url = `${protocol}://${host}:${port}${path}?${query}#${fragment}`;
+    const url = `${protocol}://${host}:${port}${pathname}${search}#${fragment}`;
     expect(certificateUrlParse(url).hostname).toEqual(host);
   });
 
@@ -27,10 +25,10 @@ describe('certificateUrlParse', () => {
     const protocol = 'https';
     const host = 'www.e*xamp*le.or*g';
     const port = '123';
-    const path = '/some/resources';
-    const query = 'query=1&other=2';
+    const pathname = '/some/resources';
+    const search = '?query=1&other=2';
     const fragment = 'myfragment';
-    const url = `${protocol}://${host}:${port}${path}?${query}#${fragment}`;
+    const url = `${protocol}://${host}:${port}${pathname}${search}#${fragment}`;
     expect(certificateUrlParse(url).hostname).toEqual(host);
   });
 
@@ -38,10 +36,10 @@ describe('certificateUrlParse', () => {
     const protocol = 'https';
     const host = '*.example.org';
     const port = '123';
-    const path = '/some/resources';
-    const query = 'query=1&other=2';
+    const pathname = '/some/resources';
+    const search = '?query=1&other=2';
     const fragment = 'myfragment';
-    const url = `${protocol}://${host}:${port}${path}?${query}#${fragment}`;
+    const url = `${protocol}://${host}:${port}${pathname}${search}#${fragment}`;
     expect(certificateUrlParse(url).hostname).toEqual(host);
   });
 
@@ -49,19 +47,19 @@ describe('certificateUrlParse', () => {
     const protocol = 'https';
     const host = 'www.example.*';
     const port = '123';
-    const path = '/some/resources';
-    const query = 'query=1&other=2';
+    const pathname = '/some/resources';
+    const search = '?query=1&other=2';
     const fragment = 'myfragment';
-    const url = `${protocol}://${host}:${port}${path}?${query}#${fragment}`;
+    const url = `${protocol}://${host}:${port}${pathname}${search}#${fragment}`;
     expect(certificateUrlParse(url).hostname).toEqual(host);
   });
 
   it('should return a host of null if no protocol is provided for a wildcard hostname', () => {
     const host = 'www.example.*';
-    const path = '/some/resources';
-    const query = 'query=1&other=2';
+    const pathname = '/some/resources';
+    const search = '?query=1&other=2';
     const fragment = 'myfragment';
-    const url = `${host}${path}?${query}#${fragment}`;
+    const url = `${host}${pathname}${search}#${fragment}`;
     expect(certificateUrlParse(url).hostname).toEqual(null);
   });
 
@@ -70,20 +68,20 @@ describe('certificateUrlParse', () => {
     const user = 'myuser';
     const password = 'mypass';
     const host = 'www.example.*';
-    const path = '/some/resources';
-    const query = 'query=1&other=2';
+    const pathname = '/some/resources';
+    const search = '?query=1&other=2';
     const fragment = 'myfragment';
-    const url = `${protocol}://${user}:${password}@${host}${path}?${query}#${fragment}`;
+    const url = `${protocol}://${user}:${password}@${host}${pathname}${search}#${fragment}`;
     expect(certificateUrlParse(url).hostname).toEqual(host);
   });
 
   it('should return the correct host if the path contains an @ symbol', () => {
     const protocol = 'https';
     const host = 'www.example.*';
-    const path = '/@some/resources';
-    const query = 'query=1&other=2';
+    const pathname = '/@some/resources';
+    const search = '?query=1&other=2';
     const fragment = 'myfragment';
-    const url = `${protocol}://${host}${path}?${query}#${fragment}`;
+    const url = `${protocol}://${host}${pathname}${search}#${fragment}`;
     expect(certificateUrlParse(url).hostname).toEqual(host);
   });
 
@@ -94,12 +92,12 @@ describe('certificateUrlParse', () => {
     const nonWildcardHost = 'www.example.';
     const host = 'www.example.*';
     const port = '123';
-    const path = '/some/resources';
-    const query = 'query=1&other=2';
+    const pathname = '/some/resources';
+    const search = 'query=1&other=2';
     const fragment = 'myfragment';
-    const url = `${protocol}://${user}:${password}@${host}:${port}${path}?${query}#${fragment}`;
-    const nonWildcardUrl = `${protocol}://${user}:${password}@${nonWildcardHost}:${port}${path}?${query}#${fragment}`;
-    const expected = urlParse(nonWildcardUrl);
+    const url = `${protocol}://${user}:${password}@${host}:${port}${pathname}${search}#${fragment}`;
+    const nonWildcardUrl = `${protocol}://${user}:${password}@${nonWildcardHost}:${port}${pathname}${search}#${fragment}`;
+    const expected = new URL(nonWildcardUrl);
     expected.hostname = host;
     expected.href = url;
     expected.host = `${host}:${port}`;
@@ -110,10 +108,10 @@ describe('certificateUrlParse', () => {
     const protocol = 'https';
     const host = 'localhost';
     const port = '*';
-    const path = '/some/resources';
-    const query = 'query=1&other=2';
+    const pathname = '/some/resources';
+    const search = 'query=1&other=2';
     const fragment = 'myfragment';
-    const url = `${protocol}://${host}:${port}${path}?${query}#${fragment}`;
+    const url = `${protocol}://${host}:${port}${pathname}${search}#${fragment}`;
     expect(certificateUrlParse(url).port).toEqual(port);
   });
 });

--- a/packages/insomnia-app/app/network/axios-request.ts
+++ b/packages/insomnia-app/app/network/axios-request.ts
@@ -1,7 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import * as https from 'https';
 import { setDefaultProtocol } from 'insomnia-url';
-import { parse as urlParse } from 'url';
 
 import { isDevelopment } from '../common/constants';
 import * as models from '../models';
@@ -29,7 +28,7 @@ export async function axiosRequest(config: AxiosRequestConfig) {
   // ignore HTTP_PROXY, HTTPS_PROXY, NO_PROXY environment variables
   finalConfig.proxy = false;
   if (settings.proxyEnabled && proxyUrl && !isUrlMatchedInNoProxyRule(finalConfig.url, settings.noProxy)) {
-    const { hostname, port } = urlParse(setDefaultProtocol(proxyUrl));
+    const { hostname, port } = new URL(setDefaultProtocol(proxyUrl));
 
     if (hostname && port) {
       finalConfig.proxy = {

--- a/packages/insomnia-app/app/network/certificate-url-parse.ts
+++ b/packages/insomnia-app/app/network/certificate-url-parse.ts
@@ -1,14 +1,12 @@
-import { parse as urlParse } from 'url';
-
 const WILDCARD_CHARACTER = '*';
 const WILDCARD_SUBSTITUTION = Math.random().toString().split('.')[1];
 const WILDCARD_SUBSTITUTION_PATTERN = new RegExp(`${WILDCARD_SUBSTITUTION}`, 'g');
 
 export default function certificateUrlParse(url) {
   if (url.indexOf(WILDCARD_CHARACTER) === -1) {
-    return urlParse(url);
+    return new URL(url);
   } else {
-    const parsed = urlParse(url.replace(/\*/g, WILDCARD_SUBSTITUTION));
+    const parsed = new URL(url.replace(/\*/g, WILDCARD_SUBSTITUTION));
     parsed.hostname = _reinstateWildcards(parsed.hostname);
     parsed.host = _reinstateWildcards(parsed.host);
     parsed.href = _reinstateWildcards(parsed.href);

--- a/packages/insomnia-app/app/network/grpc/parse-grpc-url.ts
+++ b/packages/insomnia-app/app/network/grpc/parse-grpc-url.ts
@@ -4,27 +4,19 @@ const parseGrpcUrl = (
   url: string;
   enableTls: boolean;
 } => {
-  const { protocol, host, href } = new URL(grpcUrl?.toLowerCase() || '');
 
-  switch (protocol) {
-    case 'grpcs:':
-      return {
-        url: host,
-        enableTls: true,
-      };
-
-    case 'grpc:':
-      return {
-        url: host,
-        enableTls: false,
-      };
-
-    default:
-      return {
-        url: href,
-        enableTls: false,
-      };
+  if (!grpcUrl){
+    return { url: '', enableTls: false };
   }
+  const lowercaseUrl = grpcUrl.toLowerCase();
+  const isGRPCURL = lowercaseUrl.startsWith('grpc:');
+  const isGRPCSURL = lowercaseUrl.startsWith('grpcs:');
+  if (!isGRPCURL && !isGRPCSURL){
+    return { url: lowercaseUrl || '', enableTls: false };
+  }
+
+  return { url: new URL(lowercaseUrl).host, enableTls: isGRPCSURL };
+
 };
 
 export default parseGrpcUrl;

--- a/packages/insomnia-app/app/network/grpc/parse-grpc-url.ts
+++ b/packages/insomnia-app/app/network/grpc/parse-grpc-url.ts
@@ -1,24 +1,20 @@
-import url from 'url';
-
 const parseGrpcUrl = (
   grpcUrl?: string,
 ): {
   url: string;
   enableTls: boolean;
 } => {
-  const { protocol, host, href } = url.parse(grpcUrl?.toLowerCase() || '');
+  const { protocol, host, href } = new URL(grpcUrl?.toLowerCase() || '');
 
   switch (protocol) {
     case 'grpcs:':
       return {
-        // @ts-expect-error -- TSCONVERSION host can be undefined
         url: host,
         enableTls: true,
       };
 
     case 'grpc:':
       return {
-        // @ts-expect-error -- TSCONVERSION host can be undefined
         url: host,
         enableTls: false,
       };

--- a/packages/insomnia-app/app/network/is-url-matched-in-no-proxy-rule.ts
+++ b/packages/insomnia-app/app/network/is-url-matched-in-no-proxy-rule.ts
@@ -1,5 +1,3 @@
-import { parse as urlParse } from 'url';
-
 function formatHostname(rawHostname) {
   // canonicalize the hostname, so that 'oogle.com' won't match 'google.com'
   const hostname = rawHostname.replace(/^\.*/, '.').toLowerCase();
@@ -26,7 +24,7 @@ export function isUrlMatchedInNoProxyRule(url: string | undefined, noProxyRule: 
   if (!url || !noProxyRule || typeof noProxyRule !== 'string') {
     return false;
   }
-  const uri = urlParse(url);
+  const uri = new URL(url);
   if (!uri.hostname && !uri.port && !uri.protocol) {
     return false;
   }

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -21,7 +21,6 @@ import {
 } from 'insomnia-url';
 import mkdirp from 'mkdirp';
 import { join as pathJoin } from 'path';
-import { parse as urlParse, resolve as urlResolve } from 'url';
 import * as uuid from 'uuid';
 
 import {
@@ -458,7 +457,7 @@ export async function _actuallySend(
 
       // Set proxy settings if we have them
       if (settings.proxyEnabled) {
-        const { protocol } = urlParse(renderedRequest.url);
+        const { protocol } = new URL(renderedRequest.url);
         const { httpProxy, httpsProxy, noProxy } = settings;
         const proxyHost = protocol === 'https:' ? httpsProxy : httpProxy;
         const proxy = proxyHost ? setDefaultProtocol(proxyHost) : null;
@@ -748,7 +747,7 @@ export async function _actuallySend(
           const newLocation = getLocationHeader(headers);
 
           if (newLocation !== null) {
-            currentUrl = urlResolve(currentUrl, newLocation.value);
+            currentUrl = new URL(newLocation.value, currentUrl).href;
           }
         }
 
@@ -1113,7 +1112,7 @@ export function _getAwsAuthHeaders(
   description?: string;
   disabled?: boolean;
 }[] {
-  const parsedUrl = urlParse(url);
+  const parsedUrl = new URL(url);
   const contentTypeHeader = getContentTypeHeader(headers);
   // AWS uses host header for signing so prioritize that if the user set it manually
   const hostHeader = getHostHeader(headers);
@@ -1124,7 +1123,7 @@ export function _getAwsAuthHeaders(
     host,
     body,
     method,
-    path: parsedUrl.path,
+    path: parsedUrl.pathname + parsedUrl.search,
     headers: contentTypeHeader
       ? {
         'content-type': contentTypeHeader.value,

--- a/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
-import { parse as urlParse } from 'url';
 
 import { escapeRegex } from '../../common/misc';
 import * as models from '../../models/index';
@@ -151,8 +150,8 @@ async function _authorize(
   const failureRegex = new RegExp(`${escapeRegex(redirectUri)}.*(error=)`, 'i');
   const redirectedTo = await authorizeUserInWindow(finalUrl, successRegex, failureRegex);
   console.log('[oauth2] Detected redirect ' + redirectedTo);
-  const { query } = urlParse(redirectedTo);
-  return responseToObject(query, [
+  const { searchParams } = new URL(redirectedTo);
+  return responseToObject(searchParams.toString(), [
     c.P_CODE,
     c.P_STATE,
     c.P_ERROR,

--- a/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
@@ -150,8 +150,8 @@ async function _authorize(
   const failureRegex = new RegExp(`${escapeRegex(redirectUri)}.*(error=)`, 'i');
   const redirectedTo = await authorizeUserInWindow(finalUrl, successRegex, failureRegex);
   console.log('[oauth2] Detected redirect ' + redirectedTo);
-  const { searchParams } = new URL(redirectedTo);
-  return responseToObject(searchParams.toString(), [
+  const { search } = new URL(redirectedTo);
+  return responseToObject(search.substring(1), [
     c.P_CODE,
     c.P_STATE,
     c.P_ERROR,

--- a/packages/insomnia-app/app/network/url-matches-cert-host.ts
+++ b/packages/insomnia-app/app/network/url-matches-cert-host.ts
@@ -1,5 +1,4 @@
 import { setDefaultProtocol } from 'insomnia-url';
-import { parse as urlParse } from 'url';
 
 import { escapeRegex } from '../common/misc';
 import certificateUrlParse from './certificate-url-parse';
@@ -8,12 +7,10 @@ const DEFAULT_PORT = 443;
 
 export function urlMatchesCertHost(certificateHost, requestUrl) {
   const cHostWithProtocol = setDefaultProtocol(certificateHost, 'https:');
-  const { hostname, port } = urlParse(requestUrl);
+  const { hostname, port } = new URL(requestUrl);
   const { hostname: cHostname, port: cPort } = certificateUrlParse(cHostWithProtocol);
-  // @ts-expect-error -- TSCONVERSION `parseInt(null)` returns `NaN`
-  const assumedPort = parseInt(port) || DEFAULT_PORT;
-  // @ts-expect-error -- TSCONVERSION `parseInt(null)` returns `NaN`
-  const assumedCPort = parseInt(cPort) || DEFAULT_PORT;
+  const assumedPort = +port || DEFAULT_PORT;
+  const assumedCPort = +cPort || DEFAULT_PORT;
   const cHostnameRegex = escapeRegex(cHostname || '').replace(/\\\*/g, '.*');
   const cPortRegex = escapeRegex(cPort || '').replace(/\\\*/g, '.*');
 

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -7,7 +7,6 @@ import * as path from 'path';
 import React, { createRef, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { Action, bindActionCreators, Dispatch } from 'redux';
-import { parse as urlParse } from 'url';
 
 import {  SegmentEvent, trackSegmentEvent } from '../../common/analytics';
 import {
@@ -1309,9 +1308,9 @@ class App extends PureComponent<AppProps, State> {
       App._handleShowSettingsModal(TAB_INDEX_SHORTCUTS);
     });
     ipcRenderer.on('run-command', (_, commandUri) => {
-      const parsed = urlParse(commandUri, true);
+      const parsed = new URL(commandUri);
       const command = `${parsed.hostname}${parsed.pathname}`;
-      const args = JSON.parse(JSON.stringify(parsed.query));
+      const args = JSON.parse(JSON.stringify(parsed.searchParams.toString()));
       args.workspaceId = args.workspaceId || this.props.activeWorkspace?._id;
       this.props.handleCommand(command, args);
     });

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -1308,9 +1308,9 @@ class App extends PureComponent<AppProps, State> {
       App._handleShowSettingsModal(TAB_INDEX_SHORTCUTS);
     });
     ipcRenderer.on('run-command', (_, commandUri) => {
-      const parsed = new URL(commandUri);
-      const command = `${parsed.hostname}${parsed.pathname}`;
-      const args = JSON.parse(JSON.stringify(parsed.searchParams.toString()));
+      const { hostname, pathname, search } = new URL(commandUri);
+      const command = `${hostname}${pathname}`;
+      const args = JSON.parse(JSON.stringify(search.substring(1)));
       args.workspaceId = args.workspaceId || this.props.activeWorkspace?._id;
       this.props.handleCommand(command, args);
     });

--- a/packages/insomnia-importers/src/importers/openapi-3.ts
+++ b/packages/insomnia-importers/src/importers/openapi-3.ts
@@ -3,7 +3,7 @@ import { camelCase } from 'change-case';
 import crypto from 'crypto';
 import { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import { isPlainObject } from 'ramda-adjunct';
-import { parse as urlParse } from 'url';
+import { URL } from 'url';
 import YAML from 'yaml';
 
 import { Authentication, Converter, ImportRequest } from '../entities';
@@ -63,11 +63,11 @@ const getDefaultServerUrl = (api: OpenAPIV3.Document) => {
   const foundServer = firstServer && firstServer.url;
 
   if (!foundServer) {
-    return urlParse(exampleServer);
+    return new URL(exampleServer);
   }
 
   const url = resolveVariables(firstServer);
-  return urlParse(url);
+  return new URL(url);
 };
 
 /**

--- a/packages/insomnia-url/src/querystring.ts
+++ b/packages/insomnia-url/src/querystring.ts
@@ -1,5 +1,3 @@
-import { format as urlFormat, parse as urlParse } from 'url';
-
 import { setDefaultProtocol } from './protocol';
 
 const ESCAPE_REGEX_MATCH = /[-[\]/{}()*+?.\\^$|]/g;
@@ -181,7 +179,7 @@ export const smartEncodeUrl = (url: string, encode?: boolean) => {
     return urlWithProto;
   } else {
     // Parse the URL into components
-    const parsedUrl = urlParse(urlWithProto);
+    const parsedUrl = new URL(urlWithProto);
 
     // ~~~~~~~~~~~ //
     // 1. Pathname //
@@ -194,25 +192,7 @@ export const smartEncodeUrl = (url: string, encode?: boolean) => {
         .join('/');
     }
 
-    // ~~~~~~~~~~~~~~ //
-    // 2. Querystring //
-    // ~~~~~~~~~~~~~~ //
-
-    if (parsedUrl.query) {
-      const qsParams = deconstructQueryStringToParams(parsedUrl.query);
-      const encodedQsParams = [];
-      for (const { name, value } of qsParams) {
-        encodedQsParams.push({
-          name: flexibleEncodeComponent(name),
-          value: flexibleEncodeComponent(value),
-        });
-      }
-
-      parsedUrl.query = buildQueryStringFromParams(encodedQsParams);
-      parsedUrl.search = `?${parsedUrl.query}`;
-    }
-
-    return urlFormat(parsedUrl);
+    return parsedUrl.href;
   }
 };
 

--- a/packages/insomnia-url/src/querystring.ts
+++ b/packages/insomnia-url/src/querystring.ts
@@ -191,6 +191,22 @@ export const smartEncodeUrl = (url: string, encode?: boolean) => {
         .map(s => flexibleEncodeComponent(s, URL_PATH_CHARACTER_WHITELIST))
         .join('/');
     }
+    // ~~~~~~~~~~~~~~ //
+    // 2. Querystring //
+    // ~~~~~~~~~~~~~~ //
+
+    if (parsedUrl.search) {
+      const qsParams = deconstructQueryStringToParams(parsedUrl.search.substring(1));
+      const encodedQsParams = [];
+      for (const { name, value } of qsParams) {
+        encodedQsParams.push({
+          name: flexibleEncodeComponent(name),
+          value: flexibleEncodeComponent(value),
+        });
+      }
+
+      parsedUrl.search = `?${buildQueryStringFromParams(encodedQsParams)}`;
+    }
 
     return parsedUrl.href;
   }


### PR DESCRIPTION
url functions parse, resolve, format have been deprecated in node 11 to instead use WHATWG URL API https://nodejs.org/en/blog/release/v11.0.0/
```
> require('url').parse('http://test.com/bob?a=1&b=2 1 2')
Url {
  protocol: 'http:',
  slashes: true,
  auth: null,
  host: 'test.com',
  port: null,
  hostname: 'test.com',
  hash: null,
  search: '?a=1&b=2%201%202',
  query: 'a=1&b=2%201%202',
  pathname: '/bob',
  path: '/bob?a=1&b=2%201%202',
  href: 'http://test.com/bob?a=1&b=2%201%202'
}

> new URL('http://test.com/bob?a=1&b=2 1 2')
URL {
  href: 'http://test.com/bob?a=1&b=2%201%202',
  origin: 'http://test.com',
  protocol: 'http:',
  username: '',
  password: '',
  host: 'test.com',
  hostname: 'test.com',
  port: '',
  pathname: '/bob',
  search: '?a=1&b=2%201%202',
  searchParams: URLSearchParams { 'a' => '1', 'b' => '2 1 2' },
  hash: ''
}
```

Note: WHATWG URL API has some differences
- path can be gathered by adding pathname+search
- query can be gathered using `.search.substring(1)`, 
- `.searchParams.toString()` is similar to `.search.substring(1)` but will replace spaces with `+`
- all fields default to an empty string rather than null
- doesn't need to be imported as it is in global scope
- new URL will throw with an empty input

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
