### PR TITLE
fixes styled-components wrong peer dependency

### DIFF
--- a/packages/insomnia-components/package.json
+++ b/packages/insomnia-components/package.json
@@ -33,7 +33,6 @@
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/plugin-proposal-optional-chaining": "^7.12.7",
     "@babel/plugin-transform-runtime": "^7.12.10",
-
     "@svgr/cli": "^5.5.0",
     "@testing-library/dom": "^7.30.4",
     "@testing-library/jest-dom": "^5.12.0",
@@ -80,7 +79,7 @@
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
     "react-use": "^17.2.4",
-    "styled-components": "^5.1.1"
+    "styled-components": "^4.4.1"
   },
   "gitHead": "d91e6735a76295166545a42c170328da4ab70dd3"
 }


### PR DESCRIPTION
Our recent upgrade to NPM uncovered an error in our peer dependencies.  We had been (wrongly) specifying a peer dependency for styled-components that is higher than the version we were actually using.

This is a breaking bug, now, that prevents install of some packages, e.g.:

![Screenshot_20220308_091718](https://user-images.githubusercontent.com/15232461/157256380-c901fd82-a4b3-4309-b3c6-41e859341728.png)

To reproduce run `npm run bootstrap` then `cd plugins/insomnia-plugin-kong-portal` then `npm install`