### PR TITLE
chore(deps) @jest/globals for insomnia

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bootstrap": "npm install && lerna bootstrap && lerna run --stream bootstrap",
     "version": "lerna version",
     "publish": "lerna publish from-package",
-    "clean": "lerna run clean --parallel --stream && lerna clean --yes && rimraf node_modules",
+    "clean": "lerna run clean --parallel --stream && lerna clean --yes && rimraf node_modules **/*.tsbuildinfo",
     "test": "lerna run --stream --parallel test",
     "inso-start": "npm start --prefix packages/insomnia-inso",
     "inso-package": "npm run build:sr --prefix packages/insomnia && npm run package --prefix packages/insomnia-inso",

--- a/packages/insomnia-inso/src/__mocks__/util.ts
+++ b/packages/insomnia-inso/src/__mocks__/util.ts
@@ -1,5 +1,9 @@
-// eslint-disable-next-line filenames/match-exported
-const mod = jest.requireActual('../util');
-mod.exit = jest.fn();
+import { jest } from '@jest/globals';
 
-module.exports = mod;
+import * as utilOriginal from '../util';
+
+// eslint-disable-next-line filenames/match-exported
+const util = jest.requireActual('../util') as typeof utilOriginal;
+util.exit = jest.fn();
+
+module.exports = util;

--- a/packages/insomnia-inso/src/commands/__mocks__/openapi-2-kong.ts
+++ b/packages/insomnia-inso/src/commands/__mocks__/openapi-2-kong.ts
@@ -1,5 +1,8 @@
+import { jest } from '@jest/globals';
+import openapi2Kong from 'openapi-2-kong';
+
 module.exports = {
-  ...jest.requireActual('openapi-2-kong'),
+  ...jest.requireActual('openapi-2-kong') as typeof openapi2Kong,
   generate: jest.fn(),
   generateFromString: jest.fn(),
 };

--- a/packages/insomnia-inso/src/data-directory.test.ts
+++ b/packages/insomnia-inso/src/data-directory.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { getAppDataDir } from './data-directory';
 
 jest.mock('os', () => ({
-  ...jest.requireActual('os') as unknown as typeof os,
+  ...jest.requireActual('os') as typeof os,
   homedir: (): string => 'homedir',
 }));
 

--- a/packages/insomnia-inso/src/db/__mocks__/index.ts
+++ b/packages/insomnia-inso/src/db/__mocks__/index.ts
@@ -1,5 +1,9 @@
+import { jest } from '@jest/globals';
+
+import * as dbOriginal from '../index';
+
 // eslint-disable-next-line filenames/match-exported
-const db = jest.requireActual('../index');
-const database = db.emptyDb();
-db.loadDb = jest.fn().mockResolvedValue(database);
-module.exports = db;
+const index = jest.requireActual('../index') as typeof dbOriginal;
+const database = index.emptyDb();
+index.loadDb = jest.fn().mockResolvedValue(database);
+module.exports = index;

--- a/packages/insomnia-inso/src/mocha.d.ts
+++ b/packages/insomnia-inso/src/mocha.d.ts
@@ -1,7 +1,0 @@
-declare namespace Mocha {
-  interface TestFunction {
-    // This is a hack until we can get rid of Mocha entirely from `insomnia-testing`.
-    // Until then, both declare global types which will always conflict and we need to do something like this to backport compatability.
-    each: jest.Each;
-  }
-}

--- a/packages/insomnia-smoke-test/package-lock.json
+++ b/packages/insomnia-smoke-test/package-lock.json
@@ -17,7 +17,6 @@
 				"@types/express": "^4.17.11",
 				"@types/faker": "^5.5.5",
 				"@types/mkdirp": "^1.0.1",
-				"@types/mocha": "^8.2.1",
 				"@types/oidc-provider": "^7.8.1",
 				"@types/ramda": "^0.27.45",
 				"@types/uuid": "^8.3.4",
@@ -2798,12 +2797,6 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/mocha": {
-			"version": "8.2.3",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
-			"integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
-			"dev": true
 		},
 		"node_modules/@types/node": {
 			"version": "14.0.27",
@@ -9708,12 +9701,6 @@
 			"requires": {
 				"@types/node": "*"
 			}
-		},
-		"@types/mocha": {
-			"version": "8.2.3",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
-			"integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
-			"dev": true
 		},
 		"@types/node": {
 			"version": "14.0.27",

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -35,7 +35,6 @@
     "@types/express": "^4.17.11",
     "@types/faker": "^5.5.5",
     "@types/mkdirp": "^1.0.1",
-    "@types/mocha": "^8.2.1",
     "@types/oidc-provider": "^7.8.1",
     "@types/ramda": "^0.27.45",
     "@types/uuid": "^8.3.4",

--- a/packages/insomnia/src/__mocks__/@grpc/grpc-js.ts
+++ b/packages/insomnia/src/__mocks__/@grpc/grpc-js.ts
@@ -1,5 +1,8 @@
+import grpcJSOriginal from '@grpc/grpc-js';
+import { jest } from '@jest/globals';
 import { EventEmitter } from 'events';
-const grpcJs = jest.requireActual('@grpc/grpc-js');
+
+const grpcJs = jest.requireActual('@grpc/grpc-js') as typeof grpcJSOriginal;
 
 const mockCallWrite = jest.fn();
 const mockCallEnd = jest.fn();

--- a/packages/insomnia/src/__mocks__/electron.ts
+++ b/packages/insomnia/src/__mocks__/electron.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { EventEmitter } from 'events';
 import mkdirp from 'mkdirp';
 import os from 'os';

--- a/packages/insomnia/src/__mocks__/isomorphic-git.ts
+++ b/packages/insomnia/src/__mocks__/isomorphic-git.ts
@@ -1,11 +1,11 @@
+import { jest } from '@jest/globals';
+import isomorphicGitOriginal from 'isomorphic-git';
+
 // eslint-disable-next-line filenames/match-exported
-const git = jest.requireActual('isomorphic-git');
-const mock = jest.genMockFromModule('isomorphic-git');
+const git = jest.requireActual('isomorphic-git') as typeof isomorphicGitOriginal;
+const mock = jest.createMockFromModule('isomorphic-git') as typeof isomorphicGitOriginal;
 
-// @ts-expect-error -- TSCONVERSION
 git.push = mock.push;
-
-// @ts-expect-error -- TSCONVERSION
 git.clone = mock.clone;
 
 // WARNING: changing this to `export default` will break the mock and be incredibly hard to debug. Ask me how I know.

--- a/packages/insomnia/src/__mocks__/node-forge.ts
+++ b/packages/insomnia/src/__mocks__/node-forge.ts
@@ -1,7 +1,6 @@
 /*
  * This is a stupid little mock that basically disabled encryption.
- * The reason it is needed is because the Forge module loader doesn't
- * play along with Jest.
+ * The reason it is needed is because the Forge module loader doesn't play along with Jest.
  */
 import forge from '../../node_modules/node-forge/lib/index';
 

--- a/packages/insomnia/src/__tests__/install.test.ts
+++ b/packages/insomnia/src/__tests__/install.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
 import { containsOnlyDeprecationWarnings, isDeprecatedDependencies } from '../plugins/install';
 
 describe('install.js', () => {

--- a/packages/insomnia/src/__tests__/renderer.test.ts
+++ b/packages/insomnia/src/__tests__/renderer.test.ts
@@ -8,6 +8,8 @@
 //   });
 // });
 
+import { describe, expect, it } from '@jest/globals';
+
 describe('dummy', () => {
   it('does it', () => {
     expect(true).toBe(true);

--- a/packages/insomnia/src/account/__tests__/crypt.test.ts
+++ b/packages/insomnia/src/account/__tests__/crypt.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import buffer from 'buffer/';
 
 import * as crypt from '../crypt';

--- a/packages/insomnia/src/common/__mocks__/analytics.ts
+++ b/packages/insomnia/src/common/__mocks__/analytics.ts
@@ -1,4 +1,8 @@
+import { jest } from '@jest/globals';
+
+import * as analyticsOriginal from '../analytics';
+
 // WARNING: changing this to `export default` will break the mock and be incredibly hard to debug. Ask me how I know.
-const _analytics = jest.requireActual('../analytics');
+const _analytics = jest.requireActual('../analytics') as typeof analyticsOriginal;
 _analytics.trackSegmentEvent = jest.fn();
 module.exports = _analytics;

--- a/packages/insomnia/src/common/__mocks__/render.ts
+++ b/packages/insomnia/src/common/__mocks__/render.ts
@@ -1,4 +1,8 @@
-const _render = jest.requireActual('../render');
+import { jest } from '@jest/globals';
+
+import * as renderOriginal from '../render';
+
+const _render = jest.requireActual('../render') as typeof renderOriginal;
 _render.getRenderedGrpcRequest = jest.fn();
 _render.getRenderedGrpcRequestMessage = jest.fn();
 

--- a/packages/insomnia/src/common/__tests__/api-specs.test.ts
+++ b/packages/insomnia/src/common/__tests__/api-specs.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import YAML from 'yaml';
 
 import { globalBeforeEach } from '../../__jest__/before-each';

--- a/packages/insomnia/src/common/__tests__/common-headers.test.ts
+++ b/packages/insomnia/src/common/__tests__/common-headers.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import allCharsets from '../../datasets/charsets';
 import allMimeTypes from '../../datasets/content-types';
 import allEncodings from '../../datasets/encodings';

--- a/packages/insomnia/src/common/__tests__/constants.test.ts
+++ b/packages/insomnia/src/common/__tests__/constants.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import {
   ACTIVITY_DEBUG,
   ACTIVITY_HOME,

--- a/packages/insomnia/src/common/__tests__/database.test.ts
+++ b/packages/insomnia/src/common/__tests__/database.test.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
 import { globalBeforeEach } from '../../__jest__/before-each';
 import * as models from '../../models';
 import { data as fixtures } from '../__fixtures__/nestedfolders';
@@ -662,6 +664,7 @@ describe('_repairDatabase()', () => {
 
 describe('duplicate()', () => {
   beforeEach(globalBeforeEach);
+
   afterEach(() => jest.restoreAllMocks());
 
   it('should overwrite appropriate fields on the parent when duplicating', async () => {

--- a/packages/insomnia/src/common/__tests__/electron-helpers.test.ts
+++ b/packages/insomnia/src/common/__tests__/electron-helpers.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import electron from 'electron';
 
 import { clickLink } from '../electron-helpers';

--- a/packages/insomnia/src/common/__tests__/export.test.ts
+++ b/packages/insomnia/src/common/__tests__/export.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import YAML from 'yaml';
 
 import { globalBeforeEach } from '../../__jest__/before-each';

--- a/packages/insomnia/src/common/__tests__/grpc-paths.test.ts
+++ b/packages/insomnia/src/common/__tests__/grpc-paths.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { describe, expect, it } from '@jest/globals';
 
 import { GrpcMethodTypeEnum } from '../../network/grpc/method';
 import { grpcMethodDefinitionSchema } from '../../ui/context/grpc/__schemas__';

--- a/packages/insomnia/src/common/__tests__/har.test.ts
+++ b/packages/insomnia/src/common/__tests__/har.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import path from 'path';
 
 import { globalBeforeEach } from '../../__jest__/before-each';

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/insomnia/src/common/__tests__/local-storage.test.ts
+++ b/packages/insomnia/src/common/__tests__/local-storage.test.ts
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/insomnia/src/common/__tests__/misc.test.ts
+++ b/packages/insomnia/src/common/__tests__/misc.test.ts
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import { globalBeforeEach } from '../../__jest__/before-each';
 import {

--- a/packages/insomnia/src/common/__tests__/render.test.ts
+++ b/packages/insomnia/src/common/__tests__/render.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import { globalBeforeEach } from '../../__jest__/before-each';
 import * as models from '../../models';

--- a/packages/insomnia/src/common/__tests__/sorting.test.ts
+++ b/packages/insomnia/src/common/__tests__/sorting.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { grpcRequest, request, requestGroup } from '../../models';
 import {
   METHOD_DELETE,

--- a/packages/insomnia/src/common/__tests__/strings.test.ts
+++ b/packages/insomnia/src/common/__tests__/strings.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import * as models from '../../models';
 import { WorkspaceScopeKeys } from '../../models/workspace';
 import { getWorkspaceLabel } from '../get-workspace-label';

--- a/packages/insomnia/src/common/__tests__/validate-insomnia-config.test.ts
+++ b/packages/insomnia/src/common/__tests__/validate-insomnia-config.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { mocked } from 'jest-mock';
 
 import { ConfigError, getConfigSettings as _getConfigSettings  } from '../../models/helpers/settings';

--- a/packages/insomnia/src/main/__tests__/grpc-ipc-main.test.ts
+++ b/packages/insomnia/src/main/__tests__/grpc-ipc-main.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { ipcMain } from 'electron';
 
 import { GrpcRequestEventEnum } from '../../common/grpc-events';

--- a/packages/insomnia/src/mocha.d.ts
+++ b/packages/insomnia/src/mocha.d.ts
@@ -1,7 +1,0 @@
-declare namespace Mocha {
-  interface TestFunction {
-    // This is a hack until we can get rid of Mocha entirely from `insomnia-testing`.
-    // Until then, both declare global types which will always conflict and we need to do something like this to backport compatability.
-    each: jest.Each;
-  }
-}

--- a/packages/insomnia/src/models/__tests__/grpc-request-meta.test.ts
+++ b/packages/insomnia/src/models/__tests__/grpc-request-meta.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
 import { globalBeforeEach } from '../../__jest__/before-each';
 import * as models from '../index';
 

--- a/packages/insomnia/src/models/__tests__/grpc-request.test.ts
+++ b/packages/insomnia/src/models/__tests__/grpc-request.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
 import { globalBeforeEach } from '../../__jest__/before-each';
 import * as models from '../index';
 

--- a/packages/insomnia/src/models/__tests__/index.test.ts
+++ b/packages/insomnia/src/models/__tests__/index.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../__jest__/before-each';
 import { getModel, mustGetModel } from '../index';
 import * as models from '../index';

--- a/packages/insomnia/src/models/__tests__/proto-file.test.ts
+++ b/packages/insomnia/src/models/__tests__/proto-file.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
 import { globalBeforeEach } from '../../__jest__/before-each';
 import * as models from '../index';
 

--- a/packages/insomnia/src/models/__tests__/request-meta.test.ts
+++ b/packages/insomnia/src/models/__tests__/request-meta.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../__jest__/before-each';
 import * as models from '../index';
 

--- a/packages/insomnia/src/models/__tests__/request.test.ts
+++ b/packages/insomnia/src/models/__tests__/request.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
 import { globalBeforeEach } from '../../__jest__/before-each';
 import { CONTENT_TYPE_GRAPHQL } from '../../common/constants';
 import * as models from '../index';

--- a/packages/insomnia/src/models/__tests__/response.test.ts
+++ b/packages/insomnia/src/models/__tests__/response.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 import zlib from 'zlib';

--- a/packages/insomnia/src/models/__tests__/workspace.test.ts
+++ b/packages/insomnia/src/models/__tests__/workspace.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../__jest__/before-each';
 import { database } from '../../common/database';
 import { ApiSpec } from '../api-spec';

--- a/packages/insomnia/src/models/helpers/__mocks__/settings.ts
+++ b/packages/insomnia/src/models/helpers/__mocks__/settings.ts
@@ -1,4 +1,8 @@
-const actual = jest.requireActual('../settings');
+import { jest } from '@jest/globals';
+
+import * as settingsOriginal from '../settings';
+
+const actual = jest.requireActual('../settings') as typeof settingsOriginal;
 
 actual.getConfigSettings = jest.fn();
 

--- a/packages/insomnia/src/models/helpers/__tests__/get-config-settings-error.test.ts
+++ b/packages/insomnia/src/models/helpers/__tests__/get-config-settings-error.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
 
 import { getConfigSettings } from '../settings';

--- a/packages/insomnia/src/models/helpers/__tests__/get-config-settings-once.test.ts
+++ b/packages/insomnia/src/models/helpers/__tests__/get-config-settings-once.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
 
 import { getConfigSettings } from '../settings';

--- a/packages/insomnia/src/models/helpers/__tests__/get-workspace-name.test.ts
+++ b/packages/insomnia/src/models/helpers/__tests__/get-workspace-name.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import * as models from '../../../models';
 import { WorkspaceScopeKeys } from '../../workspace';
 import getWorkspaceName from '../get-workspace-name';

--- a/packages/insomnia/src/models/helpers/__tests__/git-repository-operations.test.ts
+++ b/packages/insomnia/src/models/helpers/__tests__/git-repository-operations.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import * as models from '../../index';
 import { createGitRepository, deleteGitRepository } from '../git-repository-operations';

--- a/packages/insomnia/src/models/helpers/__tests__/is-model.test.ts
+++ b/packages/insomnia/src/models/helpers/__tests__/is-model.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { difference } from 'ramda';
 
 import { generateId } from '../../../common/misc';

--- a/packages/insomnia/src/models/helpers/__tests__/project.test.ts
+++ b/packages/insomnia/src/models/helpers/__tests__/project.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { DEFAULT_PROJECT_ID } from '../../project';
 import { sortProjects } from '../project';
 

--- a/packages/insomnia/src/models/helpers/__tests__/query-all-workspace-urls.test.ts
+++ b/packages/insomnia/src/models/helpers/__tests__/query-all-workspace-urls.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import * as models from '../../index';
 import { queryAllWorkspaceUrls } from '../query-all-workspace-urls';

--- a/packages/insomnia/src/models/helpers/__tests__/settings-database.test.ts
+++ b/packages/insomnia/src/models/helpers/__tests__/settings-database.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import { database as db } from '../../../common/database';
 import * as models from '../../../models';

--- a/packages/insomnia/src/models/helpers/__tests__/settings.test.ts
+++ b/packages/insomnia/src/models/helpers/__tests__/settings.test.ts
@@ -1,3 +1,4 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { Settings } from 'insomnia-common';
 import { mocked } from 'jest-mock';
 import { identity } from 'ramda';
@@ -16,7 +17,7 @@ import {
 } from '../settings';
 
 jest.mock('../../../common/constants', () => ({
-  ...jest.requireActual<typeof _constants>('../../../common/constants'),
+  ...jest.requireActual('../../../common/constants') as typeof _constants,
   isDevelopment: jest.fn(),
 }));
 const { isDevelopment } = mocked(_constants);

--- a/packages/insomnia/src/network/__tests__/authentication.test.ts
+++ b/packages/insomnia/src/network/__tests__/authentication.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { AUTH_OAUTH_1 } from '../../common/constants';
 import { _buildBearerHeader, getAuthHeader } from '../authentication';
 

--- a/packages/insomnia/src/network/__tests__/axios-request.test.ts
+++ b/packages/insomnia/src/network/__tests__/axios-request.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import axios from 'axios';
 
 import { globalBeforeEach } from '../../__jest__/before-each';

--- a/packages/insomnia/src/network/__tests__/certificate-url-parse.test.ts
+++ b/packages/insomnia/src/network/__tests__/certificate-url-parse.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { parse as urlParse } from 'url';
 
 import { globalBeforeEach } from '../../__jest__/before-each';

--- a/packages/insomnia/src/network/__tests__/is-url-matched-in-no-proxy-rule.test.ts
+++ b/packages/insomnia/src/network/__tests__/is-url-matched-in-no-proxy-rule.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../__jest__/before-each';
 import { isUrlMatchedInNoProxyRule } from '../is-url-matched-in-no-proxy-rule';
 

--- a/packages/insomnia/src/network/__tests__/multipart.test.ts
+++ b/packages/insomnia/src/network/__tests__/multipart.test.ts
@@ -1,10 +1,13 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import electron from 'electron';
 import fs from 'fs';
 import path from 'path';
 
 import { globalBeforeEach } from '../../__jest__/before-each';
 import { buildMultipart, DEFAULT_BOUNDARY } from '../multipart';
+
 window.app = electron.app;
+
 describe('buildMultipart()', () => {
   beforeEach(globalBeforeEach);
 

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -1,4 +1,5 @@
 import { CurlHttpVersion, CurlNetrc } from '@getinsomnia/node-libcurl';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import electron from 'electron';
 import fs from 'fs';
 import { HttpVersions } from 'insomnia-common';
@@ -22,6 +23,7 @@ import { DEFAULT_BOUNDARY } from '../multipart';
 import * as networkUtils from '../network';
 import { getSetCookiesFromResponseHeaders } from '../network';
 import { _getAwsAuthHeaders } from '../parse-header-strings';
+
 window.app = electron.app;
 
 const getRenderedRequest = async (args: Parameters<typeof getRenderedRequestAndContext>[0]) => (await getRenderedRequestAndContext(args)).request;

--- a/packages/insomnia/src/network/__tests__/parse-header-strings.test.ts
+++ b/packages/insomnia/src/network/__tests__/parse-header-strings.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { AUTH_AWS_IAM, CONTENT_TYPE_FORM_DATA } from '../../common/constants';
 import { parseHeaderStrings } from '../parse-header-strings';
 
@@ -6,14 +8,17 @@ describe('parseHeaderStrings', () => {
     const req = { authentication: {}, body: {}, headers: [] };
     expect(parseHeaderStrings({ req })).toEqual(['Accept: */*', 'Accept-Encoding:', 'content-type:']);
   });
+
   it('should disable expect and transfer-encoding with body', () => {
     const req = { authentication: {}, body: {}, headers: [] };
     expect(parseHeaderStrings({ req, requestBody: 'test' })).toEqual(['Expect:', 'Transfer-Encoding:', 'Accept: */*', 'Accept-Encoding:', 'content-type:']);
   });
+
   it('should add boundary with multipart body path', () => {
     const req = { authentication: {}, body: { mimeType: CONTENT_TYPE_FORM_DATA }, headers: [] };
     expect(parseHeaderStrings({ req, requestBodyPath: '/tmp/x.z' })).toEqual(['Expect:', 'Transfer-Encoding:', 'Content-Type: multipart/form-data; boundary=X-INSOMNIA-BOUNDARY', 'Accept: */*', 'Accept-Encoding:']);
   });
+
   it('should sign with aws iam', () => {
     const req = { authentication: {
       sessionToken: 'someTokenSomethingSomething',

--- a/packages/insomnia/src/network/__tests__/url-matches-cert-host.test.ts
+++ b/packages/insomnia/src/network/__tests__/url-matches-cert-host.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../__jest__/before-each';
 import { urlMatchesCertHost } from '../url-matches-cert-host';
 

--- a/packages/insomnia/src/network/basic-auth/__tests__/get-header.test.ts
+++ b/packages/insomnia/src/network/basic-auth/__tests__/get-header.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import { getBasicAuthHeader } from '../get-header';
 

--- a/packages/insomnia/src/network/grpc/__mocks__/index.ts
+++ b/packages/insomnia/src/network/grpc/__mocks__/index.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 module.exports = {
   start: jest.fn(),
   sendMessage: jest.fn(),

--- a/packages/insomnia/src/network/grpc/__tests__/call-cache.test.ts
+++ b/packages/insomnia/src/network/grpc/__tests__/call-cache.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
 import callCache from '../call-cache';
 
 describe('call-cache', () => {

--- a/packages/insomnia/src/network/grpc/__tests__/index.test.ts
+++ b/packages/insomnia/src/network/grpc/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
 import * as grpcJs from '@grpc/grpc-js';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import { grpcMocks } from '../../../__mocks__/@grpc/grpc-js';

--- a/packages/insomnia/src/network/grpc/__tests__/method.test.ts
+++ b/packages/insomnia/src/network/grpc/__tests__/method.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import type { GrpcMethodType } from '../method';
 import { canClientStream, getMethodType, GrpcMethodTypeEnum, GrpcMethodTypeName } from '../method';
 

--- a/packages/insomnia/src/network/grpc/__tests__/parse-grpc-url.test.ts
+++ b/packages/insomnia/src/network/grpc/__tests__/parse-grpc-url.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import parseGrpcUrl from '../parse-grpc-url';
 
 describe('parseGrpcUrl', () => {

--- a/packages/insomnia/src/network/grpc/__tests__/prepare.test.ts
+++ b/packages/insomnia/src/network/grpc/__tests__/prepare.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { mocked } from 'jest-mock';
 
 import { globalBeforeEach } from '../../../__jest__/before-each';

--- a/packages/insomnia/src/network/grpc/__tests__/proto-integration.test.ts
+++ b/packages/insomnia/src/network/grpc/__tests__/proto-integration.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';

--- a/packages/insomnia/src/network/grpc/__tests__/response-callbacks.test.ts
+++ b/packages/insomnia/src/network/grpc/__tests__/response-callbacks.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
 import { GrpcResponseEventEnum } from '../../../common/grpc-events';
 import { ResponseCallbacks } from '../response-callbacks';
 

--- a/packages/insomnia/src/network/grpc/proto-loader/__mocks__/index.ts
+++ b/packages/insomnia/src/network/grpc/proto-loader/__mocks__/index.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 module.exports = {
   loadMethods: jest.fn(),
   loadMethodsFromPath: jest.fn(),

--- a/packages/insomnia/src/network/grpc/proto-loader/__tests__/index.test.ts
+++ b/packages/insomnia/src/network/grpc/proto-loader/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import path from 'path';
 
 import { globalBeforeEach } from '../../../../__jest__/before-each';

--- a/packages/insomnia/src/network/grpc/proto-loader/__tests__/write-proto-file.test.ts
+++ b/packages/insomnia/src/network/grpc/proto-loader/__tests__/write-proto-file.test.ts
@@ -1,4 +1,6 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
+import { SpyInstance } from 'jest-mock';
 import mkdirp from 'mkdirp';
 import os from 'os';
 import path from 'path';
@@ -8,10 +10,10 @@ import * as models from '../../../../models';
 import writeProtoFile from '../write-proto-file';
 
 describe('writeProtoFile', () => {
-  let existsSyncSpy: jest.SpyInstance<any, any>;
-  let mkdirpSyncSpy: jest.SpyInstance<any, any>;
-  let tmpDirSpy: jest.SpyInstance<any, any>;
-  let writeFileSpy: jest.SpyInstance<any, any>;
+  let existsSyncSpy: SpyInstance<any>;
+  let mkdirpSyncSpy: SpyInstance<any>;
+  let tmpDirSpy: SpyInstance<any>;
+  let writeFileSpy: SpyInstance<any>;
 
   const _setupSpies = () => {
     existsSyncSpy = jest.spyOn(fs, 'existsSync');

--- a/packages/insomnia/src/network/grpc/proto-manager/__tests__/index.test.ts
+++ b/packages/insomnia/src/network/grpc/proto-manager/__tests__/index.test.ts
@@ -1,4 +1,6 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
+import { Mock } from 'jest-mock';
 import path from 'path';
 
 import { globalBeforeEach } from '../../../../__jest__/before-each';
@@ -9,8 +11,8 @@ import * as modals from '../../../../ui/components/modals';
 import { loadMethods as _loadMethods, loadMethodsFromPath as _loadMethodsFromPath } from '../../proto-loader';
 import * as protoManager from '../index';
 
-const loadMethods = _loadMethods as jest.Mock;
-const loadMethodsFromPath = _loadMethodsFromPath as jest.Mock;
+const loadMethods = _loadMethods as Mock;
+const loadMethodsFromPath = _loadMethodsFromPath as Mock;
 
 jest.mock('../../../../common/select-file-or-folder', () => ({
   selectFileOrFolder: jest.fn(),
@@ -20,7 +22,7 @@ jest.mock('../../../../ui/components/modals');
 jest.mock('../../proto-loader');
 
 describe('protoManager', () => {
-  const selectFileOrFolderMock = selectFileOrFolder as jest.Mock;
+  const selectFileOrFolderMock = selectFileOrFolder as Mock;
   beforeEach(() => {
     globalBeforeEach();
     jest.resetAllMocks();
@@ -175,7 +177,7 @@ describe('protoManager', () => {
 
       // Act
       await protoManager.deleteFile(pf, cbMock);
-      const showAlertCallArg = (modals.showAlert as jest.Mock).mock.calls[0][0];
+      const showAlertCallArg = (modals.showAlert as Mock).mock.calls[0][0];
       expect(showAlertCallArg.title).toBe('Delete pfName.proto');
       await showAlertCallArg.onConfirm();
 
@@ -205,7 +207,7 @@ describe('protoManager', () => {
 
       // Act
       await protoManager.deleteDirectory(pd, cbMock);
-      const showAlertCallArg = (modals.showAlert as jest.Mock).mock.calls[0][0];
+      const showAlertCallArg = (modals.showAlert as Mock).mock.calls[0][0];
       expect(showAlertCallArg.title).toBe('Delete pdName');
       await showAlertCallArg.onConfirm();
 
@@ -218,8 +220,8 @@ describe('protoManager', () => {
   });
 
   describe('addDirectory', () => {
-    let dbBufferChangesIndefinitelySpy: any | jest.Mock<any, any>;
-    let dbFlushChangesSpy: any | jest.Mock<any, any>;
+    let dbBufferChangesIndefinitelySpy: any | Mock<any, any>;
+    let dbFlushChangesSpy: any | Mock<any, any>;
     beforeEach(() => {
       dbBufferChangesIndefinitelySpy = jest.spyOn(db, 'bufferChangesIndefinitely');
       dbFlushChangesSpy = jest.spyOn(db, 'flushChanges');

--- a/packages/insomnia/src/network/grpc/proto-manager/__tests__/ingest-proto-directory.test.ts
+++ b/packages/insomnia/src/network/grpc/proto-manager/__tests__/ingest-proto-directory.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import path from 'path';
 
 import { globalBeforeEach } from '../../../../__jest__/before-each';

--- a/packages/insomnia/src/network/o-auth-2/__tests__/grant-authorization-code.test.ts
+++ b/packages/insomnia/src/network/o-auth-2/__tests__/grant-authorization-code.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/insomnia/src/network/o-auth-2/__tests__/grant-client-credentials.test.ts
+++ b/packages/insomnia/src/network/o-auth-2/__tests__/grant-client-credentials.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/insomnia/src/network/o-auth-2/__tests__/grant-implicit.test.ts
+++ b/packages/insomnia/src/network/o-auth-2/__tests__/grant-implicit.test.ts
@@ -1,5 +1,8 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import getToken from '../grant-implicit';
+
 // Mock some test things
 const AUTHORIZE_URL = 'https://foo.com/authorizeAuthCode';
 const CLIENT_ID = 'client_123';

--- a/packages/insomnia/src/network/o-auth-2/__tests__/grant-password.test.ts
+++ b/packages/insomnia/src/network/o-auth-2/__tests__/grant-password.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/insomnia/src/network/o-auth-2/__tests__/helpers.ts
+++ b/packages/insomnia/src/network/o-auth-2/__tests__/helpers.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import electron from 'electron';
 import EventEmitter from 'events';
 

--- a/packages/insomnia/src/network/o-auth-2/__tests__/misc.test.ts
+++ b/packages/insomnia/src/network/o-auth-2/__tests__/misc.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { mocked } from 'jest-mock';
 
 import { globalBeforeEach } from '../../../__jest__/before-each';

--- a/packages/insomnia/src/plugins/context/__tests__/app.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/app.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import electron from 'electron';
 import { mocked } from 'jest-mock';
 

--- a/packages/insomnia/src/plugins/context/__tests__/data.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/data.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/insomnia/src/plugins/context/__tests__/request.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/request.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import { CONTENT_TYPE_FORM_URLENCODED } from '../../../common/constants';
 import * as models from '../../../models';

--- a/packages/insomnia/src/plugins/context/__tests__/response.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/response.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/insomnia/src/plugins/context/__tests__/store.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/store.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import * as plugin from '../store';
 const PLUGIN = {

--- a/packages/insomnia/src/plugins/misc.test.ts
+++ b/packages/insomnia/src/plugins/misc.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { validateThemeName } from './misc';
 
 describe('validateThemeName', () => {

--- a/packages/insomnia/src/sync/__tests__/ignore-keys.test.ts
+++ b/packages/insomnia/src/sync/__tests__/ignore-keys.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { describe, expect, it } from '@jest/globals';
 
 import { baseModelSchema, workspaceModelSchema } from '../../models/__schemas__/model-schemas';
 import { deleteKeys, resetKeys, shouldIgnoreKey } from '../ignore-keys';

--- a/packages/insomnia/src/sync/delta/__tests__/diff.test.ts
+++ b/packages/insomnia/src/sync/delta/__tests__/diff.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { __internal, diff } from '../diff';
 
 describe('diff()', () => {

--- a/packages/insomnia/src/sync/delta/__tests__/patch.test.ts
+++ b/packages/insomnia/src/sync/delta/__tests__/patch.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { diff } from '../diff';
 import { patch } from '../patch';
 

--- a/packages/insomnia/src/sync/git/__mocks__/path.ts
+++ b/packages/insomnia/src/sync/git/__mocks__/path.ts
@@ -1,5 +1,8 @@
+import { jest } from '@jest/globals';
+import pathOriginal from 'path';
+
 // eslint-disable-next-line filenames/match-exported
-const path = jest.requireActual('path');
+const path = jest.requireActual('path') as typeof pathOriginal;
 
 const exportObj = { __mockPath, ...path };
 

--- a/packages/insomnia/src/sync/git/__mocks__/shallow-clone.ts
+++ b/packages/insomnia/src/sync/git/__mocks__/shallow-clone.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 // WARNING: changing this to `export default` will break the mock and be incredibly hard to debug. Ask me how I know.
 module.exports = {
   shallowClone: jest.fn(),

--- a/packages/insomnia/src/sync/git/__tests__/git-rollback.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/git-rollback.test.ts
@@ -1,3 +1,4 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import path from 'path';
 
 import type { FileWithStatus } from '../git-rollback';

--- a/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
@@ -1,3 +1,4 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import * as git from 'isomorphic-git';
 import path from 'path';
 
@@ -8,12 +9,16 @@ import { setupDateMocks } from './util';
 describe('Git-VCS', () => {
   let fooTxt = '';
   let barTxt = '';
+
   beforeAll(() => {
     fooTxt = path.join(GIT_INSOMNIA_DIR, 'foo.txt');
     barTxt = path.join(GIT_INSOMNIA_DIR, 'bar.txt');
   });
+
   afterAll(() => jest.restoreAllMocks());
+
   beforeEach(setupDateMocks);
+
   describe('common operations', () => {
     it('listFiles()', async () => {
       const fsClient = MemClient.createClient();

--- a/packages/insomnia/src/sync/git/__tests__/mem-client.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/mem-client.test.ts
@@ -1,3 +1,4 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import path from 'path';
 
 import { GIT_CLONE_DIR } from '../git-vcs';

--- a/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import path from 'path';
 import YAML from 'yaml';
 

--- a/packages/insomnia/src/sync/git/__tests__/parse-git-path.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/parse-git-path.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import * as models from '../../../models';
 import { GIT_INSOMNIA_DIR } from '../git-vcs';
 import parseGitPath from '../parse-git-path';

--- a/packages/insomnia/src/sync/git/__tests__/path-sep.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/path-sep.test.ts
@@ -1,3 +1,4 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import path from 'path';
 
 import { convertToOsSep, convertToPosixSep } from '../path-sep';
@@ -18,6 +19,7 @@ describe('convertToPosixSep()', () => {
 
 describe.each(['win32', 'posix'])('convertToOsSep() where os is %s', osType => {
   beforeAll(() => path.__mockPath(osType));
+
   afterAll(() => jest.restoreAllMocks());
 
   it.each(['win32', 'posix'])(`should convert separators from %s to ${osType}`, inputType => {

--- a/packages/insomnia/src/sync/git/__tests__/routable-fs-client.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/routable-fs-client.test.ts
@@ -1,3 +1,5 @@
+import { afterAll, describe, expect, it, jest } from '@jest/globals';
+
 import { GIT_CLONE_DIR } from '../git-vcs';
 import { MemClient } from '../mem-client';
 import { routableFSClient } from '../routable-fs-client';

--- a/packages/insomnia/src/sync/git/__tests__/utils.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/utils.test.ts
@@ -1,4 +1,7 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { addDotGit, translateSSHtoHTTP } from '../utils';
+
 const links = {
   scp: {
     bare: 'git@github.com:a/b',

--- a/packages/insomnia/src/sync/lib/__tests__/deterministicStringify.test.ts
+++ b/packages/insomnia/src/sync/lib/__tests__/deterministicStringify.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { deterministicStringify } from '../deterministicStringify';
 
 describe('deterministicStringify()', () => {

--- a/packages/insomnia/src/sync/store/__tests__/index.test.ts
+++ b/packages/insomnia/src/sync/store/__tests__/index.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import MemoryDriver from '../drivers/memory-driver';
 import Store from '../index';
 

--- a/packages/insomnia/src/sync/store/hooks/__tests__/compress.test.ts
+++ b/packages/insomnia/src/sync/store/hooks/__tests__/compress.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import hook from '../compress';
 
 describe('compress hook', () => {

--- a/packages/insomnia/src/sync/vcs/__tests__/initialize-backend-project.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/initialize-backend-project.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import * as models from '../../../models';

--- a/packages/insomnia/src/sync/vcs/__tests__/initialize-model-from.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/initialize-model-from.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import * as models from '../../../models';

--- a/packages/insomnia/src/sync/vcs/__tests__/migrate-collections.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/migrate-collections.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { mocked } from 'jest-mock';
 
 import { globalBeforeEach } from '../../../__jest__/before-each';

--- a/packages/insomnia/src/sync/vcs/__tests__/paths.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/paths.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import * as paths from '../paths';
 
 describe('paths', () => {

--- a/packages/insomnia/src/sync/vcs/__tests__/pull-backend-project.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/pull-backend-project.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { mocked } from 'jest-mock';
 
 import { globalBeforeEach } from '../../../__jest__/before-each';

--- a/packages/insomnia/src/sync/vcs/__tests__/util.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/util.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 
 import { baseModelSchema, workspaceModelSchema } from '../../../models/__schemas__/model-schemas';
 import { branchSchema, mergeConflictSchema, statusCandidateSchema } from '../../__schemas__/type-schemas';

--- a/packages/insomnia/src/sync/vcs/__tests__/vcs.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/vcs.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import { baseModelSchema, workspaceModelSchema } from '../../../models/__schemas__/model-schemas';

--- a/packages/insomnia/src/templating/__tests__/utils.test.ts
+++ b/packages/insomnia/src/templating/__tests__/utils.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../__jest__/before-each';
 import * as utils from '../utils';
 

--- a/packages/insomnia/src/test-utils.ts
+++ b/packages/insomnia/src/test-utils.ts
@@ -1,28 +1,30 @@
+import { Mock } from 'jest-mock';
+
 import { showAlert, showError, showModal, showPrompt } from './ui/components/modals';
 
 export const getAndClearShowPromptMockArgs = () => {
-  const mockFn = showPrompt as jest.Mock<typeof showPrompt, Parameters<typeof showPrompt>>;
+  const mockFn = showPrompt as Mock<typeof showPrompt>;
   const options = mockFn.mock.calls[0][0];
   mockFn.mockClear();
   return options;
 };
 
 export const getAndClearShowAlertMockArgs = () => {
-  const mockFn = showAlert as jest.Mock<typeof showAlert, Parameters<typeof showAlert>>;
+  const mockFn = showAlert as Mock<typeof showAlert>;
   const options = mockFn.mock.calls[0][0];
   mockFn.mockClear();
   return options;
 };
 
 export const getAndClearShowErrorMockArgs = () => {
-  const mockFn = showError as jest.Mock<typeof showError, Parameters<typeof showError>>;
+  const mockFn = showError as Mock<typeof showError>;
   const options = mockFn.mock.calls[0][0];
   mockFn.mockClear();
   return options;
 };
 
 export const getAndClearShowModalMockArgs = () => {
-  const mockFn = showModal as jest.Mock<typeof showModal, Parameters<typeof showModal>>;
+  const mockFn = showModal as Mock<typeof showModal>;
   const args = mockFn.mock.calls[0][1];
   mockFn.mockClear();
   return args;

--- a/packages/insomnia/src/ui/components/__tests__/workspace-card.test.ts
+++ b/packages/insomnia/src/ui/components/__tests__/workspace-card.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { getVersionDisplayment } from '../workspace-card';
 
 describe('getVersionDisplayment', () => {

--- a/packages/insomnia/src/ui/components/base/__tests__/editable.test.ts
+++ b/packages/insomnia/src/ui/components/base/__tests__/editable.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { shouldSave } from '../editable';
 
 describe('shouldSave', () => {

--- a/packages/insomnia/src/ui/components/buttons/__tests__/grpc-send-button.test.tsx
+++ b/packages/insomnia/src/ui/components/buttons/__tests__/grpc-send-button.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 

--- a/packages/insomnia/src/ui/components/codemirror/__tests__/should-indent-with-tabs.test.ts
+++ b/packages/insomnia/src/ui/components/codemirror/__tests__/should-indent-with-tabs.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { shouldIndentWithTabs } from '../should-indent-with-tabs';
 
 describe('shouldIndentWithTabs()', () => {

--- a/packages/insomnia/src/ui/components/dropdowns/grpc-method-dropdown/__tests__/grpc-method-dropdown-button.test.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/grpc-method-dropdown/__tests__/grpc-method-dropdown-button.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { render } from '@testing-library/react';
 import React from 'react';
 

--- a/packages/insomnia/src/ui/components/dropdowns/grpc-method-dropdown/__tests__/grpc-method-dropdown.test.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/grpc-method-dropdown/__tests__/grpc-method-dropdown.test.tsx
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 

--- a/packages/insomnia/src/ui/components/editors/__tests__/environment-editor.test.ts
+++ b/packages/insomnia/src/ui/components/editors/__tests__/environment-editor.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME } from '../../../../templating';
 import { checkNestedKeys, ensureKeyIsValid } from '../environment-editor';
 

--- a/packages/insomnia/src/ui/components/editors/__tests__/password-editor.test.tsx
+++ b/packages/insomnia/src/ui/components/editors/__tests__/password-editor.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 

--- a/packages/insomnia/src/ui/components/editors/auth/__tests__/o-auth-2-auth.test.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/__tests__/o-auth-2-auth.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { render } from '@testing-library/react';
 import React from 'react';
 

--- a/packages/insomnia/src/ui/components/editors/auth/components/__tests__/auth-accordion.test.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/__tests__/auth-accordion.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { FC } from 'react';

--- a/packages/insomnia/src/ui/components/editors/auth/components/__tests__/auth-input-row.test.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/__tests__/auth-input-row.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { FC } from 'react';

--- a/packages/insomnia/src/ui/components/editors/auth/components/__tests__/auth-select-row.test.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/__tests__/auth-select-row.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { FC } from 'react';

--- a/packages/insomnia/src/ui/components/editors/auth/components/__tests__/auth-toggle-row.test.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/__tests__/auth-toggle-row.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { FC } from 'react';

--- a/packages/insomnia/src/ui/components/modals/__mocks__/index.ts
+++ b/packages/insomnia/src/ui/components/modals/__mocks__/index.ts
@@ -1,5 +1,9 @@
+import { jest } from '@jest/globals';
+
+import * as modalsOriginal from '../index';
+
 // eslint-disable-next-line filenames/match-exported
-const modals = jest.requireActual('../index');
+const modals = jest.requireActual('../index') as typeof modalsOriginal;
 
 modals.showError = jest.fn();
 modals.showAlert = jest.fn();

--- a/packages/insomnia/src/ui/components/modals/__tests__/utils.test.tsx
+++ b/packages/insomnia/src/ui/components/modals/__tests__/utils.test.tsx
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { wrapToIndex } from '../utils';
 
 describe('wrapToIndex', () => {

--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane/__tests__/use-proto-file-reload.test.ts
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane/__tests__/use-proto-file-reload.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { renderHook } from '@testing-library/react-hooks';
 
 import { grpcActions } from '../../../../context/grpc';

--- a/packages/insomnia/src/ui/components/settings/__tests__/boolean-setting.test.tsx
+++ b/packages/insomnia/src/ui/components/settings/__tests__/boolean-setting.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { render } from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';

--- a/packages/insomnia/src/ui/components/settings/__tests__/enum-setting.test.tsx
+++ b/packages/insomnia/src/ui/components/settings/__tests__/enum-setting.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { render } from '@testing-library/react';
 import { UpdateChannel } from 'insomnia-common';
 import React from 'react';

--- a/packages/insomnia/src/ui/components/settings/__tests__/text-setting.test.tsx
+++ b/packages/insomnia/src/ui/components/settings/__tests__/text-setting.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { render } from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';

--- a/packages/insomnia/src/ui/components/viewers/__tests__/response-viewer.test.tsx
+++ b/packages/insomnia/src/ui/components/viewers/__tests__/response-viewer.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { render } from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';

--- a/packages/insomnia/src/ui/context/grpc/__mocks__/grpc-actions.ts
+++ b/packages/insomnia/src/ui/context/grpc/__mocks__/grpc-actions.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 // WARNING: changing this to `export default` will break the mock and be incredibly hard to debug. Ask me how I know.
 module.exports = {
   grpcActions: {

--- a/packages/insomnia/src/ui/context/grpc/__tests__/grpc-context.test.tsx
+++ b/packages/insomnia/src/ui/context/grpc/__tests__/grpc-context.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { render } from '@testing-library/react';
 import React from 'react';
 

--- a/packages/insomnia/src/ui/context/grpc/__tests__/grpc-ipc-renderer.test.ts
+++ b/packages/insomnia/src/ui/context/grpc/__tests__/grpc-ipc-renderer.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { ipcRenderer } from 'electron';
 
 import { GrpcRequestEventEnum, GrpcResponseEventEnum } from '../../../../common/grpc-events';

--- a/packages/insomnia/src/ui/context/grpc/__tests__/grpc-reducer.test.ts
+++ b/packages/insomnia/src/ui/context/grpc/__tests__/grpc-reducer.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import { globalBeforeEach } from '../../../../__jest__/before-each';
 import * as models from '../../../../models';

--- a/packages/insomnia/src/ui/context/nunjucks/__tests__/nunjucks-enabled-context.test.tsx
+++ b/packages/insomnia/src/ui/context/nunjucks/__tests__/nunjucks-enabled-context.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { renderHook } from '@testing-library/react-hooks';
 
 import { NunjucksEnabledProvider, useNunjucksEnabled } from '../nunjucks-enabled-context';

--- a/packages/insomnia/src/ui/context/nunjucks/__tests__/use-gated-nunjucks.test.tsx
+++ b/packages/insomnia/src/ui/context/nunjucks/__tests__/use-gated-nunjucks.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { renderHook } from '@testing-library/react-hooks';
 import React, { FC } from 'react';
 

--- a/packages/insomnia/src/ui/context/nunjucks/__tests__/use-nunjucks.test.ts
+++ b/packages/insomnia/src/ui/context/nunjucks/__tests__/use-nunjucks.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { renderHook } from '@testing-library/react-hooks';
 import { mocked } from 'jest-mock';
 import configureMockStore from 'redux-mock-store';

--- a/packages/insomnia/src/ui/hooks/__tests__/project.test.ts
+++ b/packages/insomnia/src/ui/hooks/__tests__/project.test.ts
@@ -1,4 +1,5 @@
 
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { act, renderHook } from '@testing-library/react-hooks';
 import { mocked } from 'jest-mock';
 import configureMockStore from 'redux-mock-store';

--- a/packages/insomnia/src/ui/redux/__tests__/proto-selectors.test.ts
+++ b/packages/insomnia/src/ui/redux/__tests__/proto-selectors.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import { reduxStateForTest } from '../../../__jest__/redux-state-for-test';
 import { ACTIVITY_DEBUG } from '../../../common/constants';

--- a/packages/insomnia/src/ui/redux/__tests__/selectors.test.ts
+++ b/packages/insomnia/src/ui/redux/__tests__/selectors.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import { reduxStateForTest } from '../../../__jest__/redux-state-for-test';
 import { ACTIVITY_DEBUG, ACTIVITY_HOME } from '../../../common/constants';

--- a/packages/insomnia/src/ui/redux/__tests__/sidebar-selectors.test.ts
+++ b/packages/insomnia/src/ui/redux/__tests__/sidebar-selectors.test.ts
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { describe, expect, it } from '@jest/globals';
 import { difference } from 'ramda';
 
 import * as models from '../../../models';

--- a/packages/insomnia/src/ui/redux/modules/__tests__/git.test.tsx
+++ b/packages/insomnia/src/ui/redux/modules/__tests__/git.test.tsx
@@ -1,4 +1,5 @@
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { PromiseFsClient } from 'isomorphic-git';
 import { mocked } from 'jest-mock';
 import path from 'path';

--- a/packages/insomnia/src/ui/redux/modules/__tests__/global.test.ts
+++ b/packages/insomnia/src/ui/redux/modules/__tests__/global.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 

--- a/packages/insomnia/src/ui/redux/modules/__tests__/helpers.test.ts
+++ b/packages/insomnia/src/ui/redux/modules/__tests__/helpers.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
 import * as modals from '../../../components/modals';
 import { askToImportIntoWorkspace, ForceToWorkspace } from '../helpers';
 

--- a/packages/insomnia/src/ui/redux/modules/__tests__/workspace.test.ts
+++ b/packages/insomnia/src/ui/redux/modules/__tests__/workspace.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 

--- a/packages/insomnia/tsconfig.build.json
+++ b/packages/insomnia/tsconfig.build.json
@@ -10,7 +10,7 @@
     "jsx": "react",
     "experimentalDecorators": true,
     "skipLibCheck": true,
-    "types": ["node", "jest"],
+    "types": ["node"],
   },
   "include": [
     "**/*.d.ts",


### PR DESCRIPTION
this is simply a follow-up to https://github.com/Kong/insomnia/pull/4793 which does exactly the same task, but for the insomnia package.

this is, therefore, _ALMOST_ the final piece of the puzzle in the aim of removing the jest globals from our project.  You see, for any project that doesn't include testing-library, it's now working as intended (no globals pollution).

<img width="50%" src="https://user-images.githubusercontent.com/15232461/169362978-5d45c600-65d9-4331-ad5c-5ffcf4e36fac.png" />

<img width="50%" src="https://user-images.githubusercontent.com/15232461/169363054-ca085f65-f53e-47c2-b515-02bfa6e0b257.png" />

If we remove the references to testing-library, then the `jest` global go away.
<img width="50%" src="https://user-images.githubusercontent.com/15232461/169363374-de8496ba-0f21-4a67-aac3-0a15404a0a29.png" />

however for some reason I don't quite understand, the presence of the mocha types in the `insomnia-tesing` package somehow manages to pollute the global type context for all other packages.
<img width="90%" src="https://user-images.githubusercontent.com/15232461/169363693-e8788328-1ac0-4db1-ac41-15b91405bfad.png" />