### PR TITLE
Fix homebrew release automation

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
@@ -36,6 +38,9 @@ jobs:
         uses: Homebrew/actions/git-user-config@master
         with:
           username: 'insomnia-infra'
+
+      - name: Update brew
+        run: brew update
 
       # Update Homebrew's Inso(mnia) formulae
       # https://github.com/Homebrew/actions/tree/master/bump-formulae


### PR DESCRIPTION
It was creating invalid PRs as the local state of the taps it based the changes on were outdated

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
