### PR TITLE
Fix pdf rendering

### DIFF
--- a/packages/insomnia-app/app/ui/components/viewers/response-pdf-viewer.tsx
+++ b/packages/insomnia-app/app/ui/components/viewers/response-pdf-viewer.tsx
@@ -1,5 +1,8 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as PDF from 'pdfjs-dist';
+import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.entry';
+PDF.GlobalWorkerOptions.workerSrc = pdfjsWorker;
+
 import React, { CSSProperties, PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';


### PR DESCRIPTION
Fixes PDF rendering by setting the workerSrc.
This is not ideal but will tie us over until we can switch to the native PDF viewer in #4720