### PR TITLE
remove pdfjs-dist in favor of native chromium pdf viewer

### DIFF
--- a/packages/insomnia/package-lock.json
+++ b/packages/insomnia/package-lock.json
@@ -121,7 +121,6 @@
 				"license-checker": "^25.0.1",
 				"ncp": "^2.0.0",
 				"objectpath": "^2.0.0",
-				"pdfjs-dist": "^2.5.207",
 				"react": "^17.0.2",
 				"react-dnd": "^7.4.5",
 				"react-dnd-html5-backend": "^7.4.4",
@@ -17224,12 +17223,6 @@
 			"engines": {
 				"node": ">=0.12"
 			}
-		},
-		"node_modules/pdfjs-dist": {
-			"version": "2.5.207",
-			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.5.207.tgz",
-			"integrity": "sha512-xGDUhnCYPfHy+unMXCLCJtlpZaaZ17Ew3WIL0tnSgKFUZXHAPD49GO9xScyszSsQMoutNDgRb+rfBXIaX/lJbw==",
-			"dev": true
 		},
 		"node_modules/pend": {
 			"version": "1.2.0",
@@ -35060,12 +35053,6 @@
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
 			}
-		},
-		"pdfjs-dist": {
-			"version": "2.5.207",
-			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.5.207.tgz",
-			"integrity": "sha512-xGDUhnCYPfHy+unMXCLCJtlpZaaZ17Ew3WIL0tnSgKFUZXHAPD49GO9xScyszSsQMoutNDgRb+rfBXIaX/lJbw==",
-			"dev": true
 		},
 		"pend": {
 			"version": "1.2.0",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -176,7 +176,6 @@
     "license-checker": "^25.0.1",
     "ncp": "^2.0.0",
     "objectpath": "^2.0.0",
-    "pdfjs-dist": "^2.5.207",
     "react": "^17.0.2",
     "react-dnd": "^7.4.5",
     "react-dnd-html5-backend": "^7.4.4",

--- a/packages/insomnia/src/ui/components/viewers/response-pdf-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-pdf-viewer.tsx
@@ -1,120 +1,16 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import * as PDF from 'pdfjs-dist';
-import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.entry';
-PDF.GlobalWorkerOptions.workerSrc = pdfjsWorker;
-
-import React, { CSSProperties, PureComponent } from 'react';
-
-import { AUTOBIND_CFG } from '../../../common/constants';
+import React from 'react';
 
 interface Props {
   body: Buffer;
-  uniqueKey: string;
 }
 
-interface State {
-  numPages: number | null;
-}
+export const ResponsePDFViewer = (props: Props) => {
+  const url = (`data:application/pdf;base64,${props.body.toString('base64')}`);
 
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class ResponsePDFViewer extends PureComponent<Props, State> {
-  container: HTMLDivElement | null = null;
-  debounceTimeout: NodeJS.Timeout | null = null;
-
-  setRef(n: HTMLDivElement) {
-    this.container = n;
-  }
-
-  loadPDF() {
-    if (this.debounceTimeout !== null) {
-      clearTimeout(this.debounceTimeout);
-    }
-    this.debounceTimeout = setTimeout(async () => {
-      // get node for this react component
-      const container = this.container;
-
-      if (!container) {
-        return;
-      }
-
-      container.innerHTML = '';
-      const containerWidth = container.clientWidth;
-      const pdf = await PDF.getDocument({
-        data: this.props.body.toString('binary'),
-      }).promise;
-
-      for (let i = 1; i <= pdf.numPages; i++) {
-        const page = await pdf.getPage(i);
-        const density = window.devicePixelRatio || 1;
-        const { width: pdfWidth, height: pdfHeight } = page.getViewport({
-          scale: 1,
-        });
-        const ratio = pdfHeight / pdfWidth;
-        const scale = containerWidth / pdfWidth;
-        const viewport = page.getViewport({
-          scale: scale * density,
-        });
-        // set canvas for page
-        const canvas = document.createElement('canvas');
-        canvas.width = containerWidth * density;
-        // canvas.height = containerWidth * (viewport.height / viewport.width);
-        canvas.height = containerWidth * ratio * density;
-        canvas.style.width = `${containerWidth}px`;
-        canvas.style.height = `${containerWidth * ratio}px`;
-        container.appendChild(canvas);
-        // get context and render page
-        const context = canvas.getContext('2d');
-
-        if (!context) {
-          return;
-        }
-
-        const renderContext = {
-          id: `${this.props.uniqueKey}.${i}`,
-          canvasContext: context,
-          viewport: viewport,
-        };
-        await page.render(renderContext).promise;
-      }
-    }, 100);
-  }
-
-  handleResize() {
-    if (!this.container) {
-      return;
-    }
-
-    if (this.debounceTimeout !== null) {
-      clearTimeout(this.debounceTimeout);
-    }
-    this.debounceTimeout = setTimeout(this.loadPDF, 300);
-  }
-
-  componentDidUpdate() {
-    this.loadPDF();
-  }
-
-  componentDidMount() {
-    this.loadPDF();
-    window.addEventListener('resize', this.handleResize);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
-  }
-
-  render() {
-    const styles: CSSProperties = {
-      width: '100%',
-      height: '100%',
-      overflowX: 'hidden',
-      overflowY: 'scroll',
-      padding: '0px',
-    };
-    return (
-      <div className="S-PDF-ID" ref={this.setRef} style={styles}>
-        <div className="faded text-center vertically-center tall">Loading PDF...</div>
-      </div>
-    );
-  }
-}
+  return (
+    <webview
+      data-testid="ResponsePDFView"
+      src={url}
+    />
+  );
+};

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -387,7 +387,7 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
     if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('application/pdf') === 0) {
       return (
         <div className="tall wide scrollable">
-          <ResponsePDFViewer body={bodyBuffer} uniqueKey={responseId} />
+          <ResponsePDFViewer body={bodyBuffer} key={responseId} />
         </div>
       );
     }


### PR DESCRIPTION
Changelog(Improvements): PDF responses are now previewed using Chromium's native PDF viewer


Remove pdfjs and use the native pdf viewer instead.

pdfjs is a big part of our bundle and is only used in the PDF preview. Since electron supports rendering PDFs natively we can remove it and save some kb!

![pdf](https://user-images.githubusercontent.com/12115431/164740046-358dcf90-026f-41ff-8aba-71346f4efdc4.gif)

TODO:
Validate the behaviour in all supported platforms
- [x] macOS
- [x] linux
- [x] windows