### PR TITLE
Update libcurl to include workarounds.

### DIFF
--- a/packages/insomnia-app/package-lock.json
+++ b/packages/insomnia-app/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.10.0-beta.0",
 			"license": "MIT",
 			"dependencies": {
-				"@getinsomnia/node-libcurl": "2.3.4-3",
+				"@getinsomnia/node-libcurl": "2.3.5-0",
 				"@hapi/hawk": "^8.0.0",
 				"@stoplight/spectral": "^5.9.0",
 				"analytics-node": "^6.0.0",
@@ -4354,9 +4354,9 @@
 			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/@getinsomnia/node-libcurl": {
-			"version": "2.3.4-3",
-			"resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.3.4-3.tgz",
-			"integrity": "sha512-ElsB2Q162b/+vdQt8Cgzz2MAhVItPrLhWVdBR46dBo3J0OY5kYCn1aoEOe3fGvhzgZV9Us1ro2R5G7/+TBji7g==",
+			"version": "2.3.5-0",
+			"resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.3.5-0.tgz",
+			"integrity": "sha512-wW70Qj3xdzukpegUqetOR4hwXQ/Qe04HjxdVhAWLUU5+lWN86hcO6Ut59qFrEcw+9bBfv7Ox4H4OmYBdRX0T/w==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@mapbox/node-pre-gyp": "1.0.5",
@@ -34302,9 +34302,9 @@
 			}
 		},
 		"@getinsomnia/node-libcurl": {
-			"version": "2.3.4-3",
-			"resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.3.4-3.tgz",
-			"integrity": "sha512-ElsB2Q162b/+vdQt8Cgzz2MAhVItPrLhWVdBR46dBo3J0OY5kYCn1aoEOe3fGvhzgZV9Us1ro2R5G7/+TBji7g==",
+			"version": "2.3.5-0",
+			"resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.3.5-0.tgz",
+			"integrity": "sha512-wW70Qj3xdzukpegUqetOR4hwXQ/Qe04HjxdVhAWLUU5+lWN86hcO6Ut59qFrEcw+9bBfv7Ox4H4OmYBdRX0T/w==",
 			"requires": {
 				"@mapbox/node-pre-gyp": "1.0.5",
 				"env-paths": "2.2.0",

--- a/packages/insomnia-app/package.json
+++ b/packages/insomnia-app/package.json
@@ -76,7 +76,7 @@
     "vkbeautify"
   ],
   "dependencies": {
-    "@getinsomnia/node-libcurl": "2.3.4-3",
+    "@getinsomnia/node-libcurl": "2.3.5-0",
     "@hapi/hawk": "^8.0.0",
     "@stoplight/spectral": "^5.9.0",
     "analytics-node": "^6.0.0",

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.10.0-beta.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@getinsomnia/node-libcurl": "2.3.4-3",
+				"@getinsomnia/node-libcurl": "2.3.5-0",
 				"@hapi/hawk": "^8.0.0",
 				"@stoplight/spectral": "^5.9.0",
 				"analytics-node": "^6.0.0",
@@ -44,9 +44,9 @@
 			}
 		},
 		"node_modules/@getinsomnia/node-libcurl": {
-			"version": "2.3.4-3",
-			"resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.3.4-3.tgz",
-			"integrity": "sha512-ElsB2Q162b/+vdQt8Cgzz2MAhVItPrLhWVdBR46dBo3J0OY5kYCn1aoEOe3fGvhzgZV9Us1ro2R5G7/+TBji7g==",
+			"version": "2.3.5-0",
+			"resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.3.5-0.tgz",
+			"integrity": "sha512-wW70Qj3xdzukpegUqetOR4hwXQ/Qe04HjxdVhAWLUU5+lWN86hcO6Ut59qFrEcw+9bBfv7Ox4H4OmYBdRX0T/w==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@mapbox/node-pre-gyp": "1.0.5",
@@ -3817,9 +3817,9 @@
 	},
 	"dependencies": {
 		"@getinsomnia/node-libcurl": {
-			"version": "2.3.4-3",
-			"resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.3.4-3.tgz",
-			"integrity": "sha512-ElsB2Q162b/+vdQt8Cgzz2MAhVItPrLhWVdBR46dBo3J0OY5kYCn1aoEOe3fGvhzgZV9Us1ro2R5G7/+TBji7g==",
+			"version": "2.3.5-0",
+			"resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.3.5-0.tgz",
+			"integrity": "sha512-wW70Qj3xdzukpegUqetOR4hwXQ/Qe04HjxdVhAWLUU5+lWN86hcO6Ut59qFrEcw+9bBfv7Ox4H4OmYBdRX0T/w==",
 			"requires": {
 				"@mapbox/node-pre-gyp": "1.0.5",
 				"env-paths": "2.2.0",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -7,7 +7,7 @@
   "main": "dist/index.js",
   "types": "dist/send-request/index.d.ts",
   "dependencies": {
-    "@getinsomnia/node-libcurl": "2.3.4-3",
+    "@getinsomnia/node-libcurl": "2.3.5-0",
     "@hapi/hawk": "^8.0.0",
     "@stoplight/spectral": "^5.9.0",
     "analytics-node": "^6.0.0",


### PR DESCRIPTION
Includes (potential) workarounds for #4543 and #4589.

Should also unblock Electron 18.

changelog(Fixes): Updated libcurl to tackle an issue where requests failed when using legacy TLS renegotiation (#4543) and another issue where it wasn't possible to use special characters in the URL (#4589)