### PR TITLE
refactor: adding HotkeyContext and its components to handle hotkey events and its callbacks

### DIFF
--- a/packages/insomnia/src/common/hotkeys-listener.ts
+++ b/packages/insomnia/src/common/hotkeys-listener.ts
@@ -51,3 +51,15 @@ export const executeHotKey = async <T extends Function>(
     callback();
   }
 };
+
+/**
+ * Check whether a hotkey has been pressed.
+ * @param event the activated keyboard event.
+ * @param bindings the hotkey binding by the hotkey definition
+ */
+export const checkPressedKeyCombs = (
+  event: KeyboardEvent,
+  bindings: KeyBindings,
+): boolean => {
+  return _pressedHotKey(event, bindings);
+};

--- a/packages/insomnia/src/common/index.ts
+++ b/packages/insomnia/src/common/index.ts
@@ -1,0 +1,2 @@
+export * from './hotkeys';
+export * from './hotkeys-listener';

--- a/packages/insomnia/src/ui/components/hotkey/hotkey-context.tsx
+++ b/packages/insomnia/src/ui/components/hotkey/hotkey-context.tsx
@@ -1,0 +1,126 @@
+import { EventEmitter } from 'events';
+import { KeyBindings } from 'insomnia-common';
+import React, {
+  createContext,
+  FunctionComponent,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
+
+import { checkPressedKeyCombs, HotKeyDefinition } from '../../../common';
+
+export interface HotkeyCommand {
+  hotkeyId: string;
+}
+interface UseHotkeyContext {
+  $hotkeyChannel: EventEmitter;
+  sendHotkeyCommand(hotkeyId: string, condition?: string): void;
+  checkHotkeyPressed(keyEvent: KeyboardEvent, definitions: Record<string, HotKeyDefinition>): null | HotKeyDefinition;
+}
+
+const HOTKEY_EVENT_TAG = 'HOTKEY_EVENT_TAG';
+const HotkeyContext = createContext<UseHotkeyContext>({} as UseHotkeyContext);
+const HotkeyProvider: FunctionComponent<{ hotKeyRegistry: Record<string, KeyBindings>; children: ReactNode}> = ({ hotKeyRegistry, children }) => {
+  const $hotkeyChannel = useMemo(() => new EventEmitter(), []);
+  const sendHotkeyCommand = useCallback((hotkeyId: string) => {
+    $hotkeyChannel.emit(HOTKEY_EVENT_TAG, { hotkeyId });
+  }, [$hotkeyChannel]);
+
+  const checkHotkeyPressed = useCallback((e: KeyboardEvent, definitions: Record<string, HotKeyDefinition>): null | HotKeyDefinition => {
+    const pressed = Object.values(definitions).find(def => checkPressedKeyCombs(e, hotKeyRegistry[def.id]));
+    if (!pressed) {
+      return null;
+    }
+
+    return pressed;
+  }, [hotKeyRegistry]);
+
+  return (
+    <HotkeyContext.Provider
+      value={{
+        sendHotkeyCommand,
+        checkHotkeyPressed,
+        $hotkeyChannel,
+      }}
+    >
+      {children}
+    </HotkeyContext.Provider>
+  );
+};
+
+/**
+ * A hook to listen to multiple hotkeys
+ * @param callback callback to be executed when a given hotkey is executed
+ * @param hotkeys a collection of hotkeys to be listened. This is used to check if a callback needs to be executed or not
+ * */
+function useHotKeysEffect(callback: (hotkeyId: string) => void, hotkeys: string[]): void {
+  const { $hotkeyChannel } = useContext(HotkeyContext);
+  const hotkeyIds = useMemo(() => new Set(hotkeys), [hotkeys]);
+  const callbackRef = useRef(callback);
+
+  /**
+   * using ref as an instance variable
+   * https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables
+   * https://reactjs.org/docs/hooks-faq.html#how-to-read-an-often-changing-value-from-usecallback
+   * */
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  useEffect(() => {
+    const handler = (e: HotkeyCommand) => {
+      if (!hotkeyIds.has(e.hotkeyId)) {
+        return;
+      }
+
+      callbackRef.current?.(e.hotkeyId);
+    };
+
+    $hotkeyChannel.on(HOTKEY_EVENT_TAG, handler);
+
+    return () => {
+      $hotkeyChannel.off(HOTKEY_EVENT_TAG, handler);
+    };
+  }, [$hotkeyChannel, callbackRef, hotkeyIds]);
+}
+
+/**
+ * A hook to listen to a single hotkey
+ * @param callback callback to be executed when a given hotkey is executed
+ * @param hotkeyId a specific hotkey id to be listened
+ * */
+function useHotKeyEffect(callback: () => void, hotkeyId: string): void {
+  const { $hotkeyChannel } = useContext(HotkeyContext);
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  useEffect(() => {
+    const handler = (e: HotkeyCommand) => {
+      if (e.hotkeyId !== hotkeyId) {
+        return;
+      }
+
+      callbackRef.current?.();
+    };
+
+    $hotkeyChannel.on(HOTKEY_EVENT_TAG, handler);
+
+    return () => {
+      $hotkeyChannel.off(HOTKEY_EVENT_TAG, handler);
+    };
+  }, [$hotkeyChannel, callbackRef, hotkeyId]);
+}
+
+function useHotKey(): Pick<UseHotkeyContext, 'sendHotkeyCommand' | 'checkHotkeyPressed'> {
+  const { sendHotkeyCommand, checkHotkeyPressed } = useContext(HotkeyContext);
+  return { sendHotkeyCommand, checkHotkeyPressed };
+}
+
+export { HotkeyProvider, useHotKeysEffect, useHotKeyEffect, useHotKey };

--- a/packages/insomnia/src/ui/components/hotkey/hotkey-context.tsx
+++ b/packages/insomnia/src/ui/components/hotkey/hotkey-context.tsx
@@ -72,12 +72,12 @@ function useHotKeysEffect(callback: (hotkeyId: string) => void, hotkeys: string[
   });
 
   useEffect(() => {
-    const handler = (e: HotkeyCommand) => {
-      if (!hotkeyIds.has(e.hotkeyId)) {
+    const handler = (command: HotkeyCommand) => {
+      if (!hotkeyIds.has(command.hotkeyId)) {
         return;
       }
 
-      callbackRef.current?.(e.hotkeyId);
+      callbackRef.current?.(command.hotkeyId);
     };
 
     $hotkeyChannel.on(HOTKEY_EVENT_TAG, handler);
@@ -102,8 +102,8 @@ function useHotKeyEffect(callback: () => void, hotkeyId: string): void {
   });
 
   useEffect(() => {
-    const handler = (e: HotkeyCommand) => {
-      if (e.hotkeyId !== hotkeyId) {
+    const handler = (command: HotkeyCommand) => {
+      if (command.hotkeyId !== hotkeyId) {
         return;
       }
 

--- a/packages/insomnia/src/ui/components/hotkey/hotkey-executor.tsx
+++ b/packages/insomnia/src/ui/components/hotkey/hotkey-executor.tsx
@@ -1,0 +1,42 @@
+import React, { FunctionComponent, ReactNode } from 'react';
+
+import { hotKeyRefs } from '../../../common';
+import { useHotKeysEffect } from './hotkey-context';
+
+type KeyOfHotKeys = keyof typeof hotKeyRefs;
+export type HotKeysExecutionMap = Map<KeyOfHotKeys, () => void>;
+interface Props {
+  children?: ReactNode;
+  keysMap: HotKeysExecutionMap;
+}
+
+/**
+ * This component is to work around the current way <App /> component is written and how hotkeys are executed. This component will need to be removed eventually when we convert the app component and other components into functional.
+ * */
+export const HotkeyExecutor: FunctionComponent<Props> = ({ children, keysMap }) => {
+  useHotKeysEffect((hotkeyId: string) => {
+    keysMap.get(hotkeyId)?.();
+  }, [
+    hotKeyRefs.PREFERENCES_SHOW_GENERAL.id,
+    hotKeyRefs.PREFERENCES_SHOW_KEYBOARD_SHORTCUTS.id,
+    hotKeyRefs.SHOW_RECENT_REQUESTS.id,
+    hotKeyRefs.WORKSPACE_SHOW_SETTINGS.id,
+    hotKeyRefs.REQUEST_SHOW_SETTINGS.id,
+    hotKeyRefs.REQUEST_QUICK_SWITCH.id,
+    hotKeyRefs.REQUEST_SEND.id,
+    hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id,
+    hotKeyRefs.SHOW_COOKIES_EDITOR.id,
+    hotKeyRefs.REQUEST_QUICK_CREATE.id,
+    hotKeyRefs.REQUEST_SHOW_CREATE.id,
+    hotKeyRefs.REQUEST_SHOW_DELETE.id,
+    hotKeyRefs.REQUEST_SHOW_CREATE_FOLDER.id,
+    hotKeyRefs.REQUEST_SHOW_GENERATE_CODE_EDITOR.id,
+    hotKeyRefs.REQUEST_SHOW_DUPLICATE.id,
+    hotKeyRefs.REQUEST_TOGGLE_PIN.id,
+    hotKeyRefs.PLUGIN_RELOAD.id,
+    hotKeyRefs.ENVIRONMENT_SHOW_VARIABLE_SOURCE_AND_VALUE.id,
+    hotKeyRefs.SIDEBAR_TOGGLE.id,
+  ]);
+
+  return <>{children}</>;
+};

--- a/packages/insomnia/src/ui/components/hotkey/hotkey-propagator.tsx
+++ b/packages/insomnia/src/ui/components/hotkey/hotkey-propagator.tsx
@@ -1,0 +1,25 @@
+import React, { FunctionComponent, ReactNode, useEffect } from 'react';
+
+import { hotKeyRefs } from '../../../common';
+import { useHotKey } from './hotkey-context';
+
+export const HotkeyPropagator: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
+  const { sendHotkeyCommand, checkHotkeyPressed } = useHotKey();
+
+  useEffect(() => {
+    const body = document.body;
+    const listener = async (e: KeyboardEvent) => {
+      const result = await checkHotkeyPressed(e, hotKeyRefs);
+      if (!result) {
+        return;
+      }
+
+      sendHotkeyCommand(result.id);
+    };
+
+    body.addEventListener('keydown', listener);
+    return () => body.removeEventListener('keydown', listener);
+  }, [sendHotkeyCommand, checkHotkeyPressed]);
+
+  return <>{children}</>;
+};

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -1,8 +1,7 @@
 import classnames from 'classnames';
 import { deconstructQueryStringToParams, extractQueryStringFromUrl } from 'insomnia-url';
-import React, { FC, useCallback, useEffect, useRef } from 'react';
+import React, { FC, useCallback } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
-import { useMount } from 'react-use';
 
 import { getAuthTypeName, getContentTypeName } from '../../../common/constants';
 import * as models from '../../../models';
@@ -132,17 +131,6 @@ export const RequestPane: FC<Props> = ({
     }
   }, [request, forceUpdateRequest]);
 
-  const requestUrlBarRef = useRef<RequestUrlBar | null>(null);
-  useMount(() => {
-    requestUrlBarRef.current?.focusInput();
-  });
-  useEffect(() => {
-    requestUrlBarRef.current?.focusInput();
-  }, [
-    request?._id, // happens when the user switches requests
-    settings.hasPromptedAnalytics, // happens when the user dismisses the analytics modal
-  ]);
-
   if (!request) {
     return (
       <PlaceholderRequestPane
@@ -167,7 +155,6 @@ export const RequestPane: FC<Props> = ({
       <PaneHeader>
         <ErrorBoundary errorClassName="font-error pad text-center">
           <RequestUrlBar
-            ref={requestUrlBarRef}
             uniquenessKey={uniqueKey}
             onMethodChange={updateRequestMethod}
             onUrlChange={updateRequestUrl}

--- a/packages/insomnia/src/ui/components/wrapper-home.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-home.tsx
@@ -9,7 +9,7 @@ import {
   DropdownItem,
   SvgIcon,
 } from 'insomnia-components';
-import React, { PureComponent } from 'react';
+import React, { ChangeEvent, FunctionComponent, PureComponent, useRef } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import styled from 'styled-components';
@@ -41,7 +41,7 @@ import { AppHeader } from './app-header';
 import { DashboardSortDropdown } from './dropdowns/dashboard-sort-dropdown';
 import { ProjectDropdown } from './dropdowns/project-dropdown';
 import { RemoteWorkspacesDropdown } from './dropdowns/remote-workspaces-dropdown';
-import { KeydownBinder } from './keydown-binder';
+import { useHotKeyEffect } from './hotkey/hotkey-context';
 import { showPrompt } from './modals';
 import { Notice } from './notice';
 import { PageLayout } from './page-layout';
@@ -156,6 +156,32 @@ const mapWorkspaceToWorkspaceCard = ({
     specFormatVersion,
     workspace,
   };
+};
+
+const DocumentFilterInput: FunctionComponent<{ onFilterValueChange(e: ChangeEvent<HTMLInputElement>): void }> = ({ onFilterValueChange }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useHotKeyEffect(() => {
+    inputRef.current?.focus();
+  }, hotKeyRefs.FILTER_DOCUMENTS.id);
+
+  return (
+    <div
+      className="form-control form-control--outlined no-margin"
+      style={{
+        maxWidth: '400px',
+      }}
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        placeholder="Filter..."
+        onChange={onFilterValueChange}
+        className="no-margin"
+      />
+      <span className="fa fa-search filter-icon" />
+    </div>
+  );
 };
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -295,23 +321,7 @@ class WrapperHome extends PureComponent<Props, State> {
     const { wrapperProps: { vcs }, handleSetDashboardSortOrder, sortOrder } = this.props;
     return (
       <div className="row row--right pad-left wide">
-        <div
-          className="form-control form-control--outlined no-margin"
-          style={{
-            maxWidth: '400px',
-          }}
-        >
-          <KeydownBinder onKeydown={this._handleKeyDown}>
-            <input
-              ref={this._setFilterInputRef}
-              type="text"
-              placeholder="Filter..."
-              onChange={this._handleFilterChange}
-              className="no-margin"
-            />
-            <span className="fa fa-search filter-icon" />
-          </KeydownBinder>
-        </div>
+        <DocumentFilterInput onFilterValueChange={this._handleFilterChange} />
         <DashboardSortDropdown value={sortOrder} onSelect={handleSetDashboardSortOrder} />
         <RemoteWorkspacesDropdown vcs={vcs} />
         {this.renderCreateMenu()}


### PR DESCRIPTION
This PR is a smaller and reopened version of this [closed draft PR](https://github.com/Kong/insomnia/pull/4814). While the close PR includes more holistic refactoring, this PR only includes a couple hotkey operations.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Context

Insomnia Desktop client supports hotkey commands to control the behaviors of the applications listed out here. Currently, the hotkey operation works by,

1. propagate the keydown event from [<KeyDownBinder />](https://github.com/Kong/insomnia/blob/40af38c3b9711ff6ba4ab647be08765a0aeefeab/packages/insomnia/src/ui/components/keydown-binder.ts#L17) to the destination component with an option to stop the propagation
2. [read](https://github.com/Kong/insomnia/blob/40af38c3b9711ff6ba4ab647be08765a0aeefeab/packages/insomnia/src/common/hotkeys-listener.ts#L35) the [NeDB](https://github.com/louischatriot/nedb) database to check if the key combination exists as a registered hotkey (every key stroke triggers this)
3. execute the callback function to act on the hotkey command in the destination component
![current-diagram](https://user-images.githubusercontent.com/103070941/170521196-3120dbb7-e019-44f6-a9cb-af57ff7b00f5.png)

### Problem Statement
The currrent pattern may work generally fine when the keydown event scope is not limited. However, it creates complications when event propagation is stopped and event is scoped to a child DOM tree.

### Proposed Solution
This proposed solution is to use the pub/sub pattern with [EventEmitter](https://nodejs.org/api/events.html#class-eventemitter) and [React Context API](https://reactjs.org/docs/context.html) in the top to flush out hotkey event from top to bottom.
![option-1-diagram](https://user-images.githubusercontent.com/103070941/170521905-118ad1ff-a2d8-4321-a6eb-5cf52ff39772.png)

### Limitations
* the prevalent pattern of using PureComponent makes this refactoring very difficult. Workaround would be to wrap these PureComponents with Functional components and merge them into one functional component over time with rollout plans. 
* this effort does not rewrite the fundamentals of the hotkey operations within the app
### Rollout Plans
Phase | Execution
--- | ---
1 | Add Playwright tests for each hot key operation
2 | Add HotkeyContext, HotkeyPropagator, HotkeyExecutor and hooks for replacing the KeydownBinder and executeCallback
3 | Migrate all the functional component workaround for pure component classes and remove HotkeyExecutor and remove any noise