### PR TITLE
fix filter help modal jsonpath

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -1194,9 +1194,8 @@ export class UnconnectedCodeEditor extends Component<CodeEditorProps, State> {
   }
 
   _showFilterHelp() {
-    const isJson = UnconnectedCodeEditor._isJSON(this.props.mode);
-
-    showModal(FilterHelpModal, isJson);
+    const isJSON = UnconnectedCodeEditor._isJSON(this.props.mode);
+    showModal(FilterHelpModal, isJSON);
   }
 
   render() {

--- a/packages/insomnia-app/app/ui/components/modals/filter-help-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/filter-help-modal.tsx
@@ -37,10 +37,10 @@ const JSONPathHelp: FC = () => (
     <HelpExamples
       helpExamples={[
         { code: '$.store.books[*].title', description: 'Get titles of all books in the store' },
-        { code: '$.store.books[?(@.price < 10)].title', description: 'Get books costing less than $10' },
+        { code: '$.store.books[?(`@.price < 10)].title', description: 'Get books costing less than $10' },
         { code: '$.store.books[-1:]', description: 'Get the last book in the store' },
         { code: '$.store.books.length', description: 'Get the number of books in the store' },
-        { code: '$.store.books[?(@.title.match(/lord.*rings/i))]', description: 'Get book by title regular expression' },
+        { code: '$.store.books[?(`@.title.match(/lord.*rings/i))]', description: 'Get book by title regular expression' },
       ]}
     />
   </ModalBody>

--- a/packages/insomnia-app/app/ui/components/modals/filter-help-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/filter-help-modal.tsx
@@ -1,5 +1,5 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import React, { PureComponent } from 'react';
+import React, { FC, PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { Link } from '../base/link';
@@ -8,13 +8,65 @@ import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 
 interface State {
-  isJson: boolean;
+  isJSON: boolean;
 }
+
+interface HelpExample {
+  code: string;
+  description: string;
+}
+
+const HelpExamples: FC<{ helpExamples: HelpExample[] }> = ({ helpExamples }) => (
+  <table className="table--fancy pad-top-sm">
+    <tbody>
+      {helpExamples.map(({ code, description }) => (
+        <tr key={code}>
+          <td><code className="selectable">{code}</code></td>
+          {description}
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+const JSONPathHelp: FC = () => (
+  <ModalBody className="pad">
+    <p>
+      Use <Link href="http://goessner.net/articles/JsonPath/">JSONPath</Link> to filter the response body. Here are some examples that you might use on a book store API:
+    </p>
+    <HelpExamples
+      helpExamples={[
+        { code: '$.store.books[*].title', description: 'Get titles of all books in the store' },
+        { code: '$.store.books[?(@.price < 10)].title', description: 'Get books costing less than $10' },
+        { code: '$.store.books[-1:]', description: 'Get the last book in the store' },
+        { code: '$.store.books.length', description: 'Get the number of books in the store' },
+        { code: '$.store.books[?(@.title.match(/lord.*rings/i))]', description: 'Get book by title regular expression' },
+      ]}
+    />
+  </ModalBody>
+);
+
+const XPathHelp: FC = () => (
+  <ModalBody className="pad">
+    <p>
+      Use <Link href="https://www.w3.org/TR/xpath/">XPath</Link> to filter the response body. Here are some examples that you might use on a
+      book store API:
+    </p>
+    <HelpExamples
+      helpExamples={[
+        { code: '/store/books/title', description: 'Get titles of all books in the store' },
+        { code: '/store/books[price < 10]', description: 'Get books costing less than $10' },
+        { code: '/store/books[last()]', description: 'Get the last book in the store' },
+        { code: 'count(/store/books)', description: 'Get the number of books in the store' },
+      ]}
+    />
+  </ModalBody>
+);
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class FilterHelpModal extends PureComponent<{}, State> {
   state: State = {
-    isJson: true,
+    isJSON: true,
   };
 
   modal: Modal | null = null;
@@ -23,8 +75,8 @@ export class FilterHelpModal extends PureComponent<{}, State> {
     this.modal = n;
   }
 
-  show(isJson: boolean) {
-    this.setState({ isJson });
+  show(isJSON: boolean) {
+    this.setState({ isJSON });
     this.modal?.show();
   }
 
@@ -33,68 +85,13 @@ export class FilterHelpModal extends PureComponent<{}, State> {
   }
 
   render() {
-    const { isJson } = this.state;
-    const link = isJson ? (
-      <Link href="http://goessner.net/articles/JsonPath/">JSONPath</Link>
-    ) : (
-      <Link href="https://www.w3.org/TR/xpath/">XPath</Link>
-    );
+    const { isJSON } = this.state;
+    const isXPath = !isJSON;
     return (
       <Modal ref={this._setModalRef}>
         <ModalHeader>Response Filtering Help</ModalHeader>
-        <ModalBody className="pad">
-          <p>
-            Use {link} to filter the response body. Here are some examples that you might use on a
-            book store API.
-          </p>
-          <table className="table--fancy pad-top-sm">
-            <tbody>
-              <tr>
-                <td>
-                  <code className="selectable">
-                    {isJson ? '$.store.books[*].title' : '/store/books/title'}
-                  </code>
-                </td>
-                <td>Get titles of all books in the store</td>
-              </tr>
-              <tr>
-                <td>
-                  <code className="selectable">
-                    {isJson ? '$.store.books[?(@.price < 10)].title' : '/store/books[price < 10]'}
-                  </code>
-                </td>
-                <td>Get books costing less than $10</td>
-              </tr>
-              <tr>
-                <td>
-                  <code className="selectable">
-                    {isJson ? '$.store.books[-1:]' : '/store/books[last()]'}
-                  </code>
-                </td>
-                <td>Get the last book in the store</td>
-              </tr>
-              <tr>
-                <td>
-                  <code className="selectable">
-                    {isJson ? '$.store.books.length' : 'count(/store/books)'}
-                  </code>
-                </td>
-                <td>Get the number of books in the store</td>
-              </tr>
-
-              {isJson && (
-                <tr>
-                  <td>
-                    <code className="selectable">
-                      $.store.books[?(@.title.match(/lord.*rings/i))]
-                    </code>
-                  </td>
-                  <td>Get book by title regular expression</td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </ModalBody>
+        {isJSON ? <JSONPathHelp /> : null}
+        {isXPath ? <XPathHelp /> : null}
       </Modal>
     );
   }

--- a/packages/insomnia-app/app/ui/components/modals/filter-help-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/filter-help-modal.tsx
@@ -43,6 +43,9 @@ const JSONPathHelp: FC = () => (
         { code: '$.store.books[?(`@.title.match(/lord.*rings/i))]', description: 'Get book by title regular expression' },
       ]}
     />
+    <p className="notice info">
+      Note that there's <Link href="https://cburgmer.github.io/json-path-comparison/">no standard</Link> for JSONPath. Insomnia uses <Link href="https://www.npmjs.com/package/jsonpath-plus">jsonpath-plus</Link>.
+    </p>
   </ModalBody>
 );
 


### PR DESCRIPTION
see https://github.com/Kong/insomnia/issues/4213#issuecomment-967353033 for more context on our usage of JSONPath and how (and why) it changed recently.  I just noticed that our examples here are out of date.  So, I updated the examples and left a note about jsonpath-plus.

| BEFORE | AFTER |
| - | - |
| ![Screenshot_20220304_190109](https://user-images.githubusercontent.com/15232461/156857785-4f3e9c9f-a55e-46ce-ab73-b04e506698b4.png) | ![Screenshot_20220304_185802](https://user-images.githubusercontent.com/15232461/156857803-ed5e8883-3db9-4fc5-97ae-43cd15486831.png) |
| ![Screenshot_20220304_190100](https://user-images.githubusercontent.com/15232461/156857815-7af4598c-015e-4526-b4c4-4b7dcefc1389.png) | (no change) ![Screenshot_20220304_185814](https://user-images.githubusercontent.com/15232461/156857819-daecb30d-65d1-4dfa-90b4-3e2e4e9e2cb1.png) |

To test this, set up a request (e.g. to mockbin.org/echo) that sends JSON or an XML body and hit the little info button in the bottom right of the response pane:
![Screenshot_20220304_190323](https://user-images.githubusercontent.com/15232461/156857923-13e94cb0-ee27-4eaa-9006-50515bd54369.png)

 