### PR TITLE
refactor: convert markdown editor to functional

### DIFF
--- a/packages/insomnia/src/ui/components/markdown-editor.tsx
+++ b/packages/insomnia/src/ui/components/markdown-editor.tsx
@@ -1,9 +1,7 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
-import React, { PureComponent } from 'react';
+import React, { forwardRef, ForwardRefRenderFunction, ReactElement, useState } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
-import { AUTOBIND_CFG } from '../../common/constants';
 import { Button } from './base/button';
 import { CodeEditor,  UnconnectedCodeEditor } from './codemirror/code-editor';
 import { MarkdownPreview } from './markdown-preview';
@@ -18,84 +16,59 @@ interface Props {
   tall?: boolean;
 }
 
-interface State {
-  markdown: string;
-}
+const MarkdownEditorForwarded: ForwardRefRenderFunction<UnconnectedCodeEditor, Props> = ({
+  mode,
+  placeholder,
+  defaultPreviewMode,
+  className,
+  tall,
+  defaultValue,
+  onChange,
+}, ref): ReactElement => {
+  const [markdown, setMarkdown] = useState(defaultValue); // this was we are cutting the flow of prop change event after the initial rendering
+  const classes = classnames('react-tabs', 'markdown-editor', 'outlined', className, {
+    'markdown-editor--dynamic-height': !tall,
+  });
 
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class MarkdownEditor extends PureComponent<Props, State> {
-  _editor: UnconnectedCodeEditor | null = null;
+  const handleChange = (markdown: string): void => {
+    onChange(markdown);
+    setMarkdown(markdown);
+  };
 
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      markdown: props.defaultValue,
-    };
-  }
+  return (
+    <Tabs className={classes} defaultIndex={defaultPreviewMode ? 1 : 0}>
+      <TabList>
+        <Tab tabIndex="-1">
+          <Button value="Write">Write</Button>
+        </Tab>
+        <Tab tabIndex="-1">
+          <Button value="Preview">Preview</Button>
+        </Tab>
+      </TabList>
+      <TabPanel className="react-tabs__tab-panel markdown-editor__edit">
+        <div className="form-control form-control--outlined">
+          <CodeEditor
+            ref={ref}
+            hideGutters
+            hideLineNumbers
+            dynamicHeight={!tall}
+            manualPrettify
+            noStyleActiveLine
+            enableNunjucks
+            mode={mode || 'text/x-markdown'}
+            placeholder={placeholder}
+            debounceMillis={300}
+            defaultValue={markdown}
+            onChange={handleChange}
+          />
+        </div>
+        <div className="txt-sm italic faint">Styling with Markdown is supported</div>
+      </TabPanel>
+      <TabPanel className="react-tabs__tab-panel markdown-editor__preview">
+        <MarkdownPreview markdown={markdown} />
+      </TabPanel>
+    </Tabs>
+  );
+};
 
-  _handleChange(markdown: string) {
-    this.props.onChange(markdown);
-    this.setState({
-      markdown,
-    });
-  }
-
-  _setEditorRef(editor: UnconnectedCodeEditor) {
-    this._editor = editor;
-  }
-
-  focusEnd() {
-    this._editor?.focusEnd();
-  }
-
-  focus() {
-    this._editor?.focus();
-  }
-
-  render() {
-    const {
-      mode,
-      placeholder,
-      defaultPreviewMode,
-      className,
-      tall,
-    } = this.props;
-    const { markdown } = this.state;
-    const classes = classnames('react-tabs', 'markdown-editor', 'outlined', className, {
-      'markdown-editor--dynamic-height': !tall,
-    });
-    return (
-      <Tabs className={classes} defaultIndex={defaultPreviewMode ? 1 : 0}>
-        <TabList>
-          <Tab tabIndex="-1">
-            <Button value="Write">Write</Button>
-          </Tab>
-          <Tab tabIndex="-1">
-            <Button value="Preview">Preview</Button>
-          </Tab>
-        </TabList>
-        <TabPanel className="react-tabs__tab-panel markdown-editor__edit">
-          <div className="form-control form-control--outlined">
-            <CodeEditor
-              ref={this._setEditorRef}
-              hideGutters
-              hideLineNumbers
-              dynamicHeight={!tall}
-              manualPrettify
-              noStyleActiveLine
-              enableNunjucks
-              mode={mode || 'text/x-markdown'}
-              placeholder={placeholder}
-              defaultValue={markdown}
-              onChange={this._handleChange}
-            />
-          </div>
-          <div className="txt-sm italic faint">Styling with Markdown is supported</div>
-        </TabPanel>
-        <TabPanel className="react-tabs__tab-panel markdown-editor__preview">
-          <MarkdownPreview markdown={markdown} />
-        </TabPanel>
-      </Tabs>
-    );
-  }
-}
+export const MarkdownEditor = forwardRef(MarkdownEditorForwarded);

--- a/packages/insomnia/src/ui/components/markdown-editor.tsx
+++ b/packages/insomnia/src/ui/components/markdown-editor.tsx
@@ -1,9 +1,9 @@
 import classnames from 'classnames';
-import React, { forwardRef, ForwardRefRenderFunction, ReactElement, useState } from 'react';
+import React, { forwardRef, ReactElement, useCallback, useState } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
 import { Button } from './base/button';
-import { CodeEditor,  UnconnectedCodeEditor } from './codemirror/code-editor';
+import { CodeEditor, UnconnectedCodeEditor } from './codemirror/code-editor';
 import { MarkdownPreview } from './markdown-preview';
 
 interface Props {
@@ -16,7 +16,7 @@ interface Props {
   tall?: boolean;
 }
 
-const MarkdownEditorForwarded: ForwardRefRenderFunction<UnconnectedCodeEditor, Props> = ({
+export const MarkdownEditor = forwardRef<UnconnectedCodeEditor, Props>(({
   mode,
   placeholder,
   defaultPreviewMode,
@@ -25,15 +25,16 @@ const MarkdownEditorForwarded: ForwardRefRenderFunction<UnconnectedCodeEditor, P
   defaultValue,
   onChange,
 }, ref): ReactElement => {
-  const [markdown, setMarkdown] = useState(defaultValue); // this was we are cutting the flow of prop change event after the initial rendering
+  // default value is added here to capture the original class component's behavior, but this way cuts the flow of prop change event after the initial rendering
+  const [markdown, setMarkdown] = useState(defaultValue);
   const classes = classnames('react-tabs', 'markdown-editor', 'outlined', className, {
     'markdown-editor--dynamic-height': !tall,
   });
 
-  const handleChange = (markdown: string): void => {
+  const handleChange = useCallback((markdown: string) => {
     onChange(markdown);
     setMarkdown(markdown);
-  };
+  }, [onChange]);
 
   return (
     <Tabs className={classes} defaultIndex={defaultPreviewMode ? 1 : 0}>
@@ -69,6 +70,5 @@ const MarkdownEditorForwarded: ForwardRefRenderFunction<UnconnectedCodeEditor, P
       </TabPanel>
     </Tabs>
   );
-};
-
-export const MarkdownEditor = forwardRef(MarkdownEditorForwarded);
+});
+MarkdownEditor.displayName = 'MarkdownEditor';

--- a/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
@@ -1,5 +1,5 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import * as React from 'react';
+import React, { createRef } from 'react';
 import { connect } from 'react-redux';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
@@ -13,6 +13,7 @@ import { DebouncedInput } from '../base/debounced-input';
 import { Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
+import { UnconnectedCodeEditor } from '../codemirror/code-editor';
 import { HelpTooltip } from '../help-tooltip';
 import { MarkdownEditor } from '../markdown-editor';
 
@@ -40,7 +41,7 @@ interface RequestGroupSettingsModalOptions {
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class UnconnectedRequestGroupSettingsModal extends React.PureComponent<Props, State> {
   modal: Modal | null = null;
-  _editor: MarkdownEditor | null = null;
+  _editorRef = createRef<UnconnectedCodeEditor>();
 
   state: State = {
     requestGroup: null,
@@ -55,10 +56,6 @@ export class UnconnectedRequestGroupSettingsModal extends React.PureComponent<Pr
 
   _setModalRef(modal: Modal) {
     this.modal = modal;
-  }
-
-  _setEditorRef(ediotr: MarkdownEditor) {
-    this._editor = ediotr;
   }
 
   async _handleNameChange(name: string) {
@@ -181,7 +178,7 @@ export class UnconnectedRequestGroupSettingsModal extends React.PureComponent<Pr
 
         if (forceEditMode) {
           setTimeout(() => {
-            this._editor?.focus();
+            this._editorRef.current?.focus();
           }, 400);
         }
       },
@@ -204,7 +201,7 @@ export class UnconnectedRequestGroupSettingsModal extends React.PureComponent<Pr
 
     return showDescription ? (
       <MarkdownEditor
-        ref={this._setEditorRef}
+        ref={this._editorRef}
         className="margin-top"
         defaultPreviewMode={defaultPreviewMode}
         placeholder="Write a description"

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -1,5 +1,5 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import React, { PureComponent } from 'react';
+import React, { createRef, PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
@@ -15,6 +15,7 @@ import { DebouncedInput } from '../base/debounced-input';
 import { Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
+import { UnconnectedCodeEditor } from '../codemirror/code-editor';
 import { HelpTooltip } from '../help-tooltip';
 import { MarkdownEditor } from '../markdown-editor';
 
@@ -42,7 +43,7 @@ interface RequestSettingsModalOptions {
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class UnconnectedRequestSettingsModal extends PureComponent<Props, State> {
   modal: Modal | null = null;
-  _editor: MarkdownEditor | null = null;
+  _editorRef = createRef<UnconnectedCodeEditor>();
 
   state: State = {
     request: null,
@@ -57,10 +58,6 @@ export class UnconnectedRequestSettingsModal extends PureComponent<Props, State>
 
   _setModalRef(modal: Modal) {
     this.modal = modal;
-  }
-
-  _setEditorRef(editor: MarkdownEditor) {
-    this._editor = editor;
   }
 
   async _updateRequestSettingBoolean(event: React.SyntheticEvent<HTMLInputElement>) {
@@ -216,7 +213,7 @@ export class UnconnectedRequestSettingsModal extends PureComponent<Props, State>
 
         if (forceEditMode) {
           setTimeout(() => {
-            this._editor?.focus();
+            this._editorRef.current?.focus();
           }, 400);
         }
       },
@@ -331,7 +328,7 @@ export class UnconnectedRequestSettingsModal extends PureComponent<Props, State>
 
     return showDescription ? (
       <MarkdownEditor
-        ref={this._setEditorRef}
+        ref={this._editorRef}
         className="margin-top"
         defaultPreviewMode={defaultPreviewMode}
         placeholder="Write a description"


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
- convert markdown component into functional component
- refactor refs using createRef for the usage of MarkdownEditor component
