### PR TITLE
updates usages of jest timers to prepare for jest 27

### DIFF
--- a/packages/insomnia-app/app/common/__tests__/misc.test.ts
+++ b/packages/insomnia-app/app/common/__tests__/misc.test.ts
@@ -16,6 +16,8 @@ import {
   xmlDecode,
 } from '../misc';
 
+jest.spyOn(global, 'setTimeout');
+
 describe('hasAuthHeader()', () => {
   beforeEach(globalBeforeEach);
 
@@ -150,7 +152,7 @@ describe('keyedDebounce()', () => {
     fn('foo', 'bar2');
     fn('foo', 'bar3');
     fn('multi', 'foo', 'bar', 'baz');
-    expect(setTimeout.mock.calls.length).toBe(5);
+    expect(setTimeout).toHaveBeenCalledTimes(5);
     expect(resultsList).toEqual([]);
     jest.runAllTimers();
     expect(resultsList).toEqual([
@@ -179,7 +181,7 @@ describe('debounce()', () => {
     fn('multi', 'foo', 'bar', 'baz');
     fn('baz', 'bar');
     fn('foo', 'bar3');
-    expect(setTimeout.mock.calls.length).toBe(5);
+    expect(setTimeout).toHaveBeenCalledTimes(5);
     expect(resultList).toEqual([]);
     jest.runAllTimers();
     expect(resultList).toEqual([['foo', 'bar3']]);


### PR DESCRIPTION
Here's a quote from the [Jest 27 changelog](https://jestjs.io/blog/2021/05/25/jest-27):

> Another default that we are changing affects Fake Timers aka [Timer Mocks](https://jestjs.io/docs/timer-mocks). We introduced an opt-in "modern" implementation of Fake Timers in Jest 26 accessed transparently through the same API, but with much more comprehensive mocking, such as for Date and queueMicrotask.
This modern fake timers implementation will now be the default. If you are among the unlucky few who are affected by the subtle implementation differences too heavily to migrate, you can get back the old implementation using jest.useFakeTimers("legacy") or, if you are enabling fake timers globally via [configuration](https://jestjs.io/docs/configuration#timers-string), "timers": "legacy".

If we try to upgrade to Jest 27 we hit this problem in two files.  When it errors, it looks like this:

<img src="https://user-images.githubusercontent.com/15232461/156394873-01c591d2-ffa5-48c3-9f3a-df6965dc5ae8.png" width="50%" />

This PR simply updates the two places where we were depending on this older style to use the new [Timer Mocks](https://jestjs.io/docs/timer-mocks).

That way, we aren't blocked by this when we update Jest.