### PR TITLE
add react-router and split on activity paths

### DIFF
--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -187,6 +187,7 @@
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.12.1",
     "react-redux": "^7.2.6",
+    "react-router-dom": "^6.3.0",
     "react-sortable-hoc": "^2.0.0",
     "react-tabs": "^3.2.3",
     "react-use": "^17.2.4",

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -348,4 +348,4 @@ const mapStateToProps = (state: RootState) => ({
   sidebarFilter: selectSidebarFilter(state),
 });
 
-export const WrapperDebug = connect(mapStateToProps)(UnconnectedWrapperDebug);
+export default connect(mapStateToProps)(UnconnectedWrapperDebug);

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -337,3 +337,5 @@ export const WrapperDesign: FC<Props> = ({
     />
   );
 };
+
+export default WrapperDesign;

--- a/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
@@ -595,3 +595,5 @@ const mapStateToProps = (state: RootState) => ({
 });
 
 export const WrapperUnitTest = connect(mapStateToProps)(UnconnectedWrapperUnitTest);
+
+export default WrapperUnitTest;

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -14,6 +14,7 @@ import { applyColorScheme } from '../plugins/misc';
 import App from './containers/app';
 import { init as initStore } from './redux/modules';
 import { initializeSentry } from './sentry';
+import { MemoryRouter as Router } from 'react-router-dom';
 
 import './css/index.less'; // this import must come after `App`.  the reason is not yet known.
 
@@ -42,7 +43,9 @@ document.title = getProductName();
   const render = App => {
     ReactDOM.render(
       <Provider store={store}>
-        <App />
+        <Router>
+          <App />
+        </Router>
       </Provider>,
       document.getElementById('root'),
     );


### PR DESCRIPTION
Adds react-router and uses the `activity` as initial paths to render routes and code-split.

Some learnings:
- Not having to evaluate all the code in initialisation cuts ~20% of startup time in initial tests I ran from ~5s to 3.5-4s depending on the initial route.
- We can incrementally add more splitting and routes to cut more unused code from being initialised so this can improve even more.
- The current paths are based on the activity kept in redux state (home/debug/design/test). We should move these navigations to `<Link to="..."/>` components and `const navigate = useNavigate()` hook usage. We might need to untangle some state management that has to do with navigation from redux also e.g. tracking events and other reducers that "listen" on the activity changing.
- Preloading works but can be done better and automatically once we come with conventions around app routing and data loading in the app
- Suspense shows an empty div to keep the same loading experience that we have now but it opens up the door to introduce loading/skeleton views for when things take time. Again this should go hand in hand with the data loading abstraction we use.
- Lazy expects a default export and the
https://github.com/reactjs/rfcs/pull/64#issuecomment-431507924 seems to be that react will use the module information for optimisations in next versions. The same is true for bundlers (e.g. vite) that use the module info to preload other modules ahead of time and code splitting.


changelog(Improvements): Improved Insomnia's startup time