### PR TITLE
INS-1501: Sentry integration.

### DIFF
--- a/packages/insomnia/config/config.json
+++ b/packages/insomnia/config/config.json
@@ -15,6 +15,7 @@
     "development": "rTOCSvGV23cHGJyb3HI9EUQDNA6ar7ay",
     "production": "4l7QUfACrIcqvC913hiIwAA2BDYP2OJ1"
   },
+  "sentryDsn": "https://aaec2e800e644070a8daba5b7ad02c16@o1147619.ingest.sentry.io/6311804",
   "plugins": [
     "insomnia-plugin-base64",
     "insomnia-plugin-hash",

--- a/packages/insomnia/package-lock.json
+++ b/packages/insomnia/package-lock.json
@@ -14,6 +14,7 @@
 				"@grpc/proto-loader": "^0.5.5",
 				"@hapi/hawk": "^8.0.0",
 				"@jest/globals": "^28.1.0",
+				"@sentry/electron": "^3.0.7",
 				"@stoplight/spectral": "^5.9.0",
 				"analytics-node": "^6.0.0",
 				"aws4": "^1.11.0",
@@ -3215,6 +3216,118 @@
 			"dependencies": {
 				"component-type": "^1.2.1",
 				"join-component": "^1.1.0"
+			}
+		},
+		"node_modules/@sentry/browser": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.2.tgz",
+			"integrity": "sha512-5VC44p5Vu2eJhVT39nLAJFgha5MjHDYCyZRR1ieeZt3a++otojPGBBAKNAtrEMGV+A2Z9AoneD6ZnDVlyb3GKg==",
+			"dependencies": {
+				"@sentry/core": "6.19.2",
+				"@sentry/types": "6.19.2",
+				"@sentry/utils": "6.19.2",
+				"tslib": "^1.9.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@sentry/core": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.2.tgz",
+			"integrity": "sha512-yu1R3ewBT4udmB4v7sc4biQZ0Z0rfB9+TzB5ZKoCftbe6kqXjFMMaFRYNUF9HicVldKAsBktgkWw3+yfqGkw/A==",
+			"dependencies": {
+				"@sentry/hub": "6.19.2",
+				"@sentry/minimal": "6.19.2",
+				"@sentry/types": "6.19.2",
+				"@sentry/utils": "6.19.2",
+				"tslib": "^1.9.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@sentry/electron": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-3.0.7.tgz",
+			"integrity": "sha512-Rahi1jgvjHnx1jGkkPPvDCxSCAME7xc2eBcFCLb4R/WDuNblR7tgJUuAtzv9JpxUgRHy1oLNct0wcvIu1mcXoA==",
+			"dependencies": {
+				"@sentry/browser": "6.19.2",
+				"@sentry/core": "6.19.2",
+				"@sentry/node": "6.19.2",
+				"@sentry/types": "6.19.2",
+				"@sentry/utils": "6.19.2",
+				"deepmerge": "^4.2.2",
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@sentry/electron/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
+		"node_modules/@sentry/hub": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.2.tgz",
+			"integrity": "sha512-W7KCgNBgdBIMagOxy5J5KQPe+maYxSqfE8a5ncQ3R8BcZDQEKnkW/1FplNbfRLZqA/tL/ndKb7pTPqVtzsbARw==",
+			"dependencies": {
+				"@sentry/types": "6.19.2",
+				"@sentry/utils": "6.19.2",
+				"tslib": "^1.9.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@sentry/minimal": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.2.tgz",
+			"integrity": "sha512-ClwxKm77iDHET7kpzv1JvzDx1er5DoNu+EUjst0kQzARIrXvu9xuZuE2/CnBWycQWqw8o3HoGoKz65uIhsUCzQ==",
+			"dependencies": {
+				"@sentry/hub": "6.19.2",
+				"@sentry/types": "6.19.2",
+				"tslib": "^1.9.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@sentry/node": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.2.tgz",
+			"integrity": "sha512-Z1qREpTpYHxaeWjc1zMUk8ZTAp1WbxMiI2TVNc+a14DVT19Z2xNXb06MiRfeLgNc9lVGdmzR62dPmMBjVgPJYg==",
+			"dependencies": {
+				"@sentry/core": "6.19.2",
+				"@sentry/hub": "6.19.2",
+				"@sentry/types": "6.19.2",
+				"@sentry/utils": "6.19.2",
+				"cookie": "^0.4.1",
+				"https-proxy-agent": "^5.0.0",
+				"lru_map": "^0.3.3",
+				"tslib": "^1.9.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@sentry/types": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.2.tgz",
+			"integrity": "sha512-XO5qmVBdTs+7PdCz7fAwn1afWxSnRE2KLBFg5/vOdKosPSSHsSHUURSkxiEZc2QsR+JpRB4AeQ26AkIRX38qTg==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@sentry/utils": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.2.tgz",
+			"integrity": "sha512-2DQQ2OJaxjtyxGq5FmMlqb6hptsqMs2xoBiVRMkTS/rvyTrk1oQdKZ8ePwjtgX3nJ728ni3IXIyXV+vfGp4EBw==",
+			"dependencies": {
+				"@sentry/types": "6.19.2",
+				"tslib": "^1.9.3"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/@sideway/address": {
@@ -6946,7 +7059,6 @@
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
 			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -7528,7 +7640,6 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
 			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -15169,6 +15280,11 @@
 				"node": "*"
 			}
 		},
+		"node_modules/lru_map": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+			"integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
+		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -22677,6 +22793,99 @@
 				"join-component": "^1.1.0"
 			}
 		},
+		"@sentry/browser": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.2.tgz",
+			"integrity": "sha512-5VC44p5Vu2eJhVT39nLAJFgha5MjHDYCyZRR1ieeZt3a++otojPGBBAKNAtrEMGV+A2Z9AoneD6ZnDVlyb3GKg==",
+			"requires": {
+				"@sentry/core": "6.19.2",
+				"@sentry/types": "6.19.2",
+				"@sentry/utils": "6.19.2",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@sentry/core": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.2.tgz",
+			"integrity": "sha512-yu1R3ewBT4udmB4v7sc4biQZ0Z0rfB9+TzB5ZKoCftbe6kqXjFMMaFRYNUF9HicVldKAsBktgkWw3+yfqGkw/A==",
+			"requires": {
+				"@sentry/hub": "6.19.2",
+				"@sentry/minimal": "6.19.2",
+				"@sentry/types": "6.19.2",
+				"@sentry/utils": "6.19.2",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@sentry/electron": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-3.0.7.tgz",
+			"integrity": "sha512-Rahi1jgvjHnx1jGkkPPvDCxSCAME7xc2eBcFCLb4R/WDuNblR7tgJUuAtzv9JpxUgRHy1oLNct0wcvIu1mcXoA==",
+			"requires": {
+				"@sentry/browser": "6.19.2",
+				"@sentry/core": "6.19.2",
+				"@sentry/node": "6.19.2",
+				"@sentry/types": "6.19.2",
+				"@sentry/utils": "6.19.2",
+				"deepmerge": "^4.2.2",
+				"tslib": "^2.3.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
+		},
+		"@sentry/hub": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.2.tgz",
+			"integrity": "sha512-W7KCgNBgdBIMagOxy5J5KQPe+maYxSqfE8a5ncQ3R8BcZDQEKnkW/1FplNbfRLZqA/tL/ndKb7pTPqVtzsbARw==",
+			"requires": {
+				"@sentry/types": "6.19.2",
+				"@sentry/utils": "6.19.2",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@sentry/minimal": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.2.tgz",
+			"integrity": "sha512-ClwxKm77iDHET7kpzv1JvzDx1er5DoNu+EUjst0kQzARIrXvu9xuZuE2/CnBWycQWqw8o3HoGoKz65uIhsUCzQ==",
+			"requires": {
+				"@sentry/hub": "6.19.2",
+				"@sentry/types": "6.19.2",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@sentry/node": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.2.tgz",
+			"integrity": "sha512-Z1qREpTpYHxaeWjc1zMUk8ZTAp1WbxMiI2TVNc+a14DVT19Z2xNXb06MiRfeLgNc9lVGdmzR62dPmMBjVgPJYg==",
+			"requires": {
+				"@sentry/core": "6.19.2",
+				"@sentry/hub": "6.19.2",
+				"@sentry/types": "6.19.2",
+				"@sentry/utils": "6.19.2",
+				"cookie": "^0.4.1",
+				"https-proxy-agent": "^5.0.0",
+				"lru_map": "^0.3.3",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@sentry/types": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.2.tgz",
+			"integrity": "sha512-XO5qmVBdTs+7PdCz7fAwn1afWxSnRE2KLBFg5/vOdKosPSSHsSHUURSkxiEZc2QsR+JpRB4AeQ26AkIRX38qTg=="
+		},
+		"@sentry/utils": {
+			"version": "6.19.2",
+			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.2.tgz",
+			"integrity": "sha512-2DQQ2OJaxjtyxGq5FmMlqb6hptsqMs2xoBiVRMkTS/rvyTrk1oQdKZ8ePwjtgX3nJ728ni3IXIyXV+vfGp4EBw==",
+			"requires": {
+				"@sentry/types": "6.19.2",
+				"tslib": "^1.9.3"
+			}
+		},
 		"@sideway/address": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
@@ -25672,8 +25881,7 @@
 		"cookie": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"dev": true
+			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
 		},
 		"copy-to-clipboard": {
 			"version": "3.3.1",
@@ -26132,8 +26340,7 @@
 		"deepmerge": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-			"dev": true
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
 		},
 		"defer-to-connect": {
 			"version": "1.1.3",
@@ -31958,6 +32165,11 @@
 					"dev": true
 				}
 			}
+		},
+		"lru_map": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+			"integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
 		},
 		"lru-cache": {
 			"version": "5.1.1",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -45,6 +45,7 @@
     "@grpc/proto-loader": "^0.5.5",
     "@hapi/hawk": "^8.0.0",
     "@jest/globals": "^28.1.0",
+    "@sentry/electron": "^3.0.7",
     "@stoplight/spectral": "^5.9.0",
     "analytics-node": "^6.0.0",
     "aws4": "^1.11.0",

--- a/packages/insomnia/src/account/fetch.ts
+++ b/packages/insomnia/src/account/fetch.ts
@@ -43,7 +43,14 @@ export async function getJson<T = any>(path: string, sessionId: string | null): 
   return response;
 }
 
-async function _fetch<T = any>(method: 'POST' | 'PUT' | 'GET', path: string, obj: unknown, sessionId: string | null, compressBody = false, retries = 0): Promise<T | string> {
+async function _fetch<T = any>(
+  method: 'POST' | 'PUT' | 'GET',
+  path: string,
+  obj: unknown,
+  sessionId: string | null,
+  compressBody = false,
+  retries = 0
+): Promise<T | string> {
   if (sessionId === undefined) {
     throw new Error(`No session ID provided to ${method}:${path}`);
   }

--- a/packages/insomnia/src/account/fetch.ts
+++ b/packages/insomnia/src/account/fetch.ts
@@ -15,19 +15,35 @@ export function onCommand(callback: Function) {
   _commandListeners.push(callback);
 }
 
-export async function post(path, obj, sessionId, compressBody = false) {
-  return _fetch('POST', path, obj, sessionId, compressBody);
+export async function post<T = any>(path: string, obj: unknown, sessionId: string | null, compressBody = false): Promise<T | string> {
+  return _fetch<T>('POST', path, obj, sessionId, compressBody);
 }
 
-export async function put(path, obj, sessionId, compressBody = false) {
-  return _fetch('PUT', path, obj, sessionId, compressBody);
+export async function postJson<T = any>(path: string, obj: unknown, sessionId: string | null, compressBody = false): Promise<T> {
+  const response = await post<T>(path, obj, sessionId, compressBody);
+  if (typeof response === 'string') {
+    throw new Error('Unexpected plaintext response');
+  }
+  return response;
 }
 
-export async function get(path, sessionId) {
-  return _fetch('GET', path, null, sessionId);
+export async function put<T = any>(path: string, obj: unknown, sessionId: string | null, compressBody = false): Promise<T | string> {
+  return _fetch<T>('PUT', path, obj, sessionId, compressBody);
 }
 
-async function _fetch(method, path, obj, sessionId, compressBody = false, retries = 0) {
+export async function get<T = any>(path: string, sessionId: string | null): Promise<T | string> {
+  return _fetch<T>('GET', path, null, sessionId);
+}
+
+export async function getJson<T = any>(path: string, sessionId: string | null): Promise<T> {
+  const response = await get<T>(path, sessionId);
+  if (typeof response === 'string') {
+    throw new Error('Unexpected plaintext response');
+  }
+  return response;
+}
+
+async function _fetch<T = any>(method: 'POST' | 'PUT' | 'GET', path: string, obj: unknown, sessionId: string | null, compressBody = false, retries = 0): Promise<T | string> {
   if (sessionId === undefined) {
     throw new Error(`No session ID provided to ${method}:${path}`);
   }
@@ -59,7 +75,7 @@ async function _fetch(method, path, obj, sessionId, compressBody = false, retrie
     config.headers['X-Session-Id'] = sessionId;
   }
 
-  let response;
+  let response: Response | undefined;
 
   const url = _getUrl(path);
 

--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -53,7 +53,6 @@ const sendSegment = async (segmentType: 'track' | 'page', options) => {
 export enum SegmentEvent {
   appStarted = 'App Started',
   collectionCreate = 'Collection Created',
-  criticalError = 'Critical Error Encountered',
   dataExport = 'Data Exported',
   dataImport = 'Data Imported',
   documentCreate = 'Document Created',

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -23,6 +23,7 @@ export const isWindows = () => getAppPlatform() === 'win32';
 const getAppEnvironment = () => process.env.INSOMNIA_ENV || 'production';
 export const isDevelopment = () => getAppEnvironment() === 'development';
 export const getSegmentWriteKey = () => appConfig.segmentWriteKeys[(isDevelopment() || env.PLAYWRIGHT) ? 'development' : 'production'];
+export const getSentryDsn = () => appConfig.sentryDsn;
 export const getAppBuildDate = () => new Date(process.env.BUILD_DATE ?? '').toLocaleDateString();
 
 export const getBrowserUserAgent = () => encodeURIComponent(

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -20,7 +20,7 @@ export const getAppPlatform = () => process.platform;
 export const isMac = () => getAppPlatform() === 'darwin';
 export const isLinux = () => getAppPlatform() === 'linux';
 export const isWindows = () => getAppPlatform() === 'win32';
-const getAppEnvironment = () => process.env.INSOMNIA_ENV || 'production';
+export const getAppEnvironment = () => process.env.INSOMNIA_ENV || 'production';
 export const isDevelopment = () => getAppEnvironment() === 'development';
 export const getSegmentWriteKey = () => appConfig.segmentWriteKeys[(isDevelopment() || env.PLAYWRIGHT) ? 'development' : 'production'];
 export const getSentryDsn = () => appConfig.sentryDsn;

--- a/packages/insomnia/src/common/sentry.ts
+++ b/packages/insomnia/src/common/sentry.ts
@@ -1,0 +1,82 @@
+import * as Sentry from '@sentry/electron';
+import type * as SentryElectronMain from '@sentry/electron/main';
+import type { SentryRequestType, Transport, TransportClass } from '@sentry/types';
+
+import { getAccountId, onLoginLogout } from '../account/session';
+import { database as db } from '../common/database';
+import * as models from '../models/index';
+import { isSettings } from '../models/settings';
+import { getAppEnvironment, getAppVersion } from './constants';
+
+let enabled = false;
+
+// Configures user info in Sentry scope. This should only be called by the
+// renderer thread, because it needs access to localStorage.
+function sentryConfigureUserInfo() {
+  Sentry.configureScope(scope => {
+    const id = getAccountId();
+    if (id) {
+      scope.setUser({ id });
+    } else {
+      scope.setUser(null);
+    }
+  });
+}
+
+// Watches user info for changes. This should only be called by the renderer
+// thread.
+export function sentryWatchUserInfo() {
+  sentryConfigureUserInfo();
+  onLoginLogout(() => sentryConfigureUserInfo());
+}
+
+// Watch analytics setting for changes. This can be called in any thread after
+// the database has been initialized.
+export function sentryWatchAnalyticsEnabled() {
+  models.settings.getOrCreate().then(settings => {
+    enabled = settings.enableAnalytics;
+  });
+
+  db.onChange(async changes => {
+    for (const change of changes) {
+      const [event, doc] = change;
+      if (isSettings(doc) && event === 'update') {
+        enabled = doc.enableAnalytics;
+      }
+    }
+  });
+}
+
+// TODO(johnwchadwick): We are vendoring ElectronOfflineNetTransport just to be
+// able to control whether or not sending is allowed, because we don't have a
+// choice right now. We should work with the upstream library to get similar
+// functionality upstream. See getsentry/sentry-electron#489.
+//
+// https://github.com/getsentry/sentry-electron/issues/489
+let transport: TransportClass<Transport> | undefined = undefined;
+
+// The transport is only needed inside the browser (main) thread.
+if (process.type === 'browser') {
+  // We need to use Electron require here, no exceptions.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { ElectronOfflineNetTransport } = require('@sentry/electron/main') as typeof SentryElectronMain;
+
+  transport = class ElectronSwitchableTransport extends ElectronOfflineNetTransport {
+    protected _isRateLimited(requestType: SentryRequestType) {
+      if (!enabled) {
+        return true;
+      }
+
+      return super._isRateLimited(requestType);
+    }
+  };
+}
+
+// Initialize Sentry. Sentry needs to be initialized as soon as possible; it
+// will fail if the Electron ready event fires before it is initialized.
+Sentry.init({
+  dsn: 'https://aaec2e800e644070a8daba5b7ad02c16@o1147619.ingest.sentry.io/6311804',
+  environment: getAppEnvironment(),
+  release: getAppVersion(),
+  transport,
+});

--- a/packages/insomnia/src/common/sentry.ts
+++ b/packages/insomnia/src/common/sentry.ts
@@ -1,82 +1,9 @@
-import * as Sentry from '@sentry/electron';
-import type * as SentryElectronMain from '@sentry/electron/main';
-import type { SentryRequestType, Transport, TransportClass } from '@sentry/types';
+import type { ElectronOptions } from '@sentry/electron';
 
-import { getAccountId, onLoginLogout } from '../account/session';
-import { database as db } from '../common/database';
-import * as models from '../models/index';
-import { isSettings } from '../models/settings';
 import { getAppEnvironment, getAppVersion } from './constants';
 
-let enabled = false;
-
-// Configures user info in Sentry scope. This should only be called by the
-// renderer thread, because it needs access to localStorage.
-function sentryConfigureUserInfo() {
-  Sentry.configureScope(scope => {
-    const id = getAccountId();
-    if (id) {
-      scope.setUser({ id });
-    } else {
-      scope.setUser(null);
-    }
-  });
-}
-
-// Watches user info for changes. This should only be called by the renderer
-// thread.
-export function sentryWatchUserInfo() {
-  sentryConfigureUserInfo();
-  onLoginLogout(() => sentryConfigureUserInfo());
-}
-
-// Watch analytics setting for changes. This can be called in any thread after
-// the database has been initialized.
-export function sentryWatchAnalyticsEnabled() {
-  models.settings.getOrCreate().then(settings => {
-    enabled = settings.enableAnalytics;
-  });
-
-  db.onChange(async changes => {
-    for (const change of changes) {
-      const [event, doc] = change;
-      if (isSettings(doc) && event === 'update') {
-        enabled = doc.enableAnalytics;
-      }
-    }
-  });
-}
-
-// TODO(johnwchadwick): We are vendoring ElectronOfflineNetTransport just to be
-// able to control whether or not sending is allowed, because we don't have a
-// choice right now. We should work with the upstream library to get similar
-// functionality upstream. See getsentry/sentry-electron#489.
-//
-// https://github.com/getsentry/sentry-electron/issues/489
-let transport: TransportClass<Transport> | undefined = undefined;
-
-// The transport is only needed inside the browser (main) thread.
-if (process.type === 'browser') {
-  // We need to use Electron require here, no exceptions.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { ElectronOfflineNetTransport } = require('@sentry/electron/main') as typeof SentryElectronMain;
-
-  transport = class ElectronSwitchableTransport extends ElectronOfflineNetTransport {
-    protected _isRateLimited(requestType: SentryRequestType) {
-      if (!enabled) {
-        return true;
-      }
-
-      return super._isRateLimited(requestType);
-    }
-  };
-}
-
-// Initialize Sentry. Sentry needs to be initialized as soon as possible; it
-// will fail if the Electron ready event fires before it is initialized.
-Sentry.init({
+export const SENTRY_OPTIONS: Partial<ElectronOptions> = {
   dsn: 'https://aaec2e800e644070a8daba5b7ad02c16@o1147619.ingest.sentry.io/6311804',
   environment: getAppEnvironment(),
   release: getAppVersion(),
-  transport,
-});
+};

--- a/packages/insomnia/src/common/sentry.ts
+++ b/packages/insomnia/src/common/sentry.ts
@@ -1,9 +1,9 @@
 import type { ElectronOptions } from '@sentry/electron';
 
-import { getAppEnvironment, getAppVersion } from './constants';
+import { getAppEnvironment, getAppVersion, getSentryDsn } from './constants';
 
 export const SENTRY_OPTIONS: Partial<ElectronOptions> = {
-  dsn: 'https://aaec2e800e644070a8daba5b7ad02c16@o1147619.ingest.sentry.io/6311804',
+  dsn: getSentryDsn(),
   environment: getAppEnvironment(),
   release: getAppVersion(),
 };

--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -10,8 +10,8 @@ import { changelogUrl, getAppVersion, isDevelopment, isMac } from './common/cons
 import { database } from './common/database';
 import { disableSpellcheckerDownload } from './common/electron-helpers';
 import log, { initializeLogging } from './common/log';
+import { sentryWatchAnalyticsEnabled } from './common/sentry';
 import { validateInsomniaConfig } from './common/validate-insomnia-config';
-import * as errorHandling from './main/error-handling';
 import * as grpcIpcMain from './main/grpc-ipc-main';
 import { checkIfRestartNeeded } from './main/squirrel-startup';
 import * as updates from './main/updates';
@@ -84,7 +84,7 @@ app.on('ready', async () => {
   // Init some important things first
   await database.init(models.types());
   await _createModelInstances();
-  errorHandling.init();
+  sentryWatchAnalyticsEnabled();
   windowUtils.init();
   await _launchApp();
 

--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -10,9 +10,9 @@ import { changelogUrl, getAppVersion, isDevelopment, isMac } from './common/cons
 import { database } from './common/database';
 import { disableSpellcheckerDownload } from './common/electron-helpers';
 import log, { initializeLogging } from './common/log';
-import { sentryWatchAnalyticsEnabled } from './common/sentry';
 import { validateInsomniaConfig } from './common/validate-insomnia-config';
 import * as grpcIpcMain from './main/grpc-ipc-main';
+import { initializeSentry, sentryWatchAnalyticsEnabled } from './main/sentry';
 import { checkIfRestartNeeded } from './main/squirrel-startup';
 import * as updates from './main/updates';
 import * as windowUtils from './main/window-utils';
@@ -22,6 +22,8 @@ import { cancelCurlRequest, curlRequest } from './network/libcurl-promise';
 import { authorizeUserInWindow } from './network/o-auth-2/misc';
 import installPlugin from './plugins/install';
 import type { ToastNotification } from './ui/components/toast';
+
+initializeSentry();
 
 // Handle potential auto-update
 if (checkIfRestartNeeded()) {

--- a/packages/insomnia/src/main/error-handling.ts
+++ b/packages/insomnia/src/main/error-handling.ts
@@ -1,8 +1,0 @@
-export function init() {
-  process.on('uncaughtException', err => {
-    console.error('[catcher] Uncaught exception:', err.stack);
-  });
-  process.on('unhandledRejection', (err: Error) => {
-    console.error('[catcher] Unhandled rejection:', err.stack);
-  });
-}

--- a/packages/insomnia/src/main/sentry.ts
+++ b/packages/insomnia/src/main/sentry.ts
@@ -8,7 +8,10 @@ import { isSettings } from '../models/settings';
 
 let enabled = false;
 
-// Watch setting for changes. This must be called after the DB is initialized.
+/**
+ * Watch setting for changes.
+ * This must be called after the DB is initialized.
+ */
 export function sentryWatchAnalyticsEnabled() {
   models.settings.getOrCreate().then(settings => {
     enabled = settings.enableAnalytics;
@@ -24,10 +27,8 @@ export function sentryWatchAnalyticsEnabled() {
   });
 }
 
-// TODO(johnwchadwick): We are vendoring ElectronOfflineNetTransport just to be
-// able to control whether or not sending is allowed, because we don't have a
-// choice right now. We should work with the upstream library to get similar
-// functionality upstream. See getsentry/sentry-electron#489.
+// TODO(johnwchadwick): We are vendoring ElectronOfflineNetTransport just to be able to control whether or not sending is allowed, because we don't have a choice right now.
+// We should work with the upstream library to get similar functionality upstream. See getsentry/sentry-electron#489.
 //
 // https://github.com/getsentry/sentry-electron/issues/489
 class ElectronSwitchableTransport extends Sentry.ElectronOfflineNetTransport {

--- a/packages/insomnia/src/main/sentry.ts
+++ b/packages/insomnia/src/main/sentry.ts
@@ -1,0 +1,48 @@
+import * as Sentry from '@sentry/electron/main';
+import type { SentryRequestType } from '@sentry/types';
+
+import { database as db } from '../common/database';
+import { SENTRY_OPTIONS } from '../common/sentry';
+import * as models from '../models/index';
+import { isSettings } from '../models/settings';
+
+let enabled = false;
+
+// Watch setting for changes. This must be called after the DB is initialized.
+export function sentryWatchAnalyticsEnabled() {
+  models.settings.getOrCreate().then(settings => {
+    enabled = settings.enableAnalytics;
+  });
+
+  db.onChange(async changes => {
+    for (const change of changes) {
+      const [event, doc] = change;
+      if (isSettings(doc) && event === 'update') {
+        enabled = doc.enableAnalytics;
+      }
+    }
+  });
+}
+
+// TODO(johnwchadwick): We are vendoring ElectronOfflineNetTransport just to be
+// able to control whether or not sending is allowed, because we don't have a
+// choice right now. We should work with the upstream library to get similar
+// functionality upstream. See getsentry/sentry-electron#489.
+//
+// https://github.com/getsentry/sentry-electron/issues/489
+class ElectronSwitchableTransport extends Sentry.ElectronOfflineNetTransport {
+  protected _isRateLimited(requestType: SentryRequestType) {
+    if (!enabled) {
+      return true;
+    }
+
+    return super._isRateLimited(requestType);
+  }
+}
+
+export function initializeSentry() {
+  Sentry.init({
+    ...SENTRY_OPTIONS,
+    transport: ElectronSwitchableTransport,
+  });
+}

--- a/packages/insomnia/src/main/sentry.ts
+++ b/packages/insomnia/src/main/sentry.ts
@@ -9,8 +9,7 @@ import { isSettings } from '../models/settings';
 let enabled = false;
 
 /**
- * Watch setting for changes.
- * This must be called after the DB is initialized.
+ * Watch setting for changes. This must be called after the DB is initialized.
  */
 export function sentryWatchAnalyticsEnabled() {
   models.settings.getOrCreate().then(settings => {

--- a/packages/insomnia/src/main/sentry.ts
+++ b/packages/insomnia/src/main/sentry.ts
@@ -26,9 +26,7 @@ export function sentryWatchAnalyticsEnabled() {
   });
 }
 
-// TODO(johnwchadwick): We are vendoring ElectronOfflineNetTransport just to be able to control whether or not sending is allowed, because we don't have a choice right now.
-// We should work with the upstream library to get similar functionality upstream. See getsentry/sentry-electron#489.
-//
+// TODO(johnwchadwick): We are vendoring ElectronOfflineNetTransport just to be able to control whether or not sending is allowed, because we don't have a choice right now. We should work with the upstream library to get similar functionality upstream. See getsentry/sentry-electron#489.
 // https://github.com/getsentry/sentry-electron/issues/489
 class ElectronSwitchableTransport extends Sentry.ElectronOfflineNetTransport {
   protected _isRateLimited(requestType: SentryRequestType) {

--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -869,7 +869,7 @@ export class VCS {
       // the user created snapshots while not logged in
       for (const snapshot of snapshots) {
         if (snapshot.author === '') {
-          snapshot.author = accountId;
+          snapshot.author = accountId || '';
         }
       }
 

--- a/packages/insomnia/src/ui/components/toast.tsx
+++ b/packages/insomnia/src/ui/components/toast.tsx
@@ -145,7 +145,7 @@ export class Toast extends PureComponent<{}, State> {
         updatesNotSupported: !updatesSupported(),
         version: getAppVersion(),
       };
-      notification = await fetch.post('/notification', data, session.getCurrentSessionId());
+      notification = await fetch.postJson<ToastNotification>('/notification', data, session.getCurrentSessionId());
     } catch (err) {
       console.warn('[toast] Failed to fetch user notifications', err);
     }

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -7,17 +7,17 @@ import { Provider } from 'react-redux';
 import { getProductName, isDevelopment } from '../common/constants';
 import { database as db } from '../common/database';
 import { initializeLogging } from '../common/log';
-import { sentryWatchAnalyticsEnabled, sentryWatchUserInfo } from '../common/sentry';
 import * as models from '../models';
 import { initNewOAuthSession } from '../network/o-auth-2/misc';
 import { init as initPlugins } from '../plugins';
 import { applyColorScheme } from '../plugins/misc';
 import App from './containers/app';
 import { init as initStore } from './redux/modules';
+import { initializeSentry } from './sentry';
 
 import './css/index.less'; // this import must come after `App`.  the reason is not yet known.
 
-sentryWatchUserInfo();
+initializeSentry();
 initializeLogging();
 // Handy little helper
 document.body.setAttribute('data-platform', process.platform);
@@ -25,7 +25,6 @@ document.title = getProductName();
 
 (async function() {
   await db.initClient();
-  sentryWatchAnalyticsEnabled();
 
   await initPlugins();
 

--- a/packages/insomnia/src/ui/sentry.ts
+++ b/packages/insomnia/src/ui/sentry.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/electron';
 import { getAccountId, onLoginLogout } from '../account/session';
 import { SENTRY_OPTIONS } from '../common/sentry';
 
-// Configures user info in Sentry scope.
+/** Configures user info in Sentry scope. */
 function sentryConfigureUserInfo() {
   Sentry.configureScope(scope => {
     const id = getAccountId();
@@ -15,13 +15,12 @@ function sentryConfigureUserInfo() {
   });
 }
 
-// Watches user info for changes.
+/** Watches user info for changes. */
 function sentryWatchUserInfo() {
   sentryConfigureUserInfo();
   onLoginLogout(() => sentryConfigureUserInfo());
 }
 
-// Initialize sentry.
 export function initializeSentry() {
   Sentry.init(SENTRY_OPTIONS);
   sentryWatchUserInfo();

--- a/packages/insomnia/src/ui/sentry.ts
+++ b/packages/insomnia/src/ui/sentry.ts
@@ -1,0 +1,28 @@
+import * as Sentry from '@sentry/electron';
+
+import { getAccountId, onLoginLogout } from '../account/session';
+import { SENTRY_OPTIONS } from '../common/sentry';
+
+// Configures user info in Sentry scope.
+function sentryConfigureUserInfo() {
+  Sentry.configureScope(scope => {
+    const id = getAccountId();
+    if (id) {
+      scope.setUser({ id });
+    } else {
+      scope.setUser(null);
+    }
+  });
+}
+
+// Watches user info for changes.
+function sentryWatchUserInfo() {
+  sentryConfigureUserInfo();
+  onLoginLogout(() => sentryConfigureUserInfo());
+}
+
+// Initialize sentry.
+export function initializeSentry() {
+  Sentry.init(SENTRY_OPTIONS);
+  sentryWatchUserInfo();
+}


### PR DESCRIPTION
This is a basic Sentry integration for Insomnia, to send error data.

As far as privacy goes, the Sentry integration is designed to respect the user's existing data collection consent. It does not intentionally send or retain any PII with the error data, and only retain data sent to Sentry for up to 90 days. For more information on Sentry's security and privacy posture, visit their [Security](https://sentry.io/security/) page.

When data collection is disabled, Sentry will still be initialized, but it will only retain information locally in the app data folder.

We have [opened an issue](https://github.com/getsentry/sentry-electron/issues/489) with Sentry to try to provide more "first class" support for explicitly operating offline. Until then, we have a custom transport that uses a small workaround to block all outgoing requests. I do not believe any requests are being made outside of this, but please note that you can't use the typical Web Inspector to view these requests, because they happen on the main thread using Electron's net package.