### PR TITLE
fix gql documentation bug

### DIFF
--- a/packages/insomnia/src/ui/components/graph-ql-explorer/graph-ql-explorer-enum.tsx
+++ b/packages/insomnia/src/ui/components/graph-ql-explorer/graph-ql-explorer-enum.tsx
@@ -7,14 +7,16 @@ interface Props {
   type: GraphQLEnumType;
 }
 
-export const GraphQLExplorerEnum: FC<Props> = ({ type: { description, getValues } }) => {
+export const GraphQLExplorerEnum: FC<Props> = ({ type }) => {
+  const values = type.getValues();
+
   return (
     <div className="graphql-explorer__type">
-      <MarkdownPreview markdown={description || '*no description*'} />
+      <MarkdownPreview markdown={type.description || '*no description*'} />
 
       <h2 className="graphql-explorer__subheading">Values</h2>
       <ul className="graphql-explorer__defs">
-        {getValues().map(value => (
+        {values.map(value => (
           <li key={value.name}>
             <span className="selectable bold">{value.name}</span>
             <div className="graphql-explorer__defs__description">


### PR DESCRIPTION
use public class function, rather than destructure

changelog(Fixes): Fixed an error where GraphQL documentation would fail to render enums