### PR TITLE
chore(deps): updates redux-thunk

### DIFF
--- a/packages/insomnia-app/app/ui/redux/modules/global.tsx
+++ b/packages/insomnia-app/app/ui/redux/modules/global.tsx
@@ -297,8 +297,10 @@ export const newCommand = (command: string, args: any) => async (dispatch: Dispa
       break;
     }
 
+    case null:
+      break;
+
     default: {
-      // Nothing
       console.log(`Unknown command: ${command}`);
     }
   }

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -67,8 +67,8 @@
 				"react-tabs": "^3.2.3",
 				"react-use": "^17.2.4",
 				"redux": "^4.1.2",
-				"redux-thunk": "^2.3.0",
-				"reselect": "^4.1.5",
+				"redux-thunk": "^2.4.1",
+				"reselect": "^4.0.0",
 				"srp-js": "^0.2.1",
 				"styled-components": "^4.4.1",
 				"swagger-ui-react": "^4.5.2",
@@ -24449,9 +24449,12 @@
 			}
 		},
 		"node_modules/redux-thunk": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-			"integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+			"integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+			"peerDependencies": {
+				"redux": "^4"
+			}
 		},
 		"node_modules/refractor": {
 			"version": "3.6.0",
@@ -50378,9 +50381,10 @@
 			}
 		},
 		"redux-thunk": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-			"integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+			"integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+			"requires": {}
 		},
 		"refractor": {
 			"version": "3.6.0",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -160,7 +160,7 @@
     "react-tabs": "^3.2.3",
     "react-use": "^17.2.4",
     "redux": "^4.1.2",
-    "redux-thunk": "^2.3.0",
+    "redux-thunk": "^2.4.1",
     "reselect": "^4.1.5",
     "srp-js": "^0.2.1",
     "styled-components": "^4.4.1",


### PR DESCRIPTION
This probably should have been done back in February in https://github.com/Kong/insomnia/pull/4456


Here's the release notes: https://github.com/reduxjs/redux-thunk/releases

Basically they updated a lot of TypeScript stuff and rewrote the thing in TypeScript.  While there's quite a lot of our typings for redux-thunk that I'd like to improve (we ignore some genuine errors, today) this PR isn't the time or place so I didn't touch it.

The null command thing (the only actual code change in this PR) may not be new, but it seems like we shouldn't be console.logging there.