### PR TITLE
Speed up the tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,15 @@ jobs:
         run: npm run bootstrap
 
       - name: Lint
+        if: matrix.os == 'ubuntu-latest'
         run: npm run lint
 
       - name: Lint markdown
+        if: matrix.os == 'ubuntu-latest'
         run: npm run lint:markdown
 
       - name: Type checks
+        if: matrix.os == 'ubuntu-latest'
         run: npm run type-check
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,46 +87,6 @@ jobs:
         env:
           VERSION: ${{ steps.inso-variables.outputs.inso-version }}
 
-      - name: Codesign & create macOS installer
-        if: matrix.os == 'macos-latest'
-        run: |
-          chmod +x ./src/scripts/macos-pkg.sh
-          ./src/scripts/macos-pkg.sh
-        shell: bash
-        working-directory: packages/insomnia-inso
-        continue-on-error: true
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.DESIGNER_MAC_CSC_LINK }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.DESIGNER_MAC_CSC_KEY_PASSWORD }}
-          PKG_NAME: ${{ steps.inso-variables.outputs.pkg-name }}
-          BUNDLE_ID: ${{ steps.inso-variables.outputs.bundle-id }}
-          VERSION: ${{ steps.inso-variables.outputs.inso-version }}
-
-      # We don't need to notarize and staple on every commit
-      # - name: Notarize installer
-      #   if: matrix.os == 'macos-latest'
-      #   uses: devbotsxyz/xcode-notarize@v1
-      #   with:
-      #     product-path: packages/insomnia-inso/artifacts/${{ steps.inso-variables.outputs.pkg-name }}.pkg
-      #     primary-bundle-id: ${{ steps.inso-variables.outputs.bundle-id }}
-      #     appstore-connect-username: ${{ secrets.DESIGNER_APPLE_ID }}
-      #     appstore-connect-password: ${{ secrets.DESIGNER_APPLE_ID_PASSWORD }}
-
-      # - name: Staple installer
-      #   if: matrix.os == 'macos-latest'
-      #   uses: devbotsxyz/xcode-staple@v1
-      #   with:
-      #     product-path: packages/insomnia-inso/artifacts/${{ steps.inso-variables.outputs.pkg-name }}.pkg
-
-      # - name: Notarize binary
-      #   if: matrix.os == 'macos-latest'
-      #   uses: devbotsxyz/xcode-notarize@v1
-      #   with:
-      #     product-path: packages/insomnia-inso/binaries/inso
-      #     primary-bundle-id: ${{ steps.inso-variables.outputs.bundle-id }}-binary
-      #     appstore-connect-username: ${{ secrets.DESIGNER_APPLE_ID }}
-      #     appstore-connect-password: ${{ secrets.DESIGNER_APPLE_ID_PASSWORD }}
-
       - name: Create Inso CLI artifacts
         run: npm run inso-package:artifacts
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - develop
-      - master
   pull_request:
     types:
       - opened

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       inso-version: ${{ steps.get-package-version.outputs.current-version }}
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Get version
         id: get-package-version
         uses: martinbeentjes/npm-get-version-action@master
@@ -35,7 +35,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Read Node version from .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"


### PR DESCRIPTION
Speeds up the tests workflow a bit by running platform independent steps on a single platform only. Ubuntu was chosen as it is the fastest one, and should be the most strict (since it has a case sensitive fs).

This PR also removes the inso .dmg build step, which was non-functional on most of our PRs as secrets do not get passed to action runs originating from a fork, and for testing having the inso macOS binary as an artifact (same as on the other platforms) should be sufficient for now.

Lastly, this PR switches to a newer version of the `checkout` action, which should speed up the git checkout as it only checks out the latest commit.

I've opted to not touch the release/publish workflows in this PR (which is also using the older checkout action, amongst other things), but plan on going over those separately in the future.