### PR TITLE
chore: use renderer compatible crypto module

### DIFF
--- a/packages/insomnia-app/app/models/cookie-jar.ts
+++ b/packages/insomnia-app/app/models/cookie-jar.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import { createHash } from 'crypto-browserify';
 
 import { database as db } from '../common/database';
 import type { BaseModel } from './index';
@@ -69,7 +69,7 @@ export async function getOrCreateForParentId(parentId: string) {
       parentId,
       // Deterministic ID. It helps reduce sync complexity since we won't have to
       // de-duplicate environments.
-      _id: `${prefix}_${crypto.createHash('sha1').update(parentId).digest('hex')}`,
+      _id: `${prefix}_${createHash('sha1').update(parentId).digest('hex')}`,
     });
   } else {
     return cookieJars[0];

--- a/packages/insomnia-app/app/models/environment.ts
+++ b/packages/insomnia-app/app/models/environment.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import { createHash } from 'crypto-browserify';
 
 import { database as db } from '../common/database';
 import type { BaseModel } from './index';
@@ -75,7 +75,7 @@ export async function getOrCreateForParentId(parentId: string) {
       name: 'Base Environment',
       // Deterministic base env ID. It helps reduce sync complexity since we won't have to
       // de-duplicate environments.
-      _id: `${prefix}_${crypto.createHash('sha1').update(parentId).digest('hex')}`,
+      _id: `${prefix}_${createHash('sha1').update(parentId).digest('hex')}`,
     });
   }
 

--- a/packages/insomnia-app/app/models/response.ts
+++ b/packages/insomnia-app/app/models/response.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import { createHash } from 'crypto-browserify';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
@@ -312,8 +312,7 @@ async function migrateBodyToFileSystem(doc: Response) {
     const bodyBuffer = Buffer.from(doc.body, doc.encoding || 'utf8');
     const dir = path.join(getDataDirectory(), 'responses');
     mkdirp.sync(dir);
-    const hash = crypto
-      .createHash('md5')
+    const hash = createHash('md5')
       .update(bodyBuffer || '')
       .digest('hex');
     const bodyPath = path.join(dir, `${hash}.zip`);

--- a/packages/insomnia-app/app/network/o-auth-1/get-token.ts
+++ b/packages/insomnia-app/app/network/o-auth-1/get-token.ts
@@ -2,7 +2,7 @@
  * Get an OAuth1Token object and also handle storing/saving/refreshing
  * @returns {Promise.<void>}
  */
-import crypto from 'crypto';
+import { createHmac, createSign } from 'crypto-browserify';
 import OAuth1 from 'oauth-1.0a';
 
 import { CONTENT_TYPE_FORM_URLENCODED } from '../../common/constants';
@@ -18,19 +18,19 @@ import {
 function hashFunction(signatureMethod: OAuth1SignatureMethod) {
   if (signatureMethod === SIGNATURE_METHOD_HMAC_SHA1) {
     return function(baseString: string, key: string) {
-      return crypto.createHmac('sha1', key).update(baseString).digest('base64');
+      return createHmac('sha1', key).update(baseString).digest('base64');
     };
   }
 
   if (signatureMethod === SIGNATURE_METHOD_HMAC_SHA256) {
     return function(baseString: string, key: string) {
-      return crypto.createHmac('sha256', key).update(baseString).digest('base64');
+      return createHmac('sha256', key).update(baseString).digest('base64');
     };
   }
 
   if (signatureMethod === SIGNATURE_METHOD_RSA_SHA1) {
     return function(baseString: string, privatekey: string) {
-      return crypto.createSign('RSA-SHA1').update(baseString).sign(privatekey, 'base64');
+      return createSign('RSA-SHA1').update(baseString).sign(privatekey, 'base64');
     };
   }
 

--- a/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
+++ b/packages/insomnia-app/app/network/o-auth-2/grant-authorization-code.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import { createHash, randomBytes } from 'crypto-browserify';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
 import { parse as urlParse } from 'url';
 
@@ -36,12 +36,10 @@ export default async function(
   let codeChallenge = '';
 
   if (usePkce) {
-    // @ts-expect-error -- TSCONVERSION
-    codeVerifier = _base64UrlEncode(crypto.randomBytes(32));
+    codeVerifier = _base64UrlEncode(randomBytes(32));
 
     if (pkceMethod === c.PKCE_CHALLENGE_S256) {
-      // @ts-expect-error -- TSCONVERSION
-      codeChallenge = _base64UrlEncode(crypto.createHash('sha256').update(codeVerifier).digest());
+      codeChallenge = _base64UrlEncode(createHash('sha256').update(codeVerifier).digest());
     } else {
       codeChallenge = codeVerifier;
     }

--- a/packages/insomnia-app/app/sync/vcs/util.ts
+++ b/packages/insomnia-app/app/sync/vcs/util.ts
@@ -1,5 +1,5 @@
 import clone from 'clone';
-import crypto from 'crypto';
+import { createHash } from 'crypto-browserify';
 
 import { strings } from '../../common/strings';
 import { BaseModel } from '../../models';
@@ -463,7 +463,7 @@ export function hash(obj?: any): {
   }
 
   const content = deterministicStringify(obj);
-  const hash = crypto.createHash('sha1').update(content).digest('hex');
+  const hash = createHash('sha1').update(content).digest('hex');
   return {
     hash,
     content,

--- a/packages/insomnia-app/app/sync/vcs/vcs.ts
+++ b/packages/insomnia-app/app/sync/vcs/vcs.ts
@@ -1,5 +1,5 @@
 import clone from 'clone';
-import crypto from 'crypto';
+import { createHash } from 'crypto-browserify';
 import path from 'path';
 
 import * as crypt from '../../account/crypt';
@@ -39,7 +39,7 @@ import {
   updateStateWithConflictResolutions,
 } from './util';
 
-const EMPTY_HASH = crypto.createHash('sha1').digest('hex').replace(/./g, '0');
+const EMPTY_HASH = createHash('sha1').digest('hex').replace(/./g, '0');
 
 type ConflictHandler = (conflicts: MergeConflict[]) => Promise<MergeConflict[]>;
 
@@ -1626,7 +1626,7 @@ export class VCS {
 
 /** Generate snapshot ID from hashing parent, backendProject, and state together */
 function _generateSnapshotID(parentId: string, backendProjectId: string, state: SnapshotState) {
-  const hash = crypto.createHash('sha1').update(backendProjectId).update(parentId);
+  const hash = createHash('sha1').update(backendProjectId).update(parentId);
   const newState = [...state].sort((a, b) => (a.blob > b.blob ? 1 : -1));
 
   for (const entry of newState) {


### PR DESCRIPTION
Relates to and supports contextIsolation and vite work

Renderer no longer depends on nodejs module crypto.
https://github.com/crypto-browserify/crypto-browserify
crypto-browserify is current coming with node-libs-browser which comes with webpack
we probably want to add it as an explicit dep.

it's also curious how many code paths use crypto features.

- team sync
- oauth1
- cookie id
- environment id
- migrate outdated response body format to a zip file for posterity?

Could alternatively be implemented as a transpiler alias "crypto": "crypto-browserify"