### PR TITLE
Add missing characters to URL regex

### DIFF
--- a/packages/insomnia/src/common/__tests__/constants.test.ts
+++ b/packages/insomnia/src/common/__tests__/constants.test.ts
@@ -18,6 +18,7 @@ describe('URL Regex', () => {
     expect('https://dash-domain.com').toMatch(FLEXIBLE_URL_REGEX);
     expect('http://localhost:8000').toMatch(FLEXIBLE_URL_REGEX);
     expect('http://localhost:8000/foo/b@@r?hi=there#hello').toMatch(FLEXIBLE_URL_REGEX);
+    expect('http://localhost:8000/foo?Signature=j4w98udA7~NbL6W4~UwAuj').toMatch(FLEXIBLE_URL_REGEX);
   });
 
   it('does not match "stop" characters', () => {

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -66,7 +66,7 @@ export const REQUEST_SETUP_TEARDOWN_COMPENSATION = 200;
 export const STATUS_CODE_PLUGIN_ERROR = -222;
 export const LARGE_RESPONSE_MB = 5;
 export const HUGE_RESPONSE_MB = 100;
-export const FLEXIBLE_URL_REGEX = /^(http|https):\/\/[\wàâäèéêëîïôóœùûüÿçÀÂÄÈÉÊËÎÏÔŒÙÛÜŸÇ\-_.]+[/\wàâäèéêëîïôóœùûüÿçÀÂÄÈÉÊËÎÏÔŒÙÛÜŸÇ.\-+=:\][@%^*&!#?;$]*/;
+export const FLEXIBLE_URL_REGEX = /^(http|https):\/\/[\wàâäèéêëîïôóœùûüÿçÀÂÄÈÉÊËÎÏÔŒÙÛÜŸÇ\-_.]+[/\wàâäèéêëîïôóœùûüÿçÀÂÄÈÉÊËÎÏÔŒÙÛÜŸÇ.\-+=:\][@%^*&!#?;$~'(),]*/;
 export const CHECK_FOR_UPDATES_INTERVAL = 1000 * 60 * 60 * 3; // 3 hours
 export const PLUGIN_PATH = path.join(getDataDirectory(), 'plugins');
 export const AUTOBIND_CFG = {


### PR DESCRIPTION
Added the unreserved character ~ and the reserved characters '(), to the URL matching regex. If I'm understanding [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2) correctly, "reserved" characters are allowed unencoded in URIs (& there already exist some of these characters in the regex) and so are "unreserved" characters like ~.

The tilde looks like its an unsafe character to have unencoded in RFC 1738, though it appears this is now superseded in most applications - and regardless, if this regex is only used to determine if a link is clickable I don't think there's much harm in including it. I'd love to get some more opinions on this.

This should fix #4705 and improve detection of clickable URLs. I have checked that this is the only place this REGEX string is used but since this is my first contribution, please can someone else check this as well.

Changelog(Fixes): Fixed an issue where URLs in JSON responses were not properly clickable if they included certain unreserved characters

