### PR TITLE
docs: update links and minor typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Good pull requests (patches, improvements, new features) are a fantastic help. T
 
 **Please ask first** before embarking on any significant pull request (e.g. implementing features, refactoring code, porting to a different language), otherwise, you risk spending a lot of time working on something that might not get accepted into the project.
 
-If you plan on helping with development, please read the [Develop Insomnia](./README.md#develop-insomnia) section of the README for how to get started. The [Development Overview](./DEVELOPMENT.md) may also prove useful for a general overview of the application architecture.
+If you plan on helping with development, please read the [Develop Insomnia](README.md#develop-insomnia) section of the README for how to get started. The [Development Overview](DEVELOPMENT.md) may also prove useful for a general overview of the application architecture.
 
 **IMPORTANT**: By submitting a patch, you agree to allow the project owner to license your work under the same license as that used by the project.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,7 +14,7 @@ There are a few more technologies and tools worth mentioning:
 - [`libcurl`](https://curl.se/libcurl/) is the library that Insomnia uses to make requests. We used libcurl as our HTTP client of choice because it allows the deepest amount of debuggability and control of HTTP requests.
 - [`NeDB`](https://github.com/louischatriot/nedb) a local in-memory database.
 - [`node-libcurl`](https://github.com/JCMais/node-libcurl) is a Node.js wrapper around the native libcurl library.
-- [`Codemirror`](https://codemirror.net/) is a web-based, extendable, code editor used for highlighting and linting of data formats like JSON, GraphQL, and XML.
+- [`CodeMirror`](https://codemirror.net/) is a web-based, extendable, code editor used for highlighting and linting of data formats like JSON, GraphQL, and XML.
 - [`Commander.js`](https://github.com/tj/commander.js) is used for building the Inso CLI.
 
 ## Project Structure
@@ -48,7 +48,7 @@ Insomnia stores data in a few places:
 - A local Redux store contains an in-memory copy of all database entities.
 - Multiple React Context stores, defined in `/src/ui/context`.
 
-> Note: NeDB is officially unmaintained (even for criticl security bugs) and was last published in February 2016. Due to this, we hope to move away from it, however doing so is tricky because of how deeply tied it is to our architecture.
+> Note: NeDB is officially unmaintained (even for critical security bugs) and was last published in February 2016. Due to this, we hope to move away from it, however doing so is tricky because of how deeply tied it is to our architecture.
 
 ## Automated testing
 
@@ -61,7 +61,7 @@ Unit tests exist alongside the file under test. For example:
 
 Unit tests for components follow the same pattern.
 
-The structure for smoke tests is explained in the smoke testing package: [`packages/insomnia-smoke-test`](/packages/insomnia-smoke-test).
+The structure for smoke tests is explained in the smoke testing package: [`packages/insomnia-smoke-test`](packages/insomnia-smoke-test).
 
 ## Technical Debt
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Insomnia API Client
 
 [![Slack Channel](https://chat.insomnia.rest/badge.svg)](https://chat.insomnia.rest/)
-[![license](https://img.shields.io/github/license/Kong/insomnia.svg)](https://github.com/Kong/insomnia/blob/master/LICENSE)
+[![license](https://img.shields.io/github/license/Kong/insomnia.svg)](LICENSE)
 
 Insomnia is an open-source, cross-platform API client for GraphQL, REST, and gRPC.
 
@@ -16,7 +16,8 @@ from the website.
 
 ## Bugs and Feature Requests
 
-Have a bug or a feature request? First, read the [issue guidelines](CONTRIBUTING.md#using-the-issue-tracker) and search for existing and closed issues. If your problem or idea is not addressed yet, [please open a new issue](/issues).
+Have a bug or a feature request? First, read the
+[issue guidelines](CONTRIBUTING.md#using-the-issue-tracker) and search for existing and closed issues. If your problem or idea is not addressed yet, [please open a new issue](https://github.com/Kong/insomnia/issues).
 
 For more generic product questions and feedback, join the [Slack Team](https://chat.insomnia.rest) or email [support@insomnia.rest](mailto:support@insomnia.rest)
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

* Makes links consistent, you used relative with no `./` in front most of the time, so I just did that everywhere.
* Makes it so links should resolve in the IDE/code-editor if in one, or the GitHub page if on GitHub. (Only exception is `/issues` which will not resolve to GitHub correctly even if clicks in a code-editor.
* Fixes 2 typos `Codemirror` → `CodeMirror` and `criticl` → `critical`.