### PR TITLE
Use the segment development write key for smoketests

### DIFF
--- a/packages/insomnia-app/app/common/constants.ts
+++ b/packages/insomnia-app/app/common/constants.ts
@@ -20,7 +20,7 @@ export const isLinux = () => getAppPlatform() === 'linux';
 export const isWindows = () => getAppPlatform() === 'win32';
 export const getAppEnvironment = () => process.env.INSOMNIA_ENV || 'production';
 export const isDevelopment = () => getAppEnvironment() === 'development';
-export const getSegmentWriteKey = () => appConfig.segmentWriteKeys[isDevelopment() ? 'development' : 'production'];
+export const getSegmentWriteKey = () => appConfig.segmentWriteKeys[(isDevelopment() || process.env.PLAYWRIGHT) ? 'development' : 'production'];
 export const getAppBuildDate = () => new Date(process.env.BUILD_DATE ?? '').toLocaleDateString();
 
 export const getBrowserUserAgent = () => encodeURIComponent(


### PR DESCRIPTION
To avoid our smoketests polluting our production segment metrics