### PR TITLE
Remove deprecated Insomnia Designer Hotkeys (INS-1411)

### DIFF
--- a/packages/insomnia-app/app/common/hotkeys.ts
+++ b/packages/insomnia-app/app/common/hotkeys.ts
@@ -108,11 +108,6 @@ export const hotKeyRefs: Record<string, HotKeyDefinition> = {
   ENVIRONMENT_SHOW_VARIABLE_SOURCE_AND_VALUE: defineHotKey('environment_showVariableSourceAndValue', 'Show variable source and value'),
   BEAUTIFY_REQUEST_BODY: defineHotKey('beautifyRequestBody', 'Beautify Active Code Editors'),
   GRAPHQL_EXPLORER_FOCUS_FILTER: defineHotKey('graphql_explorer_focus_filter', 'Focus GraphQL Explorer Filter'),
-  // Designer-specific
-  SHOW_SPEC_EDITOR: defineHotKey('activity_specEditor', 'Show Spec Activity'),
-  SHOW_TEST: defineHotKey('activity_test', 'Show Test Activity'),
-  SHOW_MONITOR: defineHotKey('activity_monitor', 'Show Monitor Activity'),
-  SHOW_HOME: defineHotKey('activity_home', 'Show Home Activity'),
   FILTER_DOCUMENTS: defineHotKey('documents_filter', 'Focus Documents Filter'),
 };
 
@@ -259,22 +254,6 @@ const defaultRegistry: HotKeyRegistry = {
   [hotKeyRefs.BEAUTIFY_REQUEST_BODY.id]: keyBinds(
     keyComb(false, false, true, true, keyboardKeys.i.keyCode),
     keyComb(true, false, true, false, keyboardKeys.i.keyCode),
-  ),
-  [hotKeyRefs.SHOW_SPEC_EDITOR.id]: keyBinds(
-    keyComb(false, false, true, true, keyboardKeys.s.keyCode),
-    keyComb(true, false, true, false, keyboardKeys.s.keyCode),
-  ),
-  [hotKeyRefs.SHOW_TEST.id]: keyBinds(
-    keyComb(false, false, true, true, keyboardKeys.t.keyCode),
-    keyComb(true, false, true, false, keyboardKeys.t.keyCode),
-  ),
-  [hotKeyRefs.SHOW_MONITOR.id]: keyBinds(
-    keyComb(false, false, true, true, keyboardKeys.m.keyCode),
-    keyComb(true, false, true, false, keyboardKeys.m.keyCode),
-  ),
-  [hotKeyRefs.SHOW_HOME.id]: keyBinds(
-    keyComb(false, false, true, true, keyboardKeys.h.keyCode),
-    keyComb(true, false, true, false, keyboardKeys.h.keyCode),
   ),
   [hotKeyRefs.FILTER_DOCUMENTS.id]: keyBinds(
     keyComb(false, false, false, true, keyboardKeys.f.keyCode),


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Before:
![Screenshot_2022-02-18_at_11_19_55](https://user-images.githubusercontent.com/11976836/154673173-76781ff6-22bc-430a-85c1-52a738d7d15a.png)


After:
![Screenshot 2022-02-18 at 11 19 29](https://user-images.githubusercontent.com/11976836/154673188-c80800d4-5e25-4db5-a1d9-d0a679b8001a.png)

In this PR we remove deprecated keyboard hotkeys that were left from the time there was an [initial Insomnia Designer merge](https://github.com/filfreire/insomnia/commit/c6a7c4d68272b3c4f3d78d4dc9031ae8e49b3f7a) back in April 2020.

The hotkeys removed are not used anywhere.

Related to: https://linear.app/insomnia/issue/INS-1379/broken-keyboard-shortcuts-for-showing-activities-dont-do-anything

changelog(Fixes): Removed deprecated Insomnia Designer Hotkeys