### PR TITLE
refactor: add icon for git providers (INS-1524)

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -267,6 +267,21 @@ class GitSyncDropdown extends PureComponent<Props, State> {
     await this._refreshState();
   }
 
+  _getProviderIconClassName(): string | undefined {
+    const { gitRepository } = this.props;
+    const providerName = getOauth2FormatName(gitRepository?.credentials);
+
+    if (providerName === 'github') {
+      return 'fa fa-github';
+    }
+
+    if (providerName === 'gitlab') {
+      return 'fa fa-gitlab';
+    }
+
+    return;
+  }
+
   componentDidMount() {
     this._refreshState();
   }
@@ -293,8 +308,10 @@ class GitSyncDropdown extends PureComponent<Props, State> {
     }
 
     const initializing = false;
+    const iconClassName = this._getProviderIconClassName();
     return renderBtn(
       <Fragment>
+        {iconClassName && <i className={classnames('space-right', iconClassName)} />}
         <div className="ellipsis">{initializing ? 'Initializing...' : branch}</div>
         <i className="fa fa-code-fork space-left" />
       </Fragment>,


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

- adding icons for GitHub and gitlab synced status in the branch button 
<img width="343" alt="image" src="https://user-images.githubusercontent.com/103070941/176324191-3f72b1c5-189a-4a2e-a628-e54cbf8308df.png">
<img width="199" alt="image" src="https://user-images.githubusercontent.com/103070941/176324390-afe7cefd-7e84-4b76-a552-bf8b85ae27b9.png">


