### PR TITLE
catches JSON.parse possible error in oauth2 identity token field

### DIFF
--- a/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia-app/app/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -299,19 +299,22 @@ const renderIdentityTokenExpiry = (token?: Pick<OAuth2Token, 'identityToken'>) =
     return;
   }
 
-  const { exp } = JSON.parse(decodedString);
-
-  if (!exp) {
-    return '(never expires)';
+  try {
+    const { exp } = JSON.parse(decodedString);
+    if (!exp) {
+      return '(never expires)';
+    }
+    const convertedExp = convertEpochToMilliseconds(exp);
+    return (
+      <span>
+        &#x28;expires <TimeFromNow timestamp={convertedExp} />
+        &#x29;
+      </span>
+    );
+  } catch (error) {
+    console.error(error);
+    return '';
   }
-
-  const convertedExp = convertEpochToMilliseconds(exp);
-  return (
-    <span>
-      &#x28;expires <TimeFromNow timestamp={convertedExp} />
-      &#x29;
-    </span>
-  );
 };
 
 const renderAccessTokenExpiry = (token?: Pick<OAuth2Token, 'accessToken' | 'expiresAt'>) => {


### PR DESCRIPTION
see https://youtu.be/PSUys7A0iVE?t=2298 for a demo of what can break and how this PR fixes it

changelog(Fixes): Fixes potential issue where typing an invalid JWT into some of the OAuth2 fields can crash the OAuth2  interface