### PR TITLE
trim 4mb off initial app bundle

### DIFF
--- a/packages/insomnia-inso/src/commands/lint-specification.ts
+++ b/packages/insomnia-inso/src/commands/lint-specification.ts
@@ -1,4 +1,3 @@
-import { isOpenApiv2, isOpenApiv3, Spectral } from '@stoplight/spectral';
 import fs from 'fs';
 import path from 'path';
 
@@ -48,7 +47,7 @@ export async function lintSpecification(
     logger.fatal(e.message);
     return false;
   }
-
+  const { isOpenApiv2, isOpenApiv3, Spectral } = await import('@stoplight/spectral');
   const spectral = new Spectral();
   spectral.registerFormat('oas2', isOpenApiv2);
   spectral.registerFormat('oas3', isOpenApiv3);

--- a/packages/insomnia/src/common/spectral.ts
+++ b/packages/insomnia/src/common/spectral.ts
@@ -1,6 +1,8 @@
-import { IRuleResult, isOpenApiv2, isOpenApiv3, Spectral } from '@stoplight/spectral';
+import type { IRuleResult } from '@stoplight/spectral';
 
-export const initializeSpectral = () => {
+export const initializeSpectral = async () => {
+  const { isOpenApiv2, isOpenApiv3, Spectral } = await import('@stoplight/spectral');
+
   const spectral = new Spectral();
   spectral.registerFormat('oas2', isOpenApiv2);
   spectral.registerFormat('oas3', isOpenApiv3);

--- a/packages/insomnia/src/network/authentication.ts
+++ b/packages/insomnia/src/network/authentication.ts
@@ -1,5 +1,4 @@
 import * as Hawk from '@hapi/hawk';
-import jwtAuthentication from 'jwt-authentication';
 
 import {
   AUTH_ASAP,
@@ -96,6 +95,7 @@ export async function getAuthHeader(renderedRequest: RenderedRequest, url: strin
 
   if (authentication.type === AUTH_ASAP) {
     const { issuer, subject, audience, keyId, additionalClaims, privateKey } = authentication;
+    const jwtAuthentication = await import ('jwt-authentication');
     const generator = jwtAuthentication.client.create();
     let claims = {
       iss: issuer,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -38,7 +38,6 @@ import { isWorkspace } from '../models/workspace';
 import * as pluginContexts from '../plugins/context/index';
 import * as plugins from '../plugins/index';
 import { getAuthHeader } from './authentication';
-import caCerts from './ca_certs';
 import { urlMatchesCertHost } from './url-matches-cert-host';
 
 export interface ResponsePatch {
@@ -138,6 +137,7 @@ export async function _actuallySend(
         mkdirp.sync(baseCAPath);
         // TODO: Should mock cacerts module for testing.
         // This is literally coercing a function to string in tests due to lack of val-loader.
+        const caCerts = await import('./ca_certs');
         fs.writeFileSync(fullCAPath, String(caCerts));
         console.log('[net] Set CA to', fullCAPath);
       }

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -9,7 +9,6 @@ import { ModifiedGraphQLJumpOptions } from 'codemirror-graphql/jump';
 import deepEqual from 'deep-equal';
 import { json as jsonPrettify } from 'insomnia-prettify';
 import { query as queryXPath } from 'insomnia-xpath';
-import { JSONPath } from 'jsonpath-plus';
 import React, { Component, CSSProperties, forwardRef, ForwardRefRenderFunction, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 import { unreachable } from 'ts-assert-unreachable';
@@ -698,13 +697,14 @@ export class UnconnectedCodeEditor extends Component<CodeEditorProps, State> {
     this._codemirrorSetValue(code, canPrettify);
   }
 
-  _prettifyJSON(code: string) {
+  async _prettifyJSON(code: string) {
     try {
       let jsonString = code;
 
       if (this.props.updateFilter && this.state.filter) {
         try {
           const codeObj = JSON.parse(code);
+          const { JSONPath } = await import('jsonpath-plus');
           const results = JSONPath({ json: codeObj, path: this.state.filter.trim() });
           jsonString = JSON.stringify(results);
         } catch (err) {
@@ -1118,7 +1118,7 @@ export class UnconnectedCodeEditor extends Component<CodeEditorProps, State> {
    * @param code the code to set in the editor
    * @param forcePrettify
    */
-  _codemirrorSetValue(code?: string, forcePrettify?: boolean) {
+  async _codemirrorSetValue(code?: string, forcePrettify?: boolean) {
     if (typeof code !== 'string') {
       console.warn('Code editor was passed non-string value', code);
       return;
@@ -1131,7 +1131,7 @@ export class UnconnectedCodeEditor extends Component<CodeEditorProps, State> {
       if (UnconnectedCodeEditor._isXML(mode)) {
         code = this._prettifyXML(code);
       } else if (UnconnectedCodeEditor._isJSON(mode)) {
-        code = this._prettifyJSON(code);
+        code = await this._prettifyJSON(code);
       } else {
         unreachable('attempted to prettify in a mode that should not support prettifying');
       }

--- a/packages/insomnia/src/ui/components/codemirror/lint/openapi.ts
+++ b/packages/insomnia/src/ui/components/codemirror/lint/openapi.ts
@@ -2,9 +2,9 @@ import CodeMirror from 'codemirror';
 
 import { initializeSpectral, isLintError } from '../../../../common/spectral';
 
-const spectral = initializeSpectral();
-
 CodeMirror.registerHelper('lint', 'openapi', async function(text) {
+
+  const spectral = await initializeSpectral();
   const results = (await spectral.run(text)).filter(isLintError);
 
   return results.map(result => ({

--- a/packages/insomnia/src/ui/components/markdown-preview.tsx
+++ b/packages/insomnia/src/ui/components/markdown-preview.tsx
@@ -1,6 +1,5 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
-import highlight from 'highlight.js/lib/common';
 import React, { FC, PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -70,12 +69,13 @@ class MarkdownPreviewInternal extends PureComponent<Props, State> {
     clickLink(e.target.getAttribute('href'));
   }
 
-  _highlightCodeBlocks() {
+  async _highlightCodeBlocks() {
     if (!this._preview) {
       return;
     }
 
     const el = ReactDOM.findDOMNode(this._preview);
+    const highlight = await import('highlight.js/lib/common');
 
     // @ts-expect-error -- TSCONVERSION
     for (const block of el.querySelectorAll('pre > code')) {
@@ -106,11 +106,11 @@ class MarkdownPreviewInternal extends PureComponent<Props, State> {
     this._compileMarkdown(nextProps.markdown);
   }
 
-  componentDidUpdate() {
+  async componentDidUpdate() {
     this._highlightCodeBlocks();
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     this._highlightCodeBlocks();
   }
 

--- a/packages/insomnia/src/ui/components/modals/request-render-error-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-render-error-modal.tsx
@@ -1,5 +1,4 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { JSONPath } from 'jsonpath-plus';
 import React, { PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
@@ -45,8 +44,9 @@ export class RequestRenderErrorModal extends PureComponent<{}, State> {
     this.modal?.hide();
   }
 
-  renderModalBody(request, error) {
+  async renderModalBody(request, error) {
     const fullPath = `Request.${error.path}`;
+    const { JSONPath } = await import('jsonpath-plus');
     const result = JSONPath({ json: request, path: `$.${error.path}` });
     const template = result && result.length ? result[0] : null;
     const locationLabel =

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -79,8 +79,6 @@ import { WrapperDesign } from './wrapper-design';
 import WrapperHome from './wrapper-home';
 import { WrapperUnitTest } from './wrapper-unit-test';
 
-const spectral = initializeSpectral();
-
 export type WrapperProps = AppProps & {
   handleActivateRequest: (activeRequestId: string) => void;
   handleSetSidebarFilter: (value: string) => Promise<void>;
@@ -250,6 +248,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
     // Handle switching away from the spec design activity. For this, we want to generate
     // requests that can be accessed from debug or test.
     // If there are errors in the spec, show the user a warning first
+    const spectral = await initializeSpectral();
     const results = (await spectral.run(activeApiSpec.contents)).filter(isLintError);
     if (activeApiSpec.contents && results && results.length) {
       showModal(AlertModal, {


### PR DESCRIPTION
inspired by https://www.electronjs.org/docs/latest/tutorial/performance#2-loading-and-running-code-too-soon

takes app bundle from 16mb to 12mb, by dynamically importing spectral, jwt-authentication, highlight.js and swagger-ui.

also removes `The vm module of Node.js is deprecated in the renderer process and will be removed.` (caused by spectral) warnings from renderer, until you open the design view.

Disadvantage is that problem with those packages now only show when the features are used rather than on app start. If we have e2e tests opening the designer that risk would be mitigated

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
