### PR TITLE
refactor: add segment tracking for git sync

### DIFF
--- a/packages/insomnia/src/models/git-repository.ts
+++ b/packages/insomnia/src/models/git-repository.ts
@@ -2,6 +2,8 @@ import { database as db } from '../common/database';
 import type { GitCredentials } from '../sync/git/git-vcs';
 import type { BaseModel } from './index';
 
+export type OauthProviderName = 'gitlab' | 'github' | 'custom';
+
 export type GitRepository = BaseModel & BaseGitRepository;
 
 export const name = 'Git Repository';

--- a/packages/insomnia/src/sync/git/utils.ts
+++ b/packages/insomnia/src/sync/git/utils.ts
@@ -1,5 +1,6 @@
 import { AuthCallback, AuthFailureCallback, AuthSuccessCallback, GitAuth, MessageCallback } from 'isomorphic-git';
 
+import { OauthProviderName } from '../../models/git-repository';
 import type { GitCredentials } from './git-vcs';
 import { getAccessToken as getGitHubAccessToken } from './github-oauth-provider';
 import { getAccessToken as getGitlabAccessToken, refreshToken as refreshGitlabToken } from './gitlab-oauth-provider';
@@ -93,6 +94,14 @@ const onAuth = (credentials?: GitCredentials): AuthCallback => (): GitAuth => {
     // @ts-expect-error -- TSCONVERSION this needs to be handled better if credentials is undefined or which union type
     password: credentials.password || credentials.token,
   };
+};
+
+export const getOauth2FormatName = (credentials?: GitCredentials | null): OauthProviderName | undefined => {
+  if (credentials && 'oauth2format' in credentials) {
+    return credentials.oauth2format;
+  }
+
+  return undefined;
 };
 
 export const gitCallbacks = (credentials?: GitCredentials | null) => ({

--- a/packages/insomnia/src/sync/git/utils.ts
+++ b/packages/insomnia/src/sync/git/utils.ts
@@ -101,7 +101,7 @@ export const getOauth2FormatName = (credentials?: GitCredentials | null): OauthP
     return credentials.oauth2format;
   }
 
-  return undefined;
+  return;
 };
 
 export const gitCallbacks = (credentials?: GitCredentials | null) => ({

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
@@ -4,7 +4,7 @@ import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
 import { AUTOBIND_CFG } from '../../../../common/constants';
 import { docsGitSync } from '../../../../common/documentation';
-import type { GitRepository } from '../../../../models/git-repository';
+import type { GitRepository, OauthProviderName } from '../../../../models/git-repository';
 import { deleteGitRepository } from '../../../../models/helpers/git-repository-operations';
 import { Link } from '../../base/link';
 import { Modal } from '../../base/modal';
@@ -88,7 +88,7 @@ interface Props {
   onReset: () => void;
 }
 
-const oauth2Formats = ['github', 'gitlab', 'custom'];
+const oauth2Formats: OauthProviderName[] = ['github', 'gitlab', 'custom'];
 
 const ModalForm = (props: Props) => {
   const { gitRepository, onSubmit, onReset } = props;
@@ -102,7 +102,7 @@ const ModalForm = (props: Props) => {
 
   const initialTab = !gitRepository ? 'github' : oauth2format;
 
-  const [selectedTab, setTab] = useState(initialTab);
+  const [selectedTab, setTab] = useState<OauthProviderName>(initialTab);
 
   const selectedTabIndex = oauth2Formats.indexOf(selectedTab);
   return (

--- a/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
@@ -36,7 +36,7 @@ interface Item {
 interface Props {
   workspace: Workspace;
   vcs: GitVCS;
-  gitRepository: GitRepository;
+  gitRepository: GitRepository | null;
 }
 
 interface State {
@@ -100,7 +100,7 @@ export class GitStagingModal extends PureComponent<Props, State> {
     }
 
     await vcs.commit(message);
-    const providerName = getOauth2FormatName(gitRepository.credentials);
+    const providerName = getOauth2FormatName(gitRepository?.credentials);
     trackSegmentEvent(SegmentEvent.vcsAction, { ...vcsSegmentEventProperties('git', 'commit'), providerName });
     this.modal?.hide();
 
@@ -126,7 +126,7 @@ export class GitStagingModal extends PureComponent<Props, State> {
       newItems[p].staged = doStage || forceAdd;
     }
 
-    const providerName = getOauth2FormatName(this.props.gitRepository.credentials);
+    const providerName = getOauth2FormatName(this.props.gitRepository?.credentials);
     trackSegmentEvent(SegmentEvent.vcsAction, { ...vcsSegmentEventProperties('git', doStage ? 'stage_all' : 'unstage_all'), providerName });
     this.setState({
       items: newItems,
@@ -143,7 +143,7 @@ export class GitStagingModal extends PureComponent<Props, State> {
 
     newItems[gitPath].staged = !newItems[gitPath].staged;
 
-    const providerName = getOauth2FormatName(this.props.gitRepository.credentials);
+    const providerName = getOauth2FormatName(this.props.gitRepository?.credentials);
     trackSegmentEvent(SegmentEvent.vcsAction, { ...vcsSegmentEventProperties('git', newItems[gitPath].staged ? 'stage' : 'unstage'), providerName });
     this.setState({
       items: newItems,
@@ -320,14 +320,14 @@ export class GitStagingModal extends PureComponent<Props, State> {
   async _handleRollbackSingle(item: Item) {
     await this._handleRollback([item]);
 
-    const providerName = getOauth2FormatName(this.props.gitRepository.credentials);
+    const providerName = getOauth2FormatName(this.props.gitRepository?.credentials);
     trackSegmentEvent(SegmentEvent.vcsAction, { ...vcsSegmentEventProperties('git', 'rollback'), providerName });
   }
 
   async _handleRollbackAll(items: Item[]) {
     await this._handleRollback(items);
 
-    const providerName = getOauth2FormatName(this.props.gitRepository.credentials);
+    const providerName = getOauth2FormatName(this.props.gitRepository?.credentials);
     trackSegmentEvent(SegmentEvent.vcsAction, { ...vcsSegmentEventProperties('git', 'rollback_all'), providerName });
   }
 

--- a/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
@@ -10,10 +10,12 @@ import { database as db } from '../../../common/database';
 import { strings } from '../../../common/strings';
 import * as models from '../../../models';
 import { isApiSpec } from '../../../models/api-spec';
+import { GitRepository } from '../../../models/git-repository';
 import type { Workspace } from '../../../models/workspace';
 import { gitRollback } from '../../../sync/git/git-rollback';
 import { GIT_INSOMNIA_DIR, GIT_INSOMNIA_DIR_NAME, GitVCS } from '../../../sync/git/git-vcs';
 import parseGitPath from '../../../sync/git/parse-git-path';
+import { getOauth2FormatName } from '../../../sync/git/utils';
 import { IndeterminateCheckbox } from '../base/indeterminate-checkbox';
 import { Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
@@ -34,6 +36,7 @@ interface Item {
 interface Props {
   workspace: Workspace;
   vcs: GitVCS;
+  gitRepository: GitRepository;
 }
 
 interface State {
@@ -78,7 +81,7 @@ export class GitStagingModal extends PureComponent<Props, State> {
   }
 
   async _handleCommit() {
-    const { vcs } = this.props;
+    const { vcs, gitRepository } = this.props;
     const { items, message } = this.state;
 
     // Set the stage
@@ -97,7 +100,8 @@ export class GitStagingModal extends PureComponent<Props, State> {
     }
 
     await vcs.commit(message);
-    trackSegmentEvent(SegmentEvent.vcsAction, vcsSegmentEventProperties('git', 'commit'));
+    const providerName = getOauth2FormatName(gitRepository.credentials);
+    trackSegmentEvent(SegmentEvent.vcsAction, { ...vcsSegmentEventProperties('git', 'commit'), providerName });
     this.modal?.hide();
 
     if (typeof this.onCommit === 'function') {
@@ -122,7 +126,8 @@ export class GitStagingModal extends PureComponent<Props, State> {
       newItems[p].staged = doStage || forceAdd;
     }
 
-    trackSegmentEvent(SegmentEvent.vcsAction, vcsSegmentEventProperties('git', doStage ? 'stage_all' : 'unstage_all'));
+    const providerName = getOauth2FormatName(this.props.gitRepository.credentials);
+    trackSegmentEvent(SegmentEvent.vcsAction, { ...vcsSegmentEventProperties('git', doStage ? 'stage_all' : 'unstage_all'), providerName });
     this.setState({
       items: newItems,
     });
@@ -137,7 +142,9 @@ export class GitStagingModal extends PureComponent<Props, State> {
     }
 
     newItems[gitPath].staged = !newItems[gitPath].staged;
-    trackSegmentEvent(SegmentEvent.vcsAction, vcsSegmentEventProperties('git', newItems[gitPath].staged ? 'stage' : 'unstage'));
+
+    const providerName = getOauth2FormatName(this.props.gitRepository.credentials);
+    trackSegmentEvent(SegmentEvent.vcsAction, { ...vcsSegmentEventProperties('git', newItems[gitPath].staged ? 'stage' : 'unstage'), providerName });
     this.setState({
       items: newItems,
     });
@@ -312,12 +319,16 @@ export class GitStagingModal extends PureComponent<Props, State> {
 
   async _handleRollbackSingle(item: Item) {
     await this._handleRollback([item]);
-    trackSegmentEvent(SegmentEvent.vcsAction, vcsSegmentEventProperties('git', 'rollback'));
+
+    const providerName = getOauth2FormatName(this.props.gitRepository.credentials);
+    trackSegmentEvent(SegmentEvent.vcsAction, { ...vcsSegmentEventProperties('git', 'rollback'), providerName });
   }
 
   async _handleRollbackAll(items: Item[]) {
     await this._handleRollback(items);
-    trackSegmentEvent(SegmentEvent.vcsAction, vcsSegmentEventProperties('git', 'rollback_all'));
+
+    const providerName = getOauth2FormatName(this.props.gitRepository.credentials);
+    trackSegmentEvent(SegmentEvent.vcsAction, { ...vcsSegmentEventProperties('git', 'rollback_all'), providerName });
   }
 
   renderItem(item: Item) {

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -585,7 +585,7 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
 
             {activeWorkspace && gitVCS ? (
               <Fragment>
-                <GitStagingModal ref={registerModal} workspace={activeWorkspace} vcs={gitVCS} />
+                <GitStagingModal ref={registerModal} workspace={activeWorkspace} vcs={gitVCS} gitRepository={activeGitRepository} />
                 <GitLogModal ref={registerModal} vcs={gitVCS} />
                 {activeGitRepository !== null && (
                   <GitBranchesModal

--- a/packages/insomnia/src/ui/redux/modules/git.tsx
+++ b/packages/insomnia/src/ui/redux/modules/git.tsx
@@ -8,7 +8,7 @@ import { database as db } from '../../../common/database';
 import { strings } from '../../../common/strings';
 import * as models from '../../../models';
 import { BaseModel } from '../../../models';
-import type { GitProviderName, GitRepository } from '../../../models/git-repository';
+import type { GitRepository } from '../../../models/git-repository';
 import { createGitRepository } from '../../../models/helpers/git-repository-operations';
 import { isWorkspace, Workspace, WorkspaceScopeKeys } from '../../../models/workspace';
 import { forceWorkspaceScopeToDesign } from '../../../sync/git/force-workspace-scope-to-design';

--- a/packages/insomnia/src/ui/redux/modules/git.tsx
+++ b/packages/insomnia/src/ui/redux/modules/git.tsx
@@ -169,6 +169,7 @@ export const cloneGitRepository = ({ createFsClient }: {
         repoSettingsPatch.uri = translateSSHtoHTTP(repoSettingsPatch.uri);
         let fsClient = createFsClient();
 
+        const providerName = getOauth2FormatName(repoSettingsPatch.credentials);
         try {
           await shallowClone({
             fsClient,
@@ -181,7 +182,7 @@ export const cloneGitRepository = ({ createFsClient }: {
               message: originalUriError.message,
             });
             dispatch(loadStop());
-            trackSegmentEvent(SegmentEvent.vcsSyncComplete, vcsSegmentEventProperties('git', 'clone', originalUriError.message));
+            trackSegmentEvent(SegmentEvent.vcsSyncComplete, { ...vcsSegmentEventProperties('git', 'clone', originalUriError.message), providerName });
             return;
           }
 
@@ -201,7 +202,7 @@ export const cloneGitRepository = ({ createFsClient }: {
               message: `Failed to clone with original url (${repoSettingsPatch.uri}): ${originalUriError.message};\n\nAlso failed to clone with \`.git\` suffix added (${dotGitUri}): ${dotGitError.message}`,
             });
             dispatch(loadStop());
-            trackSegmentEvent(SegmentEvent.vcsSyncComplete, vcsSegmentEventProperties('git', 'clone', dotGitError.message));
+            trackSegmentEvent(SegmentEvent.vcsSyncComplete, { ...vcsSegmentEventProperties('git', 'clone', dotGitError.message), providerName });
             return;
           }
         }
@@ -210,7 +211,7 @@ export const cloneGitRepository = ({ createFsClient }: {
         if (!(await containsInsomniaWorkspaceDir(fsClient))) {
           dispatch(noDocumentFound(repoSettingsPatch));
           dispatch(loadStop());
-          trackSegmentEvent(SegmentEvent.vcsSyncComplete, vcsSegmentEventProperties('git', 'clone', 'no directory found'));
+          trackSegmentEvent(SegmentEvent.vcsSyncComplete, { ...vcsSegmentEventProperties('git', 'clone', 'no directory found'), providerName });
           return;
         }
 
@@ -220,14 +221,14 @@ export const cloneGitRepository = ({ createFsClient }: {
         if (workspaces.length === 0) {
           dispatch(noDocumentFound(repoSettingsPatch));
           dispatch(loadStop());
-          trackSegmentEvent(SegmentEvent.vcsSyncComplete, vcsSegmentEventProperties('git', 'clone', 'no workspaces found'));
+          trackSegmentEvent(SegmentEvent.vcsSyncComplete, { ...vcsSegmentEventProperties('git', 'clone', 'no workspaces found'), providerName });
           return;
         }
 
         if (workspaces.length > 1) {
           cloneProblem('Multiple workspaces found in repository; expected one.');
           dispatch(loadStop());
-          trackSegmentEvent(SegmentEvent.vcsSyncComplete, vcsSegmentEventProperties('git', 'clone', 'multiple workspaces found'));
+          trackSegmentEvent(SegmentEvent.vcsSyncComplete, { ...vcsSegmentEventProperties('git', 'clone', 'multiple workspaces found'), providerName });
           return;
         }
 
@@ -246,7 +247,7 @@ export const cloneGitRepository = ({ createFsClient }: {
             </>,
           );
           dispatch(loadStop());
-          trackSegmentEvent(SegmentEvent.vcsSyncComplete, vcsSegmentEventProperties('git', 'clone', 'workspace already exists'));
+          trackSegmentEvent(SegmentEvent.vcsSyncComplete, { ...vcsSegmentEventProperties('git', 'clone', 'workspace already exists'), providerName });
           return;
         }
 
@@ -289,7 +290,7 @@ export const cloneGitRepository = ({ createFsClient }: {
             // Flush DB changes
             await db.flushChanges(bufferId);
             dispatch(loadStop());
-            trackSegmentEvent(SegmentEvent.vcsSyncComplete, vcsSegmentEventProperties('git', 'clone'));
+            trackSegmentEvent(SegmentEvent.vcsSyncComplete, { ...vcsSegmentEventProperties('git', 'clone'), providerName });
           },
         });
       },


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

- adding a oauth provider name type
- adding a util function to return oauth provider naem
- modifying the segments for git flow to add provider name

for github,
<img width="323" alt="image" src="https://user-images.githubusercontent.com/103070941/172423384-dd4f23b1-505c-4ac3-aea1-3b573ae0d2ea.png">

for gitlab,
<img width="312" alt="image" src="https://user-images.githubusercontent.com/103070941/172424852-6034e602-617a-470e-8c22-b58e6a65edfc.png">
