### PR TITLE
spike: partial workspace

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,6 +5,7 @@
     "packages/*",
     "plugins/*"
   ],
+  "useWorkspaces": true,
   "command": {
     "version": {
       "exact": true,

--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,6 @@
     "packages/*",
     "plugins/*"
   ],
-  "useWorkspaces": true,
   "command": {
     "version": {
       "exact": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/insomnia-prettify"
+      ],
       "dependencies": {
         "immer": "^9.0.6"
       },
@@ -12693,6 +12696,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/insomnia-prettify": {
+      "resolved": "packages/insomnia-prettify",
+      "link": true
+    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -23115,6 +23122,15 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "packages/insomnia-prettify": {
+      "version": "2.13.0-beta.0",
+      "license": "MIT"
+    },
+    "packages/insomnia-url": {
+      "version": "2.13.0-beta.0",
+      "extraneous": true,
+      "license": "MIT"
     }
   },
   "dependencies": {
@@ -32953,6 +32969,9 @@
           }
         }
       }
+    },
+    "insomnia-prettify": {
+      "version": "file:packages/insomnia-prettify"
     },
     "internal-slot": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "url": "https://github.com/kong/insomnia/issues"
   },
   "homepage": "https://github.com/kong/insomnia#readme",
+  "workspaces":[
+    "packages/insomnia-prettify"
+  ],
   "scripts": {
     "build": "lerna run build --parallel",
     "lint": "lerna run lint --stream --no-bail",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "lerna run lint --stream --no-bail",
     "lint:markdown": "markdownlint-cli2 \"**/*.md\" \"#**/node_modules\"",
     "lint:fix": "lerna run lint:fix --stream --no-bail",
-    "bootstrap": "npm install && lerna bootstrap && lerna run --stream bootstrap",
+    "bootstrap": "npm install && lerna bootstrap --use-workspaces && lerna run --stream bootstrap",
     "version": "lerna version",
     "publish": "lerna publish from-package",
     "clean": "lerna run clean --parallel --stream && lerna clean --yes && rimraf node_modules",

--- a/packages/insomnia-prettify/package.json
+++ b/packages/insomnia-prettify/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/Kong/insomnia/issues"
   },
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/insomnia-prettify/tsconfig.build.json
+++ b/packages/insomnia-prettify/tsconfig.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
-    "module": "CommonJS",
+    "emitDeclarationOnly": true,
     "rootDir": "src",
     "resolveJsonModule": true
   },

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -78,7 +78,6 @@
     "insomnia-plugin-request": "2.13.0-beta.0",
     "insomnia-plugin-response": "2.13.0-beta.0",
     "insomnia-plugin-uuid": "2.13.0-beta.0",
-    "insomnia-prettify": "2.13.0-beta.0",
     "insomnia-testing": "2.13.0-beta.0",
     "insomnia-url": "2.13.0-beta.0",
     "insomnia-xpath": "2.13.0-beta.0",


### PR DESCRIPTION
spike of partial workspace migration

- Test and dev dx is nicer than before as there is no build step, so changes are reflected instantly in the upstream.
- bootstrap will generate types and workspaces will handle symlinking and hoisting so we can remove deps already in root `package.json`
- I've also tried insomnia-url but plugins depend on it which creates some runtime errors I haven't found a workaround for yet.
insomnia-common seems like a good candidate too since plugins aren't aware of it.
- doesn't play nice with existing `lerna bootstrap` :cry:  https://github.com/lerna/lerna/issues/1318

TODO
- [ ] figure out how plugins can import insomnia-url as esm modules
- [ ] figure out how to install old and new workspaces at the same time
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
