### PR TITLE
Fixes ApiSpec content syncing

### DIFF
--- a/packages/insomnia-app/app/ui/components/design-empty-state.tsx
+++ b/packages/insomnia-app/app/ui/components/design-empty-state.tsx
@@ -74,7 +74,7 @@ const ImportSpecButton: FC<Props> = ({ onUpdateContents }) => {
 
   const button = (
     <StyledButton variant="outlined" bg="surprise" className="margin-left">
-      Import
+      Import OpenAPI
       <i className="fa fa-caret-down pad-left-sm" />
     </StyledButton>
   );

--- a/packages/insomnia-app/app/ui/components/design-empty-state.tsx
+++ b/packages/insomnia-app/app/ui/components/design-empty-state.tsx
@@ -6,7 +6,6 @@ import styled from 'styled-components';
 
 import { documentationLinks } from '../../common/documentation';
 import { selectFileOrFolder } from '../../common/select-file-or-folder';
-import * as models from '../../models';
 import { faint } from '../css/css-in-js';
 import { selectActiveApiSpec } from '../redux/selectors';
 import { showPrompt } from './modals';
@@ -41,22 +40,7 @@ interface Props {
   onUpdateContents: (contents: string) => void;
 }
 
-const useUpdateApiSpecContents = () => {
-  const activeApiSpec = useSelector(selectActiveApiSpec);
-  return useCallback(async (contents: string) => {
-    if (!contents) {
-      return;
-    }
-    if (!activeApiSpec) {
-      return;
-    }
-    await models.apiSpec.update(activeApiSpec, { contents });
-  }, [activeApiSpec]);
-};
-
 const ImportSpecButton: FC<Props> = ({ onUpdateContents }) => {
-  const updateApiSpecContents = useUpdateApiSpecContents();
-
   const handleImportFile = useCallback(async () => {
     const { canceled, filePath } = await selectFileOrFolder({
       extensions: ['yml', 'yaml'],
@@ -68,8 +52,8 @@ const ImportSpecButton: FC<Props> = ({ onUpdateContents }) => {
     }
 
     const contents = String(await fs.promises.readFile(filePath));
-    await updateApiSpecContents(contents);
-  }, [updateApiSpecContents]);
+    onUpdateContents(contents);
+  }, [onUpdateContents]);
 
   const handleImportUri = useCallback(async () => {
     showPrompt({
@@ -83,11 +67,10 @@ const ImportSpecButton: FC<Props> = ({ onUpdateContents }) => {
           return;
         }
         const contents = await response.text();
-        await updateApiSpecContents(contents);
         onUpdateContents(contents);
       },
     });
-  }, [updateApiSpecContents, onUpdateContents]);
+  }, [onUpdateContents]);
 
   const button = (
     <StyledButton variant="outlined" bg="surprise" className="margin-left">
@@ -117,16 +100,14 @@ const ImportSpecButton: FC<Props> = ({ onUpdateContents }) => {
 const SecondaryAction: FC<Props> = ({ onUpdateContents }) => {
   const PETSTORE_EXAMPLE_URI = 'https://gist.githubusercontent.com/gschier/4e2278d5a50b4bbf1110755d9b48a9f9/raw/801c05266ae102bcb9288ab92c60f52d45557425/petstore-spec.yaml';
 
-  const updateApiSpecContents = useUpdateApiSpecContents();
   const onClick = useCallback(async () => {
     const response = await window.fetch(PETSTORE_EXAMPLE_URI);
     if (!response) {
       return;
     }
     const contents = await response.text();
-    await updateApiSpecContents(contents);
     onUpdateContents(contents);
-  }, [updateApiSpecContents, onUpdateContents]);
+  }, [onUpdateContents]);
 
   return (
     <div>

--- a/packages/insomnia-app/app/ui/components/design-empty-state.tsx
+++ b/packages/insomnia-app/app/ui/components/design-empty-state.tsx
@@ -43,7 +43,7 @@ interface Props {
 const ImportSpecButton: FC<Props> = ({ onUpdateContents }) => {
   const handleImportFile = useCallback(async () => {
     const { canceled, filePath } = await selectFileOrFolder({
-      extensions: ['yml', 'yaml'],
+      extensions: ['yml', 'yaml', 'json'],
       itemTypes: ['file'],
     });
     // Exit if no file selected

--- a/packages/insomnia-app/app/ui/components/design-empty-state.tsx
+++ b/packages/insomnia-app/app/ui/components/design-empty-state.tsx
@@ -112,7 +112,7 @@ const SecondaryAction: FC<Props> = ({ onUpdateContents }) => {
   return (
     <div>
       <div>
-        Or import existing an OpenAPI spec or <ExampleButton onClick={onClick}>start from an example</ExampleButton>
+        Or import an existing OpenAPI spec or <ExampleButton onClick={onClick}>start from an example</ExampleButton>
       </div>
       <ImportSpecButton onUpdateContents={onUpdateContents} />
     </div>

--- a/packages/insomnia-app/app/ui/components/wrapper-design.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.tsx
@@ -77,6 +77,7 @@ interface LintMessage {
 const RenderEditor: FC<{ editor: RefObject<UnconnectedCodeEditor> }> = ({ editor }) => {
   const activeApiSpec = useSelector(selectActiveApiSpec);
   const [forceRefreshCounter, setForceRefreshCounter] = useState(0);
+  const [shouldIncrementCounter, setShouldIncrementCounter] = useState(false);
   const [lintMessages, setLintMessages] = useState<LintMessage[]>([]);
   const contents = activeApiSpec?.contents ?? '';
 
@@ -101,10 +102,18 @@ const RenderEditor: FC<{ editor: RefObject<UnconnectedCodeEditor> }> = ({ editor
       }
 
       await models.apiSpec.update({ ...activeApiSpec, contents });
-      setForceRefreshCounter(forceRefreshCounter => forceRefreshCounter + 1); // INTRODUCES RACE CONDITION!
+      setShouldIncrementCounter(true);
     };
     fn();
   }, [activeApiSpec]);
+
+  useEffect(() => {
+    if (contents && shouldIncrementCounter){
+      setForceRefreshCounter(forceRefreshCounter => forceRefreshCounter + 1);
+      setShouldIncrementCounter(false);
+    }
+
+  }, [contents, shouldIncrementCounter]);
 
   useAsync(async () => {
     // Lint only if spec has content

--- a/packages/insomnia-app/app/ui/components/wrapper-design.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.tsx
@@ -1,6 +1,6 @@
 import { IRuleResult } from '@stoplight/spectral';
 import { Button, Notice, NoticeTable } from 'insomnia-components';
-import React, { createRef, FC, Fragment, ReactNode, RefObject, useCallback, useState } from 'react';
+import React, { createRef, FC, Fragment, ReactNode, RefObject, useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAsync, useDebounce } from 'react-use';
 import styled from 'styled-components';
@@ -89,9 +89,13 @@ const RenderEditor: FC<{ editor: RefObject<UnconnectedCodeEditor> }> = ({ editor
     }
 
     await models.apiSpec.update({ ...activeApiSpec, contents: contentsState });
-    setForceRefreshCounter(forceRefreshCounter => forceRefreshCounter + 1);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- this is a problem with react-use
   }, 500, [contentsState]);
+
+  useEffect(() => {
+    setContentsState(contents);
+    setForceRefreshCounter(forceRefreshCounter => forceRefreshCounter + 1);
+  }, [contents]);
 
   useAsync(async () => {
     // Lint only if spec has content

--- a/packages/insomnia-app/app/ui/components/wrapper-design.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-design.tsx
@@ -108,7 +108,8 @@ const useDesignEmptyState = () => {
     />
   );
 
-  return { forceRefreshCounter, emptyStateNode };
+  const uniquenessKey = `${forceRefreshCounter}::${activeApiSpec?._id}`;
+  return { uniquenessKey, emptyStateNode };
 };
 
 const RenderEditor: FC<{ editor: RefObject<UnconnectedCodeEditor> }> = ({ editor }) => {
@@ -116,9 +117,7 @@ const RenderEditor: FC<{ editor: RefObject<UnconnectedCodeEditor> }> = ({ editor
   const [lintMessages, setLintMessages] = useState<LintMessage[]>([]);
   const contents = activeApiSpec?.contents ?? '';
 
-  const { forceRefreshCounter, emptyStateNode } = useDesignEmptyState();
-
-  const uniquenessKey = `${forceRefreshCounter}::${activeApiSpec?._id}`;
+  const { uniquenessKey, emptyStateNode } = useDesignEmptyState();
 
   // NOTE: will need to be debounced if current functionality is to be maintained
   const onCodeEditorChange = useCallback((contents: string) => {


### PR DESCRIPTION
closes INS-1393

To test this PR:
- type into the code editor in the design tab and observe that it updates the swagger-ui preview as normal
- import the example OpenAPI spec by clicking the "import from example"
- import an existing OpenAPI spec from a URL, for example https://gist.githubusercontent.com/gschier/4e2278d5a50b4bbf1110755d9b48a9f9/raw/801c05266ae102bcb9288ab92c60f52d45557425/petstore-spec.yaml
- import an existing OpenAPI spec from file (can use the above, if you like)