### PR TITLE
feat(ci): bump homebrew formulae

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,52 @@
+name: Update Homebrew
+
+on:
+  schedule:
+    # weekdays at 00:00
+    - cron: '0 0 * * 1-5'
+
+  workflow_dispatch:
+
+jobs:
+  update_homebrew:
+    name: Update Insomnia Formula
+    # must be macos, linux-brew doesn't have casks
+    runs-on: macos-latest
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Cache Homebrew Bundler RubyGems
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - name: Install Homebrew Bundler RubyGems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: brew install-bundler-gems
+
+      - name: Add "Versions" Tap
+        run: brew tap homebrew/homebrew-cask-versions
+
+      # Update Homebrew's Inso(mnia) formulae
+      # https://github.com/Homebrew/actions/tree/master/bump-formulae
+      - name: Bump Inso (Beta) Formula
+        uses: Homebrew/actions/bump-formulae@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          formulae: --open-pr inso-beta
+      - name: Bump Inso Formula
+        uses: Homebrew/actions/bump-formulae@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          formulae: --open-pr inso
+      - name: Bump Insomnia Formula
+        uses: Homebrew/actions/bump-formulae@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Bump only these formulae if outdated
+          formulae: --open-pr insomnia

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -37,16 +37,16 @@ jobs:
       - name: Bump Inso (Beta) Formula
         uses: Homebrew/actions/bump-formulae@master
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.HOMEBREW_PR_GH_TOKEN }}
           formulae: --open-pr inso-beta
       - name: Bump Inso Formula
         uses: Homebrew/actions/bump-formulae@master
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.HOMEBREW_PR_GH_TOKEN }}
           formulae: --open-pr inso
       - name: Bump Insomnia Formula
         uses: Homebrew/actions/bump-formulae@master
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.HOMEBREW_PR_GH_TOKEN }}
           # Bump only these formulae if outdated
           formulae: --open-pr insomnia


### PR DESCRIPTION
On pushes to develop (as when merging PRs), attempt to open version bump PRs for the `insomnia`, `inso`, and `inso-beta` Homebrew formulae.