### PR TITLE
decouple curl options from renderer

### DIFF
--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -20,6 +20,7 @@ import * as models from '../../models';
 import { _parseHeaders, getHttpVersion } from '../libcurl-promise';
 import { DEFAULT_BOUNDARY } from '../multipart';
 import * as networkUtils from '../network';
+import { getSetCookiesFromResponseHeaders } from '../network';
 import { _getAwsAuthHeaders } from '../parse-header-strings';
 window.app = electron.app;
 
@@ -994,5 +995,37 @@ describe('_parseHeaders', () => {
         version: 'HTTP/1.1',
       },
     ]);
+  });
+});
+
+describe('getSetCookiesFromResponseHeaders', () => {
+  it('defaults to empty array', () => {
+    const headers = [];
+    expect(getSetCookiesFromResponseHeaders(headers)).toEqual([]);
+  });
+  it('gets set-cookies', () => {
+    const headers = [{ name:'Set-Cookie', value:'monster' }];
+    expect(getSetCookiesFromResponseHeaders(headers)).toEqual(['monster']);
+  });
+  it('gets two case-insenstive set-cookies', () => {
+    const headers = [{ name:'Set-Cookie', value:'monster' }, { name:'set-cookie', value:'mash' }];
+    expect(getSetCookiesFromResponseHeaders(headers)).toEqual(['monster', 'mash']);
+  });
+});
+describe('getCurrentUrl', () => {
+  it('defaults to finalUrl', () => {
+    const headerResults = [];
+    const finalUrl = 'http://mergemyshit.dev';
+    expect(networkUtils.getCurrentUrl({ headerResults, finalUrl })).toEqual(finalUrl);
+  });
+  it('append location to finalUrl', () => {
+    const headerResults = [{ headers:[{ name:'Location', value:'/cookies' }] }];
+    const finalUrl = 'http://mergemyshit.dev';
+    expect(networkUtils.getCurrentUrl({ headerResults, finalUrl })).toEqual(finalUrl + '/cookies');
+  });
+  it('appends only last location to finalUrl', () => {
+    const headerResults = [{ headers:[{ name:'Location', value:'/cookies' }] }, { headers:[{ name:'location', value:'/biscuit' }] }];
+    const finalUrl = 'http://mergemyshit.dev';
+    expect(networkUtils.getCurrentUrl({ headerResults, finalUrl })).toEqual(finalUrl + '/biscuit');
   });
 });

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -1,5 +1,4 @@
-import { CurlHttpVersion } from '@getinsomnia/node-libcurl/dist/enum/CurlHttpVersion';
-import { CurlNetrc } from '@getinsomnia/node-libcurl/dist/enum/CurlNetrc';
+import { CurlHttpVersion, CurlNetrc } from '@getinsomnia/node-libcurl';
 import electron from 'electron';
 import fs from 'fs';
 import { HttpVersions } from 'insomnia-common';
@@ -18,10 +17,10 @@ import {
 import { filterHeaders } from '../../common/misc';
 import { getRenderedRequestAndContext } from '../../common/render';
 import * as models from '../../models';
-import { _parseHeaders } from '../libcurl-promise';
-import { getHttpVersion } from '../libcurl-promise';
+import { _parseHeaders, getHttpVersion } from '../libcurl-promise';
 import { DEFAULT_BOUNDARY } from '../multipart';
 import * as networkUtils from '../network';
+import { _getAwsAuthHeaders } from '../parse-header-strings';
 window.app = electron.app;
 
 const getRenderedRequest = async (args: Parameters<typeof getRenderedRequestAndContext>[0]) => (await getRenderedRequestAndContext(args)).request;
@@ -737,7 +736,7 @@ describe('actuallySend()', () => {
       ...settings,
       preferredHttpVersion: HttpVersions.V1_0,
     });
-    expect(JSON.parse(String(models.response.getBodyBuffer(responseV1))).options.HTTP_VERSION).toBe(1);
+    expect(JSON.parse(String(models.response.getBodyBuffer(responseV1))).options.HTTP_VERSION).toBe('V1_0');
     expect(getHttpVersion(HttpVersions.V1_0).curlHttpVersion).toBe(CurlHttpVersion.V1_0);
     expect(getHttpVersion(HttpVersions.V1_1).curlHttpVersion).toBe(CurlHttpVersion.V1_1);
     expect(getHttpVersion(HttpVersions.V2PriorKnowledge).curlHttpVersion).toBe(CurlHttpVersion.V2PriorKnowledge);
@@ -777,7 +776,7 @@ describe('_getAwsAuthHeaders', () => {
       sessionToken: req.authentication.sessionToken || '',
     };
 
-    const headers = networkUtils._getAwsAuthHeaders(
+    const headers = _getAwsAuthHeaders(
       credentials,
       req.headers,
       req.body.text,
@@ -811,7 +810,7 @@ describe('_getAwsAuthHeaders', () => {
       sessionToken: req.authentication.sessionToken || '',
     };
 
-    const headers = networkUtils._getAwsAuthHeaders(
+    const headers = _getAwsAuthHeaders(
       credentials,
       req.headers,
       null,

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -19,6 +19,7 @@ import { filterHeaders } from '../../common/misc';
 import { getRenderedRequestAndContext } from '../../common/render';
 import * as models from '../../models';
 import { _parseHeaders } from '../libcurl-promise';
+import { getHttpVersion } from '../libcurl-promise';
 import { DEFAULT_BOUNDARY } from '../multipart';
 import * as networkUtils from '../network';
 window.app = electron.app;
@@ -737,13 +738,13 @@ describe('actuallySend()', () => {
       preferredHttpVersion: HttpVersions.V1_0,
     });
     expect(JSON.parse(String(models.response.getBodyBuffer(responseV1))).options.HTTP_VERSION).toBe(1);
-    expect(networkUtils.getHttpVersion(HttpVersions.V1_0).curlHttpVersion).toBe(CurlHttpVersion.V1_0);
-    expect(networkUtils.getHttpVersion(HttpVersions.V1_1).curlHttpVersion).toBe(CurlHttpVersion.V1_1);
-    expect(networkUtils.getHttpVersion(HttpVersions.V2PriorKnowledge).curlHttpVersion).toBe(CurlHttpVersion.V2PriorKnowledge);
-    expect(networkUtils.getHttpVersion(HttpVersions.V2_0).curlHttpVersion).toBe(CurlHttpVersion.V2_0);
-    expect(networkUtils.getHttpVersion(HttpVersions.v3).curlHttpVersion).toBe(CurlHttpVersion.v3);
-    expect(networkUtils.getHttpVersion(HttpVersions.default).curlHttpVersion).toBe(undefined);
-    expect(networkUtils.getHttpVersion('blah').curlHttpVersion).toBe(undefined);
+    expect(getHttpVersion(HttpVersions.V1_0).curlHttpVersion).toBe(CurlHttpVersion.V1_0);
+    expect(getHttpVersion(HttpVersions.V1_1).curlHttpVersion).toBe(CurlHttpVersion.V1_1);
+    expect(getHttpVersion(HttpVersions.V2PriorKnowledge).curlHttpVersion).toBe(CurlHttpVersion.V2PriorKnowledge);
+    expect(getHttpVersion(HttpVersions.V2_0).curlHttpVersion).toBe(CurlHttpVersion.V2_0);
+    expect(getHttpVersion(HttpVersions.v3).curlHttpVersion).toBe(CurlHttpVersion.v3);
+    expect(getHttpVersion(HttpVersions.default).curlHttpVersion).toBe(undefined);
+    expect(getHttpVersion('blah').curlHttpVersion).toBe(undefined);
   });
 });
 

--- a/packages/insomnia/src/network/__tests__/parse-header-strings.test.ts
+++ b/packages/insomnia/src/network/__tests__/parse-header-strings.test.ts
@@ -3,20 +3,20 @@ import { parseHeaderStrings } from '../parse-header-strings';
 
 describe('parseHeaderStrings', () => {
   it('should default with empty inputs', () => {
-    const renderedRequest = { authentication: {}, body: {}, headers: [] };
-    expect(parseHeaderStrings({ renderedRequest })).toEqual(['Accept: */*', 'Accept-Encoding:', 'content-type:']);
+    const req = { authentication: {}, body: {}, headers: [] };
+    expect(parseHeaderStrings({ req })).toEqual(['Accept: */*', 'Accept-Encoding:', 'content-type:']);
   });
   it('should disable expect and transfer-encoding with body', () => {
-    const renderedRequest = { authentication: {}, body: {}, headers: [] };
-    expect(parseHeaderStrings({ renderedRequest, requestBody: 'test' })).toEqual(['Expect:', 'Transfer-Encoding:', 'Accept: */*', 'Accept-Encoding:', 'content-type:']);
+    const req = { authentication: {}, body: {}, headers: [] };
+    expect(parseHeaderStrings({ req, requestBody: 'test' })).toEqual(['Expect:', 'Transfer-Encoding:', 'Accept: */*', 'Accept-Encoding:', 'content-type:']);
   });
   it('should add boundary with multipart body path', () => {
-    const renderedRequest = { authentication: {}, body: { mimeType: CONTENT_TYPE_FORM_DATA }, headers: [] };
-    expect(parseHeaderStrings({ renderedRequest, requestBodyPath: '/tmp/x.z' })).toEqual(['Expect:', 'Transfer-Encoding:', 'Content-Type: multipart/form-data; boundary=X-INSOMNIA-BOUNDARY', 'Accept: */*', 'Accept-Encoding:']);
+    const req = { authentication: {}, body: { mimeType: CONTENT_TYPE_FORM_DATA }, headers: [] };
+    expect(parseHeaderStrings({ req, requestBodyPath: '/tmp/x.z' })).toEqual(['Expect:', 'Transfer-Encoding:', 'Content-Type: multipart/form-data; boundary=X-INSOMNIA-BOUNDARY', 'Accept: */*', 'Accept-Encoding:']);
   });
   it('should sign with aws iam', () => {
-    const renderedRequest = { authentication: { type: AUTH_AWS_IAM }, body: {}, headers: [] };
-    const [host, date, auth] = parseHeaderStrings({ renderedRequest, finalUrl: 'http://x.y' });
+    const req = { authentication: { type: AUTH_AWS_IAM }, body: {}, headers: [] };
+    const [host, date, auth] = parseHeaderStrings({ req, finalUrl: 'http://x.y' });
     expect(host).toBe('Host: x.y');
     expect(date).toContain('X-Amz-Date: ');
     expect(auth).toContain('Authorization: AWS4-HMAC-SHA256 ');

--- a/packages/insomnia/src/network/__tests__/parse-header-strings.test.ts
+++ b/packages/insomnia/src/network/__tests__/parse-header-strings.test.ts
@@ -1,0 +1,25 @@
+import { AUTH_AWS_IAM, CONTENT_TYPE_FORM_DATA } from '../../common/constants';
+import { parseHeaderStrings } from '../parse-header-strings';
+
+describe('parseHeaderStrings', () => {
+  it('should default with empty inputs', () => {
+    const renderedRequest = { authentication: {}, body: {}, headers: [] };
+    expect(parseHeaderStrings({ renderedRequest })).toEqual(['Accept: */*', 'Accept-Encoding:', 'content-type:']);
+  });
+  it('should disable expect and transfer-encoding with body', () => {
+    const renderedRequest = { authentication: {}, body: {}, headers: [] };
+    expect(parseHeaderStrings({ renderedRequest, requestBody: 'test' })).toEqual(['Expect:', 'Transfer-Encoding:', 'Accept: */*', 'Accept-Encoding:', 'content-type:']);
+  });
+  it('should add boundary with multipart body path', () => {
+    const renderedRequest = { authentication: {}, body: { mimeType: CONTENT_TYPE_FORM_DATA }, headers: [] };
+    expect(parseHeaderStrings({ renderedRequest, requestBodyPath: '/tmp/x.z' })).toEqual(['Expect:', 'Transfer-Encoding:', 'Content-Type: multipart/form-data; boundary=X-INSOMNIA-BOUNDARY', 'Accept: */*', 'Accept-Encoding:']);
+  });
+  it('should sign with aws iam', () => {
+    const renderedRequest = { authentication: { type: AUTH_AWS_IAM }, body: {}, headers: [] };
+    const [host, date, auth] = parseHeaderStrings({ renderedRequest, finalUrl: 'http://x.y' });
+    expect(host).toBe('Host: x.y');
+    expect(date).toContain('X-Amz-Date: ');
+    expect(auth).toContain('Authorization: AWS4-HMAC-SHA256 ');
+    expect(auth).toContain('SignedHeaders=host;x-amz-date, Signature=');
+  });
+});

--- a/packages/insomnia/src/network/libcurl-promise.ts
+++ b/packages/insomnia/src/network/libcurl-promise.ts
@@ -435,27 +435,20 @@ const parseRequestBodyPath = async body => {
   const { filePath } = await buildMultipart(body.params || [],);
   return filePath;
 };
-export const HttpVersions = {
-  V1_0: 'V1_0',
-  V1_1: 'V1_1',
-  V2PriorKnowledge: 'V2PriorKnowledge',
-  V2_0: 'V2_0',
-  v3: 'v3',
-  default: 'default',
-} as const;
+
 export const getHttpVersion = preferredHttpVersion => {
   switch (preferredHttpVersion) {
-    case HttpVersions.V1_0:
+    case 'V1_0':
       return { log: 'Using HTTP 1.0', curlHttpVersion: CurlHttpVersion.V1_0 };
-    case HttpVersions.V1_1:
+    case 'V1_1':
       return { log: 'Using HTTP 1.1', curlHttpVersion: CurlHttpVersion.V1_1 };
-    case HttpVersions.V2PriorKnowledge:
+    case 'V2PriorKnowledge':
       return { log: 'Using HTTP/2 PriorKnowledge', curlHttpVersion: CurlHttpVersion.V2PriorKnowledge };
-    case HttpVersions.V2_0:
+    case 'V2_0':
       return { log: 'Using HTTP/2', curlHttpVersion: CurlHttpVersion.V2_0 };
-    case HttpVersions.v3:
+    case 'v3':
       return { log: 'Using HTTP/3', curlHttpVersion: CurlHttpVersion.v3 };
-    case HttpVersions.default:
+    case 'default':
       return { log: 'Using default HTTP version' };
     default:
       return { log: `Unknown HTTP version specified ${preferredHttpVersion}` };

--- a/packages/insomnia/src/network/libcurl-promise.ts
+++ b/packages/insomnia/src/network/libcurl-promise.ts
@@ -99,62 +99,37 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
       if (cert) {
         curl.setOpt(Curl.option.SSLCERT, cert);
         curl.setOpt(Curl.option.SSLCERTTYPE, 'PEM');
-        debugTimeline.push({
-          name: 'TEXT',
-          value: 'Adding SSL PEM certificate',
-          timestamp: Date.now(),
-        });
+        debugTimeline.push({ value: 'Adding SSL PEM certificate', name: 'TEXT', timestamp: Date.now() });
       }
       if (pfx) {
         curl.setOpt(Curl.option.SSLCERT, pfx);
         curl.setOpt(Curl.option.SSLCERTTYPE, 'P12');
-        debugTimeline.push({
-          name: 'TEXT',
-          value: 'Adding SSL P12 certificate',
-          timestamp: Date.now(),
-        });
+        debugTimeline.push({ value: 'Adding SSL P12 certificate', name: 'TEXT', timestamp: Date.now() });
       }
       if (key) {
         curl.setOpt(Curl.option.SSLKEY, key);
-        debugTimeline.push({
-          name: 'TEXT',
-          value: 'Adding SSL KEY certificate',
-          timestamp: Date.now(),
-        });
+        debugTimeline.push({ value: 'Adding SSL KEY certificate', name: 'TEXT', timestamp: Date.now() });
       }
       if (passphrase) {
         curl.setOpt(Curl.option.KEYPASSWD, passphrase);
       }
-      debugTimeline.push({
-        name: 'TEXT',
-        value: 'Adding SSL PEM certificate',
-        timestamp: Date.now(),
-      });
     });
     const httpVersion = getHttpVersion(settings.preferredHttpVersion);
-    debugTimeline.push({
-      name: 'TEXT',
-      value: httpVersion.log,
-      timestamp: Date.now(),
-    });
+    debugTimeline.push({ value: httpVersion.log, name: 'TEXT', timestamp: Date.now() });
+
     if (httpVersion.curlHttpVersion) curl.setOpt(Curl.option.HTTP_VERSION, httpVersion.curlHttpVersion);
 
     // Set maximum amount of redirects allowed
     // NOTE: Setting this to -1 breaks some versions of libcurl
     if (settings.maxRedirects > 0) curl.setOpt(Curl.option.MAXREDIRS, settings.maxRedirects);
 
-    // Set proxy settings if we have them
     if (!settings.proxyEnabled) curl.setOpt(Curl.option.PROXY, '');
     else {
       const { protocol } = urlParse(req.url);
       const { httpProxy, httpsProxy, noProxy } = settings;
       const proxyHost = protocol === 'https:' ? httpsProxy : httpProxy;
       const proxy = proxyHost ? setDefaultProtocol(proxyHost) : null;
-      debugTimeline.push({
-        name: 'TEXT',
-        value: `Enable network proxy for ${protocol || ''}`,
-        timestamp: Date.now(),
-      });
+      debugTimeline.push({ value: `Enable network proxy for ${protocol || ''}`, name: 'TEXT', timestamp: Date.now() });
       if (proxy) {
         curl.setOpt(Curl.option.PROXY, proxy);
         curl.setOpt(Curl.option.PROXYAUTH, CurlAuth.Any);
@@ -165,24 +140,15 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
     if (timeout <= 0) curl.setOpt(Curl.option.TIMEOUT_MS, 0);
     else {
       curl.setOpt(Curl.option.TIMEOUT_MS, timeout);
-      debugTimeline.push({
-        name: 'TEXT',
-        value: `Enable timeout of ${timeout}ms`,
-        timestamp: Date.now(),
-      });
+      debugTimeline.push({ value: `Enable timeout of ${timeout}ms`, name: 'TEXT', timestamp: Date.now() });
     }
     const { validateSSL } = settings;
     if (!validateSSL) {
       curl.setOpt(Curl.option.SSL_VERIFYHOST, 0);
       curl.setOpt(Curl.option.SSL_VERIFYPEER, 0);
     }
-    debugTimeline.push({
-      name: 'TEXT',
-      value: `${validateSSL ? 'Enable' : 'Disable'} SSL validation`,
-      timestamp: Date.now(),
-    });
+    debugTimeline.push({ value: `${validateSSL ? 'Enable' : 'Disable'} SSL validation`, name: 'TEXT', timestamp: Date.now() });
 
-    // Set follow redirects setting
     if (req.settingFollowRedirects === 'off') curl.setOpt(Curl.option.FOLLOWLOCATION, false);
     else if (req.settingFollowRedirects === 'on') curl.setOpt(Curl.option.FOLLOWLOCATION, true);
     else curl.setOpt(Curl.option.FOLLOWLOCATION, settings.followRedirects);
@@ -198,27 +164,20 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
       }
       // set-cookies from previous redirects
       if (cookieJar.cookies.length) {
-        debugTimeline.push({
-          name: 'TEXT',
-          value: `Enable cookie sending with jar of ${cookieJar.cookies.length} cookie${cookieJar.cookies.length !== 1 ? 's' : ''}`,
-          timestamp: Date.now(),
-        });
+        debugTimeline.push({ value: `Enable cookie sending with jar of ${cookieJar.cookies.length} cookie${cookieJar.cookies.length !== 1 ? 's' : ''}`, name: 'TEXT', timestamp: Date.now() });
         for (const cookie of cookieJar.cookies) {
-          curl.setOpt(
-            Curl.option.COOKIELIST,
-            [
-              cookie.httpOnly ? `#HttpOnly_${cookie.domain}` : cookie.domain,
-              cookie.hostOnly ? 'FALSE' : 'TRUE',
-              cookie.path,
-              cookie.secure ? 'TRUE' : 'FALSE',
-              cookie.expires ? Math.round(new Date(cookie.expires).getTime() / 1000) : 0,
-              cookie.key,
-              cookie.value,
-            ].join('\t'),
-          );
+          const setCookie = [
+            cookie.httpOnly ? `#HttpOnly_${cookie.domain}` : cookie.domain,
+            cookie.hostOnly ? 'FALSE' : 'TRUE',
+            cookie.path,
+            cookie.secure ? 'TRUE' : 'FALSE',
+            cookie.expires ? Math.round(new Date(cookie.expires).getTime() / 1000) : 0,
+            cookie.key,
+            cookie.value,
+          ].join('\t');
+          curl.setOpt(Curl.option.COOKIELIST, setCookie);
         }
       }
-
     }
     const { method, body } = req;
     // Only set CURLOPT_CUSTOMREQUEST if not HEAD or GET.

--- a/packages/insomnia/src/network/libcurl-promise.ts
+++ b/packages/insomnia/src/network/libcurl-promise.ts
@@ -362,7 +362,7 @@ interface HeaderResult {
 export function _parseHeaders(buffer: Buffer): HeaderResult[] {
   // split on two new lines
   const redirects = buffer.toString('utf8').split(/\r?\n\r?\n|\r\r/g);
-  return redirects.map(redirect => {
+  return redirects.filter(r => !!r.trim()).map(redirect => {
     // split on one new line
     const [first, ...rest] = redirect.split(/\r?\n|\r/g);
     const headers = rest.map(l => l.split(/:\s(.+)/))

--- a/packages/insomnia/src/network/libcurl-promise.ts
+++ b/packages/insomnia/src/network/libcurl-promise.ts
@@ -117,14 +117,19 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
     const httpVersion = getHttpVersion(settings.preferredHttpVersion);
     debugTimeline.push({ value: httpVersion.log, name: 'TEXT', timestamp: Date.now() });
 
-    if (httpVersion.curlHttpVersion) curl.setOpt(Curl.option.HTTP_VERSION, httpVersion.curlHttpVersion);
+    if (httpVersion.curlHttpVersion) {
+      curl.setOpt(Curl.option.HTTP_VERSION, httpVersion.curlHttpVersion);
+    }
 
     // Set maximum amount of redirects allowed
     // NOTE: Setting this to -1 breaks some versions of libcurl
-    if (settings.maxRedirects > 0) curl.setOpt(Curl.option.MAXREDIRS, settings.maxRedirects);
+    if (settings.maxRedirects > 0) {
+      curl.setOpt(Curl.option.MAXREDIRS, settings.maxRedirects);
+    }
 
-    if (!settings.proxyEnabled) curl.setOpt(Curl.option.PROXY, '');
-    else {
+    if (!settings.proxyEnabled) {
+      curl.setOpt(Curl.option.PROXY, '');
+    } else {
       const { protocol } = urlParse(req.url);
       const { httpProxy, httpsProxy, noProxy } = settings;
       const proxyHost = protocol === 'https:' ? httpsProxy : httpProxy;
@@ -134,11 +139,14 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
         curl.setOpt(Curl.option.PROXY, proxy);
         curl.setOpt(Curl.option.PROXYAUTH, CurlAuth.Any);
       }
-      if (noProxy) curl.setOpt(Curl.option.NOPROXY, noProxy);
+      if (noProxy) {
+        curl.setOpt(Curl.option.NOPROXY, noProxy);
+      }
     }
     const { timeout } = settings;
-    if (timeout <= 0) curl.setOpt(Curl.option.TIMEOUT_MS, 0);
-    else {
+    if (timeout <= 0) {
+      curl.setOpt(Curl.option.TIMEOUT_MS, 0);
+    } else {
       curl.setOpt(Curl.option.TIMEOUT_MS, timeout);
       debugTimeline.push({ value: `Enable timeout of ${timeout}ms`, name: 'TEXT', timestamp: Date.now() });
     }
@@ -149,11 +157,17 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
     }
     debugTimeline.push({ value: `${validateSSL ? 'Enable' : 'Disable'} SSL validation`, name: 'TEXT', timestamp: Date.now() });
 
-    if (req.settingFollowRedirects === 'off') curl.setOpt(Curl.option.FOLLOWLOCATION, false);
-    else if (req.settingFollowRedirects === 'on') curl.setOpt(Curl.option.FOLLOWLOCATION, true);
-    else curl.setOpt(Curl.option.FOLLOWLOCATION, settings.followRedirects);
+    if (req.settingFollowRedirects === 'off') {
+      curl.setOpt(Curl.option.FOLLOWLOCATION, false);
+    } else if (req.settingFollowRedirects === 'on') {
+      curl.setOpt(Curl.option.FOLLOWLOCATION, true);
+    } else {
+      curl.setOpt(Curl.option.FOLLOWLOCATION, settings.followRedirects);
+    }
     // Don't rebuild dot sequences in path
-    if (!req.settingRebuildPath) curl.setOpt(Curl.option.PATH_AS_IS, true);
+    if (!req.settingRebuildPath) {
+      curl.setOpt(Curl.option.PATH_AS_IS, true);
+    }
 
     if (req.settingSendCookies) {
       const { cookieJar, cookies } = req;
@@ -183,21 +197,27 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
     // Only set CURLOPT_CUSTOMREQUEST if not HEAD or GET.
     // See https://curl.haxx.se/libcurl/c/CURLOPT_CUSTOMREQUEST.html
     // This is how you tell Curl to send a HEAD request
-    if (method.toUpperCase() === 'HEAD') curl.setOpt(Curl.option.NOBODY, 1);
-    // This is how you tell Curl to send a POST request
-    else if (method.toUpperCase() === 'POST') curl.setOpt(Curl.option.POST, 1);
-    // IMPORTANT: Only use CUSTOMREQUEST for all but HEAD and POST
-    else curl.setOpt(Curl.option.CUSTOMREQUEST, method);
+    if (method.toUpperCase() === 'HEAD') {
+      curl.setOpt(Curl.option.NOBODY, 1);
+    } else if (method.toUpperCase() === 'POST') { // This is how you tell Curl to send a POST request
+      curl.setOpt(Curl.option.POST, 1);
+    } else { // IMPORTANT: Only use CUSTOMREQUEST for all but HEAD and POST
+      curl.setOpt(Curl.option.CUSTOMREQUEST, method);
+    }
 
     const requestBody = parseRequestBody({ body, method });
-    if (requestBody) curl.setOpt(Curl.option.POSTFIELDS, requestBody);
+    if (requestBody) {
+      curl.setOpt(Curl.option.POSTFIELDS, requestBody);
+    }
     const requestBodyPath = await parseRequestBodyPath(body);
     let isMultipart = false;
     let requestFileDescriptor;
     const { authentication } = req;
     if (requestBodyPath) {
       // AWS IAM file upload not supported
-      if (authentication.type === AUTH_AWS_IAM) throw new Error('AWS authentication not supported for provided body type');
+      if (authentication.type === AUTH_AWS_IAM) {
+        throw new Error('AWS authentication not supported for provided body type');
+      }
       isMultipart = body.mimeType === CONTENT_TYPE_FORM_DATA && requestBodyPath;
       const { size: contentLength } = fs.statSync(requestBodyPath);
       curl.setOpt(Curl.option.INFILESIZE_LARGE, contentLength);
@@ -415,7 +435,9 @@ const parseRequestBody = ({ body, method }) => {
 };
 const parseRequestBodyPath = async body => {
   const isMultipartForm = body.mimeType === CONTENT_TYPE_FORM_DATA;
-  if (!isMultipartForm) return body.fileName;
+  if (!isMultipartForm) {
+    return body.fileName;
+  }
   const { filePath } = await buildMultipart(body.params || [],);
   return filePath;
 };

--- a/packages/insomnia/src/network/libcurl-promise.ts
+++ b/packages/insomnia/src/network/libcurl-promise.ts
@@ -25,7 +25,7 @@ import { buildMultipart } from './multipart';
 import { ResponsePatch } from './network';
 import { parseHeaderStrings } from './parse-header-strings';
 
-// wraps libcurl with a promise taking curl options and others required by read, write and debug callbacks
+// wraps libcurl with a promise
 // returning a response patch, debug timeline and list of headers for each redirect
 
 interface CurlRequestOptions {
@@ -36,7 +36,7 @@ interface CurlRequestOptions {
   certificates: ClientCertificate[];
   fullCAPath: string;
   socketPath?: string;
-  authHeader: {name: string; value:string};
+  authHeader?: {name: string; value:string};
 }
 
 interface ResponseTimelineEntry {

--- a/packages/insomnia/src/network/libcurl-promise.ts
+++ b/packages/insomnia/src/network/libcurl-promise.ts
@@ -14,7 +14,7 @@ import { ValueOf } from 'type-fest';
 import { parse as urlParse } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 
-import { version } from '../../config/config.json';
+import { version } from '../../package.json';
 import { AUTH_AWS_IAM, AUTH_DIGEST, AUTH_NETRC, AUTH_NTLM, CONTENT_TYPE_FORM_DATA, CONTENT_TYPE_FORM_URLENCODED } from '../common/constants';
 import { describeByteSize, hasAuthHeader, hasUserAgentHeader } from '../common/misc';
 import { ClientCertificate } from '../models/client-certificate';

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -122,22 +122,9 @@ export async function _actuallySend(
         const socketUrl = (match && match[3]) || '';
         finalUrl = `${protocol}//${socketUrl}`;
       }
-      timeline.push({
-        name: 'TEXT',
-        value: `Preparing request to ${finalUrl}`,
-        timestamp: Date.now(),
-      });
-      timeline.push({
-        name: 'TEXT',
-        value: `Current time is ${new Date().toISOString()}`,
-        timestamp: Date.now(),
-      });
-
-      timeline.push({
-        name: 'TEXT',
-        value: `${renderedRequest.settingEncodeUrl ? 'Enable' : 'Disable'} automatic URL encoding`,
-        timestamp: Date.now(),
-      });
+      timeline.push({ value: `Preparing request to ${finalUrl}`, name: 'TEXT', timestamp: Date.now() });
+      timeline.push({ value: `Current time is ${new Date().toISOString()}`, name: 'TEXT', timestamp: Date.now() });
+      timeline.push({ value: `${renderedRequest.settingEncodeUrl ? 'Enable' : 'Disable'} automatic URL encoding`, name: 'TEXT', timestamp: Date.now() });
 
       // Setup CA Root Certificates
       const baseCAPath = getTempDir();
@@ -155,11 +142,7 @@ export async function _actuallySend(
       }
 
       if (!renderedRequest.settingSendCookies) {
-        timeline.push({
-          name: 'TEXT',
-          value: 'Disable cookie sending due to user setting',
-          timestamp: Date.now(),
-        });
+        timeline.push({ value: 'Disable cookie sending due to user setting', name: 'TEXT', timestamp: Date.now() });
       }
 
       const certificates = clientCertificates.filter(c => !c.disabled && urlMatchesCertHost(setDefaultProtocol(c.host, 'https:'), renderedRequest.url));
@@ -184,9 +167,11 @@ export async function _actuallySend(
       const { patch, debugTimeline, headerResults, responseBodyPath } = await nodejsCurlRequest(requestOptions);
       const { cookieJar, settingStoreCookies } = renderedRequest;
 
+      // add set-cookie headers to file(cookiejar) and database
       if (settingStoreCookies) {
+        // supports many set-cookies over many redirects
         const redirects: string[][] = headerResults.map(getSetCookiesFromResponseHeaders);
-        const setCookieStrings = redirects.flat();
+        const setCookieStrings: string[] = redirects.flat();
         const totalSetCookies = setCookieStrings.length;
         if (totalSetCookies) {
           const currentUrl = getCurrentUrl({ headerResults, finalUrl });
@@ -237,7 +222,6 @@ export async function _actuallySend(
   });
 }
 
-// add set-cookie headers to file(cookiejar) and database
 export const getSetCookiesFromResponseHeaders = headers => getSetCookieHeaders(headers).map(h => h.value);
 
 export const getCurrentUrl = ({ headerResults, finalUrl }) => {

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -231,40 +231,22 @@ export async function _actuallySend(
         const cHostWithProtocol = setDefaultProtocol(certificate.host, 'https:');
 
         if (urlMatchesCertHost(cHostWithProtocol, renderedRequest.url)) {
-          const ensureFile = blobOrFilename => {
-            try {
-              fs.statSync(blobOrFilename);
-            } catch (err) {
-              // Certificate file not found!
-              // LEGACY: Certs used to be stored in blobs (not as paths), so let's write it to
-              // the temp directory first.
-              const fullBase = getTempDir();
-              const name = `${renderedRequest._id}_${renderedRequest.modified}`;
-              const fullPath = pathJoin(fullBase, name);
-              fs.writeFileSync(fullPath, Buffer.from(blobOrFilename, 'base64'));
-              // Set filename to the one we just saved
-              blobOrFilename = fullPath;
-            }
-
-            return blobOrFilename;
-          };
-
           const { passphrase, cert, key, pfx } = certificate;
 
           if (cert) {
-            setOpt(Curl.option.SSLCERT, ensureFile(cert));
+            setOpt(Curl.option.SSLCERT, cert);
             setOpt(Curl.option.SSLCERTTYPE, 'PEM');
             addTimelineText('Adding SSL PEM certificate');
           }
 
           if (pfx) {
-            setOpt(Curl.option.SSLCERT, ensureFile(pfx));
+            setOpt(Curl.option.SSLCERT, pfx);
             setOpt(Curl.option.SSLCERTTYPE, 'P12');
             addTimelineText('Adding SSL P12 certificate');
           }
 
           if (key) {
-            setOpt(Curl.option.SSLKEY, ensureFile(key));
+            setOpt(Curl.option.SSLKEY, key);
             addTimelineText('Adding SSL KEY certificate');
           }
 

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -36,6 +36,7 @@ import type { Settings } from '../models/settings';
 import { isWorkspace } from '../models/workspace';
 import * as pluginContexts from '../plugins/context/index';
 import * as plugins from '../plugins/index';
+import { getAuthHeader } from './authentication';
 import caCerts from './ca_certs';
 import { urlMatchesCertHost } from './url-matches-cert-host';
 
@@ -163,6 +164,8 @@ export async function _actuallySend(
 
       const certificates = clientCertificates.filter(c => !c.disabled && urlMatchesCertHost(setDefaultProtocol(c.host, 'https:'), renderedRequest.url));
 
+      const authHeader = await getAuthHeader(renderedRequest, finalUrl);
+
       // NOTE: conditionally use ipc bridge, renderer cannot import native modules directly
       const nodejsCurlRequest = process.type === 'renderer'
         ? window.main.curlRequest
@@ -176,6 +179,7 @@ export async function _actuallySend(
         settings,
         certificates,
         fullCAPath,
+        authHeader,
       };
       const { patch, debugTimeline, headerResults, responseBodyPath } = await nodejsCurlRequest(requestOptions);
       const { cookieJar, settingStoreCookies } = renderedRequest;

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -173,7 +173,7 @@ export async function _actuallySend(
         : require('./libcurl-promise').curlRequest;
       const requestOptions = {
         requestId: renderedRequest._id,
-        renderedRequest,
+        req: renderedRequest,
         finalUrl,
         socketPath,
         settings,

--- a/packages/insomnia/src/network/parse-header-strings.ts
+++ b/packages/insomnia/src/network/parse-header-strings.ts
@@ -17,12 +17,11 @@ import {
   hasContentTypeHeader,
 } from '../common/misc';
 import { RequestHeader } from '../models/request';
-import { getAuthHeader } from './authentication';
 import { DEFAULT_BOUNDARY } from './multipart';
 
 // Special header value that will prevent the header being sent
 const DISABLE_HEADER_VALUE = '__Di$aB13d__';
-export const parseHeaderStrings = async ({ renderedRequest, requestBody, requestBodyPath, finalUrl }) => {
+export const parseHeaderStrings = ({ renderedRequest, requestBody, requestBodyPath, finalUrl, authHeader }) => {
   const headers = clone(renderedRequest.headers);
 
   // Disable Expect and Transfer-Encoding headers when we have POST body/file
@@ -65,8 +64,6 @@ export const parseHeaderStrings = async ({ renderedRequest, requestBody, request
   }
   const hasNoAuthorisationAndNotDisabledAWSBasicOrDigest = !hasAuthHeader(headers) && !renderedRequest.authentication.disabled && !isAWSIAM && !isDigest && !isNTLM;
   if (hasNoAuthorisationAndNotDisabledAWSBasicOrDigest) {
-    const authHeader = await getAuthHeader(renderedRequest, finalUrl);
-
     if (authHeader) {
       headers.push({
         name: authHeader.name,

--- a/packages/insomnia/src/network/parse-header-strings.ts
+++ b/packages/insomnia/src/network/parse-header-strings.ts
@@ -1,0 +1,121 @@
+import clone from 'clone';
+
+import {
+  AUTH_AWS_IAM,
+  AUTH_DIGEST,
+  AUTH_NTLM,
+  CONTENT_TYPE_FORM_DATA,
+} from '../common/constants';
+import {
+  getContentTypeHeader,
+  hasAcceptEncodingHeader,
+  hasAcceptHeader,
+  hasAuthHeader,
+  hasContentTypeHeader,
+} from '../common/misc';
+import { getAuthHeader } from './authentication';
+import { DEFAULT_BOUNDARY } from './multipart';
+// Special header value that will prevent the header being sent
+const DISABLE_HEADER_VALUE = '__Di$aB13d__';
+export const parseHeaderStrings = async ({ renderedRequest, requestBody, requestBodyPath, finalUrl }) => {
+  const headers = clone(renderedRequest.headers);
+
+  // Disable Expect and Transfer-Encoding headers when we have POST body/file
+  const hasRequestBodyOrFilePath = requestBody || requestBodyPath;
+  if (hasRequestBodyOrFilePath) {
+    headers.push({
+      name: 'Expect',
+      value: DISABLE_HEADER_VALUE,
+    });
+    headers.push({
+      name: 'Transfer-Encoding',
+      value: DISABLE_HEADER_VALUE,
+    });
+  }
+
+  const isDigest = renderedRequest.authentication.type === AUTH_DIGEST;
+  const isNTLM = renderedRequest.authentication.type === AUTH_NTLM;
+  const isAWSIAM = renderedRequest.authentication.type === AUTH_AWS_IAM;
+  if (isAWSIAM) {
+    const { authentication } = renderedRequest;
+    const credentials = {
+      accessKeyId: authentication.accessKeyId || '',
+      secretAccessKey: authentication.secretAccessKey || '',
+      sessionToken: authentication.sessionToken || '',
+    };
+
+    const extraHeaders = _getAwsAuthHeaders(
+      credentials,
+      headers,
+      requestBody || '',
+      finalUrl,
+      renderedRequest.method,
+      authentication.region || '',
+      authentication.service || '',
+    );
+
+    for (const header of extraHeaders) {
+      headers.push(header);
+    }
+  }
+  const hasNoAuthorisationAndNotDisabledAWSBasicOrDigest = !hasAuthHeader(headers) && !renderedRequest.authentication.disabled && !isAWSIAM && !isDigest && !isNTLM;
+  if (hasNoAuthorisationAndNotDisabledAWSBasicOrDigest) {
+    const authHeader = await getAuthHeader(renderedRequest, finalUrl);
+
+    if (authHeader) {
+      headers.push({
+        name: authHeader.name,
+        value: authHeader.value,
+      });
+    }
+  }
+  const isMultipartForm = renderedRequest.body.mimeType === CONTENT_TYPE_FORM_DATA;
+  if (isMultipartForm && requestBodyPath) {
+    const contentTypeHeader = getContentTypeHeader(headers);
+    if (contentTypeHeader) contentTypeHeader.value = `multipart/form-data; boundary=${DEFAULT_BOUNDARY}`;
+    else headers.push({
+      name: 'Content-Type',
+      value: `multipart/form-data; boundary=${DEFAULT_BOUNDARY}`,
+    });
+  }
+  // Send a default Accept headers of anything
+  if (!hasAcceptHeader(headers)) {
+    headers.push({
+      name: 'Accept',
+      value: '*/*',
+    }); // Default to anything
+  }
+
+  // Don't auto-send Accept-Encoding header
+  if (!hasAcceptEncodingHeader(headers)) {
+    headers.push({
+      name: 'Accept-Encoding',
+      value: DISABLE_HEADER_VALUE,
+    });
+  }
+
+  // Prevent curl from adding default content-type header
+  if (!hasContentTypeHeader(headers)) {
+    headers.push({
+      name: 'content-type',
+      value: DISABLE_HEADER_VALUE,
+    });
+  }
+
+  return headers
+    .filter(h => h.name)
+    .map(h => {
+      const value = h.value || '';
+
+      if (value === '') {
+        // Curl needs a semicolon suffix to send empty header values
+        return `${h.name};`;
+      } else if (value === DISABLE_HEADER_VALUE) {
+        // Tell Curl NOT to send the header if value is null
+        return `${h.name}:`;
+      } else {
+        // Send normal header value
+        return `${h.name}: ${value}`;
+      }
+    });
+};

--- a/packages/insomnia/src/network/parse-header-strings.ts
+++ b/packages/insomnia/src/network/parse-header-strings.ts
@@ -16,12 +16,20 @@ import {
   hasAuthHeader,
   hasContentTypeHeader,
 } from '../common/misc';
+import type { RenderedRequest } from '../common/render';
 import { RequestHeader } from '../models/request';
 import { DEFAULT_BOUNDARY } from './multipart';
 
 // Special header value that will prevent the header being sent
 const DISABLE_HEADER_VALUE = '__Di$aB13d__';
-export const parseHeaderStrings = ({ renderedRequest, requestBody, requestBodyPath, finalUrl, authHeader }) => {
+interface Input {
+  renderedRequest: RenderedRequest;
+  finalUrl: string;
+  requestBody?: string;
+  requestBodyPath?: string;
+  authHeader?: {name: string; value:string};
+}
+export const parseHeaderStrings = ({ renderedRequest, finalUrl, requestBody, requestBodyPath,  authHeader }: Input) => {
   const headers = clone(renderedRequest.headers);
 
   // Disable Expect and Transfer-Encoding headers when we have POST body/file

--- a/scripts/changelog-image/changelog-image.ts
+++ b/scripts/changelog-image/changelog-image.ts
@@ -3,7 +3,7 @@ import { join as pathJoin, resolve as pathResolve } from 'path';
 import { optimize, OptimizedSvg } from 'svgo';
 import { dynamicImport } from 'tsimportlib';
 const { readFile, writeFile } = promises;
-import { version as appConfigVersion } from '../../packages/insomnia/config/config.json';
+import { version as appConfigVersion } from '../../packages/insomnia/package.json';
 
 async function main() {
   await renderImage();


### PR DESCRIPTION
Cut network.ts in half by moving all curl options setting to libcurl-promise
interface now better represents something we could send to an alternative request engine

Could use some feedback on how to indicate which of the database type fields we actually use with curl. These types are the best I could come up with so far.
```ts
interface CurlRequestOptions {
  requestId: string; // for cancellation
  req: RequestUsedHere;
  finalUrl: string;
  settings: SettingsUsedHere;
  certificates: ClientCertificate[];
  fullCAPath: string;
  socketPath?: string;
  authHeader?: { name: string; value: string };
}
interface RequestUsedHere {
  headers: any;
  method: string;
  body: { mimeType?: string | null };
  authentication: Record<string, any>;
  settingFollowRedirects: string;
  settingRebuildPath: boolean;
  settingSendCookies: boolean;
  url: string;
  cookieJar: any;
  cookies: { name: string; value: string }[];
}
interface SettingsUsedHere {
  preferredHttpVersion: string;
  maxRedirects: number;
  proxyEnabled: boolean;
  timeout: number;
  validateSSL: boolean;
  followRedirects: boolean;
  maxTimelineDataSizeKB: number;
  httpProxy: string;
  httpsProxy: string;
  noProxy: string;
}
```

getAuthHeader is coupled with window.localstorage and plugins, so I didn't move that down I just call it optimistically, which alters the code path but appears to be safe since it falls through to null in unused cases.

## Future work
- split and test independently get request headers from the stringification
- remove use of deprecated urlParse
- extract proxy logic to a tested method
- decouple node-libcurl only logic from insomnia domain logic for axios or alternative request engine support

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
