### PR TITLE
Fix BUILD_REF for develop and other non-PR triggers

### DIFF
--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Package
         shell: bash
-        run: BUILD_REF="$(git rev-parse --short HEAD)${{ github.event_name == 'pull_request' && '.pr-$PR_NUMBER' }}" BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
+        run: BUILD_REF="$(git rev-parse --short HEAD)${{ github.event_name == 'pull_request' && '.pr-$PR_NUMBER' || '' }}" BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Fix for case where recurring release workflow is triggered for `develop` or other non-PR related triggers, we would display something like `2021.7.2-dev+d68ad33false`.