### PR TITLE
electron v15 pre-upgrade refactoring

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/render.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/render.test.ts
@@ -49,15 +49,11 @@ describe('render tests', () => {
       expect(rendered).toBe('Hello FooBar!');
     });
 
-    it('fails on invalid template', async () => {
-      try {
-        await renderUtils.render('Hello {{ msg }!', {
-          msg: 'World',
-        });
-        fail('Render should have failed');
-      } catch (err) {
-        expect(err.message).toContain('expected variable end');
-      }
+    it('returns invalid template', async () => {
+      const rendered = await renderUtils.render('Hello {{ msg }!', {
+        msg: 'World',
+      });
+      expect(rendered).toBe('Hello {{ msg }!');
     });
 
     it('handles variables using tag before tag is defined as expected (incorrect order)', async () => {
@@ -570,7 +566,7 @@ describe('render tests', () => {
         );
         fail('Render should have failed');
       } catch (err) {
-        expect(err.message).toContain('expected variable end');
+        expect(err.message).toContain('attempted to output null or undefined value');
       }
     });
 

--- a/packages/insomnia-app/app/common/misc.ts
+++ b/packages/insomnia-app/app/common/misc.ts
@@ -341,27 +341,6 @@ export function fuzzyMatchAll(
   };
 }
 
-export async function waitForStreamToFinish(stream: Readable | Writable) {
-  return new Promise<void>(resolve => {
-    // @ts-expect-error -- access of internal values that are intended to be private.  We should _not_ do this.
-    if (stream._readableState?.finished) {
-      return resolve();
-    }
-
-    // @ts-expect-error -- access of internal values that are intended to be private.  We should _not_ do this.
-    if (stream._writableState?.finished) {
-      return resolve();
-    }
-
-    stream.on('close', () => {
-      resolve();
-    });
-    stream.on('error', () => {
-      resolve();
-    });
-  });
-}
-
 export function chunkArray<T>(arr: T[], chunkSize: number) {
   const chunks: T[][] = [];
 

--- a/packages/insomnia-app/app/common/misc.ts
+++ b/packages/insomnia-app/app/common/misc.ts
@@ -1,6 +1,5 @@
 import fuzzysort from 'fuzzysort';
 import { join as pathJoin } from 'path';
-import { Readable, Writable } from 'stream';
 import * as uuid from 'uuid';
 import zlib from 'zlib';
 

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -27,6 +27,8 @@ interface Window {
     authorizeUserInWindow: (options: { url: string; urlSuccessRegex?: RegExp; urlFailureRegex?: RegExp; sessionId: string }) => Promise<string>;
     setMenuBarVisibility: (visible: boolean) => void;
     installPlugin: (url: string) => void;
+    curlRequest: (options: { curlOptions; bodyPath; maxTimelineDataSizeKB; cancelId }) => Promise<{ patch: ResponsePatch; debugTimeline: ResponseTimelineEntry[]; headerArray: HeaderResult[] }>;
+    cancelCurlRequest: (requestId: string) => void;
   };
   dialog: {
     showOpenDialog: (options: Electron.OpenDialogOptions) => Promise<Electron.OpenDialogReturnValue>;

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -27,8 +27,19 @@ interface Window {
     authorizeUserInWindow: (options: { url: string; urlSuccessRegex?: RegExp; urlFailureRegex?: RegExp; sessionId: string }) => Promise<string>;
     setMenuBarVisibility: (visible: boolean) => void;
     installPlugin: (url: string) => void;
-    curlRequest: (options: { curlOptions; bodyPath; maxTimelineDataSizeKB; cancelId }) => Promise<{ patch: ResponsePatch; debugTimeline: ResponseTimelineEntry[]; headerArray: HeaderResult[] }>;
     cancelCurlRequest: (requestId: string) => void;
+    curlRequest: (options: {
+      curlOptions: CurlOpt[];
+      responseBodyPath: string;
+      maxTimelineDataSizeKB: number;
+      requestId: string;
+      requestBodyPath?: string;
+      isMultipart: boolean;
+    }) => Promise<{
+      patch: ResponsePatch;
+      debugTimeline: ResponseTimelineEntry[];
+      headerResults: HeaderResult[];
+    }>;
   };
   dialog: {
     showOpenDialog: (options: Electron.OpenDialogOptions) => Promise<Electron.OpenDialogReturnValue>;

--- a/packages/insomnia-app/app/global.d.ts
+++ b/packages/insomnia-app/app/global.d.ts
@@ -27,6 +27,7 @@ interface Window {
     authorizeUserInWindow: (options: { url: string; urlSuccessRegex?: RegExp; urlFailureRegex?: RegExp; sessionId: string }) => Promise<string>;
     setMenuBarVisibility: (visible: boolean) => void;
     installPlugin: (url: string) => void;
+    writeFile: (options: {path: string; content: string}) => Promise<string>;
     cancelCurlRequest: (requestId: string) => void;
     curlRequest: (options: {
       curlOptions: CurlOpt[];

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -1,6 +1,7 @@
 import * as electron from 'electron';
 import contextMenu from 'electron-context-menu';
 import installExtension, { REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } from 'electron-devtools-installer';
+import { writeFile } from 'fs';
 import path from 'path';
 
 import appConfig from '../config/config.json';
@@ -258,6 +259,17 @@ async function _trackStats() {
   ipcMain.handle('authorizeUserInWindow', (_, options) => {
     const { url, urlSuccessRegex, urlFailureRegex, sessionId } = options;
     return authorizeUserInWindow({ url, urlSuccessRegex, urlFailureRegex, sessionId });
+  });
+
+  ipcMain.handle('writeFile', (_, options) => {
+    return new Promise<string>((resolve, reject) => {
+      writeFile(options.path, options.content, err => {
+        if (err != null) {
+          reject(err);
+        }
+        resolve(options.path);
+      });
+    });
   });
 
   ipcMain.handle('curlRequest', (_, options) => {

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -265,7 +265,7 @@ async function _trackStats() {
     return new Promise<string>((resolve, reject) => {
       writeFile(options.path, options.content, err => {
         if (err != null) {
-          reject(err);
+          return reject(err);
         }
         resolve(options.path);
       });

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -17,6 +17,7 @@ import * as updates from './main/updates';
 import * as windowUtils from './main/window-utils';
 import * as models from './models/index';
 import type { Stats } from './models/stats';
+import { cancelCurlRequest, curlRequest } from './network/libcurl-promise';
 import { authorizeUserInWindow } from './network/o-auth-2/misc';
 import installPlugin from './plugins/install';
 import type { ToastNotification } from './ui/components/toast';
@@ -257,6 +258,14 @@ async function _trackStats() {
   ipcMain.handle('authorizeUserInWindow', (_, options) => {
     const { url, urlSuccessRegex, urlFailureRegex, sessionId } = options;
     return authorizeUserInWindow({ url, urlSuccessRegex, urlFailureRegex, sessionId });
+  });
+
+  ipcMain.handle('curlRequest', (_, options) => {
+    return curlRequest(options);
+  });
+
+  ipcMain.on('cancelCurlRequest', (_, requestId: string): void => {
+    cancelCurlRequest(requestId);
   });
 
   ipcMain.once('window-ready', () => {

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -1,4 +1,3 @@
-import { Curl } from '@getinsomnia/node-libcurl';
 import electron, { BrowserWindow, MenuItemConstructorOptions } from 'electron';
 import fs from 'fs';
 import * as os from 'os';
@@ -22,9 +21,6 @@ import * as log from '../common/log';
 import LocalStorage from './local-storage';
 
 const { app, Menu, shell, dialog, clipboard } = electron;
-// So we can use native modules in renderer
-// NOTE: This was (deprecated in Electron 10)[https://github.com/electron/electron/issues/18397] and (removed in Electron 14)[https://github.com/electron/electron/pull/26874]
-app.allowRendererProcessReuse = false;
 
 const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 720;
@@ -388,7 +384,6 @@ export function createWindow() {
       `Node: ${process.versions.node}`,
       `V8: ${process.versions.v8}`,
       `Architecture: ${process.arch}`,
-      `node-libcurl: ${Curl.getVersion()}`,
     ].join('\n');
 
     const msgBox = await dialog.showMessageBox({

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -21,7 +21,6 @@ import { DEFAULT_BOUNDARY } from '../multipart';
 import { CurlHttpVersion } from '../network';
 import * as networkUtils from '../network';
 window.app = electron.app;
-window.main = { cancelCurlRequest:() => {} };
 
 const getRenderedRequest = async (args: Parameters<typeof getRenderedRequestAndContext>[0]) => (await getRenderedRequestAndContext(args)).request;
 

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -746,48 +746,6 @@ describe('actuallySend()', () => {
     expect(networkUtils.getHttpVersion(HttpVersions.default).curlHttpVersion).toBe(undefined);
     expect(networkUtils.getHttpVersion('blah').curlHttpVersion).toBe(undefined);
   });
-
-  it('requests can be cancelled by requestId', async () => {
-    // GIVEN
-    const workspace = await models.workspace.create();
-    const settings = await models.settings.getOrCreate();
-    const request1 = Object.assign(models.request.init(), {
-      _id: 'req_15',
-      parentId: workspace._id,
-      url: 'http://unix:3000/requestA',
-      method: 'GET',
-    });
-    const request2 = Object.assign(models.request.init(), {
-      _id: 'req_10',
-      parentId: workspace._id,
-      url: 'http://unix:3000/requestB',
-      method: 'GET',
-    });
-    const renderedRequest1 = await getRenderedRequest({ request: request1 });
-    const renderedRequest2 = await getRenderedRequest({ request: request2 });
-
-    // WHEN
-    const response1Promise = networkUtils._actuallySend(
-      renderedRequest1,
-      workspace,
-      settings,
-    );
-
-    const response2Promise = networkUtils._actuallySend(
-      renderedRequest2,
-      workspace,
-      settings,
-    );
-
-    await networkUtils.cancelRequestById(renderedRequest1._id);
-    const response1 = await response1Promise;
-    const response2 = await response2Promise;
-    // THEN
-    expect(response1.statusMessage).toBe('Cancelled');
-    expect(response2.statusMessage).toBe('OK');
-    expect(networkUtils.hasCancelFunctionForId(request1._id)).toBe(false);
-    expect(networkUtils.hasCancelFunctionForId(request2._id)).toBe(false);
-  });
 });
 
 describe('_getAwsAuthHeaders', () => {

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -1,3 +1,4 @@
+import { CurlHttpVersion } from '@getinsomnia/node-libcurl/dist/enum/CurlHttpVersion';
 import electron from 'electron';
 import fs from 'fs';
 import { HttpVersions } from 'insomnia-common';
@@ -18,7 +19,6 @@ import { getRenderedRequestAndContext } from '../../common/render';
 import * as models from '../../models';
 import { _parseHeaders } from '../libcurl-promise';
 import { DEFAULT_BOUNDARY } from '../multipart';
-import { CurlHttpVersion } from '../network';
 import * as networkUtils from '../network';
 window.app = electron.app;
 
@@ -605,7 +605,7 @@ describe('actuallySend()', () => {
         NOPROGRESS: true,
         PROXY: '',
         TIMEOUT_MS: 0,
-        NETRC: 'Required',
+        NETRC: 2,
         URL: '',
         USERAGENT: `insomnia/${getAppVersion()}`,
         VERBOSE: true,
@@ -737,7 +737,7 @@ describe('actuallySend()', () => {
       ...settings,
       preferredHttpVersion: HttpVersions.V1_0,
     });
-    expect(JSON.parse(String(models.response.getBodyBuffer(responseV1))).options.HTTP_VERSION).toBe('V1_0');
+    expect(JSON.parse(String(models.response.getBodyBuffer(responseV1))).options.HTTP_VERSION).toBe(1);
     expect(networkUtils.getHttpVersion(HttpVersions.V1_0).curlHttpVersion).toBe(CurlHttpVersion.V1_0);
     expect(networkUtils.getHttpVersion(HttpVersions.V1_1).curlHttpVersion).toBe(CurlHttpVersion.V1_1);
     expect(networkUtils.getHttpVersion(HttpVersions.V2PriorKnowledge).curlHttpVersion).toBe(CurlHttpVersion.V2PriorKnowledge);

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -1,4 +1,5 @@
 import { CurlHttpVersion } from '@getinsomnia/node-libcurl/dist/enum/CurlHttpVersion';
+import { CurlNetrc } from '@getinsomnia/node-libcurl/dist/enum/CurlNetrc';
 import electron from 'electron';
 import fs from 'fs';
 import { HttpVersions } from 'insomnia-common';
@@ -605,7 +606,7 @@ describe('actuallySend()', () => {
         NOPROGRESS: true,
         PROXY: '',
         TIMEOUT_MS: 0,
-        NETRC: 2,
+        NETRC: CurlNetrc.Required,
         URL: '',
         USERAGENT: `insomnia/${getAppVersion()}`,
         VERBOSE: true,

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -606,7 +606,7 @@ describe('actuallySend()', () => {
         NOPROGRESS: true,
         PROXY: '',
         TIMEOUT_MS: 0,
-        NETRC: 2,
+        NETRC: 'Required',
         URL: '',
         USERAGENT: `insomnia/${getAppVersion()}`,
         VERBOSE: true,
@@ -738,7 +738,7 @@ describe('actuallySend()', () => {
       ...settings,
       preferredHttpVersion: HttpVersions.V1_0,
     });
-    expect(JSON.parse(String(models.response.getBodyBuffer(responseV1))).options.HTTP_VERSION).toBe(1);
+    expect(JSON.parse(String(models.response.getBodyBuffer(responseV1))).options.HTTP_VERSION).toBe('V1_0');
     expect(networkUtils.getHttpVersion(HttpVersions.V1_0).curlHttpVersion).toBe(CurlHttpVersion.V1_0);
     expect(networkUtils.getHttpVersion(HttpVersions.V1_1).curlHttpVersion).toBe(CurlHttpVersion.V1_1);
     expect(networkUtils.getHttpVersion(HttpVersions.V2PriorKnowledge).curlHttpVersion).toBe(CurlHttpVersion.V2PriorKnowledge);

--- a/packages/insomnia-app/app/network/libcurl-promise.ts
+++ b/packages/insomnia-app/app/network/libcurl-promise.ts
@@ -32,7 +32,6 @@ if (process.type === 'renderer') throw new Error('node-libcurl unavailable in re
 // simplify clean up callbacks
 import { Curl, CurlCode, CurlFeature, CurlInfoDebug } from '@getinsomnia/node-libcurl';
 import fs from 'fs';
-import { reject } from 'ramda';
 import { Readable, Writable } from 'stream';
 import { ValueOf } from 'type-fest';
 
@@ -154,7 +153,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
     });
     // NOTE: legacy write end callback
     curl.on('error', () => responseBodyWriteStream.end());
-    curl.on('error', async function (err, code) {
+    curl.on('error', async function(err, code) {
       const elapsedTime = curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000;
       curl.close();
       await waitForStreamToFinish(responseBodyWriteStream);

--- a/packages/insomnia-app/app/network/libcurl-promise.ts
+++ b/packages/insomnia-app/app/network/libcurl-promise.ts
@@ -16,6 +16,7 @@ if (process.type === 'renderer') throw new Error('node-libcurl unavailable in re
 // on end: close filewriter/s, close curl instance, set cookies, save timeline, return transformed headers, status
 import { Curl, CurlCode, CurlFeature, CurlInfoDebug } from '@getinsomnia/node-libcurl';
 import fs from 'fs';
+import { Readable, Writable } from 'stream';
 import { ValueOf } from 'type-fest';
 
 import { describeByteSize } from '../common/misc';

--- a/packages/insomnia-app/app/network/libcurl-promise.ts
+++ b/packages/insomnia-app/app/network/libcurl-promise.ts
@@ -1,0 +1,214 @@
+// assertion: ipc bridge cannot serialise functions so write and debug callbacks need to be simplified
+// assertion: if logic like cancellation doesn't work we won't build it in this scope
+
+// assumption: options are typechecked and don't need run time feedback.
+// therefore we can build a list of options and apply them at once.
+
+// assumption: settings timeline object can split into setup and debug timelines
+// therefore I can just pass back what happened during debug to the respond function above
+
+// overview: behaviours tightly coupled to node-libcurl implementation
+// write response to file return path to file
+// write debug output to timeline array
+// getInfo time taken size and url
+// expose a fire and forget close instance for cancel
+// on error: close filewriter/s, close curl instance, save timeline return error message
+// on end: close filewriter/s, close curl instance, set cookies, save timeline, return transformed headers, status
+import { Curl, CurlCode, CurlFeature, CurlInfoDebug } from '@getinsomnia/node-libcurl';
+import fs from 'fs';
+import { ValueOf } from 'type-fest';
+
+import { describeByteSize } from '../common/misc';
+import { ResponseHeader } from '../models/response';
+import { ResponsePatch } from './network';
+
+// wraps libcurl with a promise taking options, path to response file, and max timeline size
+// returning a response patch, debug timeline and headerArray
+interface CurlOutput {
+  patch: ResponsePatch;
+  debugTimeline: ResponseTimelineEntry[];
+  headerArray: HeaderResult[];
+}
+
+type CurlSetOptParameters = Parameters<Curl['setOpt']>;
+type CurlSetOptName = CurlSetOptParameters[0];
+type CurlSetOptValue = CurlSetOptParameters[1];
+const functionmap = {};
+export const cancelLibCurlPromise = id => functionmap[id]();
+export const libCurlPromise = (options: Record<CurlSetOptName, CurlSetOptValue>, bodyPath, maxTimelineDataSizeKB, cancelId) => new Promise<CurlOutput>(async resolve => {
+  // Create instance, poke value options in, set up write and debug callbacks, listen for events
+  const curl = new Curl();
+  functionmap[cancelId] = () => curl.close();
+  Object.entries(options).forEach(([k, v]: [CurlSetOptName, CurlSetOptValue]) => curl.setOpt(k, v));
+
+  let responseBodyBytes = 0;
+  const responseBodyWriteStream = fs.createWriteStream(bodyPath);
+  curl.setOpt(Curl.option.WRITEFUNCTION, buff => {
+    responseBodyBytes += buff.length;
+    responseBodyWriteStream.write(buff);
+    return buff.length;
+  });
+
+  const debugTimeline: any = [];
+  curl.setOpt(Curl.option.DEBUGFUNCTION, (infoType, contentBuffer) => {
+    const rawName = Object.keys(CurlInfoDebug).find(k => CurlInfoDebug[k] === infoType) || '';
+    const name = LIBCURL_DEBUG_MIGRATION_MAP[rawName] || rawName;
+
+    const isSSLData = infoType === CurlInfoDebug.SslDataIn || infoType === CurlInfoDebug.SslDataOut;
+    const isEmpty = contentBuffer.length === 0;
+    // Don't show cookie setting because this will display every domain in the jar
+    const isAddCookie = infoType === CurlInfoDebug.Text && contentBuffer.toString('utf8').indexOf('Added cookie') === 0;
+    if (isSSLData || isEmpty || isAddCookie) {
+      return 0;
+    }
+
+    // Ignore the possibly large data messages
+    if (infoType === CurlInfoDebug.DataOut) {
+      const lessThan10KB = contentBuffer.length / 1024 < maxTimelineDataSizeKB || 10;
+      debugTimeline.push({
+        name,
+        value: lessThan10KB ? contentBuffer.toString('utf8') : `(${describeByteSize(contentBuffer.length)} hidden)`,
+        timestamp: Date.now(),
+      });
+      return 0;
+    }
+
+    if (infoType === CurlInfoDebug.DataIn) {
+      debugTimeline.push({
+        name: 'TEXT',
+        value: `Received ${describeByteSize(contentBuffer.length)} chunk`,
+        timestamp: Date.now(),
+      });
+      return 0;
+    }
+
+    debugTimeline.push({
+      name,
+      value: contentBuffer.toString('utf8'),
+      timestamp: Date.now(),
+    });
+    return 0; // Must be here
+  });
+
+  curl.enable(CurlFeature.Raw); // makes rawHeaders a buffer, rather than HeaderInfo[]
+  curl.on('end', () => responseBodyWriteStream.end());
+  curl.on('end', async (_1, _2, rawHeaders: Buffer) => {
+    const patch = {
+      bytesContent: responseBodyBytes,
+      bytesRead: curl.getInfo(Curl.info.SIZE_DOWNLOAD) as number,
+      elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000,
+      url: curl.getInfo(Curl.info.EFFECTIVE_URL) as string,
+    };
+    curl.close();
+    responseBodyWriteStream.end();
+    await waitForStreamToFinish(responseBodyWriteStream);
+
+    const headerArray = _parseHeaders(rawHeaders);
+    resolve({ patch, debugTimeline, headerArray });
+  });
+  curl.on('error', () => responseBodyWriteStream.end());
+  curl.on('error', async function(err, code) {
+    const elapsedTime = curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000;
+    curl.close();
+    await waitForStreamToFinish(responseBodyWriteStream);
+
+    let error = err + '';
+    let statusMessage = 'Error';
+
+    if (code === CurlCode.CURLE_ABORTED_BY_CALLBACK) {
+      error = 'Request aborted';
+      statusMessage = 'Abort';
+    }
+    const patch = {
+      statusMessage,
+      error: error || 'Something went wrong',
+      elapsedTime,
+    };
+
+    resolve({ patch, debugTimeline, headerArray: [{ version:'', code:-1, reason:'', headers:[] }] });
+  });
+  curl.perform();
+});
+
+// Because node-libcurl changed some names that we used in the timeline
+const LIBCURL_DEBUG_MIGRATION_MAP = {
+  HeaderIn: 'HEADER_IN',
+  DataIn: 'DATA_IN',
+  SslDataIn: 'SSL_DATA_IN',
+  HeaderOut: 'HEADER_OUT',
+  DataOut: 'DATA_OUT',
+  SslDataOut: 'SSL_DATA_OUT',
+  Text: 'TEXT',
+  '': '',
+};
+
+interface ResponseTimelineEntry {
+  name: ValueOf<typeof LIBCURL_DEBUG_MIGRATION_MAP>;
+  timestamp: number;
+  value: string;
+}
+interface HeaderResult {
+  headers: ResponseHeader[];
+  version: string;
+  code: number;
+  reason: string;
+}
+
+export function _parseHeaders(
+  buffer: Buffer,
+) {
+  const results: HeaderResult[] = [];
+  const lines = buffer.toString('utf8').split(/\r?\n|\r/g);
+
+  for (let i = 0, currentResult: HeaderResult | null = null; i < lines.length; i++) {
+    const line = lines[i];
+    const isEmptyLine = line.trim() === '';
+
+    // If we hit an empty line, start parsing the next response
+    if (isEmptyLine && currentResult) {
+      results.push(currentResult);
+      currentResult = null;
+      continue;
+    }
+
+    if (!currentResult) {
+      const [version, code, ...other] = line.split(/ +/g);
+      currentResult = {
+        version,
+        code: parseInt(code, 10),
+        reason: other.join(' '),
+        headers: [],
+      };
+    } else {
+      const [name, value] = line.split(/:\s(.+)/);
+      const header: ResponseHeader = {
+        name,
+        value: value || '',
+      };
+      currentResult.headers.push(header);
+    }
+  }
+
+  return results;
+}
+
+export async function waitForStreamToFinish(stream: Readable | Writable) {
+  return new Promise<void>(resolve => {
+    // @ts-expect-error -- access of internal values that are intended to be private.  We should _not_ do this.
+    if (stream._readableState?.finished) {
+      return resolve();
+    }
+
+    // @ts-expect-error -- access of internal values that are intended to be private.  We should _not_ do this.
+    if (stream._writableState?.finished) {
+      return resolve();
+    }
+
+    stream.on('close', () => {
+      resolve();
+    });
+    stream.on('error', () => {
+      resolve();
+    });
+  });
+}

--- a/packages/insomnia-app/app/network/libcurl-promise.ts
+++ b/packages/insomnia-app/app/network/libcurl-promise.ts
@@ -196,8 +196,8 @@ interface HeaderResult {
   code: number;
   reason: string;
 }
-// NOTE: legacy, could be simplified
-function _parseHeaders(buffer: Buffer) {
+// NOTE: legacy, has tests, could be simplified
+export function _parseHeaders(buffer: Buffer) {
   const results: HeaderResult[] = [];
   const lines = buffer.toString('utf8').split(/\r?\n|\r/g);
 

--- a/packages/insomnia-app/app/network/libcurl-promise.ts
+++ b/packages/insomnia-app/app/network/libcurl-promise.ts
@@ -161,6 +161,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
       elapsedTime,
     };
 
+    // NOTE: legacy, default headerResults
     resolve({ patch, debugTimeline, headerResults: [{ version: '', code: -1, reason: '', headers: [] }] });
   });
   curl.perform();

--- a/packages/insomnia-app/app/network/libcurl-promise.ts
+++ b/packages/insomnia-app/app/network/libcurl-promise.ts
@@ -2,34 +2,6 @@
 // Related issue https://github.com/JCMais/node-libcurl/issues/155
 if (process.type === 'renderer') throw new Error('node-libcurl unavailable in renderer');
 
-// Design
-// constrant: ipc bridge cannot serialise functions so read, write and debug callbacks need to be simplified
-// and handled in nodejs here
-
-// assertion: network.ts is coupled with database, plugins, and auth logic.
-
-// assertion: options are typechecked and don't need run time feedback.
-// therefore we can build a list of options and apply them at once.
-// excluding READDATA, WRITEFUNCTION and DEBUGFUNCTION which expect non-primitive inputs
-
-// assertion: settings timeline objects can split into setup and debug timelines and contains timestamps
-// therefore they can be merged easily
-
-// overview: behaviours tightly coupled to node-libcurl implementation
-// write response to file return path to file
-// write debug output to timeline array
-// read file and file descriptor teardown
-// getInfo time taken size and url
-// expose a fire and forget close instance for cancel
-// on error: close filewriter/s, close curl instance, save timeline return error message
-// on end: close filewriter/s, close curl instance, set cookies, save timeline, return transformed headers, status
-// most of end callback now happens after this promise resolves at the callsite
-
-// future work: scoped out in order to avoid creating new code paths
-// reject promise on error rather than resolve
-// simplify _parseHeaders
-// get renderer side curl types from node-libcurl somehow
-// simplify clean up callbacks
 import { Curl, CurlCode, CurlFeature, CurlInfoDebug } from '@getinsomnia/node-libcurl';
 import fs from 'fs';
 import { Readable, Writable } from 'stream';

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -260,11 +260,9 @@ export async function _actuallySend(
         null,
       );
     }
-    // NOTE: can have duplicate cookie options
-    const curlOptions: { key: string; value: any }[] = [];
-    /** Helper function to set Curl options*/
-    const setOpt = (key: string, value: any) => {
-      // const key = Object.keys(Curl.option).find(name => Curl.option[name] === opt);
+    // NOTE: can have duplicate keys because of cookie options
+    const curlOptions: { key: string; value: string | string[] | number | boolean }[] = [];
+    const setOpt = (key: string, value: string | string[] | number | boolean) => {
       curlOptions.push({ key, value });
     };
 
@@ -709,8 +707,8 @@ export async function _actuallySend(
         responseBodyPath,
         requestBodyPath,
         isMultipart,
-        maxTimelineDataSizeKB:settings.maxTimelineDataSizeKB,
-        cancelId: renderedRequest._id,
+        maxTimelineDataSizeKB: settings.maxTimelineDataSizeKB,
+        requestId: renderedRequest._id,
       };
 
       const { patch, debugTimeline, headerResults } = await nodejsCurlRequest(requestOptions);

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -1019,18 +1019,21 @@ export function _getAwsAuthHeaders(
 }
 
 function storeTimeline(timeline: ResponseTimelineEntry[]) {
+  const timelineStr = JSON.stringify(timeline, null, '\t');
+  const timelineHash = uuid.v4();
+  const responsesDir = pathJoin(getDataDirectory(), 'responses');
+  mkdirp.sync(responsesDir);
+  const timelinePath = pathJoin(responsesDir, timelineHash + '.timeline');
+  if (process.type === 'renderer'){
+    return window.main.writeFile({ path: timelinePath, content: timelineStr });
+  }
   return new Promise<string>((resolve, reject) => {
-    const timelineStr = JSON.stringify(timeline, null, '\t');
-    const timelineHash = uuid.v4();
-    const responsesDir = pathJoin(getDataDirectory(), 'responses');
-    mkdirp.sync(responsesDir);
-    const timelinePath = pathJoin(responsesDir, timelineHash + '.timeline');
     fs.writeFile(timelinePath, timelineStr, err => {
       if (err != null) {
         reject(err);
       }
+      resolve(timelinePath);
     });
-    resolve(timelinePath);
   });
 }
 

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -282,8 +282,12 @@ export async function _actuallySend(
           },
           null,
         );
-        // Kill it!
-        window.main.cancelCurlRequest(renderedRequest._id);
+        // NOTE: conditionally use ipc bridge, renderer cannot import native modules directly
+        const nodejsCancelCurlRequest = process.type === 'renderer'
+          ? window.main.cancelCurlRequest
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          : require('./libcurl-promise').cancelCurlRequest;
+        nodejsCancelCurlRequest(renderedRequest._id);
       };
 
       // Set all the basic options
@@ -695,8 +699,7 @@ export async function _actuallySend(
       const responsesDir = pathJoin(getDataDirectory(), 'responses');
       mkdirp.sync(responsesDir);
       const responseBodyPath = pathJoin(responsesDir, uuid.v4() + '.response');
-      // this function is also called by inso unit tests
-      // fallback to require in that case
+      // NOTE: conditionally use ipc bridge, renderer cannot import native modules directly
       const nodejsCurlRequest = process.type === 'renderer'
         ? window.main.curlRequest
         // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -13,7 +13,7 @@ import {
 import mkdirp from 'mkdirp';
 import { join as pathJoin } from 'path';
 import { parse as urlParse, resolve as urlResolve } from 'url';
-import uuid from 'uuid';
+import * as uuid from 'uuid';
 
 import {
   AUTH_AWS_IAM,

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -59,7 +59,6 @@ import caCerts from './ca-certs';
 import { buildMultipart } from './multipart';
 import { urlMatchesCertHost } from './url-matches-cert-host';
 
-// TODO: make this better
 enum CurlAuth {
   Basic = 1 << 0,
   Digest = 1 << 1,
@@ -68,29 +67,19 @@ enum CurlAuth {
   Any = ~DigestIe,
 }
 
-export const CurlHttpVersion = {
-  None: 'None',
-  V1_0: 'V1_0',
-  V1_1: 'V1_1',
-  V2_0: 'V2_0',
-  V2Tls: 'V2Tls',
-  V2PriorKnowledge: 'V2PriorKnowledge',
-  v3: 'v3',
-};
 const CurlNetrc = {
-  Ignored: 'Ignored',
-  Optional: 'Optional',
   Required: 'Required',
 };
-class Curl {
-  static option = {
+// Based on list of option properties but with callback options removed
+// Avoids importing from native module node-libcurl
+const Curl = {
+  option: {
     ACCEPT_ENCODING: 'ACCEPT_ENCODING',
     CAINFO: 'CAINFO',
     COOKIE: 'COOKIE',
     COOKIEFILE: 'COOKIEFILE',
     COOKIELIST: 'COOKIELIST',
     CUSTOMREQUEST: 'CUSTOMREQUEST',
-    DEBUGFUNCTION: 'DEBUGFUNCTION',
     FOLLOWLOCATION: 'FOLLOWLOCATION',
     HTTPAUTH: 'HTTPAUTH',
     HTTPGET: 'HTTPGET',
@@ -110,8 +99,6 @@ class Curl {
     PATH_AS_IS: 'PATH_AS_IS',
     PROXY: 'PROXY',
     PROXYAUTH: 'PROXYAUTH',
-    READDATA: 'READDATA',
-    READFUNCTION: 'READFUNCTION',
     SSLCERT: 'SSLCERT',
     SSLCERTTYPE: 'SSLCERTTYPE',
     SSLKEY: 'SSLKEY',
@@ -124,9 +111,8 @@ class Curl {
     USERAGENT: 'USERAGENT',
     USERNAME: 'USERNAME',
     VERBOSE: 'VERBOSE',
-    WRITEFUNCTION: 'WRITEFUNCTION',
-  };
-}
+  },
+};
 export interface ResponsePatch {
   bodyCompression?: 'zip' | null;
   bodyPath?: string;
@@ -157,6 +143,16 @@ const DISABLE_HEADER_VALUE = '__Di$aB13d__';
 const cancelRequestFunctionMap = {};
 
 let lastUserInteraction = Date.now();
+
+export const CurlHttpVersion = {
+  None: 'None',
+  V1_0: 'V1_0',
+  V1_1: 'V1_1',
+  V2_0: 'V2_0',
+  V2Tls: 'V2Tls',
+  V2PriorKnowledge: 'V2PriorKnowledge',
+  v3: 'v3',
+};
 
 export const getHttpVersion = preferredHttpVersion => {
   switch (preferredHttpVersion) {

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -68,20 +68,20 @@ enum CurlAuth {
   Any = ~DigestIe,
 }
 
-export enum CurlHttpVersion {
-  None,
-  V1_0,
-  V1_1,
-  V2_0,
-  V2Tls,
-  V2PriorKnowledge,
-  v3,
-}
-enum CurlNetrc {
-  Ignored,
-  Optional,
-  Required,
-}
+export const CurlHttpVersion = {
+  None: 'None',
+  V1_0: 'V1_0',
+  V1_1: 'V1_1',
+  V2_0: 'V2_0',
+  V2Tls: 'V2Tls',
+  V2PriorKnowledge: 'V2PriorKnowledge',
+  v3: 'v3',
+};
+const CurlNetrc = {
+  Ignored: 'Ignored',
+  Optional: 'Optional',
+  Required: 'Required',
+};
 class Curl {
   static option = {
     ACCEPT_ENCODING: 'ACCEPT_ENCODING',
@@ -709,7 +709,6 @@ export async function _actuallySend(
         maxTimelineDataSizeKB:settings.maxTimelineDataSizeKB,
         cancelId: renderedRequest._id,
       };
-      console.log(requestOptions);
 
       const { patch, debugTimeline, headerResults } = await nodejsCurlRequest(requestOptions);
 

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -3,7 +3,6 @@ import { CurlHttpVersion } from '@getinsomnia/node-libcurl/dist/enum/CurlHttpVer
 import { CurlNetrc } from '@getinsomnia/node-libcurl/dist/enum/CurlNetrc';
 import aws4 from 'aws4';
 import clone from 'clone';
-import crypto from 'crypto';
 import fs from 'fs';
 import { HttpVersions } from 'insomnia-common';
 import { cookiesFromJar, jarFromCookies } from 'insomnia-cookies';
@@ -1022,17 +1021,16 @@ export function _getAwsAuthHeaders(
 function storeTimeline(timeline: ResponseTimelineEntry[]) {
   return new Promise<string>((resolve, reject) => {
     const timelineStr = JSON.stringify(timeline, null, '\t');
-    const timelineHash = crypto.createHash('sha1').update(timelineStr).digest('hex');
+    const timelineHash = uuid.v4();
     const responsesDir = pathJoin(getDataDirectory(), 'responses');
     mkdirp.sync(responsesDir);
     const timelinePath = pathJoin(responsesDir, timelineHash + '.timeline');
     fs.writeFile(timelinePath, timelineStr, err => {
       if (err != null) {
         reject(err);
-      } else {
-        resolve(timelinePath);
       }
     });
+    resolve(timelinePath);
   });
 }
 

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -168,7 +168,7 @@ export async function _actuallySend(
   environment?: Environment | null,
   validateSSL = true,
 ) {
-  return new Promise<ResponsePatch>(async resolve => {
+  return new Promise<ResponsePatch>(async (resolve, reject) => {
     const timeline: ResponseTimelineEntry[] = [];
 
     const addTimelineItem = (name: ResponseTimelineEntry['name']) => (value: string) => {
@@ -180,6 +180,7 @@ export async function _actuallySend(
     };
 
     const addTimelineText = addTimelineItem(LIBCURL_DEBUG_MIGRATION_MAP.Text);
+    console.log('[debug] init curl');
 
     /** Helper function to respond with a success */
     async function respond(
@@ -187,7 +188,7 @@ export async function _actuallySend(
       bodyPath: string | null,
       debugTimeline: any[] = []
     ) {
-
+      console.log('[debug] respond', { patch });
       const timelinePath = await storeTimeline([...timeline, ...debugTimeline]);
       // Tear Down the cancellation logic
       if (cancelRequestFunctionMap.hasOwnProperty(renderedRequest._id)) {
@@ -211,6 +212,8 @@ export async function _actuallySend(
 
     /** Helper function to respond with an error */
     async function handleError(err: Error) {
+      console.log('[debug] handle error', { err });
+
       await respond(
         {
           url: renderedRequest.url,
@@ -233,6 +236,8 @@ export async function _actuallySend(
     try {
       // Setup the cancellation logic
       cancelRequestFunctionMap[renderedRequest._id] = async () => {
+        console.log('[debug] create cancel function');
+
         await respond(
           {
             elapsedTime: 0,
@@ -657,10 +662,12 @@ export async function _actuallySend(
           }
         });
       setOpt(Curl.option.HTTPHEADER, headerStrings);
+      console.log('[debug] setOpts done');
+
       const responsesDir = pathJoin(getDataDirectory(), 'responses');
       mkdirp.sync(responsesDir);
       const responseBodyPath = pathJoin(responsesDir, uuid.v4() + '.response');
-      console.log('[network] Sending request over ipc');
+      console.log('[debug] get body path', { responseBodyPath });
       // NOTE: conditionally use ipc bridge, renderer cannot import native modules directly
       const nodejsCurlRequest = process.type === 'renderer'
         ? window.main.curlRequest
@@ -674,9 +681,10 @@ export async function _actuallySend(
         maxTimelineDataSizeKB: settings.maxTimelineDataSizeKB,
         requestId: renderedRequest._id,
       };
-
+      const id = setTimeout(() => reject(new Error('Curl did not respond in 5 seconds')), 5000);
       const { patch, debugTimeline, headerResults } = await nodejsCurlRequest(requestOptions);
-      console.log('[network] Handling response');
+      clearTimeout(id);
+      console.log('[debug] response complete', { patch, debugTimeline });
 
       // Headers are an array (one for each redirect)
       const lastCurlHeadersObject = headerResults[headerResults.length - 1];
@@ -823,12 +831,13 @@ export async function send(
    */
   const timeSinceLastInteraction = Date.now() - lastUserInteraction;
   const delayMillis = Math.max(0, MAX_DELAY_TIME - timeSinceLastInteraction);
-
   if (delayMillis > 0) {
     await delay(delayMillis);
+    console.log('[debug] Added delay', delayMillis);
   }
 
   // Fetch some things
+
   const request = await models.request.getById(requestId);
   const settings = await models.settings.getOrCreate();
   const ancestors = await db.withAncestors(request, [
@@ -851,10 +860,13 @@ export async function send(
       extraInfo,
     },
   );
+  console.log('[debug] resolve render result', { renderResult });
+
   const renderedRequestBeforePlugins = renderResult.request;
   const renderedContextBeforePlugins = renderResult.context;
   const workspaceDoc = ancestors.find(isWorkspace);
   const workspace = await models.workspace.getById(workspaceDoc ? workspaceDoc._id : 'n/a');
+  console.log('[debug] fetch workspace', { workspace });
 
   if (!workspace) {
     throw new Error(`Failed to find workspace for request: ${requestId}`);
@@ -880,6 +892,7 @@ export async function send(
       url: renderedRequestBeforePlugins.url,
     } as ResponsePatch;
   }
+  console.log('[debug] pre hooks', { renderedRequest });
 
   const response = await _actuallySend(
     renderedRequest,
@@ -888,6 +901,8 @@ export async function send(
     environment,
     settings.validateSSL,
   );
+  console.log('[debug] _actuallySend', { response });
+
   console.log(
     response.error
       ? `[network] Response failed req=${requestId} err=${response.error || 'n/a'}`
@@ -1028,12 +1043,18 @@ function storeTimeline(timeline: ResponseTimelineEntry[]) {
     return window.main.writeFile({ path: timelinePath, content: timelineStr });
   }
   return new Promise<string>((resolve, reject) => {
+    const timelineStr = JSON.stringify(timeline, null, '\t');
+    const timelineHash = uuid.v4();
+    const responsesDir = pathJoin(getDataDirectory(), 'responses');
+    mkdirp.sync(responsesDir);
+    const timelinePath = pathJoin(responsesDir, timelineHash + '.timeline');
     fs.writeFile(timelinePath, timelineStr, err => {
       if (err != null) {
         reject(err);
       }
       resolve(timelinePath);
     });
+    resolve(timelinePath);
   });
 }
 

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -1,3 +1,6 @@
+import { CurlAuth } from '@getinsomnia/node-libcurl/dist/enum/CurlAuth';
+import { CurlHttpVersion } from '@getinsomnia/node-libcurl/dist/enum/CurlHttpVersion';
+import { CurlNetrc } from '@getinsomnia/node-libcurl/dist/enum/CurlNetrc';
 import aws4 from 'aws4';
 import clone from 'clone';
 import crypto from 'crypto';
@@ -59,19 +62,7 @@ import caCerts from './ca-certs';
 import { buildMultipart } from './multipart';
 import { urlMatchesCertHost } from './url-matches-cert-host';
 
-enum CurlAuth {
-  Basic = 1 << 0,
-  Digest = 1 << 1,
-  Ntlm = 1 << 3,
-  DigestIe = 1 << 4,
-  Any = ~DigestIe,
-}
-
-const CurlNetrc = {
-  Required: 'Required',
-};
 // Based on list of option properties but with callback options removed
-// Avoids importing from native module node-libcurl
 const Curl = {
   option: {
     ACCEPT_ENCODING: 'ACCEPT_ENCODING',
@@ -143,16 +134,6 @@ const DISABLE_HEADER_VALUE = '__Di$aB13d__';
 const cancelRequestFunctionMap = {};
 
 let lastUserInteraction = Date.now();
-
-export const CurlHttpVersion = {
-  None: 'None',
-  V1_0: 'V1_0',
-  V1_1: 'V1_1',
-  V2_0: 'V2_0',
-  V2Tls: 'V2Tls',
-  V2PriorKnowledge: 'V2PriorKnowledge',
-  v3: 'v3',
-};
 
 export const getHttpVersion = preferredHttpVersion => {
   switch (preferredHttpVersion) {

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -160,8 +160,6 @@ export async function cancelRequestById(requestId) {
     return cancelRequestFunctionMap[requestId]();
   }
   console.log(`[network] Failed to cancel req=${requestId} because cancel function not found`);
-  // Tidy up race condition, where cancel doesn't work and keeps spinning becuase requestId is unset or has been removed
-  return cancelRequestFunctionMap['fallback']();
 }
 
 export async function _actuallySend(
@@ -235,15 +233,7 @@ export async function _actuallySend(
 
     try {
       // Setup the cancellation logic
-      cancelRequestFunctionMap['fallback'] = () => respond({
-        elapsedTime: 0,
-        bytesRead: 0,
-        url: renderedRequest.url,
-        statusMessage: 'Cancelled',
-        error: 'Request was cancelled',
-      }, null);
       cancelRequestFunctionMap[renderedRequest._id] = async () => {
-
         await respond(
           {
             elapsedTime: 0,

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -31,7 +31,6 @@ import {
 import { database as db } from '../common/database';
 import { getDataDirectory, getTempDir } from '../common/electron-helpers';
 import {
-  delay,
   getContentTypeHeader,
   getHostHeader,
   getLocationHeader,
@@ -125,15 +124,10 @@ export interface ResponsePatch {
   url?: string;
 }
 
-// Time since user's last keypress to wait before making the request
-const MAX_DELAY_TIME = 1000;
-
 // Special header value that will prevent the header being sent
 const DISABLE_HEADER_VALUE = '__Di$aB13d__';
 
 const cancelRequestFunctionMap = {};
-
-let lastUserInteraction = Date.now();
 
 export const getHttpVersion = preferredHttpVersion => {
   switch (preferredHttpVersion) {
@@ -823,21 +817,6 @@ export async function send(
   extraInfo?: ExtraRenderInfo,
 ) {
   console.log(`[network] Sending req=${requestId} env=${environmentId || 'null'}`);
-  // HACK: wait for all debounces to finish
-
-  /*
-   * TODO: Do this in a more robust way
-   * The following block adds a "long" delay to let potential debounces and
-   * database updates finish before making the request. This is done by tracking
-   * the time of the user's last keypress and making sure the request is sent a
-   * significant time after the last press.
-   */
-  const timeSinceLastInteraction = Date.now() - lastUserInteraction;
-  const delayMillis = Math.max(0, MAX_DELAY_TIME - timeSinceLastInteraction);
-
-  if (delayMillis > 0) {
-    await delay(delayMillis);
-  }
 
   // Fetch some things
   const request = await models.request.getById(requestId);
@@ -1040,18 +1019,5 @@ function storeTimeline(timeline: ResponseTimelineEntry[]) {
         resolve(timelinePath);
       }
     });
-  });
-}
-
-if (global.document) {
-  document.addEventListener('keydown', (e: KeyboardEvent) => {
-    if (e.ctrlKey || e.metaKey || e.altKey) {
-      return;
-    }
-
-    lastUserInteraction = Date.now();
-  });
-  document.addEventListener('paste', () => {
-    lastUserInteraction = Date.now();
   });
 }

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -7,6 +7,7 @@ const main = {
   installPlugin: options => ipcRenderer.invoke('installPlugin', options),
   curlRequest: options => ipcRenderer.invoke('curlRequest', options),
   cancelCurlRequest: options => ipcRenderer.send('cancelCurlRequest', options),
+  writeFile: options => ipcRenderer.invoke('writeFile', options),
 };
 const dialog = {
   showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),

--- a/packages/insomnia-app/app/preload.js
+++ b/packages/insomnia-app/app/preload.js
@@ -5,6 +5,8 @@ const main = {
   authorizeUserInWindow: options => ipcRenderer.invoke('authorizeUserInWindow', options),
   setMenuBarVisibility: options => ipcRenderer.send('setMenuBarVisibility', options),
   installPlugin: options => ipcRenderer.invoke('installPlugin', options),
+  curlRequest: options => ipcRenderer.invoke('curlRequest', options),
+  cancelCurlRequest: options => ipcRenderer.send('cancelCurlRequest', options),
 };
 const dialog = {
   showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),

--- a/packages/insomnia-app/app/templating/index.ts
+++ b/packages/insomnia-app/app/templating/index.ts
@@ -44,7 +44,9 @@ export function render(
     renderMode?: string;
   } = {},
 ) {
-  if (!text.includes('{{')) return text;
+  const hasNunjucksInterpolationSymbols = text.includes('{{') && text.includes('}}');
+  const hasNunjucksCustomTagSymbols = text.includes('{%') && text.includes('%}');
+  if (!hasNunjucksInterpolationSymbols && !hasNunjucksCustomTagSymbols) return text;
   const context = config.context || {};
   // context needs to exist on the root for the old templating syntax, and in _ for the new templating syntax
   // old: {{ arr[0].prop }}
@@ -56,6 +58,7 @@ export function render(
     const nj = await getNunjucks(renderMode);
     nj?.renderString(text, templatingContext, (err, result) => {
       if (err) {
+        console.log(err);
         const sanitizedMsg = err.message
           .replace(/\(unknown path\)\s/, '')
           .replace(/\[Line \d+, Column \d*]/, '')

--- a/packages/insomnia-app/app/templating/index.ts
+++ b/packages/insomnia-app/app/templating/index.ts
@@ -55,8 +55,10 @@ export function render(
   const path = config.path || null;
   const renderMode = config.renderMode || RENDER_ALL;
   return new Promise<string | null>(async (resolve, reject) => {
+    const id = setTimeout(() => reject(new Error('Nunjucks did not respond in 5 seconds')), 5000);
     const nj = await getNunjucks(renderMode);
     nj?.renderString(text, templatingContext, (err, result) => {
+      clearTimeout(id);
       if (err) {
         console.log(err);
         const sanitizedMsg = err.message

--- a/packages/insomnia-app/app/templating/index.ts
+++ b/packages/insomnia-app/app/templating/index.ts
@@ -44,6 +44,7 @@ export function render(
     renderMode?: string;
   } = {},
 ) {
+  if (!text.includes('{{')) return text;
   const context = config.context || {};
   // context needs to exist on the root for the old templating syntax, and in _ for the new templating syntax
   // old: {{ arr[0].prop }}

--- a/packages/insomnia-app/app/templating/index.ts
+++ b/packages/insomnia-app/app/templating/index.ts
@@ -46,7 +46,8 @@ export function render(
 ) {
   const hasNunjucksInterpolationSymbols = text.includes('{{') && text.includes('}}');
   const hasNunjucksCustomTagSymbols = text.includes('{%') && text.includes('%}');
-  if (!hasNunjucksInterpolationSymbols && !hasNunjucksCustomTagSymbols) return text;
+  const hasNunjucksCommentSymbols = text.includes('{#') && text.includes('#}');
+  if (!hasNunjucksInterpolationSymbols && !hasNunjucksCustomTagSymbols && !hasNunjucksCommentSymbols) return text;
   const context = config.context || {};
   // context needs to exist on the root for the old templating syntax, and in _ for the new templating syntax
   // old: {{ arr[0].prop }}
@@ -55,7 +56,8 @@ export function render(
   const path = config.path || null;
   const renderMode = config.renderMode || RENDER_ALL;
   return new Promise<string | null>(async (resolve, reject) => {
-    const id = setTimeout(() => reject(new Error('Nunjucks did not respond in 5 seconds')), 5000);
+    // NOTE: this is added as a breadcrumb because renderString sometimes hangs
+    const id = setTimeout(() => console.log('Warning: nunjucks failed to respond within 5 seconds'), 5000);
     const nj = await getNunjucks(renderMode);
     nj?.renderString(text, templatingContext, (err, result) => {
       clearTimeout(id);

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
@@ -19,7 +19,6 @@ import { ImportExport } from '../settings/import-export';
 import { Plugins } from '../settings/plugins';
 import { Shortcuts } from '../settings/shortcuts';
 import { ThemePanel } from '../settings/theme-panel';
-import { Tooltip } from '../tooltip';
 import { showModal } from './index';
 
 export const TAB_INDEX_EXPORT = 1;

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
@@ -1,4 +1,3 @@
-import { Curl } from '@getinsomnia/node-libcurl';
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { HotKeyRegistry } from 'insomnia-common';
 import React, { PureComponent } from 'react';
@@ -80,9 +79,6 @@ export class UnconnectedSettingsModal extends PureComponent<Props, State> {
           {getAppName()} Preferences
           <span className="faint txt-sm">
             &nbsp;&nbsp;–&nbsp; v{getAppVersion()}
-            <Tooltip position="bottom" message={Curl.getVersion()}>
-              <i className="fa fa-info-circle" />
-            </Tooltip>
             {email ? ` – ${email}` : null}
           </span>
         </ModalHeader>

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -804,8 +804,12 @@ class App extends PureComponent<AppProps, State> {
     handleStartLoading(requestId);
 
     try {
+      console.log('[debug] start loading', { requestId });
       const responsePatch = await network.send(requestId, environmentId);
+      console.log('[debug] got network.send', { responsePatch });
       await models.response.create(responsePatch, settings.maxHistoryResponses);
+      console.log('[debug] save that to db');
+
     } catch (err) {
       if (err.type === 'render') {
         showModal(RequestRenderErrorModal, {
@@ -831,6 +835,8 @@ class App extends PureComponent<AppProps, State> {
     await updateRequestMetaByParentId(requestId, {
       activeResponseId: null,
     });
+    console.log('[debug] grpc janky await complete', { requestId });
+
     // Stop loading
     handleStopLoading(requestId);
   }

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -804,11 +804,8 @@ class App extends PureComponent<AppProps, State> {
     handleStartLoading(requestId);
 
     try {
-      console.log('[debug] start loading', { requestId });
       const responsePatch = await network.send(requestId, environmentId);
-      console.log('[debug] got network.send', { responsePatch });
       await models.response.create(responsePatch, settings.maxHistoryResponses);
-      console.log('[debug] save that to db');
 
     } catch (err) {
       if (err.type === 'render') {
@@ -835,7 +832,6 @@ class App extends PureComponent<AppProps, State> {
     await updateRequestMetaByParentId(requestId, {
       activeResponseId: null,
     });
-    console.log('[debug] grpc janky await complete', { requestId });
 
     // Stop loading
     handleStopLoading(requestId);

--- a/packages/insomnia-inso/src/jest/setup.ts
+++ b/packages/insomnia-inso/src/jest/setup.ts
@@ -1,2 +1,1 @@
-jest.mock('@getinsomnia/node-libcurl');
 process.env.DEFAULT_APP_NAME = process.env.DEFAULT_APP_NAME || 'insomnia-app';

--- a/packages/insomnia-smoke-test/cli/app.test.ts
+++ b/packages/insomnia-smoke-test/cli/app.test.ts
@@ -34,6 +34,7 @@ describe.each(compact([npmPackageBinPath, ...binaries]))('inso with %s', binPath
         srcInsoNedb,
         ['--env', 'Dev'],
         'Echo Test Suite',
+        '--verbose',
       );
 
       expect(failed).toBe(false);

--- a/packages/insomnia-smoke-test/fixtures/oauth.yaml
+++ b/packages/insomnia-smoke-test/fixtures/oauth.yaml
@@ -7,7 +7,7 @@ resources:
     parentId: fld_0e50ba4426bb4540ade91e0525ea1f29
     modified: 1645664215605
     created: 1645544268127
-    url: "{{ _.oidc_base_path }}/me"
+    url: "http://127.0.0.1:4010/oidc/me"
     name: No PKCE
     description: ""
     method: GET
@@ -15,13 +15,13 @@ resources:
     parameters: []
     headers: []
     authentication:
-      accessTokenUrl: "{{ _.oidc_base_path }}/token"
-      authorizationUrl: "{{ _.oidc_base_path }}/auth"
-      clientId: "{{ _.client_id_authorization_code }}"
-      clientSecret: "{{ _.client_secret }}"
+      accessTokenUrl: "http://127.0.0.1:4010/oidc/token"
+      authorizationUrl: "http://127.0.0.1:4010/oidc/auth"
+      clientId: "authorization_code"
+      clientSecret: "secret"
       disabled: false
       grantType: authorization_code
-      redirectUrl: "{{ _.oidc_callback }}"
+      redirectUrl: "http://127.0.0.1:4010/callback"
       responseType: id_token
       scope: openid offline_access
       state: ""
@@ -60,7 +60,7 @@ resources:
     parentId: fld_0e50ba4426bb4540ade91e0525ea1f29
     modified: 1645664217727
     created: 1645220819802
-    url: "{{ _.oidc_base_path }}/me"
+    url: "http://127.0.0.1:4010/oidc/me"
     name: PKCE SHA256
     description: ""
     method: GET
@@ -68,13 +68,13 @@ resources:
     parameters: []
     headers: []
     authentication:
-      accessTokenUrl: "{{ _.oidc_base_path }}/token"
-      authorizationUrl: "{{ _.oidc_base_path }}/auth"
-      clientId: "{{ _.client_id_authorization_code_pkce }}"
-      clientSecret: "{{ _.client_secret }}"
+      accessTokenUrl: "http://127.0.0.1:4010/oidc/token"
+      authorizationUrl: "http://127.0.0.1:4010/oidc/auth"
+      clientId: "authorization_code_pkce"
+      clientSecret: "secret"
       disabled: false
       grantType: authorization_code
-      redirectUrl: "{{ _.oidc_callback }}"
+      redirectUrl: "http://127.0.0.1:4010/callback"
       responseType: id_token
       scope: openid offline_access
       state: ""
@@ -93,7 +93,7 @@ resources:
     parentId: fld_0e50ba4426bb4540ade91e0525ea1f29
     modified: 1645664218264
     created: 1645543526615
-    url: "{{ _.oidc_base_path }}/me"
+    url: "http://127.0.0.1:4010/oidc/me"
     name: PKCE Plain
     description: ""
     method: GET
@@ -101,13 +101,13 @@ resources:
     parameters: []
     headers: []
     authentication:
-      accessTokenUrl: "{{ _.oidc_base_path }}/token"
-      authorizationUrl: "{{ _.oidc_base_path }}/auth"
-      clientId: "{{ _.client_id_authorization_code_pkce }}"
-      clientSecret: "{{ _.client_secret }}"
+      accessTokenUrl: "http://127.0.0.1:4010/oidc/token"
+      authorizationUrl: "http://127.0.0.1:4010/oidc/auth"
+      clientId: "authorization_code_pkce"
+      clientSecret: "secret"
       disabled: false
       grantType: authorization_code
-      redirectUrl: "{{ _.oidc_callback }}"
+      redirectUrl: "http://127.0.0.1:4010/callback"
       responseType: id_token
       scope: openid offline_access
       state: ""
@@ -128,7 +128,7 @@ resources:
     parentId: fld_d34790add1584643b6688c3add5bbe85
     modified: 1645664218947
     created: 1645545802379
-    url: "{{ _.oidc_base_path }}/id-token"
+    url: "http://127.0.0.1:4010/oidc/id-token"
     name: ID Token
     description: ""
     method: GET
@@ -136,13 +136,13 @@ resources:
     parameters: []
     headers: []
     authentication:
-      accessTokenUrl: "{{ _.oidc_base_path }}/token"
-      authorizationUrl: "{{ _.oidc_base_path }}/auth"
-      clientId: "{{ _.client_id_implicit }}"
-      clientSecret: "{{ _.client_secret }}"
+      accessTokenUrl: "http://127.0.0.1:4010/oidc/token"
+      authorizationUrl: "http://127.0.0.1:4010/oidc/auth"
+      clientId: "implicit"
+      clientSecret: "secret"
       disabled: false
       grantType: implicit
-      redirectUrl: "{{ _.oidc_callback }}"
+      redirectUrl: "http://127.0.0.1:4010/callback"
       responseType: id_token
       scope: openid
       state: ""
@@ -173,7 +173,7 @@ resources:
     parentId: fld_d34790add1584643b6688c3add5bbe85
     modified: 1645664219446
     created: 1645567186775
-    url: "{{ _.oidc_base_path }}/me"
+    url: "http://127.0.0.1:4010/oidc/me"
     name: ID and Access Token
     description: ""
     method: GET
@@ -181,13 +181,13 @@ resources:
     parameters: []
     headers: []
     authentication:
-      accessTokenUrl: "{{ _.oidc_base_path }}/token"
-      authorizationUrl: "{{ _.oidc_base_path }}/auth"
-      clientId: "{{ _.client_id_implicit }}"
-      clientSecret: "{{ _.client_secret }}"
+      accessTokenUrl: "http://127.0.0.1:4010/oidc/token"
+      authorizationUrl: "http://127.0.0.1:4010/oidc/auth"
+      clientId: "implicit"
+      clientSecret: "secret"
       disabled: false
       grantType: implicit
-      redirectUrl: "{{ _.oidc_callback }}"
+      redirectUrl: "http://127.0.0.1:4010/callback"
       responseType: id_token token
       scope: openid
       state: ""
@@ -208,7 +208,7 @@ resources:
     parentId: wrk_392055e2aa29457b9d2904396cd7631f
     modified: 1645664219861
     created: 1645637343873
-    url: "{{ _.oidc_base_path }}/client-credential"
+    url: "http://127.0.0.1:4010/oidc/client-credential"
     name: Client Credentials
     description: ""
     method: GET
@@ -216,13 +216,13 @@ resources:
     parameters: []
     headers: []
     authentication:
-      accessTokenUrl: "{{ _.oidc_base_path }}/token"
-      authorizationUrl: "{{ _.oidc_base_path }}/auth"
-      clientId: "{{ _.client_id_client_creds }}"
-      clientSecret: "{{ _.client_secret }}"
+      accessTokenUrl: "http://127.0.0.1:4010/oidc/token"
+      authorizationUrl: "http://127.0.0.1:4010/oidc/auth"
+      clientId: "client_credentials"
+      clientSecret: "secret"
       disabled: false
       grantType: client_credentials
-      redirectUrl: "{{ _.oidc_callback }}"
+      redirectUrl: "http://127.0.0.1:4010/callback"
       responseType: id_token
       scope: openid
       state: ""
@@ -245,7 +245,7 @@ resources:
     parentId: wrk_392055e2aa29457b9d2904396cd7631f
     modified: 1645664220407
     created: 1645636233910
-    url: "{{ _.oidc_base_path }}/me"
+    url: "http://127.0.0.1:4010/oidc/me"
     name: Resource Owner Password Credentials
     description: ""
     method: GET
@@ -253,13 +253,13 @@ resources:
     parameters: []
     headers: []
     authentication:
-      accessTokenUrl: "{{ _.oidc_base_path }}/token"
-      authorizationUrl: "{{ _.oidc_base_path }}/auth"
-      clientId: "{{ _.client_id_resource_owner }}"
-      clientSecret: "{{ _.client_secret }}"
+      accessTokenUrl: "http://127.0.0.1:4010/oidc/token"
+      authorizationUrl: "http://127.0.0.1:4010/oidc/auth"
+      clientId: "resource_owner"
+      clientSecret: "secret"
       disabled: false
       grantType: password
-      redirectUrl: "{{ _.oidc_callback }}"
+      redirectUrl: "http://127.0.0.1:4010/callback"
       responseType: id_token
       scope: openid
       state: ""
@@ -283,27 +283,8 @@ resources:
     modified: 1645661876119
     created: 1645220798237
     name: Base Environment
-    data:
-      base_url: http://127.0.0.1:4010
-      oidc_base_path: "{{ _.base_url }}/oidc"
-      oidc_callback: "{{ _.base_url }}/callback"
-      client_id_authorization_code: authorization_code
-      client_id_authorization_code_pkce: authorization_code_pkce
-      client_id_implicit: implicit
-      client_id_client_creds: client_credentials
-      client_id_resource_owner: resource_owner
-      client_secret: secret
-    dataPropertyOrder:
-      "&":
-        - base_url
-        - oidc_base_path
-        - oidc_callback
-        - client_id_authorization_code
-        - client_id_authorization_code_pkce
-        - client_id_implicit
-        - client_id_client_creds
-        - client_id_resource_owner
-        - client_secret
+    data: {}
+    dataPropertyOrder: null
     color: null
     isPrivate: false
     metaSortKey: 1639556944617

--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -57,7 +57,7 @@ export const test = baseTest.extend<{
   page: async ({ app }, use) => {
     const page = await app.firstWindow();
 
-    if (process.platform === 'win32') await page.reload();
+    await page.waitForLoadState();
 
     await page.click("text=Don't share usage analytics");
 

--- a/packages/insomnia-smoke-test/tests/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/app.test.ts
@@ -59,8 +59,24 @@ test('can send requests', async ({ app, page }) => {
   await expect(responseBody).toContainText('Set-Cookie: insomnia-test-cookie=value123');
 });
 
-// TODO: write a cancel request test which doesn't hang on windows
-// hitting cancel function not found error
+// This feature is unsafe to place beside other tests, cancelling a request can cause network code to block
+// related to https://linear.app/insomnia/issue/INS-973
+test('can cancel requests', async ({ app, page }) => {
+  await page.click('[data-testid="project"]');
+  await page.click('text=Create');
+
+  const text = await loadFixture('smoke-test-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+  await page.click('button:has-text("Clipboard")');
+  await page.click('text=CollectionSmoke testsjust now');
+
+  await page.click('button:has-text("GETdelayed request")');
+  await page.click('text=http://127.0.0.1:4010/delay/seconds/20Send >> button');
+
+  await page.click('[data-testid="response-pane"] button:has-text("Cancel Request")');
+  await page.click('text=Request was cancelled');
+});
 
 test('url field is focused for first time users', async ({ page }) => {
   const urlInput = ':nth-match(textarea, 2)';

--- a/packages/insomnia-smoke-test/tests/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/app.test.ts
@@ -59,7 +59,7 @@ test('can send requests', async ({ app, page }) => {
   await expect(responseBody).toContainText('Set-Cookie: insomnia-test-cookie=value123');
 });
 
-// This feature is unsafe to place beside other tests, cancelling a request causes node-libcurl to block
+// This feature is unsafe to place beside other tests, cancelling a request can cause network code to block
 // related to https://linear.app/insomnia/issue/INS-973
 test('can cancel requests', async ({ app, page }) => {
   await page.click('[data-testid="project"]');
@@ -73,8 +73,10 @@ test('can cancel requests', async ({ app, page }) => {
 
   await page.click('button:has-text("GETdelayed request")');
   await page.click('text=http://127.0.0.1:4010/delay/seconds/20Send >> button');
-  await page.click('text=seconds...'); // Theory: cancel request could hang if its pressed too quickly, because the function map isn't initialised?
-  await page.click('text=Loading...Cancel Request >> button');
+  // Note: cancel request could hang if its pressed too quickly, because the function map isn't initialised
+  // therefore we wait until 'x.x seconds...' is rendered before cancelling
+  await page.click('text=seconds...');
+  await page.locator('[data-testid="response-pane"] button:has-text("Cancel Request")').click();
   await page.click('text=Request was cancelled');
 });
 

--- a/packages/insomnia-smoke-test/tests/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/app.test.ts
@@ -61,7 +61,7 @@ test('can send requests', async ({ app, page }) => {
 
 // This feature is unsafe to place beside other tests, cancelling a request causes node-libcurl to block
 // related to https://linear.app/insomnia/issue/INS-973
-test('can cancel requests', async ({ app, page }) => {
+test.skip('can cancel requests', async ({ app, page }) => {
   await page.click('[data-testid="project"]');
   await page.click('text=Create');
 

--- a/packages/insomnia-smoke-test/tests/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/app.test.ts
@@ -59,26 +59,8 @@ test('can send requests', async ({ app, page }) => {
   await expect(responseBody).toContainText('Set-Cookie: insomnia-test-cookie=value123');
 });
 
-// This feature is unsafe to place beside other tests, cancelling a request can cause network code to block
-// related to https://linear.app/insomnia/issue/INS-973
-test('can cancel requests', async ({ app, page }) => {
-  await page.click('[data-testid="project"]');
-  await page.click('text=Create');
-
-  const text = await loadFixture('smoke-test-collection.yaml');
-  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
-
-  await page.click('button:has-text("Clipboard")');
-  await page.click('text=CollectionSmoke testsjust now');
-
-  await page.click('button:has-text("GETdelayed request")');
-  await page.click('text=http://127.0.0.1:4010/delay/seconds/20Send >> button');
-  // Note: cancel request could hang if its pressed too quickly, because the function map isn't initialised
-  // therefore we wait until 'x.x seconds...' is rendered before cancelling
-  await page.click('text=seconds...');
-  await page.locator('[data-testid="response-pane"] button:has-text("Cancel Request")').click();
-  await page.click('text=Request was cancelled');
-});
+// TODO: write a cancel request test which doesn't hang on windows
+// hitting cancel function not found error
 
 test('url field is focused for first time users', async ({ page }) => {
   const urlInput = ':nth-match(textarea, 2)';

--- a/packages/insomnia-smoke-test/tests/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/app.test.ts
@@ -61,7 +61,7 @@ test('can send requests', async ({ app, page }) => {
 
 // This feature is unsafe to place beside other tests, cancelling a request causes node-libcurl to block
 // related to https://linear.app/insomnia/issue/INS-973
-test.skip('can cancel requests', async ({ app, page }) => {
+test('can cancel requests', async ({ app, page }) => {
   await page.click('[data-testid="project"]');
   await page.click('text=Create');
 
@@ -73,6 +73,7 @@ test.skip('can cancel requests', async ({ app, page }) => {
 
   await page.click('button:has-text("GETdelayed request")');
   await page.click('text=http://127.0.0.1:4010/delay/seconds/20Send >> button');
+  await page.click('text=seconds...'); // Theory: cancel request could hang if its pressed too quickly, because the function map isn't initialised?
   await page.click('text=Loading...Cancel Request >> button');
   await page.click('text=Request was cancelled');
 });

--- a/packages/insomnia-smoke-test/tests/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/oauth.test.ts
@@ -26,7 +26,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
 
   // No PKCE
   await page.locator('button:has-text("No PKCE")').click();
-  
+
   // Wait for environment interpolation to be rendered
   await expect(page.locator('[data-testid="request-pane"]')).toContainText('_.oidc_base_path');
 

--- a/packages/insomnia-smoke-test/tests/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/oauth.test.ts
@@ -27,11 +27,6 @@ test('can make oauth2 requests', async ({ app, page }) => {
   // No PKCE
   await page.locator('button:has-text("No PKCE")').click();
 
-  // Wait for environment interpolation to be rendered
-  await page.locator('text=_.oidc_base_path/me').click();
-  await page.locator('textarea:has-text("http://127.0.0.1:4010/oidc")').click();
-  await page.locator('text=Done').click();
-
   const [authorizationCodePage] = await Promise.all([
     app.context().waitForEvent('page'),
     sendButton.click(),

--- a/packages/insomnia-smoke-test/tests/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/oauth.test.ts
@@ -26,6 +26,9 @@ test('can make oauth2 requests', async ({ app, page }) => {
 
   // No PKCE
   await page.locator('button:has-text("No PKCE")').click();
+  
+  // Wait for environment interpolation to be rendered
+  await expect(page.locator('[data-testid="request-pane"]')).toContainText('_.oidc_base_path');
 
   const [authorizationCodePage] = await Promise.all([
     app.context().waitForEvent('page'),

--- a/packages/insomnia-smoke-test/tests/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/oauth.test.ts
@@ -28,7 +28,9 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await page.locator('button:has-text("No PKCE")').click();
 
   // Wait for environment interpolation to be rendered
-  await expect(page.locator('[data-testid="request-pane"]')).toContainText('_.oidc_base_path');
+  await page.locator('text=_.oidc_base_path/me').click();
+  await page.locator('textarea:has-text("http://127.0.0.1:4010/oidc")').click();
+  await page.locator('text=Done').click();
 
   const [authorizationCodePage] = await Promise.all([
     app.context().waitForEvent('page'),


### PR DESCRIPTION
- [x] extract native curl instance to nodejs only file
- [x] conditional ipc bridge and preload
- [x] readfilefunction
- [x] teardown file stream on cancel
- [x] make electron v15 upgrade branch #4529

due to the design of the original code there are some refactoring opportunities which has higher risk implications so I scoped them out below.

future work
- reject promise on error rather than resolve
- simplify _parseHeaders
- get renderer side curl types from node-libcurl somehow
- simplify clean up callbacks
- typescript refinements
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
notes:
- arbitrary delay is questionable
- multipart implementation is questionable

reference #2403