### PR TITLE
chore: add metrics tracking for design preview button

### DIFF
--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -84,9 +84,6 @@ export enum SegmentEvent {
  * ourselves to make product decisions
  */
 interface SegmentEventProperties {
-  /**
-   * a sub category of an event, useful for analytics querying
-   * */
   type: string;
 
   /**
@@ -95,7 +92,7 @@ interface SegmentEventProperties {
   action: string;
 
   /**
-   * any error message as a consequence of the event
+   * a description of an error that occured as a result of the user action
    * */
   error?: string;
 }

--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -76,7 +76,7 @@ export enum SegmentEvent {
   buttonClick = 'Button Clicked',
 }
 
-interface SegmentEventProperties {
+export interface SegmentEventProperties {
   /**
    * TODO: what do we mean by type?
    * */
@@ -93,15 +93,6 @@ interface SegmentEventProperties {
   error?: string;
 }
 
-export type BaseButtonAction = 'show' | 'hide';
-export function buildEventProperties<T extends string>(
-  type: string,
-  action: T,
-  error?: string
-): SegmentEventProperties {
-  return { type, action, error };
-}
-
 type PushPull = 'push' | 'pull';
 type VCSAction = PushPull | `force_${PushPull}` |
   'create_branch' | 'merge_branch' | 'delete_branch' | 'checkout_branch' |
@@ -112,7 +103,7 @@ export function vcsSegmentEventProperties(
   action: VCSAction,
   error?: string
 ): SegmentEventProperties {
-  return buildEventProperties<VCSAction>(type, action, error);
+  return { type, action, error };
 }
 
 interface QueuedSegmentEvent {

--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -73,6 +73,7 @@ export enum SegmentEvent {
   vcsSyncStart = 'VCS Sync Started',
   vcsSyncComplete = 'VCS Sync Completed',
   vcsAction = 'VCS Action Executed',
+  designOutputPreviewToggle = 'Design Output Preview Toggled',
 }
 
 type PushPull = 'push' | 'pull';

--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -76,8 +76,24 @@ export enum SegmentEvent {
   buttonClick = 'Button Clicked',
 }
 
-type PushPull = 'push' | 'pull';
+interface SegmentEventProperties {
+  /**
+   * TODO: what do we mean by type?
+   * */
+  type: string;
 
+  /**
+   * TODO: what do we mean by action?
+   * */
+  action: string;
+
+  /**
+   * TODO: what is this error for and where is it coming from?
+   * */
+  error?: string;
+}
+
+type PushPull = 'push' | 'pull';
 export function vcsSegmentEventProperties(
   type: 'git',
   action: PushPull | `force_${PushPull}` |
@@ -85,7 +101,24 @@ export function vcsSegmentEventProperties(
     'commit' | 'stage_all' | 'stage' | 'unstage_all' | 'unstage' | 'rollback' | 'rollback_all' |
     'update' | 'setup' | 'clone',
   error?: string
-) {
+): SegmentEventProperties {
+  return {
+    'type': type,
+    'action': action,
+    'error': error,
+  };
+}
+
+export enum BaseButtonEvent {
+  show = 'show',
+  hide = 'hide',
+}
+
+export function buildEventProperties<T extends string>(
+  type: string,
+  action: T,
+  error?: string
+): SegmentEventProperties {
   return {
     'type': type,
     'action': action,

--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -80,8 +80,7 @@ export enum SegmentEvent {
  * You may refer to this Segment API Document - https://segment.com/docs/connections/spec/track/#properties
  * to understand what 'event properties' is for.
  *
- * The following properties are custom defined attributes for our own metrics purpose to help
- * ourselves to make product decisions
+ * The following properties are custom defined attributes for our own metrics purpose to help ourselves to make product decisions
  */
 interface SegmentEventProperties {
   type: string;

--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -77,8 +77,7 @@ export enum SegmentEvent {
 }
 
 /**
- * You may refer to this Segment API Document - https://segment.com/docs/connections/spec/track/#properties
- * to understand what 'event properties' is for.
+ * You may refer to this Segment API Document - https://segment.com/docs/connections/spec/track/#properties to understand what 'event properties' is for.
  *
  * The following properties are custom defined attributes for our own metrics purpose to help ourselves to make product decisions
  */

--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -73,7 +73,7 @@ export enum SegmentEvent {
   vcsSyncStart = 'VCS Sync Started',
   vcsSyncComplete = 'VCS Sync Completed',
   vcsAction = 'VCS Action Executed',
-  designOutputPreviewToggle = 'Design Output Preview Toggled',
+  buttonClick = 'Button Clicked',
 }
 
 type PushPull = 'push' | 'pull';

--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -109,10 +109,7 @@ export function vcsSegmentEventProperties(
   };
 }
 
-export enum BaseButtonEvent {
-  show = 'show',
-  hide = 'hide',
-}
+export type BaseButtonEvent = 'show' | 'hide';
 
 export function buildEventProperties<T extends string>(
   type: string,

--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -76,19 +76,26 @@ export enum SegmentEvent {
   buttonClick = 'Button Clicked',
 }
 
-export interface SegmentEventProperties {
+/**
+ * You may refer to this Segment API Document - https://segment.com/docs/connections/spec/track/#properties
+ * to understand what 'event properties' is for.
+ *
+ * The following properties are custom defined attributes for our own metrics purpose to help
+ * ourselves to make product decisions
+ */
+interface SegmentEventProperties {
   /**
-   * TODO: what do we mean by type?
+   * a sub category of an event, useful for analytics querying
    * */
   type: string;
 
   /**
-   * TODO: what do we mean by action?
+   * a short description clarifying the specific action the user took
    * */
   action: string;
 
   /**
-   * TODO: what is this error for and where is it coming from?
+   * any error message as a consequence of the event
    * */
   error?: string;
 }

--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -93,34 +93,26 @@ interface SegmentEventProperties {
   error?: string;
 }
 
-type PushPull = 'push' | 'pull';
-export function vcsSegmentEventProperties(
-  type: 'git',
-  action: PushPull | `force_${PushPull}` |
-    'create_branch' | 'merge_branch' | 'delete_branch' | 'checkout_branch' |
-    'commit' | 'stage_all' | 'stage' | 'unstage_all' | 'unstage' | 'rollback' | 'rollback_all' |
-    'update' | 'setup' | 'clone',
-  error?: string
-): SegmentEventProperties {
-  return {
-    'type': type,
-    'action': action,
-    'error': error,
-  };
-}
-
-export type BaseButtonEvent = 'show' | 'hide';
-
+export type BaseButtonAction = 'show' | 'hide';
 export function buildEventProperties<T extends string>(
   type: string,
   action: T,
   error?: string
 ): SegmentEventProperties {
-  return {
-    'type': type,
-    'action': action,
-    'error': error,
-  };
+  return { type, action, error };
+}
+
+type PushPull = 'push' | 'pull';
+type VCSAction = PushPull | `force_${PushPull}` |
+  'create_branch' | 'merge_branch' | 'delete_branch' | 'checkout_branch' |
+  'commit' | 'stage_all' | 'stage' | 'unstage_all' | 'unstage' | 'rollback' | 'rollback_all' |
+  'update' | 'setup' | 'clone';
+export function vcsSegmentEventProperties(
+  type: 'git',
+  action: VCSAction,
+  error?: string
+): SegmentEventProperties {
+  return buildEventProperties<VCSAction>(type, action, error);
 }
 
 interface QueuedSegmentEvent {

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -57,7 +57,7 @@ const RenderPageHeader: FC<Pick<Props,
       {
         type: 'user_event',
         action: `preview_button_click__previewHidden_${!previewHidden}`,
-        previewHidden: !previewHidden,
+        location: 'wrapper-design',
       });
   }, [activeWorkspace, previewHidden]);
 

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -52,7 +52,13 @@ const RenderPageHeader: FC<Pick<Props,
     const workspaceId = activeWorkspace._id;
     await models.workspaceMeta.updateByParentId(workspaceId, { previewHidden: !previewHidden });
 
-    trackSegmentEvent(SegmentEvent.designOutputPreviewToggle, { previewHidden: !previewHidden });
+    trackSegmentEvent(
+      SegmentEvent.buttonClick,
+      {
+        type: 'user_event',
+        action: `preview_button_click__previewHidden_${!previewHidden}`,
+        previewHidden: !previewHidden,
+      });
   }, [activeWorkspace, previewHidden]);
 
   return (

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -6,7 +6,12 @@ import { useAsync } from 'react-use';
 import styled from 'styled-components';
 import SwaggerUI from 'swagger-ui-react';
 
-import { BaseButtonEvent, buildEventProperties, SegmentEvent, trackSegmentEvent } from '../../common/analytics';
+import {
+  BaseButtonAction,
+  buildEventProperties,
+  SegmentEvent,
+  trackSegmentEvent,
+} from '../../common/analytics';
 import { parseApiSpec, ParsedApiSpec } from '../../common/api-specs';
 import { debounce } from '../../common/misc';
 import { initializeSpectral, isLintError } from '../../common/spectral';
@@ -52,7 +57,7 @@ const RenderPageHeader: FC<Pick<Props,
     const workspaceId = activeWorkspace._id;
     await models.workspaceMeta.updateByParentId(workspaceId, { previewHidden: !previewHidden });
 
-    const eventProperties = buildEventProperties<BaseButtonEvent>('design preview toggle', previewHidden ? 'show' : 'hide');
+    const eventProperties = buildEventProperties<BaseButtonAction>('design preview toggle', previewHidden ? 'show' : 'hide');
     trackSegmentEvent(SegmentEvent.buttonClick, eventProperties);
   }, [activeWorkspace, previewHidden]);
 

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -6,7 +6,7 @@ import { useAsync } from 'react-use';
 import styled from 'styled-components';
 import SwaggerUI from 'swagger-ui-react';
 
-import { SegmentEvent, trackSegmentEvent } from '../../common/analytics';
+import { BaseButtonEvent, buildEventProperties, SegmentEvent, trackSegmentEvent } from '../../common/analytics';
 import { parseApiSpec, ParsedApiSpec } from '../../common/api-specs';
 import { debounce } from '../../common/misc';
 import { initializeSpectral, isLintError } from '../../common/spectral';
@@ -14,7 +14,7 @@ import * as models from '../../models/index';
 import { superFaint } from '../css/css-in-js';
 import previewIcon from '../images/icn-eye.svg';
 import { selectActiveApiSpec, selectActiveWorkspace, selectActiveWorkspaceMeta } from '../redux/selectors';
-import { CodeEditor,  UnconnectedCodeEditor } from './codemirror/code-editor';
+import { CodeEditor, UnconnectedCodeEditor } from './codemirror/code-editor';
 import { DesignEmptyState } from './design-empty-state';
 import { ErrorBoundary } from './error-boundary';
 import { PageLayout } from './page-layout';
@@ -52,13 +52,8 @@ const RenderPageHeader: FC<Pick<Props,
     const workspaceId = activeWorkspace._id;
     await models.workspaceMeta.updateByParentId(workspaceId, { previewHidden: !previewHidden });
 
-    trackSegmentEvent(
-      SegmentEvent.buttonClick,
-      {
-        type: 'user_event',
-        action: `preview_button_click__previewHidden_${!previewHidden}`,
-        location: 'wrapper-design',
-      });
+    const eventProperties = buildEventProperties<BaseButtonEvent>('design preview toggle', previewHidden ? BaseButtonEvent.show : BaseButtonEvent.hide);
+    trackSegmentEvent(SegmentEvent.buttonClick, eventProperties);
   }, [activeWorkspace, previewHidden]);
 
   return (

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -10,6 +10,7 @@ import {
   BaseButtonAction,
   buildEventProperties,
   SegmentEvent,
+  SegmentEventProperties,
   trackSegmentEvent,
 } from '../../common/analytics';
 import { parseApiSpec, ParsedApiSpec } from '../../common/api-specs';
@@ -57,8 +58,10 @@ const RenderPageHeader: FC<Pick<Props,
     const workspaceId = activeWorkspace._id;
     await models.workspaceMeta.updateByParentId(workspaceId, { previewHidden: !previewHidden });
 
-    const eventProperties = buildEventProperties<BaseButtonAction>('design preview toggle', previewHidden ? 'show' : 'hide');
-    trackSegmentEvent(SegmentEvent.buttonClick, eventProperties);
+    trackSegmentEvent(SegmentEvent.buttonClick, {
+      type: 'design preview toggle',
+      action: previewHidden ? 'show' : 'hide',
+    });
   }, [activeWorkspace, previewHidden]);
 
   return (

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -6,13 +6,7 @@ import { useAsync } from 'react-use';
 import styled from 'styled-components';
 import SwaggerUI from 'swagger-ui-react';
 
-import {
-  BaseButtonAction,
-  buildEventProperties,
-  SegmentEvent,
-  SegmentEventProperties,
-  trackSegmentEvent,
-} from '../../common/analytics';
+import { SegmentEvent, trackSegmentEvent } from '../../common/analytics';
 import { parseApiSpec, ParsedApiSpec } from '../../common/api-specs';
 import { debounce } from '../../common/misc';
 import { initializeSpectral, isLintError } from '../../common/spectral';

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -52,7 +52,7 @@ const RenderPageHeader: FC<Pick<Props,
     const workspaceId = activeWorkspace._id;
     await models.workspaceMeta.updateByParentId(workspaceId, { previewHidden: !previewHidden });
 
-    const eventProperties = buildEventProperties<BaseButtonEvent>('design preview toggle', previewHidden ? BaseButtonEvent.show : BaseButtonEvent.hide);
+    const eventProperties = buildEventProperties<BaseButtonEvent>('design preview toggle', previewHidden ? 'show' : 'hide');
     trackSegmentEvent(SegmentEvent.buttonClick, eventProperties);
   }, [activeWorkspace, previewHidden]);
 

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -6,6 +6,7 @@ import { useAsync } from 'react-use';
 import styled from 'styled-components';
 import SwaggerUI from 'swagger-ui-react';
 
+import { SegmentEvent, trackSegmentEvent } from '../../common/analytics';
 import { parseApiSpec, ParsedApiSpec } from '../../common/api-specs';
 import { debounce } from '../../common/misc';
 import { initializeSpectral, isLintError } from '../../common/spectral';
@@ -50,6 +51,8 @@ const RenderPageHeader: FC<Pick<Props,
 
     const workspaceId = activeWorkspace._id;
     await models.workspaceMeta.updateByParentId(workspaceId, { previewHidden: !previewHidden });
+
+    trackSegmentEvent(SegmentEvent.designOutputPreviewToggle, { previewHidden: !previewHidden });
   }, [activeWorkspace, previewHidden]);
 
   return (


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

We would like to make better designs with more metrics in some area of this project. We need to add tracking logic to this button click event.
- added trackSegmentEvent in wrapper-design.tsx
- added a new enum key in analytics.ts