### PR TITLE
removes duplicated "config.longName"

### DIFF
--- a/packages/insomnia-app/app/common/analytics.ts
+++ b/packages/insomnia-app/app/common/analytics.ts
@@ -7,9 +7,9 @@ import { database as db } from '../common/database';
 import * as models from '../models/index';
 import { isSettings } from '../models/settings';
 import {
-  getAppName,
   getAppPlatform,
   getAppVersion,
+  getProductName,
   getSegmentWriteKey,
 } from './constants';
 
@@ -37,7 +37,7 @@ const sendSegment = async (segmentType: 'track' | 'page', options) => {
     const anonymousId = await getDeviceId();
     const userId = getAccountId();
     const context = {
-      app: { name: getAppName(), version: getAppVersion() },
+      app: { name: getProductName(), version: getAppVersion() },
       os: { name: _getOsName(), version: process.getSystemVersion() },
     };
     segmentClient?.[segmentType]({ ...options, context, anonymousId, userId }, error => {

--- a/packages/insomnia-app/app/common/constants.ts
+++ b/packages/insomnia-app/app/common/constants.ts
@@ -9,7 +9,7 @@ const env = process['env'];
 
 // App Stuff
 export const getAppVersion = () => appConfig.version;
-export const getAppName = () => appConfig.appName;
+export const getProductName = () => appConfig.productName;
 export const getAppDefaultTheme = () => appConfig.theme;
 export const getAppDefaultLightTheme = () => appConfig.lightTheme;
 export const getAppDefaultDarkTheme = () => appConfig.darkTheme;

--- a/packages/insomnia-app/app/common/constants.ts
+++ b/packages/insomnia-app/app/common/constants.ts
@@ -9,7 +9,7 @@ const env = process['env'];
 
 // App Stuff
 export const getAppVersion = () => appConfig.version;
-export const getAppName = () => appConfig.productName;
+export const getAppName = () => appConfig.appName;
 export const getAppDefaultTheme = () => appConfig.theme;
 export const getAppDefaultLightTheme = () => appConfig.lightTheme;
 export const getAppDefaultDarkTheme = () => appConfig.darkTheme;

--- a/packages/insomnia-app/app/common/constants.ts
+++ b/packages/insomnia-app/app/common/constants.ts
@@ -9,7 +9,6 @@ const env = process['env'];
 
 // App Stuff
 export const getAppVersion = () => appConfig.version;
-export const getAppLongName = () => appConfig.longName;
 export const getAppName = () => appConfig.productName;
 export const getAppDefaultTheme = () => appConfig.theme;
 export const getAppDefaultLightTheme = () => appConfig.lightTheme;

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -39,9 +39,7 @@ const envDataPath = process.env.INSOMNIA_DATA_PATH;
 if (envDataPath) {
   app.setPath('userData', envDataPath);
 } else if (!isDevelopment()) {
-  // Explicitly set userData folder from config because it's sketchy to
-  // rely on electron-builder to use productName, which could be changed
-  // by accident.
+  // Explicitly set userData folder from config because it's sketchy to rely on electron-builder to use apName, which could be changed by accident.
   const defaultPath = app.getPath('userData');
   const newPath = path.join(defaultPath, '../', appConfig.userDataFolder);
   app.setPath('userData', newPath);

--- a/packages/insomnia-app/app/main.development.ts
+++ b/packages/insomnia-app/app/main.development.ts
@@ -39,7 +39,7 @@ const envDataPath = process.env.INSOMNIA_DATA_PATH;
 if (envDataPath) {
   app.setPath('userData', envDataPath);
 } else if (!isDevelopment()) {
-  // Explicitly set userData folder from config because it's sketchy to rely on electron-builder to use apName, which could be changed by accident.
+  // Explicitly set userData folder from config because it's sketchy to rely on electron-builder to use productName, which could be changed by accident.
   const defaultPath = app.getPath('userData');
   const newPath = path.join(defaultPath, '../', appConfig.userDataFolder);
   app.setPath('userData', newPath);

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from 'url';
 import {
   changelogUrl,
   getAppBuildDate,
+  getAppVersion,
   getProductName,
   isDevelopment,
   isLinux,
@@ -376,7 +377,7 @@ export function createWindow() {
     const ok = 'OK';
     const buttons = isLinux() ? [copy, ok] : [ok, copy];
     const detail = [
-      `Version: ${getProductName()} ${getProductName()}`,
+      `Version: ${getProductName()} ${getAppVersion()}`,
       `Build date: ${getAppBuildDate()}`,
       `OS: ${os.type()} ${os.arch()} ${os.release()}`,
       `Electron: ${process.versions.electron}`,

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -7,8 +7,7 @@ import { pathToFileURL } from 'url';
 import {
   changelogUrl,
   getAppBuildDate,
-  getAppName,
-  getAppVersion,
+  getProductName,
   isDevelopment,
   isLinux,
   isMac,
@@ -71,7 +70,7 @@ export function createWindow() {
     backgroundColor: '#2C2C2C',
     fullscreen: fullscreen,
     fullscreenable: true,
-    title: getAppName(),
+    title: getProductName(),
     width: width || DEFAULT_WIDTH,
     height: height || DEFAULT_HEIGHT,
     minHeight: MINIMUM_HEIGHT,
@@ -377,7 +376,7 @@ export function createWindow() {
     const ok = 'OK';
     const buttons = isLinux() ? [copy, ok] : [ok, copy];
     const detail = [
-      `Version: ${getAppName()} ${getAppVersion()}`,
+      `Version: ${getProductName()} ${getProductName()}`,
       `Build date: ${getAppBuildDate()}`,
       `OS: ${os.type()} ${os.arch()} ${os.release()}`,
       `Electron: ${process.versions.electron}`,
@@ -388,8 +387,8 @@ export function createWindow() {
 
     const msgBox = await dialog.showMessageBox({
       type: 'info',
-      title: getAppName(),
-      message: getAppName(),
+      title: getProductName(),
+      message: getProductName(),
       detail,
       buttons,
       defaultId: buttons.indexOf(ok),
@@ -406,7 +405,7 @@ export function createWindow() {
     // @ts-expect-error -- TSCONVERSION type splitting
     applicationMenu.submenu?.unshift(
       {
-        label: `A${MNEMONIC_SYM}bout ${getAppName()}`,
+        label: `A${MNEMONIC_SYM}bout ${getProductName()}`,
         click: aboutMenuClickHandler,
       },
       {

--- a/packages/insomnia-app/app/main/window-utils.ts
+++ b/packages/insomnia-app/app/main/window-utils.ts
@@ -7,7 +7,6 @@ import { pathToFileURL } from 'url';
 import {
   changelogUrl,
   getAppBuildDate,
-  getAppLongName,
   getAppName,
   getAppVersion,
   isDevelopment,
@@ -378,7 +377,7 @@ export function createWindow() {
     const ok = 'OK';
     const buttons = isLinux() ? [copy, ok] : [ok, copy];
     const detail = [
-      `Version: ${getAppLongName()} ${getAppVersion()}`,
+      `Version: ${getAppName()} ${getAppVersion()}`,
       `Build date: ${getAppBuildDate()}`,
       `OS: ${os.type()} ${os.arch()} ${os.release()}`,
       `Electron: ${process.versions.electron}`,
@@ -390,7 +389,7 @@ export function createWindow() {
     const msgBox = await dialog.showMessageBox({
       type: 'info',
       title: getAppName(),
-      message: getAppLongName(),
+      message: getAppName(),
       detail,
       buttons,
       defaultId: buttons.indexOf(ok),

--- a/packages/insomnia-app/app/models/project.ts
+++ b/packages/insomnia-app/app/models/project.ts
@@ -1,4 +1,4 @@
-import { getAppName } from '../common/constants';
+import { getProductName } from '../common/constants';
 import { database as db } from '../common/database';
 import { generateId } from '../common/misc';
 import type { BaseModel } from './index';
@@ -78,7 +78,7 @@ export async function all() {
   const projects = await db.all<Project>(type);
 
   if (!projects.find(c => c._id === DEFAULT_PROJECT_ID)) {
-    await create({ _id: DEFAULT_PROJECT_ID, name: getAppName(), remoteId: null });
+    await create({ _id: DEFAULT_PROJECT_ID, name: getProductName(), remoteId: null });
     return db.all<Project>(type);
   }
 

--- a/packages/insomnia-app/app/ui/components/modals/analytics-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/analytics-modal.tsx
@@ -3,7 +3,7 @@ import React, { FC, useCallback, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
-import { getAppName, getAppSynopsis } from '../../../common/constants';
+import { getAppSynopsis, getProductName } from '../../../common/constants';
 import * as models from '../../../models';
 import chartSrc from '../../images/chart.svg';
 import coreLogo from '../../images/insomnia-logo.svg';
@@ -109,7 +109,7 @@ export const AnalyticsModal: FC = () => {
         </InsomniaLogo>
 
         <Header>
-          <Headline>Welcome to {getAppName()}</Headline>
+          <Headline>Welcome to {getProductName()}</Headline>
           <SubHeader>{getAppSynopsis()}</SubHeader>
         </Header>
 
@@ -118,7 +118,7 @@ export const AnalyticsModal: FC = () => {
 
           <DemonstrationChart src={chartSrc} alt="Demonstration chart" />
 
-          <p>Help us understand how <strong>you</strong> use {getAppName()} so we can make it better.</p>
+          <p>Help us understand how <strong>you</strong> use {getProductName()} so we can make it better.</p>
         </Body>
 
         <ActionButtons>

--- a/packages/insomnia-app/app/ui/components/modals/analytics-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/analytics-modal.tsx
@@ -3,7 +3,7 @@ import React, { FC, useCallback, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
-import { getAppLongName, getAppSynopsis } from '../../../common/constants';
+import { getAppName, getAppSynopsis } from '../../../common/constants';
 import * as models from '../../../models';
 import chartSrc from '../../images/chart.svg';
 import coreLogo from '../../images/insomnia-logo.svg';
@@ -109,7 +109,7 @@ export const AnalyticsModal: FC = () => {
         </InsomniaLogo>
 
         <Header>
-          <Headline>Welcome to {getAppLongName()}</Headline>
+          <Headline>Welcome to {getAppName()}</Headline>
           <SubHeader>{getAppSynopsis()}</SubHeader>
         </Header>
 
@@ -118,7 +118,7 @@ export const AnalyticsModal: FC = () => {
 
           <DemonstrationChart src={chartSrc} alt="Demonstration chart" />
 
-          <p>Help us understand how <strong>you</strong> use {getAppLongName()} so we can make it better.</p>
+          <p>Help us understand how <strong>you</strong> use {getAppName()} so we can make it better.</p>
         </Body>
 
         <ActionButtons>

--- a/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia-app/app/ui/components/modals/settings-modal.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
 import * as session from '../../../account/session';
-import { AUTOBIND_CFG, getAppName, getAppVersion } from '../../../common/constants';
+import { AUTOBIND_CFG, getAppVersion, getProductName } from '../../../common/constants';
 import * as models from '../../../models/index';
 import { RootState } from '../../redux/modules';
 import { selectSettings } from '../../redux/selectors';
@@ -75,7 +75,7 @@ export class UnconnectedSettingsModal extends PureComponent<Props, State> {
     return (
       <Modal ref={this._setModalRef} tall freshState {...this.props}>
         <ModalHeader>
-          {getAppName()} Preferences
+          {getProductName()} Preferences
           <span className="faint txt-sm">
             &nbsp;&nbsp;–&nbsp; v{getAppVersion()}
             {email ? ` – ${email}` : null}

--- a/packages/insomnia-app/app/ui/components/settings/import-export.tsx
+++ b/packages/insomnia-app/app/ui/components/settings/import-export.tsx
@@ -2,7 +2,7 @@ import { importers } from 'insomnia-importers';
 import React, { FC, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { getAppName } from '../../../common/constants';
+import { getProductName } from '../../../common/constants';
 import { docsImportExport } from '../../../common/documentation';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
 import { strings } from '../../../common/strings';
@@ -24,7 +24,7 @@ interface Props {
 
 export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
   const dispatch = useDispatch();
-  const projectName = useSelector(selectActiveProjectName) ?? getAppName();
+  const projectName = useSelector(selectActiveProjectName) ?? getProductName();
   const activeWorkspace = useSelector(selectActiveWorkspace);
   const forceToWorkspace = activeWorkspace?._id ? ForceToWorkspace.current : ForceToWorkspace.existing;
 

--- a/packages/insomnia-app/app/ui/components/toast.tsx
+++ b/packages/insomnia-app/app/ui/components/toast.tsx
@@ -9,9 +9,9 @@ import * as session from '../../account/session';
 import {
   AUTOBIND_CFG,
   getAppId,
-  getAppName,
   getAppPlatform,
   getAppVersion,
+  getProductName,
   updatesSupported,
 } from '../../common/constants';
 import * as models from '../../models/index';
@@ -30,7 +30,7 @@ export interface ToastNotification {
 interface State {
   notification: ToastNotification | null;
   visible: boolean;
-  appName: string;
+  productName: string;
 }
 
 const StyledLogo = styled.div`
@@ -67,7 +67,7 @@ export class Toast extends PureComponent<{}, State> {
   state: State = {
     notification: null,
     visible: false,
-    appName: getAppName(),
+    productName: getProductName(),
   };
 
   _cancel() {
@@ -200,7 +200,7 @@ export class Toast extends PureComponent<{}, State> {
   }
 
   render() {
-    const { notification, visible, appName } = this.state;
+    const { notification, visible, productName } = this.state;
 
     if (!notification) {
       return null;
@@ -213,7 +213,7 @@ export class Toast extends PureComponent<{}, State> {
         })}
       >
         <StyledLogo>
-          <img src={imgSrcCore} alt={appName} />
+          <img src={imgSrcCore} alt={productName} />
         </StyledLogo>
         <StyledContent>
           <p>{notification?.message || 'Unknown'}</p>

--- a/packages/insomnia-app/app/ui/containers/app.tsx
+++ b/packages/insomnia-app/app/ui/containers/app.tsx
@@ -17,7 +17,7 @@ import {
   DEFAULT_PANE_HEIGHT,
   DEFAULT_PANE_WIDTH,
   DEFAULT_SIDEBAR_WIDTH,
-  getAppName,
+  getProductName,
   isDevelopment,
   MAX_PANE_HEIGHT,
   MAX_PANE_WIDTH,
@@ -1059,7 +1059,7 @@ class App extends PureComponent<AppProps, State> {
     let title;
 
     if (activeActivity === ACTIVITY_HOME) {
-      title = getAppName();
+      title = getProductName();
     } else if (activeWorkspace && activeWorkspaceName) {
       title = activeProject.name;
       title += ` - ${activeWorkspaceName}`;
@@ -1073,7 +1073,7 @@ class App extends PureComponent<AppProps, State> {
       }
     }
 
-    document.title = title || getAppName();
+    document.title = title || getProductName();
   }
 
   componentDidUpdate(prevProps: AppProps) {

--- a/packages/insomnia-app/app/ui/index.tsx
+++ b/packages/insomnia-app/app/ui/index.tsx
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
 import { SegmentEvent, trackSegmentEvent } from '../common/analytics';
-import { getAppName, isDevelopment } from '../common/constants';
+import { getProductName, isDevelopment } from '../common/constants';
 import { database as db } from '../common/database';
 import { initializeLogging } from '../common/log';
 import * as models from '../models';
@@ -20,7 +20,7 @@ import './css/index.less'; // this import must come after `App`.  the reason is 
 initializeLogging();
 // Handy little helper
 document.body.setAttribute('data-platform', process.platform);
-document.title = getAppName();
+document.title = getProductName();
 
 (async function() {
   await db.initClient();

--- a/packages/insomnia-app/app/ui/index.tsx
+++ b/packages/insomnia-app/app/ui/index.tsx
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
 import { SegmentEvent, trackSegmentEvent } from '../common/analytics';
-import { getAppLongName, isDevelopment } from '../common/constants';
+import { getAppName, isDevelopment } from '../common/constants';
 import { database as db } from '../common/database';
 import { initializeLogging } from '../common/log';
 import * as models from '../models';
@@ -20,7 +20,7 @@ import './css/index.less'; // this import must come after `App`.  the reason is 
 initializeLogging();
 // Handy little helper
 document.body.setAttribute('data-platform', process.platform);
-document.title = getAppLongName();
+document.title = getAppName();
 
 (async function() {
   await db.initClient();

--- a/packages/insomnia-app/config/config.json
+++ b/packages/insomnia-app/config/config.json
@@ -6,7 +6,6 @@
   "userDataFolder": "Insomnia",
   "productName": "Insomnia",
   "binaryPrefix": "Insomnia.Core",
-  "longName": "Insomnia",
   "synopsis": "The Collaborative API Client and Design Tool",
   "icon": "https://github.com/kong/insomnia/blob/develop/packages/insomnia-app/app/icons/icon.ico?raw=true",
   "changelogUrl": "https://insomnia.rest/changelog",

--- a/packages/insomnia-app/config/config.json
+++ b/packages/insomnia-app/config/config.json
@@ -4,7 +4,7 @@
   "executableName": "insomnia",
   "appId": "com.insomnia.app",
   "userDataFolder": "Insomnia",
-  "appName": "Insomnia",
+  "productName": "Insomnia",
   "binaryPrefix": "Insomnia.Core",
   "synopsis": "The Collaborative API Client and Design Tool",
   "icon": "https://github.com/kong/insomnia/blob/develop/packages/insomnia-app/app/icons/icon.ico?raw=true",

--- a/packages/insomnia-app/config/config.json
+++ b/packages/insomnia-app/config/config.json
@@ -4,7 +4,7 @@
   "executableName": "insomnia",
   "appId": "com.insomnia.app",
   "userDataFolder": "Insomnia",
-  "productName": "Insomnia",
+  "appName": "Insomnia",
   "binaryPrefix": "Insomnia.Core",
   "synopsis": "The Collaborative API Client and Design Tool",
   "icon": "https://github.com/kong/insomnia/blob/develop/packages/insomnia-app/app/icons/icon.ico?raw=true",

--- a/packages/insomnia-app/scripts/afterSignHook.js
+++ b/packages/insomnia-app/scripts/afterSignHook.js
@@ -14,10 +14,10 @@ module.exports = async function(params) {
   // Same appId in electron-builder.
   const { appId } = appConfig;
 
-  const appName = `${params.packager.appInfo.productFilename}.app`;
-  const appPath = path.join(params.appOutDir, appName);
+  const productName = `${params.packager.appInfo.productFilename}.app`;
+  const appPath = path.join(params.appOutDir, productName);
   if (!fs.existsSync(appPath)) {
-    throw new Error(`Cannot find application at: ${appName}`);
+    throw new Error(`Cannot find application at: ${productName}`);
   }
 
   if (!process.env.APPLE_ID) {
@@ -37,7 +37,7 @@ module.exports = async function(params) {
     appleIdPassword: process.env.APPLE_ID_PASSWORD,
   };
 
-  console.log(`[afterSign] Notarizing ${appName} (${appId})`);
+  console.log(`[afterSign] Notarizing ${productName} (${appId})`);
 
   try {
     await electronNotarize.notarize(args);

--- a/packages/insomnia-app/scripts/build.ts
+++ b/packages/insomnia-app/scripts/build.ts
@@ -151,7 +151,6 @@ const generatePackageJson = async (relBasePkg: string, relOutPkg: string) => {
     name: appConfig.name,
     version: appConfig.version,
     productName: appConfig.productName,
-    longName: appConfig.longName,
     description: pkg.description,
     license: pkg.license,
     homepage: pkg.homepage,

--- a/packages/insomnia-app/scripts/build.ts
+++ b/packages/insomnia-app/scripts/build.ts
@@ -150,7 +150,7 @@ const generatePackageJson = async (relBasePkg: string, relOutPkg: string) => {
   const appPkg = {
     name: appConfig.name,
     version: appConfig.version,
-    appName: appConfig.appName,
+    productName: appConfig.productName,
     description: pkg.description,
     license: pkg.license,
     homepage: pkg.homepage,

--- a/packages/insomnia-app/scripts/build.ts
+++ b/packages/insomnia-app/scripts/build.ts
@@ -150,7 +150,7 @@ const generatePackageJson = async (relBasePkg: string, relOutPkg: string) => {
   const appPkg = {
     name: appConfig.name,
     version: appConfig.version,
-    productName: appConfig.productName,
+    appName: appConfig.appName,
     description: pkg.description,
     license: pkg.license,
     homepage: pkg.homepage,

--- a/packages/insomnia-inso/src/db/index.ts
+++ b/packages/insomnia-inso/src/db/index.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { getAppDataDir } from '../data-directory';
 import { logger } from '../logger';
-import { getDefaultAppName } from '../util';
+import { getDefaultProductName } from '../util';
 import gitAdapter from './adapters/git-adapter';
 import insomniaAdapter from './adapters/insomnia-adapter';
 import neDbAdapter from './adapters/ne-db-adapter';
@@ -70,7 +70,7 @@ export const loadDb = async ({
 
   // try load from nedb
   if (!db) {
-    const dir = src || appDataDir || getAppDataDir(getDefaultAppName());
+    const dir = src || appDataDir || getAppDataDir(getDefaultProductName());
     db = await neDbAdapter(dir, filterTypes);
     db && logger.debug(`Data store configured from app data directory at \`${path.resolve(dir)}\``); // Try to load from the Designer data dir, if the Core data directory does not exist
   } // return empty db

--- a/packages/insomnia-inso/src/util.test.ts
+++ b/packages/insomnia-inso/src/util.test.ts
@@ -2,7 +2,7 @@ import * as packageJson from '../package.json';
 import { InsoError } from './errors';
 import { globalBeforeAll, globalBeforeEach } from './jest/before';
 import { logger } from './logger';
-import { exit, getDefaultAppName, getVersion, logErrorExit1, noop } from './util';
+import { exit, getDefaultProductName, getVersion, logErrorExit1, noop } from './util';
 
 describe('exit()', () => {
   beforeAll(() => {
@@ -99,7 +99,7 @@ describe('logErrorExit1()', () => {
   });
 });
 
-describe('getDefaultAppName()', () => {
+describe('getDefaultProductName()', () => {
   const OLD_ENV = process.env;
   beforeEach(() => {
     process.env = { ...OLD_ENV }; // make a copy
@@ -112,12 +112,12 @@ describe('getDefaultAppName()', () => {
   it('should return value if set', () => {
     const value = 'dir';
     process.env.DEFAULT_APP_NAME = value;
-    expect(getDefaultAppName()).toBe(value);
+    expect(getDefaultProductName()).toBe(value);
   });
 
   it('should throw error if not set', () => {
     process.env.DEFAULT_APP_NAME = '';
-    expect(getDefaultAppName).toThrowError('Environment variable DEFAULT_APP_NAME is not set.');
+    expect(getDefaultProductName).toThrowError('Environment variable DEFAULT_APP_NAME is not set.');
   });
 });
 

--- a/packages/insomnia-inso/src/util.ts
+++ b/packages/insomnia-inso/src/util.ts
@@ -14,7 +14,7 @@ export const exit = async (result: Promise<boolean>): Promise<void> => {
   return result.then(r => process.exit(r ? 0 : 1)).catch(logErrorExit1);
 };
 
-export const getDefaultAppName = (): string => {
+export const getDefaultProductName = (): string => {
   const name = process.env.DEFAULT_APP_NAME;
 
   if (!name) {


### PR DESCRIPTION
while reviewing https://github.com/Kong/insomnia/pull/4704 I noticed that `longName` and `productName` are exactly the same value and _ALMOST_ everywhere in the app `productName` was used.

I spent longer than I probably should have trying to verify _ANY_ justification for this, but I turned up with nothing.  Before there was a config file these values were just hardcoded https://github.com/Kong/insomnia/blob/c79d7fdd7757b062278131f817af7120848ded13/.electronbuilder.  Then later the config file first appeared in the (private) Insomnia Designer repo.  But even there, it had duplicated values for `productName` and `longName` (`Insomnia Designer`):
<img src="https://user-images.githubusercontent.com/15232461/163874774-7eb828f6-04fb-4434-9454-f4414273d2a4.png" width="30%" />

So I can only conclude that this was a premature optimization that never found a purpose.

Beyond that, I also searched electron-builder to make sure these aren't special values in some way.  So far as I can tell, they are not.
<img src="https://user-images.githubusercontent.com/15232461/163874952-4d72c930-6f9a-4b22-8444-706a5a06e300.png" width="30%" />
<img src="https://user-images.githubusercontent.com/15232461/163874955-24647e8e-b78b-43c9-b6cd-5f3bd2d701b8.png" width="30%" />

Second of that, since I already went through the diligence of figuring all of this out, I went ahead and made the config.json key match what we actually call it in the app: `appName`:
<img src="https://user-images.githubusercontent.com/15232461/163875102-c3882b18-1863-44d4-9256-d3955792adb4.png" width="30%" />

