### PR TITLE
Setting rendering purpose in oauth2 for plugins

### DIFF
--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -2,6 +2,9 @@ import React, { ChangeEvent, FC, ReactNode, useCallback, useMemo, useState } fro
 import { useSelector } from 'react-redux';
 
 import { convertEpochToMilliseconds, toKebabCase } from '../../../../common/misc';
+import {
+  RENDER_PURPOSE_SEND,
+} from '../../../../common/render';
 import accessTokenUrls from '../../../../datasets/access-token-urls';
 import authorizationUrls from '../../../../datasets/authorization-urls';
 import * as models from '../../../../models';
@@ -439,7 +442,7 @@ const useActiveOAuth2Token = () => {
     setLoading(true);
 
     try {
-      const renderedAuthentication = await handleRender(authentication);
+      const renderedAuthentication = await handleRender(authentication, null, RENDER_PURPOSE_SEND);
       await getAccessToken(requestId, renderedAuthentication, true);
       setLoading(false);
     } catch (err) {


### PR DESCRIPTION
Closes #4778

## Context
When you are trying to use the plugin `insomnia-plugin-keepass` to get the client secret for the oauth2 token refresh, the body of the request will contain the rendered text used in the UI, e.g. `KeepassXC - password of https://example.edu` instead of the actual secret. This is because in contrast to the API call, during oauth2 the RenderPurpose is not set and passed on to any plugin.

## What this PR changes
This is a quick fix, adding an optional parameter of type RenderPurpose to `use-nunjucks.handleRender` and sets it to 'send' during oauth2 token refresh.


