### PR TITLE
Fix incrementing npm package versions for pre-release revisions

### DIFF
--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -21,7 +21,7 @@ on:
       major-npm:
         required: false
         type: boolean
-        description: whether to increment the major version of the NPM packages or not
+        description: increment the major version of the NPM packages
         default: false
 
 env:
@@ -59,8 +59,13 @@ jobs:
       - name: Run bootstrap
         run: npm run bootstrap
 
-      - name: Lerna version
-        run: npm run version -- --preid "${{ github.event.inputs.channel }}" --yes "${{ github.event.inputs.channel != 'stable' && 'pre' || '' }}${{ github.event.inputs.major-npm != 'true' && 'minor' || 'major' }}"
+      - name: Lerna version (stable)
+        if: github.event.inputs.channel == 'stable'
+        run: npm run version -- --yes "${{ github.event.inputs.major-npm != 'true' && 'minor' || 'major' }}"
+
+      - name: Lerna version (alpha/beta)
+        if: github.event.inputs.channel != 'stable'
+        run: npm run version -- --yes --preid "${{ github.event.inputs.channel }}" "${{ github.event.inputs.iteration == '0' && (github.event.inputs.major-npm != 'true' && 'preminor' || 'premajor') || 'prerelease' }}"
 
       - name: Config version
         run: APP_VERSION="${{ env.RELEASE_VERSION }}" npm run app-bump-version

--- a/packages/insomnia/scripts/bumpVersion.ts
+++ b/packages/insomnia/scripts/bumpVersion.ts
@@ -23,7 +23,7 @@ export const start = async () => {
   const buildRef = process.env.BUILD_REF;
   if (buildRef) {
     // Ignore any existing semver prerelease/build tags
-    const cleanedVersion = packageConfig.version.match(/^(\d{4}\.\d+\.\d)/);
+    const cleanedVersion = packageConfig.version.match(/^(\d{4}\.\d+\.\d+)/);
     if (!cleanedVersion) {
       console.log('[build] Invalid version found in app config');
       process.exit(1);

--- a/scripts/changelog-image/changelog-image.ts
+++ b/scripts/changelog-image/changelog-image.ts
@@ -15,7 +15,7 @@ async function renderImage() {
 
   if (appConfigVersion.includes('beta')) {
     type = 'beta';
-    const appConfigRevision = appConfigVersion.match(/^\d{4}\.\d+\.\d-beta\.(\d+)/);
+    const appConfigRevision = appConfigVersion.match(/^\d{4}\.\d+\.\d+-beta\.(\d+)/);
     if (!appConfigRevision) {
       throw new Error('Invalid app version beta revision');
     }
@@ -25,7 +25,7 @@ async function renderImage() {
   }
 
   // Ignore any semver prerelease/build tags
-  const cleanedAppConfigVersion = appConfigVersion.match(type === 'major' ? /^(\d{4}\.\d+)/ : /^(\d{4}\.\d+\.\d)/);
+  const cleanedAppConfigVersion = appConfigVersion.match(type === 'major' ? /^(\d{4}\.\d+)/ : /^(\d{4}\.\d+\.\d+)/);
   if (!cleanedAppConfigVersion) {
     throw new Error('Invalid app version');
   }


### PR DESCRIPTION
By passing `prerelease` to `lerna version` for iterations greater then zero, which makes it correctly bump from `beta.0` to `beta.1` and similar.

Also fixes a bug in the bumpVersion/changelog-image version regexes.