### PR TITLE
Chore/some-fc

### DIFF
--- a/packages/insomnia-components/src/list-group/list-group-item.tsx
+++ b/packages/insomnia-components/src/list-group/list-group-item.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import styled, { css } from 'styled-components';
 
 export interface ListGroupItemProps extends React.LiHTMLAttributes<HTMLLIElement> {
@@ -33,4 +33,4 @@ const StyledListGroupItem = styled.li<ListGroupItemProps>`
     `};
 `;
 
-export const ListGroupItem: React.FC<ListGroupItemProps> = props => <StyledListGroupItem {...props} />;
+export const ListGroupItem: FC<ListGroupItemProps> = props => <StyledListGroupItem {...props} />;

--- a/packages/insomnia/.eslintignore
+++ b/packages/insomnia/.eslintignore
@@ -2,4 +2,5 @@ build
 bin
 send-request
 coverage
-**/main.min.js
+src/main.min.js
+src/preload.js

--- a/packages/insomnia/src/ui/components/base/copy-button.tsx
+++ b/packages/insomnia/src/ui/components/base/copy-button.tsx
@@ -1,6 +1,6 @@
 import { clipboard } from 'electron';
 import { Button, ButtonProps } from 'insomnia-components';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 interface Props extends ButtonProps {
   confirmMessage?: string;
@@ -16,17 +16,20 @@ export const CopyButton: React.FC<Props> = ({
   ...buttonProps
 }) => {
   const [showConfirmation, setshowConfirmation] = useState(false);
-  const onClick = async (event: React.MouseEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-    const toCopy = typeof content === 'string' ? content : await content();
+  const onClick = useCallback((event: React.MouseEvent) => {
+    const fn = async () => {
+      event.preventDefault();
+      event.stopPropagation();
+      const toCopy = typeof content === 'string' ? content : await content();
 
-    if (toCopy) {
-      clipboard.writeText(toCopy);
-    }
-    setshowConfirmation(true);
+      if (toCopy) {
+        clipboard.writeText(toCopy);
+      }
+      setshowConfirmation(true);
+    };
+    fn();
+  }, [content]);
 
-  };
   useEffect(() => {
     const timer = setTimeout(() => {
       setshowConfirmation(false);

--- a/packages/insomnia/src/ui/components/base/copy-button.tsx
+++ b/packages/insomnia/src/ui/components/base/copy-button.tsx
@@ -1,9 +1,8 @@
 import { clipboard } from 'electron';
 import { Button, ButtonProps } from 'insomnia-components';
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface Props extends ButtonProps {
-  children?: ReactNode;
   confirmMessage?: string;
   content: string | Function;
   title?: string;
@@ -14,7 +13,7 @@ export const CopyButton: React.FC<Props> = ({
   confirmMessage,
   content,
   title,
-  ...other
+  ...buttonProps
 }) => {
   const [showConfirmation, setshowConfirmation] = useState(false);
   const onClick = async (event: React.MouseEvent) => {
@@ -38,7 +37,7 @@ export const CopyButton: React.FC<Props> = ({
   const confirm = typeof confirmMessage === 'string' ? confirmMessage : 'Copied';
   return (
     <Button
-      {...other}
+      {...buttonProps}
       title={title}
       onClick={onClick}
     >

--- a/packages/insomnia/src/ui/components/base/copy-button.tsx
+++ b/packages/insomnia/src/ui/components/base/copy-button.tsx
@@ -1,6 +1,7 @@
 import { clipboard } from 'electron';
 import { Button, ButtonProps } from 'insomnia-components';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
+import { useInterval } from 'react-use';
 
 interface Props extends ButtonProps {
   confirmMessage?: string;
@@ -30,12 +31,9 @@ export const CopyButton: React.FC<Props> = ({
     fn();
   }, [content]);
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setshowConfirmation(false);
-    }, 2000);
-    return () => clearTimeout(timer);
-  }, [showConfirmation]);
+  useInterval(() => {
+    setshowConfirmation(false);
+  }, 2000);
 
   const confirm = typeof confirmMessage === 'string' ? confirmMessage : 'Copied';
   return (

--- a/packages/insomnia/src/ui/components/base/copy-button.tsx
+++ b/packages/insomnia/src/ui/components/base/copy-button.tsx
@@ -1,6 +1,6 @@
 import { clipboard } from 'electron';
 import { Button, ButtonProps } from 'insomnia-components';
-import React, { useCallback, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import { useInterval } from 'react-use';
 
 interface Props extends ButtonProps {
@@ -9,7 +9,7 @@ interface Props extends ButtonProps {
   title?: string;
 }
 
-export const CopyButton: React.FC<Props> = ({
+export const CopyButton: FC<Props> = ({
   children,
   confirmMessage,
   content,

--- a/packages/insomnia/src/ui/components/base/copy-button.tsx
+++ b/packages/insomnia/src/ui/components/base/copy-button.tsx
@@ -1,76 +1,54 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { clipboard } from 'electron';
 import { Button, ButtonProps } from 'insomnia-components';
-import React, { PureComponent, ReactNode } from 'react';
-
-import { AUTOBIND_CFG } from '../../../common/constants';
+import React, { ReactNode, useEffect, useState } from 'react';
 
 interface Props extends ButtonProps {
-  content: string | Function;
   children?: ReactNode;
-  title?: string;
   confirmMessage?: string;
+  content: string | Function;
+  title?: string;
 }
 
-interface State {
-  showConfirmation: boolean;
-}
-
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class CopyButton extends PureComponent<Props, State> {
-  state: State = {
-    showConfirmation: false,
-  };
-
-  _triggerTimeout: NodeJS.Timeout | null = null;
-
-  async _handleClick(event: React.MouseEvent<HTMLButtonElement>) {
+export const CopyButton: React.FC<Props> = ({
+  children,
+  confirmMessage,
+  content,
+  title,
+  ...other
+}) => {
+  const [showConfirmation, setshowConfirmation] = useState(false);
+  const onClick = async (event: React.MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
-    const content =
-      typeof this.props.content === 'string' ? this.props.content : await this.props.content();
+    const toCopy = typeof content === 'string' ? content : await content();
 
-    if (content) {
-      clipboard.writeText(content);
+    if (toCopy) {
+      clipboard.writeText(toCopy);
     }
+    setshowConfirmation(true);
 
-    this.setState({
-      showConfirmation: true,
-    });
-    this._triggerTimeout = setTimeout(() => {
-      this.setState({
-        showConfirmation: false,
-      });
+  };
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setshowConfirmation(false);
     }, 2000);
-  }
+    return () => clearTimeout(timer);
+  }, [showConfirmation]);
 
-  componentWillUnmount() {
-    if (this._triggerTimeout === null) {
-      return;
-    }
-    clearTimeout(this._triggerTimeout);
-  }
-
-  render() {
-    const {
-      content,
-      children,
-      title,
-      confirmMessage,
-      ...other
-    } = this.props;
-    const { showConfirmation } = this.state;
-    const confirm = typeof confirmMessage === 'string' ? confirmMessage : 'Copied';
-    return (
-      <Button {...other} title={title} onClick={this._handleClick}>
-        {showConfirmation ? (
-          <span>
-            {confirm} <i className="fa fa-check-circle-o" />
-          </span>
-        ) : (
-          children || 'Copy to Clipboard'
-        )}
-      </Button>
-    );
-  }
-}
+  const confirm = typeof confirmMessage === 'string' ? confirmMessage : 'Copied';
+  return (
+    <Button
+      {...other}
+      title={title}
+      onClick={onClick}
+    >
+      {showConfirmation ? (
+        <span>
+          {confirm} <i className="fa fa-check-circle-o" />
+        </span>
+      ) : (
+        children || 'Copy to Clipboard'
+      )}
+    </Button>
+  );
+};

--- a/packages/insomnia/src/ui/components/base/editable.tsx
+++ b/packages/insomnia/src/ui/components/base/editable.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { ReactElement, useCallback, useRef, useState } from 'react';
 
 import { KeydownBinder } from '../keydown-binder';
+import { HighlightProps } from './highlight';
 
 export const shouldSave = (oldValue: string, newValue: string | undefined, preventBlank = false) => {
   // Should not save if length = 0 and we want to prevent blank
@@ -21,10 +22,10 @@ interface Props {
   blankValue?: string;
   className?: string;
   fallbackValue?: string;
-  onEditStart?: Function;
+  onEditStart?: () => void;
   onSubmit: (value?: string) => void;
   preventBlank?: boolean;
-  renderReadView?: Function;
+  renderReadView?: (value: string | undefined, props: any) => ReactElement<HighlightProps>;
   singleClick?: boolean;
   value: string;
 }

--- a/packages/insomnia/src/ui/components/base/editable.tsx
+++ b/packages/insomnia/src/ui/components/base/editable.tsx
@@ -39,17 +39,13 @@ export const Editable: React.FC<Props> = ({
   renderReadView,
   singleClick,
   value,
-  ...extra
+  ...childProps
 }) => {
   const [editing, setEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const _handleSingleClickEditStart = () => {
-    if (singleClick) {
-      _handleEditStart();
-    }
-  };
+  const onSingleClick = () => singleClick && handleEditStart();
 
-  const _handleEditStart = () => {
+  const handleEditStart = () => {
     setEditing(true);
 
     setTimeout(() => {
@@ -62,7 +58,7 @@ export const Editable: React.FC<Props> = ({
     }
   };
 
-  const _handleEditEnd = () => {
+  const handleEditEnd = () => {
     if (shouldSave(value, inputRef.current?.value.trim(), preventBlank)) {
       // Don't run onSubmit for values that haven't been changed
       onSubmit(inputRef.current?.value.trim());
@@ -73,10 +69,10 @@ export const Editable: React.FC<Props> = ({
     setTimeout(() => setEditing(false), 100);
   };
 
-  const _handleEditKeyDown = (event: KeyboardEvent) => {
+  const handleEditKeyDown = (event: KeyboardEvent) => {
     if (event.keyCode === 13) {
       // Pressed Enter
-      _handleEditEnd();
+      handleEditEnd();
     }
     if (event.keyCode === 27) {
       // Pressed Escape
@@ -87,7 +83,7 @@ export const Editable: React.FC<Props> = ({
         // Set the input to the original value
         inputRef.current.value = value;
 
-        _handleEditEnd();
+        handleEditEnd();
       }
     }
   };
@@ -96,14 +92,14 @@ export const Editable: React.FC<Props> = ({
     return (
       // KeydownBinder must be used here to properly stop propagation
       // from reaching other scoped KeydownBinders
-      <KeydownBinder onKeydown={_handleEditKeyDown} scoped>
+      <KeydownBinder onKeydown={handleEditKeyDown} scoped>
         <input
-          {...extra}
+          {...childProps}
           className={`editable ${className || ''}`}
           type="text"
           ref={inputRef}
           defaultValue={initialValue}
-          onBlur={_handleEditEnd}
+          onBlur={handleEditEnd}
         />
       </KeydownBinder>
     );
@@ -111,9 +107,9 @@ export const Editable: React.FC<Props> = ({
   const readViewProps = {
     className: `editable ${className} ${!initialValue && 'empty'}`,
     title: singleClick ? 'Click to edit' : 'Double click to edit',
-    onClick: _handleSingleClickEditStart,
-    onDoubleClick: _handleEditStart,
-    ...extra,
+    onClick: onSingleClick,
+    onDoubleClick: handleEditStart,
+    ...childProps,
   };
   return renderReadView ?
     renderReadView(initialValue, readViewProps)

--- a/packages/insomnia/src/ui/components/base/editable.tsx
+++ b/packages/insomnia/src/ui/components/base/editable.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 
 import { KeydownBinder } from '../keydown-binder';
 
@@ -58,7 +58,7 @@ export const Editable: React.FC<Props> = ({
     }
   };
 
-  const handleEditEnd = () => {
+  const handleEditEnd = useCallback(() => {
     if (shouldSave(value, inputRef.current?.value.trim(), preventBlank)) {
       // Don't run onSubmit for values that haven't been changed
       onSubmit(inputRef.current?.value.trim());
@@ -67,9 +67,9 @@ export const Editable: React.FC<Props> = ({
     // This timeout prevents the UI from showing the old value after submit.
     // It should give the UI enough time to redraw the new value.
     setTimeout(() => setEditing(false), 100);
-  };
+  }, [onSubmit, preventBlank, value]);
 
-  const handleEditKeyDown = (event: KeyboardEvent) => {
+  const handleEditKeyDown = useCallback((event: KeyboardEvent) => {
     if (event.keyCode === 13) {
       // Pressed Enter
       handleEditEnd();
@@ -86,7 +86,7 @@ export const Editable: React.FC<Props> = ({
         handleEditEnd();
       }
     }
-  };
+  }, [value, handleEditEnd]);
   const initialValue = value || fallbackValue;
   if (editing) {
     return (

--- a/packages/insomnia/src/ui/components/base/editable.tsx
+++ b/packages/insomnia/src/ui/components/base/editable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useRef, useState } from 'react';
+import React, { FC, ReactElement, useCallback, useRef, useState } from 'react';
 
 import { KeydownBinder } from '../keydown-binder';
 import { HighlightProps } from './highlight';
@@ -30,7 +30,7 @@ interface Props {
   value: string;
 }
 
-export const Editable: React.FC<Props> = ({
+export const Editable: FC<Props> = ({
   blankValue,
   className,
   fallbackValue,

--- a/packages/insomnia/src/ui/components/base/editable.tsx
+++ b/packages/insomnia/src/ui/components/base/editable.tsx
@@ -44,7 +44,6 @@ export const Editable: React.FC<Props> = ({
 }) => {
   const [editing, setEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const onSingleClick = () => singleClick && handleEditStart();
 
   const handleEditStart = () => {
     setEditing(true);
@@ -58,6 +57,8 @@ export const Editable: React.FC<Props> = ({
       onEditStart();
     }
   };
+
+  const onSingleClick = () => singleClick && handleEditStart();
 
   const handleEditEnd = useCallback(() => {
     if (shouldSave(value, inputRef.current?.value.trim(), preventBlank)) {
@@ -88,6 +89,7 @@ export const Editable: React.FC<Props> = ({
       }
     }
   }, [value, handleEditEnd]);
+
   const initialValue = value || fallbackValue;
   if (editing) {
     return (

--- a/packages/insomnia/src/ui/components/base/highlight.tsx
+++ b/packages/insomnia/src/ui/components/base/highlight.tsx
@@ -3,13 +3,13 @@ import React, { FC } from 'react';
 
 import { fuzzyMatch } from '../../../common/misc';
 
-interface Props {
+export interface HighlightProps {
   search: string;
   text: string;
   blankValue?: String;
 }
 
-export const Highlight: FC<Props> = ({
+export const Highlight: FC<HighlightProps> = ({
   search,
   text,
   blankValue,

--- a/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import {
   AUTH_ASAP,
@@ -40,7 +40,7 @@ export const AuthDropdown: React.FC<Props> = ({ children, className, onChange, r
       </DropdownItem>
     );
   };
-  const handleTypeChange = async (type: string) => {
+  const handleTypeChange = useCallback(async (type: string) => {
     if (type === authentication.type) {
       // Type didn't change
       return;
@@ -69,7 +69,7 @@ export const AuthDropdown: React.FC<Props> = ({ children, className, onChange, r
       }
     }
     onChange(request, newAuthentication);
-  };
+  }, [authentication, onChange, request]);
   return (
     <Dropdown
       beside

--- a/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
@@ -1,5 +1,4 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import React, { PureComponent, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 
 import {
   AUTH_ASAP,
@@ -13,7 +12,6 @@ import {
   AUTH_NTLM,
   AUTH_OAUTH_1,
   AUTH_OAUTH_2,
-  AUTOBIND_CFG,
   getAuthTypeName,
 } from '../../../common/constants';
 import * as models from '../../../models';
@@ -26,18 +24,24 @@ import { showModal } from '../modals';
 import { AlertModal } from '../modals/alert-modal';
 
 interface Props {
+  children?: ReactNode;
+  className?: string;
   onChange: (r: Request, arg1: RequestAuthentication) => Promise<Request>;
   request: Request;
-  className?: string;
-  children?: ReactNode;
 }
 
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class AuthDropdown extends PureComponent<Props> {
-  async _handleTypeChange(type: string) {
-    const { request, onChange } = this.props;
-    const { authentication } = request;
-
+export const AuthDropdown: React.FC<Props> = ({ children, className, onChange, request }) => {
+  const { authentication } = request;
+  const renderAuthType = (type: string, nameOverride: string | null = null) => {
+    const currentType = authentication.type || AUTH_NONE;
+    return (
+      <DropdownItem onClick={() => handleTypeChange(type)}>
+        {currentType === type ? <i className="fa fa-check" /> : <i className="fa fa-empty" />}{' '}
+        {nameOverride || getAuthTypeName(type, true)}
+      </DropdownItem>
+    );
+  };
+  const handleTypeChange = async (type: string) => {
     if (type === authentication.type) {
       // Type didn't change
       return;
@@ -65,44 +69,28 @@ export class AuthDropdown extends PureComponent<Props> {
         break;
       }
     }
-
     onChange(request, newAuthentication);
-  }
-
-  renderAuthType(type: string, nameOverride: string | null = null) {
-    const { authentication } = this.props.request;
-    const currentType = authentication.type || AUTH_NONE;
-    return (
-      <DropdownItem onClick={this._handleTypeChange} value={type}>
-        {currentType === type ? <i className="fa fa-check" /> : <i className="fa fa-empty" />}{' '}
-        {nameOverride || getAuthTypeName(type, true)}
-      </DropdownItem>
-    );
-  }
-
-  render() {
-    const { children, className } = this.props;
-    return (
-      <Dropdown
-        beside
-        // @ts-expect-error -- TSCONVERSION appears to be genuine
-        debug="true"
-      >
-        <DropdownDivider>Auth Types</DropdownDivider>
-        <DropdownButton className={className}>{children}</DropdownButton>
-        {this.renderAuthType(AUTH_BASIC)}
-        {this.renderAuthType(AUTH_DIGEST)}
-        {this.renderAuthType(AUTH_OAUTH_1)}
-        {this.renderAuthType(AUTH_OAUTH_2)}
-        {this.renderAuthType(AUTH_NTLM)}
-        {this.renderAuthType(AUTH_AWS_IAM)}
-        {this.renderAuthType(AUTH_BEARER)}
-        {this.renderAuthType(AUTH_HAWK)}
-        {this.renderAuthType(AUTH_ASAP)}
-        {this.renderAuthType(AUTH_NETRC)}
-        <DropdownDivider>Other</DropdownDivider>
-        {this.renderAuthType(AUTH_NONE, 'No Authentication')}
-      </Dropdown>
-    );
-  }
-}
+  };
+  return (
+    <Dropdown
+      beside
+      // @ts-expect-error -- TSCONVERSION appears to be genuine
+      debug="true"
+    >
+      <DropdownDivider>Auth Types</DropdownDivider>
+      <DropdownButton className={className}>{children}</DropdownButton>
+      {renderAuthType(AUTH_BASIC)}
+      {renderAuthType(AUTH_DIGEST)}
+      {renderAuthType(AUTH_OAUTH_1)}
+      {renderAuthType(AUTH_OAUTH_2)}
+      {renderAuthType(AUTH_NTLM)}
+      {renderAuthType(AUTH_AWS_IAM)}
+      {renderAuthType(AUTH_BEARER)}
+      {renderAuthType(AUTH_HAWK)}
+      {renderAuthType(AUTH_ASAP)}
+      {renderAuthType(AUTH_NETRC)}
+      <DropdownDivider>Other</DropdownDivider>
+      {renderAuthType(AUTH_NONE, 'No Authentication')}
+    </Dropdown>
+  );
+};

--- a/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 
 import {
   AUTH_ASAP,
@@ -24,7 +24,6 @@ import { showModal } from '../modals';
 import { AlertModal } from '../modals/alert-modal';
 
 interface Props {
-  children?: ReactNode;
   className?: string;
   onChange: (r: Request, arg1: RequestAuthentication) => Promise<Request>;
   request: Request;
@@ -35,8 +34,8 @@ export const AuthDropdown: React.FC<Props> = ({ children, className, onChange, r
   const renderAuthType = (type: string, nameOverride: string | null = null) => {
     const currentType = authentication.type || AUTH_NONE;
     return (
-      <DropdownItem onClick={() => handleTypeChange(type)}>
-        {currentType === type ? <i className="fa fa-check" /> : <i className="fa fa-empty" />}{' '}
+      <DropdownItem onClick={handleTypeChange} value={type}>
+        {<i className={`fa fa-${currentType === type ? 'check' : 'empty'}`} />}{' '}
         {nameOverride || getAuthTypeName(type, true)}
       </DropdownItem>
     );

--- a/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
@@ -41,7 +41,7 @@ interface Props {
   request: Request;
 }
 
-export const AuthDropdown: React.FC<Props> = ({ children, className, onChange, request }) => {
+export const AuthDropdown: FC<Props> = ({ children, className, onChange, request }) => {
   const { authentication } = request;
 
   const onClick = useCallback((type: string) => {

--- a/packages/insomnia/src/ui/components/dropdowns/content-type-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/content-type-dropdown.tsx
@@ -1,9 +1,7 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import React, { PureComponent } from 'react';
+import React from 'react';
 
 import { SegmentEvent, trackSegmentEvent } from '../../../common/analytics';
 import {
-  AUTOBIND_CFG,
   CONTENT_TYPE_EDN,
   CONTENT_TYPE_FILE,
   CONTENT_TYPE_FORM_DATA,
@@ -32,9 +30,8 @@ interface Props extends DropdownProps {
 }
 const EMPTY_MIME_TYPE = null;
 
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class ContentTypeDropdown extends PureComponent<Props> {
-  async _checkMimeTypeChange(body: RequestBody, mimeType: string | null) {
+export const ContentTypeDropdown: React.FC<Props> = ({ children, className, request, contentType, onChange, ...extraProps }) => {
+  const _checkMimeTypeChange = async (body: RequestBody, mimeType: string | null) => {
     // Nothing to do
     if (body.mimeType === mimeType) {
       return;
@@ -62,63 +59,56 @@ export class ContentTypeDropdown extends PureComponent<Props> {
         addCancel: true,
       });
     }
-  }
+  };
 
-  async _handleChangeMimeType(mimeType: string | null) {
-    const { request } = this.props;
-
+  const _handleChangeMimeType = async (mimeType: string | null) => {
     if (request) {
-      await this._checkMimeTypeChange(request.body, mimeType);
+      await _checkMimeTypeChange(request.body, mimeType);
     }
 
-    this.props.onChange(mimeType);
-    trackSegmentEvent(SegmentEvent.requestBodyTypeSelect, { type:mimeType });
-  }
-
-  _renderDropdownItem(mimeType: string | null, forcedName = '') {
-    const contentType =
-      typeof this.props.contentType === 'string' ? this.props.contentType : EMPTY_MIME_TYPE;
-    const iconClass = mimeType === contentType ? 'fa-check' : 'fa-empty';
+    onChange(mimeType);
+    trackSegmentEvent(SegmentEvent.requestBodyTypeSelect, { type: mimeType });
+  };
+  const _renderDropdownItem = (mimeType: string | null, forcedName = '') => {
+    const contentTypeFallback =
+      typeof contentType === 'string' ? contentType : EMPTY_MIME_TYPE;
+    const iconClass = mimeType === contentTypeFallback ? 'fa-check' : 'fa-empty';
     return (
-      <DropdownItem onClick={this._handleChangeMimeType} value={mimeType}>
+      <DropdownItem onClick={_handleChangeMimeType} value={mimeType}>
         <i className={`fa ${iconClass}`} />
         {forcedName || getContentTypeName(mimeType, true)}
       </DropdownItem>
     );
-  }
-
-  render() {
-    const { children, className, ...extraProps } = this.props;
-    return (
-      <Dropdown beside {...extraProps}>
-        <DropdownButton className={className}>{children}</DropdownButton>
-        <DropdownDivider>
-          <span>
-            <i className="fa fa-bars" /> Structured
-          </span>
-        </DropdownDivider>
-        {this._renderDropdownItem(CONTENT_TYPE_FORM_DATA)}
-        {this._renderDropdownItem(CONTENT_TYPE_FORM_URLENCODED)}
-        {this._renderDropdownItem(CONTENT_TYPE_GRAPHQL)}
-        <DropdownDivider>
-          <span>
-            <i className="fa fa-code" /> Text
-          </span>
-        </DropdownDivider>
-        {this._renderDropdownItem(CONTENT_TYPE_JSON)}
-        {this._renderDropdownItem(CONTENT_TYPE_XML)}
-        {this._renderDropdownItem(CONTENT_TYPE_YAML)}
-        {this._renderDropdownItem(CONTENT_TYPE_EDN)}
-        {this._renderDropdownItem(CONTENT_TYPE_PLAINTEXT)}
-        {this._renderDropdownItem(CONTENT_TYPE_OTHER)}
-        <DropdownDivider>
-          <span>
-            <i className="fa fa-ellipsis-h" /> Other
-          </span>
-        </DropdownDivider>
-        {this._renderDropdownItem(CONTENT_TYPE_FILE)}
-        {this._renderDropdownItem(EMPTY_MIME_TYPE, 'No Body')}
-      </Dropdown>
-    );
-  }
-}
+  };
+  return (
+    <Dropdown beside {...extraProps}>
+      <DropdownButton className={className}>{children}</DropdownButton>
+      <DropdownDivider>
+        <span>
+          <i className="fa fa-bars" /> Structured
+        </span>
+      </DropdownDivider>
+      {_renderDropdownItem(CONTENT_TYPE_FORM_DATA)}
+      {_renderDropdownItem(CONTENT_TYPE_FORM_URLENCODED)}
+      {_renderDropdownItem(CONTENT_TYPE_GRAPHQL)}
+      <DropdownDivider>
+        <span>
+          <i className="fa fa-code" /> Text
+        </span>
+      </DropdownDivider>
+      {_renderDropdownItem(CONTENT_TYPE_JSON)}
+      {_renderDropdownItem(CONTENT_TYPE_XML)}
+      {_renderDropdownItem(CONTENT_TYPE_YAML)}
+      {_renderDropdownItem(CONTENT_TYPE_EDN)}
+      {_renderDropdownItem(CONTENT_TYPE_PLAINTEXT)}
+      {_renderDropdownItem(CONTENT_TYPE_OTHER)}
+      <DropdownDivider>
+        <span>
+          <i className="fa fa-ellipsis-h" /> Other
+        </span>
+      </DropdownDivider>
+      {_renderDropdownItem(CONTENT_TYPE_FILE)}
+      {_renderDropdownItem(EMPTY_MIME_TYPE, 'No Body')}
+    </Dropdown>
+  );
+};

--- a/packages/insomnia/src/ui/components/dropdowns/content-type-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/content-type-dropdown.tsx
@@ -88,7 +88,7 @@ const MimeTypeItem: FC<{
   );
 };
 
-export const ContentTypeDropdown: React.FC<Props> = ({
+export const ContentTypeDropdown: FC<Props> = ({
   children,
   className,
   onChange,

--- a/packages/insomnia/src/ui/components/dropdowns/content-type-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/content-type-dropdown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { SegmentEvent, trackSegmentEvent } from '../../../common/analytics';
 import {
@@ -31,7 +31,7 @@ interface Props extends DropdownProps {
 const EMPTY_MIME_TYPE = null;
 
 export const ContentTypeDropdown: React.FC<Props> = ({ children, className, request, contentType, onChange, ...extraProps }) => {
-  const handleChangeMimeType = async (mimeType: string | null) => {
+  const handleChangeMimeType = useCallback(async (mimeType: string | null) => {
     if (request) {
       // Nothing to do
       const { body } = request;
@@ -65,7 +65,7 @@ export const ContentTypeDropdown: React.FC<Props> = ({ children, className, requ
 
     onChange(mimeType);
     trackSegmentEvent(SegmentEvent.requestBodyTypeSelect, { type: mimeType });
-  };
+  }, [onChange, request]);
   const renderMimeType = (mimeType: string | null, forcedName = '') => {
     const contentTypeFallback = typeof contentType === 'string' ? contentType : EMPTY_MIME_TYPE;
     const iconClass = mimeType === contentTypeFallback ? 'fa-check' : 'fa-empty';

--- a/packages/insomnia/src/ui/components/dropdowns/content-type-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/content-type-dropdown.tsx
@@ -14,7 +14,7 @@ import {
   CONTENT_TYPE_YAML,
   getContentTypeName,
 } from '../../../common/constants';
-import type { Request, RequestBody } from '../../../models/request';
+import type { Request } from '../../../models/request';
 import { Dropdown, DropdownProps } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -31,50 +31,46 @@ interface Props extends DropdownProps {
 const EMPTY_MIME_TYPE = null;
 
 export const ContentTypeDropdown: React.FC<Props> = ({ children, className, request, contentType, onChange, ...extraProps }) => {
-  const _checkMimeTypeChange = async (body: RequestBody, mimeType: string | null) => {
-    // Nothing to do
-    if (body.mimeType === mimeType) {
-      return;
-    }
-
-    const hasParams = body.params && body.params.length;
-    const hasText = body.text && body.text.length;
-    const hasFile = body.fileName && body.fileName.length;
-    const isEmpty = !hasParams && !hasText && !hasFile;
-    const isFile = body.mimeType === CONTENT_TYPE_FILE;
-    const isMultipart = body.mimeType === CONTENT_TYPE_FORM_DATA;
-    const isFormUrlEncoded = body.mimeType === CONTENT_TYPE_FORM_URLENCODED;
-    const isText = !isFile && !isMultipart;
-    const willBeFile = mimeType === CONTENT_TYPE_FILE;
-    const willBeMultipart = mimeType === CONTENT_TYPE_FORM_DATA;
-    const willBeGraphQL = mimeType === CONTENT_TYPE_GRAPHQL;
-    const willConvertToText = !willBeGraphQL && !willBeFile && !willBeMultipart;
-    const willPreserveText = willConvertToText && isText;
-    const willPreserveForm = isFormUrlEncoded && willBeMultipart;
-
-    if (!isEmpty && !willPreserveText && !willPreserveForm) {
-      await showModal(AlertModal, {
-        title: 'Switch Body Type?',
-        message: 'Current body will be lost. Are you sure you want to continue?',
-        addCancel: true,
-      });
-    }
-  };
-
-  const _handleChangeMimeType = async (mimeType: string | null) => {
+  const handleChangeMimeType = async (mimeType: string | null) => {
     if (request) {
-      await _checkMimeTypeChange(request.body, mimeType);
+      // Nothing to do
+      const { body } = request;
+      if (body.mimeType === mimeType) {
+        return;
+      }
+
+      const hasParams = body.params && body.params.length;
+      const hasText = body.text && body.text.length;
+      const hasFile = body.fileName && body.fileName.length;
+      const isEmpty = !hasParams && !hasText && !hasFile;
+      const isFile = body.mimeType === CONTENT_TYPE_FILE;
+      const isMultipart = body.mimeType === CONTENT_TYPE_FORM_DATA;
+      const isFormUrlEncoded = body.mimeType === CONTENT_TYPE_FORM_URLENCODED;
+      const isText = !isFile && !isMultipart;
+      const willBeFile = mimeType === CONTENT_TYPE_FILE;
+      const willBeMultipart = mimeType === CONTENT_TYPE_FORM_DATA;
+      const willBeGraphQL = mimeType === CONTENT_TYPE_GRAPHQL;
+      const willConvertToText = !willBeGraphQL && !willBeFile && !willBeMultipart;
+      const willPreserveText = willConvertToText && isText;
+      const willPreserveForm = isFormUrlEncoded && willBeMultipart;
+
+      if (!isEmpty && !willPreserveText && !willPreserveForm) {
+        await showModal(AlertModal, {
+          title: 'Switch Body Type?',
+          message: 'Current body will be lost. Are you sure you want to continue?',
+          addCancel: true,
+        });
+      }
     }
 
     onChange(mimeType);
     trackSegmentEvent(SegmentEvent.requestBodyTypeSelect, { type: mimeType });
   };
-  const _renderDropdownItem = (mimeType: string | null, forcedName = '') => {
-    const contentTypeFallback =
-      typeof contentType === 'string' ? contentType : EMPTY_MIME_TYPE;
+  const renderMimeType = (mimeType: string | null, forcedName = '') => {
+    const contentTypeFallback = typeof contentType === 'string' ? contentType : EMPTY_MIME_TYPE;
     const iconClass = mimeType === contentTypeFallback ? 'fa-check' : 'fa-empty';
     return (
-      <DropdownItem onClick={_handleChangeMimeType} value={mimeType}>
+      <DropdownItem onClick={handleChangeMimeType} value={mimeType}>
         <i className={`fa ${iconClass}`} />
         {forcedName || getContentTypeName(mimeType, true)}
       </DropdownItem>
@@ -88,27 +84,27 @@ export const ContentTypeDropdown: React.FC<Props> = ({ children, className, requ
           <i className="fa fa-bars" /> Structured
         </span>
       </DropdownDivider>
-      {_renderDropdownItem(CONTENT_TYPE_FORM_DATA)}
-      {_renderDropdownItem(CONTENT_TYPE_FORM_URLENCODED)}
-      {_renderDropdownItem(CONTENT_TYPE_GRAPHQL)}
+      {renderMimeType(CONTENT_TYPE_FORM_DATA)}
+      {renderMimeType(CONTENT_TYPE_FORM_URLENCODED)}
+      {renderMimeType(CONTENT_TYPE_GRAPHQL)}
       <DropdownDivider>
         <span>
           <i className="fa fa-code" /> Text
         </span>
       </DropdownDivider>
-      {_renderDropdownItem(CONTENT_TYPE_JSON)}
-      {_renderDropdownItem(CONTENT_TYPE_XML)}
-      {_renderDropdownItem(CONTENT_TYPE_YAML)}
-      {_renderDropdownItem(CONTENT_TYPE_EDN)}
-      {_renderDropdownItem(CONTENT_TYPE_PLAINTEXT)}
-      {_renderDropdownItem(CONTENT_TYPE_OTHER)}
+      {renderMimeType(CONTENT_TYPE_JSON)}
+      {renderMimeType(CONTENT_TYPE_XML)}
+      {renderMimeType(CONTENT_TYPE_YAML)}
+      {renderMimeType(CONTENT_TYPE_EDN)}
+      {renderMimeType(CONTENT_TYPE_PLAINTEXT)}
+      {renderMimeType(CONTENT_TYPE_OTHER)}
       <DropdownDivider>
         <span>
           <i className="fa fa-ellipsis-h" /> Other
         </span>
       </DropdownDivider>
-      {_renderDropdownItem(CONTENT_TYPE_FILE)}
-      {_renderDropdownItem(EMPTY_MIME_TYPE, 'No Body')}
+      {renderMimeType(CONTENT_TYPE_FILE)}
+      {renderMimeType(EMPTY_MIME_TYPE, 'No Body')}
     </Dropdown>
   );
 };

--- a/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
@@ -32,7 +32,7 @@ export const EnvironmentsDropdown: FC<Props> = ({
   hotKeyRegistry,
   workspace,
 }) => {
-  const dropdownRef = useRef<Dropdown | null>(null);
+  const dropdownRef = useRef<Dropdown>(null);
   const handleShowEnvironmentModal = useCallback(() => {
     showModal(WorkspaceEnvironmentsEditModal, workspace);
   }, [workspace]);

--- a/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
@@ -1,8 +1,6 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { EnvironmentHighlightColorStyle, HotKeyRegistry } from 'insomnia-common';
-import React, { PureComponent } from 'react';
+import React, { useRef } from 'react';
 
-import { AUTOBIND_CFG } from '../../../common/constants';
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
 import type { Environment } from '../../../models/environment';
@@ -18,127 +16,105 @@ import { WorkspaceEnvironmentsEditModal } from '../modals/workspace-environments
 import { Tooltip } from '../tooltip';
 
 interface Props {
-  handleChangeEnvironment: Function;
-  workspace: Workspace;
-  environments: Environment[];
-  environmentHighlightColorStyle: EnvironmentHighlightColorStyle;
-  hotKeyRegistry: HotKeyRegistry;
-  className?: string;
   activeEnvironment?: Environment | null;
+  className?: string;
+  environmentHighlightColorStyle: EnvironmentHighlightColorStyle;
+  environments: Environment[];
+  handleChangeEnvironment: Function;
+  hotKeyRegistry: HotKeyRegistry;
+  workspace: Workspace;
 }
-
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class EnvironmentsDropdown extends PureComponent<Props> {
-  _dropdown: Dropdown | null = null;
-
-  _handleActivateEnvironment(environmentId: string) {
-    this.props.handleChangeEnvironment(environmentId);
-  }
-
-  _handleShowEnvironmentModal() {
-    showModal(WorkspaceEnvironmentsEditModal, this.props.workspace);
-  }
-
-  _setDropdownRef(dropdown: Dropdown) {
-    this._dropdown = dropdown;
-  }
-
-  renderEnvironmentItem(environment: Environment) {
-    return (
-      <DropdownItem
-        key={environment._id}
-        value={environment._id}
-        onClick={this._handleActivateEnvironment}
-      >
-        <i
-          className="fa fa-random"
-          style={{
-            // @ts-expect-error -- TSCONVERSION don't set color if undefined
-            color: environment.color,
-          }}
-        />
-        Use <strong>{environment.name}</strong>
-      </DropdownItem>
-    );
-  }
-
-  _handleKeydown(event: KeyboardEvent) {
+export const EnvironmentsDropdown: React.FC<Props> = ({
+  activeEnvironment,
+  className,
+  environmentHighlightColorStyle,
+  environments,
+  handleChangeEnvironment,
+  hotKeyRegistry,
+  workspace,
+  ...other
+}) => {
+  const dropdownRef = useRef<Dropdown>(null);
+  const _handleActivateEnvironment = (environmentId?: string) => {
+    handleChangeEnvironment(environmentId);
+  };
+  const _handleShowEnvironmentModal = () => {
+    showModal(WorkspaceEnvironmentsEditModal, workspace);
+  };
+  const _handleKeydown = (event: KeyboardEvent) => {
     executeHotKey(event, hotKeyRefs.ENVIRONMENT_SHOW_SWITCH_MENU, () => {
-      this._dropdown?.toggle(true);
+      dropdownRef.current?.toggle(true);
     });
-  }
+  };
+  // NOTE: Base environment might not exist if the users hasn't managed environments yet.
+  const baseEnvironment = environments.find(environment => environment.parentId === workspace._id);
+  const subEnvironments = environments
+    .filter(environment => environment.parentId === (baseEnvironment && baseEnvironment._id))
+    .sort((e1, e2) => e1.metaSortKey - e2.metaSortKey);
+  const description =  (!activeEnvironment || activeEnvironment === baseEnvironment) ? 'No Environment' : activeEnvironment.name;
 
-  render() {
-    const {
-      className,
-      workspace,
-      environments,
-      activeEnvironment,
-      environmentHighlightColorStyle,
-      hotKeyRegistry,
-      ...other
-    } = this.props;
-    // NOTE: Base environment might not exist if the users hasn't managed environments yet.
-    const baseEnvironment = environments.find(environment => environment.parentId === workspace._id);
-    const subEnvironments = environments
-      .filter(environment => environment.parentId === (baseEnvironment && baseEnvironment._id))
-      .sort((e1, e2) => e1.metaSortKey - e2.metaSortKey);
-    let description;
-
-    if (!activeEnvironment || activeEnvironment === baseEnvironment) {
-      description = 'No Environment';
-    } else {
-      description = activeEnvironment.name;
-    }
-
-    return (
-      <KeydownBinder onKeydown={this._handleKeydown}>
-        <Dropdown
-          ref={this._setDropdownRef}
-          {...(other as Record<string, any>)}
-          className={className}
-        >
-          <DropdownButton className="btn btn--super-compact no-wrap">
-            <div className="sidebar__menu__thing">
-              {!activeEnvironment && subEnvironments.length > 0 && (
-                <Tooltip
-                  message="No environments active. Please select one to use."
-                  className="space-right"
-                  position="right"
-                >
-                  <i className="fa fa-exclamation-triangle notice" />
-                </Tooltip>
-              )}
-              <div className="sidebar__menu__thing__text">
-                {activeEnvironment?.color && environmentHighlightColorStyle === 'sidebar-indicator' ? (
-                  <i
-                    className="fa fa-circle space-right"
-                    style={{
-                      color: activeEnvironment.color,
-                    }}
-                  />
-                ) : null}
-                {description}
-              </div>
-              <i className="space-left fa fa-caret-down" />
+  return (
+    <KeydownBinder onKeydown={_handleKeydown}>
+      <Dropdown
+        ref={dropdownRef}
+        {...(other as Record<string, any>)}
+        className={className}
+      >
+        <DropdownButton className="btn btn--super-compact no-wrap">
+          <div className="sidebar__menu__thing">
+            {!activeEnvironment && subEnvironments.length > 0 && (
+              <Tooltip
+                message="No environments active. Please select one to use."
+                className="space-right"
+                position="right"
+              >
+                <i className="fa fa-exclamation-triangle notice" />
+              </Tooltip>
+            )}
+            <div className="sidebar__menu__thing__text">
+              {activeEnvironment?.color && environmentHighlightColorStyle === 'sidebar-indicator' ? (
+                <i
+                  className="fa fa-circle space-right"
+                  style={{
+                    color: activeEnvironment.color,
+                  }}
+                />
+              ) : null}
+              {description}
             </div>
-          </DropdownButton>
+            <i className="space-left fa fa-caret-down" />
+          </div>
+        </DropdownButton>
 
-          <DropdownDivider>Activate Environment</DropdownDivider>
-          {subEnvironments.map(this.renderEnvironmentItem)}
-
-          <DropdownItem value={null} onClick={this._handleActivateEnvironment}>
-            <i className="fa fa-empty" /> No Environment
+        <DropdownDivider>Activate Environment</DropdownDivider>
+        {subEnvironments.map(environment => (
+          <DropdownItem
+            key={environment._id}
+            value={environment._id}
+            onClick={_handleActivateEnvironment}
+          >
+            <i
+              className="fa fa-random"
+              style={{
+              // @ts-expect-error -- TSCONVERSION don't set color if undefined
+                color: environment.color,
+              }}
+            />
+            Use <strong>{environment.name}</strong>
           </DropdownItem>
+        ))}
 
-          <DropdownDivider>General</DropdownDivider>
+        <DropdownItem onClick={_handleActivateEnvironment}>
+          <i className="fa fa-empty" /> No Environment
+        </DropdownItem>
 
-          <DropdownItem onClick={this._handleShowEnvironmentModal}>
-            <i className="fa fa-wrench" /> Manage Environments
-            <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]} />
-          </DropdownItem>
-        </Dropdown>
-      </KeydownBinder>
-    );
-  }
-}
+        <DropdownDivider>General</DropdownDivider>
+
+        <DropdownItem onClick={_handleShowEnvironmentModal}>
+          <i className="fa fa-wrench" /> Manage Environments
+          <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]} />
+        </DropdownItem>
+      </Dropdown>
+    </KeydownBinder>
+  );
+};

--- a/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
@@ -32,13 +32,10 @@ export const EnvironmentsDropdown: React.FC<Props> = ({
   handleChangeEnvironment,
   hotKeyRegistry,
   workspace,
-  ...other
+  ...dropdownProps
 }) => {
   const dropdownRef = useRef<Dropdown>(null);
-  const _handleActivateEnvironment = (environmentId?: string) => {
-    handleChangeEnvironment(environmentId);
-  };
-  const _handleShowEnvironmentModal = () => {
+  const handleShowEnvironmentModal = () => {
     showModal(WorkspaceEnvironmentsEditModal, workspace);
   };
   const _handleKeydown = (event: KeyboardEvent) => {
@@ -57,7 +54,7 @@ export const EnvironmentsDropdown: React.FC<Props> = ({
     <KeydownBinder onKeydown={_handleKeydown}>
       <Dropdown
         ref={dropdownRef}
-        {...(other as Record<string, any>)}
+        {...(dropdownProps as Record<string, any>)}
         className={className}
       >
         <DropdownButton className="btn btn--super-compact no-wrap">
@@ -91,7 +88,7 @@ export const EnvironmentsDropdown: React.FC<Props> = ({
           <DropdownItem
             key={environment._id}
             value={environment._id}
-            onClick={_handleActivateEnvironment}
+            onClick={handleChangeEnvironment}
           >
             <i
               className="fa fa-random"
@@ -104,13 +101,13 @@ export const EnvironmentsDropdown: React.FC<Props> = ({
           </DropdownItem>
         ))}
 
-        <DropdownItem onClick={_handleActivateEnvironment}>
+        <DropdownItem onClick={handleChangeEnvironment}>
           <i className="fa fa-empty" /> No Environment
         </DropdownItem>
 
         <DropdownDivider>General</DropdownDivider>
 
-        <DropdownItem onClick={_handleShowEnvironmentModal}>
+        <DropdownItem onClick={handleShowEnvironmentModal}>
           <i className="fa fa-wrench" /> Manage Environments
           <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]} />
         </DropdownItem>

--- a/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
@@ -1,5 +1,5 @@
 import { EnvironmentHighlightColorStyle, HotKeyRegistry } from 'insomnia-common';
-import React, { useCallback, useRef } from 'react';
+import React, { FC, useCallback, useRef } from 'react';
 
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
@@ -24,7 +24,7 @@ interface Props {
   workspace: Workspace;
 }
 
-export const EnvironmentsDropdown: React.FC<Props> = ({
+export const EnvironmentsDropdown: FC<Props> = ({
   activeEnvironment,
   environmentHighlightColorStyle,
   environments,

--- a/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
@@ -35,7 +35,7 @@ export const EnvironmentsDropdown: React.FC<Props> = ({
   ...dropdownProps
 }) => {
   const dropdownRef = useRef<Dropdown>(null);
-  const handleShowEnvironmentModal = () => {
+  const _handleShowEnvironmentModal = () => {
     showModal(WorkspaceEnvironmentsEditModal, workspace);
   };
   const _handleKeydown = (event: KeyboardEvent) => {
@@ -107,7 +107,7 @@ export const EnvironmentsDropdown: React.FC<Props> = ({
 
         <DropdownDivider>General</DropdownDivider>
 
-        <DropdownItem onClick={handleShowEnvironmentModal}>
+        <DropdownItem onClick={_handleShowEnvironmentModal}>
           <i className="fa fa-wrench" /> Manage Environments
           <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.ENVIRONMENT_SHOW_EDITOR.id]} />
         </DropdownItem>

--- a/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
@@ -30,11 +30,7 @@ export const MethodDropdown = forwardRef<MethodDropdownHandle, Props>(({
   const [recent, setRecent] = useState<string[]>(JSON.parse(window.localStorage.getItem(LOCALSTORAGE_KEY) || '[]'));
 
   const dropdownRef = useRef<Dropdown>(null);
-  const toggle = useCallback(() => {
-    if (dropdownRef.current) {
-      dropdownRef.current.toggle();
-    }
-  }, [dropdownRef]);
+  const toggle = useCallback(() => dropdownRef.current?.toggle(), [dropdownRef]);
   useImperativeHandle(ref, () => ({ toggle }), [toggle]);
   const handleSetCustomMethod = useCallback(() => {
     showPrompt({
@@ -56,12 +52,10 @@ export const MethodDropdown = forwardRef<MethodDropdownHandle, Props>(({
         if (!methodToAdd) {
           return;
         }
-
         // Don't add base methods
         if (constants.HTTP_METHODS.includes(methodToAdd)) {
           return;
         }
-
         // Save method as recent
         if (recent.includes(methodToAdd)) {
           return;
@@ -69,7 +63,6 @@ export const MethodDropdown = forwardRef<MethodDropdownHandle, Props>(({
         setRecent([...recent, methodToAdd]);
         window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(recent));
         onChange(methodToAdd);
-
       },
     });
   }, [method, onChange, recent]);

--- a/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
@@ -1,8 +1,7 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import React, { PureComponent } from 'react';
+import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
 
 import * as constants from '../../../common/constants';
-import { AUTOBIND_CFG, METHOD_GRPC } from '../../../common/constants';
+import { METHOD_GRPC } from '../../../common/constants';
 import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -18,16 +17,22 @@ interface Props {
   showGrpc?: boolean;
   className?: string;
 }
-
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class MethodDropdown extends PureComponent<Props> {
-  _dropdown: Dropdown | null = null;
-
-  _setDropdownRef(dropdown: Dropdown) {
-    this._dropdown = dropdown;
-  }
-
-  _handleSetCustomMethod() {
+export const MethodDropdown = forwardRef<{toggle:()=>void}, Props>(({
+  method,
+  right,
+  onChange,
+  showGrpc,
+  className,
+}, ref) => {
+  const dropdownRef = useRef<Dropdown>(null);
+  const toggle = useCallback(() => {
+    if (dropdownRef.current) {
+      dropdownRef.current.toggle();
+    }
+  }, [dropdownRef]);
+  useImperativeHandle(ref, () => ({ toggle }), [toggle]
+  );
+  const _handleSetCustomMethod = () => {
     let recentMethods: string[];
 
     try {
@@ -39,7 +44,7 @@ export class MethodDropdown extends PureComponent<Props> {
 
     // Prompt user for the method
     showPrompt({
-      defaultValue: this.props.method,
+      defaultValue: method,
       title: 'HTTP Method',
       submitName: 'Done',
       upperCase: true,
@@ -68,62 +73,44 @@ export class MethodDropdown extends PureComponent<Props> {
         recentMethods.unshift(method);
         window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(recentMethods));
         // Invoke callback
-        this.props.onChange(method);
+        onChange(method);
       },
     });
-  }
+  };
 
-  _handleChange(method: string) {
-    this.props.onChange(method);
-  }
-
-  toggle() {
-    this._dropdown?.toggle(true);
-  }
-
-  render() {
-    const {
-      method,
-      right,
-      onChange,
-      // eslint-disable-line @typescript-eslint/no-unused-vars
-      showGrpc,
-      ...extraProps
-    } = this.props;
-    const buttonLabel = method === METHOD_GRPC ? GRPC_LABEL : method;
-    return (
-      <Dropdown ref={this._setDropdownRef} className="method-dropdown" right={right}>
-        <DropdownButton {...extraProps}>
-          <span className={`http-method-${method}`}>{buttonLabel}</span>{' '}
-          <i className="fa fa-caret-down space-left" />
-        </DropdownButton>
-        {constants.HTTP_METHODS.map(method => (
-          <DropdownItem
-            key={method}
-            className={`http-method-${method}`}
-            onClick={this._handleChange}
-            value={method}
-          >
-            {method}
-          </DropdownItem>
-        ))}
-        {showGrpc && (
-          <>
-            <DropdownDivider />
-            <DropdownItem className="method-grpc" onClick={this._handleChange} value={METHOD_GRPC}>
-              {GRPC_LABEL}
-            </DropdownItem>
-          </>
-        )}
-        <DropdownDivider />
+  const buttonLabel = method === METHOD_GRPC ? GRPC_LABEL : method;
+  return (
+    <Dropdown ref={dropdownRef} className="method-dropdown" right={right}>
+      <DropdownButton className={className}>
+        <span className={`http-method-${method}`}>{buttonLabel}</span>{' '}
+        <i className="fa fa-caret-down space-left" />
+      </DropdownButton>
+      {constants.HTTP_METHODS.map(method => (
         <DropdownItem
-          className="http-method-custom"
-          onClick={this._handleSetCustomMethod}
+          key={method}
+          className={`http-method-${method}`}
+          onClick={onChange}
           value={method}
         >
-          Custom Method
+          {method}
         </DropdownItem>
-      </Dropdown>
-    );
-  }
-}
+      ))}
+      {showGrpc && (
+        <>
+          <DropdownDivider />
+          <DropdownItem className="method-grpc" onClick={onChange} value={METHOD_GRPC}>
+            {GRPC_LABEL}
+          </DropdownItem>
+        </>
+      )}
+      <DropdownDivider />
+      <DropdownItem
+        className="http-method-custom"
+        onClick={_handleSetCustomMethod}
+      >
+        Custom Method
+      </DropdownItem>
+    </Dropdown>
+  );
+});
+MethodDropdown.displayName = 'MethodDropdown';

--- a/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
@@ -36,7 +36,7 @@ export const MethodDropdown = forwardRef<MethodDropdownHandle, Props>(({
     }
   }, [dropdownRef]);
   useImperativeHandle(ref, () => ({ toggle }), [toggle]);
-  const handleSetCustomMethod = () => {
+  const handleSetCustomMethod = useCallback(() => {
     showPrompt({
       defaultValue: method,
       title: 'HTTP Method',
@@ -72,7 +72,7 @@ export const MethodDropdown = forwardRef<MethodDropdownHandle, Props>(({
 
       },
     });
-  };
+  }, [method, onChange, recent]);
 
   const buttonLabel = method === METHOD_GRPC ? GRPC_LABEL : method;
   return (

--- a/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useState } from 'react';
 
 import * as constants from '../../../common/constants';
 import { METHOD_GRPC } from '../../../common/constants';
@@ -7,6 +7,7 @@ import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
 import { DropdownItem } from '../base/dropdown/dropdown-item';
 import { showPrompt } from '../modals/index';
+
 const LOCALSTORAGE_KEY = 'insomnia.httpMethods';
 const GRPC_LABEL = 'gRPC';
 
@@ -17,21 +18,18 @@ interface Props {
   right?: boolean;
   showGrpc?: boolean;
 }
-export interface MethodDropdownHandle {
-  toggle: () => void;
-}
-export const MethodDropdown = forwardRef<MethodDropdownHandle, Props>(({
+
+export const MethodDropdown = forwardRef<Dropdown, Props>(({
   className,
   method,
   onChange,
   right,
   showGrpc,
 }, ref) => {
-  const [recent, setRecent] = useState<string[]>(JSON.parse(window.localStorage.getItem(LOCALSTORAGE_KEY) || '[]'));
+  const localStorageHttpMethods = window.localStorage.getItem(LOCALSTORAGE_KEY);
+  const parsedLocalStorageHttpMethods = localStorageHttpMethods ? JSON.parse(localStorageHttpMethods) as string[] : [];
+  const [recent, setRecent] = useState(parsedLocalStorageHttpMethods);
 
-  const dropdownRef = useRef<Dropdown>(null);
-  const toggle = useCallback(() => dropdownRef.current?.toggle(), [dropdownRef]);
-  useImperativeHandle(ref, () => ({ toggle }), [toggle]);
   const handleSetCustomMethod = useCallback(() => {
     showPrompt({
       defaultValue: method,
@@ -69,11 +67,12 @@ export const MethodDropdown = forwardRef<MethodDropdownHandle, Props>(({
 
   const buttonLabel = method === METHOD_GRPC ? GRPC_LABEL : method;
   return (
-    <Dropdown ref={dropdownRef} className="method-dropdown" right={right}>
+    <Dropdown ref={ref} className="method-dropdown" right={right}>
       <DropdownButton className={className}>
         <span className={`http-method-${method}`}>{buttonLabel}</span>{' '}
         <i className="fa fa-caret-down space-left" />
       </DropdownButton>
+
       {constants.HTTP_METHODS.map(method => (
         <DropdownItem
           key={method}
@@ -84,6 +83,7 @@ export const MethodDropdown = forwardRef<MethodDropdownHandle, Props>(({
           {method}
         </DropdownItem>
       ))}
+
       {showGrpc && (
         <>
           <DropdownDivider />
@@ -92,6 +92,7 @@ export const MethodDropdown = forwardRef<MethodDropdownHandle, Props>(({
           </DropdownItem>
         </>
       )}
+
       <DropdownDivider />
       <DropdownItem
         className="http-method-custom"

--- a/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
@@ -17,7 +17,10 @@ interface Props {
   showGrpc?: boolean;
   className?: string;
 }
-export const MethodDropdown = forwardRef<{toggle:()=>void}, Props>(({
+export interface MethodDropdownHandle {
+  toggle:()=>void;
+}
+export const MethodDropdown = forwardRef<MethodDropdownHandle, Props>(({
   method,
   right,
   onChange,

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -71,7 +71,7 @@ export const RequestActionsDropdown = forwardRef<RequestActionsDropdownHandle, P
     const actionPlugins = await getRequestActions();
     setActionPlugins(actionPlugins);
   };
-  const handlePluginClick = async (p: RequestAction) => {
+  const handlePluginClick = useCallback(async (p: RequestAction) => {
     setLoadingActions({ ...loadingActions, [p.label]: true });
 
     try {
@@ -94,7 +94,15 @@ export const RequestActionsDropdown = forwardRef<RequestActionsDropdownHandle, P
     }
     setLoadingActions({ ...loadingActions, [p.label]: false });
     hide();
-  };
+  }, [request, activeEnvironment, hide, requestGroup, loadingActions, activeProject._id]);
+  const duplicate = useCallback(() => handleDuplicateRequest(request), [handleDuplicateRequest, request]);
+  const generateCode = useCallback(() => handleGenerateCode(request), [handleGenerateCode, request]);
+  const copyAsCurl = useCallback(() => handleCopyAsCurl(request), [handleCopyAsCurl, request]);
+  const togglePin = useCallback(() => handleSetRequestPinned(request, !isPinned), [handleSetRequestPinned, isPinned, request]);
+  const deleteRequest = useCallback(() => {
+    incrementDeletedRequests();
+    requestOperations.remove(request);
+  }, [request]);
   // Can only generate code for regular requests, not gRPC requests
   const canGenerateCode = isRequest(request);
   return (
@@ -103,13 +111,13 @@ export const RequestActionsDropdown = forwardRef<RequestActionsDropdownHandle, P
         <i className="fa fa-caret-down" />
       </DropdownButton>
 
-      <DropdownItem onClick={() => handleDuplicateRequest(request)}>
+      <DropdownItem onClick={duplicate}>
         <i className="fa fa-copy" /> Duplicate
         <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_DUPLICATE.id]} />
       </DropdownItem>
 
       {canGenerateCode && (
-        <DropdownItem onClick={() => handleGenerateCode(request)}>
+        <DropdownItem onClick={generateCode}>
           <i className="fa fa-code" /> Generate Code
           <DropdownHint
             keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_GENERATE_CODE_EDITOR.id]}
@@ -117,23 +125,20 @@ export const RequestActionsDropdown = forwardRef<RequestActionsDropdownHandle, P
         </DropdownItem>
       )}
 
-      <DropdownItem onClick={() => handleSetRequestPinned(request, !isPinned)}>
+      <DropdownItem onClick={togglePin}>
         <i className="fa fa-thumb-tack" /> {isPinned ? 'Unpin' : 'Pin'}
         <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_TOGGLE_PIN.id]} />
       </DropdownItem>
 
       {canGenerateCode && (
-        <DropdownItem onClick={() => handleCopyAsCurl(request)}>
+        <DropdownItem onClick={copyAsCurl}>
           <i className="fa fa-copy" /> Copy as Curl
         </DropdownItem>
       )}
 
       <DropdownItem
         buttonClass={PromptButton}
-        onClick={() => {
-          incrementDeletedRequests();
-          return requestOperations.remove(request);
-        }}
+        onClick={deleteRequest}
         addIcon
       >
         <i className="fa fa-trash-o" /> Delete

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -67,11 +67,11 @@ export const RequestActionsDropdown = forwardRef<RequestActionsDropdownHandle, P
   useImperativeHandle(ref, () => ({ show, hide }), [show, hide]);
   const [actionPlugins, setActionPlugins] = useState<RequestAction[]>([]);
   const [loadingActions, setLoadingActions] = useState<Record<string, boolean>>({});
-  const _onOpen = async () => {
+  const onOpen = async () => {
     const actionPlugins = await getRequestActions();
     setActionPlugins(actionPlugins);
   };
-  const _handlePluginClick = async (p: RequestAction) => {
+  const handlePluginClick = async (p: RequestAction) => {
     setLoadingActions({ ...loadingActions, [p.label]: true });
 
     try {
@@ -98,7 +98,7 @@ export const RequestActionsDropdown = forwardRef<RequestActionsDropdownHandle, P
   // Can only generate code for regular requests, not gRPC requests
   const canGenerateCode = isRequest(request);
   return (
-    <Dropdown ref={dropdownRef} onOpen={_onOpen}>
+    <Dropdown ref={dropdownRef} onOpen={onOpen}>
       <DropdownButton>
         <i className="fa fa-caret-down" />
       </DropdownButton>
@@ -145,7 +145,7 @@ export const RequestActionsDropdown = forwardRef<RequestActionsDropdownHandle, P
         <DropdownItem
           key={`${plugin.plugin.name}::${plugin.label}`}
           value={plugin}
-          onClick={_handlePluginClick}
+          onClick={handlePluginClick}
           stayOpenAfterClick
         >
           {loadingActions[plugin.label] ? (

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -36,8 +36,11 @@ interface Props extends Pick<DropdownProps, 'right'> {
   request: Request | GrpcRequest;
   requestGroup?: RequestGroup;
 }
-
-export const RequestActionsDropdown: React.FC<Props> = forwardRef<{show:()=>void; hide:()=>void}, Props>(({
+export interface RequestActionsDropdownHandle {
+  show:()=>void;
+  hide:()=>void;
+}
+export const RequestActionsDropdown = forwardRef<RequestActionsDropdownHandle, Props>(({
   activeEnvironment,
   activeProject,
   handleCopyAsCurl,

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -26,10 +26,10 @@ import { showError } from '../modals';
 interface Props extends Pick<DropdownProps, 'right'> {
   activeEnvironment?: Environment | null;
   activeProject: Project;
-  handleCopyAsCurl: (reqeust: Request | GrpcRequest) => void;
-  handleDuplicateRequest: (reqeust: Request | GrpcRequest) => void;
-  handleGenerateCode: (reqeust: Request | GrpcRequest) => void;
-  handleSetRequestPinned: (reqeust: Request | GrpcRequest, isPinned: boolean) => void;
+  handleSetRequestPinned: Function;
+  handleDuplicateRequest: Function;
+  handleGenerateCode: Function;
+  handleCopyAsCurl: Function;
   handleShowSettings: () => void;
   hotKeyRegistry: HotKeyRegistry;
   isPinned: Boolean;

--- a/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -42,7 +42,7 @@ export const RequestGroupActionsDropdown = forwardRef<RequestGroupActionsDropdow
 }, ref) => {
   const [actionPlugins, setActionPlugins] = useState<RequestGroupAction[]>([]);
   const [loadingActions, setLoadingActions] = useState< Record<string, boolean>>({});
-  const dropdownRef = useRef<Dropdown | null>(null);
+  const dropdownRef = useRef<Dropdown>(null);
 
   const activeProject = useSelector(selectActiveProject);
   const activeEnvironment = useSelector(selectActiveEnvironment);

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -71,7 +71,7 @@ export const ResponseHistoryDropdown: React.FC<Props> = ({
 
     categories.other.push(response);
   });
-  const renderDropdownItem = (response: Response) => {
+  const renderResponseRow = (response: Response) => {
     const activeResponseId = activeResponse ? activeResponse._id : 'n/a';
     const active = response._id === activeResponseId;
     const requestVersion = requestVersions.find(v => v._id === response.requestVersionId);
@@ -113,7 +113,7 @@ export const ResponseHistoryDropdown: React.FC<Props> = ({
     );
   };
 
-  const _handleKeydown = (event: KeyboardEvent) => {
+  const handleKeydown = (event: KeyboardEvent) => {
     executeHotKey(event, hotKeyRefs.REQUEST_TOGGLE_HISTORY, () => {
       dropdownRef.current?.toggle(true);
     });
@@ -121,7 +121,7 @@ export const ResponseHistoryDropdown: React.FC<Props> = ({
   const environmentName = activeEnvironment ? activeEnvironment.name : 'Base';
   const isLatestResponseActive = !responses.length || activeResponse._id === responses[0]._id;
   return (
-    <KeydownBinder onKeydown={_handleKeydown}>
+    <KeydownBinder onKeydown={handleKeydown}>
       <Dropdown
         ref={dropdownRef}
         key={activeResponse ? activeResponse._id : 'n/a'}
@@ -148,15 +148,15 @@ export const ResponseHistoryDropdown: React.FC<Props> = ({
         </DropdownItem>
         <Fragment>
           <DropdownDivider>Just Now</DropdownDivider>
-          {categories.minutes.map(renderDropdownItem)}
+          {categories.minutes.map(renderResponseRow)}
           <DropdownDivider>Less Than Two Hours Ago</DropdownDivider>
-          {categories.hours.map(renderDropdownItem)}
+          {categories.hours.map(renderResponseRow)}
           <DropdownDivider>Today</DropdownDivider>
-          {categories.today.map(renderDropdownItem)}
+          {categories.today.map(renderResponseRow)}
           <DropdownDivider>This Week</DropdownDivider>
-          {categories.week.map(renderDropdownItem)}
+          {categories.week.map(renderResponseRow)}
           <DropdownDivider>Older Than This Week</DropdownDivider>
-          {categories.other.map(renderDropdownItem)}
+          {categories.other.map(renderResponseRow)}
         </Fragment>
       </Dropdown>
     </KeydownBinder>

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -1,5 +1,5 @@
 import { differenceInHours, differenceInMinutes, isThisWeek, isToday } from 'date-fns';
-import React, { Fragment, useCallback, useRef } from 'react';
+import React, { FC, Fragment, useCallback, useRef } from 'react';
 
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
@@ -30,7 +30,7 @@ interface Props {
   requestVersions: RequestVersion[];
   responses: Response[];
 }
-export const ResponseHistoryDropdown: React.FC<Props> = ({
+export const ResponseHistoryDropdown: FC<Props> = ({
   activeEnvironment,
   activeResponse,
   className,

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -1,8 +1,6 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { differenceInHours, differenceInMinutes, isThisWeek, isToday } from 'date-fns';
-import React, { Fragment, PureComponent, useRef } from 'react';
+import React, { Fragment, useRef } from 'react';
 
-import { AUTOBIND_CFG } from '../../../common/constants';
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
 import { decompressObject } from '../../../common/misc';
@@ -83,7 +81,7 @@ export const ResponseHistoryDropdown: React.FC<Props> = ({
         key={response._id}
         disabled={active}
         value={response}
-        onClick={_handleSetActiveResponse}
+        onClick={handleSetActiveResponse}
       >
         {active ? <i className="fa fa-thumb-tack" /> : <i className="fa fa-empty" />}{' '}
         <StatusTag

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -30,6 +30,7 @@ interface Props {
   requestVersions: RequestVersion[];
   responses: Response[];
 }
+
 export const ResponseHistoryDropdown: FC<Props> = ({
   activeEnvironment,
   activeResponse,
@@ -44,7 +45,13 @@ export const ResponseHistoryDropdown: FC<Props> = ({
   const dropdownRef = useRef<Dropdown>(null);
 
   const now = new Date();
-  const categories: Record<string, Response[]> = { minutes: [], hours: [], today: [], week: [], other: [] };
+  const categories: Record<string, Response[]> = {
+    minutes: [],
+    hours: [],
+    today: [],
+    week: [],
+    other: [],
+  };
 
   responses.forEach(response => {
     const responseTime = new Date(response.created);
@@ -71,10 +78,11 @@ export const ResponseHistoryDropdown: FC<Props> = ({
 
     categories.other.push(response);
   });
+
   const renderResponseRow = (response: Response) => {
     const activeResponseId = activeResponse ? activeResponse._id : 'n/a';
     const active = response._id === activeResponseId;
-    const requestVersion = requestVersions.find(v => v._id === response.requestVersionId);
+    const requestVersion = requestVersions.find(({ _id }) => _id === response.requestVersionId);
     const request = requestVersion ? decompressObject(requestVersion.compressedRequest) : null;
     return (
       <DropdownItem

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -1,5 +1,5 @@
 import { differenceInHours, differenceInMinutes, isThisWeek, isToday } from 'date-fns';
-import React, { Fragment, useRef } from 'react';
+import React, { Fragment, useCallback, useRef } from 'react';
 
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
@@ -113,11 +113,7 @@ export const ResponseHistoryDropdown: React.FC<Props> = ({
     );
   };
 
-  const handleKeydown = (event: KeyboardEvent) => {
-    executeHotKey(event, hotKeyRefs.REQUEST_TOGGLE_HISTORY, () => {
-      dropdownRef.current?.toggle(true);
-    });
-  };
+  const handleKeydown = useCallback((event: KeyboardEvent) => executeHotKey(event, hotKeyRefs.REQUEST_TOGGLE_HISTORY, () => dropdownRef.current?.toggle(true)), []);
   const environmentName = activeEnvironment ? activeEnvironment.name : 'Base';
   const isLatestResponseActive = !responses.length || activeResponse._id === responses[0]._id;
   return (

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { differenceInHours, differenceInMinutes, isThisWeek, isToday } from 'date-fns';
-import React, { Fragment, PureComponent } from 'react';
+import React, { Fragment, PureComponent, useRef } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { hotKeyRefs } from '../../../common/hotkeys';
@@ -22,48 +22,60 @@ import { URLTag } from '../tags/url-tag';
 import { TimeFromNow } from '../time-from-now';
 
 interface Props {
-  handleSetActiveResponse: Function;
-  handleDeleteResponses: Function;
-  handleDeleteResponse: Function;
-  requestId: string;
-  responses: Response[];
-  requestVersions: RequestVersion[];
-  activeResponse: Response;
   activeEnvironment?: Environment | null;
+  activeResponse: Response;
   className?: string;
+  handleDeleteResponse: Function;
+  handleDeleteResponses: Function;
+  handleSetActiveResponse: Function;
+  requestId: string;
+  requestVersions: RequestVersion[];
+  responses: Response[];
 }
+export const ResponseHistoryDropdown: React.FC<Props> = ({
+  activeEnvironment,
+  activeResponse,
+  className,
+  handleDeleteResponse,
+  handleDeleteResponses,
+  handleSetActiveResponse,
+  requestId,
+  requestVersions,
+  responses,
+}) => {
+  const dropdownRef = useRef<Dropdown>(null);
 
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class ResponseHistoryDropdown extends PureComponent<Props> {
-  _dropdown: Dropdown | null = null;
+  const now = new Date();
+  const categories: Record<string, Response[]> = { minutes: [], hours: [], today: [], week: [], other: [] };
 
-  _handleDeleteResponses() {
-    const { requestId, activeEnvironment } = this.props;
-    const environmentId = activeEnvironment ? activeEnvironment._id : null;
-    this.props.handleDeleteResponses(requestId, environmentId);
-  }
+  responses.forEach(response => {
+    const responseTime = new Date(response.created);
 
-  _handleDeleteResponse() {
-    this.props.handleDeleteResponse(this.props.activeResponse);
-  }
+    if (differenceInMinutes(now, responseTime) < 5) {
+      categories.minutes.push(response);
+      return;
+    }
 
-  _handleSetActiveResponse(response: Response) {
-    this.props.handleSetActiveResponse(response);
-  }
+    if (differenceInHours(now, responseTime) < 2) {
+      categories.hours.push(response);
+      return;
+    }
 
-  _handleKeydown(event: KeyboardEvent) {
-    executeHotKey(event, hotKeyRefs.REQUEST_TOGGLE_HISTORY, () => {
-      this._dropdown?.toggle(true);
-    });
-  }
+    if (isToday(responseTime)) {
+      categories.today.push(response);
+      return;
+    }
 
-  renderDropdownItem(response: Response) {
-    const { activeResponse, requestVersions } = this.props;
+    if (isThisWeek(responseTime)) {
+      categories.week.push(response);
+      return;
+    }
+
+    categories.other.push(response);
+  });
+  const renderDropdownItem = (response: Response) => {
     const activeResponseId = activeResponse ? activeResponse._id : 'n/a';
     const active = response._id === activeResponseId;
-    const message =
-      'Request will not be restored with this response because ' +
-      'it was created before this ability was added';
     const requestVersion = requestVersions.find(v => v._id === response.requestVersionId);
     const request = requestVersion ? decompressObject(requestVersion.compressedRequest) : null;
     return (
@@ -71,7 +83,7 @@ export class ResponseHistoryDropdown extends PureComponent<Props> {
         key={response._id}
         disabled={active}
         value={response}
-        onClick={this._handleSetActiveResponse}
+        onClick={_handleSetActiveResponse}
       >
         {active ? <i className="fa fa-thumb-tack" /> : <i className="fa fa-empty" />}{' '}
         <StatusTag
@@ -93,111 +105,62 @@ export class ResponseHistoryDropdown extends PureComponent<Props> {
           small
           tooltipDelay={1000}
         />
-        {!response.requestVersionId && <i className="icon fa fa-info-circle" title={message} />}
+        {!response.requestVersionId ?
+          <i
+            className="icon fa fa-info-circle"
+            title={'Request will not be restored with this response because it was created before this ability was added'}
+          />
+          : null}
       </DropdownItem>
     );
-  }
+  };
 
-  renderPastResponses(responses: Response[]) {
-    const now = new Date();
-
-    const categories: Record<string, Response[]> = {
-      minutes: [],
-      hours: [],
-      today: [],
-      week: [],
-      other: [],
-    };
-
-    responses.forEach(response => {
-      const responseTime = new Date(response.created);
-
-      if (differenceInMinutes(now, responseTime) < 5) {
-        categories.minutes.push(response);
-        return;
-      }
-
-      if (differenceInHours(now, responseTime) < 2) {
-        categories.hours.push(response);
-        return;
-      }
-
-      if (isToday(responseTime)) {
-        categories.today.push(response);
-        return;
-      }
-
-      if (isThisWeek(responseTime)) {
-        categories.week.push(response);
-        return;
-      }
-
-      categories.other.push(response);
+  const _handleKeydown = (event: KeyboardEvent) => {
+    executeHotKey(event, hotKeyRefs.REQUEST_TOGGLE_HISTORY, () => {
+      dropdownRef.current?.toggle(true);
     });
-
-    return (
-      <Fragment>
-        <DropdownDivider>Just Now</DropdownDivider>
-        {categories.minutes.map(this.renderDropdownItem)}
-        <DropdownDivider>Less Than Two Hours Ago</DropdownDivider>
-        {categories.hours.map(this.renderDropdownItem)}
-        <DropdownDivider>Today</DropdownDivider>
-        {categories.today.map(this.renderDropdownItem)}
-        <DropdownDivider>This Week</DropdownDivider>
-        {categories.week.map(this.renderDropdownItem)}
-        <DropdownDivider>Older Than This Week</DropdownDivider>
-        {categories.other.map(this.renderDropdownItem)}
-      </Fragment>
-    );
-  }
-
-  render() {
-    const {
-      activeResponse,
-      // eslint-disable-line @typescript-eslint/no-unused-vars
-      handleSetActiveResponse,
-      // eslint-disable-line @typescript-eslint/no-unused-vars
-      handleDeleteResponses,
-      // eslint-disable-line @typescript-eslint/no-unused-vars
-      handleDeleteResponse,
-      // eslint-disable-line @typescript-eslint/no-unused-vars
-      responses,
-      activeEnvironment,
-      ...extraProps
-    } = this.props;
-    const environmentName = activeEnvironment ? activeEnvironment.name : 'Base';
-    const isLatestResponseActive = !responses.length || activeResponse._id === responses[0]._id;
-    return (
-      <KeydownBinder onKeydown={this._handleKeydown}>
-        <Dropdown
-          ref={ref => {
-            this._dropdown = ref;
-          }}
-          key={activeResponse ? activeResponse._id : 'n/a'}
-          {...extraProps}
-        >
-          <DropdownButton className="btn btn--super-compact tall" title="Response history">
-            {activeResponse && <TimeFromNow timestamp={activeResponse.created} titleCase />}
-            {!isLatestResponseActive ? (
-              <i className="fa fa-thumb-tack space-left" />
-            ) : (
-              <i className="fa fa-caret-down space-left" />
-            )}
-          </DropdownButton>
-          <DropdownDivider>
-            <strong>{environmentName}</strong> Responses
-          </DropdownDivider>
-          <DropdownItem buttonClass={PromptButton} addIcon onClick={this._handleDeleteResponse}>
-            <i className="fa fa-trash-o" />
-            Delete Current Response
-          </DropdownItem>
-          <DropdownItem buttonClass={PromptButton} addIcon onClick={this._handleDeleteResponses}>
-            <i className="fa fa-trash-o" />
-            Clear History
-          </DropdownItem>
-          {this.renderPastResponses(responses)}
-        </Dropdown>
-      </KeydownBinder>
-    );
-  }
-}
+  };
+  const environmentName = activeEnvironment ? activeEnvironment.name : 'Base';
+  const isLatestResponseActive = !responses.length || activeResponse._id === responses[0]._id;
+  return (
+    <KeydownBinder onKeydown={_handleKeydown}>
+      <Dropdown
+        ref={dropdownRef}
+        key={activeResponse ? activeResponse._id : 'n/a'}
+        className={className}
+      >
+        <DropdownButton className="btn btn--super-compact tall" title="Response history">
+          {activeResponse && <TimeFromNow timestamp={activeResponse.created} titleCase />}
+          {!isLatestResponseActive ? (
+            <i className="fa fa-thumb-tack space-left" />
+          ) : (
+            <i className="fa fa-caret-down space-left" />
+          )}
+        </DropdownButton>
+        <DropdownDivider>
+          <strong>{environmentName}</strong> Responses
+        </DropdownDivider>
+        <DropdownItem buttonClass={PromptButton} addIcon onClick={handleDeleteResponse}>
+          <i className="fa fa-trash-o" />
+          Delete Current Response
+        </DropdownItem>
+        <DropdownItem buttonClass={PromptButton} addIcon onClick={() => handleDeleteResponses(requestId, activeEnvironment ? activeEnvironment._id : null)}>
+          <i className="fa fa-trash-o" />
+          Clear History
+        </DropdownItem>
+        <Fragment>
+          <DropdownDivider>Just Now</DropdownDivider>
+          {categories.minutes.map(renderDropdownItem)}
+          <DropdownDivider>Less Than Two Hours Ago</DropdownDivider>
+          {categories.hours.map(renderDropdownItem)}
+          <DropdownDivider>Today</DropdownDivider>
+          {categories.today.map(renderDropdownItem)}
+          <DropdownDivider>This Week</DropdownDivider>
+          {categories.week.map(renderDropdownItem)}
+          <DropdownDivider>Older Than This Week</DropdownDivider>
+          {categories.other.map(renderDropdownItem)}
+        </Fragment>
+      </Dropdown>
+    </KeydownBinder>
+  );
+};

--- a/packages/insomnia/src/ui/components/modals/analytics-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/analytics-modal.tsx
@@ -74,7 +74,7 @@ const ActionButtons = styled.div({
 
 export const AnalyticsModal: FC = () => {
   const { hasPromptedAnalytics } = useSelector(selectSettings);
-  const ref = useRef<Modal | null>(null);
+  const ref = useRef<Modal>(null);
 
   const onEnable = useCallback(async () => {
     await models.settings.patch({

--- a/packages/insomnia/src/ui/components/page-layout.tsx
+++ b/packages/insomnia/src/ui/components/page-layout.tsx
@@ -20,11 +20,11 @@ const Pane = forwardRef<HTMLElement, { position: string; children: ReactNode }>(
 
 interface Props {
   wrapperProps: WrapperProps;
-  renderPageSidebar?: () => ReactNode;
-  renderPageHeader?: () => ReactNode;
-  renderPageBody?: () => ReactNode;
-  renderPaneOne?: () => ReactNode;
-  renderPaneTwo?: () => ReactNode;
+  renderPageSidebar?: ReactNode;
+  renderPageHeader?: ReactNode;
+  renderPageBody?: ReactNode;
+  renderPaneOne?: ReactNode;
+  renderPaneTwo?: ReactNode;
 }
 
 export const PageLayout: FC<Props> = ({
@@ -68,13 +68,12 @@ export const PageLayout: FC<Props> = ({
   }, [handleStartDragSidebar]);
 
   const realSidebarWidth = sidebarHidden ? 0 : sidebarWidth;
-  const paneTwo = renderPaneTwo?.();
-  const gridRows = paneTwo
+  const gridRows = renderPaneTwo
     ? `auto minmax(0, ${paneHeight}fr) 0 minmax(0, ${1 - paneHeight}fr)`
     : 'auto 1fr';
   const gridColumns =
-      `auto ${realSidebarWidth}rem 0 ` +
-      `${paneTwo ? `minmax(0, ${paneWidth}fr) 0 minmax(0, ${1 - paneWidth}fr)` : '1fr'}`;
+    `auto ${realSidebarWidth}rem 0 ` +
+    `${renderPaneTwo ? `minmax(0, ${paneWidth}fr) 0 minmax(0, ${1 - paneWidth}fr)` : '1fr'}`;
   return (
     <div
       key="wrapper"
@@ -87,32 +86,32 @@ export const PageLayout: FC<Props> = ({
         gridTemplateRows: gridRows,
         boxSizing: 'border-box',
         borderTop:
-            activeEnvironment &&
+          activeEnvironment &&
             activeEnvironment.color &&
             settings.environmentHighlightColorStyle === 'window-top'
-              ? '5px solid ' + activeEnvironment.color
-              : undefined,
+            ? '5px solid ' + activeEnvironment.color
+            : undefined,
         borderBottom:
-            activeEnvironment &&
+          activeEnvironment &&
             activeEnvironment.color &&
             settings.environmentHighlightColorStyle === 'window-bottom'
-              ? '5px solid ' + activeEnvironment.color
-              : undefined,
+            ? '5px solid ' + activeEnvironment.color
+            : undefined,
         borderLeft:
-            activeEnvironment &&
+          activeEnvironment &&
             activeEnvironment.color &&
             settings.environmentHighlightColorStyle === 'window-left'
-              ? '5px solid ' + activeEnvironment.color
-              : undefined,
+            ? '5px solid ' + activeEnvironment.color
+            : undefined,
         borderRight:
-            activeEnvironment &&
+          activeEnvironment &&
             activeEnvironment.color &&
             settings.environmentHighlightColorStyle === 'window-right'
-              ? '5px solid ' + activeEnvironment.color
-              : undefined,
+            ? '5px solid ' + activeEnvironment.color
+            : undefined,
       }}
     >
-      {renderPageHeader && <ErrorBoundary showAlert>{renderPageHeader()}</ErrorBoundary>}
+      {renderPageHeader && <ErrorBoundary showAlert>{renderPageHeader}</ErrorBoundary>}
 
       {renderPageSidebar && (
         <ErrorBoundary showAlert>
@@ -132,7 +131,7 @@ export const PageLayout: FC<Props> = ({
             width={sidebarWidth}
             workspacesForActiveProject={workspacesForActiveProject}
           >
-            {renderPageSidebar()}
+            {renderPageSidebar}
           </Sidebar>
 
           <div className="drag drag--sidebar">
@@ -144,7 +143,7 @@ export const PageLayout: FC<Props> = ({
         </ErrorBoundary>
       )}
       {renderPageBody ? (
-        <ErrorBoundary showAlert>{renderPageBody()}</ErrorBoundary>
+        <ErrorBoundary showAlert>{renderPageBody}</ErrorBoundary>
       ) : (
         <>
           {renderPaneOne && (
@@ -153,11 +152,11 @@ export const PageLayout: FC<Props> = ({
                 position="one"
                 ref={requestPaneRef}
               >
-                {renderPaneOne()}
+                {renderPaneOne}
               </Pane>
             </ErrorBoundary>
           )}
-          {paneTwo && (
+          {renderPaneTwo && (
             <>
               <div className="drag drag--pane-horizontal">
                 <div
@@ -178,7 +177,7 @@ export const PageLayout: FC<Props> = ({
                   position="two"
                   ref={responsePaneRef}
                 >
-                  {paneTwo}
+                  {renderPaneTwo}
                 </Pane>
               </ErrorBoundary>
             </>

--- a/packages/insomnia/src/ui/components/page-layout.tsx
+++ b/packages/insomnia/src/ui/components/page-layout.tsx
@@ -3,7 +3,7 @@ import React, { FC, forwardRef, ReactNode, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectIsLoading } from '../redux/modules/global';
-import { selectActiveEnvironment, selectActiveGitRepository, selectSettings, selectUnseenWorkspaces, selectWorkspacesForActiveProject } from '../redux/selectors';
+import { selectActiveEnvironment, selectSettings, selectUnseenWorkspaces, selectWorkspacesForActiveProject } from '../redux/selectors';
 import { ErrorBoundary } from './error-boundary';
 import { Sidebar } from './sidebar/sidebar';
 import type { WrapperProps } from './wrapper';
@@ -36,15 +36,12 @@ export const PageLayout: FC<Props> = ({
   wrapperProps,
 }) => {
   const activeEnvironment = useSelector(selectActiveEnvironment);
-  const activeGitRepository = useSelector(selectActiveGitRepository);
   const isLoading = useSelector(selectIsLoading);
   const settings = useSelector(selectSettings);
   const unseenWorkspaces = useSelector(selectUnseenWorkspaces);
   const workspacesForActiveProject = useSelector(selectWorkspacesForActiveProject);
 
   const {
-    gitVCS,
-    handleInitializeEntities,
     handleResetDragSidebar,
     handleStartDragSidebar,
     handleSetActiveEnvironment,
@@ -118,16 +115,12 @@ export const PageLayout: FC<Props> = ({
           <Sidebar
             ref={sidebarRef}
             activeEnvironment={activeEnvironment}
-            // @ts-expect-error -- TSCONVERSION
-            activeGitRepository={activeGitRepository}
             environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
-            handleInitializeEntities={handleInitializeEntities}
             handleSetActiveEnvironment={handleSetActiveEnvironment}
             hidden={sidebarHidden || false}
             hotKeyRegistry={settings.hotKeyRegistry}
             isLoading={isLoading}
             unseenWorkspaces={unseenWorkspaces}
-            gitVCS={gitVCS}
             width={sidebarWidth}
             workspacesForActiveProject={workspacesForActiveProject}
           >

--- a/packages/insomnia/src/ui/components/panes/pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/pane.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React from 'react';
+import React, { FC } from 'react';
 
 interface PaneProps {
   className?: string;
@@ -15,20 +15,20 @@ interface PaneBodyProps {
   placeholder?: boolean;
 }
 
-export const Pane: React.FC<PaneProps> = ({ className, type, children }) => (
+export const Pane: FC<PaneProps> = ({ className, type, children }) => (
   <section className={classnames(`${type}-pane`, 'theme--pane', 'pane', className)} data-testid={`${type}-pane`}>
     {children}
   </section>
 );
 
-export const PaneHeader: React.FC<PaneHeaderProps> = ({ className, children }) => (
+export const PaneHeader: FC<PaneHeaderProps> = ({ className, children }) => (
   <header className={classnames('pane__header', 'theme--pane__header', className)}>
     {children}
   </header>
 );
 
 export const paneBodyClasses = 'pane__body theme--pane__body';
-export const PaneBody: React.FC<PaneBodyProps> = ({ placeholder, children }) => (
+export const PaneBody: FC<PaneBodyProps> = ({ placeholder, children }) => (
   <div className={classnames(paneBodyClasses, placeholder && 'pane__body--placeholder')}>
     {children}
   </div>

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -130,7 +130,7 @@ export const RequestPane: FC<Props> = ({
     }
   }, [request, forceUpdateRequest]);
 
-  const requestUrlBarRef = useRef<RequestUrlBar | null>(null);
+  const requestUrlBarRef = useRef<RequestUrlBar>(null);
   useMount(() => {
     requestUrlBarRef.current?.focusInput();
   });

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -185,8 +185,6 @@ export const RequestPane: FC<Props> = ({
           <Tab tabIndex="=1">
             <ContentTypeDropdown
               onChange={updateRequestMimeType}
-              contentType={request.body.mimeType}
-              request={request}
               className="tall"
             >
               {typeof request.body.mimeType === 'string'

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -14,7 +14,7 @@ import { DropdownHint } from './base/dropdown/dropdown-hint';
 import { DropdownItem } from './base/dropdown/dropdown-item';
 import { PromptButton } from './base/prompt-button';
 import { OneLineEditor } from './codemirror/one-line-editor';
-import { MethodDropdown, MethodDropdownHandle } from './dropdowns/method-dropdown';
+import { MethodDropdown } from './dropdowns/method-dropdown';
 import { KeydownBinder } from './keydown-binder';
 import { showPrompt } from './modals/index';
 
@@ -45,7 +45,7 @@ export class RequestUrlBar extends PureComponent<Props, State> {
   _sendTimeout: NodeJS.Timeout | null = null;
   _sendInterval: NodeJS.Timeout | null = null;
   _dropdown: Dropdown | null = null;
-  _methodDropdown: MethodDropdownHandle | null = null;
+  _methodDropdown: Dropdown | null = null;
   _input: OneLineEditor | null = null;
   state: State = {
     currentInterval: null,
@@ -58,7 +58,7 @@ export class RequestUrlBar extends PureComponent<Props, State> {
     this._dropdown = dropdown;
   }
 
-  _setMethodDropdownRef(methodDropdown: MethodDropdownHandle) {
+  _setMethodDropdownRef(methodDropdown: Dropdown) {
     this._methodDropdown = methodDropdown;
   }
 

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -14,7 +14,7 @@ import { DropdownHint } from './base/dropdown/dropdown-hint';
 import { DropdownItem } from './base/dropdown/dropdown-item';
 import { PromptButton } from './base/prompt-button';
 import { OneLineEditor } from './codemirror/one-line-editor';
-import { MethodDropdown } from './dropdowns/method-dropdown';
+import { MethodDropdown, MethodDropdownHandle } from './dropdowns/method-dropdown';
 import { KeydownBinder } from './keydown-binder';
 import { showPrompt } from './modals/index';
 
@@ -45,7 +45,7 @@ export class RequestUrlBar extends PureComponent<Props, State> {
   _sendTimeout: NodeJS.Timeout | null = null;
   _sendInterval: NodeJS.Timeout | null = null;
   _dropdown: Dropdown | null = null;
-  _methodDropdown: MethodDropdown | null = null;
+  _methodDropdown: MethodDropdownHandle | null = null;
   _input: OneLineEditor | null = null;
   state: State = {
     currentInterval: null,
@@ -58,7 +58,7 @@ export class RequestUrlBar extends PureComponent<Props, State> {
     this._dropdown = dropdown;
   }
 
-  _setMethodDropdownRef(methodDropdown: MethodDropdown) {
+  _setMethodDropdownRef(methodDropdown: MethodDropdownHandle) {
     this._methodDropdown = methodDropdown;
   }
 
@@ -370,9 +370,7 @@ export class RequestUrlBar extends PureComponent<Props, State> {
             ref={this._setMethodDropdownRef}
             onChange={this._handleMethodChange}
             method={method}
-          >
-            {method} <i className="fa fa-caret-down" />
-          </MethodDropdown>
+          />
           <form onSubmit={this._handleFormSubmit}>
             <OneLineEditor
               key={uniquenessKey}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -27,11 +27,11 @@ import { DnDProps, DragObject, dropHandleCreator, hoverHandleCreator, sourceColl
 interface RawProps {
   disableDragAndDrop?: boolean;
   filter: string;
-  handleActivateRequest: (requestId?: string) => void;
-  handleCopyAsCurl: (reqeust: Request | GrpcRequest) => void;
-  handleDuplicateRequest: (reqeust: Request | GrpcRequest) => void;
-  handleGenerateCode: (reqeust: Request | GrpcRequest) => void;
-  handleSetRequestPinned: (reqeust: Request | GrpcRequest, isPinned: boolean) => void;
+  handleActivateRequest: Function;
+  handleSetRequestPinned: Function;
+  handleDuplicateRequest: Function;
+  handleGenerateCode: Function;
+  handleCopyAsCurl: Function;
   hotKeyRegistry: HotKeyRegistry;
   isActive: boolean;
   isPinned: boolean;

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -13,9 +13,10 @@ import { RequestGroup } from '../../../models/request-group';
 import { useNunjucks } from '../../context/nunjucks/use-nunjucks';
 import { createRequest } from '../../hooks/create-request';
 import { selectActiveEnvironment, selectActiveProject, selectActiveWorkspace } from '../../redux/selectors';
+import { Dropdown } from '../base/dropdown/dropdown';
 import { Editable } from '../base/editable';
 import { Highlight } from '../base/highlight';
-import { RequestActionsDropdown, RequestActionsDropdownHandle } from '../dropdowns/request-actions-dropdown';
+import { RequestActionsDropdown } from '../dropdowns/request-actions-dropdown';
 import { GrpcSpinner } from '../grpc-spinner';
 import { showModal } from '../modals/index';
 import { RequestSettingsModal } from '../modals/request-settings-modal';
@@ -24,19 +25,18 @@ import { MethodTag } from '../tags/method-tag';
 import { DnDProps, DragObject, dropHandleCreator, hoverHandleCreator, sourceCollect, targetCollect } from './dnd';
 
 interface RawProps {
-  handleActivateRequest: Function;
-  handleSetRequestPinned: Function;
-  handleDuplicateRequest: Function;
-  handleGenerateCode: Function;
-  handleCopyAsCurl: Function;
+  disableDragAndDrop?: boolean;
   filter: string;
+  handleActivateRequest: (requestId?: string) => void;
+  handleCopyAsCurl: (reqeust: Request | GrpcRequest) => void;
+  handleDuplicateRequest: (reqeust: Request | GrpcRequest) => void;
+  handleGenerateCode: (reqeust: Request | GrpcRequest) => void;
+  handleSetRequestPinned: (reqeust: Request | GrpcRequest, isPinned: boolean) => void;
+  hotKeyRegistry: HotKeyRegistry;
   isActive: boolean;
   isPinned: boolean;
-  hotKeyRegistry: HotKeyRegistry;
-  requestGroup?: RequestGroup;
-  /** can be Request or GrpcRequest */
   request?: Request | GrpcRequest;
-  disableDragAndDrop?: boolean;
+  requestGroup?: RequestGroup;
 }
 
 type Props = RawProps & DnDProps;
@@ -99,7 +99,7 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
 
   const [renderedUrl, setRenderedUrl] = useState('');
 
-  const requestActionsDropdown = useRef<RequestActionsDropdownHandle>(null);
+  const requestActionsDropdown = useRef<Dropdown>(null);
 
   const handleShowRequestActions = useCallback((event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -239,7 +239,7 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
                 className="inline-block"
                 onEditStart={startEditing}
                 onSubmit={handleRequestUpdateName}
-                renderReadView={(value: string, props: any) => (
+                renderReadView={(value, props) => (
                   <Highlight
                     search={filter}
                     text={value}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -15,7 +15,7 @@ import { createRequest } from '../../hooks/create-request';
 import { selectActiveEnvironment, selectActiveProject, selectActiveWorkspace } from '../../redux/selectors';
 import { Editable } from '../base/editable';
 import { Highlight } from '../base/highlight';
-import { RequestActionsDropdown } from '../dropdowns/request-actions-dropdown';
+import { RequestActionsDropdown, RequestActionsDropdownHandle } from '../dropdowns/request-actions-dropdown';
 import { GrpcSpinner } from '../grpc-spinner';
 import { showModal } from '../modals/index';
 import { RequestSettingsModal } from '../modals/request-settings-modal';
@@ -99,7 +99,7 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
 
   const [renderedUrl, setRenderedUrl] = useState('');
 
-  const requestActionsDropdown = useRef<RequestActionsDropdown | null>(null);
+  const requestActionsDropdown = useRef<RequestActionsDropdownHandle>(null);
 
   const handleShowRequestActions = useCallback((event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();

--- a/packages/insomnia/src/ui/components/viewers/response-csv-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-csv-viewer.tsx
@@ -1,65 +1,31 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import Papa from 'papaparse';
-import React, { PureComponent } from 'react';
-
-import { AUTOBIND_CFG } from '../../../common/constants';
+import React, { useCallback, useEffect, useState } from 'react';
 
 interface Props {
   body: Buffer;
 }
 
-interface State {
-  result: null | {
-    data: string[][];
-  };
-}
-
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class ResponseCSVViewer extends PureComponent<Props, State> {
-  state: State = {
-    result: null,
-  };
-
-  currentHash = '';
-
-  update(body: Buffer) {
-    const csv = body.toString('utf8');
-    Papa.parse<string[]>(csv, {
+export const ResponseCSVViewer: React.FC<Props> = ({ body }) => {
+  const [csv, setCSV] = useState<{ data: string[][] } | null>(null);
+  const parse = useCallback(() =>
+    Papa.parse<string[]>(body.toString('utf8'), {
       skipEmptyLines: true,
       complete: result => {
-        this.setState({ result });
+        setCSV(result);
       },
-    });
-  }
+    }), [body]);
+  useEffect(() => {
+    parse();
+  }, [parse]);
 
-  componentDidMount() {
-    this.update(this.props.body);
-  }
-
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillUpdate(nextProps: Props) {
-    if (this.props.body === nextProps.body) {
-      return;
-    }
-
-    this.update(nextProps.body);
-  }
-
-  render() {
-    const { result } = this.state;
-
-    if (!result) {
-      return 'Parsing CSV...';
-    }
-
-    return (
-      <div className="pad-sm">
+  return (
+    <div className="pad-sm">
+      {csv ?
         <table className="table--fancy table--striped table--compact selectable">
           <tbody>
-            {result.data.map(row => (
-              // TODO: figure out what to key this with
-              // eslint-disable-next-line react/jsx-key
-              <tr>
+            {csv.data.map((row, index) => (
+            // eslint-disable-next-line react/no-array-index-key -- data structure is unknown, cannot compute a valid key
+              <tr key={index}>
                 {row.map(c => (
                   <td key={c}>{c}</td>
                 ))}
@@ -67,7 +33,6 @@ export class ResponseCSVViewer extends PureComponent<Props, State> {
             ))}
           </tbody>
         </table>
-      </div>
-    );
-  }
-}
+        : 'Parsing CSV...'}
+    </div>);
+};

--- a/packages/insomnia/src/ui/components/viewers/response-csv-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-csv-viewer.tsx
@@ -1,11 +1,11 @@
 import Papa from 'papaparse';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 
 interface Props {
   body: Buffer;
 }
 
-export const ResponseCSVViewer: React.FC<Props> = ({ body }) => {
+export const ResponseCSVViewer: FC<Props> = ({ body }) => {
   const [csv, setCSV] = useState<{ data: string[][] } | null>(null);
   const parse = useCallback(() =>
     Papa.parse<string[]>(body.toString('utf8'), {

--- a/packages/insomnia/src/ui/components/viewers/response-csv-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-csv-viewer.tsx
@@ -1,5 +1,5 @@
 import Papa from 'papaparse';
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 
 interface Props {
   body: Buffer;
@@ -7,7 +7,8 @@ interface Props {
 
 export const ResponseCSVViewer: FC<Props> = ({ body }) => {
   const [csv, setCSV] = useState<{ data: string[][] } | null>(null);
-  const parse = useCallback(() => {
+
+  useEffect(() => {
     Papa.parse<string[]>(body.toString('utf8'), {
       skipEmptyLines: true,
       complete: result => {
@@ -15,10 +16,6 @@ export const ResponseCSVViewer: FC<Props> = ({ body }) => {
       },
     });
   }, [body]);
-
-  useEffect(() => {
-    parse();
-  }, [parse]);
 
   return (
     <div className="pad-sm">

--- a/packages/insomnia/src/ui/components/viewers/response-csv-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-csv-viewer.tsx
@@ -7,13 +7,15 @@ interface Props {
 
 export const ResponseCSVViewer: FC<Props> = ({ body }) => {
   const [csv, setCSV] = useState<{ data: string[][] } | null>(null);
-  const parse = useCallback(() =>
+  const parse = useCallback(() => {
     Papa.parse<string[]>(body.toString('utf8'), {
       skipEmptyLines: true,
       complete: result => {
         setCSV(result);
       },
-    }), [body]);
+    });
+  }, [body]);
+
   useEffect(() => {
     parse();
   }, [parse]);

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -120,7 +120,7 @@ export const WrapperDebug: React.FC<Props> = ({
   return (
     <PageLayout
       wrapperProps={wrapperProps}
-      renderPageHeader={() => activeWorkspace ?
+      renderPageHeader={activeWorkspace ?
         <WorkspacePageHeader
           handleActivityChange={handleActivityChange}
           gridRight={isTeamSync ? <SyncDropdown
@@ -132,7 +132,7 @@ export const WrapperDebug: React.FC<Props> = ({
           /> : isDesign(activeWorkspace) ? gitSyncDropdown : null}
         />
         : null}
-      renderPageSidebar={() => activeWorkspace ? <Fragment>
+      renderPageSidebar={activeWorkspace ? <Fragment>
         <div className="sidebar__menu">
           <EnvironmentsDropdown
             handleChangeEnvironment={handleChangeEnvironment}
@@ -171,7 +171,7 @@ export const WrapperDebug: React.FC<Props> = ({
         />
       </Fragment>
         : null}
-      renderPaneOne={() => activeWorkspace ?
+      renderPaneOne={activeWorkspace ?
         <ErrorBoundary showAlert>
           {activeRequest && isGrpcRequest(activeRequest) ?
             <GrpcRequestPane
@@ -209,7 +209,7 @@ export const WrapperDebug: React.FC<Props> = ({
             />}
         </ErrorBoundary>
         : null}
-      renderPaneTwo={() => <ErrorBoundary showAlert>
+      renderPaneTwo={<ErrorBoundary showAlert>
         {activeRequest && isGrpcRequest(activeRequest) ?
           <GrpcResponsePane
             activeRequest={activeRequest}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactNode } from 'react';
+import React, { FC, Fragment, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
 import { SortOrder } from '../../common/constants';
@@ -50,7 +50,7 @@ interface Props {
   handleUpdateSettingsUseBulkParametersEditor: (useBulkParametersEditor: boolean) => Promise<Settings>;
   wrapperProps: WrapperProps;
 }
-export const WrapperDebug: React.FC<Props> = ({
+export const WrapperDebug: FC<Props> = ({
   forceRefreshKey,
   gitSyncDropdown,
   handleActivityChange,

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -1,14 +1,12 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import React, { Fragment, PureComponent, ReactNode } from 'react';
-import { connect } from 'react-redux';
+import React, { Fragment, ReactNode } from 'react';
+import { useSelector } from 'react-redux';
 
-import { AUTOBIND_CFG, SortOrder } from '../../common/constants';
+import { SortOrder } from '../../common/constants';
 import { isGrpcRequest } from '../../models/grpc-request';
 import { isRemoteProject } from '../../models/project';
 import { Request, RequestAuthentication, RequestBody, RequestHeader, RequestParameter } from '../../models/request';
 import { Settings } from '../../models/settings';
 import { isCollection, isDesign } from '../../models/workspace';
-import { RootState } from '../redux/modules';
 import { selectActiveEnvironment, selectActiveRequest, selectActiveRequestResponses, selectActiveResponse, selectActiveUnitTestResult, selectActiveWorkspace, selectEnvironments, selectLoadStartTime, selectRequestVersions, selectResponseDownloadPath, selectResponseFilter, selectResponseFilterHistory, selectResponsePreviewMode, selectSettings } from '../redux/selectors';
 import { selectSidebarChildren, selectSidebarFilter } from '../redux/sidebar-selectors';
 import { EnvironmentsDropdown } from './dropdowns/environments-dropdown';
@@ -25,7 +23,7 @@ import { SidebarFilter } from './sidebar/sidebar-filter';
 import { WorkspacePageHeader } from './workspace-page-header';
 import type { HandleActivityChange, WrapperProps } from './wrapper';
 
-interface Props extends ReturnType<typeof mapStateToProps> {
+interface Props {
   forceRefreshKey: number;
   gitSyncDropdown: ReactNode;
   handleActivityChange: HandleActivityChange;
@@ -52,75 +50,89 @@ interface Props extends ReturnType<typeof mapStateToProps> {
   handleUpdateSettingsUseBulkParametersEditor: (useBulkParametersEditor: boolean) => Promise<Settings>;
   wrapperProps: WrapperProps;
 }
+export const WrapperDebug: React.FC<Props> = ({
+  forceRefreshKey,
+  gitSyncDropdown,
+  handleActivityChange,
+  handleChangeEnvironment,
+  handleDeleteResponse,
+  handleDeleteResponses,
+  handleForceUpdateRequest,
+  handleForceUpdateRequestHeaders,
+  handleImport,
+  handleSendAndDownloadRequestWithActiveEnvironment,
+  handleSendRequestWithActiveEnvironment,
+  handleSetActiveResponse,
+  handleSetPreviewMode,
+  handleSetResponseFilter,
+  handleShowRequestSettingsModal,
+  handleSidebarSort,
+  handleUpdateRequestAuthentication,
+  handleUpdateRequestBody,
+  handleUpdateRequestHeaders,
+  handleUpdateRequestMethod,
+  handleUpdateRequestParameters,
+  handleUpdateRequestUrl,
+  handleUpdateSettingsUseBulkHeaderEditor,
+  handleUpdateSettingsUseBulkParametersEditor,
+  wrapperProps,
 
-@autoBindMethodsForReact(AUTOBIND_CFG)
-class UnconnectedWrapperDebug extends PureComponent<Props> {
-  _renderPageHeader() {
-    const { gitSyncDropdown, handleActivityChange, wrapperProps: {
-      vcs,
-      activeWorkspace,
-      activeWorkspaceMeta,
-      activeProject,
-      syncItems,
-      isLoggedIn,
-    } } = this.props;
+}) => {
+  const {
+    activeProject,
+    activeWorkspaceMeta,
+    handleActivateRequest,
+    handleCopyAsCurl,
+    handleDuplicateRequest,
+    handleDuplicateRequestGroup,
+    handleGenerateCode,
+    handleGenerateCodeForActiveRequest,
+    handleSetRequestGroupCollapsed,
+    handleSetRequestPinned,
+    handleSetSidebarFilter,
+    handleUpdateDownloadPath,
+    handleUpdateRequestMimeType,
+    headerEditorKey,
+    isLoggedIn,
+    syncItems,
+    vcs,
+  } = wrapperProps;
 
-    if (!activeWorkspace) {
-      return null;
-    }
+  const activeEnvironment = useSelector(selectActiveEnvironment);
+  const activeRequest = useSelector(selectActiveRequest);
+  const activeRequestResponses = useSelector(selectActiveRequestResponses);
+  const activeResponse = useSelector(selectActiveResponse);
+  const activeUnitTestResult = useSelector(selectActiveUnitTestResult);
+  const activeWorkspace = useSelector(selectActiveWorkspace);
+  const environments = useSelector(selectEnvironments);
+  const loadStartTime = useSelector(selectLoadStartTime);
+  const requestVersions = useSelector(selectRequestVersions);
+  const responseDownloadPath = useSelector(selectResponseDownloadPath);
+  const responseFilter = useSelector(selectResponseFilter);
+  const responseFilterHistory = useSelector(selectResponseFilterHistory);
+  const responsePreviewMode = useSelector(selectResponsePreviewMode);
+  const settings = useSelector(selectSettings);
+  const sidebarChildren = useSelector(selectSidebarChildren);
+  const sidebarFilter = useSelector(selectSidebarFilter);
 
-    const collection = isCollection(activeWorkspace);
+  const isTeamSync = isLoggedIn && activeWorkspace && isCollection(activeWorkspace) && isRemoteProject(activeProject) && vcs;
 
-    let insomniaSync: ReactNode = null;
-    if (isLoggedIn && collection && isRemoteProject(activeProject) && vcs) {
-      insomniaSync = <SyncDropdown
-        workspace={activeWorkspace}
-        workspaceMeta={activeWorkspaceMeta}
-        project={activeProject}
-        vcs={vcs}
-        syncItems={syncItems}
-      />;
-    }
-
-    const gitSync = isDesign(activeWorkspace) && gitSyncDropdown;
-    const sync = insomniaSync || gitSync;
-
-    return (
-      <WorkspacePageHeader
-        handleActivityChange={handleActivityChange}
-        gridRight={sync}
-      />
-    );
-  }
-
-  _renderPageSidebar() {
-    const {
-      activeEnvironment,
-      activeWorkspace,
-      environments,
-      handleChangeEnvironment,
-      handleSidebarSort,
-      settings,
-      sidebarChildren,
-      sidebarFilter,
-    } = this.props;
-    const {
-      handleActivateRequest,
-      handleCopyAsCurl,
-      handleDuplicateRequest,
-      handleDuplicateRequestGroup,
-      handleGenerateCode,
-      handleSetRequestGroupCollapsed,
-      handleSetRequestPinned,
-      handleSetSidebarFilter,
-    } = this.props.wrapperProps;
-
-    if (!activeWorkspace) {
-      return null;
-    }
-
-    return (
-      <Fragment>
+  return (
+    <PageLayout
+      wrapperProps={wrapperProps}
+      renderPageHeader={() => activeWorkspace ?
+        <WorkspacePageHeader
+          handleActivityChange={handleActivityChange}
+          gridRight={isTeamSync ? <SyncDropdown
+            workspace={activeWorkspace}
+            workspaceMeta={activeWorkspaceMeta}
+            project={activeProject}
+            vcs={vcs}
+            syncItems={syncItems}
+          /> : isDesign(activeWorkspace) ? gitSyncDropdown : null}
+        />
+        : null}
+      renderPageSidebar={() => activeWorkspace ? <Fragment>
         <div className="sidebar__menu">
           <EnvironmentsDropdown
             handleChangeEnvironment={handleChangeEnvironment}
@@ -158,182 +170,77 @@ class UnconnectedWrapperDebug extends PureComponent<Props> {
           hotKeyRegistry={settings.hotKeyRegistry}
         />
       </Fragment>
-    );
-  }
-
-  _renderRequestPane() {
-    const {
-      activeEnvironment,
-      activeRequest,
-      activeWorkspace,
-      forceRefreshKey,
-      handleForceUpdateRequest,
-      handleForceUpdateRequestHeaders,
-      handleImport,
-      handleSendAndDownloadRequestWithActiveEnvironment,
-      handleSendRequestWithActiveEnvironment,
-      handleUpdateRequestAuthentication,
-      handleUpdateRequestBody,
-      handleUpdateRequestHeaders,
-      handleUpdateRequestMethod,
-      handleUpdateRequestParameters,
-      handleUpdateRequestUrl,
-      handleUpdateSettingsUseBulkHeaderEditor,
-      handleUpdateSettingsUseBulkParametersEditor,
-      responseDownloadPath,
-      settings,
-    } = this.props;
-    const {
-      handleGenerateCodeForActiveRequest,
-      handleUpdateDownloadPath,
-      handleUpdateRequestMimeType,
-      headerEditorKey,
-    } = this.props.wrapperProps;
-
-    if (!activeWorkspace) {
-      return null;
-    }
-
-    // activeRequest being truthy only needs to be checked for isGrpcRequest (for now)
-    // The RequestPane and ResponsePane components already handle the case where activeRequest is null
-    if (activeRequest && isGrpcRequest(activeRequest)) {
-      return (
+        : null}
+      renderPaneOne={() => activeWorkspace ?
         <ErrorBoundary showAlert>
-          <GrpcRequestPane
-            activeRequest={activeRequest}
-            environmentId={activeEnvironment ? activeEnvironment._id : ''}
-            workspaceId={activeWorkspace._id}
-            forceRefreshKey={forceRefreshKey}
-            settings={settings}
-          />
+          {activeRequest && isGrpcRequest(activeRequest) ?
+            <GrpcRequestPane
+              activeRequest={activeRequest}
+              environmentId={activeEnvironment ? activeEnvironment._id : ''}
+              workspaceId={activeWorkspace._id}
+              forceRefreshKey={forceRefreshKey}
+              settings={settings}
+            />
+            :
+            <RequestPane
+              downloadPath={responseDownloadPath}
+              environmentId={activeEnvironment ? activeEnvironment._id : ''}
+              forceRefreshCounter={forceRefreshKey}
+              forceUpdateRequest={handleForceUpdateRequest}
+              forceUpdateRequestHeaders={handleForceUpdateRequestHeaders}
+              handleGenerateCode={handleGenerateCodeForActiveRequest}
+              handleImport={handleImport}
+              handleSend={handleSendRequestWithActiveEnvironment}
+              handleSendAndDownload={handleSendAndDownloadRequestWithActiveEnvironment}
+              handleUpdateDownloadPath={handleUpdateDownloadPath}
+              headerEditorKey={headerEditorKey}
+              request={activeRequest}
+              settings={settings}
+              updateRequestAuthentication={handleUpdateRequestAuthentication}
+              updateRequestBody={handleUpdateRequestBody}
+              updateRequestHeaders={handleUpdateRequestHeaders}
+              updateRequestMethod={handleUpdateRequestMethod}
+              updateRequestMimeType={handleUpdateRequestMimeType}
+              updateRequestParameters={handleUpdateRequestParameters}
+              updateRequestUrl={handleUpdateRequestUrl}
+              updateSettingsUseBulkHeaderEditor={handleUpdateSettingsUseBulkHeaderEditor}
+              updateSettingsUseBulkParametersEditor={handleUpdateSettingsUseBulkParametersEditor}
+              workspace={activeWorkspace}
+            />}
         </ErrorBoundary>
-      );
-    }
-
-    return (
-      <ErrorBoundary showAlert>
-        <RequestPane
-          downloadPath={responseDownloadPath}
-          environmentId={activeEnvironment ? activeEnvironment._id : ''}
-          forceRefreshCounter={forceRefreshKey}
-          forceUpdateRequest={handleForceUpdateRequest}
-          forceUpdateRequestHeaders={handleForceUpdateRequestHeaders}
-          handleGenerateCode={handleGenerateCodeForActiveRequest}
-          handleImport={handleImport}
-          handleSend={handleSendRequestWithActiveEnvironment}
-          handleSendAndDownload={handleSendAndDownloadRequestWithActiveEnvironment}
-          handleUpdateDownloadPath={handleUpdateDownloadPath}
-          headerEditorKey={headerEditorKey}
-          request={activeRequest}
-          settings={settings}
-          updateRequestAuthentication={handleUpdateRequestAuthentication}
-          updateRequestBody={handleUpdateRequestBody}
-          updateRequestHeaders={handleUpdateRequestHeaders}
-          updateRequestMethod={handleUpdateRequestMethod}
-          updateRequestMimeType={handleUpdateRequestMimeType}
-          updateRequestParameters={handleUpdateRequestParameters}
-          updateRequestUrl={handleUpdateRequestUrl}
-          updateSettingsUseBulkHeaderEditor={handleUpdateSettingsUseBulkHeaderEditor}
-          updateSettingsUseBulkParametersEditor={handleUpdateSettingsUseBulkParametersEditor}
-          workspace={activeWorkspace}
-        />
-      </ErrorBoundary>
-    );
-  }
-
-  _renderResponsePane() {
-    const {
-      forceRefreshKey,
-      handleDeleteResponse,
-      handleDeleteResponses,
-      handleSetActiveResponse,
-      handleSetPreviewMode,
-      handleSetResponseFilter,
-      handleShowRequestSettingsModal,
-      activeEnvironment,
-      activeRequest,
-      activeRequestResponses,
-      activeResponse,
-      activeUnitTestResult,
-      loadStartTime,
-      requestVersions,
-      responseFilter,
-      responseFilterHistory,
-      responsePreviewMode,
-      settings,
-    } = this.props;
-
-    // activeRequest being truthy only needs to be checked for isGrpcRequest (for now)
-    // The RequestPane and ResponsePane components already handle the case where activeRequest is null
-    if (activeRequest && isGrpcRequest(activeRequest)) {
-      return (
-        <ErrorBoundary showAlert>
+        : null}
+      renderPaneTwo={() => <ErrorBoundary showAlert>
+        {activeRequest && isGrpcRequest(activeRequest) ?
           <GrpcResponsePane
             activeRequest={activeRequest}
             forceRefreshKey={forceRefreshKey}
           />
-        </ErrorBoundary>
-      );
-    }
+          :
+          <ResponsePane
+            disableHtmlPreviewJs={settings.disableHtmlPreviewJs}
+            disableResponsePreviewLinks={settings.disableResponsePreviewLinks}
+            editorFontSize={settings.editorFontSize}
+            environment={activeEnvironment}
+            filter={responseFilter}
+            filterHistory={responseFilterHistory}
+            handleDeleteResponse={handleDeleteResponse}
+            handleDeleteResponses={handleDeleteResponses}
+            handleSetActiveResponse={handleSetActiveResponse}
+            handleSetFilter={handleSetResponseFilter}
+            handleSetPreviewMode={handleSetPreviewMode}
+            handleShowRequestSettings={handleShowRequestSettingsModal}
+            hotKeyRegistry={settings.hotKeyRegistry}
+            loadStartTime={loadStartTime}
+            previewMode={responsePreviewMode}
+            request={activeRequest}
+            requestVersions={requestVersions}
+            response={activeResponse}
+            responses={activeRequestResponses}
+            unitTestResult={activeUnitTestResult}
+          />}
+      </ErrorBoundary>}
+    />
+  );
+};
 
-    return (
-      <ErrorBoundary showAlert>
-        <ResponsePane
-          disableHtmlPreviewJs={settings.disableHtmlPreviewJs}
-          disableResponsePreviewLinks={settings.disableResponsePreviewLinks}
-          editorFontSize={settings.editorFontSize}
-          environment={activeEnvironment}
-          filter={responseFilter}
-          filterHistory={responseFilterHistory}
-          handleDeleteResponse={handleDeleteResponse}
-          handleDeleteResponses={handleDeleteResponses}
-          handleSetActiveResponse={handleSetActiveResponse}
-          handleSetFilter={handleSetResponseFilter}
-          handleSetPreviewMode={handleSetPreviewMode}
-          handleShowRequestSettings={handleShowRequestSettingsModal}
-          hotKeyRegistry={settings.hotKeyRegistry}
-          loadStartTime={loadStartTime}
-          previewMode={responsePreviewMode}
-          request={activeRequest}
-          requestVersions={requestVersions}
-          response={activeResponse}
-          responses={activeRequestResponses}
-          unitTestResult={activeUnitTestResult}
-        />
-      </ErrorBoundary>
-    );
-  }
-
-  render() {
-    return (
-      <PageLayout
-        wrapperProps={this.props.wrapperProps}
-        renderPageHeader={this._renderPageHeader}
-        renderPageSidebar={this._renderPageSidebar}
-        renderPaneOne={this._renderRequestPane}
-        renderPaneTwo={this._renderResponsePane}
-      />
-    );
-  }
-}
-
-const mapStateToProps = (state: RootState) => ({
-  activeEnvironment: selectActiveEnvironment(state),
-  activeRequest: selectActiveRequest(state),
-  activeRequestResponses: selectActiveRequestResponses(state),
-  activeResponse: selectActiveResponse(state),
-  activeUnitTestResult: selectActiveUnitTestResult(state),
-  activeWorkspace: selectActiveWorkspace(state),
-  environments: selectEnvironments(state),
-  loadStartTime: selectLoadStartTime(state),
-  requestVersions: selectRequestVersions(state),
-  responseDownloadPath: selectResponseDownloadPath(state),
-  responseFilter: selectResponseFilter(state),
-  responseFilterHistory: selectResponseFilterHistory(state),
-  responsePreviewMode: selectResponsePreviewMode(state),
-  settings: selectSettings(state),
-  sidebarChildren: selectSidebarChildren(state),
-  sidebarFilter: selectSidebarFilter(state),
-});
-
-export default connect(mapStateToProps)(UnconnectedWrapperDebug);
+export default WrapperDebug;

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -209,36 +209,37 @@ export const WrapperDebug: React.FC<Props> = ({
             />}
         </ErrorBoundary>
         : null}
-      renderPaneTwo={<ErrorBoundary showAlert>
-        {activeRequest && isGrpcRequest(activeRequest) ?
-          <GrpcResponsePane
-            activeRequest={activeRequest}
-            forceRefreshKey={forceRefreshKey}
-          />
-          :
-          <ResponsePane
-            disableHtmlPreviewJs={settings.disableHtmlPreviewJs}
-            disableResponsePreviewLinks={settings.disableResponsePreviewLinks}
-            editorFontSize={settings.editorFontSize}
-            environment={activeEnvironment}
-            filter={responseFilter}
-            filterHistory={responseFilterHistory}
-            handleDeleteResponse={handleDeleteResponse}
-            handleDeleteResponses={handleDeleteResponses}
-            handleSetActiveResponse={handleSetActiveResponse}
-            handleSetFilter={handleSetResponseFilter}
-            handleSetPreviewMode={handleSetPreviewMode}
-            handleShowRequestSettings={handleShowRequestSettingsModal}
-            hotKeyRegistry={settings.hotKeyRegistry}
-            loadStartTime={loadStartTime}
-            previewMode={responsePreviewMode}
-            request={activeRequest}
-            requestVersions={requestVersions}
-            response={activeResponse}
-            responses={activeRequestResponses}
-            unitTestResult={activeUnitTestResult}
-          />}
-      </ErrorBoundary>}
+      renderPaneTwo={
+        <ErrorBoundary showAlert>
+          {activeRequest && isGrpcRequest(activeRequest) ?
+            <GrpcResponsePane
+              activeRequest={activeRequest}
+              forceRefreshKey={forceRefreshKey}
+            />
+            :
+            <ResponsePane
+              disableHtmlPreviewJs={settings.disableHtmlPreviewJs}
+              disableResponsePreviewLinks={settings.disableResponsePreviewLinks}
+              editorFontSize={settings.editorFontSize}
+              environment={activeEnvironment}
+              filter={responseFilter}
+              filterHistory={responseFilterHistory}
+              handleDeleteResponse={handleDeleteResponse}
+              handleDeleteResponses={handleDeleteResponses}
+              handleSetActiveResponse={handleSetActiveResponse}
+              handleSetFilter={handleSetResponseFilter}
+              handleSetPreviewMode={handleSetPreviewMode}
+              handleShowRequestSettings={handleShowRequestSettingsModal}
+              hotKeyRegistry={settings.hotKeyRegistry}
+              loadStartTime={loadStartTime}
+              previewMode={responsePreviewMode}
+              request={activeRequest}
+              requestVersions={requestVersions}
+              response={activeResponse}
+              responses={activeRequestResponses}
+              unitTestResult={activeUnitTestResult}
+            />}
+        </ErrorBoundary>}
     />
   );
 };

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -135,12 +135,12 @@ export const WrapperDebug: React.FC<Props> = ({
       renderPageSidebar={activeWorkspace ? <Fragment>
         <div className="sidebar__menu">
           <EnvironmentsDropdown
-            handleChangeEnvironment={handleChangeEnvironment}
             activeEnvironment={activeEnvironment}
-            environments={environments}
-            workspace={activeWorkspace}
             environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
+            environments={environments}
+            handleChangeEnvironment={handleChangeEnvironment}
             hotKeyRegistry={settings.hotKeyRegistry}
+            workspace={activeWorkspace}
           />
           <button className="btn btn--super-compact" onClick={showCookiesModal}>
             <div className="sidebar__menu__thing">

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -34,8 +34,8 @@ const EmptySpaceHelper = styled.div({
 const spectral = initializeSpectral();
 
 const RenderPageHeader: FC<Pick<Props,
-| 'gitSyncDropdown'
-| 'handleActivityChange'
+  | 'gitSyncDropdown'
+  | 'handleActivityChange'
 >> = ({
   gitSyncDropdown,
   handleActivityChange,
@@ -65,7 +65,7 @@ const RenderPageHeader: FC<Pick<Props,
         <Fragment>
           <Button variant="contained" onClick={handleTogglePreview}>
             <img src={previewIcon} alt="Preview" width="15" />
-            &nbsp; {previewHidden ? 'Preview: Off' : 'Preview: On'}
+              &nbsp; {previewHidden ? 'Preview: Off' : 'Preview: On'}
           </Button>
           {gitSyncDropdown}
         </Fragment>
@@ -215,7 +215,7 @@ const RenderPreview: FC = () => {
 
   try {
     swaggerUiSpec = parseApiSpec(activeApiSpec.contents).contents;
-  } catch (err) {}
+  } catch (err) { }
 
   if (!swaggerUiSpec) {
     swaggerUiSpec = {};
@@ -253,7 +253,7 @@ const RenderPreview: FC = () => {
   );
 };
 
-const RenderPageSidebar: FC<{ editor: RefObject<UnconnectedCodeEditor>}> = ({ editor }) => {
+const RenderPageSidebar: FC<{ editor: RefObject<UnconnectedCodeEditor> }> = ({ editor }) => {
   const activeApiSpec = useSelector(selectActiveApiSpec);
   const handleScrollToSelection = useCallback((chStart: number, chEnd: number, lineStart: number, lineEnd: number) => {
     if (!editor.current) {
@@ -308,32 +308,17 @@ export const WrapperDesign: FC<Props> = ({
 }) => {
   const editor = createRef<UnconnectedCodeEditor>();
 
-  const renderPageHeader = useCallback(() => (
-    <RenderPageHeader
-      gitSyncDropdown={gitSyncDropdown}
-      handleActivityChange={handleActivityChange}
-    />
-  ), [gitSyncDropdown, handleActivityChange]);
-
-  const renderEditor = useCallback(() => (
-    <RenderEditor editor={editor} />
-  ), [editor]);
-
-  const renderPreview = useCallback(() => (
-    <RenderPreview />
-  ), []);
-
-  const renderPageSidebar = useCallback(() => (
-    <RenderPageSidebar editor={editor} />
-  ), [editor]);
-
   return (
     <PageLayout
       wrapperProps={wrapperProps}
-      renderPageHeader={renderPageHeader}
-      renderPaneOne={renderEditor}
-      renderPaneTwo={renderPreview}
-      renderPageSidebar={renderPageSidebar}
+      renderPageHeader={
+        <RenderPageHeader
+          gitSyncDropdown={gitSyncDropdown}
+          handleActivityChange={handleActivityChange}
+        />}
+      renderPaneOne={<RenderEditor editor={editor} />}
+      renderPaneTwo={<RenderPreview />}
+      renderPageSidebar={<RenderPageSidebar editor={editor} />}
     />
   );
 };

--- a/packages/insomnia/src/ui/components/wrapper-home.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-home.tsx
@@ -8,7 +8,7 @@ import {
   DropdownItem,
   SvgIcon,
 } from 'insomnia-components';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { FC, useCallback, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { unreachableCase } from 'ts-assert-unreachable';
@@ -148,7 +148,7 @@ const mapWorkspaceToWorkspaceCard = ({
   };
 };
 
-const WrapperHome: React.FC<Props> = (({ wrapperProps }) => {
+const WrapperHome: FC<Props> = (({ wrapperProps }) => {
   const sortOrder = useSelector(selectDashboardSortOrder);
   const activeProject = useSelector(selectActiveProject);
   const isLoggedIn = useSelector(selectIsLoggedIn);

--- a/packages/insomnia/src/ui/components/wrapper-home.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-home.tsx
@@ -102,9 +102,7 @@ const mapWorkspaceToWorkspaceCard = ({
   }
 
   // Get cached branch from WorkspaceMeta
-  const workspaceMeta = workspaceMetas?.find(
-    wm => wm.parentId === workspace._id
-  );
+  const workspaceMeta = workspaceMetas?.find(({ parentId }) => parentId === workspace._id);
 
   const lastActiveBranch = workspaceMeta?.cachedGitRepositoryBranch;
 
@@ -159,13 +157,33 @@ const WrapperHome: FC<Props> = (({ wrapperProps }) => {
 
   const dispatch = useDispatch();
 
-  const handleCreateWorkspace = useCallback(({ scope, onCreate }) => dispatch(createWorkspace({ scope, onCreate })), [dispatch]);
-  const handleGitCloneWorkspace = useCallback(({ createFsClient }) => dispatch(cloneGitRepository({ createFsClient })), [dispatch]);
-  const handleImportFile = useCallback(({ forceToWorkspace }) => dispatch(importFile({ forceToWorkspace })), [dispatch]);
-  const handleImportUri = useCallback((uri, { forceToWorkspace }) => dispatch(importUri(uri, { forceToWorkspace })), [dispatch]);
-  const handleImportClipboard = useCallback(({ forceToWorkspace }) => dispatch(importClipBoard({ forceToWorkspace })), [dispatch]);
-  const handleSetDashboardSortOrder = useCallback(sortOrder => dispatch(setDashboardSortOrder(sortOrder)), [dispatch]);
-  const handleActivateWorkspace = useCallback(({ workspace }) => dispatch(activateWorkspace({ workspace })), [dispatch]);
+  const handleCreateWorkspace = useCallback(({ scope, onCreate }) => {
+    dispatch(createWorkspace({ scope, onCreate }));
+  }, [dispatch]);
+
+  const handleGitCloneWorkspace = useCallback(({ createFsClient }) => {
+    dispatch(cloneGitRepository({ createFsClient }));
+  }, [dispatch]);
+
+  const handleImportFile = useCallback(({ forceToWorkspace }) => {
+    dispatch(importFile({ forceToWorkspace }));
+  }, [dispatch]);
+
+  const handleImportUri = useCallback((uri, { forceToWorkspace }) => {
+    dispatch(importUri(uri, { forceToWorkspace }));
+  }, [dispatch]);
+
+  const handleImportClipboard = useCallback(({ forceToWorkspace }) => {
+    dispatch(importClipBoard({ forceToWorkspace }));
+  }, [dispatch]);
+
+  const handleSetDashboardSortOrder = useCallback(sortOrder => {
+    dispatch(setDashboardSortOrder(sortOrder));
+  }, [dispatch]);
+
+  const handleActivateWorkspace = useCallback(({ workspace }) => {
+    dispatch(activateWorkspace({ workspace }));
+  }, [dispatch]);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const [filter, setFilter] = useState('');
@@ -185,30 +203,55 @@ const WrapperHome: FC<Props> = (({ wrapperProps }) => {
         filter={filter}
       />
     ));
-  const createRequestCollection = useCallback(() => handleCreateWorkspace({
-    scope: WorkspaceScopeKeys.collection,
-    onCreate: async (workspace: Workspace) => {
+
+  const createRequestCollection = useCallback(() => {
+    handleCreateWorkspace({
+      scope: WorkspaceScopeKeys.collection,
+      onCreate: async (workspace: Workspace) => {
       // Don't mark for sync if not logged in at the time of creation
-      if (isLoggedIn && vcs && isRemoteProject(activeProject)) {
-        await initializeLocalBackendProjectAndMarkForSync({ vcs: vcs.newInstance(), workspace });
-      }
-    },
-  }), [activeProject, handleCreateWorkspace, isLoggedIn, vcs]);
-  const createDesignDocument = useCallback(() => handleCreateWorkspace({ scope: WorkspaceScopeKeys.design }), [handleCreateWorkspace]);
-  const importFromURL = useCallback(() => showPrompt({
-    title: 'Import document from URL',
-    submitName: 'Fetch and Import',
-    label: 'URL',
-    placeholder: 'https://website.com/insomnia-import.json',
-    onComplete: uri => {
-      handleImportUri(uri, { forceToWorkspace: ForceToWorkspace.existing });
-    },
-  }), [handleImportUri]);
-  const importFromClipboard = useCallback(() => handleImportClipboard({ forceToWorkspace: ForceToWorkspace.existing }), [handleImportClipboard]);
-  const importFromFile = useCallback(() => handleImportFile({ forceToWorkspace: ForceToWorkspace.existing }), [handleImportFile]);
-  const importFromGit = useCallback(() => handleGitCloneWorkspace({ createFsClient: MemClient.createClient }), [handleGitCloneWorkspace]);
-  const onChangeFilter = useCallback(event => setFilter(event.currentTarget.value), []);
-  const onKeydown = useCallback(event => executeHotKey(event, hotKeyRefs.FILTER_DOCUMENTS, () => inputRef.current?.focus()), []);
+        if (isLoggedIn && vcs && isRemoteProject(activeProject)) {
+          await initializeLocalBackendProjectAndMarkForSync({ vcs: vcs.newInstance(), workspace });
+        }
+      },
+    });
+  }, [activeProject, handleCreateWorkspace, isLoggedIn, vcs]);
+
+  const createDesignDocument = useCallback(() => {
+    handleCreateWorkspace({ scope: WorkspaceScopeKeys.design });
+  }, [handleCreateWorkspace]);
+
+  const importFromURL = useCallback(() => {
+    showPrompt({
+      title: 'Import document from URL',
+      submitName: 'Fetch and Import',
+      label: 'URL',
+      placeholder: 'https://website.com/insomnia-import.json',
+      onComplete: uri => {
+        handleImportUri(uri, { forceToWorkspace: ForceToWorkspace.existing });
+      },
+    });
+  }, [handleImportUri]);
+
+  const importFromClipboard = useCallback(() => {
+    handleImportClipboard({ forceToWorkspace: ForceToWorkspace.existing });
+  }, [handleImportClipboard]);
+
+  const importFromFile = useCallback(() => {
+    handleImportFile({ forceToWorkspace: ForceToWorkspace.existing });
+  }, [handleImportFile]);
+
+  const importFromGit = useCallback(() => {
+    handleGitCloneWorkspace({ createFsClient: MemClient.createClient });
+  }, [handleGitCloneWorkspace]);
+
+  const onChangeFilter = useCallback(event => {
+    setFilter(event.currentTarget.value);
+  }, []);
+
+  const onKeydown = useCallback(event => {
+    executeHotKey(event, hotKeyRefs.FILTER_DOCUMENTS, () => inputRef.current?.focus());
+  }, []);
+
   return (
     <PageLayout
       wrapperProps={wrapperProps}

--- a/packages/insomnia/src/ui/components/wrapper-home.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-home.tsx
@@ -167,7 +167,7 @@ const WrapperHome: FC<Props> = (({ wrapperProps }) => {
   const handleSetDashboardSortOrder = useCallback(sortOrder => dispatch(setDashboardSortOrder(sortOrder)), [dispatch]);
   const handleActivateWorkspace = useCallback(({ workspace }) => dispatch(activateWorkspace({ workspace })), [dispatch]);
 
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const [filter, setFilter] = useState('');
 
   const { vcs } = wrapperProps;

--- a/packages/insomnia/src/ui/components/wrapper-home.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-home.tsx
@@ -188,7 +188,7 @@ const WrapperHome: React.FC<Props> = (({ wrapperProps }) => {
   const createRequestCollection = useCallback(() => handleCreateWorkspace({
     scope: WorkspaceScopeKeys.collection,
     onCreate: async (workspace: Workspace) => {
-    // Don't mark for sync if not logged in at the time of creation
+      // Don't mark for sync if not logged in at the time of creation
       if (isLoggedIn && vcs && isRemoteProject(activeProject)) {
         await initializeLocalBackendProjectAndMarkForSync({ vcs: vcs.newInstance(), workspace });
       }
@@ -212,7 +212,7 @@ const WrapperHome: React.FC<Props> = (({ wrapperProps }) => {
   return (
     <PageLayout
       wrapperProps={wrapperProps}
-      renderPageHeader={() => (
+      renderPageHeader={
         <AppHeader
           breadcrumbProps={{
             crumbs: [
@@ -224,8 +224,8 @@ const WrapperHome: React.FC<Props> = (({ wrapperProps }) => {
             isLoading,
           }}
         />
-      )}
-      renderPageBody={() => (
+      }
+      renderPageBody={
         <div className="document-listing theme--pane layout-body">
           <div className="document-listing__body pad-bottom">
             <div className="row-spaced margin-top margin-bottom-sm">
@@ -309,7 +309,7 @@ const WrapperHome: React.FC<Props> = (({ wrapperProps }) => {
             </a>
           </div>
         </div>
-      )}
+      }
     />
   );
 });

--- a/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
@@ -241,19 +241,21 @@ const WrapperUnitTest: FC<Props> = ({
   }, []);
 
   const handleDeleteUnitTestSuite = useCallback((unitTestSuite: UnitTestSuite) => {
-    showAlert({
-      title: `Delete ${unitTestSuite.name}`,
-      message: (
-        <span>
-          Really delete <strong>{unitTestSuite.name}</strong>?
-        </span>
-      ),
-      addCancel: true,
-      onConfirm: async () => {
-        await models.unitTestSuite.remove(unitTestSuite);
-        trackSegmentEvent(SegmentEvent.testSuiteDelete);
-      },
-    });
+    return () => {
+      showAlert({
+        title: `Delete ${unitTestSuite.name}`,
+        message: (
+          <span>
+            Really delete <strong>{unitTestSuite.name}</strong>?
+          </span>
+        ),
+        addCancel: true,
+        onConfirm: async () => {
+          await models.unitTestSuite.remove(unitTestSuite);
+          trackSegmentEvent(SegmentEvent.testSuiteDelete);
+        },
+      });
+    };
   }, []);
 
   const handleChangeTestName = useCallback((unitTest: UnitTest, name?: string) => {
@@ -348,7 +350,7 @@ const WrapperUnitTest: FC<Props> = ({
                     >
                       {testsRunning ? 'Running... ' : 'Run Tests'}
                     </DropdownItem>
-                    <DropdownItem onClick={handleDeleteUnitTestSuite.bind(this, suite)}>
+                    <DropdownItem onClick={handleDeleteUnitTestSuite(suite)}>
                       Delete Suite
                     </DropdownItem>
                   </Dropdown>

--- a/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
@@ -42,14 +42,14 @@ const HeaderButton = styled(Button)({
 });
 
 interface Props {
-  children: SidebarChildObjects;
+  sidebarChildren: SidebarChildObjects;
   gitSyncDropdown: ReactNode;
   handleActivityChange: HandleActivityChange;
   wrapperProps: WrapperProps;
 }
 
 const WrapperUnitTest: React.FC<Props> = ({
-  children,
+  sidebarChildren,
   wrapperProps,
   gitSyncDropdown,
   handleActivityChange,
@@ -101,9 +101,9 @@ const WrapperUnitTest: React.FC<Props> = ({
       }
     };
 
-    next('', children.all);
+    next('', sidebarChildren.all);
     return selectableRequests;
-  }, [children.all]);
+  }, [sidebarChildren.all]);
 
   const selectableRequests = buildSelectableRequests();
 

--- a/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
@@ -427,7 +427,7 @@ const WrapperUnitTest: React.FC<Props> = ({
               selectableRequests={selectableRequests}
               testNameEditable={
                 <UnitTestEditable
-                  onSubmit={() => _handleChangeTestName(unitTest)}
+                  onSubmit={name => _handleChangeTestName(unitTest, name)}
                   value={unitTest.name}
                 />
               }

--- a/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
@@ -10,7 +10,7 @@ import {
 } from 'insomnia-components';
 import { generate, runTests, Test } from 'insomnia-testing';
 import { isEmpty } from 'ramda';
-import React, { ReactNode, useCallback, useState } from 'react';
+import React, { FC, ReactNode, useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
@@ -48,7 +48,7 @@ interface Props {
   wrapperProps: WrapperProps;
 }
 
-const WrapperUnitTest: React.FC<Props> = ({
+const WrapperUnitTest: FC<Props> = ({
   sidebarChildren,
   wrapperProps,
   gitSyncDropdown,
@@ -440,7 +440,7 @@ interface TestRunStatusProps{
   testsRunning:UnitTest[] | null;
   resultsError:string | null;
 }
-const TestRunStatus: React.FC<TestRunStatusProps> = ({ testsRunning, resultsError }) => {
+const TestRunStatus: FC<TestRunStatusProps> = ({ testsRunning, resultsError }) => {
   const activeUnitTestResult = useSelector(selectActiveUnitTestResult);
 
   if (resultsError) {

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -628,9 +628,8 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
                   gitSyncDropdown={gitSyncDropdown}
                   wrapperProps={this.props}
                   handleActivityChange={this._handleWorkspaceActivityChange}
-                >
-                  {sidebarChildren}
-                </WrapperUnitTest>
+                  sidebarChildren={sidebarChildren}
+                />
               </Suspense>
             }
           />

--- a/packages/insomnia/tsconfig.json
+++ b/packages/insomnia/tsconfig.json
@@ -10,6 +10,7 @@
     "esbuild.sr.ts",
     "jest.config.js",
     "package.json",
+    "preload.js",
     "scripts",
     "send-request",
     "src",
@@ -17,11 +18,12 @@
   ],
   "exclude": [
     "**/@types/mocha",
-    "**/main.min.js",
     "bin",
     "build",
     "config",
     "node_modules",
     "src/coverage",
+    "src/main.min.js",
+    "src/preload.js",
   ],
 }


### PR DESCRIPTION
motivation; remove another 10% of autobind classes, learn and highlight examples for discussion of migration techniques for the following:
- ref forwarding to child component
- ref interaction
- set timeout

scope: 12 functional components tested and with limited impact, pagelayout takes render props rather than render functions, which allows us to nest FCs inside it without classes.

takeaways:
- createRef in the class and forwardRef alone in the FC is good when we don't need the forwarder to care about or override the ref functions.
- set Timeout can be replaced with useInterval
- `onClick(e=>fn(e))` and `onClick((e,v)=>fn(v))` and value={v} are used inconsistently on buttons and dropdown and we could find a more consistent approach.
- useCallback and function memoization still feels like premature optimisation.
- modals and code editor ref passing is still hard
- these changes should improve HMR dx
- our Button component extends HTMLButtonElement to add a function we don't use.
- our Button and Dropdown components are duplicated in insomnia-components and the ui/.../base folder, holding up any effective migration or improvements.
- we redefine FC prop types a lot, would be great to have more inference.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->