### PR TITLE
refactor: disable URI input for github & gitlab

### DIFF
--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
@@ -1,7 +1,7 @@
 import { AxiosResponse } from 'axios';
 import type { GraphQLError } from 'graphql';
 import { Button } from 'insomnia-components';
-import React, { useEffect, useState } from 'react';
+import React, { MouseEvent, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useInterval, useLocalStorage } from 'react-use';
 import styled from 'styled-components';
@@ -196,6 +196,21 @@ const GitHubRepositoryForm = ({
     undefined
   );
 
+  const handleSignOut = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    showAlert({
+      title: 'Sign out of GitHub',
+      message:
+        'Are you sure you want to sign out? You will need to re-authenticate with GitHub to use this feature.',
+      okLabel: 'Sign out',
+      onConfirm: () => {
+        removeUser();
+        onSignOut();
+      },
+    });
+  };
+
   useEffect(() => {
     let isMounted = true;
 
@@ -289,22 +304,7 @@ const GitHubRepositoryForm = ({
             </span>
           </Details>
         </AccountDetails>
-        <Button
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            showAlert({
-              title: 'Sign out of GitHub',
-              message:
-                'Are you sure you want to sign out? You will need to re-authenticate with GitHub to use this feature.',
-              okLabel: 'Sign out',
-              onConfirm: () => {
-                removeUser();
-                onSignOut();
-              },
-            });
-          }}
-        >
+        <Button onClick={handleSignOut}>
           Sign out
         </Button>
       </AccountViewContainer>

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
@@ -259,6 +259,7 @@ const GitHubRepositoryForm = ({
             <input
               className="form-control"
               defaultValue={uri}
+              disabled={Boolean(uri)}
               type="url"
               name="uri"
               autoFocus
@@ -289,7 +290,7 @@ const GitHubRepositoryForm = ({
           </Details>
         </AccountDetails>
         <Button
-          onClick={event => {
+          onClick={(event) => {
             event.preventDefault();
             event.stopPropagation();
             showAlert({

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/gitlab-repository-settings-form-group.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/gitlab-repository-settings-form-group.tsx
@@ -214,6 +214,7 @@ const GitLabRepositoryForm = ({
               type="url"
               name="uri"
               autoFocus
+              disabled={Boolean(uri)}
               required
               placeholder="https://gitlab.com/org/repo.git"
             />


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

- Adding logic to disable the form fields if the git repository is already cloned unless reset. This is to prevent any miscellaneous conflicts, such as pulling a Github repository in the Gitlab authenticated & cloned form, which creates a conflict.