### PR TITLE
Fix default headers plugin README

### DIFF
--- a/plugins/insomnia-plugin-default-headers/README.md
+++ b/plugins/insomnia-plugin-default-headers/README.md
@@ -20,6 +20,7 @@ Headers can be added by setting a `DEFAULT_HEADERS` environment variable.
     "Connection": "close"
   }
 }
+```
 
 Default header can be removed by setting value to null. For example, use folder environment variables to remove authorization header from anonymous calls
 


### PR DESCRIPTION
When a linter previously ran on this Markdown file, it merged the two
code blocks resulting in invalid JSON being rendered. Changing back
to two separate code blocks.