### PR TITLE
prevent focus loss

### DIFF
--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -563,6 +563,7 @@ function getBounds() {
 
 const ZOOM_MAX = 6;
 const ZOOM_DEFAULT = 1;
+const ZOOM_MIN = 0.05;
 
 const getZoomFactor = () => {
   try {

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -104,7 +104,7 @@ export function createWindow() {
 
   // Open generic links (<a .../>) in default browser
   mainWindow?.webContents.on('will-navigate', (event, url) => {
-    if (url === appUrl) {
+    if (url.startsWith(appUrl)) {
       return;
     }
 
@@ -563,7 +563,6 @@ function getBounds() {
 
 const ZOOM_MAX = 6;
 const ZOOM_DEFAULT = 1;
-const ZOOM_MIN = 0.05;
 
 const getZoomFactor = () => {
   try {

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -104,6 +104,7 @@ export function createWindow() {
 
   // Open generic links (<a .../>) in default browser
   mainWindow?.webContents.on('will-navigate', (event, url) => {
+    // Prevents local dev full-reload events from opening browser window, see https://github.com/Kong/insomnia/pull/4925
     if (url.startsWith(appUrl)) {
       return;
     }


### PR DESCRIPTION
during development, when modifying a class component hmr triggers a full-reload event on the ws connection. This event is picked up by the browserwindow will-navigate and causes chrome to steal focus. This change corrects that behaviour.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
