### PR TITLE
Chore/network dejanking

### DIFF
--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -100,7 +100,7 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      workspace,
+      [],
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -174,7 +174,7 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      workspace,
+      [],
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -273,7 +273,7 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      workspace,
+      [],
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -332,7 +332,7 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      workspace,
+      [],
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -411,7 +411,7 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      workspace,
+      [],
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -471,7 +471,7 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      workspace,
+      [],
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -510,7 +510,7 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      workspace,
+      [],
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -548,7 +548,7 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      workspace,
+      [],
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -587,7 +587,7 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      workspace,
+      [],
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -683,7 +683,7 @@ describe('actuallySend()', () => {
     const renderedRequest = await getRenderedRequest({ request });
     const response = await networkUtils._actuallySend(
       renderedRequest,
-      workspace,
+      [],
       settings,
       null,
       false
@@ -734,7 +734,7 @@ describe('actuallySend()', () => {
       parentId: workspace._id,
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const responseV1 = await networkUtils._actuallySend(renderedRequest, workspace, {
+    const responseV1 = await networkUtils._actuallySend(renderedRequest, [], {
       ...settings,
       preferredHttpVersion: HttpVersions.V1_0,
     });

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -685,8 +685,6 @@ describe('actuallySend()', () => {
       renderedRequest,
       [],
       settings,
-      null,
-      false
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));

--- a/packages/insomnia-app/app/network/__tests__/network.test.ts
+++ b/packages/insomnia-app/app/network/__tests__/network.test.ts
@@ -684,7 +684,7 @@ describe('actuallySend()', () => {
     const response = await networkUtils._actuallySend(
       renderedRequest,
       [],
-      settings,
+      { ...settings, validateSSL:false },
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -206,9 +206,6 @@ export async function _actuallySend(
           statusMessage: 'Cancelled',
           error: 'Request was cancelled',
           timelinePath,
-          parentId: renderedRequest._id,
-          settingSendCookies: renderedRequest.settingSendCookies,
-          settingStoreCookies: renderedRequest.settingStoreCookies,
         });
       };
 
@@ -485,9 +482,6 @@ export async function _actuallySend(
               elapsedTime: 0,
               statusMessage: 'Error',
               timelinePath,
-              parentId: renderedRequest._id,
-              settingSendCookies: renderedRequest.settingSendCookies,
-              settingStoreCookies: renderedRequest.settingStoreCookies,
             });
           }
         }
@@ -545,11 +539,7 @@ export async function _actuallySend(
       }
       return resolve({
         timelinePath,
-        parentId: renderedRequest._id,
-        bodyCompression: null,
-        bodyPath: responseBodyPath || '',
-        settingSendCookies: renderedRequest.settingSendCookies,
-        settingStoreCookies: renderedRequest.settingStoreCookies,
+        bodyPath: responseBodyPath,
         ...responsePatch,
       });
     } catch (err) {
@@ -565,9 +555,6 @@ export async function _actuallySend(
         elapsedTime: 0, // 0 because this path is hit during plugin calls
         statusMessage: 'Error',
         timelinePath,
-        parentId: renderedRequest._id,
-        settingSendCookies: renderedRequest.settingSendCookies,
-        settingStoreCookies: renderedRequest.settingStoreCookies,
       });
     }
   });
@@ -796,6 +783,7 @@ export async function sendWithSettings(
     clientCertificates,
     { ...settings, validateSSL: settings.validateAuthSSL },
   );
+  response.parentId = renderResult.request._id;
   response.environmentId = environmentId;
   if (response.error) {
     return response;
@@ -884,7 +872,10 @@ export async function send(
     clientCertificates,
     settings,
   );
+  response.parentId = renderResult.request._id;
   response.environmentId = environmentId;
+  response.settingSendCookies = renderedRequest.settingSendCookies;
+  response.settingStoreCookies = renderedRequest.settingStoreCookies;
 
   console.log(
     response.error
@@ -958,7 +949,6 @@ async function _applyResponsePluginHooks(
   } catch (err) {
     return {
       url: renderedRequest.url,
-      parentId: renderedRequest._id,
       error: `[plugin] Response hook failed plugin=${err.plugin.name} err=${err.message}`,
       elapsedTime: 0, // 0 because this path is hit during plugin calls
       statusMessage: 'Error',

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -794,6 +794,7 @@ export async function sendWithSettings(
     clientCertificates,
     { ...settings, validateSSL: settings.validateAuthSSL },
   );
+  response.environmentId = environmentId;
   if (response.error) {
     return response;
   }
@@ -881,6 +882,7 @@ export async function send(
     clientCertificates,
     settings,
   );
+  response.environmentId = environmentId;
 
   console.log(
     response.error

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -574,7 +574,6 @@ const parseRequestBody = req => {
   if (hasMimetypeAndUpdateMethod) {
     return req.body.text;
   }
-  return;
 };
 
 const parseRequestBodyPath = async req => {

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -180,8 +180,6 @@ export async function _actuallySend(
 
     const addTimelineText = addTimelineItem(LIBCURL_DEBUG_MIGRATION_MAP.Text);
 
-    /** Helper function to respond with a success */
-
     // NOTE: can have duplicate keys because of cookie options
     const curlOptions: { key: string; value: string | string[] | number | boolean }[] = [];
     const setOpt = (key: string, value: string | string[] | number | boolean) => {
@@ -210,8 +208,6 @@ export async function _actuallySend(
           error: 'Request was cancelled',
           timelinePath,
           parentId: renderedRequest._id,
-          bodyCompression: null,
-          bodyPath: '',
           settingSendCookies: renderedRequest.settingSendCookies,
           settingStoreCookies: renderedRequest.settingStoreCookies,
         });
@@ -511,8 +507,6 @@ export async function _actuallySend(
               statusMessage: 'Error',
               timelinePath,
               parentId: renderedRequest._id,
-              bodyCompression: null,
-              bodyPath: '',
               settingSendCookies: renderedRequest.settingSendCookies,
               settingStoreCookies: renderedRequest.settingStoreCookies,
             });
@@ -661,8 +655,6 @@ export async function _actuallySend(
         statusMessage: 'Error',
         timelinePath,
         parentId: renderedRequest._id,
-        bodyCompression: null,
-        bodyPath: '',
         settingSendCookies: renderedRequest.settingSendCookies,
         settingStoreCookies: renderedRequest.settingStoreCookies,
       });

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -494,7 +494,7 @@ export async function _actuallySend(
           setOpt(Curl.option.USERNAME, username || '');
           setOpt(Curl.option.PASSWORD, password || '');
         } else if (renderedRequest.authentication.type === AUTH_AWS_IAM) {
-          if (hasRequestBodyOrFilePath && !requestBody) {
+          if (!requestBody) {
             const timelinePath = await storeTimeline(timeline);
             // Tear Down the cancellation logic
             if (cancelRequestFunctionMap.hasOwnProperty(renderedRequest._id)) {

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -464,11 +464,13 @@ export async function _actuallySend(
           setOpt(Curl.option.HTTPAUTH, CurlAuth.Digest);
           setOpt(Curl.option.USERNAME, username || '');
           setOpt(Curl.option.PASSWORD, password || '');
-        } else if (renderedRequest.authentication.type === AUTH_NTLM) {
+        }
+        if (renderedRequest.authentication.type === AUTH_NTLM) {
           setOpt(Curl.option.HTTPAUTH, CurlAuth.Ntlm);
           setOpt(Curl.option.USERNAME, username || '');
           setOpt(Curl.option.PASSWORD, password || '');
-        } else if (renderedRequest.authentication.type === AUTH_AWS_IAM) {
+        }
+        if (renderedRequest.authentication.type === AUTH_AWS_IAM) {
           // AWS IAM file upload not supported
           if (requestBodyPath) {
             const timelinePath = await storeTimeline(timeline);
@@ -785,6 +787,9 @@ export async function sendWithSettings(
   );
   response.parentId = renderResult.request._id;
   response.environmentId = environmentId;
+  response.bodyCompression = null;
+  response.settingSendCookies = renderResult.request.settingSendCookies;
+  response.settingStoreCookies = renderResult.request.settingStoreCookies;
   if (response.error) {
     return response;
   }
@@ -874,6 +879,7 @@ export async function send(
   );
   response.parentId = renderResult.request._id;
   response.environmentId = environmentId;
+  response.bodyCompression = null;
   response.settingSendCookies = renderedRequest.settingSendCookies;
   response.settingStoreCookies = renderedRequest.settingStoreCookies;
 

--- a/packages/insomnia-app/app/network/network.ts
+++ b/packages/insomnia-app/app/network/network.ts
@@ -658,7 +658,9 @@ const parseRequestBodyOptions = async renderedRequest => {
   const hasMimetypeAndUpdateMethod = typeof renderedRequest.body.mimeType === 'string' || expectsBody;
 
   if (isUrlEncodedForm) {
-    return { requestBody: buildQueryStringFromParams(renderedRequest.body.params || [], false) };
+    const urlSearchParams = new URLSearchParams();
+    renderedRequest.body.params.map(p => urlSearchParams.append(p.name, p?.value || ''));
+    return { requestBody: urlSearchParams.toString() };
   }
   if (isMultipartForm) {
     const { filePath, boundary, contentLength } = await buildMultipart(renderedRequest.body.params || [],);


### PR DESCRIPTION
Problem: network.ts is too long and some of it should not be run in the renderer. The code is difficult to move over an ipc bridge because it couples curl option setting with db and fs reads.
Idea: attempt to reduce complexity and improve readability by grouping database and filesystem calls and simplifying code paths.



Done
- simplified promise resolution code paths
- hoisted certs db call to to send()
- created a post request function for setting cookies
- created a parse body functions for handling request body/files and multipart
- removed some unused parameters
- removed the helper methods that made the code harder to follow and simplify.
- created a request header parsing function

Scoped out
- split network.ts into more files
- move all option setting and timeline to main context

I scoped these out in order to keep the diff easy to review in this pass, and to avoid introducing concepts.

How it works today
```
send()
-> _actuallySend(renderedRequest, settings)
--IPC--> nodejsLibcurlPromise(curlOptions)
```
How it might work, if we move db calls up to send() and fs calls over the bridge
```
send()
--IPC--> nodejsLibcurlPromise(renderedRequest, settings)
```
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
