### PR TITLE
Add debug log for missing AWS auth in getAuthHeader, #4894

### DIFF
--- a/packages/insomnia/src/network/authentication.ts
+++ b/packages/insomnia/src/network/authentication.ts
@@ -3,6 +3,7 @@ import jwtAuthentication from 'jwt-authentication';
 
 import {
   AUTH_ASAP,
+  AUTH_AWS_IAM,
   AUTH_BASIC,
   AUTH_BEARER,
   AUTH_HAWK,
@@ -138,6 +139,10 @@ export async function getAuthHeader(renderedRequest: RenderedRequest, url: strin
     });
   }
 
+  if (authentication.type === AUTH_AWS_IAM) {
+    // TODO: Implement
+    console.error('AWS IAM authentication is not yet supported for getAuthHeader');
+  }
   return;
 }
 


### PR DESCRIPTION
While triaging issue #4894 with @kreosus we found that we are not getting AWS auth header likely due to the fact it's not implemented on `getAuthHeader` method, which is used on HAR request export, and also to generate code snippet.

Opening a draft now so we can tackle it asap.