### PR TITLE
convert WrapperDesign to a function component

### DIFF
--- a/packages/insomnia-app/app/ui/components/design-empty-state.tsx
+++ b/packages/insomnia-app/app/ui/components/design-empty-state.tsx
@@ -38,7 +38,7 @@ const ExampleButton = styled.div({
 });
 
 interface Props {
-  onUpdateContents: () => void;
+  onUpdateContents: (contents: string) => void;
 }
 
 const useUpdateApiSpecContents = () => {
@@ -84,7 +84,7 @@ const ImportSpecButton: FC<Props> = ({ onUpdateContents }) => {
         }
         const contents = await response.text();
         await updateApiSpecContents(contents);
-        onUpdateContents();
+        onUpdateContents(contents);
       },
     });
   }, [updateApiSpecContents, onUpdateContents]);
@@ -125,7 +125,7 @@ const SecondaryAction: FC<Props> = ({ onUpdateContents }) => {
     }
     const contents = await response.text();
     await updateApiSpecContents(contents);
-    onUpdateContents();
+    onUpdateContents(contents);
   }, [updateApiSpecContents, onUpdateContents]);
 
   return (

--- a/packages/insomnia-app/app/ui/components/wrapper-design.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Button, NoticeTable } from 'insomnia-components';
-import React, { Fragment, PureComponent, ReactNode } from 'react';
+import React, { createRef, Fragment, PureComponent, ReactNode } from 'react';
 import styled from 'styled-components';
 import SwaggerUI from 'swagger-ui-react';
 
@@ -49,7 +49,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class WrapperDesign extends PureComponent<Props, State> {
-  editor: UnconnectedCodeEditor | null = null;
+  editor = createRef<UnconnectedCodeEditor>();
   debounceTimeout: NodeJS.Timeout | null = null;
 
   constructor(props: Props) {
@@ -65,10 +65,6 @@ export class WrapperDesign extends PureComponent<Props, State> {
   static lintOptions = {
     delay: 1000,
   };
-
-  _setEditorRef(n: UnconnectedCodeEditor) {
-    this.editor = n;
-  }
 
   async _handleTogglePreview() {
     const { activeWorkspace } = this.props.wrapperProps;
@@ -104,13 +100,11 @@ export class WrapperDesign extends PureComponent<Props, State> {
   }
 
   _handleSetSelection(chStart: number, chEnd: number, lineStart: number, lineEnd: number) {
-    const editor = this.editor;
-
-    if (!editor) {
+    if (!this.editor.current) {
       return;
     }
 
-    editor.scrollToSelection(chStart, chEnd, lineStart, lineEnd);
+    this.editor.current.scrollToSelection(chStart, chEnd, lineStart, lineEnd);
   }
 
   _handleLintClick(notice) {
@@ -179,7 +173,7 @@ export class WrapperDesign extends PureComponent<Props, State> {
         <div className="tall relative overflow-hidden">
           <CodeEditor
             manualPrettify
-            ref={this._setEditorRef}
+            ref={this.editor}
             lintOptions={WrapperDesign.lintOptions}
             mode="openapi"
             defaultValue={activeApiSpec.contents}

--- a/packages/insomnia-app/app/ui/components/wrapper-design.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.tsx
@@ -162,10 +162,6 @@ export class WrapperDesign extends PureComponent<Props, State> {
     }
   }
 
-  _handleBreadcrumb() {
-    this.props.wrapperProps.handleSetActiveActivity(ACTIVITY_HOME);
-  }
-
   async componentDidMount() {
     await this._reLint();
   }

--- a/packages/insomnia-app/app/ui/components/wrapper-design.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.tsx
@@ -117,13 +117,15 @@ const RenderEditor: FC<Pick<Props, 'wrapperProps'> & {
     }
   }, [contents]);
 
-  const handleScrollToSelection = useCallback((notice: Notice<Pick<LintMessage, 'range'>>) => {
+  const handleScrollToSelection = useCallback((notice: Notice) => {
     if (!editor.current) {
       return;
     }
+    // @ts-expect-error Notice is not generic, and thus cannot be provided more data like we are doing elsewhere in this file
     if (!notice.range) {
       return;
     }
+    // @ts-expect-error Notice is not generic, and thus cannot be provided more data like we are doing elsewhere in this file
     const { start, end } = notice.range;
     editor.current.scrollToSelection(start.character, end.character, start.line, end.line);
   }, [editor]);
@@ -149,7 +151,7 @@ const RenderEditor: FC<Pick<Props, 'wrapperProps'> & {
         />
       </div>
       {lintMessages.length > 0 && (
-        <NoticeTable<Pick<LintMessage, 'range'>>
+        <NoticeTable
           notices={lintMessages}
           onClick={handleScrollToSelection}
         />

--- a/packages/insomnia-app/app/ui/components/wrapper.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper.tsx
@@ -14,7 +14,6 @@ import {
 import { database as db } from '../../common/database';
 import { importRaw } from '../../common/import';
 import { initializeSpectral, isLintError } from '../../common/spectral';
-import type { ApiSpec } from '../../models/api-spec';
 import type { Cookie } from '../../models/cookie-jar';
 import * as models from '../../models/index';
 import {
@@ -153,10 +152,6 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
 
   _handleForceUpdateRequestHeaders(r: Request, headers: RequestHeader[]) {
     return this._handleForceUpdateRequest(r, { headers });
-  }
-
-  async _handleUpdateApiSpec(apiSpec: ApiSpec) {
-    await models.apiSpec.update(apiSpec);
   }
 
   static _handleUpdateRequestBody(request: Request, body: RequestBody) {
@@ -646,7 +641,6 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
             <WrapperDesign
               gitSyncDropdown={gitSyncDropdown}
               handleActivityChange={this._handleWorkspaceActivityChange}
-              handleUpdateApiSpec={this._handleUpdateApiSpec}
               wrapperProps={this.props}
             />
           )}

--- a/packages/insomnia-components/src/index.ts
+++ b/packages/insomnia-components/src/index.ts
@@ -8,7 +8,7 @@ export { CardContainer } from './card-container';
 export { Card, CardProps } from './card';
 export { Header, HeaderProps } from './header';
 export { MultiSwitch } from './multi-switch';
-export { NoticeTable, NoticeTableProps } from './notice-table';
+export { NoticeTable, NoticeTableProps, Notice } from './notice-table';
 export { RadioButtonGroup, RadioButtonGroupProps } from './radio-button-group';
 export { SvgIcon, SvgIconProps, IconEnum, ThemeEnum, IconId } from './svg-icon';
 export { Switch, SwitchProps, SwitchItem } from './switch';

--- a/packages/insomnia-components/src/notice-table.tsx
+++ b/packages/insomnia-components/src/notice-table.tsx
@@ -5,15 +5,15 @@ import { Button } from './button';
 import { IconEnum, SvgIcon } from './svg-icon';
 import { Table, TableBody, TableData, TableHead, TableHeader, TableRow } from './table';
 
-export type Notice<T extends Record<string, any> = {}> = T & {
+export interface Notice {
   type: 'warning' | 'error';
   line: number;
   message: string;
-};
+}
 
-export interface NoticeTableProps<T extends Record<string, any> = {}> {
-  notices: Notice<T>[];
-  onClick?: (n: Notice<T>, e: React.SyntheticEvent<HTMLElement>) => any;
+export interface NoticeTableProps {
+  notices: Notice[];
+  onClick?: (n: Notice, e: React.SyntheticEvent<HTMLElement>) => any;
   onVisibilityToggle?: (expanded: boolean) => any;
   compact?: boolean;
   className?: string;
@@ -94,7 +94,7 @@ const Header = styled.header`
   padding-left: var(--padding-md);
 `;
 
-export class NoticeTable<T extends Record<string, any> = {}> extends PureComponent<NoticeTableProps<T>, State> {
+export class NoticeTable extends PureComponent<NoticeTableProps, State> {
   state: State = {
     collapsed: false,
   };
@@ -113,7 +113,7 @@ export class NoticeTable<T extends Record<string, any> = {}> extends PureCompone
     );
   }
 
-  onClick(notice: Notice<T>, e: React.SyntheticEvent<HTMLButtonElement>) {
+  onClick(notice: Notice, e: React.SyntheticEvent<HTMLButtonElement>) {
     const { onClick } = this.props;
 
     if (!onClick) {

--- a/packages/insomnia-components/src/notice-table.tsx
+++ b/packages/insomnia-components/src/notice-table.tsx
@@ -5,15 +5,15 @@ import { Button } from './button';
 import { IconEnum, SvgIcon } from './svg-icon';
 import { Table, TableBody, TableData, TableHead, TableHeader, TableRow } from './table';
 
-export interface Notice {
+export type Notice<T extends Record<string, any> = {}> = T & {
   type: 'warning' | 'error';
   line: number;
   message: string;
-}
+};
 
-export interface NoticeTableProps {
-  notices: Notice[];
-  onClick?: (n: Notice, e: React.SyntheticEvent<HTMLElement>) => any;
+export interface NoticeTableProps<T extends Record<string, any> = {}> {
+  notices: Notice<T>[];
+  onClick?: (n: Notice<T>, e: React.SyntheticEvent<HTMLElement>) => any;
   onVisibilityToggle?: (expanded: boolean) => any;
   compact?: boolean;
   className?: string;
@@ -94,7 +94,7 @@ const Header = styled.header`
   padding-left: var(--padding-md);
 `;
 
-export class NoticeTable extends PureComponent<NoticeTableProps, State> {
+export class NoticeTable<T extends Record<string, any> = {}> extends PureComponent<NoticeTableProps<T>, State> {
   state: State = {
     collapsed: false,
   };
@@ -113,7 +113,7 @@ export class NoticeTable extends PureComponent<NoticeTableProps, State> {
     );
   }
 
-  onClick(notice: Notice, e: React.SyntheticEvent<HTMLButtonElement>) {
+  onClick(notice: Notice<T>, e: React.SyntheticEvent<HTMLButtonElement>) {
     const { onClick } = this.props;
 
     if (!onClick) {


### PR DESCRIPTION
closes INS-1389

This PR converts the WrapperDesign component to a function component and tries to change as little else as possible.  3 of the 4 sections were pretty straightforward, but the Editor one had some fidgeting that was necessary to keep the debounce behavior intact.  There are no intended behavioral changes as a result of this PR.

I encourage any reviewer to read commit by commit.  With the exception of the very last commit, which contains a small fix, I tried to keep the scope of each commit constrained to what's in the commit message.