### PR TITLE
send button -> split button

### DIFF
--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -26,7 +26,7 @@ import { MarkdownPreview } from '../markdown-preview';
 import { showModal } from '../modals';
 import { RequestSettingsModal } from '../modals/request-settings-modal';
 import { RenderedQueryString } from '../rendered-query-string';
-import { RequestUrlBar } from '../request-url-bar';
+import { RequestUrlBar, RequestUrlBarHandle } from '../request-url-bar';
 import { Pane, paneBodyClasses, PaneHeader } from './pane';
 import { PlaceholderRequestPane } from './placeholder-request-pane';
 
@@ -129,7 +129,7 @@ export const RequestPane: FC<Props> = ({
     }
   }, [request, forceUpdateRequest]);
 
-  const requestUrlBarRef = useRef<RequestUrlBar>(null);
+  const requestUrlBarRef = useRef<RequestUrlBarHandle>(null);
   useMount(() => {
     requestUrlBarRef.current?.focusInput();
   });

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -156,6 +156,7 @@ export const RequestPane: FC<Props> = ({
       <PaneHeader>
         <ErrorBoundary errorClassName="font-error pad text-center">
           <RequestUrlBar
+            key={request._id}
             ref={requestUrlBarRef}
             uniquenessKey={uniqueKey}
             onMethodChange={updateRequestMethod}

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -1,9 +1,7 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { OpenDialogOptions } from 'electron';
 import { HotKeyRegistry } from 'insomnia-common';
-import React, { PureComponent, ReactNode } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
-import { AUTOBIND_CFG, DEBOUNCE_MILLIS, isMac } from '../../common/constants';
+import { isMac } from '../../common/constants';
 import { hotKeyRefs } from '../../common/hotkeys';
 import { executeHotKey } from '../../common/hotkeys-listener';
 import type { Request } from '../../models/request';
@@ -34,359 +32,253 @@ interface Props {
   downloadPath: string | null;
 }
 
-interface State {
-  currentInterval: number | null;
-  currentTimeout: number | null;
+export interface RequestUrlBarHandle {
+  focusInput: () => void;
 }
+export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
+  downloadPath,
+  handleAutocompleteUrls,
+  handleImport,
+  handleGenerateCode,
+  handleSend,
+  handleSendAndDownload,
+  handleUpdateDownloadPath,
+  hotKeyRegistry,
+  onMethodChange,
+  onUrlChange,
+  request,
+  uniquenessKey,
+}, ref) => {
 
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class RequestUrlBar extends PureComponent<Props, State> {
-  _urlChangeDebounceTimeout: NodeJS.Timeout | null = null;
-  _sendTimeout: NodeJS.Timeout | null = null;
-  _sendInterval: NodeJS.Timeout | null = null;
-  _dropdown: Dropdown | null = null;
-  _methodDropdown: Dropdown | null = null;
-  _input: OneLineEditor | null = null;
-  state: State = {
-    currentInterval: null,
-    currentTimeout: null,
+  const methodDropdownRef = useRef<Dropdown>(null);
+  const dropdownRef = useRef<Dropdown>(null);
+  const inputRef = useRef<OneLineEditor>(null);
+
+  const focusInput = useCallback(() => {
+    if (inputRef.current) {
+      inputRef.current.focus(true);
+    }
+  }, [inputRef]);
+
+  useImperativeHandle(ref, () => ({ focusInput }), [focusInput]);
+
+  const timeoutRef = useRef<number | undefined>(undefined);
+  const intervalRef = useRef<number | undefined>(undefined);
+  const handleStop = () => {
+    const { clearInterval, clearTimeout } = window;
+    clearTimeout(timeoutRef.current);
+    clearInterval(intervalRef.current);
+    setCurrentInterval(null);
+    setCurrentTimeout(null);
   };
-
-  _lastPastedText?: string;
-
-  _setDropdownRef(dropdown: Dropdown) {
-    this._dropdown = dropdown;
-  }
-
-  _setMethodDropdownRef(methodDropdown: Dropdown) {
-    this._methodDropdown = methodDropdown;
-  }
-
-  _setInputRef(input: OneLineEditor) {
-    this._input = input;
-  }
-
-  _handleMetaClickSend(event: React.MouseEvent<HTMLButtonElement>) {
-    event.preventDefault();
-    this._dropdown?.show();
-  }
-
-  _handleFormSubmit(event: React.SyntheticEvent<HTMLFormElement>) {
-    event.preventDefault();
-    event.stopPropagation();
-
-    this._handleSend();
-  }
-
-  _handleMethodChange(method: string) {
-    this.props.onMethodChange(this.props.request, method);
-  }
-
-  _handleUrlChange(url: string) {
-    if (this._urlChangeDebounceTimeout !== null) {
-      clearTimeout(this._urlChangeDebounceTimeout);
-    }
-    this._urlChangeDebounceTimeout = setTimeout(async () => {
-      const pastedText = this._lastPastedText;
-
-      // If no pasted text in the queue, just fire the regular change handler
-      if (!pastedText) {
-        this.props.onUrlChange(this.props.request, url);
-        return;
-      }
-
-      // Reset pasted text cache
-      this._lastPastedText = undefined;
-      // Attempt to import the pasted text
-      const importedRequest = await this.props.handleImport(pastedText);
-
-      // Update depending on whether something was imported
-      if (!importedRequest) {
-        this.props.onUrlChange(this.props.request, url);
-      }
-    }, DEBOUNCE_MILLIS);
-  }
-
-  _handleUrlPaste(event: ClipboardEvent) {
-    // NOTE: We're not actually doing the import here to avoid races with onChange
-    this._lastPastedText = event.clipboardData?.getData('text/plain');
-  }
-
-  _handleGenerateCode() {
-    this.props.handleGenerateCode();
-  }
-
-  async _handleSetDownloadLocation() {
-    const { request } = this.props;
-    const options: OpenDialogOptions = {
-      title: 'Select Download Location',
-      buttonLabel: 'Select',
-      properties: ['openDirectory'],
+  useEffect(() => {
+    return () => {
+      handleStop();
     };
-    const { canceled, filePaths } = await window.dialog.showOpenDialog(options);
+  }, [request._id]);
 
-    if (canceled) {
-      return;
-    }
-
-    this.props.handleUpdateDownloadPath(request._id, filePaths[0]);
-  }
-
-  _handleClearDownloadLocation() {
-    const { request } = this.props;
-    this.props.handleUpdateDownloadPath(request._id, null);
-  }
-
-  async _handleKeyDown(event: KeyboardEvent) {
-    if (!this._input) {
-      return;
-    }
-
-    if (event.code === 'Enter' && this.props.request.url) {
-      this._handleSend();
-      return;
-    }
-
-    executeHotKey(event, hotKeyRefs.REQUEST_FOCUS_URL, () => {
-      this._input?.focus();
-      this._input?.selectAll();
-    });
-    executeHotKey(event, hotKeyRefs.REQUEST_TOGGLE_HTTP_METHOD_MENU, () => {
-      this._methodDropdown?.toggle();
-    });
-    executeHotKey(event, hotKeyRefs.REQUEST_SHOW_OPTIONS, () => {
-      this._dropdown?.toggle(true);
-    });
-  }
-
-  _handleSend() {
-    // Don't stop interval because duh, it needs to keep going!
-    // XXX this._handleStopInterval(); XXX
-    this._handleStopTimeout();
-
-    const { downloadPath } = this.props;
-
+  const [currentTimeout, setCurrentTimeout] = useState<number | null>(null);
+  const [currentInterval, setCurrentInterval] = useState<number | null>(null);
+  const sendWrapper = useCallback(() => {
+    clearTimeout(timeoutRef.current);
+    clearInterval(intervalRef.current);
     if (downloadPath) {
-      this.props.handleSendAndDownload(downloadPath);
+      handleSendAndDownload(downloadPath);
     } else {
-      this.props.handleSend();
+      handleSend();
     }
-  }
-
-  _handleClickSendAndDownload() {
-    this.props.handleSendAndDownload();
-  }
-
-  _handleSendAfterDelay() {
+  }, [downloadPath, handleSend, handleSendAndDownload]);
+  const handleSendAfterDelay = () => {
     showPrompt({
       inputType: 'decimal',
       title: 'Send After Delay',
       label: 'Delay in seconds',
-      // @ts-expect-error TSCONVERSION string vs number issue
-      defaultValue: 3,
+      defaultValue: '3',
       submitName: 'Start',
       onComplete: seconds => {
-        this._handleStopTimeout();
-
-        // @ts-expect-error TSCONVERSION string vs number issue
-        this._sendTimeout = setTimeout(this._handleSend, seconds * 1000);
-        this.setState({
-          // @ts-expect-error TSCONVERSION string vs number issue
-          currentTimeout: seconds,
-        });
+        const { setTimeout, clearTimeout } = window;
+        clearTimeout(timeoutRef.current);
+        setCurrentTimeout(+seconds);
+        timeoutRef.current = setTimeout(() => {
+          sendWrapper();
+          setCurrentTimeout(null);
+        }, +seconds * 1000);
       },
     });
-  }
-
-  _handleSendOnInterval() {
+  };
+  const handleSendOnInterval = useCallback(() => {
     showPrompt({
       inputType: 'decimal',
       title: 'Send on Interval',
       label: 'Interval in seconds',
-      // @ts-expect-error TSCONVERSION string vs number issue
-      defaultValue: 3,
+      defaultValue: '3',
       submitName: 'Start',
       onComplete: seconds => {
-        this._handleStopInterval();
-
-        // @ts-expect-error TSCONVERSION string vs number issue
-        this._sendInterval = setInterval(this._handleSend, seconds * 1000);
-        this.setState({
-          // @ts-expect-error TSCONVERSION string vs number issue
-          currentInterval: seconds,
-        });
+        const { setInterval, clearInterval } = window;
+        setCurrentInterval(+seconds);
+        clearInterval(intervalRef.current);
+        intervalRef.current = setInterval(() => {
+          sendWrapper();
+          setCurrentInterval(null);
+        }, +seconds * 1000);
       },
     });
-  }
-
-  _handleStopInterval() {
-    if (this._sendInterval) {
-      clearInterval(this._sendInterval);
-    }
-
-    if (this.state.currentInterval) {
-      this.setState({
-        currentInterval: null,
-      });
-    }
-  }
-
-  _handleStopTimeout() {
-    if (this._sendTimeout !== null) {
-      clearTimeout(this._sendTimeout);
-    }
-
-    if (this.state.currentTimeout) {
-      this.setState({
-        currentTimeout: null,
-      });
-    }
-  }
-
-  _handleResetTimeouts() {
-    this._handleStopTimeout();
-
-    this._handleStopInterval();
-  }
-
-  _handleClickSend(event: React.MouseEvent<HTMLButtonElement>) {
+  }, [sendWrapper]);
+  const handleClickSend = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     const metaPressed = isMac() ? event.metaKey : event.ctrlKey;
-
-    // If we're pressing a meta key, let the dropdown open
     if (metaPressed) {
+      dropdownRef.current?.show();
       return;
     }
-
-    // If we're not pressing a meta key, cancel dropdown and send the request
-    event.stopPropagation(); // Don't trigger the dropdown
-
-    this._handleSend();
-  }
-
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    if (nextProps.request._id !== this.props.request._id) {
-      this._handleResetTimeouts();
+    sendWrapper();
+  }, [sendWrapper]);
+  const handleFormSubmit = useCallback((event: React.SyntheticEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    sendWrapper();
+  }, [sendWrapper]);
+  const handleSetDownloadLocation = useCallback(async () => {
+    const { canceled, filePaths } = await window.dialog.showOpenDialog({
+      title: 'Select Download Location',
+      buttonLabel: 'Select',
+      properties: ['openDirectory'],
+    });
+    if (canceled) {
+      return;
     }
-  }
+    handleUpdateDownloadPath(request._id, filePaths[0]);
+  }, [handleUpdateDownloadPath, request._id]);
+  const handleClearDownloadLocation = () => handleUpdateDownloadPath(request._id, null);
 
-  renderSendButton() {
-    const { hotKeyRegistry, downloadPath } = this.props;
-    const { currentInterval, currentTimeout } = this.state;
-    let cancelButton: ReactNode = null;
-
-    if (currentInterval) {
-      cancelButton = (
-        <button
-          type="button"
-          key="cancel-interval"
-          className="urlbar__send-btn danger"
-          onClick={this._handleStopInterval}
-        >
-          Stop
-        </button>
-      );
-    } else if (currentTimeout) {
-      cancelButton = (
-        <button
-          type="button"
-          key="cancel-timeout"
-          className="urlbar__send-btn danger"
-          onClick={this._handleStopTimeout}
-        >
-          Cancel
-        </button>
-      );
+  const handleKeyDown = useCallback(async (event: KeyboardEvent) => {
+    if (event.code === 'Enter' && request.url) {
+      sendWrapper();
+      return;
     }
-
-    let sendButton;
-
-    if (!cancelButton) {
-      sendButton = (
-        <Dropdown key="dropdown" className="tall" right ref={this._setDropdownRef}>
-          <DropdownButton
-            className="urlbar__send-btn"
-            onContextMenu={this._handleMetaClickSend}
-            onClick={this._handleClickSend}
-          >
-            {downloadPath ? 'Download' : 'Send'}
-          </DropdownButton>
-          <DropdownDivider>Basic</DropdownDivider>
-          <DropdownItem onClick={this._handleClickSend}>
-            <i className="fa fa-arrow-circle-o-right" /> Send Now
-            <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SEND.id]} />
-          </DropdownItem>
-          <DropdownItem onClick={this._handleGenerateCode}>
-            <i className="fa fa-code" /> Generate Client Code
-          </DropdownItem>
-          <DropdownDivider>Advanced</DropdownDivider>
-          <DropdownItem onClick={this._handleSendAfterDelay}>
-            <i className="fa fa-clock-o" /> Send After Delay
-          </DropdownItem>
-          <DropdownItem onClick={this._handleSendOnInterval}>
-            <i className="fa fa-repeat" /> Repeat on Interval
-          </DropdownItem>
-          {downloadPath ? (
-            <DropdownItem
-              stayOpenAfterClick
-              addIcon
-              buttonClass={PromptButton}
-              onClick={this._handleClearDownloadLocation}
-            >
-              <i className="fa fa-stop-circle" /> Stop Auto-Download
-            </DropdownItem>
-          ) : (
-            <DropdownItem onClick={this._handleSetDownloadLocation}>
-              <i className="fa fa-download" /> Download After Send
-            </DropdownItem>
-          )}
-          <DropdownItem onClick={this._handleClickSendAndDownload}>
-            <i className="fa fa-download" /> Send And Download
-          </DropdownItem>
-        </Dropdown>
-      );
+    if (!inputRef.current) {
+      return;
     }
+    executeHotKey(event, hotKeyRefs.REQUEST_FOCUS_URL, () => {
+      inputRef.current?.focus();
+      inputRef.current?.selectAll();
+    });
+    executeHotKey(event, hotKeyRefs.REQUEST_TOGGLE_HTTP_METHOD_MENU, () => {
+      methodDropdownRef.current?.toggle();
+    });
+    executeHotKey(event, hotKeyRefs.REQUEST_SHOW_OPTIONS, () => {
+      dropdownRef.current?.toggle(true);
+    });
+  }, [request.url, sendWrapper]);
 
-    return [cancelButton, sendButton];
-  }
+  const [lastPastedText, setLastPastedText] = useState<string>();
+  // TODO: put the debounce back in
+  const handleUrlChange = useCallback(async (url: string) => {
+    const pastedText = lastPastedText;
+    // If no pasted text in the queue, just fire the regular change handler
+    if (!pastedText) {
+      onUrlChange(request, url);
+      return;
+    }
+    // Reset pasted text cache
+    setLastPastedText(undefined);
+    // Attempt to import the pasted text
+    const importedRequest = await handleImport(pastedText);
+    // Update depending on whether something was imported
+    if (!importedRequest) {
+      onUrlChange(request, url);
+    }
+  }, [handleImport, lastPastedText, onUrlChange, request]);
+  const handleUrlPaste = useCallback((event: ClipboardEvent) => {
+    // NOTE: We're not actually doing the import here to avoid races with onChange
+    setLastPastedText(event.clipboardData?.getData('text/plain'));
+  }, []);
 
-  // note: not an unused function, used by parent, RequestPane
-  focusInput() {
-    this._input?.focus(true);
-  }
-
-  render() {
-    const {
-      request,
-      handleAutocompleteUrls,
-      uniquenessKey,
-    } = this.props;
-    const { url, method } = request;
-
-    return (
-      <KeydownBinder onKeydown={this._handleKeyDown} scoped>
-        <div className="urlbar">
-          <MethodDropdown
-            ref={this._setMethodDropdownRef}
-            onChange={this._handleMethodChange}
-            method={method}
+  const { url, method } = request;
+  return (
+    <KeydownBinder onKeydown={handleKeyDown} scoped>
+      <div className="urlbar">
+        <MethodDropdown
+          ref={methodDropdownRef}
+          onChange={() => onMethodChange(request, method)}
+          method={method}
+        />
+        <form onSubmit={handleFormSubmit}>
+          <OneLineEditor
+            key={uniquenessKey}
+            ref={inputRef}
+            onPaste={handleUrlPaste}
+            forceEditor
+            type="text"
+            getAutocompleteConstants={handleAutocompleteUrls}
+            placeholder="https://api.myproduct.com/v1/users"
+            defaultValue={url}
+            onChange={handleUrlChange}
           />
-          <form onSubmit={this._handleFormSubmit}>
-            <OneLineEditor
-              key={uniquenessKey}
-              ref={this._setInputRef}
-              onPaste={this._handleUrlPaste}
-              forceEditor
-              type="text"
-              getAutocompleteConstants={handleAutocompleteUrls}
-              placeholder="https://api.myproduct.com/v1/users"
-              defaultValue={url}
-              onChange={this._handleUrlChange}
-            />
-            {this.renderSendButton()}
-          </form>
-        </div>
-      </KeydownBinder>
-    );
-  }
-}
+          {currentInterval || currentTimeout ? (
+            <button
+              type="button"
+              className="urlbar__send-btn danger"
+              onClick={handleStop}
+            >
+              {currentInterval ? 'Stop' : 'Cancel'}
+            </button>
+          ) : (
+            <>
+              <button
+                disabled={!request.url}
+                type="button"
+                className="urlbar__send-btn"
+                onClick={handleClickSend}
+              >
+                {downloadPath ? 'Download' : 'Send'}
+              </button>
+              <Dropdown key="dropdown" className="tall" right ref={dropdownRef}>
+                <DropdownButton
+                  disabled={!request.url}
+                  className="urlbar__send-btn-context"
+                  onClick={() => dropdownRef.current?.show()}
+                >
+                  <i className="fa fa-caret-down" />
+                </DropdownButton>
+                <DropdownDivider>Basic</DropdownDivider>
+                <DropdownItem onClick={handleClickSend}>
+                  <i className="fa fa-arrow-circle-o-right" /> Send Now
+                  <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SEND.id]} />
+                </DropdownItem>
+                <DropdownItem onClick={handleGenerateCode}>
+                  <i className="fa fa-code" /> Generate Client Code
+                </DropdownItem>
+                <DropdownDivider>Advanced</DropdownDivider>
+                <DropdownItem onClick={handleSendAfterDelay}>
+                  <i className="fa fa-clock-o" /> Send After Delay
+                </DropdownItem>
+                <DropdownItem onClick={handleSendOnInterval}>
+                  <i className="fa fa-repeat" /> Repeat on Interval
+                </DropdownItem>
+                {downloadPath ? (
+                  <DropdownItem
+                    stayOpenAfterClick
+                    addIcon
+                    buttonClass={PromptButton}
+                    onClick={handleClearDownloadLocation}
+                  >
+                    <i className="fa fa-stop-circle" /> Stop Auto-Download
+                  </DropdownItem>
+                ) : (
+                  <DropdownItem onClick={handleSetDownloadLocation}>
+                    <i className="fa fa-download" /> Download After Send
+                  </DropdownItem>
+                )}
+                <DropdownItem onClick={handleSendAndDownload}>
+                  <i className="fa fa-download" /> Send And Download
+                </DropdownItem>
+              </Dropdown>
+            </>
+          )}
+        </form>
+      </div>
+    </KeydownBinder>
+  );
+});
+
+RequestUrlBar.displayName = 'RequestUrlBar';

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -1,5 +1,5 @@
 import { HotKeyRegistry } from 'insomnia-common';
-import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import { useInterval } from 'react-use';
 
 import { hotKeyRefs } from '../../common/hotkeys';
@@ -81,11 +81,6 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     setCurrentInterval(null);
     setCurrentTimeout(undefined);
   };
-  useEffect(() => {
-    return () => {
-      handleStop();
-    };
-  }, [request._id]);
 
   const handleSendOnInterval = useCallback(() => {
     showPrompt({

--- a/packages/insomnia/src/ui/css/components/request-url-bar.less
+++ b/packages/insomnia/src/ui/css/components/request-url-bar.less
@@ -41,24 +41,12 @@
     * {
       font-size: var(--font-size-md);
     }
-  }
 
+  }
   .urlbar__send-btn,
-  & > .dropdown {
-    height: 100%;
+  .surprise {
+    border-right: 1px solid var(--color-bg);
   }
-
-  button:focus,
-  button:hover {
-    filter: brightness(0.8);
-  }
-
-  & > .dropdown > button {
-    padding-left: var(--padding-md);
-    padding-right: calc(var(--padding-md) / 2);
-  }
-
-
   .urlbar__send-context {
     padding-right: var(--padding-sm);
     padding-left: var(--padding-sm);

--- a/packages/insomnia/src/ui/css/components/request-url-bar.less
+++ b/packages/insomnia/src/ui/css/components/request-url-bar.less
@@ -27,13 +27,12 @@
     padding-right: var(--padding-md);
     padding-left: var(--padding-md);
     margin-left: 0.75em;
-    min-width: 5em;
     text-align: center;
     background: var(--color-surprise);
     color: var(--color-font-surprise);
   }
 
-  form {
+  .urlbar__flex__right {
     width: 100%;
     display: flex;
     flex-direction: row;
@@ -59,14 +58,15 @@
     padding-right: calc(var(--padding-md) / 2);
   }
 
-  .urlbar__send-btn-context {
+
+  .urlbar__send-context {
     padding-right: var(--padding-sm);
     padding-left: var(--padding-sm);
     text-align: center;
     background: var(--color-surprise);
     color: var(--color-font-surprise);
   }
-  .urlbar__send-btn-context,
+  .urlbar__send-context,
   & > .dropdown {
     height: 100%;
   }

--- a/packages/insomnia/src/ui/css/components/request-url-bar.less
+++ b/packages/insomnia/src/ui/css/components/request-url-bar.less
@@ -58,4 +58,21 @@
     padding-left: var(--padding-md);
     padding-right: calc(var(--padding-md) / 2);
   }
+
+  .urlbar__send-btn-context {
+    padding-right: var(--padding-sm);
+    padding-left: var(--padding-sm);
+    text-align: center;
+    background: var(--color-surprise);
+    color: var(--color-font-surprise);
+  }
+  .urlbar__send-btn-context,
+  & > .dropdown {
+    height: 100%;
+  }
+
+  button:focus,
+  button:hover {
+    filter: brightness(0.8);
+  }
 }

--- a/packages/insomnia/src/ui/css/components/request-url-bar.less
+++ b/packages/insomnia/src/ui/css/components/request-url-bar.less
@@ -48,8 +48,8 @@
     border-right: 1px solid var(--color-bg);
   }
   .urlbar__send-context {
-    padding-right: var(--padding-sm);
-    padding-left: var(--padding-sm);
+    padding-right: var(--padding-xs);
+    padding-left: var(--padding-xs);
     text-align: center;
     background: var(--color-surprise);
     color: var(--color-font-surprise);

--- a/packages/insomnia/src/ui/css/components/request-url-bar.less
+++ b/packages/insomnia/src/ui/css/components/request-url-bar.less
@@ -45,7 +45,7 @@
   }
   .urlbar__send-btn,
   .surprise {
-    border-right: 1px solid var(--color-bg);
+    border-right: 1px solid var(--hl);
   }
   .urlbar__send-context {
     padding-right: var(--padding-xs);

--- a/packages/insomnia/src/ui/hooks/useTimeoutWhen.ts
+++ b/packages/insomnia/src/ui/hooks/useTimeoutWhen.ts
@@ -36,6 +36,7 @@ function useTimeoutWhen(
         console.warn('useTimeoutWhen: window is undefined.');
       }
     }
+    return;
   }, [timeoutDelayMs, when]);
 }
 

--- a/packages/insomnia/src/ui/hooks/useTimeoutWhen.ts
+++ b/packages/insomnia/src/ui/hooks/useTimeoutWhen.ts
@@ -1,0 +1,42 @@
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * A setTimeout hook that calls a callback after a timeout duration
+ * when a condition is true
+ *
+ * @param cb The callback to be invoked after timeout
+ * @param timeoutDelayMs Amount of time in ms after which to invoke
+ * @param when The condition which when true, sets the timeout
+ */
+function useTimeoutWhen(
+  callback_: () => void,
+  timeoutDelayMs = 0,
+  when = true
+): void {
+  const savedRefCallback = useRef<() => any>();
+
+  useEffect(() => {
+    savedRefCallback.current = callback_;
+  });
+
+  function callback() {
+    savedRefCallback.current && savedRefCallback.current();
+  }
+
+  useEffect(() => {
+    if (when) {
+      if (typeof window !== 'undefined') {
+        const timeout = window.setTimeout(callback, timeoutDelayMs);
+
+        return () => {
+          window.clearTimeout(timeout);
+        };
+      } else {
+        console.warn('useTimeoutWhen: window is undefined.');
+      }
+    }
+  }, [when]);
+}
+
+export { useTimeoutWhen };

--- a/packages/insomnia/src/ui/hooks/useTimeoutWhen.ts
+++ b/packages/insomnia/src/ui/hooks/useTimeoutWhen.ts
@@ -1,6 +1,6 @@
 
 import { useEffect, useRef } from 'react';
-
+// https://github.com/imbhargav5/rooks/blob/main/src/hooks/useTimeoutWhen.ts
 /**
  * A setTimeout hook that calls a callback after a timeout duration
  * when a condition is true
@@ -36,7 +36,7 @@ function useTimeoutWhen(
         console.warn('useTimeoutWhen: window is undefined.');
       }
     }
-  }, [when]);
+  }, [timeoutDelayMs, when]);
 }
 
 export { useTimeoutWhen };


### PR DESCRIPTION
motivation: seems this component might be getting some work soon with the first websockets pass, so it would be nice for it to have good hmr and be a bit easier to reason about.

### todo
- [x] fc conversion
- [x] split button
- [x] timer simplification
- [x] styling
- [x] hotkey behaviour


<img width="532" alt="image" src="https://user-images.githubusercontent.com/3679927/176884477-f92d194e-321d-47fa-841f-db0c53e145a9.png">

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

changelog(Improvements): Changed the Send Request button into a split-button to tell apart the basic send from other advanced send options 