### PR TITLE
fix: set default header on isomorphic-git to fix BitBucket and AWS CodeCommit git sync

### DIFF
--- a/packages/insomnia/src/sync/git/http-client.ts
+++ b/packages/insomnia/src/sync/git/http-client.ts
@@ -6,9 +6,9 @@ export const httpClient = {
     let response;
     let body: Buffer | null = null;
 
-    const defaultGitAcceptHeader = {
-      'Accept': '*/*',
-    };
+    if (config.headers && !config.headers.Accept) {
+      config.headers.Accept = '*/*';
+    }
 
     if (Array.isArray(config.body)) {
       body = Buffer.concat(config.body);
@@ -18,7 +18,7 @@ export const httpClient = {
       response = await axiosRequest({
         url: config.url,
         method: config.method,
-        headers: defaultGitAcceptHeader,
+        headers: config.headers,
         data: body,
         responseType: 'arraybuffer',
         maxRedirects: 10,

--- a/packages/insomnia/src/sync/git/http-client.ts
+++ b/packages/insomnia/src/sync/git/http-client.ts
@@ -6,6 +6,14 @@ export const httpClient = {
     let response;
     let body: Buffer | null = null;
 
+    const defaultGitAcceptHeader = {
+      'Accept': '*/*',
+    };
+    const httpClientHeaders = {
+      ...defaultGitAcceptHeader,
+      ...config.headers,
+    };
+
     if (Array.isArray(config.body)) {
       body = Buffer.concat(config.body);
     }
@@ -14,7 +22,7 @@ export const httpClient = {
       response = await axiosRequest({
         url: config.url,
         method: config.method,
-        headers: config.headers,
+        headers: httpClientHeaders,
         data: body,
         responseType: 'arraybuffer',
         maxRedirects: 10,

--- a/packages/insomnia/src/sync/git/http-client.ts
+++ b/packages/insomnia/src/sync/git/http-client.ts
@@ -9,10 +9,6 @@ export const httpClient = {
     const defaultGitAcceptHeader = {
       'Accept': '*/*',
     };
-    const httpClientHeaders = {
-      ...defaultGitAcceptHeader,
-      ...config.headers,
-    };
 
     if (Array.isArray(config.body)) {
       body = Buffer.concat(config.body);
@@ -22,7 +18,7 @@ export const httpClient = {
       response = await axiosRequest({
         url: config.url,
         method: config.method,
-        headers: httpClientHeaders,
+        headers: defaultGitAcceptHeader,
         data: body,
         responseType: 'arraybuffer',
         maxRedirects: 10,


### PR DESCRIPTION
### Context

When trying to do git operations with at least on premise BitBucket servers, the request could result in a 404.

### Possible Solution

Set deafult header for isomorphic-git httpClient.
Deafult behaviour for cli git command adds "Accept: */*" header,
to mimic this behaviour an defaultGitAcceptHeader will be set and merged with optional provided config headers.

Closes #2220 

Also,
Closes #4660
Closes INS-1811


Changelog(Fixes): Fixed an issue that prevented users from using Git Sync when trying to clone projects hosted in BitBucket Server and AWS CodeCommit
