### PR TITLE
Feature/ins 1573 duplicating request makes original

### DIFF
--- a/packages/insomnia/src/ui/components/base/modal.tsx
+++ b/packages/insomnia/src/ui/components/base/modal.tsx
@@ -45,6 +45,7 @@ export class Modal extends PureComponent<ModalProps, State> {
   };
 
   async _handleKeyDown(event: KeyboardEvent) {
+    event.stopPropagation();
     if (!this.state.open) {
       return;
     }
@@ -179,7 +180,7 @@ export class Modal extends PureComponent<ModalProps, State> {
     }
 
     return (
-      <KeydownBinder onKeydown={this._handleKeyDown}>
+      <KeydownBinder capture={false} scoped onKeydown={this._handleKeyDown}>
         <div
           ref={this._setModalRef}
           tabIndex={-1}

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -18,12 +18,10 @@ import vkBeautify from 'vkbeautify';
 import {
   AUTOBIND_CFG,
   DEBOUNCE_MILLIS,
-  EditorKeyMap,
   isMac,
 } from '../../../common/constants';
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
-import { keyboardKeys as keyCodes } from '../../../common/keyboard-keys';
 import * as misc from '../../../common/misc';
 import { getTagDefinitions } from '../../../templating/index';
 import { NunjucksParsedTag } from '../../../templating/utils';
@@ -80,6 +78,7 @@ const BASE_CODEMIRROR_OPTIONS: CodeMirror.EditorConfiguration = {
     },
     [isMac() ? 'Cmd-Enter' : 'Ctrl-Enter']: function() {
       // HACK: So nothing conflicts withe the "Send Request" shortcut
+      return CodeMirror.Pass;
     },
     [isMac() ? 'Cmd-/' : 'Ctrl-/']: 'toggleComment',
     // Autocomplete
@@ -1044,15 +1043,7 @@ export class UnconnectedCodeEditor extends Component<CodeEditorProps, State> {
   }
 
   _codemirrorKeyHandled(_codeMirror: CodeMirror.Editor, _keyName: string, event: Event) {
-    const { keyMap } = this.props;
-    // @ts-expect-error -- unsound property access
-    const { keyCode } = event;
-    const isVimKeyMap = keyMap === EditorKeyMap.vim;
-    const pressedEscape = keyCode === keyCodes.esc.keyCode;
-
-    if (isVimKeyMap && pressedEscape) {
-      event.stopPropagation();
-    }
+    event.stopPropagation();
   }
 
   _codemirrorValueBeforeChange(doc: CodeMirror.Editor, change: CodeMirror.EditorChangeCancellable) {

--- a/packages/insomnia/src/ui/components/keydown-binder.ts
+++ b/packages/insomnia/src/ui/components/keydown-binder.ts
@@ -11,6 +11,7 @@ interface Props {
   disabled?: boolean;
   scoped?: boolean;
   stopMetaPropagation?: boolean;
+  capture?: boolean;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -55,11 +56,12 @@ export class KeydownBinder extends PureComponent<Props> {
     if (this.props.scoped) {
       // TODO: unsound casting
       const el = ReactDOM.findDOMNode(this) as HTMLElement | null;
-      el?.addEventListener('keydown', this._handleKeydown, { capture: true });
-      el?.addEventListener('keyup', this._handleKeyup, { capture: true });
+      // @TODO - Inverse the capture flag
+      el?.addEventListener('keydown', this._handleKeydown, { capture: this.props.capture ?? true });
+      el?.addEventListener('keyup', this._handleKeyup, { capture: this.props.capture ?? true });
     } else {
-      document.body && document.body.addEventListener('keydown', this._handleKeydown, { capture: true });
-      document.body && document.body.addEventListener('keyup', this._handleKeyup, { capture: true });
+      document.body && document.body.addEventListener('keydown', this._handleKeydown, { capture: this.props.capture ?? true });
+      document.body && document.body.addEventListener('keyup', this._handleKeyup, { capture: this.props.capture ?? true });
     }
   }
 
@@ -67,11 +69,11 @@ export class KeydownBinder extends PureComponent<Props> {
     if (this.props.scoped) {
       // TODO: unsound casting
       const el = ReactDOM.findDOMNode(this) as HTMLElement | null;
-      el?.removeEventListener('keydown', this._handleKeydown, { capture: true });
-      el?.removeEventListener('keyup', this._handleKeyup, { capture: true });
+      el?.removeEventListener('keydown', this._handleKeydown, { capture: this.props.capture ?? true });
+      el?.removeEventListener('keyup', this._handleKeyup, { capture: this.props.capture ?? true });
     } else {
-      document.body && document.body.removeEventListener('keydown', this._handleKeydown, { capture: true });
-      document.body && document.body.removeEventListener('keyup', this._handleKeyup, { capture: true });
+      document.body && document.body.removeEventListener('keydown', this._handleKeydown, { capture: this.props.capture ?? true });
+      document.body && document.body.removeEventListener('keyup', this._handleKeyup, { capture: this.props.capture ?? true });
     }
   }
 

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -1417,7 +1417,7 @@ class App extends PureComponent<AppProps, State> {
     } = this.state;
     const uniquenessKey = `${forceRefreshCounter}::${activeWorkspace?._id || 'n/a'}`;
     return (
-      <KeydownBinder onKeydown={this._handleKeyDown}>
+      <KeydownBinder capture={false} onKeydown={this._handleKeyDown}>
         <GrpcProvider>
           <NunjucksEnabledProvider>
             <AppHooks />


### PR DESCRIPTION
- Uses `capture: false` on global keypress events to respect bubbling (don't handle keypresses that other components already handled)
- Modals stop propagation for keypress events since they run on their own focus context.

Concerns:
- Code editor handles the `Esc` key in the default keymap and there's no way to move focus outside with the keyboard.
- There seems to be a need for really `global` keypress handlers which requires going through all the events and defining their focus scope.