### PR TITLE
Change build ref of recurring build if PR

### DIFF
--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Package
         shell: bash
-        run: BUILD_REF="$(git rev-parse --short HEAD)" BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
+        run: BUILD_REF="${{ github.event_name == 'pull_request' && 'PR-${{ github.event.number }}' || '$(git rev-parse --short HEAD)' }}" BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Package
         shell: bash
-        run: BUILD_REF="${{ github.event_name == 'pull_request' && '$PR_NUMBER' || '$(git rev-parse --short HEAD)' }}" BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
+        run: BUILD_REF="$(git rev-parse --short HEAD)${{ github.event_name == 'pull_request' && '.pr-$PR_NUMBER' }}" BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -12,7 +12,8 @@ on:
 concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-
+env:
+  PR_NUMBER: ${{ github.event.number }}
 jobs:
   build-and-upload-artifacts:
     runs-on: ${{ matrix.os }}
@@ -40,7 +41,7 @@ jobs:
 
       - name: Package
         shell: bash
-        run: BUILD_REF="${{ github.event_name == 'pull_request' && 'PR-${{ github.event.number }}' || '$(git rev-parse --short HEAD)' }}" BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
+        run: BUILD_REF="${{ github.event_name == 'pull_request' && '$PR_NUMBER' || '$(git rev-parse --short HEAD)' }}" BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

This PR improves the build reference for recurring builds.

- If the workflow is triggered in a PR - the build reference will be `<stable>-dev+<commit_short_sha>.pr-<pr_number>` (e.g. `2021.7.2-dev+c8e2197.pr-4490`);
- If the workflow is triggered for `develop`, the reference is `<stable>-dev+<commit_short_sha>`.

![Screenshot 2022-02-14 at 16 12 54](https://user-images.githubusercontent.com/11976836/153901908-5fc41f7c-fda2-4bad-b8fe-b06f9c0b12de.png)

