### PR TITLE
(Partial) removal of WrapperProps (part 2)

### DIFF
--- a/packages/insomnia-app/app/ui/components/modals/request-group-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-group-settings-modal.tsx
@@ -14,7 +14,7 @@ import { HelpTooltip } from '../help-tooltip';
 import { MarkdownEditor } from '../markdown-editor';
 
 interface Props {
-  workspaces: Workspace[];
+  workspacesForActiveProject: Workspace[];
 }
 
 interface State {
@@ -23,7 +23,7 @@ interface State {
   defaultPreviewMode: boolean;
   activeWorkspaceIdToCopyTo: string | null;
   workspace?: Workspace;
-  workspaces: Workspace[];
+  workspacesForActiveProject: Workspace[];
   justCopied: boolean;
   justMoved: boolean;
 }
@@ -44,7 +44,7 @@ export class RequestGroupSettingsModal extends React.PureComponent<Props, State>
     defaultPreviewMode: false,
     activeWorkspaceIdToCopyTo: null,
     workspace: undefined,
-    workspaces: [],
+    workspacesForActiveProject: [],
     justCopied: false,
     justMoved: false,
   };
@@ -154,7 +154,7 @@ export class RequestGroupSettingsModal extends React.PureComponent<Props, State>
     requestGroup,
     forceEditMode,
   }: RequestGroupSettingsModalOptions) {
-    const { workspaces } = this.props;
+    const { workspacesForActiveProject } = this.props;
 
     const hasDescription = !!requestGroup.description;
 
@@ -162,7 +162,7 @@ export class RequestGroupSettingsModal extends React.PureComponent<Props, State>
     const ancestors = await db.withAncestors(requestGroup);
     const doc = ancestors.find(doc => doc.type === models.workspace.type);
     const workspaceId = doc ? doc._id : 'should-never-happen';
-    const workspace = workspaces.find(w => w._id === workspaceId);
+    const workspace = workspacesForActiveProject.find(w => w._id === workspaceId);
 
     this.setState(
       {
@@ -218,7 +218,7 @@ export class RequestGroupSettingsModal extends React.PureComponent<Props, State>
   }
 
   _renderMoveCopy() {
-    const { workspaces } = this.props;
+    const { workspacesForActiveProject } = this.props;
 
     const {
       activeWorkspaceIdToCopyTo,
@@ -246,7 +246,7 @@ export class RequestGroupSettingsModal extends React.PureComponent<Props, State>
               onChange={this._handleUpdateMoveCopyWorkspace}
             >
               <option value="__NULL__">-- Select Workspace --</option>
-              {workspaces.map(w => {
+              {workspacesForActiveProject.map(w => {
                 if (workspace && workspace._id === w._id) {
                   return null;
                 }

--- a/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-settings-modal.tsx
@@ -16,7 +16,7 @@ import { HelpTooltip } from '../help-tooltip';
 import { MarkdownEditor } from '../markdown-editor';
 
 interface Props {
-  workspaces: Workspace[];
+  workspacesForActiveProject: Workspace[];
 }
 
 interface State {
@@ -25,7 +25,7 @@ interface State {
   defaultPreviewMode: boolean;
   activeWorkspaceIdToCopyTo: string | null;
   workspace?: Workspace;
-  workspaces: Workspace[];
+  workspacesForActiveProject: Workspace[];
   justCopied: boolean;
   justMoved: boolean;
 }
@@ -46,7 +46,7 @@ export class RequestSettingsModal extends PureComponent<Props, State> {
     defaultPreviewMode: false,
     activeWorkspaceIdToCopyTo: null,
     workspace: undefined,
-    workspaces: [],
+    workspacesForActiveProject: [],
     justCopied: false,
     justMoved: false,
   };
@@ -192,13 +192,13 @@ export class RequestSettingsModal extends PureComponent<Props, State> {
   }
 
   async show({ request, forceEditMode }: RequestSettingsModalOptions) {
-    const { workspaces } = this.props;
+    const { workspacesForActiveProject } = this.props;
     const hasDescription = !!request.description;
     // Find workspaces for use with moving workspace
     const ancestors = await db.withAncestors(request);
     const doc = ancestors.find(isWorkspace);
     const workspaceId = doc ? doc._id : 'should-never-happen';
-    const workspace = workspaces.find(w => w._id === workspaceId);
+    const workspace = workspacesForActiveProject.find(w => w._id === workspaceId);
     this.setState(
       {
         request,
@@ -360,7 +360,7 @@ export class RequestSettingsModal extends PureComponent<Props, State> {
   }
 
   _renderMoveCopy() {
-    const { workspaces } = this.props;
+    const { workspacesForActiveProject } = this.props;
     const { activeWorkspaceIdToCopyTo, justMoved, justCopied, workspace, request } = this.state;
 
     // Don't show move/copy items if it doesn't exist, or if it is a gRPC request
@@ -382,7 +382,7 @@ export class RequestSettingsModal extends PureComponent<Props, State> {
               onChange={this._handleUpdateMoveCopyWorkspace}
             >
               <option value="__NULL__">-- Select Workspace --</option>
-              {workspaces.map(w => {
+              {workspacesForActiveProject.map(w => {
                 if (workspace && workspace._id === w._id) {
                   return null;
                 }

--- a/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.tsx
@@ -38,7 +38,7 @@ const mapStateToProps = (state: RootState) => {
     workspacesForActiveProject: selectWorkspacesForActiveProject(state),
     requestMetas: selectRequestMetas(state),
     grpcRequestMetas: selectGrpcRequestMetas(state),
-    workspaceChildren: selectWorkspaceRequestsAndRequestGroups(state),
+    workspaceRequestsAndRequestGroups: selectWorkspaceRequestsAndRequestGroups(state),
   };
 };
 
@@ -194,8 +194,8 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
 
   /** Return array of path segments for given request or folder */
   _groupOf(requestOrRequestGroup: Request | GrpcRequest | RequestGroup): string[] {
-    const { workspaceChildren } = this.props;
-    const requestGroups = workspaceChildren.filter(isRequestGroup);
+    const { workspaceRequestsAndRequestGroups } = this.props;
+    const requestGroups = workspaceRequestsAndRequestGroups.filter(isRequestGroup);
     const matchedGroups = requestGroups.filter(g => g._id === requestOrRequestGroup.parentId);
     const currentGroupName = isRequestGroup(requestOrRequestGroup) ? `${requestOrRequestGroup.name}` : '';
 
@@ -250,7 +250,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
   }
 
   _handleChangeValue(searchString: string) {
-    const { workspace, workspaceChildren, workspacesForActiveProject, requestMetas, grpcRequestMetas, activeRequest } = this.props;
+    const { workspace, workspaceRequestsAndRequestGroups, workspacesForActiveProject, requestMetas, grpcRequestMetas, activeRequest } = this.props;
     const { maxRequests, maxWorkspaces, hideNeverActiveRequests } = this.state;
     const lastActiveMap = {};
 
@@ -262,7 +262,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
     }
 
     // OPTIMIZATION: This only filters if we have a filter
-    let matchedRequests = (workspaceChildren
+    let matchedRequests = (workspaceRequestsAndRequestGroups
       .filter(child => isRequest(child) || isGrpcRequest(child)) as (Request | GrpcRequest)[])
       .sort((a, b) => {
         const aLA = lastActiveMap[a._id] || 0;
@@ -415,8 +415,8 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
       title,
       isModalVisible,
     } = this.state;
-    const { workspaceChildren, workspace } = this.props;
-    const requestGroups = workspaceChildren.filter(isRequestGroup);
+    const { workspaceRequestsAndRequestGroups, workspace } = this.props;
+    const requestGroups = workspaceRequestsAndRequestGroups.filter(isRequestGroup);
     return (
       <KeydownBinder onKeydown={this._handleKeydown} onKeyup={this._handleKeyup}>
         <Modal

--- a/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/request-switcher-modal.tsx
@@ -35,7 +35,7 @@ const mapStateToProps = (state: RootState) => {
   return {
     activeRequest,
     workspace: selectActiveWorkspace(state),
-    workspaces: selectWorkspacesForActiveProject(state),
+    workspacesForActiveProject: selectWorkspacesForActiveProject(state),
     requestMetas: selectRequestMetas(state),
     grpcRequestMetas: selectGrpcRequestMetas(state),
     workspaceChildren: selectWorkspaceRequestsAndRequestGroups(state),
@@ -55,7 +55,7 @@ interface Props extends ReduxProps {
 
 interface State {
   searchString: string;
-  workspaces: Workspace[];
+  workspacesForActiveProject: Workspace[];
   matchedRequests: (Request | GrpcRequest)[];
   matchedWorkspaces: Workspace[];
   activeIndex: number;
@@ -76,7 +76,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
 
   state: State = {
     searchString: '',
-    workspaces: [],
+    workspacesForActiveProject: [],
     matchedRequests: [],
     matchedWorkspaces: [],
     activeIndex: -1,
@@ -250,7 +250,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
   }
 
   _handleChangeValue(searchString: string) {
-    const { workspace, workspaceChildren, workspaces, requestMetas, grpcRequestMetas, activeRequest } = this.props;
+    const { workspace, workspaceChildren, workspacesForActiveProject, requestMetas, grpcRequestMetas, activeRequest } = this.props;
     const { maxRequests, maxWorkspaces, hideNeverActiveRequests } = this.state;
     const lastActiveMap = {};
 
@@ -291,7 +291,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
         .map(v => v.request);
     }
 
-    const matchedWorkspaces = workspaces
+    const matchedWorkspaces = workspacesForActiveProject
       .filter(w => w._id !== workspace?._id)
       .filter(w => {
         const name = w.name.toLowerCase();

--- a/packages/insomnia-app/app/ui/components/page-layout.tsx
+++ b/packages/insomnia-app/app/ui/components/page-layout.tsx
@@ -40,7 +40,7 @@ export const PageLayout: FC<Props> = ({
   const isLoading = useSelector(selectIsLoading);
   const settings = useSelector(selectSettings);
   const unseenWorkspaces = useSelector(selectUnseenWorkspaces);
-  const workspaces = useSelector(selectWorkspacesForActiveProject);
+  const workspacesForActiveProject = useSelector(selectWorkspacesForActiveProject);
 
   const {
     gitVCS,
@@ -130,7 +130,7 @@ export const PageLayout: FC<Props> = ({
             unseenWorkspaces={unseenWorkspaces}
             gitVCS={gitVCS}
             width={sidebarWidth}
-            workspaces={workspaces}
+            workspacesForActiveProject={workspacesForActiveProject}
           >
             {renderPageSidebar()}
           </Sidebar>

--- a/packages/insomnia-app/app/ui/components/sidebar/sidebar.tsx
+++ b/packages/insomnia-app/app/ui/components/sidebar/sidebar.tsx
@@ -19,7 +19,7 @@ interface Props {
   isLoading: boolean;
   unseenWorkspaces: Workspace[];
   width: number;
-  workspaces: Workspace[];
+  workspacesForActiveProject: Workspace[];
 }
 
 export const Sidebar = memo(

--- a/packages/insomnia-app/app/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-debug.tsx
@@ -1,5 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import React, { Fragment, PureComponent, ReactNode } from 'react';
+import { connect } from 'react-redux';
 
 import { AUTOBIND_CFG, SortOrder } from '../../common/constants';
 import { isGrpcRequest } from '../../models/grpc-request';
@@ -7,6 +8,9 @@ import { isRemoteProject } from '../../models/project';
 import { Request, RequestAuthentication, RequestBody, RequestHeader, RequestParameter } from '../../models/request';
 import { Settings } from '../../models/settings';
 import { isCollection, isDesign } from '../../models/workspace';
+import { RootState } from '../redux/modules';
+import { selectActiveEnvironment, selectActiveRequest, selectActiveRequestResponses, selectActiveResponse, selectActiveUnitTestResult, selectActiveWorkspace, selectEnvironments, selectLoadStartTime, selectRequestVersions, selectResponseDownloadPath, selectResponseFilter, selectResponseFilterHistory, selectResponsePreviewMode, selectSettings } from '../redux/selectors';
+import { selectSidebarChildren, selectSidebarFilter } from '../redux/sidebar-selectors';
 import { EnvironmentsDropdown } from './dropdowns/environments-dropdown';
 import { SyncDropdown } from './dropdowns/sync-dropdown';
 import { ErrorBoundary } from './error-boundary';
@@ -21,7 +25,7 @@ import { SidebarFilter } from './sidebar/sidebar-filter';
 import { WorkspacePageHeader } from './workspace-page-header';
 import type { HandleActivityChange, WrapperProps } from './wrapper';
 
-interface Props {
+interface Props extends ReturnType<typeof mapStateToProps> {
   forceRefreshKey: number;
   gitSyncDropdown: ReactNode;
   handleActivityChange: HandleActivityChange;
@@ -52,7 +56,7 @@ interface Props {
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-export class WrapperDebug extends PureComponent<Props> {
+class UnconnectedWrapperDebug extends PureComponent<Props> {
   _renderPageHeader() {
     const { gitSyncDropdown, handleActivityChange, wrapperProps: {
       vcs,
@@ -93,15 +97,18 @@ export class WrapperDebug extends PureComponent<Props> {
 
   _renderPageSidebar() {
     const {
+      activeEnvironment,
+      activeWorkspace,
+      environments,
       handleChangeEnvironment,
       handleRequestCreate,
       handleRequestGroupCreate,
       handleSidebarSort,
+      settings,
+      sidebarChildren,
+      sidebarFilter,
     } = this.props;
     const {
-      activeEnvironment,
-      activeWorkspace,
-      environments,
       handleActivateRequest,
       handleCopyAsCurl,
       handleCreateRequest,
@@ -112,9 +119,6 @@ export class WrapperDebug extends PureComponent<Props> {
       handleSetRequestGroupCollapsed,
       handleSetRequestPinned,
       handleSetSidebarFilter,
-      settings,
-      sidebarChildren,
-      sidebarFilter,
     } = this.props.wrapperProps;
 
     if (!activeWorkspace) {
@@ -169,6 +173,9 @@ export class WrapperDebug extends PureComponent<Props> {
 
   _renderRequestPane() {
     const {
+      activeEnvironment,
+      activeRequest,
+      activeWorkspace,
       forceRefreshKey,
       handleForceUpdateRequest,
       handleForceUpdateRequestHeaders,
@@ -183,18 +190,15 @@ export class WrapperDebug extends PureComponent<Props> {
       handleUpdateRequestUrl,
       handleUpdateSettingsUseBulkHeaderEditor,
       handleUpdateSettingsUseBulkParametersEditor,
+      responseDownloadPath,
+      settings,
     } = this.props;
     const {
-      activeEnvironment,
-      activeRequest,
-      activeWorkspace,
       handleCreateRequestForWorkspace,
       handleGenerateCodeForActiveRequest,
       handleUpdateDownloadPath,
       handleUpdateRequestMimeType,
       headerEditorKey,
-      responseDownloadPath,
-      settings,
     } = this.props.wrapperProps;
 
     if (!activeWorkspace) {
@@ -258,8 +262,6 @@ export class WrapperDebug extends PureComponent<Props> {
       handleSetPreviewMode,
       handleSetResponseFilter,
       handleShowRequestSettingsModal,
-    } = this.props;
-    const {
       activeEnvironment,
       activeRequest,
       activeRequestResponses,
@@ -271,7 +273,7 @@ export class WrapperDebug extends PureComponent<Props> {
       responseFilterHistory,
       responsePreviewMode,
       settings,
-    } = this.props.wrapperProps;
+    } = this.props;
 
     // activeRequest being truthy only needs to be checked for isGrpcRequest (for now)
     // The RequestPane and ResponsePane components already handle the case where activeRequest is null
@@ -326,3 +328,24 @@ export class WrapperDebug extends PureComponent<Props> {
     );
   }
 }
+
+const mapStateToProps = (state: RootState) => ({
+  activeEnvironment: selectActiveEnvironment(state),
+  activeRequest: selectActiveRequest(state),
+  activeRequestResponses: selectActiveRequestResponses(state),
+  activeResponse: selectActiveResponse(state),
+  activeUnitTestResult: selectActiveUnitTestResult(state),
+  activeWorkspace: selectActiveWorkspace(state),
+  environments: selectEnvironments(state),
+  loadStartTime: selectLoadStartTime(state),
+  requestVersions: selectRequestVersions(state),
+  responseDownloadPath: selectResponseDownloadPath(state),
+  responseFilter: selectResponseFilter(state),
+  responseFilterHistory: selectResponseFilterHistory(state),
+  responsePreviewMode: selectResponsePreviewMode(state),
+  settings: selectSettings(state),
+  sidebarChildren: selectSidebarChildren(state),
+  sidebarFilter: selectSidebarFilter(state),
+});
+
+export const WrapperDebug = connect(mapStateToProps)(UnconnectedWrapperDebug);

--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -29,12 +29,13 @@ import { isDesign, Workspace, WorkspaceScopeKeys } from '../../models/workspace'
 import { WorkspaceMeta } from '../../models/workspace-meta';
 import { MemClient } from '../../sync/git/mem-client';
 import { initializeLocalBackendProjectAndMarkForSync } from '../../sync/vcs/initialize-backend-project';
+import { RootState } from '../redux/modules';
 import { cloneGitRepository } from '../redux/modules/git';
-import { setDashboardSortOrder } from '../redux/modules/global';
+import { selectIsLoading, setDashboardSortOrder } from '../redux/modules/global';
 import { ForceToWorkspace } from '../redux/modules/helpers';
 import { importClipBoard, importFile, importUri } from '../redux/modules/import';
 import { activateWorkspace, createWorkspace } from '../redux/modules/workspace';
-import { selectDashboardSortOrder } from '../redux/selectors';
+import { selectActiveProject, selectAllApiSpecs, selectAllWorkspaces, selectDashboardSortOrder, selectIsLoggedIn, selectWorkspaceMetas } from '../redux/selectors';
 import { AppHeader } from './app-header';
 import { DashboardSortDropdown } from './dropdowns/dashboard-sort-dropdown';
 import { ProjectDropdown } from './dropdowns/project-dropdown';
@@ -176,8 +177,10 @@ class WrapperHome extends PureComponent<Props, State> {
 
   _handleCollectionCreate() {
     const {
+      activeProject,
+      isLoggedIn,
       handleCreateWorkspace,
-      wrapperProps: { activeProject, vcs, isLoggedIn },
+      wrapperProps: { vcs },
     } = this.props;
 
     handleCreateWorkspace({
@@ -283,8 +286,7 @@ class WrapperHome extends PureComponent<Props, State> {
   }
 
   renderDashboardMenu() {
-    const { wrapperProps, handleSetDashboardSortOrder, sortOrder } = this.props;
-    const { vcs } = wrapperProps;
+    const { wrapperProps: { vcs }, handleSetDashboardSortOrder, sortOrder } = this.props;
     return (
       <div className="row row--right pad-left wide">
         <div
@@ -312,15 +314,17 @@ class WrapperHome extends PureComponent<Props, State> {
   }
 
   render() {
-    const { sortOrder, wrapperProps, handleActivateWorkspace } = this.props;
     const {
-      workspaces,
-      isLoading,
-      vcs,
       activeProject,
-      workspaceMetas,
+      isLoading,
+      sortOrder,
+      wrapperProps,
       apiSpecs,
-    } = wrapperProps;
+      workspaces,
+      handleActivateWorkspace,
+      workspaceMetas,
+    } = this.props;
+    const { vcs } = wrapperProps;
     const { filter } = this.state;
     // Render each card, removing all the ones that don't match the filter
     const cards = workspaces
@@ -344,7 +348,7 @@ class WrapperHome extends PureComponent<Props, State> {
 
     return (
       <PageLayout
-        wrapperProps={this.props.wrapperProps}
+        wrapperProps={wrapperProps}
         renderPageHeader={() => (
           <AppHeader
             breadcrumbProps={{
@@ -384,8 +388,14 @@ class WrapperHome extends PureComponent<Props, State> {
   }
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state: RootState) => ({
   sortOrder: selectDashboardSortOrder(state),
+  activeProject: selectActiveProject(state),
+  isLoggedIn: selectIsLoggedIn(state),
+  isLoading: selectIsLoading(state),
+  apiSpecs: selectAllApiSpecs(state),
+  workspaceMetas: selectWorkspaceMetas(state),
+  workspaces: selectAllWorkspaces(state),
 });
 
 const mapDispatchToProps = dispatch => {

--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -35,7 +35,7 @@ import { selectIsLoading, setDashboardSortOrder } from '../redux/modules/global'
 import { ForceToWorkspace } from '../redux/modules/helpers';
 import { importClipBoard, importFile, importUri } from '../redux/modules/import';
 import { activateWorkspace, createWorkspace } from '../redux/modules/workspace';
-import { selectActiveProject, selectAllApiSpecs, selectAllWorkspaces, selectDashboardSortOrder, selectIsLoggedIn, selectWorkspaceMetas } from '../redux/selectors';
+import { selectActiveProject, selectApiSpecs, selectDashboardSortOrder, selectIsLoggedIn, selectWorkspaceMetas, selectWorkspaces } from '../redux/selectors';
 import { AppHeader } from './app-header';
 import { DashboardSortDropdown } from './dropdowns/dashboard-sort-dropdown';
 import { ProjectDropdown } from './dropdowns/project-dropdown';
@@ -393,9 +393,9 @@ const mapStateToProps = (state: RootState) => ({
   activeProject: selectActiveProject(state),
   isLoggedIn: selectIsLoggedIn(state),
   isLoading: selectIsLoading(state),
-  apiSpecs: selectAllApiSpecs(state),
+  apiSpecs: selectApiSpecs(state),
   workspaceMetas: selectWorkspaceMetas(state),
-  workspaces: selectAllWorkspaces(state),
+  workspaces: selectWorkspaces(state),
 });
 
 const mapDispatchToProps = dispatch => {

--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -35,7 +35,7 @@ import { selectIsLoading, setDashboardSortOrder } from '../redux/modules/global'
 import { ForceToWorkspace } from '../redux/modules/helpers';
 import { importClipBoard, importFile, importUri } from '../redux/modules/import';
 import { activateWorkspace, createWorkspace } from '../redux/modules/workspace';
-import { selectActiveProject, selectApiSpecs, selectDashboardSortOrder, selectIsLoggedIn, selectWorkspaceMetas, selectWorkspaces } from '../redux/selectors';
+import { selectActiveProject, selectApiSpecs, selectDashboardSortOrder, selectIsLoggedIn, selectWorkspaceMetas, selectWorkspacesForActiveProject } from '../redux/selectors';
 import { AppHeader } from './app-header';
 import { DashboardSortDropdown } from './dropdowns/dashboard-sort-dropdown';
 import { ProjectDropdown } from './dropdowns/project-dropdown';
@@ -395,7 +395,7 @@ const mapStateToProps = (state: RootState) => ({
   isLoading: selectIsLoading(state),
   apiSpecs: selectApiSpecs(state),
   workspaceMetas: selectWorkspaceMetas(state),
-  workspaces: selectWorkspaces(state),
+  workspaces: selectWorkspacesForActiveProject(state),
 });
 
 const mapDispatchToProps = dispatch => {

--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -320,14 +320,14 @@ class WrapperHome extends PureComponent<Props, State> {
       sortOrder,
       wrapperProps,
       apiSpecs,
-      workspaces,
+      workspacesForActiveProject,
       handleActivateWorkspace,
       workspaceMetas,
     } = this.props;
     const { vcs } = wrapperProps;
     const { filter } = this.state;
     // Render each card, removing all the ones that don't match the filter
-    const cards = workspaces
+    const cards = workspacesForActiveProject
       .map(
         mapWorkspaceToWorkspaceCard({
           workspaceMetas,
@@ -395,7 +395,7 @@ const mapStateToProps = (state: RootState) => ({
   isLoading: selectIsLoading(state),
   apiSpecs: selectApiSpecs(state),
   workspaceMetas: selectWorkspaceMetas(state),
-  workspaces: selectWorkspacesForActiveProject(state),
+  workspacesForActiveProject: selectWorkspacesForActiveProject(state),
 });
 
 const mapDispatchToProps = dispatch => {

--- a/packages/insomnia-app/app/ui/components/wrapper.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper.tsx
@@ -219,7 +219,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
   }
 
   async _handleWorkspaceActivityChange({ workspaceId, nextActivity }: Parameters<HandleActivityChange>[0]): ReturnType<HandleActivityChange> {
-    const { activity, activeApiSpec, handleSetActiveActivity } = this.props;
+    const { activeActivity, activeApiSpec, handleSetActiveActivity } = this.props;
 
     // Remember last activity on workspace for later, but only if it isn't HOME
     if (workspaceId && nextActivity !== ACTIVITY_HOME) {
@@ -228,7 +228,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
       });
     }
 
-    const editingASpec = activity === ACTIVITY_SPEC;
+    const editingASpec = activeActivity === ACTIVITY_SPEC;
 
     if (!editingASpec) {
       handleSetActiveActivity(nextActivity);
@@ -445,7 +445,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
       activeProject,
       activeApiSpec,
       activeWorkspaceClientCertificates,
-      activity,
+      activeActivity,
       gitVCS,
       handleActivateRequest,
       handleExportRequestsToFile,
@@ -636,13 +636,13 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
           </ErrorBoundary>
         </div>
         <Fragment key={`views::${this.state.activeGitBranch}`}>
-          {(activity === ACTIVITY_HOME || !activeWorkspace) && (
+          {(activeActivity === ACTIVITY_HOME || !activeWorkspace) && (
             <WrapperHome
               wrapperProps={this.props}
             />
           )}
 
-          {activity === ACTIVITY_SPEC && (
+          {activeActivity === ACTIVITY_SPEC && (
             <WrapperDesign
               gitSyncDropdown={gitSyncDropdown}
               handleActivityChange={this._handleWorkspaceActivityChange}
@@ -650,7 +650,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
             />
           )}
 
-          {activity === ACTIVITY_UNIT_TEST && (
+          {activeActivity === ACTIVITY_UNIT_TEST && (
             <WrapperUnitTest
               gitSyncDropdown={gitSyncDropdown}
               wrapperProps={this.props}
@@ -660,7 +660,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
             </WrapperUnitTest>
           )}
 
-          {activity === ACTIVITY_DEBUG && (
+          {activeActivity === ACTIVITY_DEBUG && (
             <WrapperDebug
               forceRefreshKey={this.state.forceRefreshKey}
               gitSyncDropdown={gitSyncDropdown}

--- a/packages/insomnia-app/app/ui/components/wrapper.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper.tsx
@@ -329,7 +329,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
   }
 
   async _handleRemoveActiveWorkspace() {
-    const { workspaces, activeWorkspace, handleSetActiveActivity } = this.props;
+    const { workspacesForActiveProject, activeWorkspace, handleSetActiveActivity } = this.props;
 
     if (!activeWorkspace) {
       return;
@@ -338,7 +338,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
     await models.stats.incrementDeletedRequestsForDescendents(activeWorkspace);
     await models.workspace.remove(activeWorkspace);
 
-    if (workspaces.length <= 1) {
+    if (workspacesForActiveProject.length <= 1) {
       handleSetActiveActivity(ACTIVITY_HOME);
     }
   }
@@ -455,7 +455,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
       sidebarChildren,
       syncItems,
       vcs,
-      workspaces,
+      workspacesForActiveProject,
     } = this.props;
 
     // Setup git sync dropdown for use in Design/Debug pages
@@ -506,12 +506,12 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
 
             <RequestSettingsModal
               ref={registerModal}
-              workspaces={workspaces}
+              workspacesForActiveProject={workspacesForActiveProject}
             />
 
             <RequestGroupSettingsModal
               ref={registerModal}
-              workspaces={workspaces}
+              workspacesForActiveProject={workspacesForActiveProject}
             />
 
             {activeWorkspace ? <>

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -1050,11 +1050,11 @@ class App extends PureComponent<AppProps, State> {
       activeWorkspaceName,
       activeEnvironment,
       activeRequest,
-      activity,
+      activeActivity,
     } = this.props;
     let title;
 
-    if (activity === ACTIVITY_HOME) {
+    if (activeActivity === ACTIVITY_HOME) {
       title = getAppName();
     } else if (activeWorkspace && activeWorkspaceName) {
       title = activeProject.name;
@@ -1595,7 +1595,7 @@ function mapStateToProps(state: RootState) {
   const activeUnitTestResult = selectActiveUnitTestResult(state);
 
   return {
-    activity: activeActivity,
+    activeActivity,
     activeProject,
     activeApiSpec,
     activeWorkspaceName,

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -1524,124 +1524,53 @@ class App extends PureComponent<AppProps, State> {
   }
 }
 
-function mapStateToProps(state: RootState) {
-  const activeActivity = selectActiveActivity(state);
-  const isLoading = selectIsLoading(state);
-  const isLoggedIn = selectIsLoggedIn(state);
-  const isFinishedBooting = selectIsFinishedBooting(state);
-
-  // Entities
-  const apiSpecs = selectApiSpecs(state);
-  const environments = selectEnvironments(state);
-  const gitRepositories = selectGitRepositories(state);
-  const requestGroups = selectRequestGroups(state);
-  const requestMetas = selectRequestMetas(state);
-  const requestVersions = selectRequestVersions(state);
-  const requests = selectRequests(state);
-  const workspaceMetas = selectWorkspaceMetas(state);
-
-  const stats = selectStats(state);
-  const settings = selectSettings(state);
-
-  // Workspace stuff
-  const activeProject = selectActiveProject(state);
-  const workspacesForActiveProject = selectWorkspacesForActiveProject(state);
-  const activeWorkspaceMeta = selectActiveWorkspaceMeta(state);
-  const activeWorkspace = selectActiveWorkspace(state);
-  const activeWorkspaceName = selectActiveWorkspaceName(state);
-  const activeWorkspaceClientCertificates = selectActiveWorkspaceClientCertificates(state);
-  const activeGitRepository = selectActiveGitRepository(state);
-
-  const sidebarHidden = selectSidebarHidden(state);
-  const sidebarFilter = selectSidebarFilter(state);
-  const sidebarWidth = selectSidebarWidth(state);
-  const paneWidth = selectPaneWidth(state);
-  const paneHeight = selectPaneHeight(state);
-
-  // Request stuff
-  const activeRequest = selectActiveRequest(state);
-
-  const responsePreviewMode = selectResponsePreviewMode(state);
-  const responseFilter = selectResponseFilter(state);
-  const responseFilterHistory = selectResponseFilterHistory(state);
-  const responseDownloadPath = selectResponseDownloadPath(state);
-
-  // Cookie Jar
-  const activeCookieJar = selectActiveCookieJar(state);
-
-  // Response stuff
-  const activeRequestResponses = selectActiveRequestResponses(state);
-  const activeResponse = selectActiveResponse(state);
-
-  // Environment stuff
-  const activeEnvironment = selectActiveEnvironment(state);
-
-  // Find other meta things
-  const loadStartTime = selectLoadStartTime(state);
-  const sidebarChildren = selectSidebarChildren(state);
-  const workspaceChildren = selectWorkspaceRequestsAndRequestGroups(state);
-  const unseenWorkspaces = selectUnseenWorkspaces(state);
-
-  // Sync stuff
-  const syncItems = selectSyncItems(state);
-
-  // Api spec stuff
-  const activeApiSpec = selectActiveApiSpec(state);
-
-  // Test stuff
-  const activeUnitTests = selectActiveUnitTests(state);
-  const activeUnitTestSuite = selectActiveUnitTestSuite(state);
-  const activeUnitTestSuites = selectActiveUnitTestSuites(state);
-  const activeUnitTestResult = selectActiveUnitTestResult(state);
-
-  return {
-    activeActivity,
-    activeProject,
-    activeApiSpec,
-    activeWorkspaceName,
-    activeCookieJar,
-    activeEnvironment,
-    activeGitRepository,
-    activeRequest,
-    activeRequestResponses,
-    activeResponse,
-    activeUnitTestResult,
-    activeUnitTestSuite,
-    activeUnitTestSuites,
-    activeUnitTests,
-    activeWorkspace,
-    activeWorkspaceClientCertificates,
-    activeWorkspaceMeta,
-    apiSpecs,
-    environments,
-    gitRepositories,
-    isLoading,
-    isLoggedIn,
-    isFinishedBooting,
-    loadStartTime,
-    paneHeight,
-    paneWidth,
-    requestGroups,
-    requestMetas,
-    requestVersions,
-    requests,
-    responseDownloadPath,
-    responseFilter,
-    responseFilterHistory,
-    responsePreviewMode,
-    settings,
-    sidebarChildren,
-    sidebarFilter,
-    sidebarHidden,
-    sidebarWidth,
-    stats,
-    syncItems,
-    unseenWorkspaces,
-    workspaceChildren,
-    workspacesForActiveProject,
-    workspaceMetas,
-  };
-}
+const mapStateToProps = (state: RootState) => ({
+  activeActivity: selectActiveActivity(state),
+  activeProject: selectActiveProject(state),
+  activeApiSpec: selectActiveApiSpec(state),
+  activeWorkspaceName: selectActiveWorkspaceName(state),
+  activeCookieJar: selectActiveCookieJar(state),
+  activeEnvironment: selectActiveEnvironment(state),
+  activeGitRepository: selectActiveGitRepository(state),
+  activeRequest: selectActiveRequest(state),
+  activeRequestResponses: selectActiveRequestResponses(state),
+  activeResponse: selectActiveResponse(state),
+  activeUnitTestResult: selectActiveUnitTestResult(state),
+  activeUnitTestSuite: selectActiveUnitTestSuite(state),
+  activeUnitTestSuites: selectActiveUnitTestSuites(state),
+  activeUnitTests: selectActiveUnitTests(state),
+  activeWorkspace: selectActiveWorkspace(state),
+  activeWorkspaceClientCertificates: selectActiveWorkspaceClientCertificates(state),
+  activeWorkspaceMeta: selectActiveWorkspaceMeta(state),
+  apiSpecs: selectApiSpecs(state),
+  environments: selectEnvironments(state),
+  gitRepositories: selectGitRepositories(state),
+  isLoading: selectIsLoading(state),
+  isLoggedIn: selectIsLoggedIn(state),
+  isFinishedBooting: selectIsFinishedBooting(state),
+  loadStartTime: selectLoadStartTime(state),
+  paneHeight: selectPaneHeight(state),
+  paneWidth: selectPaneWidth(state),
+  requestGroups: selectRequestGroups(state),
+  requestMetas: selectRequestMetas(state),
+  requestVersions: selectRequestVersions(state),
+  requests: selectRequests(state),
+  responseDownloadPath: selectResponseDownloadPath(state),
+  responseFilter: selectResponseFilter(state),
+  responseFilterHistory: selectResponseFilterHistory(state),
+  responsePreviewMode: selectResponsePreviewMode(state),
+  settings: selectSettings(state),
+  sidebarChildren: selectSidebarChildren(state),
+  sidebarFilter: selectSidebarFilter(state),
+  sidebarHidden: selectSidebarHidden(state),
+  sidebarWidth: selectSidebarWidth(state),
+  stats: selectStats(state),
+  syncItems: selectSyncItems(state),
+  unseenWorkspaces: selectUnseenWorkspaces(state),
+  workspaceChildren: selectWorkspaceRequestsAndRequestGroups(state),
+  workspacesForActiveProject: selectWorkspacesForActiveProject(state),
+  workspaceMetas: selectWorkspaceMetas(state),
+});
 
 const mapDispatchToProps = (dispatch: Dispatch<Action<any>>) => {
   const {

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -25,7 +25,6 @@ import {
   MIN_PANE_HEIGHT,
   MIN_PANE_WIDTH,
   MIN_SIDEBAR_REMS,
-  PREVIEW_MODE_SOURCE,
   SortOrder,
 } from '../../common/constants';
 import { database as db } from '../../common/database';
@@ -88,18 +87,19 @@ import {
   loadRequestStart,
   loadRequestStop,
   newCommand,
+  selectIsLoading,
   setActiveActivity,
 } from '../redux/modules/global';
 import { importUri } from '../redux/modules/import';
 import { activateWorkspace } from '../redux/modules/workspace';
 import {
+  selectActiveActivity,
   selectActiveApiSpec,
   selectActiveCookieJar,
   selectActiveEnvironment,
   selectActiveGitRepository,
   selectActiveProject,
   selectActiveRequest,
-  selectActiveRequestMeta,
   selectActiveRequestResponses,
   selectActiveResponse,
   selectActiveUnitTestResult,
@@ -110,15 +110,29 @@ import {
   selectActiveWorkspaceClientCertificates,
   selectActiveWorkspaceMeta,
   selectActiveWorkspaceName,
-  selectEntitiesLists,
+  selectAllApiSpecs,
+  selectEnvironments,
+  selectGitRepositories,
+  selectIsFinishedBooting,
+  selectIsLoggedIn,
+  selectLoadStartTime,
+  selectRequestGroups,
+  selectRequestMetas,
+  selectRequests,
+  selectRequestVersions,
+  selectResponseDownloadPath,
+  selectResponseFilter,
+  selectResponseFilterHistory,
+  selectResponsePreviewMode,
   selectSettings,
   selectStats,
   selectSyncItems,
   selectUnseenWorkspaces,
+  selectWorkspaceMetas,
   selectWorkspaceRequestsAndRequestGroups,
   selectWorkspacesForActiveProject,
 } from '../redux/selectors';
-import { selectSidebarChildren } from '../redux/sidebar-selectors';
+import { selectPaneHeight, selectPaneWidth, selectSidebarChildren, selectSidebarFilter, selectSidebarHidden, selectSidebarWidth } from '../redux/sidebar-selectors';
 import { AppHooks } from './app-hooks';
 
 export type AppProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
@@ -1511,26 +1525,20 @@ class App extends PureComponent<AppProps, State> {
 }
 
 function mapStateToProps(state: RootState) {
-  const {
-    activeActivity,
-    isLoading,
-    loadingRequestIds,
-    isLoggedIn,
-    isFinishedBooting,
-  } = state.global;
+  const activeActivity = selectActiveActivity(state);
+  const isLoading = selectIsLoading(state);
+  const isLoggedIn = selectIsLoggedIn(state);
+  const isFinishedBooting = selectIsFinishedBooting(state);
 
   // Entities
-  const entitiesLists = selectEntitiesLists(state);
-  const {
-    apiSpecs,
-    environments,
-    gitRepositories,
-    requestGroups,
-    requestMetas,
-    requestVersions,
-    requests,
-    workspaceMetas,
-  } = entitiesLists;
+  const apiSpecs = selectAllApiSpecs(state);
+  const environments = selectEnvironments(state);
+  const gitRepositories = selectGitRepositories(state);
+  const requestGroups = selectRequestGroups(state);
+  const requestMetas = selectRequestMetas(state);
+  const requestVersions = selectRequestVersions(state);
+  const requests = selectRequests(state);
+  const workspaceMetas = selectWorkspaceMetas(state);
 
   const stats = selectStats(state);
   const settings = selectSettings(state);
@@ -1544,20 +1552,19 @@ function mapStateToProps(state: RootState) {
   const activeWorkspaceClientCertificates = selectActiveWorkspaceClientCertificates(state);
   const activeGitRepository = selectActiveGitRepository(state);
 
-  const sidebarHidden = activeWorkspaceMeta?.sidebarHidden || false;
-  const sidebarFilter = activeWorkspaceMeta?.sidebarFilter || '';
-  const sidebarWidth = activeWorkspaceMeta?.sidebarWidth || DEFAULT_SIDEBAR_WIDTH;
-  const paneWidth = activeWorkspaceMeta?.paneWidth || DEFAULT_PANE_WIDTH;
-  const paneHeight = activeWorkspaceMeta?.paneHeight || DEFAULT_PANE_HEIGHT;
+  const sidebarHidden = selectSidebarHidden(state);
+  const sidebarFilter = selectSidebarFilter(state);
+  const sidebarWidth = selectSidebarWidth(state);
+  const paneWidth = selectPaneWidth(state);
+  const paneHeight = selectPaneHeight(state);
 
   // Request stuff
-  const requestMeta = selectActiveRequestMeta(state);
   const activeRequest = selectActiveRequest(state);
 
-  const responsePreviewMode = requestMeta?.previewMode || PREVIEW_MODE_SOURCE;
-  const responseFilter = requestMeta?.responseFilter || '';
-  const responseFilterHistory = requestMeta?.responseFilterHistory || [];
-  const responseDownloadPath = requestMeta?.downloadPath || null;
+  const responsePreviewMode = selectResponsePreviewMode(state);
+  const responseFilter = selectResponseFilter(state);
+  const responseFilterHistory = selectResponseFilterHistory(state);
+  const responseDownloadPath = selectResponseDownloadPath(state);
 
   // Cookie Jar
   const activeCookieJar = selectActiveCookieJar(state);
@@ -1570,7 +1577,7 @@ function mapStateToProps(state: RootState) {
   const activeEnvironment = selectActiveEnvironment(state);
 
   // Find other meta things
-  const loadStartTime = loadingRequestIds[activeRequest ? activeRequest._id : 'n/a'] || -1;
+  const loadStartTime = selectLoadStartTime(state);
   const sidebarChildren = selectSidebarChildren(state);
   const workspaceChildren = selectWorkspaceRequestsAndRequestGroups(state);
   const unseenWorkspaces = selectUnseenWorkspaces(state);

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -1545,7 +1545,7 @@ function mapStateToProps(state: RootState) {
 
   // Workspace stuff
   const activeProject = selectActiveProject(state);
-  const workspaces = selectWorkspacesForActiveProject(state);
+  const workspacesForActiveProject = selectWorkspacesForActiveProject(state);
   const activeWorkspaceMeta = selectActiveWorkspaceMeta(state);
   const activeWorkspace = selectActiveWorkspace(state);
   const activeWorkspaceName = selectActiveWorkspaceName(state);
@@ -1638,7 +1638,7 @@ function mapStateToProps(state: RootState) {
     syncItems,
     unseenWorkspaces,
     workspaceChildren,
-    workspaces,
+    workspacesForActiveProject,
     workspaceMetas,
   };
 }

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -110,7 +110,7 @@ import {
   selectActiveWorkspaceClientCertificates,
   selectActiveWorkspaceMeta,
   selectActiveWorkspaceName,
-  selectAllApiSpecs,
+  selectApiSpecs,
   selectEnvironments,
   selectGitRepositories,
   selectIsFinishedBooting,
@@ -1531,7 +1531,7 @@ function mapStateToProps(state: RootState) {
   const isFinishedBooting = selectIsFinishedBooting(state);
 
   // Entities
-  const apiSpecs = selectAllApiSpecs(state);
+  const apiSpecs = selectApiSpecs(state);
   const environments = selectEnvironments(state);
   const gitRepositories = selectGitRepositories(state);
   const requestGroups = selectRequestGroups(state);

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -129,7 +129,6 @@ import {
   selectSyncItems,
   selectUnseenWorkspaces,
   selectWorkspaceMetas,
-  selectWorkspaceRequestsAndRequestGroups,
   selectWorkspacesForActiveProject,
 } from '../redux/selectors';
 import { selectPaneHeight, selectPaneWidth, selectSidebarChildren, selectSidebarFilter, selectSidebarHidden, selectSidebarWidth } from '../redux/sidebar-selectors';
@@ -1567,7 +1566,6 @@ const mapStateToProps = (state: RootState) => ({
   stats: selectStats(state),
   syncItems: selectSyncItems(state),
   unseenWorkspaces: selectUnseenWorkspaces(state),
-  workspaceChildren: selectWorkspaceRequestsAndRequestGroups(state),
   workspacesForActiveProject: selectWorkspacesForActiveProject(state),
   workspaceMetas: selectWorkspaceMetas(state),
 });

--- a/packages/insomnia-app/app/ui/hooks/workspace.ts
+++ b/packages/insomnia-app/app/ui/hooks/workspace.ts
@@ -8,7 +8,7 @@ import { BackendProjectWithTeam } from '../../sync/vcs/normalize-backend-project
 import { pullBackendProject } from '../../sync/vcs/pull-backend-project';
 import { VCS } from '../../sync/vcs/vcs';
 import { showAlert } from '../components/modals';
-import { selectActiveProject, selectAllWorkspaces, selectIsLoggedIn, selectRemoteProjects, selectSettings } from '../redux/selectors';
+import { selectActiveProject, selectIsLoggedIn, selectRemoteProjects, selectSettings, selectWorkspaces } from '../redux/selectors';
 import { useSafeReducerDispatch } from './use-safe-reducer-dispatch';
 
 interface State {
@@ -48,7 +48,7 @@ const reducer: Reducer<State, Action> = (prevState, action) => {
 
 export const useRemoteWorkspaces = (vcs?: VCS) => {
   // Fetch from redux
-  const workspaces = useSelector(selectAllWorkspaces);
+  const workspaces = useSelector(selectWorkspaces);
   const activeProject = useSelector(selectActiveProject);
   const remoteProjects = useSelector(selectRemoteProjects);
   const isLoggedIn = useSelector(selectIsLoggedIn);

--- a/packages/insomnia-app/app/ui/redux/modules/global.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/global.tsx
@@ -434,9 +434,9 @@ export const exportAllToFile = () => async (dispatch: Dispatch, getState) => {
   dispatch(loadStart());
   const state = getState();
   const activeProjectName = selectActiveProjectName(state);
-  const workspaces = selectWorkspacesForActiveProject(state);
+  const workspacesForActiveProject = selectWorkspacesForActiveProject(state);
 
-  if (!workspaces.length) {
+  if (!workspacesForActiveProject.length) {
     dispatch(loadStop());
     showAlert({
       title: 'Cannot export',
@@ -475,15 +475,15 @@ export const exportAllToFile = () => async (dispatch: Dispatch, getState) => {
       try {
         switch (selectedFormat) {
           case VALUE_HAR:
-            stringifiedExport = await exportWorkspacesHAR(workspaces, exportPrivateEnvironments);
+            stringifiedExport = await exportWorkspacesHAR(workspacesForActiveProject, exportPrivateEnvironments);
             break;
 
           case VALUE_YAML:
-            stringifiedExport = await exportWorkspacesData(workspaces, exportPrivateEnvironments, 'yaml');
+            stringifiedExport = await exportWorkspacesData(workspacesForActiveProject, exportPrivateEnvironments, 'yaml');
             break;
 
           case VALUE_JSON:
-            stringifiedExport = await exportWorkspacesData(workspaces, exportPrivateEnvironments, 'json');
+            stringifiedExport = await exportWorkspacesData(workspacesForActiveProject, exportPrivateEnvironments, 'json');
             break;
 
           default:

--- a/packages/insomnia-app/app/ui/redux/modules/workspace.ts
+++ b/packages/insomnia-app/app/ui/redux/modules/workspace.ts
@@ -7,7 +7,7 @@ import { database } from '../../../common/database';
 import * as models from '../../../models';
 import { isCollection, isDesign, Workspace, WorkspaceScope } from '../../../models/workspace';
 import { showPrompt } from '../../components/modals';
-import { selectActiveActivity, selectActiveProject, selectAllWorkspaces } from '../selectors';
+import { selectActiveActivity, selectActiveProject, selectWorkspaces } from '../selectors';
 import { RootState } from '.';
 import { setActiveActivity, setActiveProject, setActiveWorkspace } from './global';
 
@@ -77,7 +77,7 @@ export const activateWorkspace = ({ workspace, workspaceId }: RequireExactlyOne<
   return async (dispatch: Dispatch, getState: () => RootState) => {
     // If we have no workspace but we do have an id, search for it
     if (!workspace && workspaceId) {
-      workspace = selectAllWorkspaces(getState()).find(({ _id }) => _id === workspaceId);
+      workspace = selectWorkspaces(getState()).find(({ _id }) => _id === workspaceId);
     }
 
     // If we still have no workspace, exit

--- a/packages/insomnia-app/app/ui/redux/selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import { ValueOf } from 'type-fest';
 
-import { isWorkspaceActivity } from '../../common/constants';
+import { isWorkspaceActivity, PREVIEW_MODE_SOURCE } from '../../common/constants';
 import * as models from '../../models';
 import { BaseModel } from '../../models';
 import { GrpcRequest, isGrpcRequest } from '../../models/grpc-request';
@@ -204,15 +204,40 @@ export const selectActiveWorkspaceName = createSelector(
   }
 );
 
+export const selectEnvironments = createSelector(
+  selectEntitiesLists,
+  entities => entities.environments,
+);
+
+export const selectGitRepositories = createSelector(
+  selectEntitiesLists,
+  entities => entities.gitRepositories,
+);
+
+export const selectRequestGroups = createSelector(
+  selectEntitiesLists,
+  entities => entities.requestGroups,
+);
+
+export const selectRequestVersions = createSelector(
+  selectEntitiesLists,
+  entities => entities.requestVersions,
+);
+
+export const selectRequests = createSelector(
+  selectEntitiesLists,
+  entities => entities.requests,
+);
+
 export const selectActiveEnvironment = createSelector(
   selectActiveWorkspaceMeta,
-  selectEntitiesLists,
-  (meta, entities) => {
+  selectEnvironments,
+  (meta, environments) => {
     if (!meta) {
       return null;
     }
 
-    return entities.environments.find(e => e._id === meta.activeEnvironmentId) || null;
+    return environments.find(environment => environment._id === meta.activeEnvironmentId) || null;
   },
 );
 
@@ -344,6 +369,17 @@ export const selectActiveOAuth2Token = createSelector(
   },
 );
 
+export const selectLoadingRequestIds = createSelector(
+  selectGlobal,
+  global => global.loadingRequestIds,
+);
+
+export const selectLoadStartTime = createSelector(
+  selectLoadingRequestIds,
+  selectActiveRequest,
+  (loadingRequestIds, activeRequest) => loadingRequestIds[activeRequest ? activeRequest._id : 'n/a'] || -1
+);
+
 export const selectUnseenWorkspaces = createSelector(
   selectEntitiesLists,
   entities => {
@@ -361,6 +397,26 @@ export const selectActiveRequestMeta = createSelector(
     const id = activeRequest?._id || 'n/a';
     return entities.requestMetas.find(m => m.parentId === id);
   },
+);
+
+export const selectResponsePreviewMode = createSelector(
+  selectActiveRequestMeta,
+  requestMeta => requestMeta?.previewMode || PREVIEW_MODE_SOURCE,
+);
+
+export const selectResponseFilter = createSelector(
+  selectActiveRequestMeta,
+  requestMeta => requestMeta?.responseFilter || '',
+);
+
+export const selectResponseFilterHistory = createSelector(
+  selectActiveRequestMeta,
+  requestMeta => requestMeta?.responseFilterHistory || [],
+);
+
+export const selectResponseDownloadPath = createSelector(
+  selectActiveRequestMeta,
+  requestMeta => requestMeta?.downloadPath || null,
 );
 
 export const selectActiveRequestResponses = createSelector(
@@ -482,4 +538,9 @@ export const selectIsLoggedIn = createSelector(
 export const selectActiveActivity = createSelector(
   selectGlobal,
   global => global.activeActivity,
+);
+
+export const selectIsFinishedBooting = createSelector(
+  selectGlobal,
+  global => global.isFinishedBooting,
 );

--- a/packages/insomnia-app/app/ui/redux/selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/selectors.ts
@@ -132,6 +132,11 @@ export const selectActiveWorkspace = createSelector(
   },
 );
 
+export const selectWorkspaceMetas = createSelector(
+  selectEntitiesLists,
+  entities => entities.workspaceMetas,
+);
+
 export const selectActiveWorkspaceMeta = createSelector(
   selectActiveWorkspace,
   selectEntitiesLists,

--- a/packages/insomnia-app/app/ui/redux/selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/selectors.ts
@@ -106,13 +106,13 @@ export const selectDashboardSortOrder = createSelector(
   global => global.dashboardSortOrder
 );
 
-export const selectAllWorkspaces = createSelector(
+export const selectWorkspaces = createSelector(
   selectEntitiesLists,
   entities => entities.workspaces,
 );
 
 export const selectWorkspacesForActiveProject = createSelector(
-  selectAllWorkspaces,
+  selectWorkspaces,
   selectActiveProject,
   (workspaces, activeProject) => workspaces.filter(workspace => workspace.parentId === activeProject._id),
 );
@@ -146,14 +146,14 @@ export const selectActiveWorkspaceMeta = createSelector(
   },
 );
 
-export const selectAllApiSpecs = createSelector(
+export const selectApiSpecs = createSelector(
   selectEntitiesLists,
   entities => entities.apiSpecs,
 );
 
 export const selectWorkspacesWithResolvedNameForActiveProject = createSelector(
   selectWorkspacesForActiveProject,
-  selectAllApiSpecs,
+  selectApiSpecs,
   (workspaces, apiSpecs) => {
     return workspaces.map(workspace => {
       if (isCollection(workspace)) {
@@ -173,7 +173,7 @@ export const selectWorkspacesWithResolvedNameForActiveProject = createSelector(
 );
 
 export const selectActiveApiSpec = createSelector(
-  selectAllApiSpecs,
+  selectApiSpecs,
   selectActiveWorkspace,
   (apiSpecs, activeWorkspace) => {
     if (!activeWorkspace) {

--- a/packages/insomnia-app/app/ui/redux/sidebar-selectors.ts
+++ b/packages/insomnia-app/app/ui/redux/sidebar-selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 
+import { DEFAULT_PANE_HEIGHT, DEFAULT_PANE_WIDTH, DEFAULT_SIDEBAR_WIDTH } from '../../common/constants';
 import { fuzzyMatchAll } from '../../common/misc';
 import type { BaseModel } from '../../models';
 import { GrpcRequest, isGrpcRequest } from '../../models/grpc-request';
@@ -42,18 +43,41 @@ export interface SidebarChildren {
   pinned: Child[];
 }
 
+export const selectSidebarHidden = createSelector(
+  selectActiveWorkspaceMeta,
+  activeWorkspaceMeta => activeWorkspaceMeta?.sidebarHidden || false,
+);
+
+export const selectSidebarWidth = createSelector(
+  selectActiveWorkspaceMeta,
+  activeWorkspaceMeta =>  activeWorkspaceMeta?.sidebarWidth || DEFAULT_SIDEBAR_WIDTH,
+);
+
+export const selectPaneWidth = createSelector(
+  selectActiveWorkspaceMeta,
+  activeWorkspaceMeta => activeWorkspaceMeta?.paneWidth || DEFAULT_PANE_WIDTH,
+);
+
+export const selectPaneHeight = createSelector(
+  selectActiveWorkspaceMeta,
+  activeWorkspaceMeta =>  activeWorkspaceMeta?.paneHeight || DEFAULT_PANE_HEIGHT,
+);
+
+export const selectSidebarFilter = createSelector(
+  selectActiveWorkspaceMeta,
+  activeWorkspaceMeta => activeWorkspaceMeta ? activeWorkspaceMeta.sidebarFilter : '',
+);
+
 export const selectSidebarChildren = createSelector(
   selectCollapsedRequestGroups,
   selectPinnedRequests,
   selectActiveWorkspace,
-  selectActiveWorkspaceMeta,
   selectEntitiesChildrenMap,
-  (collapsed, pinned, activeWorkspace, activeWorkspaceMeta, childrenMap): SidebarChildren => {
+  selectSidebarFilter,
+  (collapsed, pinned, activeWorkspace, childrenMap, sidebarFilter): SidebarChildren => {
     if (!activeWorkspace) {
       return { all: [], pinned: [] };
     }
-
-    const sidebarFilter = activeWorkspaceMeta ? activeWorkspaceMeta.sidebarFilter : '';
 
     function next(parentId: string, pinnedChildren: Child[]) {
       const children: SidebarModel[] = (childrenMap[parentId] || [])


### PR DESCRIPTION
This PR relates to (but does not close) the wrapper props ticket, INS-1058.  This continues the work started in https://github.com/Kong/insomnia/pull/4431.

Specifically, it focuses on the data (not callbacks) that have (or can/should have) simple state selectors.

This severs the tie at the root, where the props are first passed.  Yes, ultimately this will mean more work for us _overall_, but, as the previous PR and now this PR demonstrate, this is a gigantic job.  I don't want to change too much all at once.  The changes done this way in this PR are relatively safe, comparatively, since we're using (in most cases) exactly the same selector that Wrapper or App used in the first place.  Where there weren't selectors in those cases, I created some using exactly the same logic.

I don't agree, by the way, with some of the decisions and fallbacks in some of these selectors, but this is no time for scope creep.  It's already quite complicated.  Once we have it all wired up a little better later, we can address the fallbacks.

I would encourage a commit-by-commit review.  I tried to keep all the changes mostly atomic so that it'd be easier to reason about what happened in this PR.