### PR TITLE
removes TOGGLE_MAIN_MENU shortcut since there (essentially) isn't a main menu anymore

### DIFF
--- a/packages/insomnia-app/app/common/hotkeys.ts
+++ b/packages/insomnia-app/app/common/hotkeys.ts
@@ -70,7 +70,6 @@ export const hotKeyRefs: Record<string, HotKeyDefinition> = {
     'Show Keyboard Shortcuts',
   ),
   PREFERENCES_SHOW_GENERAL: defineHotKey('preferences_showGeneral', 'Show App Preferences'),
-  TOGGLE_MAIN_MENU: defineHotKey('toggleMainMenu', 'Toggle Main Menu'),
   REQUEST_QUICK_SWITCH: defineHotKey('request_quickSwitch', 'Switch Requests'),
   SHOW_RECENT_REQUESTS: defineHotKey('request_showRecent', 'Show Recent Requests'),
   SHOW_RECENT_REQUESTS_PREVIOUS: defineHotKey(
@@ -130,10 +129,6 @@ const defaultRegistry: HotKeyRegistry = {
   [hotKeyRefs.PREFERENCES_SHOW_GENERAL.id]: keyBinds(
     keyComb(false, false, false, true, keyboardKeys.comma.keyCode),
     keyComb(true, false, false, false, keyboardKeys.comma.keyCode),
-  ),
-  [hotKeyRefs.TOGGLE_MAIN_MENU.id]: keyBinds(
-    keyComb(false, true, false, true, keyboardKeys.comma.keyCode),
-    keyComb(true, true, false, false, keyboardKeys.comma.keyCode),
   ),
   [hotKeyRefs.REQUEST_QUICK_SWITCH.id]: keyBinds(
     keyComb(false, false, false, true, keyboardKeys.p.keyCode),

--- a/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/workspace-dropdown.tsx
@@ -7,7 +7,6 @@ import { AUTOBIND_CFG } from '../../../common/constants';
 import { database as db } from '../../../common/database';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
 import { hotKeyRefs } from '../../../common/hotkeys';
-import { executeHotKey } from '../../../common/hotkeys-listener';
 import { RENDER_PURPOSE_NO_RENDER } from '../../../common/render';
 import { isRequest } from '../../../models/request';
 import { isRequestGroup } from '../../../models/request-group';
@@ -23,7 +22,6 @@ import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
 import { DropdownHint } from '../base/dropdown/dropdown-hint';
 import { DropdownItem } from '../base/dropdown/dropdown-item';
-import { KeydownBinder } from '../keydown-binder';
 import { showError, showModal } from '../modals';
 import { showGenerateConfigModal } from '../modals/generate-config-modal';
 import { SettingsModal, TAB_INDEX_EXPORT } from '../modals/settings-modal';
@@ -111,12 +109,6 @@ export class UnconnectedWorkspaceDropdown extends PureComponent<Props, State> {
     showModal(WorkspaceSettingsModal);
   }
 
-  _handleKeydown(event: KeyboardEvent) {
-    executeHotKey(event, hotKeyRefs.TOGGLE_MAIN_MENU, () => {
-      this._dropdown?.toggle(true);
-    });
-  }
-
   async _handleGenerateConfig(label: string) {
     const { activeApiSpec } = this.props;
     if (!activeApiSpec) {
@@ -145,72 +137,70 @@ export class UnconnectedWorkspaceDropdown extends PureComponent<Props, State> {
     }
 
     return (
-      <KeydownBinder onKeydown={this._handleKeydown}>
-        <Dropdown
-          beside
-          ref={this._setDropdownRef}
-          className={classes}
-          onOpen={this._handleDropdownOpen}
-          // @ts-expect-error -- TSCONVERSION appears to be genuine
-          onHide={this._handleDropdownHide}
-          {...(other as Record<string, any>)}
-        >
-          <DropdownButton className="row">
-            <div
-              className="ellipsis"
-              style={{
-                maxWidth: '400px',
-              }}
-              title={activeWorkspaceName}
-            >
-              {activeWorkspaceName}
-            </div>
-            <i className="fa fa-caret-down space-left" />
-            {isLoading ? <i className="fa fa-refresh fa-spin space-left" /> : null}
-          </DropdownButton>
-          <DropdownItem onClick={WorkspaceDropdown._handleShowWorkspaceSettings}>
-            <i className="fa fa-wrench" /> {getWorkspaceLabel(activeWorkspace).singular} Settings
-            <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.WORKSPACE_SHOW_SETTINGS.id]} />
-          </DropdownItem>
+      <Dropdown
+        beside
+        ref={this._setDropdownRef}
+        className={classes}
+        onOpen={this._handleDropdownOpen}
+        // @ts-expect-error -- TSCONVERSION appears to be genuine
+        onHide={this._handleDropdownHide}
+        {...(other as Record<string, any>)}
+      >
+        <DropdownButton className="row">
+          <div
+            className="ellipsis"
+            style={{
+              maxWidth: '400px',
+            }}
+            title={activeWorkspaceName}
+          >
+            {activeWorkspaceName}
+          </div>
+          <i className="fa fa-caret-down space-left" />
+          {isLoading ? <i className="fa fa-refresh fa-spin space-left" /> : null}
+        </DropdownButton>
+        <DropdownItem onClick={WorkspaceDropdown._handleShowWorkspaceSettings}>
+          <i className="fa fa-wrench" /> {getWorkspaceLabel(activeWorkspace).singular} Settings
+          <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.WORKSPACE_SHOW_SETTINGS.id]} />
+        </DropdownItem>
 
-          <DropdownItem onClick={WorkspaceDropdown._handleShowExport}>
-            <i className="fa fa-share" /> Import/Export
-          </DropdownItem>
+        <DropdownItem onClick={WorkspaceDropdown._handleShowExport}>
+          <i className="fa fa-share" /> Import/Export
+        </DropdownItem>
 
-          {actionPlugins.length > 0 && <DropdownDivider>Plugins</DropdownDivider>}
-          {actionPlugins.map((p: WorkspaceAction) => (
-            <DropdownItem
-              key={p.label}
-              onClick={() => this._handlePluginClick(p, activeWorkspace)}
-              stayOpenAfterClick
-            >
-              {loadingActions[p.label] ? (
-                <i className="fa fa-refresh fa-spin" />
-              ) : (
-                <i className={classnames('fa', p.icon || 'fa-code')} />
-              )}
-              {p.label}
-            </DropdownItem>
-          ))}
-          {isDesign(activeWorkspace) && (
-            <>
-              {configGeneratorPlugins.length > 0 && (
-                <DropdownDivider>Config Generators</DropdownDivider>
-              )}
-              {configGeneratorPlugins.map((p: ConfigGenerator) => (
-                <DropdownItem
-                  key="generateConfig"
-                  onClick={this._handleGenerateConfig}
-                  value={p.label}
-                >
-                  <i className="fa fa-code" />
-                  {p.label}
-                </DropdownItem>
-              ))}
-            </>
-          )}
-        </Dropdown>
-      </KeydownBinder>
+        {actionPlugins.length > 0 && <DropdownDivider>Plugins</DropdownDivider>}
+        {actionPlugins.map((p: WorkspaceAction) => (
+          <DropdownItem
+            key={p.label}
+            onClick={() => this._handlePluginClick(p, activeWorkspace)}
+            stayOpenAfterClick
+          >
+            {loadingActions[p.label] ? (
+              <i className="fa fa-refresh fa-spin" />
+            ) : (
+              <i className={classnames('fa', p.icon || 'fa-code')} />
+            )}
+            {p.label}
+          </DropdownItem>
+        ))}
+        {isDesign(activeWorkspace) && (
+          <>
+            {configGeneratorPlugins.length > 0 && (
+              <DropdownDivider>Config Generators</DropdownDivider>
+            )}
+            {configGeneratorPlugins.map((p: ConfigGenerator) => (
+              <DropdownItem
+                key="generateConfig"
+                onClick={this._handleGenerateConfig}
+                value={p.label}
+              >
+                <i className="fa fa-code" />
+                {p.label}
+              </DropdownItem>
+            ))}
+          </>
+        )}
+      </Dropdown>
     );
   }
 }


### PR DESCRIPTION
Insomnia used to have a main menu with a lot of important functionality.  It looked like this:

<img src="https://user-images.githubusercontent.com/15232461/163455409-fcf49d73-6be5-46a5-89c3-1fa3af828c28.png" width="50%" />

But today, that functionality has been moved around quite a bit:

<img src="https://user-images.githubusercontent.com/15232461/163455622-e485dc80-b80f-4bff-b400-a77b1708edbb.png" width="50%" />

to the point where this keyboard shortcut that was created to toggle the main menu isn't useful anymore:

<img src="https://user-images.githubusercontent.com/15232461/163455729-0c7e387e-802b-422d-a82c-7e7966af5c38.png" width="50%" />

changelog(Fixes): Removes shortcut for focusing the "main menu" since there isn't a main menu in Insomnia anymore (as of more than a year ago)