### PR TITLE
remove zprint-clj and EDN beautifying

### DIFF
--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -14,7 +14,6 @@ import React, { Component, CSSProperties, forwardRef, ForwardRefRenderFunction, 
 import { useSelector } from 'react-redux';
 import { unreachable } from 'ts-assert-unreachable';
 import vkBeautify from 'vkbeautify';
-import zprint from 'zprint-clj';
 
 import {
   AUTOBIND_CFG,
@@ -725,14 +724,6 @@ export class UnconnectedCodeEditor extends Component<CodeEditorProps, State> {
     }
   }
 
-  static _prettifyEDN(code: string) {
-    try {
-      return zprint(code, null);
-    } catch (e) {
-      return code;
-    }
-  }
-
   _prettifyXML(code: string) {
     if (this.props.updateFilter && this.state.filter) {
       try {
@@ -1143,8 +1134,6 @@ export class UnconnectedCodeEditor extends Component<CodeEditorProps, State> {
     if (shouldPrettify && this._canPrettify()) {
       if (UnconnectedCodeEditor._isXML(mode)) {
         code = this._prettifyXML(code);
-      } else if (UnconnectedCodeEditor._isEDN(mode)) {
-        code = UnconnectedCodeEditor._prettifyEDN(code);
       } else if (UnconnectedCodeEditor._isJSON(mode)) {
         code = this._prettifyJSON(code);
       } else {
@@ -1190,7 +1179,7 @@ export class UnconnectedCodeEditor extends Component<CodeEditorProps, State> {
 
   _canPrettify() {
     const { mode } = this.props;
-    return UnconnectedCodeEditor._isJSON(mode) || UnconnectedCodeEditor._isXML(mode) || UnconnectedCodeEditor._isEDN(mode);
+    return UnconnectedCodeEditor._isJSON(mode) || UnconnectedCodeEditor._isXML(mode);
   }
 
   _showFilterHelp() {
@@ -1266,8 +1255,6 @@ export class UnconnectedCodeEditor extends Component<CodeEditorProps, State> {
         contentTypeName = 'JSON';
       } else if (UnconnectedCodeEditor._isXML(mode)) {
         contentTypeName = 'XML';
-      } else if (UnconnectedCodeEditor._isEDN(mode)) {
-        contentTypeName = 'EDN';
       }
 
       toolbarChildren.push(

--- a/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia-app/app/ui/components/codemirror/code-editor.tsx
@@ -678,14 +678,6 @@ export class UnconnectedCodeEditor extends Component<CodeEditorProps, State> {
     return mode.indexOf('xml') !== -1;
   }
 
-  static _isEDN(mode?: string) {
-    if (!mode) {
-      return false;
-    }
-
-    return mode === 'application/edn' || mode.indexOf('clojure') !== -1;
-  }
-
   _indentChars() {
     return this.codeMirror?.getOption('indentWithTabs')
       ? '\t'
@@ -956,7 +948,7 @@ export class UnconnectedCodeEditor extends Component<CodeEditorProps, State> {
       return 'graphql';
     } else if (UnconnectedCodeEditor._isJSON(mimeType)) {
       return 'application/json';
-    } else if (UnconnectedCodeEditor._isEDN(mimeType)) {
+    } else if (mimeType.includes('clojure')) {
       return 'application/edn';
     } else if (UnconnectedCodeEditor._isXML(mimeType)) {
       return 'application/xml';

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -80,7 +80,7 @@
 				"whatwg-fetch": "^2.0.1",
 				"yaml": "^1.5.0",
 				"yaml-source-map": "^2.1.1",
-				"zprint-clj": "0.2.0"
+				"zprint-clj": "0.8.0"
 			},
 			"devDependencies": {
 				"@babel/preset-env": "^7.15.8",
@@ -32324,14 +32324,30 @@
 			}
 		},
 		"node_modules/zprint-clj": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/zprint-clj/-/zprint-clj-0.2.0.tgz",
-			"integrity": "sha512-Xq2Q2s8lpDg3be/jShseQtaFg+yDpDq5XrbmdYQ9gL2GxtmJ9mwnLlK7Y8GjgdbyJ+Q1Ui9gNKZ9mdd2lwOXhQ==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/zprint-clj/-/zprint-clj-0.8.0.tgz",
+			"integrity": "sha512-9Z9p5d6UK/rnrvX/pZ0UM3H9octsdAy+UaGr6hMSK3KXtPFFD3PIrTJ6cNXYvsWiAeFmitcYK/AQQVw/vTf1NQ==",
 			"dependencies": {
-				"commander": "^2.13.0"
+				"commander": "^2.13.0",
+				"fast-glob": "3.1.0"
 			},
 			"bin": {
 				"zprint-clj": "js-src/cli.js"
+			}
+		},
+		"node_modules/zprint-clj/node_modules/fast-glob": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+			"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.0",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		}
 	},
@@ -58143,11 +58159,26 @@
 			}
 		},
 		"zprint-clj": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/zprint-clj/-/zprint-clj-0.2.0.tgz",
-			"integrity": "sha512-Xq2Q2s8lpDg3be/jShseQtaFg+yDpDq5XrbmdYQ9gL2GxtmJ9mwnLlK7Y8GjgdbyJ+Q1Ui9gNKZ9mdd2lwOXhQ==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/zprint-clj/-/zprint-clj-0.8.0.tgz",
+			"integrity": "sha512-9Z9p5d6UK/rnrvX/pZ0UM3H9octsdAy+UaGr6hMSK3KXtPFFD3PIrTJ6cNXYvsWiAeFmitcYK/AQQVw/vTf1NQ==",
 			"requires": {
-				"commander": "^2.13.0"
+				"commander": "^2.13.0",
+				"fast-glob": "3.1.0"
+			},
+			"dependencies": {
+				"fast-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+					"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.0",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.2"
+					}
+				}
 			}
 		}
 	}

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -79,8 +79,7 @@
 				"vkbeautify": "^0.99.1",
 				"whatwg-fetch": "^2.0.1",
 				"yaml": "^1.5.0",
-				"yaml-source-map": "^2.1.1",
-				"zprint-clj": "0.8.0"
+				"yaml-source-map": "^2.1.1"
 			},
 			"devDependencies": {
 				"@babel/preset-env": "^7.15.8",
@@ -32322,33 +32321,6 @@
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
-		},
-		"node_modules/zprint-clj": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/zprint-clj/-/zprint-clj-0.8.0.tgz",
-			"integrity": "sha512-9Z9p5d6UK/rnrvX/pZ0UM3H9octsdAy+UaGr6hMSK3KXtPFFD3PIrTJ6cNXYvsWiAeFmitcYK/AQQVw/vTf1NQ==",
-			"dependencies": {
-				"commander": "^2.13.0",
-				"fast-glob": "3.1.0"
-			},
-			"bin": {
-				"zprint-clj": "js-src/cli.js"
-			}
-		},
-		"node_modules/zprint-clj/node_modules/fast-glob": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
-			"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
-			"dependencies": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.0",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
 		}
 	},
 	"dependencies": {
@@ -58154,29 +58126,6 @@
 					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.2.0"
-					}
-				}
-			}
-		},
-		"zprint-clj": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/zprint-clj/-/zprint-clj-0.8.0.tgz",
-			"integrity": "sha512-9Z9p5d6UK/rnrvX/pZ0UM3H9octsdAy+UaGr6hMSK3KXtPFFD3PIrTJ6cNXYvsWiAeFmitcYK/AQQVw/vTf1NQ==",
-			"requires": {
-				"commander": "^2.13.0",
-				"fast-glob": "3.1.0"
-			},
-			"dependencies": {
-				"fast-glob": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
-					"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.2",
-						"@nodelib/fs.walk": "^1.2.3",
-						"glob-parent": "^5.1.0",
-						"merge2": "^1.3.0",
-						"micromatch": "^4.0.2"
 					}
 				}
 			}

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -74,8 +74,7 @@
     "srp-js",
     "styled-components",
     "swagger-ui-react",
-    "vkbeautify",
-    "zprint-clj"
+    "vkbeautify"
   ],
   "dependencies": {
     "@getinsomnia/node-libcurl": "2.3.4-3",
@@ -173,8 +172,7 @@
     "vkbeautify": "^0.99.1",
     "whatwg-fetch": "^2.0.1",
     "yaml": "^1.5.0",
-    "yaml-source-map": "^2.1.1",
-    "zprint-clj": "0.8.0"
+    "yaml-source-map": "^2.1.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.8",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -174,7 +174,7 @@
     "whatwg-fetch": "^2.0.1",
     "yaml": "^1.5.0",
     "yaml-source-map": "^2.1.1",
-    "zprint-clj": "0.2.0"
+    "zprint-clj": "0.8.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.8",


### PR DESCRIPTION
### What's the big picture.

We want to move all prettifying to https://www.npmjs.com/package/prettier.  That will mean that anything that can be prettified using prettier (or a prettier plugin) (i.e. GraphQL, JSON, YAML, etc.) will be supported by Insomnia.  In general, if we have outreach from users to add EDN prettifying back: we can think about it from that direction (i.e. a prettier plugin for EDN).

### zprint-clj

We use the [`zprint-clj`](https://www.npmjs.com/package/zprint-clj) package for only one thing: prettifying EDN.  [Here](https://learnxinyminutes.com/docs/edn/)'s a little thingy about what EDN is.  It's not... shall we say... common.  That's not, in itself, a reason _not_ to support prettifying it, please read on:

When upgrading this dependency I could not find source code for this npm, nor could I find a changelog.  Still.. it appeared to be a straightforward thing to update.  It takes EDN (https://github.com/edn-format/edn) and prettifies it.

But then I tried upgrading it and I got:
![Screenshot_20220316_160045](https://user-images.githubusercontent.com/15232461/158690206-4d4e4c92-ddde-4a51-927d-4c8ea531b921.png)

I thought I could solve it quickly, but I couldn't. There's a shebang at the top of the new release, and there's a few different ways to solve it (babel plugin, webpack loader, etc.) and I can't decide which is best, and none of them are awesome. I did, as I said, test it, but by just deleting the shebang manually.

| BEFORE | AFTER |
| - | - |
| ![Screenshot_20220317_111958](https://user-images.githubusercontent.com/15232461/158834410-6276989f-7420-4f16-9468-3094f01d8f02.png) | ![Screenshot_20220317_111652](https://user-images.githubusercontent.com/15232461/158834439-936ce6c3-0987-499a-86d3-61060f6ea0d9.png) |

### Why remove prettifying for EDN

This was introduced in https://github.com/Kong/insomnia/pull/1176.  If we see anything from users suggesting a way to keep using it, we can do so.

Note that this doesn't have any impact on EDN syntax highlighting in the code editor.

changelog(Removal): Removed EDN prettifying ahead of a move to prettier for all prettifying