### PR TITLE
fix: multipart is now called from main

### DIFF
--- a/packages/insomnia/src/network/multipart.ts
+++ b/packages/insomnia/src/network/multipart.ts
@@ -1,3 +1,8 @@
+if (process.type === 'renderer') {
+  throw new Error('multipart.ts unavailable in renderer');
+}
+
+import electron from 'electron';
 import fs from 'fs';
 import { lookup } from 'mime-types';
 import path from 'path';
@@ -14,7 +19,7 @@ interface Multipart {
 
 export async function buildMultipart(params: RequestBodyParameter[]) {
   return new Promise<Multipart>(async (resolve, reject) => {
-    const filePath = path.join(window.app.getPath('temp'), Math.random() + '.body');
+    const filePath = path.join(electron.app.getPath('temp'), Math.random() + '.body');
     const writeStream = fs.createWriteStream(filePath);
     const lineBreak = '\r\n';
     let totalSize = 0;


### PR DESCRIPTION
Since moving most of the file handling into main I noticed we are gathering the temp directory from preloaded window object in buildMultipart which (was originally evaluated in the render and) is constructing a single file of the many parts the user is expecting to be uploaded. This should now be gathered from electron. 

I was hoping there may be some static analysis way to determine this since we do not have a clear separation of concerns between main and renderer. I have investigated splitting out the main folder, and using a linter. So far adding an exception at the top of the file is the temporary workaround to avoid importing main modules in the renderer and give clarity about evaluation context. There are linter options in the form of code-layers in vscode but its bespoke and may not suit our needs. The main folder approach would need a approach for working with the database and shared types before its viable.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
