### PR TITLE
adds coverage files to eslintignore

### DIFF
--- a/packages/insomnia-common/.eslintignore
+++ b/packages/insomnia-common/.eslintignore
@@ -1,1 +1,2 @@
 dist
+coverage


### PR DESCRIPTION
We have test code coverage reporting enabled on `insomnia-common`.  It happened to have been enabled _after_ linting was set up, which caused it to be missed from being excluded from the linter.  This is a very simple fix: tell eslint to ignore the coverage report.

So.  When we do:

![Screenshot_20220124_164516](https://user-images.githubusercontent.com/15232461/150870287-a33237a3-d9f4-4bd1-b732-969ccb5a30c1.png)


This PR makes the following change:

| BEFORE | AFTER |
| - | - |
| ![Screenshot_20220124_164442](https://user-images.githubusercontent.com/15232461/150870504-da2891fa-70dc-4639-8400-e1dbc4d1a943.png) | ![Screenshot_20220124_164844](https://user-images.githubusercontent.com/15232461/150870566-3ddc528f-c840-4d73-8498-8067b051856f.png) |
 