### PR TITLE
Follow-up: rename shadowing variable r.

### DIFF
--- a/packages/insomnia/src/ui/components/modals/request-switcher-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-switcher-modal.tsx
@@ -456,7 +456,7 @@ class RequestSwitcherModal extends PureComponent<Props, State> {
                 );
                 return (
                   <li key={r._id}>
-                    <Button onClick={(_e, r) => this._activateRequest(r)} value={r} className={buttonClasses}>
+                    <Button onClick={(_e, request) => this._activateRequest(request)} value={r} className={buttonClasses}>
                       <div>
                         {requestGroup ? (
                           <div className="pull-right faint italic">


### PR DESCRIPTION
This is a follow-up to #4853 to rename the shadowing variable `r`. Sorry!