### PR TITLE
[DRAFT] Add ability to build deb files on aarch64

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -24,6 +24,10 @@ jobs:
         - uses: uraimo/run-on-arch-action@v2
           with:
             run: uname -a
+
+        - name: Install updated fpm
+          run: sudo apt-get install ruby-dev build-essential && sudo gem i fpm -f
+
         - uses: actions/checkout@v3
           name: Checkout branch
 
@@ -47,12 +51,12 @@ jobs:
             echo "INSO_VERSION=$(jq .version packages/insomnia-inso/package.json -rj)" >> $GITHUB_ENV
 
         - name: Package inso
-          run: npm run inso-package
+          run: USE_SYSTEM_FPM=true npm run inso-package
           env:
             VERSION: ${{ env.INSO_VERSION }}
 
         - name: Create inso artifacts
-          run: npm run inso-package:artifacts
+          run: USE_SYSTEM_FPM=true npm run inso-package:artifacts
 
         - name: Upload artifacts
           uses: actions/upload-artifact@v3

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,9 +21,11 @@ jobs:
               csc_link_secret: ''
               csc_key_password_secret: ''
       steps:
-        - name: Checkout branch
-          uses: uraimo/run-on-arch-action@v2
-          uses: actions/checkout@v3
+        - uses: uraimo/run-on-arch-action@v2
+          with:
+            run: uname -a
+        - uses: actions/checkout@v3
+          name: Checkout branch
 
         - name: Setup Node
           uses: actions/setup-node@v3

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -10,6 +10,69 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  name: Release Build
+
+on:
+  push:
+    branches:
+      - 'release/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-upload-release-artifacts-aarch64:
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          include:
+            - arch: aarch64
+              distro: ubuntu_latest
+              csc_link_secret: ''
+              csc_key_password_secret: ''
+      steps:
+        - name: Checkout branch
+          uses: uraimo/run-on-arch-action@v2
+          uses: actions/checkout@v3
+
+        - name: Setup Node
+          uses: actions/setup-node@v3
+          with:
+            node-version-file: '.nvmrc'
+
+        - name: Bootstrap packages
+          run: npm run bootstrap
+
+        - name: Package app
+          shell: bash
+          run: npm run app-package
+          env:
+            CSC_LINK: ${{ matrix.csc_link_secret != '' && secrets[matrix.csc_link_secret] || '' }}
+            CSC_KEY_PASSWORD: ${{ matrix.csc_key_password_secret != '' && secrets[matrix.csc_key_password_secret] || ''  }}
+
+        - name: Setup Inso CLI version env var
+          run:
+            echo "INSO_VERSION=$(jq .version packages/insomnia-inso/package.json -rj)" >> $GITHUB_ENV
+
+        - name: Package inso
+          run: npm run inso-package
+          env:
+            VERSION: ${{ env.INSO_VERSION }}
+
+        - name: Create inso artifacts
+          run: npm run inso-package:artifacts
+
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v3
+          with:
+            if-no-files-found: ignore
+            name: ${{ matrix.os }}-${{matrix.arch}}-artifacts
+            path: |
+              packages/insomnia/dist/*.deb
+              
+              
   build-and-upload-release-artifacts:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -11,17 +11,6 @@ concurrency:
 
 jobs:
   name: Release Build
-
-on:
-  push:
-    branches:
-      - 'release/**'
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-jobs:
   build-and-upload-release-artifacts-aarch64:
       runs-on: ubuntu-latest
       strategy:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -10,7 +10,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  name: Release Build
   build-and-upload-release-artifacts-aarch64:
       runs-on: ubuntu-latest
       strategy:

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -49,7 +49,7 @@ jobs:
 
         - name: Package
           shell: bash
-          run: USE_SYSTEM_FPM=true BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
+          run: uname -a && USE_SYSTEM_FPM=true BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
 
         - name: Upload artifacts
           uses: actions/upload-artifact@v3

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -45,8 +45,11 @@ jobs:
               curl -sL https://deb.nodesource.com/setup_16.x  | bash -
               apt install -y nodejs
               gem i fpm -f
+              npm install -g npm@latest
             run: |
               cd /app
+              npm install -g n
+              n `cat .nvmrc`
               npm install
               chown -R 1001:121 "/root/.npm"
               npm run bootstrap

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -47,6 +47,7 @@ jobs:
               gem i fpm -f
             run: |
               cd /app
+              npm install
               chown -R 1001:121 "/root/.npm"
               npm run bootstrap
               BUILD_REF="$(git rev-parse --short HEAD)${{ github.event_name == 'pull_request' && '.pr-$PR_NUMBER' || '' }}" npm run app-bump-version

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -28,7 +28,7 @@ jobs:
       steps:
         - uses: uraimo/run-on-arch-action@v2
           with:
-            run: echo "we are here"
+            run: uname -a
         - uses: actions/checkout@v3
           name: Checkout branch
 

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -26,31 +26,23 @@ jobs:
               build-targets: "deb"
               os: ubuntu-latest
       steps:
-        - uses: uraimo/run-on-arch-action@v2
-          with:
-            run: uname -a
-        - name: Install updated fpm
-          run: sudo apt-get install ruby-dev build-essential && sudo gem i fpm -f
-          
         - uses: actions/checkout@v3
           name: Checkout branch
-
         - name: Setup Node
           uses: actions/setup-node@v3
           with:
             node-version-file: '.nvmrc'
-
-        - name: Bootstrap packages
-          run: npm run bootstrap
-
-        - name: Bump version
-          shell: bash
-          run: BUILD_REF="$(git rev-parse --short HEAD)${{ github.event_name == 'pull_request' && '.pr-$PR_NUMBER' || '' }}" npm run app-bump-version
-
-        - name: Package
-          shell: bash
-          run: uname -a && USE_SYSTEM_FPM=true BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
-
+            arch: aarch64
+            
+        - uses: uraimo/run-on-arch-action@v2
+          with:
+            run: |
+              #install fpm
+              sudo apt-get install ruby-dev build-essential && sudo gem i fpm -f
+              npm run bootstrap
+              BUILD_REF="$(git rev-parse --short HEAD)${{ github.event_name == 'pull_request' && '.pr-$PR_NUMBER' || '' }}" npm run app-bump-version
+              USE_SYSTEM_FPM=true BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
+              
         - name: Upload artifacts
           uses: actions/upload-artifact@v3
           with:

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -29,6 +29,9 @@ jobs:
         - uses: uraimo/run-on-arch-action@v2
           with:
             run: uname -a
+        - name: Install updated fpm
+          run: sudo apt-get install ruby-dev build-essential && sudo gem i fpm -f
+          
         - uses: actions/checkout@v3
           name: Checkout branch
 
@@ -46,7 +49,7 @@ jobs:
 
         - name: Package
           shell: bash
-          run: BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
+          run: USE_SYSTEM_FPM=true BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
 
         - name: Upload artifacts
           uses: actions/upload-artifact@v3

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -27,6 +27,8 @@ jobs:
               os: ubuntu-latest
       steps:
         - uses: uraimo/run-on-arch-action@v2
+          with:
+            run: echo "we are here"
         - uses: actions/checkout@v3
           name: Checkout branch
 

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -15,6 +15,45 @@ concurrency:
 env:
   PR_NUMBER: ${{ github.event.number }}
 jobs:
+  build-and-upload-release-artifacts-aarch64:
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          include:
+            - arch: aarch64
+              distro: ubuntu_latest
+              build-targets: "deb"
+              os: ubuntu-latest
+      steps:
+        - uses: uraimo/run-on-arch-action@v2
+        - uses: actions/checkout@v3
+          name: Checkout branch
+
+        - name: Setup Node
+          uses: actions/setup-node@v3
+          with:
+            node-version-file: '.nvmrc'
+
+        - name: Bootstrap packages
+          run: npm run bootstrap
+
+        - name: Bump version
+          shell: bash
+          run: BUILD_REF="$(git rev-parse --short HEAD)${{ github.event_name == 'pull_request' && '.pr-$PR_NUMBER' || '' }}" npm run app-bump-version
+
+        - name: Package
+          shell: bash
+          run: BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
+
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v3
+          with:
+            if-no-files-found: ignore
+            name: ${{ matrix.os }}-${{matrix.arch}}-artifacts-${{ github.run_number }}
+            path: |
+              packages/insomnia/dist/*.deb
+
   build-and-upload-artifacts:
     # Skip jobs for release PRs
     if: "!startsWith(github.head_ref, 'release/')"

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -28,21 +28,28 @@ jobs:
       steps:
         - uses: actions/checkout@v3
           name: Checkout branch
-        - name: Setup Node
-          uses: actions/setup-node@v3
-          with:
-            node-version-file: '.nvmrc'
-            arch: aarch64
-            
         - uses: uraimo/run-on-arch-action@v2
+          name: setup aarch container
           with:
+            arch: ${{ matrix.arch }}
+            distro: ${{ matrix.distro }}
+            # Not required, but speeds up builds
+            githubToken: ${{ github.token }}
+            shell: /bin/sh
+            # Mount the artifacts directory as /artifacts in the container
+            dockerRunArgs: |
+              --volume \"${PWD}:/app\"
+            install: |
+              apt update
+              apt install -y curl ruby-dev build-essential
+              curl -sL https://deb.nodesource.com/setup_16.x  | bash -
+              apt install -y nodejs
+              gem i fpm -f
             run: |
-              #install fpm
-              sudo apt-get install ruby-dev build-essential && sudo gem i fpm -f
+              cd /app
               npm run bootstrap
               BUILD_REF="$(git rev-parse --short HEAD)${{ github.event_name == 'pull_request' && '.pr-$PR_NUMBER' || '' }}" npm run app-bump-version
               USE_SYSTEM_FPM=true BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
-              
         - name: Upload artifacts
           uses: actions/upload-artifact@v3
           with:

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -48,10 +48,10 @@ jobs:
               npm install -g npm@latest
             run: |
               cd /app
+              npm config set -g user=`whoami`
               npm install -g n
               n `cat .nvmrc`
               npm install
-              chown -R 1001:121 "/root/.npm"
               npm run bootstrap
               BUILD_REF="$(git rev-parse --short HEAD)${{ github.event_name == 'pull_request' && '.pr-$PR_NUMBER' || '' }}" npm run app-bump-version
               USE_SYSTEM_FPM=true BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -47,6 +47,7 @@ jobs:
               gem i fpm -f
             run: |
               cd /app
+              chown -R 1001:121 "/root/.npm"
               npm run bootstrap
               BUILD_REF="$(git rev-parse --short HEAD)${{ github.event_name == 'pull_request' && '.pr-$PR_NUMBER' || '' }}" npm run app-bump-version
               USE_SYSTEM_FPM=true BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package


### PR DESCRIPTION
This PR is a draft. 

I was able to add support of aarch64 containers for building the sources but I do not know how to add arm64 arch for building the packages.

Due to the logs of github actions it still builds x64 on aarch64

I need help with this.

I've checked out the insomnia on my ubuntu 20.04 ARM and ran it through ```npm run dev```. Everything seems to be ok. 
Maybe someone could advise better solution for building the arm version of snap or deb files? Would be great