### PR TITLE
spike: add error handling when cancelling an import

### DIFF
--- a/packages/insomnia/src/ui/components/modals/ask-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/ask-modal.tsx
@@ -13,6 +13,7 @@ interface State {
   yesText: string;
   noText: string;
   loading: boolean;
+  onCancel?: () => void;
 }
 
 interface AskModalOptions {
@@ -21,6 +22,7 @@ interface AskModalOptions {
   onDone?: (success: boolean) => Promise<void>;
   yesText?: string;
   noText?: string;
+  onCancel?: () => void;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -31,6 +33,7 @@ export class AskModal extends PureComponent<{}, State> {
     yesText: 'Yes',
     noText: 'No',
     loading: false,
+    onCancel: () => {},
   };
 
   modal: Modal | null = null;
@@ -71,7 +74,7 @@ export class AskModal extends PureComponent<{}, State> {
     this.modal?.hide();
   }
 
-  show({ title, message, onDone, yesText, noText }: AskModalOptions = {}) {
+  show({ title, message, onDone, yesText, noText, onCancel }: AskModalOptions = {}) {
     this._doneCallback = onDone;
     this.setState({
       title: title || 'Confirm',
@@ -79,6 +82,7 @@ export class AskModal extends PureComponent<{}, State> {
       yesText: yesText || 'Yes',
       noText: noText || 'No',
       loading: false,
+      onCancel,
     });
     this.modal?.show();
 
@@ -92,9 +96,9 @@ export class AskModal extends PureComponent<{}, State> {
   }
 
   render() {
-    const { message, title, yesText, noText, loading } = this.state;
+    const { message, title, yesText, noText, loading, onCancel } = this.state;
     return (
-      <Modal noEscape ref={this._setModalRef} closeOnKeyCodes={[13]}>
+      <Modal ref={this._setModalRef} onCancel={onCancel} closeOnKeyCodes={[13]}>
         <ModalHeader>{title || 'Confirm?'}</ModalHeader>
         <ModalBody className="wide pad">{message}</ModalBody>
         <ModalFooter>

--- a/packages/insomnia/src/ui/redux/modules/helpers.ts
+++ b/packages/insomnia/src/ui/redux/modules/helpers.ts
@@ -30,12 +30,15 @@ export function askToSelectExistingWorkspace(workspaces: Workspace[]): SelectExi
 }
 
 async function askToImportIntoNewWorkspace(): Promise<boolean> {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     showModal(AskModal, {
       title: 'Import',
       message: `Do you want to import into an existing ${strings.workspace.singular.toLowerCase()} or a new one?`,
       yesText: 'Existing',
       noText: 'New',
+      onCancel: () => {
+        reject(new Error('Import cancelled'));
+      },
       onDone: (yes: boolean) => {
         resolve(yes);
       },
@@ -82,12 +85,15 @@ export function askToImportIntoWorkspace({ workspaceId, forceToWorkspace, active
           return null;
         }
 
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
           showModal(AskModal, {
             title: 'Import',
             message: 'Do you want to import into the current workspace or a new one?',
             yesText: 'Current',
             noText: 'New Workspace',
+            onCancel: () => {
+              reject(new Error('Import cancelled'));
+            },
             onDone: (yes: boolean) => {
               resolve(yes ? workspaceId : null);
             },
@@ -107,7 +113,7 @@ export function askToSetWorkspaceScope(scope?: WorkspaceScope): SetWorkspaceScop
         return scope;
 
       default:
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
           const message = name
             ? `How would you like to import "${name}"?`
             : 'Do you want to import as a Request Collection or a Design Document?';
@@ -117,6 +123,9 @@ export function askToSetWorkspaceScope(scope?: WorkspaceScope): SetWorkspaceScop
             message,
             noText: 'Request Collection',
             yesText: 'Design Document',
+            onCancel: () => {
+              reject(new Error('Import cancelled'));
+            },
             onDone: yes => {
               resolve(yes ? WorkspaceScopeKeys.design : WorkspaceScopeKeys.collection);
             },
@@ -129,7 +138,7 @@ export function askToSetWorkspaceScope(scope?: WorkspaceScope): SetWorkspaceScop
 export type SetProjectIdPrompt = () => Promise<string>;
 export function askToImportIntoProject({ projects, activeProject }: { projects: Project[]; activeProject: Project }): SetProjectIdPrompt {
   return function() {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       // If only one project exists, return that
       if (projects.length === 1) {
         return resolve(projects[0]._id);
@@ -143,7 +152,10 @@ export function askToImportIntoProject({ projects, activeProject }: { projects: 
         message: `Select a ${strings.project.singular.toLowerCase()} to import into`,
         options,
         value: defaultValue,
-        noEscape: true,
+        noEscape: false,
+        onCancel: () => {
+          reject(new Error('Import cancelled'));
+        },
         onDone: selectedProjectId => {
           // @ts-expect-error onDone can send null as an argument; why/how?
           resolve(selectedProjectId);

--- a/packages/insomnia/src/ui/redux/modules/import.ts
+++ b/packages/insomnia/src/ui/redux/modules/import.ts
@@ -30,7 +30,7 @@ const handleImportResult = (result: ImportResult, errorMessage: string) => {
   if (error) {
     showError({
       title: 'Import Failed',
-      message: errorMessage,
+      message: error.message ?? errorMessage,
       error,
     });
     return [];


### PR DESCRIPTION
A take on minimal changes to allow cancelling imports.

The current issue:
- When a user imports a collection/document there is no way to cancel the import.

Concerns of this solution:
- No guarantee that the resources are going to be imported in the correct order. This means there might be resources that are stored in the database even when we cancel an import.
- Error handling is not straightforward and throwing errors from modals is a hacky workaround.

How it works:
- If the user decides to cancel the import we throw an error to pause the importer and *hopefully* not store unused data in the db.

A better approach:
Add a prepare phase for the data to be imported, gather any missing data (by user input etc.) and then start the actual import to the database.