### PR TITLE
Properly handle 204 from notifications endpoint

### DIFF
--- a/packages/insomnia/src/ui/components/toast.tsx
+++ b/packages/insomnia/src/ui/components/toast.tsx
@@ -145,7 +145,10 @@ export class Toast extends PureComponent<{}, State> {
         updatesNotSupported: !updatesSupported(),
         version: getAppVersion(),
       };
-      notification = await fetch.postJson<ToastNotification>('/notification', data, session.getCurrentSessionId());
+      const notificationOrEmpty = await fetch.post<ToastNotification>('/notification', data, session.getCurrentSessionId());
+      if (notificationOrEmpty && typeof notificationOrEmpty !== 'string') {
+        notification = notificationOrEmpty;
+      }
     } catch (err) {
       console.warn('[toast] Failed to fetch user notifications', err);
     }


### PR DESCRIPTION
In some cases, the notifications endpoint can return a 204 response with no body. This commit fixes a regression where this causes a warning.

Note that there is no user facing impact.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
