### PR TITLE
Add git merge info to release-build.

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -77,7 +77,6 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           HEAD: release/${{ env.RELEASE_VERSION }}
           RELEASE_NAME: ${{ env.RELEASE_VERSION }}
-          SHOW_MISSING: ${{ env.SHOW_MISSING }}
 
       - name: Read changelog
         id: read-changelog

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -139,5 +139,21 @@ jobs:
             ```bash
             gh workflow run release-publish.yml -f version=${{ steps.release_version.outputs.version }} --repo ${{ github.repository }}
             ```
+
+            <details>
+            <summary>Conflicts? Merge branch step failed on the publish workflow? Try this...</summary>
+            Run locally:
+            ```bash
+            # Make sure git remote is Kong/insomnia...
+
+            git checkout develop
+            git merge --no-ff release/${{ steps.release_version.outputs.version }}
+
+            # Solve merge conflicts ...
+            # If there's package-lock conflicts, run `npm run bootstrap` and commit the package-lock changes
+
+            git push
+            ```
+            </details>
           destination_branch: develop
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -142,12 +142,14 @@ jobs:
 
             <details>
             <summary>Conflicts? Merge branch step failed on the publish workflow? Try this...</summary>
+
             Run locally:
+
             ```bash
             # Make sure git remote is Kong/insomnia...
 
             git checkout develop
-            git merge --no-ff release/${{ steps.release_version.outputs.version }}
+            git merge --no-ff release/<replaced with version>
 
             # Solve merge conflicts ...
             # If there's package-lock conflicts, run `npm run bootstrap` and commit the package-lock changes


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Adding helper info to release PRs' auto-generated text when each `release-build` runs.

The info is for cases folks need to merge a release branch locally due to merge conflicts, in the scenario where `release-publish` already did all its work and only the final merge step failed.

![Screenshot 2022-03-24 at 11 32 33](https://user-images.githubusercontent.com/11976836/159907576-1f1d5b96-2381-4316-a21c-1092a68b06d1.png)

