### PR TITLE
Fix timeout setting in milliseconds

### DIFF
--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -286,10 +286,11 @@ export const General: FC = () => {
           min={-1}
         />
         <NumberSetting
-          label="Request timeout"
+          label="Request timeout (ms)"
           setting="timeout"
-          help="Enter the maximum seconds allotted before a request will timeout. Enter -1 to disable timeouts. "
-          min={-1}
+          help="Enter the maximum milliseconds allotted before a request will timeout. Enter 0 to disable timeouts. "
+          min={0}
+          step={100}
         />
       </div>
 

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -138,11 +138,12 @@ export const General: FC = () => {
         />
 
         <NumberSetting
-          label="Autocomplete popup delay"
+          label="Autocomplete popup delay (ms)"
           setting="autocompleteDelay"
           help="Delay the autocomplete popup by milliseconds. Enter 0 to disable the autocomplete delay."
           min={0}
           max={3000}
+          step={100}
         />
       </div>
 

--- a/packages/insomnia/src/ui/components/settings/number-setting.tsx
+++ b/packages/insomnia/src/ui/components/settings/number-setting.tsx
@@ -13,6 +13,7 @@ interface Props {
   max?: InputHTMLAttributes<HTMLInputElement>['max'];
   min: InputHTMLAttributes<HTMLInputElement>['min'];
   setting: SettingsOfType<number>;
+  step?: InputHTMLAttributes<HTMLInputElement>['step'];
 }
 
 export const NumberSetting: FC<Props> = ({
@@ -21,6 +22,7 @@ export const NumberSetting: FC<Props> = ({
   max,
   min,
   setting,
+  step = 0,
 }) => {
   const settings = useSelector(selectSettings);
 
@@ -54,6 +56,7 @@ export const NumberSetting: FC<Props> = ({
           name={setting}
           onChange={handleOnChange}
           type={'number'}
+          step={step}
         />
       </label>
     </div>

--- a/packages/insomnia/src/ui/components/settings/number-setting.tsx
+++ b/packages/insomnia/src/ui/components/settings/number-setting.tsx
@@ -22,7 +22,7 @@ export const NumberSetting: FC<Props> = ({
   max,
   min,
   setting,
-  step = 0,
+  step = 1,
 }) => {
   const settings = useSelector(selectSettings);
 


### PR DESCRIPTION
## Closes #4666 



changelog(Fixes): Fixed request timeout setting to display milliseconds instead of seconds
