### PR TITLE
Always generate base environment id when importing

### DIFF
--- a/packages/insomnia-smoke-test/tests/prerelease/cookie-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/cookie-editor-interactions.test.ts
@@ -9,6 +9,7 @@ test.describe('Cookie editor', async () => {
     const text = await loadFixture('simple.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
     await page.click('button:has-text("Clipboard")');
+    await page.click('div[role="dialog"] button:has-text("New")');
     await page.click('text=Collectionsimplejust now');
   });
 

--- a/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
@@ -6,7 +6,7 @@ import { test } from '../../playwright/test';
 test.describe('Dashboard', async () => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
   test.describe('Projects', async () => {
-    test.skip('Can create, rename and delete new project', async ({ page }) => {
+    test('Can create, rename and delete new project', async ({ page }) => {
       // Return to Dashboard
       await page.click('[data-testid="project"] >> text=Insomnia');
       await expect(page.locator('.app')).toContainText('All Files (1)');

--- a/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
@@ -6,7 +6,7 @@ import { test } from '../../playwright/test';
 test.describe('Dashboard', async () => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
   test.describe('Projects', async () => {
-    test('Can create, rename and delete new project', async ({ page }) => {
+    test.skip('Can create, rename and delete new project', async ({ page }) => {
       // Return to Dashboard
       await page.click('[data-testid="project"] >> text=Insomnia');
       await expect(page.locator('.app')).toContainText('All Files (1)');
@@ -24,6 +24,9 @@ test.describe('Dashboard', async () => {
       await page.click('button:has-text("Project Settings")');
       await page.click('[placeholder="My Project"]');
       await page.locator('[placeholder="My Project"]').fill('My Project123');
+
+      // Check that the project name is updated on modal
+      await expect(page.locator('.app')).toContainText('My Project123');
 
       // Close project settings modal
       await page.locator('.app').press('Escape');
@@ -54,6 +57,7 @@ test.describe('Dashboard', async () => {
       const text = await loadFixture('multiple-workspaces.yaml');
       await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
       await page.click('button:has-text("Clipboard")');
+      await page.click('div[role="dialog"] button:has-text("New")');
 
       // Check that 10 new workspaces are imported besides the default one
       const workspaceCards = page.locator('.card-badge');

--- a/packages/insomnia-smoke-test/tests/prerelease/debug-sidebar-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/debug-sidebar-interactions.test.ts
@@ -11,6 +11,7 @@ test.describe('Debug-Sidebar', async () => {
     const text = await loadFixture('simple.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
     await page.click('button:has-text("Clipboard")');
+    await page.click('div[role="dialog"] button:has-text("New")');
     await page.click('text=Collectionsimplejust now');
   });
 

--- a/packages/insomnia-smoke-test/tests/prerelease/design-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/design-interactions.test.ts
@@ -57,6 +57,7 @@ test.describe('Design interactions', async () => {
     const text = await loadFixture('unit-test.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
     await page.click('button:has-text("Clipboard")');
+    await page.click('div[role="dialog"] button:has-text("New")');
     await page.click('text=unit-test.yamljust now');
 
     // Switch to Test tab

--- a/packages/insomnia-smoke-test/tests/smoke/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/app.test.ts
@@ -17,6 +17,7 @@ test('can send requests', async ({ app, page }) => {
   await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
 
   await page.click('button:has-text("Clipboard")');
+  await page.click('div[role="dialog"] button:has-text("New")');
   await page.click('text=CollectionSmoke testsjust now');
 
   await page.click('button:has-text("GETsend JSON request")');
@@ -69,6 +70,7 @@ test('can cancel requests', async ({ app, page }) => {
   await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
 
   await page.click('button:has-text("Clipboard")');
+  await page.click('div[role="dialog"] button:has-text("New")');
   await page.click('text=CollectionSmoke testsjust now');
 
   await page.click('button:has-text("GETdelayed request")');

--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -16,6 +16,8 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
 
   // Import from clipboard
   await page.click('button:has-text("Clipboard")');
+  // Import as new collection
+  await page.click('div[role="dialog"] button:has-text("New")');
   // Open the new collection workspace
   await page.click('text=CollectionSmoke GraphQLjust now');
   // Open the graphql request

--- a/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
@@ -17,6 +17,7 @@ test('can send gRPC requests', async ({ app, page }) => {
   await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
 
   await page.click('button:has-text("Clipboard")');
+  await page.click('div[role="dialog"] button:has-text("New")');
   await page.click('text=CollectionSmoke gRPCjust now');
 
   await page.click('button:has-text("gRPCsay hi!")');

--- a/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
@@ -24,6 +24,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
 
   await page.locator('button:has-text("Clipboard")').click();
+  await page.click('div[role="dialog"] button:has-text("New")');
   await page.locator('text=CollectionOauth Testingjust now').click();
 
   // Authorization code

--- a/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
@@ -17,6 +17,7 @@ test('can make websocket connection', async ({ app, page }) => {
   await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
 
   await page.click('button:has-text("Clipboard")');
+  await page.click('div[role="dialog"] button:has-text("New")');
   await page.click('text=CollectionWebSocketsjust now');
 
   await page.click('button:has-text("localhost:4010")');

--- a/packages/insomnia/src/common/__fixtures__/insomnia/insomnia-example-input.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia/insomnia-example-input.yaml
@@ -1,0 +1,70 @@
+_type: export
+__export_format: 4
+__export_date: 2022-11-29T16:27:19.066Z
+__export_source: insomnia.desktop.app:v2022.7.0-beta.5
+resources:
+  - _id: req_123
+    parentId: wrk_123
+    modified: 1669739211182
+    created: 1669739179867
+    url: mockbin.org/request/any/{{ _.base }}/{{ _.sub }}
+    name: New Request
+    description: ""
+    method: GET
+    body: {}
+    parameters: []
+    headers: []
+    authentication: {}
+    metaSortKey: -1669739179868
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: wrk_123
+    parentId: null
+    modified: 1669739177487
+    created: 1669739177487
+    name: Example
+    description: ""
+    scope: collection
+    _type: workspace
+  - _id: env_123_from_export
+    parentId: wrk_123
+    modified: 1669739193740
+    created: 1669739177493
+    name: Base Environment
+    data:
+      base: 123
+    dataPropertyOrder:
+      "&":
+        - base
+    color: null
+    isPrivate: false
+    metaSortKey: 1669739177493
+    _type: environment
+  - _id: spc_5c1a165d02d34d228374d37566154a4a
+    parentId: wrk_123
+    modified: 1669739177487
+    created: 1669739177487
+    fileName: Example
+    contents: ""
+    contentType: yaml
+    _type: api_spec
+  - _id: env_sub123
+    parentId: env_123_from_export
+    modified: 1669739204645
+    created: 1669739194224
+    name: sub
+    data:
+      sub: 456
+    dataPropertyOrder:
+      "&":
+        - sub
+    color: null
+    isPrivate: false
+    metaSortKey: 1669739194224
+    _type: environment

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { globalBeforeEach } from '../../__jest__/before-each';
-import { apiSpec, request, requestGroup, workspace, environment, workspaceMeta } from '../../models';
+import { apiSpec, environment, request, requestGroup, workspace } from '../../models';
 import { DEFAULT_PROJECT_ID } from '../../models/project';
 import * as importUtil from '../import';
 

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { globalBeforeEach } from '../../__jest__/before-each';
-import { apiSpec, request, requestGroup, workspace } from '../../models';
+import { apiSpec, request, requestGroup, workspace, environment, workspaceMeta } from '../../models';
 import { DEFAULT_PROJECT_ID } from '../../models/project';
 import * as importUtil from '../import';
 
@@ -197,5 +197,34 @@ describe('importRaw()', () => {
     const createdApiSpec = await apiSpec.getByParentId(existingWorkspace._id);
 
     expect(createdApiSpec?.contents).toContain('openapi: \'3.0.2\'');
+  });
+
+  it('should not leave dangling environments when reimporting a collection', async () => {
+    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'insomnia', 'insomnia-example-input.yaml');
+    const rawFixture = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const existingWorkspace = await workspace.create({ scope: 'collection', _id: 'wrk_123' });
+
+    // Simulate pre-existing base and sub environment
+    await environment.create({ parentId: 'wrk_123', _id: 'env_123' });
+    await environment.create({ parentId: 'env_123', _id: 'env_sub123' });
+
+    const importConfig: importUtil.ImportRawConfig = {
+      getWorkspaceId: () => existingWorkspace._id,
+      getProjectId: async () => DEFAULT_PROJECT_ID,
+      getWorkspaceScope: () => 'collection',
+    };
+
+    await importUtil.importRaw(
+      rawFixture,
+      importConfig
+    );
+
+    const totalEnvironments = await environment.all();
+    const baseEnvironmentsFound = await environment.findByParentId('wrk_123');
+    const subEnvironmentsFound = await environment.findByParentId('env_123');
+    expect(totalEnvironments).toHaveLength(2);
+    expect(baseEnvironmentsFound).toHaveLength(1);
+    expect(subEnvironmentsFound).toHaveLength(1);
   });
 });

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -15,6 +15,7 @@ import { convert, ConvertResultType } from '../utils/importers/convert';
 import {
   BASE_ENVIRONMENT_ID_KEY,
   CONTENT_TYPE_GRAPHQL,
+  EXPORT_TYPE_ENVIRONMENT,
   EXPORT_TYPE_WORKSPACE,
   WORKSPACE_ID_KEY,
 } from './constants';
@@ -187,6 +188,15 @@ export async function importRaw(
     // Replace null parentIds with current workspace
     if (!resource.parentId && resource._type !== EXPORT_TYPE_WORKSPACE) {
       resource.parentId = WORKSPACE_ID_KEY;
+    }
+
+    // Always generate base environment id, ensuring to not create another one
+    if (resource._type === EXPORT_TYPE_ENVIRONMENT) {
+      if (resource.parentId === WORKSPACE_ID_KEY || resource.parentId.match(`${models.workspace.prefix}_\w*`)) {
+        resource._id = BASE_ENVIRONMENT_ID_KEY;
+      } else {
+        resource.parentId = BASE_ENVIRONMENT_ID_KEY;
+      }
     }
 
     // Replace ID placeholders (eg. __WORKSPACE_ID__) with generated values


### PR DESCRIPTION
changelog(Fixes): Fixed an issue that caused dangling base environments when importing an Insomnia collection

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

This pull request ensures the "regeneration" of the base environment id when importing a collection.
Preventing the creation of an additional base environment,  will be possible to import into an existing collection (modifying the export file) without losing all the exported environments .

Closes #4178 