### PR TITLE
Enable strict TypeScript in insomnia.

### DIFF
--- a/packages/insomnia-components/src/list-group/unit-test-item.tsx
+++ b/packages/insomnia-components/src/list-group/unit-test-item.tsx
@@ -19,7 +19,7 @@ export interface UnitTestItemProps {
   onRunTest?: () => void;
   testNameEditable?: ReactNode;
   testsRunning?: TestItem[] | null;
-  onSetActiveRequest: () => void;
+  onSetActiveRequest: React.ChangeEventHandler<HTMLSelectElement>;
   selectedRequestId?: string | null;
   selectableRequests: {
     name: string;

--- a/packages/insomnia-components/src/list-group/unit-test-request-selector.tsx
+++ b/packages/insomnia-components/src/list-group/unit-test-request-selector.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 export interface UnitTestRequestSelectorProps {
-  onSetActiveRequest: () => void;
+  onSetActiveRequest: React.ChangeEventHandler<HTMLSelectElement>;
   selectedRequestId?: string | null;
   selectableRequests: {
     name: string;

--- a/packages/insomnia/src/account/fetch.ts
+++ b/packages/insomnia/src/account/fetch.ts
@@ -93,7 +93,7 @@ async function _fetch<T = any>(
     if (response.status === 502 && retries < 5) {
       retries++;
       await delay(retries * 200);
-      return this._fetch(method, path, obj, sessionId, compressBody, retries);
+      return _fetch(method, path, obj, sessionId, compressBody, retries);
     }
   } catch (err) {
     throw new Error(`Failed to fetch '${url}'`);

--- a/packages/insomnia/src/common/misc.ts
+++ b/packages/insomnia/src/common/misc.ts
@@ -159,6 +159,7 @@ export function debounce<T extends Function>(
   milliseconds: number = DEBOUNCE_MILLIS,
 ): T {
   // For regular debounce, just use a keyed debounce with a fixed key
+  // @ts-expect-error -- unsound contravariance
   return keyedDebounce(results => {
     // eslint-disable-next-line prefer-spread -- don't know if there was a "this binding" reason for this being this way so I'm leaving it alone
     callback.apply(null, results.__key__);

--- a/packages/insomnia/src/models/helpers/query-all-workspace-urls.ts
+++ b/packages/insomnia/src/models/helpers/query-all-workspace-urls.ts
@@ -8,10 +8,10 @@ export const queryAllWorkspaceUrls = async (
   reqType: typeof RequestType | typeof GrpcRequestType,
   reqId = 'n/a',
 ): Promise<string[]> => {
-  const docs = await db.withDescendants(workspace, reqType);
+  const docs = await db.withDescendants(workspace, reqType) as (Request | GrpcRequest)[];
   const urls = docs
     .filter(
-      (d: Request | GrpcRequest) =>
+      d =>
         d.type === reqType &&
         d._id !== reqId && // Not current request
         (d.url || ''), // Only ones with non-empty URLs

--- a/packages/insomnia/src/models/helpers/settings.ts
+++ b/packages/insomnia/src/models/helpers/settings.ts
@@ -291,8 +291,9 @@ export const omitControlledSettings = <
   T extends Settings,
   U extends Partial<Settings>
 >(settings: T, patch: U) => {
-  return omitBy((_value, setting: keyof Settings) => (
-    getControlledStatus(settings)(setting).isControlled
+  return omitBy((_value, setting: string) => (
+    // TODO: unsound type casting
+    getControlledStatus(settings)(setting as keyof Settings).isControlled
   ), patch);
 };
 

--- a/packages/insomnia/src/network/grpc/index.ts
+++ b/packages/insomnia/src/network/grpc/index.ts
@@ -274,8 +274,8 @@ const _setupServerStreamListeners = (call: Call, requestId: string, respond: Res
 
 // This function returns a function
 const _createUnaryCallback = (requestId: string, respond: ResponseCallbacks) => (
-  err: ServiceError,
-  value: Record<string, any>,
+  err: ServiceError | null,
+  value?: Record<string, any>,
 ) => {
   if (err) {
     // Don't do anything if cancelled
@@ -284,7 +284,9 @@ const _createUnaryCallback = (requestId: string, respond: ResponseCallbacks) => 
       respond.sendError(requestId, err);
     }
   } else {
-    respond.sendData(requestId, value);
+    // TODO: unsound non-null assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    respond.sendData(requestId, value!);
   }
 
   respond.sendEnd(requestId);

--- a/packages/insomnia/src/network/grpc/proto-manager/index.tsx
+++ b/packages/insomnia/src/network/grpc/proto-manager/index.tsx
@@ -184,7 +184,7 @@ export async function updateFile(protoFile: ProtoFile, callback: (arg0: string) 
   }
 }
 
-export async function renameFile(protoFile: ProtoFile, name: string) {
+export async function renameFile(protoFile: ProtoFile, name?: string) {
   await models.protoFile.update(protoFile, {
     name,
   });

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -361,7 +361,7 @@ export class GitVCS {
     }
   }
 
-  async undoPendingChanges(fileFilter?: String[]) {
+  async undoPendingChanges(fileFilter?: string[]) {
     console.log('[git] Undo pending changes');
     await git.checkout({
       ...this._baseOpts,

--- a/packages/insomnia/src/sync/store/drivers/memory-driver.ts
+++ b/packages/insomnia/src/sync/store/drivers/memory-driver.ts
@@ -1,6 +1,7 @@
 import type { BaseDriver } from './base';
 export default class MemoryDriver implements BaseDriver {
-  _db: Record<string, Buffer>;
+  // TODO: unsound definite property assignment assertion
+  _db!: Record<string, Buffer>;
 
   constructor() {
     this._init();

--- a/packages/insomnia/src/templating/index.ts
+++ b/packages/insomnia/src/templating/index.ts
@@ -7,15 +7,17 @@ import BaseExtension from './base-extension';
 import type { NunjucksParsedTag } from './utils';
 
 export class RenderError extends Error {
-  message: string;
-  path: string | null;
-  location: {
+  // TODO: unsound definite assignment assertions
+  // This is easy to fix, but be careful: extending from Error has especially tricky behavior.
+  message!: string;
+  path!: string | null;
+  location!: {
     line: number;
     column: number;
   };
 
-  type: string;
-  reason: string;
+  type!: string;
+  reason!: string;
 }
 
 // Some constants

--- a/packages/insomnia/src/ui/components/activity-toggle.tsx
+++ b/packages/insomnia/src/ui/components/activity-toggle.tsx
@@ -31,8 +31,12 @@ export const ActivityToggle: FunctionComponent<Props> = ({ handleActivityChange 
   const activeActivity = useSelector(selectActiveActivity);
   const activeWorkspace = useSelector(selectActiveWorkspace);
 
-  const onChange = useCallback((nextActivity: GlobalActivity) => {
-    handleActivityChange({ workspaceId: activeWorkspace?._id, nextActivity });
+  const onChange = useCallback((nextActivity: string) => {
+    handleActivityChange({
+      workspaceId: activeWorkspace?._id,
+      // TODO: unsound cast
+      nextActivity: nextActivity as GlobalActivity,
+    });
   }, [handleActivityChange, activeWorkspace]);
 
   if (!activeActivity) {

--- a/packages/insomnia/src/ui/components/base/dropdown/dropdown-item.tsx
+++ b/packages/insomnia/src/ui/components/base/dropdown/dropdown-item.tsx
@@ -7,7 +7,7 @@ import { AUTOBIND_CFG } from '../../../../common/constants';
 interface Props {
   addIcon?: boolean; // TODO(TSCONVERSION) some consumers are passing this prop but it appears to be unused
   title?: string;
-  buttonClass?: React.ComponentType;
+  buttonClass?: React.ElementType;
   stayOpenAfterClick?: boolean;
   value?: any;
   disabled?: boolean;
@@ -66,7 +66,6 @@ export class DropdownItem extends PureComponent<Props> {
       onClick: this._handleClick,
       ...props,
     };
-    // @ts-expect-error -- TSCONVERSION
     return createElement(buttonClass || 'button', buttonProps, inner);
   }
 }

--- a/packages/insomnia/src/ui/components/codemirror/extensions/autocomplete.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/autocomplete.ts
@@ -42,7 +42,7 @@ const ICONS = {
   },
 };
 
-CodeMirror.defineExtension('isHintDropdownActive', function() {
+CodeMirror.defineExtension('isHintDropdownActive', function(this: CodeMirror.Editor) {
   return (
     this.state.completionActive &&
     this.state.completionActive.data &&
@@ -51,16 +51,16 @@ CodeMirror.defineExtension('isHintDropdownActive', function() {
   );
 });
 
-CodeMirror.defineExtension('closeHintDropdown', function() {
+CodeMirror.defineExtension('closeHintDropdown', function(this: CodeMirror.Editor) {
   this.state.completionActive?.close();
 });
 
-CodeMirror.defineOption('environmentAutocomplete', null, (cm: CodeMirror.EditorFromTextArea, options: EnvironmentAutocompleteOptions) => {
+CodeMirror.defineOption('environmentAutocomplete', null, (cm: CodeMirror.Editor, options: EnvironmentAutocompleteOptions) => {
   if (!options) {
     return;
   }
 
-  async function completeAfter(cm: CodeMirror.EditorFromTextArea, callback?: () => boolean, showAllOnNoMatch = false) {
+  async function completeAfter(cm: CodeMirror.Editor, callback?: () => boolean, showAllOnNoMatch = false) {
     // Bail early if didn't match the callback test
     if (callback && !callback()) {
       return;
@@ -114,7 +114,7 @@ CodeMirror.defineOption('environmentAutocomplete', null, (cm: CodeMirror.EditorF
     });
   }
 
-  function completeIfInVariableName(cm: CodeMirror.EditorFromTextArea) {
+  function completeIfInVariableName(cm: CodeMirror.Editor) {
     completeAfter(cm, () => {
       const cur = cm.getCursor();
       const pos = CodeMirror.Pos(cur.line, cur.ch - MAX_HINT_LOOK_BACK);
@@ -125,7 +125,7 @@ CodeMirror.defineOption('environmentAutocomplete', null, (cm: CodeMirror.EditorF
     return CodeMirror.Pass;
   }
 
-  function completeIfAfterTagOrVarOpen(cm: CodeMirror.EditorFromTextArea) {
+  function completeIfAfterTagOrVarOpen(cm: CodeMirror.Editor) {
     completeAfter(
       cm,
       () => {
@@ -140,22 +140,22 @@ CodeMirror.defineOption('environmentAutocomplete', null, (cm: CodeMirror.EditorF
     return CodeMirror.Pass;
   }
 
-  function completeForce(cm: CodeMirror.EditorFromTextArea) {
+  function completeForce(cm: CodeMirror.Editor) {
     completeAfter(cm, undefined, true);
     return CodeMirror.Pass;
   }
 
   function setupKeyMap(
-    cm: CodeMirror.EditorFromTextArea,
+    cm: CodeMirror.Editor,
     {
       completeIfAfterTagOrVarOpen,
       completeForce,
     }: {
       completeIfAfterTagOrVarOpen: (
-        cm: CodeMirror.EditorFromTextArea
+        cm: CodeMirror.Editor
       ) => void | typeof CodeMirror.Pass;
       completeForce: (
-        cm: CodeMirror.EditorFromTextArea
+        cm: CodeMirror.Editor
       ) => void | typeof CodeMirror.Pass;
     }
   ) {
@@ -187,7 +187,7 @@ CodeMirror.defineOption('environmentAutocomplete', null, (cm: CodeMirror.EditorF
   }
 
   let keydownTimeoutHandle: NodeJS.Timeout | null = null;
-  cm.on('keydown', (cm: CodeMirror.EditorFromTextArea, event) => {
+  cm.on('keydown', (cm: CodeMirror.Editor, event) => {
     // Close autocomplete on Escape if it's open
     if (cm.isHintDropdownActive() && event.key === 'Escape') {
       if (!cm.state.completionActive) {
@@ -232,7 +232,7 @@ CodeMirror.defineOption('environmentAutocomplete', null, (cm: CodeMirror.EditorF
  * @param options
  * @returns {Promise.<{list: Array, from, to}>}
  */
-function hint(cm: CodeMirror.EditorFromTextArea, options: ShowHintOptions) {
+function hint(cm: CodeMirror.Editor, options: ShowHintOptions) {
   // Add type to all things (except constants, which need to convert to an object)
   const variablesToMatch: VariableCompletionItem[] = (options.variables || []).map(v => ({ ...v, type: TYPE_VARIABLE }));
   const snippetsToMatch: SnippetCompletionItem[] = (options.snippets || []).map(v => ({ ...v, type: TYPE_SNIPPET }));
@@ -358,7 +358,7 @@ function hint(cm: CodeMirror.EditorFromTextArea, options: ShowHintOptions) {
  * @param self
  * @param data
  */
-async function replaceHintMatch(cm: CodeMirror.EditorFromTextArea, _self: any, data: any) {
+async function replaceHintMatch(cm: CodeMirror.Editor, _self: any, data: any) {
   if (typeof data.text === 'function') {
     data.text = await data.text();
   }

--- a/packages/insomnia/src/ui/components/codemirror/extensions/clickable.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/clickable.ts
@@ -6,7 +6,7 @@ import { AllHtmlEntities } from 'html-entities';
 import { FLEXIBLE_URL_REGEX } from '../../../../common/constants';
 const entities = new AllHtmlEntities();
 
-CodeMirror.defineExtension('makeLinksClickable', function(handleClick: CodeMirrorLinkClickCallback) {
+CodeMirror.defineExtension('makeLinksClickable', function(this: CodeMirror.Editor, handleClick: CodeMirrorLinkClickCallback) {
   // Only add the click mode if we have links to click
   this.addOverlay({
     token: function(stream: any) {

--- a/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
@@ -8,6 +8,7 @@ import { showModal } from '../../modals/index';
 import { NunjucksModal } from '../../modals/nunjucks-modal';
 
 CodeMirror.defineExtension('enableNunjucksTags', function(
+  this: CodeMirror.Editor,
   handleRender: HandleRender,
   handleGetRenderContext: HandleGetRenderContext,
   showVariableSourceAndValue = false,
@@ -44,7 +45,7 @@ CodeMirror.defineExtension('enableNunjucksTags', function(
 },
 );
 
-async function _highlightNunjucksTags(render: any, renderContext: any, showVariableSourceAndValue: boolean) {
+async function _highlightNunjucksTags(this: CodeMirror.Editor, render: any, renderContext: any, showVariableSourceAndValue: boolean) {
   const renderCacheKey = Math.random() + '';
 
   const renderString = (text: any) => render(text, renderCacheKey);
@@ -127,6 +128,7 @@ async function _highlightNunjucksTags(render: any, renderContext: any, showVaria
       el.setAttribute('data-error', 'off');
       el.setAttribute('data-template', tok.string);
       const mark = this.markText(start, end, {
+        // @ts-expect-error not a known property of TextMarkerOptions
         __nunjucks: true,
         // Mark that we created it
         __template: tok.string,
@@ -158,13 +160,16 @@ async function _highlightNunjucksTags(render: any, renderContext: any, showVaria
       el.addEventListener('click', async () => {
         // Define the dialog HTML
         showModal(NunjucksModal, {
+          // @ts-expect-error not a known property of TextMarkerOptions
           template: mark.__template,
           onDone: (template: string | null) => {
             const pos = mark.find();
 
             if (pos) {
               const { from, to } = pos;
-              this.replaceRange(template, from, to);
+              // TODO: unsound non-null assertion
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              this.replaceRange(template!, from, to);
             } else {
               console.warn('Tried to replace mark that did not exist', mark);
             }
@@ -205,7 +210,9 @@ async function _highlightNunjucksTags(render: any, renderContext: any, showVaria
         // TODO: Actually only use dropEffect for this logic. For some reason
         // changing it doesn't seem to take affect in Chromium 56 (maybe bug?)
         if (droppedInSameEditor) {
-          const { from, to } = mark.find();
+          // TODO: unsound non-null assertion
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const { from, to } = mark.find()!;
           this.replaceRange('', from, to, '+dnd');
         }
 

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -120,7 +120,7 @@ export class OneLineEditor extends PureComponent<Props, State> {
     document.body.removeEventListener('mousedown', this._handleDocumentMousedown);
   }
 
-  _handleDocumentMousedown(event: KeyboardEvent) {
+  _handleDocumentMousedown(event: MouseEvent) {
     if (!this._editor) {
       return;
     }
@@ -180,7 +180,7 @@ export class OneLineEditor extends PureComponent<Props, State> {
     this.props.onFocus?.(event);
   }
 
-  _handleInputFocus(event: React.FocusEvent<HTMLInputElement>) {
+  _handleInputFocus(event: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement, Element>) {
     // If we're focusing the whole thing, blur the input. This happens when
     // the user tabs to the field.
     const start = this._input?.getSelectionStart();

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-toggle-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-toggle-row.tsx
@@ -28,7 +28,7 @@ export const AuthToggleRow: FC<Props> = ({
 
   const databaseValue = Boolean(authentication[property]);
   const toggle = useCallback(
-    (_event: React.MouseEvent, value: boolean) =>
+    (_event: React.MouseEvent<HTMLButtonElement>, value?: boolean) =>
       patchAuth({ [property]: value }), [patchAuth, property]
   );
 

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
-import { EditorFromTextArea, LintOptions, ShowHintOptions, TextMarker } from 'codemirror';
+import CodeMirror, { LintOptions, ShowHintOptions, TextMarker } from 'codemirror';
 import { GraphQLInfoOptions } from 'codemirror-graphql/info';
 import { ModifiedGraphQLJumpOptions } from 'codemirror-graphql/jump';
 import { OpenDialogOptions } from 'electron';
@@ -101,7 +101,7 @@ export class GraphQLEditor extends PureComponent<Props, State> {
   _disabledOperationMarkers: TextMarker[] = [];
   _documentAST: null | DocumentNode = null;
   _isMounted = false;
-  _queryEditor: null | EditorFromTextArea = null;
+  _queryEditor: null | CodeMirror.Editor = null;
   _schemaFetchTimeout: NodeJS.Timeout | null = null;
 
   constructor(props: Props) {
@@ -272,7 +272,7 @@ export class GraphQLEditor extends PureComponent<Props, State> {
     });
   }
 
-  _handleQueryEditorInit(codeMirror: EditorFromTextArea) {
+  _handleQueryEditorInit(codeMirror: CodeMirror.Editor) {
     this._queryEditor = codeMirror;
     // @ts-expect-error -- TSCONVERSION window.cm doesn't exist
     window.cm = this._queryEditor;

--- a/packages/insomnia/src/ui/components/export-requests/request-group-row.tsx
+++ b/packages/insomnia/src/ui/components/export-requests/request-group-row.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class RequestGroupRow extends PureComponent<Props> {
-  checkbox: HTMLInputElement;
+  checkbox?: HTMLInputElement;
 
   setCheckboxRef(checkbox: HTMLInputElement) {
     this.checkbox = checkbox;

--- a/packages/insomnia/src/ui/components/graph-ql-explorer/graph-ql-explorer-type.tsx
+++ b/packages/insomnia/src/ui/components/graph-ql-explorer/graph-ql-explorer-type.tsx
@@ -7,22 +7,23 @@ import { ascendingNameSort } from '../../../common/sorting';
 import { MarkdownPreview } from '../markdown-preview';
 import { GraphQLExplorerFieldsList } from './graph-ql-explorer-fields-list';
 import { GraphQLExplorerTypeLink } from './graph-ql-explorer-type-link';
+import { type GraphQLFieldWithParentName } from './graph-ql-types';
 
 interface Props {
-  onNavigateType: (type: Record<string, any>) => void;
-  onNavigateField: (field: Record<string, any>) => void;
+  onNavigateType: (type: GraphQLType) => void;
+  onNavigateField: (field: GraphQLFieldWithParentName) => void;
   type: GraphQLType;
   schema: GraphQLSchema | null;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class GraphQLExplorerType extends PureComponent<Props> {
-  _handleNavigateType(type: Record<string, any>) {
+  _handleNavigateType(type: GraphQLType) {
     const { onNavigateType } = this.props;
     onNavigateType(type);
   }
 
-  _handleNavigateField(field: Record<string, any>) {
+  _handleNavigateField(field: GraphQLFieldWithParentName) {
     const { onNavigateField } = this.props;
     onNavigateField(field);
   }

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -186,7 +186,7 @@ export class KeyValueEditor extends PureComponent<Props, State> {
     this._addPair();
   }
 
-  _handleKeyDown(_pair: Pair, event: KeyboardEvent, value?: any) {
+  _handleKeyDown(_pair: Pair, event: KeyboardEvent | React.KeyboardEvent<Element>, value?: any) {
     if (event.metaKey || event.ctrlKey) {
       return;
     }

--- a/packages/insomnia/src/ui/components/key-value-editor/row.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/row.tsx
@@ -36,18 +36,18 @@ type DragDirection = 0 | 1 | -1;
 interface Props {
   onChange: (pair: Pair) => void;
   onDelete: (pair: Pair) => void;
-  onFocusName: (pair: Pair, event: FocusEvent) => void;
-  onFocusValue: (pair: Pair, event: FocusEvent) => void;
-  onFocusDescription: (pair: Pair, event: FocusEvent) => void;
+  onFocusName: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
+  onFocusValue: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
+  onFocusDescription: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
   displayDescription: boolean;
   index: number;
   pair: Pair;
   readOnly?: boolean;
   onMove?: (pairToMove: Pair, pairToTarget: Pair, targetOffset: 1 | -1) => void;
-  onKeyDown?: (pair: Pair, event: KeyboardEvent, value?: any) => void;
-  onBlurName?: (pair: Pair, event: FocusEvent) => void;
-  onBlurValue?: (pair: Pair, event: FocusEvent) => void;
-  onBlurDescription?: (pair: Pair, event: FocusEvent) => void;
+  onKeyDown?: (pair: Pair, event: KeyboardEvent | React.KeyboardEvent<Element>, value?: any) => void;
+  onBlurName?: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
+  onBlurValue?: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
+  onBlurDescription?: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
   enableNunjucks?: boolean;
   handleGetAutocompleteNameConstants?: AutocompleteHandler;
   handleGetAutocompleteValueConstants?: AutocompleteHandler;
@@ -188,33 +188,33 @@ class KeyValueEditorRowInternal extends PureComponent<Props, State> {
     });
   }
 
-  _handleDisableChange(_event: React.MouseEvent, disabled: boolean) {
+  _handleDisableChange(_event: React.MouseEvent, disabled?: boolean) {
     this._sendChange({
       disabled,
     });
   }
 
-  _handleFocusName(event: FocusEvent) {
+  _handleFocusName(event: FocusEvent | React.FocusEvent<Element, Element>) {
     this.props.onFocusName(this.props.pair, event);
   }
 
-  _handleFocusValue(event: FocusEvent) {
+  _handleFocusValue(event: FocusEvent | React.FocusEvent<Element, Element>) {
     this.props.onFocusValue(this.props.pair, event);
   }
 
-  _handleFocusDescription(event: FocusEvent) {
+  _handleFocusDescription(event: FocusEvent | React.FocusEvent<Element, Element>) {
     this.props.onFocusDescription(this.props.pair, event);
   }
 
-  _handleBlurName(event: FocusEvent) {
+  _handleBlurName(event: FocusEvent | React.FocusEvent<Element, Element>) {
     this.props.onBlurName?.(this.props.pair, event);
   }
 
-  _handleBlurValue(event: FocusEvent) {
+  _handleBlurValue(event: FocusEvent | React.FocusEvent<Element, Element>) {
     this.props.onBlurValue?.(this.props.pair, event);
   }
 
-  _handleBlurDescription(event: FocusEvent) {
+  _handleBlurDescription(event: FocusEvent | React.FocusEvent<Element, Element>) {
     this.props.onBlurDescription?.(this.props.pair, event);
   }
 
@@ -222,7 +222,7 @@ class KeyValueEditorRowInternal extends PureComponent<Props, State> {
     this.props.onDelete?.(this.props.pair);
   }
 
-  _handleKeyDown(event: KeyboardEvent, value?: any) {
+  _handleKeyDown(event: KeyboardEvent | React.KeyboardEvent<Element>, value?: any) {
     this.props.onKeyDown?.(this.props.pair, event, value);
   }
 

--- a/packages/insomnia/src/ui/components/keydown-binder.ts
+++ b/packages/insomnia/src/ui/components/keydown-binder.ts
@@ -53,7 +53,8 @@ export class KeydownBinder extends PureComponent<Props> {
 
   componentDidMount() {
     if (this.props.scoped) {
-      const el = ReactDOM.findDOMNode(this);
+      // TODO: unsound casting
+      const el = ReactDOM.findDOMNode(this) as HTMLElement | null;
       el?.addEventListener('keydown', this._handleKeydown, { capture: true });
       el?.addEventListener('keyup', this._handleKeyup, { capture: true });
     } else {
@@ -64,7 +65,8 @@ export class KeydownBinder extends PureComponent<Props> {
 
   componentWillUnmount() {
     if (this.props.scoped) {
-      const el = ReactDOM.findDOMNode(this);
+      // TODO: unsound casting
+      const el = ReactDOM.findDOMNode(this) as HTMLElement | null;
       el?.removeEventListener('keydown', this._handleKeydown, { capture: true });
       el?.removeEventListener('keyup', this._handleKeyup, { capture: true });
     } else {

--- a/packages/insomnia/src/ui/components/modals/alert-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/alert-modal.tsx
@@ -30,7 +30,7 @@ export class AlertModal extends PureComponent<{}, State> {
   _cancel: HTMLButtonElement | null = null;
   _ok: HTMLButtonElement | null = null;
 
-  _okCallback: (value: void | PromiseLike<void>) => void;
+  _okCallback?: (value: void | PromiseLike<void>) => void;
   _okCallback2: AlertModalOptions['onConfirm'];
 
   _setModalRef(modal: Modal) {
@@ -40,7 +40,9 @@ export class AlertModal extends PureComponent<{}, State> {
   _handleOk() {
     this.hide();
 
-    this._okCallback();
+    // TODO: unsound non-null assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this._okCallback!();
 
     if (typeof this._okCallback2 === 'function') {
       this._okCallback2();

--- a/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
@@ -34,7 +34,7 @@ interface State {
 export class GitBranchesModal extends PureComponent<Props, State> {
   modal: Modal | null = null;
   input: HTMLInputElement | null = null;
-  _onHide: (() => void) | null;
+  _onHide?: (() => void) | null;
 
   state: State = {
     error: '',

--- a/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
@@ -56,7 +56,7 @@ const INITIAL_STATE: State = {
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class GitStagingModal extends PureComponent<Props, State> {
   modal: Modal | null = null;
-  statusNames: Record<string, string>;
+  statusNames?: Record<string, string>;
   textarea: HTMLTextAreaElement | null = null;
   onCommit: null | (() => void);
 
@@ -333,7 +333,9 @@ export class GitStagingModal extends PureComponent<Props, State> {
 
   renderItem(item: Item) {
     const { path: gitPath, staged, editable } = item;
-    const docName = this.statusNames[gitPath] || 'n/a';
+    // TODO: unsound non-null assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const docName = this.statusNames![gitPath] || 'n/a';
     return (
       <tr key={gitPath} className="table--no-outline-row">
         <td>

--- a/packages/insomnia/src/ui/components/modals/prompt-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/prompt-modal.tsx
@@ -26,7 +26,7 @@ interface State {
   onComplete?: (arg0: string) => Promise<void> | void;
   onCancel?: (() => void) | null;
   onHide?: () => void;
-  onDeleteHint?: ((arg0: string) => void) | null;
+  onDeleteHint?: ((arg0?: string) => void) | null;
   currentValue: string;
   loading: boolean;
 }
@@ -46,7 +46,7 @@ export interface PromptModalOptions {
   hints?: string[];
   onComplete?: (arg0: string) => Promise<void> | void;
   onHide?: () => void;
-  onDeleteHint?: (arg0: string) => void;
+  onDeleteHint?: (arg0?: string) => void;
   onCancel?: () => void;
 }
 
@@ -76,10 +76,14 @@ export class PromptModal extends PureComponent<{}, State> {
     loading: false,
   };
 
-  async _done(rawValue: string) {
+  async _done(rawValue?: string) {
     const { onComplete, upperCase } = this.state;
-    const value = upperCase ? rawValue.toUpperCase() : rawValue;
-    await onComplete?.(value);
+    // TODO: unsound non-null assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const value = upperCase ? rawValue!.toUpperCase() : rawValue;
+    // TODO: unsound non-null assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await onComplete?.(value!);
     this.hide();
   }
 
@@ -100,11 +104,11 @@ export class PromptModal extends PureComponent<{}, State> {
     this.modal = modal;
   }
 
-  _handleSelectHint(_event: React.MouseEvent, hint: string) {
+  _handleSelectHint(_event: React.MouseEvent, hint?: string) {
     this._done(hint);
   }
 
-  _handleDeleteHint(_event: React.MouseEvent, hint: string) {
+  _handleDeleteHint(_event: React.MouseEvent, hint?: string) {
     const { onDeleteHint } = this.state;
     onDeleteHint?.(hint);
     const hints = this.state.hints.filter(h => h !== hint);

--- a/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
@@ -137,7 +137,7 @@ class ProtoFilesModal extends PureComponent<Props, State> {
     return protoManager.addDirectory(workspace._id);
   }
 
-  _handleRename(protoFile: ProtoFile, name: string) {
+  _handleRename(protoFile: ProtoFile, name?: string) {
     return protoManager.renameFile(protoFile, name);
   }
 

--- a/packages/insomnia/src/ui/components/modals/sync-history-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-history-modal.tsx
@@ -25,7 +25,7 @@ interface State {
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class SyncHistoryModal extends PureComponent<Props, State> {
   modal: Modal | null = null;
-  handleRollback: (arg0: Snapshot) => Promise<void>;
+  handleRollback?: (arg0: Snapshot) => Promise<void>;
 
   state: State = {
     branch: '',
@@ -37,7 +37,9 @@ export class SyncHistoryModal extends PureComponent<Props, State> {
   }
 
   async _handleClickRollback(snapshot: Snapshot) {
-    await this.handleRollback(snapshot);
+    // TODO: unsound non-null assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await this.handleRollback!(snapshot);
     await this.refreshState();
   }
 

--- a/packages/insomnia/src/ui/components/modals/sync-merge-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-merge-modal.tsx
@@ -25,7 +25,7 @@ interface State {
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class UnconnectedSyncMergeModal extends PureComponent<Props, State> {
   modal: Modal | null = null;
-  _handleDone: (arg0: MergeConflict[]) => void;
+  _handleDone?: (arg0: MergeConflict[]) => void;
 
   state: State = {
     conflicts: [],
@@ -36,7 +36,9 @@ export class UnconnectedSyncMergeModal extends PureComponent<Props, State> {
   }
 
   _handleOk() {
-    this._handleDone(this.state.conflicts);
+    // TODO: unsound non-null assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this._handleDone!(this.state.conflicts);
 
     this.hide();
   }

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -234,13 +234,15 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
     this._load(workspace, environment);
   }
 
-  async _handleDuplicateEnvironment(_event: React.MouseEvent, environment: Environment) {
+  async _handleDuplicateEnvironment(_event: React.MouseEvent, environment?: Environment) {
     const { workspace } = this.state;
-    const newEnvironment = await models.environment.duplicate(environment);
+    // TODO: unsound non-null assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const newEnvironment = await models.environment.duplicate(environment!);
     await this._load(workspace, newEnvironment);
   }
 
-  async _handleDeleteEnvironment(_event: React.MouseEvent, environment: Environment) {
+  async _handleDeleteEnvironment(_event: React.MouseEvent, environment?: Environment) {
     const { handleChangeEnvironment, activeEnvironmentId } = this.props;
     const { rootEnvironment, workspace } = this.state;
 
@@ -250,12 +252,16 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
     }
 
     // Unset active environment if it's being deleted
-    if (activeEnvironmentId === environment._id) {
+    // TODO: unsound non-null assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (activeEnvironmentId === environment!._id) {
       handleChangeEnvironment(null);
     }
 
     // Delete the current one
-    await models.environment.remove(environment);
+    // TODO: unsound non-null assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await models.environment.remove(environment!);
     await this._load(workspace, rootEnvironment);
   }
 
@@ -284,7 +290,7 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
     }
   }
 
-  async _handleChangeEnvironmentName(environment: Environment, name: string) {
+  async _handleChangeEnvironmentName(environment: Environment, name?: string) {
     await this._updateEnvironment(environment, {
       name,
     });
@@ -452,7 +458,7 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
                 'env-modal__sidebar-item--active': selectedEnvironment === rootEnvironment,
               })}
             >
-              <Button onClick={this._handleShowEnvironment} value={rootEnvironment}>
+              <Button onClick={this._handleShowEnvironment} value={rootEnvironment ?? undefined}>
                 {ROOT_ENVIRONMENT_NAME}
                 <HelpTooltip className="space-left">
                   The variables in this environment are always available, regardless of which

--- a/packages/insomnia/src/ui/components/proto-file/proto-file-list-item.tsx
+++ b/packages/insomnia/src/ui/components/proto-file/proto-file-list-item.tsx
@@ -43,7 +43,7 @@ export const ProtoFileListItem: FunctionComponent<Props> = ({
     [handleDelete, protoFile],
   );
   const handleRenameCallback = useCallback(
-    async (newName: string) => {
+    async (newName?: string) => {
       await handleRename(protoFile, newName);
     },
     [handleRename, protoFile],

--- a/packages/insomnia/src/ui/components/proto-file/proto-file-list.tsx
+++ b/packages/insomnia/src/ui/components/proto-file/proto-file-list.tsx
@@ -11,7 +11,7 @@ export type SelectProtoFileHandler = (id: string) => void;
 export type DeleteProtoFileHandler = (protofile: ProtoFile) => Promise<void>;
 export type DeleteProtoDirectoryHandler = (protoDirectory: ProtoDirectory) => Promise<void>;
 export type UpdateProtoFileHandler = (protofile: ProtoFile) => Promise<void>;
-export type RenameProtoFileHandler = (protoFile: ProtoFile, name: string) => Promise<void>;
+export type RenameProtoFileHandler = (protoFile: ProtoFile, name?: string) => Promise<void>;
 
 interface Props {
   protoDirectories: ExpandedProtoDirectory[];

--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -38,7 +38,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class Plugins extends PureComponent<Props, State> {
-  _isMounted: boolean;
+  _isMounted = false;
 
   state: State = {
     plugins: [],

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -107,7 +107,7 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
     requestActionsDropdown.current?.show();
   }, [requestActionsDropdown]);
 
-  const handleRequestUpdateName = useCallback((name: string) => {
+  const handleRequestUpdateName = useCallback((name?: string) => {
     if (!request) {
       return;
     }

--- a/packages/insomnia/src/ui/components/unit-test-editable.tsx
+++ b/packages/insomnia/src/ui/components/unit-test-editable.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent } from 'react';
 import { Editable } from './base/editable';
 
 interface Props {
-  onSubmit: () => void;
+  onSubmit: (value?: string) => void;
   value: string;
 }
 

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -51,7 +51,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class ResponseViewer extends Component<ResponseViewerProps, State> {
-  _selectableView: typeof ResponseRawViewer | UnconnectedCodeEditor | null;
+  _selectableView: typeof ResponseRawViewer | UnconnectedCodeEditor | null = null;
 
   state: State = {
     blockingBecauseTooLarge: false,

--- a/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
@@ -252,13 +252,13 @@ class UnconnectedWrapperUnitTest extends PureComponent<Props, State> {
     });
   }
 
-  async _handleChangeTestName(unitTest: UnitTest, name: string) {
+  async _handleChangeTestName(unitTest: UnitTest, name?: string) {
     await models.unitTest.update(unitTest, {
       name,
     });
   }
 
-  async _handleChangeActiveSuiteName(name: string) {
+  async _handleChangeActiveSuiteName(name?: string) {
     const { activeUnitTestSuite } = this.props;
     if (!activeUnitTestSuite) {
       return;

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -151,7 +151,7 @@ export type WrapperProps = AppProps & {
   handleSetRequestPinned: Function;
   handleSendRequestWithEnvironment: Function;
   handleSendAndDownloadRequestWithEnvironment: Function;
-  handleUpdateRequestMimeType: (mimeType: string) => Promise<Request | null>;
+  handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   handleUpdateDownloadPath: Function;
 
   paneWidth: number;

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -543,7 +543,7 @@ class App extends PureComponent<AppProps, State> {
     });
   }
 
-  async _handleSetActiveEnvironment(activeEnvironmentId: string) {
+  async _handleSetActiveEnvironment(activeEnvironmentId: string | null) {
     await this._updateActiveWorkspaceMeta({
       activeEnvironmentId,
     });

--- a/packages/insomnia/tsconfig.build.json
+++ b/packages/insomnia/tsconfig.build.json
@@ -4,8 +4,6 @@
     "outDir": "./build",
     "rootDir": ".",
     "resolveJsonModule": true,
-    "strict": true,
-    "noImplicitAny": true,
     "isolatedModules": true,
     "strictNullChecks": true,
     "jsx": "react",

--- a/packages/insomnia/tsconfig.build.json
+++ b/packages/insomnia/tsconfig.build.json
@@ -4,7 +4,7 @@
     "outDir": "./build",
     "rootDir": ".",
     "resolveJsonModule": true,
-    "strict": false,
+    "strict": true,
     "noImplicitAny": true,
     "isolatedModules": true,
     "strictNullChecks": true,


### PR DESCRIPTION
All trivial changes. The only non-type change I have here is that `_fetch` seems to erroneously call `this._fetch` in its retry loop, likely crashing. I'm pretty confident insomnia-api never returns 502 in its current form, so this codepath is likely not called (there's no evidence of it in Sentry.)

This one was a lot easier/quicker to do than the other one (only a couple hours,) so I am not worried about needing to rebase it a few times. That said, I'm eager to see it merged so we can catch more bugs, and fix some of the soundness errors that are uncovered with it.

As with the last one, bugfixes and almost any change that would modify the behavior are out of scope here. I only included the fetch change because there is literally no way it isn't already broken + the solution is very trivial.