### PR TITLE
feat: add upstream target weighting to servers block in oas

### DIFF
--- a/packages/openapi-2-kong/src/declarative-config/fixtures/api-with-examples.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/api-with-examples.expected.json
@@ -47,6 +47,7 @@
       "targets": [
         {
           "target": "backend.com:80",
+          "weight": 100,
           "tags": ["OAS3_import", "OAS3file_api-with-examples.yaml"]
         }
       ]

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/httpbin.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/httpbin.expected.json
@@ -250,10 +250,12 @@
       "targets": [
         {
           "target": "httpbin.org:443",
+          "weight": 60,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"]
         },
         {
           "target": "eu.httpbin.org:443",
+          "weight": 40,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"]
         }
       ]

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/httpbin.yaml
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/httpbin.yaml
@@ -7,8 +7,10 @@ info:
 servers:
   - url: https://httpbin.org
   #- url: http://httpbin.org
+    x-kong-upstream-target-weight: 60
   - url: https://eu.httpbin.org
   #- url: http://eu.httpbin.org
+    x-kong-upstream-target-weight: 40
 
 tags:
   - name: auth

--- a/packages/openapi-2-kong/src/declarative-config/upstreams.test.ts
+++ b/packages/openapi-2-kong/src/declarative-config/upstreams.test.ts
@@ -11,6 +11,7 @@ const getSpecResult = (): DCUpstream =>
       targets: [
         {
           target: 'server1.com:443',
+          weight: 100,
           tags,
         },
       ],

--- a/packages/openapi-2-kong/src/declarative-config/upstreams.ts
+++ b/packages/openapi-2-kong/src/declarative-config/upstreams.ts
@@ -34,10 +34,12 @@ export function generateUpstreams(api: OpenApi3Spec, tags: string[]) {
   for (const server of servers) {
     const serverWithVars = fillServerVariables(server);
     const hostWithPort = parseUrl(serverWithVars).host;
+    const targetWeight = server['x-kong-upstream-target-weight'] || 100;
 
     if (hostWithPort) {
       upstream.targets.push({
         target: hostWithPort,
+        weight: targetWeight,
         tags,
       });
     }

--- a/packages/openapi-2-kong/src/types/declarative-config.ts
+++ b/packages/openapi-2-kong/src/types/declarative-config.ts
@@ -25,6 +25,7 @@ export interface DCService extends Taggable, Pluggable {
 
 export interface DCTarget extends Taggable {
   target: string;
+  weight: number;
 }
 
 export interface DCUpstream extends Taggable {

--- a/packages/openapi-2-kong/src/types/kong.ts
+++ b/packages/openapi-2-kong/src/types/kong.ts
@@ -25,6 +25,11 @@ export interface XKongServiceDefaults {
   [xKongServiceDefaults]?: Partial<DCService>;
 }
 
+export const xKongUpstreamTargetWeight: XKongProperty<'upstream-target-weight'> = 'x-kong-upstream-target-weight';
+export interface XKongUpstreamTargetWeight {
+  [xKongUpstreamTargetWeight]?: number;
+}
+
 export type XKongPluginProperty<Name extends string = string> = XKongProperty<`plugin-${Name}`>;
 
 // Note: it's important that `Name` doesn't have a default argument.  We want to force the consumer of this type to specify the name as specifically as possible because this value is instrumental to how the plugins are used and discriminated.

--- a/packages/openapi-2-kong/src/types/openapi3.ts
+++ b/packages/openapi-2-kong/src/types/openapi3.ts
@@ -7,6 +7,7 @@ import {
   XKongRouteDefaults,
   XKongServiceDefaults,
   XKongUpstreamDefaults,
+  XKongUpstreamTargetWeight,
 } from './kong';
 import { K8sIngressTLS } from './kubernetes-config';
 import { Taggable } from './outputs';
@@ -106,7 +107,8 @@ export type OA3Server = {
   variables?: Record<string, OA3ServerVariable>;
 } & OA3ServerKubernetesTLS
   & OA3ServerKubernetesBackend
-  & OA3ServerKubernetesService;
+  & OA3ServerKubernetesService
+  & XKongUpstreamTargetWeight;
 
 export interface OA3ResponsesObject {
   $ref?: string;


### PR DESCRIPTION
My client wants to have the ability to adjust the target weighting on the "upstream targets" via the OpenAPI Spec (when converted to the Kong Deck YAML format).

This will allow them to easily do canary releases by deploying a 'green' backend, and forwarding some of the old 'blue' backend traffic to it. Once they are satisfied with the results, they will remove the 'blue' backend target from the OAS.

It defaults to "100.00" or just "100" as is normal for the Kong defaults.
