### PR TITLE
chore(deps): removes whatwg-fetch (not needed since 5 years ago)

### DIFF
--- a/packages/insomnia-app/app/__jest__/setup.ts
+++ b/packages/insomnia-app/app/__jest__/setup.ts
@@ -1,5 +1,3 @@
-import 'whatwg-fetch';
-
 const localStorageMock: Storage = (function() {
   let store: Record<string, string> = {};
   return {

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -77,7 +77,6 @@
 				"url-join": "^4.0.1",
 				"uuid": "^8.3.2",
 				"vkbeautify": "^0.99.1",
-				"whatwg-fetch": "^2.0.1",
 				"yaml": "^1.5.0",
 				"yaml-source-map": "^2.1.1"
 			},
@@ -30469,11 +30468,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/whatwg-fetch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
-		},
 		"node_modules/whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -55294,11 +55288,6 @@
 					}
 				}
 			}
-		},
-		"whatwg-fetch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -170,7 +170,6 @@
     "url-join": "^4.0.1",
     "uuid": "^8.3.2",
     "vkbeautify": "^0.99.1",
-    "whatwg-fetch": "^2.0.1",
     "yaml": "^1.5.0",
     "yaml-source-map": "^2.1.1"
   },

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -40,7 +40,6 @@
 				"ts-assert-unreachable": "^0.0.9",
 				"url-join": "^4.0.1",
 				"uuid": "^8.3.2",
-				"whatwg-fetch": "^3.1.0",
 				"yaml": "^1.10.0"
 			}
 		},
@@ -3677,11 +3676,6 @@
 				"extsprintf": "^1.2.0"
 			}
 		},
-		"node_modules/whatwg-fetch": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-			"integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6642,11 +6636,6 @@
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
 			}
-		},
-		"whatwg-fetch": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-			"integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
 		},
 		"which": {
 			"version": "2.0.2",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -43,7 +43,6 @@
     "ts-assert-unreachable": "^0.0.9",
     "url-join": "^4.0.1",
     "uuid": "^8.3.2",
-    "whatwg-fetch": "^3.1.0",
     "yaml": "^1.10.0"
   }
 }


### PR DESCRIPTION
so here's what I found on this one:

- this dependency was introduced _just_ for the sake of jest mocking in https://github.com/Kong/insomnia/commit/3f5e7e2e141143fe945cd6c63804c910dc01ec3b for test around OAuth2
- in https://github.com/Kong/insomnia/commit/d506e0b4c11ebc5efbd4344f0a7440631e56b8c4 that approach (using window.fetch) was abandoned and we switched to using Insomnia's network stack
- all the tests pass if you remove it

conclusion: we can remove it