### PR TITLE
update swagger-parser and support oas 3.0.3

### DIFF
--- a/packages/openapi-2-kong/package-lock.json
+++ b/packages/openapi-2-kong/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"openapi-types": "^8.0.0",
 				"slugify": "^1.3.6",
-				"swagger-parser": "^8.0.3",
+				"swagger-parser": "^10.0.3",
 				"url-join": "^4.0.1",
 				"yaml": "2.0.0-5"
 			},
@@ -20,6 +20,62 @@
 				"@types/yaml": "^1.9.7",
 				"jest": "^26.6.3",
 				"type-fest": "^2.12.0"
+			}
+		},
+		"node_modules/@apidevtools/json-schema-ref-parser": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+			"integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+			"dependencies": {
+				"@jsdevtools/ono": "^7.1.3",
+				"@types/json-schema": "^7.0.6",
+				"call-me-maybe": "^1.0.1",
+				"js-yaml": "^4.1.0"
+			}
+		},
+		"node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+		},
+		"node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/@apidevtools/openapi-schemas": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+			"integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@apidevtools/swagger-methods": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+		},
+		"node_modules/@apidevtools/swagger-parser": {
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+			"integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+			"dependencies": {
+				"@apidevtools/json-schema-ref-parser": "^9.0.6",
+				"@apidevtools/openapi-schemas": "^2.0.4",
+				"@apidevtools/swagger-methods": "^3.0.2",
+				"@jsdevtools/ono": "^7.1.3",
+				"call-me-maybe": "^1.0.1",
+				"z-schema": "^5.0.1"
+			},
+			"peerDependencies": {
+				"openapi-types": ">=7"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1305,6 +1361,11 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@jsdevtools/ono": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+		},
 		"node_modules/@sinonjs/commons": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -1396,6 +1457,11 @@
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
 			}
+		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
 		},
 		"node_modules/@types/node": {
 			"version": "14.14.25",
@@ -1563,6 +1629,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -2488,6 +2555,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -5603,6 +5671,7 @@
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
 			"dependencies": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -5685,16 +5754,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 			"dev": true
-		},
-		"node_modules/json-schema-ref-parser": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.2.tgz",
-			"integrity": "sha512-bi2Nns2UqdX7wThX5qSHd+lOxlu9oeJvlCnWGuR3qS4Ex4UZtuwygkyq/43J31GuNGX8xBHeV6zjQztYk/G5VA==",
-			"dependencies": {
-				"call-me-maybe": "^1.0.1",
-				"js-yaml": "^3.13.1",
-				"ono": "^5.1.0"
-			}
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -6191,19 +6250,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ono": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
-			"integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
-		},
-		"node_modules/openapi-schemas": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.3.tgz",
-			"integrity": "sha512-KtMWcK2VtOS+nD8RKSIyScJsj8JrmVWcIX7Kjx4xEHijFYuvMTDON8WfeKOgeSb4uNG6UsqLj5Na7nKbSav9RQ==",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/openapi-types": {
@@ -7218,7 +7264,8 @@
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"node_modules/sshpk": {
 			"version": "1.16.1",
@@ -7398,29 +7445,16 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/swagger-methods": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.2.tgz",
-			"integrity": "sha512-/RNqvBZkH8+3S/FqBPejHxJxZenaYq3MrpeXnzi06aDIS39Mqf5YCUNb/ZBjsvFFt8h9FxfKs8EXPtcYdfLiRg=="
-		},
 		"node_modules/swagger-parser": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
-			"integrity": "sha512-y2gw+rTjn7Z9J+J1qwbBm0UL93k/VREDCveKBK6iGjf7KXC6QGshbnpEmeHL0ZkCgmIghsXzpNzPSbBH91BAEQ==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+			"integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
 			"dependencies": {
-				"call-me-maybe": "^1.0.1",
-				"json-schema-ref-parser": "^7.1.1",
-				"ono": "^5.1.0",
-				"openapi-schemas": "^1.0.2",
-				"openapi-types": "^1.3.5",
-				"swagger-methods": "^2.0.1",
-				"z-schema": "^4.1.1"
+				"@apidevtools/swagger-parser": "10.0.3"
+			},
+			"engines": {
+				"node": ">=10"
 			}
-		},
-		"node_modules/swagger-parser/node_modules/openapi-types": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
-			"integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
 		},
 		"node_modules/symbol-tree": {
 			"version": "3.2.4",
@@ -7754,9 +7788,9 @@
 			}
 		},
 		"node_modules/validator": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
-			"integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg==",
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+			"integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
 			"engines": {
 				"node": ">= 0.10"
 			}
@@ -8104,19 +8138,19 @@
 			}
 		},
 		"node_modules/z-schema": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.2.tgz",
-			"integrity": "sha512-7bGR7LohxSdlK1EOdvA/OHksvKGE4jTLSjd8dBj9YKT0S43N9pdMZ0Z7GZt9mHrBFhbNTRh3Ky6Eu2MHsPJe8g==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.2.tgz",
+			"integrity": "sha512-40TH47ukMHq5HrzkeVE40Ad7eIDKaRV2b+Qpi2prLc9X9eFJFzV7tMe5aH12e6avaSS/u5l653EQOv+J9PirPw==",
 			"dependencies": {
 				"lodash.get": "^4.4.2",
 				"lodash.isequal": "^4.5.0",
-				"validator": "^11.0.0"
+				"validator": "^13.7.0"
 			},
 			"bin": {
 				"z-schema": "bin/z-schema"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=8.0.0"
 			},
 			"optionalDependencies": {
 				"commander": "^2.7.1"
@@ -8124,6 +8158,55 @@
 		}
 	},
 	"dependencies": {
+		"@apidevtools/json-schema-ref-parser": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+			"integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+			"requires": {
+				"@jsdevtools/ono": "^7.1.3",
+				"@types/json-schema": "^7.0.6",
+				"call-me-maybe": "^1.0.1",
+				"js-yaml": "^4.1.0"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+				},
+				"js-yaml": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"requires": {
+						"argparse": "^2.0.1"
+					}
+				}
+			}
+		},
+		"@apidevtools/openapi-schemas": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+			"integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="
+		},
+		"@apidevtools/swagger-methods": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+		},
+		"@apidevtools/swagger-parser": {
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+			"integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+			"requires": {
+				"@apidevtools/json-schema-ref-parser": "^9.0.6",
+				"@apidevtools/openapi-schemas": "^2.0.4",
+				"@apidevtools/swagger-methods": "^3.0.2",
+				"@jsdevtools/ono": "^7.1.3",
+				"call-me-maybe": "^1.0.1",
+				"z-schema": "^5.0.1"
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
@@ -9175,6 +9258,11 @@
 				}
 			}
 		},
+		"@jsdevtools/ono": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+		},
 		"@sinonjs/commons": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -9266,6 +9354,11 @@
 			"requires": {
 				"@types/istanbul-lib-report": "*"
 			}
+		},
+		"@types/json-schema": {
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
 		},
 		"@types/node": {
 			"version": "14.14.25",
@@ -9406,6 +9499,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -10150,7 +10244,8 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
 		},
 		"estraverse": {
 			"version": "4.3.0",
@@ -12538,6 +12633,7 @@
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -12600,16 +12696,6 @@
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 			"dev": true
-		},
-		"json-schema-ref-parser": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.2.tgz",
-			"integrity": "sha512-bi2Nns2UqdX7wThX5qSHd+lOxlu9oeJvlCnWGuR3qS4Ex4UZtuwygkyq/43J31GuNGX8xBHeV6zjQztYk/G5VA==",
-			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"js-yaml": "^3.13.1",
-				"ono": "^5.1.0"
-			}
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -13017,16 +13103,6 @@
 			"requires": {
 				"mimic-fn": "^2.1.0"
 			}
-		},
-		"ono": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
-			"integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
-		},
-		"openapi-schemas": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.3.tgz",
-			"integrity": "sha512-KtMWcK2VtOS+nD8RKSIyScJsj8JrmVWcIX7Kjx4xEHijFYuvMTDON8WfeKOgeSb4uNG6UsqLj5Na7nKbSav9RQ=="
 		},
 		"openapi-types": {
 			"version": "8.0.0",
@@ -13828,7 +13904,8 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.16.1",
@@ -13964,30 +14041,12 @@
 				}
 			}
 		},
-		"swagger-methods": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.2.tgz",
-			"integrity": "sha512-/RNqvBZkH8+3S/FqBPejHxJxZenaYq3MrpeXnzi06aDIS39Mqf5YCUNb/ZBjsvFFt8h9FxfKs8EXPtcYdfLiRg=="
-		},
 		"swagger-parser": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
-			"integrity": "sha512-y2gw+rTjn7Z9J+J1qwbBm0UL93k/VREDCveKBK6iGjf7KXC6QGshbnpEmeHL0ZkCgmIghsXzpNzPSbBH91BAEQ==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+			"integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
 			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"json-schema-ref-parser": "^7.1.1",
-				"ono": "^5.1.0",
-				"openapi-schemas": "^1.0.2",
-				"openapi-types": "^1.3.5",
-				"swagger-methods": "^2.0.1",
-				"z-schema": "^4.1.1"
-			},
-			"dependencies": {
-				"openapi-types": {
-					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
-					"integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
-				}
+				"@apidevtools/swagger-parser": "10.0.3"
 			}
 		},
 		"symbol-tree": {
@@ -14257,9 +14316,9 @@
 			}
 		},
 		"validator": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
-			"integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+			"integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -14535,14 +14594,14 @@
 			}
 		},
 		"z-schema": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.2.tgz",
-			"integrity": "sha512-7bGR7LohxSdlK1EOdvA/OHksvKGE4jTLSjd8dBj9YKT0S43N9pdMZ0Z7GZt9mHrBFhbNTRh3Ky6Eu2MHsPJe8g==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.2.tgz",
+			"integrity": "sha512-40TH47ukMHq5HrzkeVE40Ad7eIDKaRV2b+Qpi2prLc9X9eFJFzV7tMe5aH12e6avaSS/u5l653EQOv+J9PirPw==",
 			"requires": {
 				"commander": "^2.7.1",
 				"lodash.get": "^4.4.2",
 				"lodash.isequal": "^4.5.0",
-				"validator": "^11.0.0"
+				"validator": "^13.7.0"
 			}
 		}
 	}

--- a/packages/openapi-2-kong/package.json
+++ b/packages/openapi-2-kong/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "openapi-types": "^8.0.0",
     "slugify": "^1.3.6",
-    "swagger-parser": "^8.0.3",
+    "swagger-parser": "^10.0.3",
     "url-join": "^4.0.1",
     "yaml": "2.0.0-5"
   },

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/openapi-303.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/openapi-303.expected.json
@@ -1,0 +1,19 @@
+{
+    "_format_version": "1.1",
+    "services": [
+       {
+          "name": "Greeting_API",
+          "host": "example.org",
+          "path": "/",
+          "port": 80,
+          "protocol": "http",
+          "plugins": [],
+          "routes": [],
+          "tags": [
+             "OAS3_import",
+             "OAS3file_openapi-303.yaml"
+          ]
+       }
+    ]
+ } 
+ 

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/openapi-303.yaml
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/openapi-303.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: Greeting API
+  termsOfService: https://example.com/terms/
+  contact:
+    email: contact@example.com
+    url: http://example.com/contact
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://example.org
+paths: {}


### PR DESCRIPTION
Updates the swagger-parser dependency in openapi-2-kong to support OAS 3.0.3

changelog(Improvements): Insomnia and OpenAPI-2-Kong now support OpenAPI Spec 3.0.3