### PR TITLE
Allow using ID Token to retrieve schema

### DIFF
--- a/packages/insomnia/src/models/o-auth-2-token.ts
+++ b/packages/insomnia/src/models/o-auth-2-token.ts
@@ -70,7 +70,7 @@ export function remove(token: OAuth2Token) {
 }
 
 export function getByParentId(parentId: string) {
-  return db.getWhere<OAuth2Token>(type, { parentId });
+  return db.getWhere<OAuth2Token>(type, { parentId: normaliseRequestId(parentId) });
 }
 
 export async function getOrCreateByParentId(parentId: string) {
@@ -89,4 +89,12 @@ export async function getOrCreateByParentId(parentId: string) {
 
 export function all() {
   return db.all<OAuth2Token>(type);
+}
+
+function normaliseRequestId(requestId: string) {
+  // HACK: GraphQL requests use a child request to fetch the schema with an
+  // ID of "{{request_id}}.graphql". Here we are removing the .graphql suffix and
+  // pretending we are fetching a token for the original request. This makes sure
+  // the same tokens are used for schema fetching. See issue #835 on GitHub.
+  return requestId.match(/\.graphql$/) ? requestId.replace(/\.graphql$/, '') : requestId;
 }

--- a/packages/insomnia/src/network/authentication.ts
+++ b/packages/insomnia/src/network/authentication.ts
@@ -59,12 +59,7 @@ export async function getAuthHeader(renderedRequest: RenderedRequest, url: strin
   }
 
   if (authentication.type === AUTH_OAUTH_2) {
-    // HACK: GraphQL requests use a child request to fetch the schema with an
-    // ID of "{{request_id}}.graphql". Here we are removing the .graphql suffix and
-    // pretending we are fetching a token for the original request. This makes sure
-    // the same tokens are used for schema fetching. See issue #835 on GitHub.
-    const tokenId = requestId.match(/\.graphql$/) ? requestId.replace(/\.graphql$/, '') : requestId;
-    const oAuth2Token = await getOAuth2Token(tokenId, authentication);
+    const oAuth2Token = await getOAuth2Token(requestId, authentication);
 
     if (oAuth2Token) {
       const token = oAuth2Token.accessToken;


### PR DESCRIPTION
#3211 Allowed for using an identity token for auth rather than auth token. When using that feature, the GraphQL schema could not be fetched due to `throw new Error('No OAuth 2.0 identity tokens found for request');`. This commit moves the normalization of the request ID further up the chain so it can be used where this error would otherwise be thrown.

Closes #3013
