### PR TITLE
4688 Header ending with -bin need buffer values

### DIFF
--- a/packages/insomnia/src/network/grpc/index.ts
+++ b/packages/insomnia/src/network/grpc/index.ts
@@ -323,7 +323,7 @@ const _parseMetadata = (
   for (const entry of metadata) {
     if (!entry.disabled) {
       try {
-        grpcMetadata.add(entry.name, entry.value);
+        grpcMetadata.add(entry.name, _parseMetadataValue(entry));
       } catch (err) {
         respond.sendError(requestId, err);
         return undefined;
@@ -331,4 +331,26 @@ const _parseMetadata = (
     }
   }
   return grpcMetadata;
+};
+
+const _parseMetadataValue = (
+  metadataEntry: GrpcRequestHeader
+): string | Buffer => {
+  const isBinHeader = metadataEntry.name.endsWith("-bin");
+  if (isBinHeader) {
+    return _parseMetadataBinValue(metadataEntry.value);
+  } else {
+    return metadataEntry.value;
+  }
+};
+
+const _parseMetadataBinValue = (
+  entryValue: string
+) : Buffer => {
+  const regex = /^(?:([\w\-]+?):\/\/)?(.*)$/;
+  const parts = regex.exec(entryValue)!;
+  const encoding = parts[1] as BufferEncoding;
+  const value = parts[2];
+  const encodedValue = Buffer.from(value, encoding);
+  return encodedValue;
 };


### PR DESCRIPTION
For metadata entries where the name ends with -bin the values must be
Buffers instead of strings.

The solution checks if the metadata entry should be a buffer and, when
yes, constructs a Buffer from the value. The value is split into the
encoding part and the real value part. If no encoding is specified the
Buffer will be constructed with the default encoding.

The default encoding when none is provided to the `Buffer.from` call is `utf8`.

The solution accepts empty values, as well as values without the encoding part.

The encoding part is not restricted to the current encoding values, so it should
be ok if in future new values are added. It is restricted though to some characters:
* a-z
* A-Z
* 0-9
* underscore (_)
* hyphen (-)

Closes #4688.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
