### PR TITLE
fixes active unit test suite selector

### DIFF
--- a/packages/insomnia-app/app/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-unit-test.tsx
@@ -24,7 +24,7 @@ import { isRequestGroup } from '../../models/request-group';
 import type { UnitTest } from '../../models/unit-test';
 import type { UnitTestSuite } from '../../models/unit-test-suite';
 import { RootState } from '../redux/modules';
-import { selectActiveEnvironment, selectActiveUnitTestResult, selectActiveUnitTests, selectActiveUnitTestSuites, selectActiveWorkspace } from '../redux/selectors';
+import { selectActiveEnvironment, selectActiveUnitTestResult, selectActiveUnitTests, selectActiveUnitTestSuite, selectActiveUnitTestSuites, selectActiveWorkspace } from '../redux/selectors';
 import { Editable } from './base/editable';
 import { CodeEditor } from './codemirror/code-editor';
 import { ErrorBoundary } from './error-boundary';
@@ -575,7 +575,7 @@ class UnconnectedWrapperUnitTest extends PureComponent<Props, State> {
 
 const mapStateToProps = (state: RootState) => ({
   activeWorkspace: selectActiveWorkspace(state),
-  activeUnitTestSuite: selectActiveWorkspace(state),
+  activeUnitTestSuite: selectActiveUnitTestSuite(state),
   activeUnitTestSuites: selectActiveUnitTestSuites(state),
   activeUnitTests: selectActiveUnitTests(state),
   activeEnvironment: selectActiveEnvironment(state),


### PR DESCRIPTION
There was a bug preventing unit tests from being created.

### When?
This bug was introduced in 24017885093d08a527176f04159b8d37b34d3df1, specifically https://github.com/Kong/insomnia/pull/4510/commits/c9a749aab9f82fa913aa74b7ee3989c1c191edc5#diff-7b127f485633a1d83f10336cd270f890c5658093e683a45a80f7b82c62c67c5eR578, the commit that handled unit test suites.

### Why is this a bug?
It means that in the following code:
```ts
  async _handleCreateTest() {
    const { activeUnitTestSuite } = this.props;
    showPrompt({
      title: 'New Test',
      defaultValue: 'Returns 200',
      submitName: 'New Test',
      label: 'Test Name',
      selectText: true,
      onComplete: async name => {
        await models.unitTest.create({
          parentId: activeUnitTestSuite?._id,
          code: this.generateSendReqSnippet('', ''),
          name,
        });
        trackSegmentEvent(SegmentEvent.unitTestCreate);
      },
    });
  }
```
A workspace id was being passed for `parentId`, instead of a unit test sute id.

### Can't TypeScript catch this?

Generally, yes.  But we have strict mode off... Strict mode contains the `strictFunctionTypes` (read more [here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-6.html#strict-function-types)) option, which catches this exact error, however, not for aliases.

TypeScript is covariant by design for most things, unfortunately, and since the property being accessed here is `_id` which all models have, then it means that this particular line will never fail for any given model.

If you're wondering why the type of unitTest.create didn't reject the input of a Workspace... here's why.  So it is typed correctly:

![Screenshot_20220225_164224](https://user-images.githubusercontent.com/15232461/155807045-fc41bb9e-c6c8-4035-b3dc-2a71c98ef286.png)
 
But let's look at `Workspace` (the wrong type that was being sent to this function before this PR).  Note the `name` property:
 
![Screenshot_20220225_164341](https://user-images.githubusercontent.com/15232461/155807189-bc226164-3d24-4210-8662-f6eeb20582f1.png)

Now let's look at `UnitTest` (the declared type).  Again, note the `name` property:
![Screenshot_20220225_164424](https://user-images.githubusercontent.com/15232461/155807267-fd97ddd3-a566-4e42-bd90-bc37e736121a.png)

Since
1. UnitTest only requires `name: string;`
1. Workspace has `name: string;`
1. TypeScript is covariant for strings

what ultimately happens is that _any place where a `UnitTest` is asked for, a `Workspace` will be accepted.

THIS is something TypeScript _can_ handle, but we have to use discriminated unions and type guards and the like.

### Can we validate this better?

Yes.  Now that I see this bug in action, it's a bit surprising that the database doesn't error when you try to update a document with a valid parent id that isn't an actual parent.  That makes me wonder where else this exact problem is happening.  We'd have no way to know other than if we throw.  That also amounts to a sort of memory leak because means that the created objects are put into the database and can never be deleted by the app.  For example, here's my `insomnia.UnitTest.db` file:
```jsonb
{"_id":"ut_140891520e0b462abe243add5949232c","type":"UnitTest","parentId":"wrk_0c00b2e2dfe5429f9439093c00389a6e","modified":1645823821528,"created":1645823821528,"requestId":null,"name":"Returns 200","code":"const response1 = await insomnia.send();\nexpect(response1.status).to.equal(200);"}
{"_id":"ut_4e1e30e0ef9140b49f5d3e3e2ac60dfe","type":"UnitTest","parentId":"wrk_0c00b2e2dfe5429f9439093c00389a6e","modified":1645824162349,"created":1645824162349,"requestId":null,"name":"Returns 200","code":"const response1 = await insomnia.send();\nexpect(response1.status).to.equal(200);"}
{"_id":"ut_d6b487abd9084ea5acd8b0ad43f0bd52","type":"UnitTest","parentId":"uts_8c4fc6eec4784a6aa2cc5e560a7b77f6","modified":1645824894551,"created":1645824894551,"requestId":null,"name":"Returns 200","code":"const response1 = await insomnia.send();\nexpect(response1.status).to.equal(200);"}
{"$$deleted":true,"_id":"ut_d6b487abd9084ea5acd8b0ad43f0bd52"}
```

Notice that the `parentId` of the top two are workspaces....  Yikes.
_______

Anyway.  The PR that caused this bug was trying to unweave the mess.  A very very similar bug was found and caught during review before merge.  I checked back to see 