### PR TITLE
Added error handling for github auth urls

### DIFF
--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
@@ -362,7 +362,7 @@ const GitHubSignInForm = ({ token }: GitHubSignInFormProps) => {
               try {
                 parsedURL = new URL(link);
               } catch (e) {
-                setError('It appears the URL that you entered is invalid');
+                setError('Invalid URL');
                 return;
               }
 

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
@@ -325,6 +325,7 @@ interface GitHubSignInFormProps {
 }
 
 const GitHubSignInForm = ({ token }: GitHubSignInFormProps) => {
+  const [error, setError] = useState('');
   const [authUrl, setAuthUrl] = useState(() => generateAuthorizationUrl());
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const dispatch = useDispatch();
@@ -361,8 +362,7 @@ const GitHubSignInForm = ({ token }: GitHubSignInFormProps) => {
               try {
                 parsedURL = new URL(link);
               } catch (e) {
-                // setError('It appears the URL that you entered is invalid');
-                console.error('Provided url is invalid');
+                setError('It appears the URL that you entered is invalid');
                 return;
               }
 
@@ -377,8 +377,7 @@ const GitHubSignInForm = ({ token }: GitHubSignInFormProps) => {
 
                 command(dispatch);
               } else {
-                // setError('It appears the URL that you entered is incomplete');
-                console.error('Provided url is missing code or state');
+                setError('It appears the URL that you entered is incomplete');
                 return;
               }
             }
@@ -393,6 +392,14 @@ const GitHubSignInForm = ({ token }: GitHubSignInFormProps) => {
               <Button name="add-token">Add</Button>
             </div>
           </label>
+          {error && (
+            <p className="notice error margin-bottom-sm">
+              <button className="pull-right icon" onClick={() => setError('')}>
+                <i className="fa fa-times" />
+              </button>
+              {error}
+            </p>
+          )}
         </form>
       )}
     </AuthorizationFormContainer>

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
@@ -369,17 +369,17 @@ const GitHubSignInForm = ({ token }: GitHubSignInFormProps) => {
               const code = parsedURL.searchParams.get('code');
               const state = parsedURL.searchParams.get('state');
 
-              if (typeof code === 'string' && typeof state === 'string') {
-                const command = newCommand(COMMAND_GITHUB_OAUTH_AUTHENTICATE, {
-                  code,
-                  state,
-                });
-
-                command(dispatch);
-              } else {
-                setError('It appears the URL that you entered is incomplete');
+              if (!(typeof code === 'string') || !(typeof state === 'string')) {
+                setError('Incomplete URL');
                 return;
               }
+
+              const command = newCommand(COMMAND_GITHUB_OAUTH_AUTHENTICATE, {
+                code,
+                state,
+              });
+
+              command(dispatch);
             }
           }}
         >

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
@@ -357,7 +357,15 @@ const GitHubSignInForm = ({ token }: GitHubSignInFormProps) => {
             const formData = new FormData(e.currentTarget);
             const link = formData.get('link');
             if (typeof link === 'string') {
-              const parsedURL = new URL(link);
+              let parsedURL: URL;
+              try {
+                parsedURL = new URL(link);
+              } catch (e) {
+                // setError('It appears the URL that you entered is invalid');
+                console.error('Provided url is invalid');
+                return;
+              }
+
               const code = parsedURL.searchParams.get('code');
               const state = parsedURL.searchParams.get('state');
 
@@ -368,14 +376,17 @@ const GitHubSignInForm = ({ token }: GitHubSignInFormProps) => {
                 });
 
                 command(dispatch);
+              } else {
+                // setError('It appears the URL that you entered is incomplete');
+                console.error('Provided url is missing code or state');
+                return;
               }
             }
           }}
         >
           <label className="form-control form-control--outlined">
             <div>
-              If you aren't redirected to the app you can manually paste your
-              code here:
+              If you aren't redirected to the app you can manually paste the authentication url here:
             </div>
             <div className="form-row">
               <input name="link" />


### PR DESCRIPTION
Changelog(Improvements): Improved error messages for Github Sync

I'm not sure how best show these errors to the user, but I feel that instead of these two `console.error`'s that I added there should be some kind of error modal or something like that, but I'm not sure how best to do that in this project