### PR TITLE
menu presets for window sizes and zooms

### DIFF
--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -27,7 +27,7 @@ const { app, Menu, shell, dialog, clipboard } = electron;
 app.allowRendererProcessReuse = false;
 
 const DEFAULT_WIDTH = 1280;
-const DEFAULT_HEIGHT = 700;
+const DEFAULT_HEIGHT = 720;
 const MINIMUM_WIDTH = 500;
 const MINIMUM_HEIGHT = 400;
 
@@ -275,21 +275,27 @@ export function createWindow() {
         type: 'separator',
       },
       {
-        label: `Resize to Defaul${MNEMONIC_SYM}t`,
+        label: `Resize to ${MNEMONIC_SYM}Small (qHD 540)`,
         click: () =>
           mainWindow?.setBounds({
-            x: 100,
-            y: 100,
+            width: 960,
+            height: 540,
+          }),
+      },
+      {
+        label: `Resize to Defaul${MNEMONIC_SYM}t (HD 720)`,
+        click: () =>
+          mainWindow?.setBounds({
             width: DEFAULT_WIDTH,
             height: DEFAULT_HEIGHT,
           }),
       },
       {
-        label: `Resize to ${MNEMONIC_SYM}Small`,
+        label: `Resize to ${MNEMONIC_SYM}Large (FHD 1080)`,
         click: () =>
           mainWindow?.setBounds({
-            width: 1024,
-            height: 512,
+            width: 1920,
+            height: 1080,
           }),
       },
       {

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -466,6 +466,16 @@ export function createWindow() {
         label: `R${MNEMONIC_SYM}estart`,
         click: window?.main.restart,
       },
+      {
+        label: `Set window for ${MNEMONIC_SYM}FHD Screenshot`,
+        click: () => {
+          mainWindow?.setBounds({
+            width: 1920,
+            height: 1080,
+          });
+          setZoom(() => 4)();
+        },
+      },
     ],
   };
   const toolsMenu: MenuItemConstructorOptions = {


### PR DESCRIPTION
Recently in https://github.com/Kong/insomnia/pull/4384, @develohpanda added some functionality for preset zoom levels.  I have found this wildly useful.

Take a PR like https://github.com/Kong/insomnia/pull/4498.

I had to take all 6 of those screenshots 3 times by the end of the PR.  No big deal, but the drag is that I had to take the (nearly!) exact same BEFORE pictures each time because (since, visual comparison) I must have the window size and zoom level match.

That part is what #4384 started, but I added one more for FHD size.
<img width="25%" src="https://user-images.githubusercontent.com/15232461/154576341-2bed92b6-97d2-4f2a-9a34-e53a9456f6d4.png" />


Then, in the next commit, I added the same kind of thing, except for zoom preset levels.
<img width="25%" src="https://user-images.githubusercontent.com/15232461/154576206-7a238498-47c3-44f2-b81c-372f15f6b557.png" />

To tie it all together, then in the last commit I added the thing I want most: a single standard preset (only enabled in development mode) that sets the window to FHD and the zoom to 400%:

<img width="25%" src="https://user-images.githubusercontent.com/15232461/154576424-b1ea518d-6eda-4182-9ced-71bcf6428ce5.png" />

For reference, that creates a window that looks like this, and is idea for screenshots of the type I need in my daily work (such as the PR mentioned above).
![Screenshot_20220217_164947](https://user-images.githubusercontent.com/15232461/154576550-066658a0-94f6-40ab-8f27-30d5510064fd.png)

changelog(Improvements): Adds zoom preset levels and more window size presets