### PR TITLE
chore(deps): reselect

### DIFF
--- a/packages/insomnia-app/app/models/api-spec.ts
+++ b/packages/insomnia-app/app/models/api-spec.ts
@@ -12,7 +12,7 @@ export const canDuplicate = true;
 
 export const canSync = false;
 
-interface BaseApiSpec {
+export interface BaseApiSpec {
   fileName: string;
   contentType: 'json' | 'yaml';
   contents: string;

--- a/packages/insomnia-app/app/models/cookie-jar.ts
+++ b/packages/insomnia-app/app/models/cookie-jar.ts
@@ -30,7 +30,7 @@ export interface Cookie {
   lastAccessed?: Date;
 }
 
-interface BaseCookieJar {
+export interface BaseCookieJar {
   name: string;
   cookies: Cookie[];
 }

--- a/packages/insomnia-app/app/models/environment.ts
+++ b/packages/insomnia-app/app/models/environment.ts
@@ -9,7 +9,7 @@ export const prefix = 'env';
 export const canDuplicate = true;
 export const canSync = true;
 
-interface BaseEnvironment {
+export interface BaseEnvironment {
   name: string;
   data: Record<string, any>;
   dataPropertyOrder: Record<string, any> | null;

--- a/packages/insomnia-app/app/models/git-repository.ts
+++ b/packages/insomnia-app/app/models/git-repository.ts
@@ -27,7 +27,7 @@ export function init(): BaseGitRepository {
   };
 }
 
-interface BaseGitRepository {
+export interface BaseGitRepository {
   needsFullClone: boolean;
   uri: string;
   credentials: GitCredentials | null;

--- a/packages/insomnia-app/app/models/o-auth-2-token.ts
+++ b/packages/insomnia-app/app/models/o-auth-2-token.ts
@@ -13,7 +13,7 @@ export const canDuplicate = false;
 
 export const canSync = false;
 
-interface BaseOAuth2Token {
+export interface BaseOAuth2Token {
   refreshToken: string;
   accessToken: string;
   identityToken: string;

--- a/packages/insomnia-app/app/models/request-meta.ts
+++ b/packages/insomnia-app/app/models/request-meta.ts
@@ -10,7 +10,7 @@ export const canSync = false;
 
 export type RequestAccordionKeys = 'OAuth2AdvancedOptions';
 
-interface BaseRequestMeta {
+export interface BaseRequestMeta {
   parentId: string;
   previewMode: string;
   responseFilter: string;

--- a/packages/insomnia-app/app/models/response.ts
+++ b/packages/insomnia-app/app/models/response.ts
@@ -35,7 +35,7 @@ export interface ResponseTimelineEntry {
 
 type Compression = 'zip' | null | '__NEEDS_MIGRATION__' | undefined;
 
-interface BaseResponse {
+export interface BaseResponse {
   environmentId: string | null;
   statusCode: number;
   statusMessage: string;

--- a/packages/insomnia-app/app/models/stats.ts
+++ b/packages/insomnia-app/app/models/stats.ts
@@ -16,7 +16,7 @@ export const canDuplicate = false;
 
 export const canSync = false;
 
-interface BaseStats {
+export interface BaseStats {
   currentLaunch: number | null;
   lastLaunch: number | null;
   currentVersion: string | null;

--- a/packages/insomnia-app/app/models/unit-test-result.ts
+++ b/packages/insomnia-app/app/models/unit-test-result.ts
@@ -11,7 +11,7 @@ export const canDuplicate = false;
 
 export const canSync = false;
 
-interface BaseUnitTestResult {
+export interface BaseUnitTestResult {
   results: Record<string, any>;
 }
 

--- a/packages/insomnia-app/app/models/unit-test-suite.ts
+++ b/packages/insomnia-app/app/models/unit-test-suite.ts
@@ -10,7 +10,7 @@ export const prefix = 'uts';
 export const canDuplicate = true;
 
 export const canSync = true;
-interface BaseUnitTestSuite {
+export interface BaseUnitTestSuite {
   name: string;
 }
 

--- a/packages/insomnia-app/app/models/workspace-meta.ts
+++ b/packages/insomnia-app/app/models/workspace-meta.ts
@@ -12,7 +12,7 @@ export const prefix = 'wrkm';
 export const canDuplicate = false;
 export const canSync = false;
 
-interface BaseWorkspaceMeta {
+export interface BaseWorkspaceMeta {
   activeActivity: string | null;
   activeEnvironmentId: string | null;
   activeRequestId: string | null;

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -68,7 +68,7 @@
 				"react-use": "^17.2.4",
 				"redux": "^4.1.2",
 				"redux-thunk": "^2.3.0",
-				"reselect": "^4.0.0",
+				"reselect": "^4.1.5",
 				"srp-js": "^0.2.1",
 				"styled-components": "^4.4.1",
 				"swagger-ui-react": "^4.5.2",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -161,7 +161,7 @@
     "react-use": "^17.2.4",
     "redux": "^4.1.2",
     "redux-thunk": "^2.3.0",
-    "reselect": "^4.0.0",
+    "reselect": "^4.1.5",
     "srp-js": "^0.2.1",
     "styled-components": "^4.4.1",
     "swagger-ui-react": "^4.5.2",

--- a/packages/insomnia-inso/src/db/models/types.ts
+++ b/packages/insomnia-inso/src/db/models/types.ts
@@ -7,7 +7,7 @@ export interface BaseModel {
     parentId: string;
 }
 
-interface BaseApiSpec {
+export interface BaseApiSpec {
     fileName: string;
     contentType: 'json' | 'yaml';
     contents: string;


### PR DESCRIPTION
QUITE a lot has changed with reselect between 4.0.0 and 4.1.5, believe it or not! https://github.com/reduxjs/reselect/releases but the good news is, it's almost exclusively internal improvements for TypeScript. 

We did have to make some upgrades now that the inferencing improved, but nothing more than a few exports for previously unexported interfaces.  Here's an example:
![Screenshot_20220321_150342](https://user-images.githubusercontent.com/15232461/159346678-ed7325ba-11bf-4a41-9b78-a32ee3a4f630.png)

