### PR TITLE
upgrades to electron 17.3

### DIFF
--- a/packages/insomnia-app/.babelrc.js
+++ b/packages/insomnia-app/.babelrc.js
@@ -1,7 +1,7 @@
 /** @type { import('@babel/core').TransformOptions } */
 module.exports = {
   presets: [
-    ['@babel/preset-env',{targets: {electron: '17.1.0'}}],
+    ['@babel/preset-env',{targets: {electron: '17.3.0'}}],
     '@babel/preset-typescript',
     '@babel/preset-react',
   ],

--- a/packages/insomnia-app/.npmrc
+++ b/packages/insomnia-app/.npmrc
@@ -1,3 +1,3 @@
 runtime = electron
-target = 17.1.0
+target = 17.3.0
 disturl = https://electronjs.org/headers

--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -137,7 +137,7 @@
 				"css-loader": "^2.1.1",
 				"date-fns": "^2.28.0",
 				"deep-equal": "^1.0.1",
-				"electron": "17.1.0",
+				"electron": "17.3.0",
 				"electron-builder": "23.0.3",
 				"electron-builder-squirrel-windows": "23.0.3",
 				"electron-devtools-installer": "^3.2.0",
@@ -13101,9 +13101,9 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "17.1.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-17.1.0.tgz",
-			"integrity": "sha512-X/qdldmQ8lA15NmeraubWCTtMeTO8K9Ser0wtSCgOXVh53Sr1Ea0VQQ7Q9LuGgWRVz4qtr40cntuEdM8icdmTw==",
+			"version": "17.3.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-17.3.0.tgz",
+			"integrity": "sha512-KuYHCOw1a+CE9thZlWRqTScf6M81KLd6n5qpdBGb0rl62+50RUuau9CnYpBb3EJxrjsXLaiQCBBSdPsozf/XUg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -41494,9 +41494,9 @@
 			}
 		},
 		"electron": {
-			"version": "17.1.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-17.1.0.tgz",
-			"integrity": "sha512-X/qdldmQ8lA15NmeraubWCTtMeTO8K9Ser0wtSCgOXVh53Sr1Ea0VQQ7Q9LuGgWRVz4qtr40cntuEdM8icdmTw==",
+			"version": "17.3.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-17.3.0.tgz",
+			"integrity": "sha512-KuYHCOw1a+CE9thZlWRqTScf6M81KLd6n5qpdBGb0rl62+50RUuau9CnYpBb3EJxrjsXLaiQCBBSdPsozf/XUg==",
 			"dev": true,
 			"requires": {
 				"@electron/get": "^1.13.0",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -229,7 +229,7 @@
     "css-loader": "^2.1.1",
     "date-fns": "^2.28.0",
     "deep-equal": "^1.0.1",
-    "electron": "17.1.0",
+    "electron": "17.3.0",
     "electron-builder": "23.0.3",
     "electron-builder-squirrel-windows": "23.0.3",
     "electron-devtools-installer": "^3.2.0",


### PR DESCRIPTION
changelog(Improvements): Upgraded to Electron 17.3.1 which contains a patch for CVE-2022-1096 and fixes a crash on Wayland