### PR TITLE
graphql empty url error

### DIFF
--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -293,7 +293,9 @@ export class GraphQLEditor extends PureComponent<Props, State> {
       schemaIsFetching: false,
     };
     let responsePatch: ResponsePatch | null = null;
-
+    if (!rawRequest.url) {
+      return;
+    }
     try {
       const bodyJson = JSON.stringify({
         query: getIntrospectionQuery(),

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -634,23 +634,21 @@ export class GraphQLEditor extends PureComponent<Props, State> {
   }
 
   renderSchemaFetchMessage() {
-    let message;
-    const { schemaLastFetchTime, schemaIsFetching } = this.state;
     if (!this.props.request.url) {
-      message = '';
-    } else if (schemaIsFetching) {
-      message = 'fetching schema...';
-    } else if (schemaLastFetchTime > 0) {
-      message = (
+      return '';
+    }
+    const { schemaLastFetchTime, schemaIsFetching } = this.state;
+    if (schemaIsFetching) {
+      return 'fetching schema...';
+    }
+    if (schemaLastFetchTime > 0) {
+      return (
         <span>
           schema fetched <TimeFromNow timestamp={schemaLastFetchTime} />
         </span>
       );
-    } else {
-      message = <span>schema not yet fetched</span>;
     }
-
-    return message;
+    return <span>schema not yet fetched</span>;
   }
 
   static renderMarkdown(text: string) {

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -636,8 +636,9 @@ export class GraphQLEditor extends PureComponent<Props, State> {
   renderSchemaFetchMessage() {
     let message;
     const { schemaLastFetchTime, schemaIsFetching } = this.state;
-
-    if (schemaIsFetching) {
+    if (!this.props.request.url) {
+      message = '';
+    } else if (schemaIsFetching) {
       message = 'fetching schema...';
     } else if (schemaLastFetchTime > 0) {
       message = (


### PR DESCRIPTION
motivation: after adding the quick GraphQL request button, an error from the introspection query would be shown because there is no default url.
The introspection query only runs with a url now.
<img width="746" alt="image" src="https://user-images.githubusercontent.com/3679927/171840247-94758999-3e3c-4383-89b0-72bb1b852981.png">

changelog(Fixes): Fixed an issue where users would see a fetch error before defining a URL for brand new GraphQL requests