### PR TITLE
always show debug oauth2 request timeline button

### DIFF
--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -417,7 +417,7 @@ const OAuth2Error: FC = () => {
       </div>
     );
   }
-  return null;
+  return debugButton;
 };
 
 const useActiveOAuth2Token = () => {


### PR DESCRIPTION
_if this doesn't get the award for "best one-liner" I don't know what will, haha_

## Context

When you do OAuth2 "stuff" (in general) there are separate out-of-band calls that happen sometimes, for example to a `/token` endpoint to fetch your token.  Of course, when using OAuth2 Authentication in Insomnia, Insomnia handles this for you.  Great!

What's not great, though, is that you can't actually _see_ that request.  If you look at the timeline you see the timeline for the request corresponding to what's in your URL bar, which in this example is `/client-credentials`.

![Screenshot_20220510_164927](https://user-images.githubusercontent.com/15232461/167719396-73345300-2249-4251-92e9-47de950e9d36.png)

## The behavior before this PR

Today [on the stream](https://youtu.be/n5nsA_fJ4vI?t=432) we were debugging https://github.com/Kong/insomnia/issues/4715 but had a pretty hard time because prior to now, you could not see successful requests to the `/token` endpoint and the bug we were looking into related to this OAuth-specific request.  Hilariously, the stream is a good example of exactly the kind of problems our users face when trying to debug such things on their own.

However, we located something of an escape hatch.  You see, when you have an _error_ in a request, just recently we added the functionality to see the timeline for the error.

It looks like this:
![Screenshot_20220510_164206](https://user-images.githubusercontent.com/15232461/167748331-6641ca6b-2904-42bf-b537-da5aa598f93a.png)

## What this PR changes

To solve this, we tried (and failed at a few things), but eventually noticed that if we simply render the button at all times, it will correctly show the `/token` request whenever it has been made (including if it's cached) and not otherwise.

Notice the button on the `AFTER` that reads "Response Timeline"
| BEFORE | AFTER |
| - | - |
| ![Screenshot_20220510_164148](https://user-images.githubusercontent.com/15232461/167748471-16e8a3b4-eed0-4328-9755-b8147127c0ed.png) | ![Screenshot_20220510_164130](https://user-images.githubusercontent.com/15232461/167748418-a416c731-9cd1-4e96-8d69-30a322ff63fb.png) |

While from a code perspective this is a pretty minor (literal one line) change... this has pretty cool implications for users trying to investigate the OAuth calls that Insomnia makes.

The result of this is that when a user clicks this new (now, always present) button, they can see the full timeline whenever they wish:

![Screenshot_20220510_210641](https://user-images.githubusercontent.com/15232461/167748777-eaec4e08-a10d-4dd8-9470-1e2c7cd93ed2.png)

changelog(Improvements): adds a "Response Timeline" so that now you can see a raw timeline output of all OAuth 2 token requests