### PR TITLE
fix: prettify graphql query variables

### DIFF
--- a/packages/insomnia-prettify/src/fixtures/nunjucks-output.json
+++ b/packages/insomnia-prettify/src/fixtures/nunjucks-output.json
@@ -4,4 +4,3 @@
   {# This is a comment #}
   "tag": {% foo 'bar', "baz" %}
 }
-

--- a/packages/insomnia-prettify/src/json.ts
+++ b/packages/insomnia-prettify/src/json.ts
@@ -29,7 +29,7 @@ const NUNJUCKS_CLOSE_STATES: {
 /**
  * Format a JSON string without parsing it as JavaScript.
  *
- * Code taken from jsonlint (http://zaa.ch/jsonlint/)
+ * Code taken from JSON Lint (https://github.com/zaach/jsonlint)
  */
 export const prettify = (json?: string, indentChars = '\t', replaceUnicode = true) => {
   if (!json) {

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -482,7 +482,7 @@ export class GraphQLEditor extends PureComponent<Props, State> {
       tabWidth: editorIndentSize,
     });
 
-    const indentChars = (editorIndentWithTabs) ? '\t' : ' '.repeat(editorIndentSize);
+    const indentChars = editorIndentWithTabs ? '\t' : ' '.repeat(editorIndentSize);
     const prettyVariables = jsonPrettify(variables, indentChars);
 
     this._handleBodyChange(prettyQuery, prettyVariables, this.state.body.operationName);
@@ -563,7 +563,9 @@ export class GraphQLEditor extends PureComponent<Props, State> {
   _handleVariablesChange(variables: string) {
     try {
       this._handleBodyChange(this.state.body.query, variables, this.state.body.operationName);
-      JSON.parse(variables || 'null');
+      if (variables) {
+        JSON.parse(variables);
+      }
     } catch (err) {
       this.setState({
         variablesSyntaxError: err.message,


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Before the "Prettify GraphQL" button only prettified the query, but not the variables.
Now the variables are prettified too! (While respecting the tab/indent-size settings!)

I'm honestly not really sure what it was doing with the variables before. 🤔
As in, it was calling prettify on the JSON before as well, but it just wasn't updating the object in the GUI. Not sure if that was a bug or maybe I'm missing something?

### Before
![old](https://user-images.githubusercontent.com/22801583/169407427-f659321d-538e-4153-b63f-2b8a0cd7bdf2.gif)

### After
![new](https://user-images.githubusercontent.com/22801583/169407586-802b7dc6-a248-4e11-8b74-c245b49e0162.gif)

---

On the side this also makes 2 minor edits in the context of this PR:
* Trim whitespace on one of the fixtures.
* Update the link to JSON Lint (and use the correct capitalization) as the domain expired and was bought by someone else it seems. 🤔 