### PR TITLE
undoes prop drilling for creating request groups

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -11,6 +11,7 @@ import type { RequestGroupAction } from '../../../plugins';
 import { getRequestGroupActions } from '../../../plugins';
 import * as pluginContexts from '../../../plugins/context/index';
 import { createRequest, CreateRequestType } from '../../hooks/create-request';
+import { createRequestGroup } from '../../hooks/create-request-group';
 import { selectActiveEnvironment, selectActiveProject, selectActiveWorkspace } from '../../redux/selectors';
 import { Dropdown, DropdownProps } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
@@ -26,7 +27,6 @@ interface Props extends Partial<DropdownProps> {
   hotKeyRegistry: HotKeyRegistry;
   handleDuplicateRequestGroup: (requestGroup: RequestGroup) => any;
   handleShowSettings: (requestGroup: RequestGroup) => any;
-  handleCreateRequestGroup: (requestGroup: string) => any;
 }
 
 interface RequestGroupActionsDropdownHandle {
@@ -38,7 +38,6 @@ export const RequestGroupActionsDropdown = forwardRef<RequestGroupActionsDropdow
   hotKeyRegistry,
   handleShowSettings,
   handleDuplicateRequestGroup,
-  handleCreateRequestGroup,
   ...other
 }, ref) => {
   const [actionPlugins, setActionPlugins] = useState<RequestGroupAction[]>([]);
@@ -72,9 +71,9 @@ export const RequestGroupActionsDropdown = forwardRef<RequestGroupActionsDropdow
     handleDuplicateRequestGroup(requestGroup);
   }, [requestGroup, handleDuplicateRequestGroup]);
 
-  const handleRequestGroupCreate = useCallback(() => {
-    handleCreateRequestGroup(requestGroup._id);
-  }, [handleCreateRequestGroup, requestGroup._id]);
+  const createGroup = useCallback(() => {
+    createRequestGroup(requestGroup._id);
+  }, [requestGroup._id]);
 
   const handleDeleteFolder = useCallback(() => {
     models.stats.incrementDeletedRequestsForDescendents(requestGroup).then(() => {
@@ -140,7 +139,7 @@ export const RequestGroupActionsDropdown = forwardRef<RequestGroupActionsDropdow
         <i className="fa fa-plus-circle" />New gRPC Request
       </DropdownItem>
 
-      <DropdownItem onClick={handleRequestGroupCreate}>
+      <DropdownItem onClick={createGroup}>
         <i className="fa fa-folder" /> New Folder
         <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_CREATE_FOLDER.id]} />
       </DropdownItem>

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
@@ -35,7 +35,6 @@ const mapStateToProps = (state: RootState) => ({
 
 interface Props extends ReduxProps {
   handleActivateRequest: Function;
-  handleCreateRequestGroup: (parentId: string) => void;
   handleSetRequestPinned: Function;
   handleSetRequestGroupCollapsed: Function;
   handleDuplicateRequest: Function;
@@ -52,7 +51,6 @@ class UnconnectedSidebarChildren extends PureComponent<Props> {
   _renderChildren(children: Child[], isInPinnedList: boolean) {
     const {
       filter,
-      handleCreateRequestGroup,
       handleSetRequestPinned,
       handleSetRequestGroupCollapsed,
       handleDuplicateRequest,
@@ -117,7 +115,6 @@ class UnconnectedSidebarChildren extends PureComponent<Props> {
           handleSetRequestGroupCollapsed={handleSetRequestGroupCollapsed}
           handleDuplicateRequestGroup={handleDuplicateRequestGroup}
           isCollapsed={child.collapsed}
-          handleCreateRequestGroup={handleCreateRequestGroup}
           requestGroup={requestGroup}
           hotKeyRegistry={hotKeyRegistry}
         >
@@ -137,20 +134,12 @@ class UnconnectedSidebarChildren extends PureComponent<Props> {
     );
   }
 
-  _handleCreateRequestGroup() {
-    const { handleCreateRequestGroup, workspace } = this.props;
-    if (workspace) {
-      handleCreateRequestGroup(workspace._id);
-    }
-  }
-
   render() {
     const { childObjects, hotKeyRegistry } = this.props;
     const showSeparator = childObjects.pinned.length > 0;
     const contextMenuPortal = ReactDOM.createPortal(
       <div className="hide">
         <SidebarCreateDropdown
-          handleCreateRequestGroup={this._handleCreateRequestGroup}
           hotKeyRegistry={hotKeyRegistry}
         />
       </div>,

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-create-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-create-dropdown.tsx
@@ -3,8 +3,8 @@ import React, { FC, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import { hotKeyRefs } from '../../../common/hotkeys';
-import { RequestGroup } from '../../../models/request-group';
 import { createRequest, CreateRequestType } from '../../hooks/create-request';
+import { createRequestGroup } from '../../hooks/create-request-group';
 import { selectActiveWorkspace } from '../../redux/selectors';
 import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
@@ -12,13 +12,11 @@ import { DropdownHint } from '../base/dropdown/dropdown-hint';
 import { DropdownItem } from '../base/dropdown/dropdown-item';
 
 interface Props {
-  handleCreateRequestGroup: (requestGroup: RequestGroup) => any;
   hotKeyRegistry: HotKeyRegistry;
   right?: boolean;
 }
 
 export const SidebarCreateDropdown: FC<Props> = ({
-  handleCreateRequestGroup,
   hotKeyRegistry,
   right,
 }) => {
@@ -32,6 +30,14 @@ export const SidebarCreateDropdown: FC<Props> = ({
         workspaceId: activeWorkspaceId,
       });
     }
+  }, [activeWorkspaceId]);
+
+  const createGroup = useCallback(() => {
+    if (!activeWorkspaceId) {
+      return;
+    }
+
+    createRequestGroup(activeWorkspaceId);
   }, [activeWorkspaceId]);
 
   return (
@@ -54,7 +60,7 @@ export const SidebarCreateDropdown: FC<Props> = ({
         <i className="fa fa-plus-circle" />gRPC Request
       </DropdownItem>
 
-      <DropdownItem onClick={handleCreateRequestGroup}>
+      <DropdownItem onClick={createGroup}>
         <i className="fa fa-folder" />New Folder
         <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SHOW_CREATE_FOLDER.id]} />
       </DropdownItem>

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-filter.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-filter.tsx
@@ -11,7 +11,6 @@ import { SidebarSortDropdown } from './sidebar-sort-dropdown';
 
 interface Props {
   onChange: (value: string) => Promise<void>;
-  requestGroupCreate: () => void;
   sidebarSort: (sortOrder: SortOrder) => void;
   filter: string;
   hotKeyRegistry: HotKeyRegistry;
@@ -46,10 +45,6 @@ export class SidebarFilter extends PureComponent<Props> {
     }, DEBOUNCE_MILLIS);
   }
 
-  _handleRequestGroupCreate() {
-    this.props.requestGroupCreate();
-  }
-
   _handleKeydown(event: KeyboardEvent) {
     executeHotKey(event, hotKeyRefs.SIDEBAR_FOCUS_FILTER, () => {
       this._input?.focus();
@@ -77,7 +72,6 @@ export class SidebarFilter extends PureComponent<Props> {
           </div>
           <SidebarSortDropdown handleSort={sidebarSort} />
           <SidebarCreateDropdown
-            handleCreateRequestGroup={this._handleRequestGroupCreate}
             hotKeyRegistry={hotKeyRegistry}
           />
         </div>

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
@@ -30,7 +30,6 @@ interface Props extends DnDProps, ReduxProps, PropsWithChildren<{}> {
   handleSetRequestGroupCollapsed: Function;
   handleDuplicateRequestGroup: (requestGroup: RequestGroup) => any;
   handleActivateRequest: Function;
-  handleCreateRequestGroup: (requestGroup: string) => any;
   filter: string;
   isActive: boolean;
   isCollapsed: boolean;
@@ -89,7 +88,6 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
       requestGroup,
       isCollapsed,
       isActive,
-      handleCreateRequestGroup,
       handleDuplicateRequestGroup,
       isDragging,
       isDraggingOver,
@@ -143,7 +141,6 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
           <div className="sidebar__actions">
             <RequestGroupActionsDropdown
               ref={this.dropdownRef}
-              handleCreateRequestGroup={handleCreateRequestGroup}
               handleDuplicateRequestGroup={handleDuplicateRequestGroup}
               handleShowSettings={this._handleShowRequestGroupSettings}
               requestGroup={requestGroup}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -35,7 +35,6 @@ interface Props extends ReturnType<typeof mapStateToProps> {
   handleForceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
   handleForceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleImport: Function;
-  handleRequestGroupCreate: () => void;
   handleSendAndDownloadRequestWithActiveEnvironment: (filepath?: string) => Promise<void>;
   handleSendRequestWithActiveEnvironment: () => void;
   handleSetActiveResponse: Function;
@@ -100,7 +99,6 @@ class UnconnectedWrapperDebug extends PureComponent<Props> {
       activeWorkspace,
       environments,
       handleChangeEnvironment,
-      handleRequestGroupCreate,
       handleSidebarSort,
       settings,
       sidebarChildren,
@@ -109,7 +107,6 @@ class UnconnectedWrapperDebug extends PureComponent<Props> {
     const {
       handleActivateRequest,
       handleCopyAsCurl,
-      handleCreateRequestGroup,
       handleDuplicateRequest,
       handleDuplicateRequestGroup,
       handleGenerateCode,
@@ -143,7 +140,6 @@ class UnconnectedWrapperDebug extends PureComponent<Props> {
         <SidebarFilter
           key={`${activeWorkspace._id}::filter`}
           onChange={handleSetSidebarFilter}
-          requestGroupCreate={handleRequestGroupCreate}
           sidebarSort={handleSidebarSort}
           filter={sidebarFilter || ''}
           hotKeyRegistry={settings.hotKeyRegistry}
@@ -152,7 +148,6 @@ class UnconnectedWrapperDebug extends PureComponent<Props> {
         <SidebarChildren
           childObjects={sidebarChildren}
           handleActivateRequest={handleActivateRequest}
-          handleCreateRequestGroup={handleCreateRequestGroup}
           handleSetRequestGroupCollapsed={handleSetRequestGroupCollapsed}
           handleSetRequestPinned={handleSetRequestPinned}
           handleDuplicateRequest={handleDuplicateRequest}

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -133,7 +133,6 @@ export type WrapperProps = AppProps & {
   handleSetActiveEnvironment: (environmentId: string | null) => Promise<void>;
   handleDuplicateRequest: Function;
   handleDuplicateRequestGroup: (requestGroup: RequestGroup) => void;
-  handleCreateRequestGroup: (parentId: string) => void;
   handleGenerateCodeForActiveRequest: Function;
   handleGenerateCode: Function;
   handleCopyAsCurl: Function;
@@ -433,16 +432,6 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
     this.props.handleSetResponseFilter(activeRequestId, filter);
   }
 
-  _handleCreateRequestGroupInWorkspace() {
-    const { activeWorkspace, handleCreateRequestGroup } = this.props;
-
-    if (!activeWorkspace) {
-      return;
-    }
-
-    handleCreateRequestGroup(activeWorkspace._id);
-  }
-
   _handleChangeEnvironment(id: string | null) {
     const { handleSetActiveEnvironment } = this.props;
     handleSetActiveEnvironment(id);
@@ -671,7 +660,6 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
                   handleForceUpdateRequest={this._handleForceUpdateRequest}
                   handleForceUpdateRequestHeaders={this._handleForceUpdateRequestHeaders}
                   handleImport={this._handleImport}
-                  handleRequestGroupCreate={this._handleCreateRequestGroupInWorkspace}
                   handleSendAndDownloadRequestWithActiveEnvironment={this._handleSendAndDownloadRequestWithActiveEnvironment}
                   handleSendRequestWithActiveEnvironment={this._handleSendRequestWithActiveEnvironment}
                   handleSetActiveResponse={this._handleSetActiveResponse}

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -82,6 +82,7 @@ import { Wrapper } from '../components/wrapper';
 import withDragDropContext from '../context/app/drag-drop-context';
 import { GrpcProvider } from '../context/grpc';
 import { NunjucksEnabledProvider } from '../context/nunjucks/nunjucks-enabled-context';
+import { createRequestGroup } from '../hooks/create-request-group';
 import { RootState } from '../redux/modules';
 import { initialize } from '../redux/modules/entities';
 import {
@@ -321,7 +322,7 @@ class App extends PureComponent<AppProps, State> {
           }
 
           const parentId = activeRequest ? activeRequest.parentId : activeWorkspace._id;
-          this._requestGroupCreate(parentId);
+          createRequestGroup(parentId);
         },
       ],
       [
@@ -370,26 +371,6 @@ class App extends PureComponent<AppProps, State> {
       activeRequest ? activeRequest._id : 'n/a',
       activeEnvironment ? activeEnvironment._id : 'n/a',
     );
-  }
-
-  _requestGroupCreate(parentId: string) {
-    showPrompt({
-      title: 'New Folder',
-      defaultValue: 'My Folder',
-      submitName: 'Create',
-      label: 'Name',
-      selectText: true,
-      onComplete: async name => {
-        const requestGroup = await models.requestGroup.create({
-          parentId,
-          name,
-        });
-        await models.requestGroupMeta.create({
-          parentId: requestGroup._id,
-          collapsed: false,
-        });
-      },
-    });
   }
 
   async _recalculateMetaSortKey(docs: (RequestGroup | Request | GrpcRequest)[]) {
@@ -1463,7 +1444,6 @@ class App extends PureComponent<AppProps, State> {
                   handleResetDragPaneVertical={this._resetDragPaneVertical}
                   handleDuplicateRequest={this._requestDuplicate}
                   handleDuplicateRequestGroup={App._requestGroupDuplicate}
-                  handleCreateRequestGroup={this._requestGroupCreate}
                   handleGenerateCode={App._handleGenerateCode}
                   handleGenerateCodeForActiveRequest={this._handleGenerateCodeForActiveRequest}
                   handleCopyAsCurl={this._handleCopyAsCurl}

--- a/packages/insomnia/src/ui/hooks/create-request-group.ts
+++ b/packages/insomnia/src/ui/hooks/create-request-group.ts
@@ -1,0 +1,22 @@
+import * as models from '../../models';
+import { showPrompt } from '../components/modals';
+
+export const createRequestGroup = (parentId: string) => {
+  showPrompt({
+    title: 'New Folder',
+    defaultValue: 'My Folder',
+    submitName: 'Create',
+    label: 'Name',
+    selectText: true,
+    onComplete: async name => {
+      const requestGroup = await models.requestGroup.create({
+        parentId,
+        name,
+      });
+      await models.requestGroupMeta.create({
+        parentId: requestGroup._id,
+        collapsed: false,
+      });
+    },
+  });
+};


### PR DESCRIPTION
This PR is a continuation of the groundwork in https://github.com/Kong/insomnia/pull/4862, except it stays focused on creating request groups (rather than creating requests themselves).

### Before
![image](https://user-images.githubusercontent.com/15232461/176028601-425c3ea0-5b9a-4591-9ea1-055f8f2c9e50.png)

### After
![image](https://user-images.githubusercontent.com/15232461/176028673-4d63ad6e-7ca9-4b44-b631-6d2edd90df2a.png)

To test this PR: there are exactly 3 situations where this code is executed:
1. create a new request via the hotkey in a workspace with no requests (shift+meta+n on mac, ctrl+shift+n on win/linux) and observe that a new folder is created in the workspace
    ![image](https://user-images.githubusercontent.com/15232461/176027993-725ee13b-826e-4f3a-8cc5-341f21e27eb2.png)
1. click the plus button and select "New Folder"
    ![image](https://user-images.githubusercontent.com/15232461/176028254-7bce6c02-e784-4d21-8cd2-550e208d1b67.png)
1. create a new folder from the dropdown of an existing folder
    ![image](https://user-images.githubusercontent.com/15232461/176028332-c87d0956-98b8-4aee-b5e6-0f44355383c9.png)
