### PR TITLE
chore: skip build:sr in bootstrap and app-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "publish": "lerna publish from-package",
     "clean": "lerna run clean --parallel --stream && lerna clean --yes && rimraf node_modules **/*.tsbuildinfo",
     "test": "lerna run --stream --parallel test",
-    "inso-start": "npm start --prefix packages/insomnia-inso",
+    "inso-start": "npm run build:sr --prefix packages/insomnia && npm start --prefix packages/insomnia-inso",
     "inso-package": "npm run build:sr --prefix packages/insomnia && npm run package --prefix packages/insomnia-inso",
     "inso-package:artifacts": "npm run artifacts --prefix packages/insomnia-inso",
     "watch:app": "npm run build:main.min.js --prefix packages/insomnia && npm run start:dev-server --prefix packages/insomnia",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -17,9 +17,8 @@
   "author": "Kong <office@konghq.com>",
   "main": "src/main.min.js",
   "scripts": {
-    "bootstrap": "npm run build:sr",
     "prebuild": "npm run clean",
-    "build": "npm run build:sr && npm run build:app",
+    "build": "npm run build:app",
     "build:app": "esr --cache ./scripts/build.ts --noErrorTruncation",
     "build:main.min.js": "cross-env NODE_ENV=development esr esbuild.main.ts",
     "build:sr": "concurrently --names sr:source,sr:types \"npm run build:sr:source\" \"npm run build:sr:types\"",


### PR DESCRIPTION
Motivation: we build send-request unnecessarily in bootstrap. This would save some time.
This PR moves send-request build (`build:sr`) triggering out of bootstrapping and app build, to just inso dx and inso packaging. This change helps send-request from interfering with the insomnia app dx happy path, while still ensuring it runs in documented dx's.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
