### PR TITLE
Chore: bump playwright version to 1.20.2

### DIFF
--- a/packages/insomnia-smoke-test/package-lock.json
+++ b/packages/insomnia-smoke-test/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.12.0-beta.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
-				"@playwright/test": "^1.19.2",
+				"@playwright/test": "^1.20.2",
 				"@types/concurrently": "^6.0.1",
 				"@types/express": "^4.17.11",
 				"@types/faker": "^5.5.5",
@@ -680,10 +680,13 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
-			"integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
-			"dev": true
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
 			"version": "7.13.12",
@@ -873,15 +876,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-proposal-class-properties/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/plugin-proposal-dynamic-import": {
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
@@ -896,15 +890,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-proposal-dynamic-import/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/plugin-proposal-export-namespace-from": {
@@ -923,15 +908,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-proposal-export-namespace-from/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/plugin-proposal-logical-assignment-operators": {
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz",
@@ -946,15 +922,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-proposal-logical-assignment-operators/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
@@ -973,15 +940,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-proposal-nullish-coalescing-operator/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/plugin-proposal-numeric-separator": {
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz",
@@ -996,15 +954,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-proposal-numeric-separator/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/plugin-proposal-optional-chaining": {
@@ -1024,15 +973,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-proposal-optional-chaining/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/plugin-proposal-private-methods": {
 			"version": "7.16.11",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz",
@@ -1047,15 +987,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-proposal-private-methods/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/plugin-proposal-private-property-in-object": {
@@ -1074,15 +1005,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-proposal-private-property-in-object/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/plugin-syntax-async-generators": {
@@ -1167,30 +1089,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
-			"integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.16.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-jsx/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/plugin-syntax-logical-assignment-operators": {
@@ -1280,15 +1178,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-syntax-private-property-in-object/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/plugin-syntax-top-level-await": {
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz",
@@ -1314,15 +1203,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-typescript/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
@@ -1422,15 +1302,6 @@
 				"@babel/traverse": "^7.17.3",
 				"@babel/types": "^7.17.0"
 			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1613,68 +1484,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/@babel/plugin-transform-react-jsx": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.7.tgz",
-			"integrity": "sha512-8D16ye66fxiE8m890w0BpPpngG9o9OVBBy0gH2E+2AR7qMR2ZpTYJEqLxAsoroenMId0p/wMW+Blc0meDgu0Ag==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.16.7",
-				"@babel/helper-module-imports": "^7.16.7",
-				"@babel/helper-plugin-utils": "^7.16.7",
-				"@babel/plugin-syntax-jsx": "^7.16.7",
-				"@babel/types": "^7.16.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/helper-module-imports": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-			"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.16.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/types": {
-			"version": "7.17.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-			"integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.16.7",
-				"to-fast-properties": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/plugin-transform-typescript": {
 			"version": "7.16.8",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz",
@@ -1692,15 +1501,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-transform-typescript/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/preset-typescript": {
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz",
@@ -1716,15 +1516,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/preset-typescript/node_modules/@babel/helper-plugin-utils": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/preset-typescript/node_modules/@babel/helper-validator-option": {
@@ -2242,13 +2033,14 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.19.2.tgz",
-			"integrity": "sha512-5oCmlYHjtOL662OxSkZBYGnoHWIQui7b4YHWNeSCYwhQjmjVcV5njRc8oBZlU8IwJgG7ZH2yhDk1haU96ygbWw==",
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.20.2.tgz",
+			"integrity": "sha512-unkLa+xe/lP7MVC0qpgadc9iSG1+LEyGBzlXhGS/vLGAJaSFs8DNfI89hNd5shHjWfNzb34JgPVnkRKCSNo5iw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "7.16.7",
 				"@babel/core": "7.16.12",
+				"@babel/helper-plugin-utils": "7.16.7",
 				"@babel/plugin-proposal-class-properties": "7.16.7",
 				"@babel/plugin-proposal-dynamic-import": "7.16.7",
 				"@babel/plugin-proposal-export-namespace-from": "7.16.7",
@@ -2263,24 +2055,19 @@
 				"@babel/plugin-syntax-object-rest-spread": "7.8.3",
 				"@babel/plugin-syntax-optional-catch-binding": "7.8.3",
 				"@babel/plugin-transform-modules-commonjs": "7.16.8",
-				"@babel/plugin-transform-react-jsx": "7.16.7",
 				"@babel/preset-typescript": "7.16.7",
-				"babel-plugin-module-resolver": "4.1.0",
 				"colors": "1.4.0",
 				"commander": "8.3.0",
 				"debug": "4.3.3",
 				"expect": "27.2.5",
 				"jest-matcher-utils": "27.2.5",
-				"jpeg-js": "0.4.3",
-				"json5": "2.2.0",
+				"json5": "2.2.1",
 				"mime": "3.0.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
 				"open": "8.4.0",
 				"pirates": "4.0.4",
-				"pixelmatch": "5.2.1",
-				"playwright-core": "1.19.2",
-				"pngjs": "6.0.0",
+				"playwright-core": "1.20.2",
 				"rimraf": "3.0.2",
 				"source-map-support": "0.4.18",
 				"stack-utils": "2.0.5",
@@ -2732,29 +2519,6 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
-		"node_modules/@playwright/test/node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@playwright/test/node_modules/debug/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"node_modules/@playwright/test/node_modules/diff-sequences": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
@@ -3113,36 +2877,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/@playwright/test/node_modules/playwright-core": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.19.2.tgz",
-			"integrity": "sha512-OsL3sJZIo1UxKNWSP7zW7sk3FyUGG06YRHxHeBw51eIOxTCQRx5t+hXd0cvXashN2CHnd3hIZTs2aKa/im4hZQ==",
-			"dev": true,
-			"dependencies": {
-				"commander": "8.3.0",
-				"debug": "4.3.3",
-				"extract-zip": "2.0.1",
-				"https-proxy-agent": "5.0.0",
-				"jpeg-js": "0.4.3",
-				"mime": "3.0.0",
-				"pngjs": "6.0.0",
-				"progress": "2.0.3",
-				"proper-lockfile": "4.1.2",
-				"proxy-from-env": "1.1.0",
-				"rimraf": "3.0.2",
-				"socks-proxy-agent": "6.1.1",
-				"stack-utils": "2.0.5",
-				"ws": "8.4.2",
-				"yauzl": "2.10.0",
-				"yazl": "2.5.1"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@playwright/test/node_modules/pretty-format": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -3194,27 +2928,6 @@
 			"dev": true,
 			"dependencies": {
 				"source-map": "^0.5.6"
-			}
-		},
-		"node_modules/@playwright/test/node_modules/stack-utils": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-			"integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
-			"dev": true,
-			"dependencies": {
-				"escape-string-regexp": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@playwright/test/node_modules/stack-utils/node_modules/escape-string-regexp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/@playwright/test/node_modules/supports-color": {
@@ -3962,22 +3675,6 @@
 			},
 			"engines": {
 				"node": ">= 10.14.2"
-			}
-		},
-		"node_modules/babel-plugin-module-resolver": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz",
-			"integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
-			"dev": true,
-			"dependencies": {
-				"find-babel-config": "^1.2.0",
-				"glob": "^7.1.6",
-				"pkg-up": "^3.1.0",
-				"reselect": "^4.0.0",
-				"resolve": "^1.13.1"
-			},
-			"engines": {
-				"node": ">= 8.0.0"
 			}
 		},
 		"node_modules/babel-preset-current-node-syntax": {
@@ -4852,13 +4549,20 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dev": true,
 			"dependencies": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/decamelize": {
@@ -5718,37 +5422,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
-		},
-		"node_modules/find-babel-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
-			"integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
-			"dev": true,
-			"dependencies": {
-				"json5": "^0.5.1",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/find-babel-config/node_modules/json5": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true,
-			"bin": {
-				"json5": "lib/cli.js"
-			}
-		},
-		"node_modules/find-babel-config/node_modules/path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/find-up": {
 			"version": "4.1.0",
@@ -7539,13 +7212,10 @@
 			"dev": true
 		},
 		"node_modules/json5": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
 			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			},
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -7658,23 +7328,6 @@
 			},
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/koa/node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/koa/node_modules/depd": {
@@ -8290,23 +7943,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/oidc-provider/node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/oidc-provider/node_modules/http-errors": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
@@ -8687,62 +8323,36 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/pkg-up": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-			"integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+		"node_modules/playwright-core": {
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.20.2.tgz",
+			"integrity": "sha512-iV6+HftSPalynkq0CYJala1vaTOq7+gU9BRfKCdM9bAxNq/lFLrwbluug2Wt5OoUwbMABcnTThIEm3/qUhCdJQ==",
 			"dev": true,
 			"dependencies": {
-				"find-up": "^3.0.0"
+				"colors": "1.4.0",
+				"commander": "8.3.0",
+				"debug": "4.3.3",
+				"extract-zip": "2.0.1",
+				"https-proxy-agent": "5.0.0",
+				"jpeg-js": "0.4.3",
+				"mime": "3.0.0",
+				"pixelmatch": "5.2.1",
+				"pngjs": "6.0.0",
+				"progress": "2.0.3",
+				"proper-lockfile": "4.1.2",
+				"proxy-from-env": "1.1.0",
+				"rimraf": "3.0.2",
+				"socks-proxy-agent": "6.1.1",
+				"stack-utils": "2.0.5",
+				"ws": "8.4.2",
+				"yauzl": "2.10.0",
+				"yazl": "2.5.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/pkg-up/node_modules/find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/pkg-up/node_modules/locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/pkg-up/node_modules/p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/pkg-up/node_modules/path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
+				"node": ">=12"
 			}
 		},
 		"node_modules/pngjs": {
@@ -9129,12 +8739,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true
-		},
-		"node_modules/reselect": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
-			"integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==",
 			"dev": true
 		},
 		"node_modules/resolve": {
@@ -9893,23 +9497,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/socks-proxy-agent/node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10032,9 +9619,9 @@
 			}
 		},
 		"node_modules/stack-utils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-			"integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+			"integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
 			"dev": true,
 			"dependencies": {
 				"escape-string-regexp": "^2.0.0"
@@ -11444,9 +11031,9 @@
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
-			"integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
 			"dev": true
 		},
 		"@babel/helper-replace-supers": {
@@ -11606,14 +11193,6 @@
 			"requires": {
 				"@babel/helper-create-class-features-plugin": "^7.16.7",
 				"@babel/helper-plugin-utils": "^7.16.7"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
@@ -11624,14 +11203,6 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.16.7",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-proposal-export-namespace-from": {
@@ -11642,14 +11213,6 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.16.7",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-proposal-logical-assignment-operators": {
@@ -11660,14 +11223,6 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.16.7",
 				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-proposal-nullish-coalescing-operator": {
@@ -11678,14 +11233,6 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.16.7",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-proposal-numeric-separator": {
@@ -11696,14 +11243,6 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.16.7",
 				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-proposal-optional-chaining": {
@@ -11715,14 +11254,6 @@
 				"@babel/helper-plugin-utils": "^7.16.7",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-proposal-private-methods": {
@@ -11733,14 +11264,6 @@
 			"requires": {
 				"@babel/helper-create-class-features-plugin": "^7.16.10",
 				"@babel/helper-plugin-utils": "^7.16.7"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-proposal-private-property-in-object": {
@@ -11753,14 +11276,6 @@
 				"@babel/helper-create-class-features-plugin": "^7.16.7",
 				"@babel/helper-plugin-utils": "^7.16.7",
 				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -11826,23 +11341,6 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
-		"@babel/plugin-syntax-jsx": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
-			"integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.16.7"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
-			}
-		},
 		"@babel/plugin-syntax-logical-assignment-operators": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
@@ -11904,14 +11402,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-syntax-top-level-await": {
@@ -11930,14 +11420,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.16.7"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
@@ -12016,12 +11498,6 @@
 						"@babel/traverse": "^7.17.3",
 						"@babel/types": "^7.17.0"
 					}
-				},
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
 				},
 				"@babel/helper-simple-access": {
 					"version": "7.16.7",
@@ -12161,52 +11637,6 @@
 				}
 			}
 		},
-		"@babel/plugin-transform-react-jsx": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.7.tgz",
-			"integrity": "sha512-8D16ye66fxiE8m890w0BpPpngG9o9OVBBy0gH2E+2AR7qMR2ZpTYJEqLxAsoroenMId0p/wMW+Blc0meDgu0Ag==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.16.7",
-				"@babel/helper-module-imports": "^7.16.7",
-				"@babel/helper-plugin-utils": "^7.16.7",
-				"@babel/plugin-syntax-jsx": "^7.16.7",
-				"@babel/types": "^7.16.7"
-			},
-			"dependencies": {
-				"@babel/helper-module-imports": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-					"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.16.7"
-					}
-				},
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-					"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-					"dev": true
-				},
-				"@babel/types": {
-					"version": "7.17.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-					"integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.16.7",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
-			}
-		},
 		"@babel/plugin-transform-typescript": {
 			"version": "7.16.8",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz",
@@ -12216,14 +11646,6 @@
 				"@babel/helper-create-class-features-plugin": "^7.16.7",
 				"@babel/helper-plugin-utils": "^7.16.7",
 				"@babel/plugin-syntax-typescript": "^7.16.7"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/preset-typescript": {
@@ -12237,12 +11659,6 @@
 				"@babel/plugin-transform-typescript": "^7.16.7"
 			},
 			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
-					"dev": true
-				},
 				"@babel/helper-validator-option": {
 					"version": "7.16.7",
 					"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
@@ -12689,13 +12105,14 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.19.2.tgz",
-			"integrity": "sha512-5oCmlYHjtOL662OxSkZBYGnoHWIQui7b4YHWNeSCYwhQjmjVcV5njRc8oBZlU8IwJgG7ZH2yhDk1haU96ygbWw==",
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.20.2.tgz",
+			"integrity": "sha512-unkLa+xe/lP7MVC0qpgadc9iSG1+LEyGBzlXhGS/vLGAJaSFs8DNfI89hNd5shHjWfNzb34JgPVnkRKCSNo5iw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.16.7",
 				"@babel/core": "7.16.12",
+				"@babel/helper-plugin-utils": "7.16.7",
 				"@babel/plugin-proposal-class-properties": "7.16.7",
 				"@babel/plugin-proposal-dynamic-import": "7.16.7",
 				"@babel/plugin-proposal-export-namespace-from": "7.16.7",
@@ -12710,24 +12127,19 @@
 				"@babel/plugin-syntax-object-rest-spread": "7.8.3",
 				"@babel/plugin-syntax-optional-catch-binding": "7.8.3",
 				"@babel/plugin-transform-modules-commonjs": "7.16.8",
-				"@babel/plugin-transform-react-jsx": "7.16.7",
 				"@babel/preset-typescript": "7.16.7",
-				"babel-plugin-module-resolver": "4.1.0",
 				"colors": "1.4.0",
 				"commander": "8.3.0",
 				"debug": "4.3.3",
 				"expect": "27.2.5",
 				"jest-matcher-utils": "27.2.5",
-				"jpeg-js": "0.4.3",
-				"json5": "2.2.0",
+				"json5": "2.2.1",
 				"mime": "3.0.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
 				"open": "8.4.0",
 				"pirates": "4.0.4",
-				"pixelmatch": "5.2.1",
-				"playwright-core": "1.19.2",
-				"pngjs": "6.0.0",
+				"playwright-core": "1.20.2",
 				"rimraf": "3.0.2",
 				"source-map-support": "0.4.18",
 				"stack-utils": "2.0.5",
@@ -13064,23 +12476,6 @@
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
-				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.1.2",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-							"dev": true
-						}
-					}
-				},
 				"diff-sequences": {
 					"version": "27.5.1",
 					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
@@ -13351,30 +12746,6 @@
 					"integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==",
 					"dev": true
 				},
-				"playwright-core": {
-					"version": "1.19.2",
-					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.19.2.tgz",
-					"integrity": "sha512-OsL3sJZIo1UxKNWSP7zW7sk3FyUGG06YRHxHeBw51eIOxTCQRx5t+hXd0cvXashN2CHnd3hIZTs2aKa/im4hZQ==",
-					"dev": true,
-					"requires": {
-						"commander": "8.3.0",
-						"debug": "4.3.3",
-						"extract-zip": "2.0.1",
-						"https-proxy-agent": "5.0.0",
-						"jpeg-js": "0.4.3",
-						"mime": "3.0.0",
-						"pngjs": "6.0.0",
-						"progress": "2.0.3",
-						"proper-lockfile": "4.1.2",
-						"proxy-from-env": "1.1.0",
-						"rimraf": "3.0.2",
-						"socks-proxy-agent": "6.1.1",
-						"stack-utils": "2.0.5",
-						"ws": "8.4.2",
-						"yauzl": "2.10.0",
-						"yazl": "2.5.1"
-					}
-				},
 				"pretty-format": {
 					"version": "27.5.1",
 					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -13413,23 +12784,6 @@
 					"dev": true,
 					"requires": {
 						"source-map": "^0.5.6"
-					}
-				},
-				"stack-utils": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-					"integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "^2.0.0"
-					},
-					"dependencies": {
-						"escape-string-regexp": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-							"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-							"dev": true
-						}
 					}
 				},
 				"supports-color": {
@@ -14083,19 +13437,6 @@
 				"@babel/types": "^7.3.3",
 				"@types/babel__core": "^7.0.0",
 				"@types/babel__traverse": "^7.0.6"
-			}
-		},
-		"babel-plugin-module-resolver": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz",
-			"integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
-			"dev": true,
-			"requires": {
-				"find-babel-config": "^1.2.0",
-				"glob": "^7.1.6",
-				"pkg-up": "^3.1.0",
-				"reselect": "^4.0.0",
-				"resolve": "^1.13.1"
 			}
 		},
 		"babel-preset-current-node-syntax": {
@@ -14791,12 +14132,12 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dev": true,
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
 		},
 		"decamelize": {
@@ -15481,30 +14822,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
-		"find-babel-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
-			"integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
-			"dev": true,
-			"requires": {
-				"json5": "^0.5.1",
-				"path-exists": "^3.0.0"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-					"dev": true
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				}
 			}
@@ -16901,13 +16218,10 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.5"
-			}
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -16982,15 +16296,6 @@
 				"vary": "^1.1.2"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"depd": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -17475,15 +16780,6 @@
 					"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
 					"dev": true
 				},
-				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"http-errors": {
 					"version": "1.8.1",
 					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
@@ -17767,49 +17063,30 @@
 				"find-up": "^4.0.0"
 			}
 		},
-		"pkg-up": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-			"integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+		"playwright-core": {
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.20.2.tgz",
+			"integrity": "sha512-iV6+HftSPalynkq0CYJala1vaTOq7+gU9BRfKCdM9bAxNq/lFLrwbluug2Wt5OoUwbMABcnTThIEm3/qUhCdJQ==",
 			"dev": true,
 			"requires": {
-				"find-up": "^3.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				}
+				"colors": "1.4.0",
+				"commander": "8.3.0",
+				"debug": "4.3.3",
+				"extract-zip": "2.0.1",
+				"https-proxy-agent": "5.0.0",
+				"jpeg-js": "0.4.3",
+				"mime": "3.0.0",
+				"pixelmatch": "5.2.1",
+				"pngjs": "6.0.0",
+				"progress": "2.0.3",
+				"proper-lockfile": "4.1.2",
+				"proxy-from-env": "1.1.0",
+				"rimraf": "3.0.2",
+				"socks-proxy-agent": "6.1.1",
+				"stack-utils": "2.0.5",
+				"ws": "8.4.2",
+				"yauzl": "2.10.0",
+				"yazl": "2.5.1"
 			}
 		},
 		"pngjs": {
@@ -18103,12 +17380,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true
-		},
-		"reselect": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
-			"integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==",
 			"dev": true
 		},
 		"resolve": {
@@ -18725,17 +17996,6 @@
 				"agent-base": "^6.0.2",
 				"debug": "^4.3.1",
 				"socks": "^2.6.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				}
 			}
 		},
 		"source-map": {
@@ -18844,9 +18104,9 @@
 			}
 		},
 		"stack-utils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-			"integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+			"integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^2.0.0"

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -28,7 +28,7 @@
     "test:cli": "npm run with-mock \"npm run cli\""
   },
   "devDependencies": {
-    "@playwright/test": "^1.19.2",
+    "@playwright/test": "^1.20.2",
     "@types/concurrently": "^6.0.1",
     "@types/express": "^4.17.11",
     "@types/faker": "^5.5.5",


### PR DESCRIPTION
[Playwright](https://playwright.dev/) has released 1.20 recently, and some patches ([changelog](https://github.com/microsoft/playwright/releases/tag/v1.20.2)).