### PR TITLE
fix(styled-components): add specificity selector

### DIFF
--- a/packages/insomnia-app/app/ui/components/app-header.tsx
+++ b/packages/insomnia-app/app/ui/components/app-header.tsx
@@ -6,8 +6,10 @@ import coreLogo from '../images/insomnia-logo.svg';
 import { SettingsButton } from './buttons/settings-button';
 import { AccountDropdownButton } from './dropdowns/account-dropdown';
 
-const Header = styled(_Header)({
-  whiteSpace: 'nowrap',
+const Header =  styled(_Header)({
+  '&&': {
+    whiteSpace: 'nowrap',
+  },
 });
 
 const RightWrapper = styled.div({

--- a/packages/insomnia-app/app/ui/components/design-empty-state.tsx
+++ b/packages/insomnia-app/app/ui/components/design-empty-state.tsx
@@ -20,10 +20,12 @@ const Wrapper = styled.div({
 });
 
 const StyledButton = styled(Button)({
-  pointerEvents: 'all',
-  color: 'var(--color-font)',
-  marginTop: 'var(--padding-md)',
-  marginLeft: '0 !important', // unfortunately, we're in specificty battle with a default marginLeft
+  '&&': {
+    pointerEvents: 'all',
+    color: 'var(--color-font)',
+    marginTop: 'var(--padding-md)',
+    marginLeft: '0 !important', // unfortunately, we're in specificty battle with a default marginLeft
+  },
 });
 
 const ExampleButton = styled.div({

--- a/packages/insomnia-app/app/ui/components/dropdowns/dashboard-sort-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/dashboard-sort-dropdown.tsx
@@ -11,9 +11,11 @@ interface DashboardSortDropdownProps {
 }
 
 const Checkmark = styled(SvgIcon)({
-  ...svgPlacementHack,
-  '& svg': {
-    fill: 'var(--color-surprise)',
+  '&&': {
+    ...svgPlacementHack,
+    '& svg': {
+      fill: 'var(--color-surprise)',
+    },
   },
 });
 

--- a/packages/insomnia-app/app/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/project-dropdown.tsx
@@ -16,21 +16,27 @@ import ProjectSettingsModal from '../modals/project-settings-modal';
 import { svgPlacementHack, tooltipIconPlacementHack } from './dropdown-placement-hacks';
 
 const Checkmark = styled(SvgIcon)({
-  ...svgPlacementHack,
-  '& svg': {
-    fill: 'var(--color-surprise)',
+  '&&': {
+    ...svgPlacementHack,
+    '& svg': {
+      fill: 'var(--color-surprise)',
+    },
   },
 });
 
 const StyledSvgIcon = styled(SvgIcon)({
-  ...svgPlacementHack,
-  '& svg': {
-    fill: 'var(--hl)',
+  '&&': {
+    ...svgPlacementHack,
+    '& svg': {
+      fill: 'var(--hl)',
+    },
   },
 });
 
 const StyledTooltip = styled(Tooltip)({
-  ...tooltipIconPlacementHack,
+  '&&': {
+    ...tooltipIconPlacementHack,
+  },
 });
 
 const TooltipIcon = ({ message, icon }: { message: string; icon: SvgIconProps['icon'] }) => (

--- a/packages/insomnia-app/app/ui/components/dropdowns/remote-workspaces-dropdown.tsx
+++ b/packages/insomnia-app/app/ui/components/dropdowns/remote-workspaces-dropdown.tsx
@@ -20,7 +20,9 @@ const PullButton = styled(({ disabled, className }) => (
     Pull <i className="fa fa-caret-down pad-left-sm" />
   </Button>
 ))({
-  marginLeft: 'var(--padding-md)',
+  '&&': {
+    marginLeft: 'var(--padding-md)',
+  },
 });
 
 export const RemoteWorkspacesDropdown: FC<Props> = ({ vcs }) => {

--- a/packages/insomnia-app/app/ui/components/panes/empty-state-pane.tsx
+++ b/packages/insomnia-app/app/ui/components/panes/empty-state-pane.tsx
@@ -57,18 +57,22 @@ const DocumentationLinks = styled.div({
 });
 
 const StyledLink = styled(Link)({
-  display: 'flex',
-  marginTop: 'var(--padding-md)',
-  color: 'var(--color-font) !important', // unfortunately, we've set at the root with !important
-  fontWeight: 'normal !important', // unfortunately, we've set at the root with !important
-  pointerEvents: 'all',
-  '& hover': {
-    textDecoration: 'none',
+  '&&': {
+    display: 'flex',
+    marginTop: 'var(--padding-md)',
+    color: 'var(--color-font) !important', // unfortunately, we've set at the root with !important
+    fontWeight: 'normal !important', // unfortunately, we've set at the root with !important
+    pointerEvents: 'all',
+    '& hover': {
+      textDecoration: 'none',
+    },
   },
 });
 
 const LinkIcon = styled(SvgIcon)({
-  paddingLeft: 'var(--padding-sm)',
+  '&&': {
+    paddingLeft: 'var(--padding-sm)',
+  },
 });
 
 export const EmptyStatePane: FC<{

--- a/packages/insomnia-app/app/ui/components/rendered-query-string.tsx
+++ b/packages/insomnia-app/app/ui/components/rendered-query-string.tsx
@@ -19,9 +19,11 @@ const Wrapper = styled.div({
 });
 
 const CopyButton = styled(_CopyButton)({
-  alignSelf: 'start',
-  position: 'sticky',
-  top: 0,
+  '&&': {
+    alignSelf: 'start',
+    position: 'sticky',
+    top: 0,
+  },
 });
 
 interface Props {

--- a/packages/insomnia-app/app/ui/components/wrapper-home.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-home.tsx
@@ -49,7 +49,9 @@ import { WorkspaceCard, WorkspaceCardProps } from './workspace-card';
 import type { WrapperProps } from './wrapper';
 
 const CreateButton = styled(Button)({
-  marginLeft: 'var(--padding-md)',
+  '&&': {
+    marginLeft: 'var(--padding-md)',
+  },
 });
 
 interface Props

--- a/packages/insomnia-app/app/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia-app/app/ui/components/wrapper-unit-test.tsx
@@ -39,7 +39,9 @@ import { WorkspacePageHeader } from './workspace-page-header';
 import type { HandleActivityChange, WrapperProps } from './wrapper';
 
 const HeaderButton = styled(Button)({
-  marginRight: 'var(--padding-md)',
+  '&&': {
+    marginRight: 'var(--padding-md)',
+  },
 });
 
 interface Props extends ReturnType<typeof mapStateToProps> {

--- a/packages/insomnia-components/src/button/circle-button.tsx
+++ b/packages/insomnia-components/src/button/circle-button.tsx
@@ -10,20 +10,22 @@ export interface CircleButtonProps extends ButtonProps {
 }
 
 const StyledCircleButton = styled(Button)<CircleButtonProps>`
-  padding: unset;
-  font-size: var(--font-size-xl);
-  border-radius: 50%;
-
-  ${({ height }) => css`
-    height: ${height || css`var(--line-height-xs)`};
-  `};
-
-  ${({ width }) => css`
-    width: ${width || css`var(--line-height-xs)`};
-  `};
-
-  svg {
-    padding: var(--padding-xs);
+  && {
+    padding: unset;
+    font-size: var(--font-size-xl);
+    border-radius: 50%;
+  
+    ${({ height }) => css`
+      height: ${height || css`var(--line-height-xs)`};
+    `};
+  
+    ${({ width }) => css`
+      width: ${width || css`var(--line-height-xs)`};
+    `};
+  
+    svg {
+      padding: var(--padding-xs);
+    }
   }
 `;
 

--- a/packages/insomnia-components/src/list-group/unit-test-item.tsx
+++ b/packages/insomnia-components/src/list-group/unit-test-item.tsx
@@ -30,27 +30,29 @@ export interface UnitTestItemProps {
 }
 
 const StyledResultListItem = styled(ListGroupItem)`
-  padding: 0 var(--padding-sm);
+  && {
+    padding: 0 var(--padding-sm);
 
-  > div:first-of-type {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    align-items: center;
-  }
+    > div:first-of-type {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      align-items: center;
+    }
 
-  svg {
-    fill: var(--hl-xl);
-  }
+    svg {
+      fill: var(--hl-xl);
+    }
 
-  h2 {
-    font-size: var(--font-size-md);
-    font-weight: var(--font-weight-normal);
-    margin: 0px;
-  }
+    h2 {
+      font-size: var(--font-size-md);
+      font-weight: var(--font-weight-normal);
+      margin: 0px;
+    }
 
-  button {
-    padding: 0px var(--padding-sm);
+    button {
+      padding: 0px var(--padding-sm);
+    }
   }
 `;
 

--- a/packages/insomnia-components/src/list-group/unit-test-result-badge.tsx
+++ b/packages/insomnia-components/src/list-group/unit-test-result-badge.tsx
@@ -19,13 +19,17 @@ const StyledBadge = styled.span`
 `;
 
 const StyledFailedBadge = styled(StyledBadge)`
-  border-color: var(--color-danger);
-  color: var(--color-danger);
+  && {
+    border-color: var(--color-danger);
+    color: var(--color-danger);
+  }
 `;
 
 const StyledPassedBadge = styled(StyledBadge)`
-  border-color: var(--color-success);
-  color: var(--color-success);
+  && {
+    border-color: var(--color-success);
+    color: var(--color-success);
+  }
 `;
 
 export const UnitTestResultBadge: FunctionComponent<UnitTestResultBadgeProps> = ({ failed }) => failed ? (

--- a/packages/insomnia-components/src/list-group/unit-test-result-item.tsx
+++ b/packages/insomnia-components/src/list-group/unit-test-result-item.tsx
@@ -16,30 +16,32 @@ export interface UnitTestResultItemProps {
 }
 
 const StyledResultListItem = styled(ListGroupItem)`
-  > div:first-of-type {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-
-    > *:not(:first-child) {
-      margin: var(--padding-xs) 0 var(--padding-xs) var(--padding-sm);
+  && {
+    > div:first-of-type {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+  
+      > *:not(:first-child) {
+        margin: var(--padding-xs) 0 var(--padding-xs) var(--padding-sm);
+      }
     }
-  }
-
-  code {
-    background-color: var(--hl-xs);
-    padding: var(--padding-sm) var(--padding-md) var(--padding-sm) var(--padding-md);
-    color: var(--color-danger);
-    display: block;
-    margin: var(--padding-sm) 0 0 0;
-  }
-
-  p {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    flex-grow: 1;
+  
+    code {
+      background-color: var(--hl-xs);
+      padding: var(--padding-sm) var(--padding-md) var(--padding-sm) var(--padding-md);
+      color: var(--color-danger);
+      display: block;
+      margin: var(--padding-sm) 0 0 0;
+    }
+  
+    p {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      flex-grow: 1;
+    }
   }
 `;
 

--- a/packages/insomnia-components/src/multi-switch.tsx
+++ b/packages/insomnia-components/src/multi-switch.tsx
@@ -5,33 +5,35 @@ import type { RadioButtonGroupProps } from './radio-button-group';
 import { RadioButtonGroup } from './radio-button-group';
 
 const ThemedButtonGroup = styled(RadioButtonGroup)<RadioButtonGroupProps>`
-  font-weight: 500;
-  background: var(--hl-xs);
-  color: var(--color-font);
-  border: 0;
-  border-radius: 100px;
-  align-content: space-evenly;
-  padding: var(--padding-xxs);
-  transform: scale(0.9);
-  transformOrigin: 'center';
-
-  label {
-    padding: 0;
-  }
-
-  span {
-    text-transform: uppercase;
-    padding: var(--padding-xs) var(--padding-xxs);
-    color: var(--hl);
-    background: transparent;
-    font-size: var(--font-size-xs);
-    margin: 0 auto;
-    min-width: 4rem;
-  }
-
-  input:checked + span {
+  && {
+    font-weight: 500;
+    background: var(--hl-xs);
     color: var(--color-font);
-    background: var(--color-bg);
+    border: 0;
+    border-radius: 100px;
+    align-content: space-evenly;
+    padding: var(--padding-xxs);
+    transform: scale(0.9);
+    transformOrigin: 'center';
+  
+    label {
+      padding: 0;
+    }
+  
+    span {
+      text-transform: uppercase;
+      padding: var(--padding-xs) var(--padding-xxs);
+      color: var(--hl);
+      background: transparent;
+      font-size: var(--font-size-xs);
+      margin: 0 auto;
+      min-width: 4rem;
+    }
+  
+    input:checked + span {
+      color: var(--color-font);
+      background: var(--color-bg);
+    }
   }
 `;
 

--- a/packages/insomnia-components/src/toggle-switch.tsx
+++ b/packages/insomnia-components/src/toggle-switch.tsx
@@ -14,17 +14,19 @@ export interface ToggleSwitchProps {
 }
 
 const ThemedSwitch = styled(Switch)<{ checked: boolean }>`
-  .react-switch-bg {
-    background: ${({ checked }) => (checked ? 'var(--color-surprise)' : 'var(--hl-xl)')} !important;
-    
-    ${({ checked }) => checked && css`
-    path {
-      fill: var(--color-font-surprise) !important
+  && {
+    .react-switch-bg {
+      background: ${({ checked }) => (checked ? 'var(--color-surprise)' : 'var(--hl-xl)')} !important;
+      
+      ${({ checked }) => checked && css`
+      path {
+        fill: var(--color-font-surprise) !important
+      }
+      `}
     }
-    `}
-  }
 
-  vertical-align: middle;
+    vertical-align: middle;
+  } 
 `;
 
 const StyledLabel = styled.label`


### PR DESCRIPTION
Fixes specificity issues with styled components that rely on import order.

The order of css/styled imports can affect which styles get applied to an element.
When we extend a styled component we usually override it's styles like so:
```tsx
const StyledBytton = styled(Button)({
  marginLeft: 5
})
```
The intend here is to override the marginLeft value for the Button. This will only happen if the className with the marginLeft override loads last in the Document.
To guarantee that the styles will override the previous ones we need to [increase the specificity](https://styled-components.com/docs/faqs#how-can-i-override-styles-with-higher-specificity)