### PR TITLE
fixes it.each malformed usage

### DIFF
--- a/packages/insomnia-app/app/ui/redux/modules/__tests__/global.test.ts
+++ b/packages/insomnia-app/app/ui/redux/modules/__tests__/global.test.ts
@@ -183,11 +183,11 @@ describe('global', () => {
       expect(store.getActions()).toEqual([expectedEvent]);
     });
 
-    it.each(
+    it.each([
       'something',
       null,
       undefined,
-    )('should go to home if initialized with an unsupported value: %s', async activity => {
+    ])('should go to home if initialized with an unsupported value: %s', async activity => {
       const settings = createSettings(true);
       const store = mockStore({
         global: {},


### PR DESCRIPTION
https://github.com/Kong/insomnia/pull/3116/commits/c7edb76cd492421f70552c2d83574b8296b61ab5#diff-ff308af3165600e53d41556ef1fddef93c1534ed0545591592b45a01fa0cc1a8R219 introduced this change by accident.  It didn't error before because prior to Jest 27 this wasn't validated.  From Jest 27 onward this case is validated and it is not allowed to be variadic.

![Screenshot_20220304_140838](https://user-images.githubusercontent.com/15232461/156826403-ceec32fb-18c3-4032-a9fe-72eb951266cf.png)

Yes.  That's right.  Apparently prior to now it was looping through each character in `'something'`.  :scream: 