### PR TITLE
Improve experience when debugging with vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,8 @@
         "name": "Electron: main",
         "runtimeExecutable": "${workspaceFolder}/packages/insomnia/node_modules/.bin/electron.cmd"
       },
+      "preLaunchTask": "Insomnia: Compile Main",
+      "postDebugTask": "Terminate All Tasks",
       "env": {
         "NODE_ENV": "development",
         "ELECTRON_IS_DEV": "1"
@@ -36,6 +38,7 @@
         "group": "Insomnia",
         "order": 2
       },
+      "preLaunchTask": "Insomnia: Compile Renderer (Watch)",
       "port": 9222,
       "webRoot": "${workspaceFolder}/packages/insomnia/src",
       "timeout": 60000

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,10 +8,37 @@
       "detail": "esbuild.main.ts",
       "type": "shell",
       "promptOnClose": false,
+      "isBackground": true,
       "options": {
         "cwd": "${workspaceFolder}/packages/insomnia",
         "env": {
           "NODE_ENV": "development",
+        }
+      },
+      "problemMatcher": {
+        "owner": "esbuild",
+        "severity": "error",
+        "fileLocation": "absolute",
+        "pattern": [
+          {
+            "regexp": "ERROR in (.*)",
+            "file": 1
+          },
+          {
+            "regexp": "\\((\\d+),(\\d+)\\):(.*)",
+            "line": 1,
+            "column": 2,
+            "message": 3
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": {
+            "regexp": "watching"
+          },
+          "endsPattern": {
+            "regexp": "Build complete!"
+          }
         }
       },
       "command": "${workspaceRoot}/packages/insomnia/node_modules/.bin/esr esbuild.main.ts"
@@ -24,7 +51,7 @@
       "options": {
         "cwd": "${workspaceFolder}/packages/insomnia",
         "env": {
-          "NODE_ENV": "development",
+          "NODE_ENV": "development"
         }
       },
       "isBackground": true,
@@ -95,6 +122,24 @@
         }
       },
       "command": "npm run inso-start"
+    },
+    {
+      "label": "Terminate All Tasks",
+      "command": "echo ${input:terminate}",
+      "type": "shell",
+      "problemMatcher": []
+    },
+    {
+      "label": "Terminate Renderer",
+      "command": "echo ${input:terminateRenderer}",
+      "type": "shell",
+      "problemMatcher": []
+    },
+    {
+      "label": "Terminate Main",
+      "command": "echo ${input:terminateMain}",
+      "type": "shell",
+      "problemMatcher": []
     }
   ],
   "inputs": [
@@ -103,6 +148,12 @@
       "type": "promptString",
       "description": "Arguments to pass to inso",
       "default": "-v"
+    },
+    {
+      "id": "terminate",
+      "type": "command",
+      "command": "workbench.action.tasks.terminate",
+      "args": "terminateAll"
     }
   ]
 }

--- a/packages/insomnia/esbuild.main.ts
+++ b/packages/insomnia/esbuild.main.ts
@@ -48,6 +48,7 @@ export default async function build(options: Options) {
     platform: 'node',
     sourcemap: true,
     format: 'cjs',
+    watch: __DEV__,
     define: env,
     external: [
       'electron',
@@ -65,5 +66,16 @@ const isMain = require.main === module;
 if (isMain) {
   const mode =
     process.env.NODE_ENV === 'development' ? 'development' : 'production';
-  build({ mode });
+
+  async function main() {
+    const result = await build({ mode });
+
+    if (result.errors.length > 0) {
+      console.error('Error building:', result.errors);
+    } else {
+      console.log('Build complete!');
+    }
+  }
+
+  main();
 }


### PR DESCRIPTION
Currently when stopping the debug session the tasks remain open.

This PR uses the postDebugTask to stop all running tasks with it but there's some more work to make it robust.
e.g. when reloading etc.