### PR TITLE
useCallback with async is ok, after all

### DIFF
--- a/packages/insomnia/src/ui/components/base/copy-button.tsx
+++ b/packages/insomnia/src/ui/components/base/copy-button.tsx
@@ -17,18 +17,15 @@ export const CopyButton: FC<Props> = ({
   ...buttonProps
 }) => {
   const [showConfirmation, setshowConfirmation] = useState(false);
-  const onClick = useCallback((event: React.MouseEvent) => {
-    const fn = async () => {
-      event.preventDefault();
-      event.stopPropagation();
-      const toCopy = typeof content === 'string' ? content : await content();
+  const onClick = useCallback(async (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const toCopy = typeof content === 'string' ? content : await content();
 
-      if (toCopy) {
-        clipboard.writeText(toCopy);
-      }
-      setshowConfirmation(true);
-    };
-    fn();
+    if (toCopy) {
+      clipboard.writeText(toCopy);
+    }
+    setshowConfirmation(true);
   }, [content]);
 
   useInterval(() => {

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -53,42 +53,36 @@ export const RequestActionsDropdown = forwardRef<Dropdown, Props>(({
   const [actionPlugins, setActionPlugins] = useState<RequestAction[]>([]);
   const [loadingActions, setLoadingActions] = useState<Record<string, boolean>>({});
 
-  const onOpen = useCallback(() => {
-    const fn = async () => {
-      const actionPlugins = await getRequestActions();
-      setActionPlugins(actionPlugins);
-    };
-    fn();
+  const onOpen = useCallback(async () => {
+    const actionPlugins = await getRequestActions();
+    setActionPlugins(actionPlugins);
   }, []);
 
-  const handlePluginClick = useCallback(({ plugin, action, label }: RequestAction) => {
-    const fn = async () => {
-      setLoadingActions({ ...loadingActions, [label]: true });
+  const handlePluginClick = useCallback(async ({ plugin, action, label }: RequestAction) => {
+    setLoadingActions({ ...loadingActions, [label]: true });
 
-      try {
-        const activeEnvironmentId = activeEnvironment ? activeEnvironment._id : null;
-        const context = {
-          ...(pluginContexts.app.init(RENDER_PURPOSE_NO_RENDER)),
-          ...pluginContexts.data.init(activeProject._id),
-          ...(pluginContexts.store.init(plugin)),
-          ...(pluginContexts.network.init(activeEnvironmentId)),
-        };
-        await action(context, {
-          request,
-          requestGroup,
-        });
-      } catch (error) {
-        showError({
-          title: 'Plugin Action Failed',
-          error,
-        });
-      }
-      setLoadingActions({ ...loadingActions, [label]: false });
-      if (ref && 'current' in ref) { // this `in` operator statement type-narrows to `MutableRefObject`
-        ref.current?.hide();
-      }
-    };
-    fn();
+    try {
+      const activeEnvironmentId = activeEnvironment ? activeEnvironment._id : null;
+      const context = {
+        ...(pluginContexts.app.init(RENDER_PURPOSE_NO_RENDER)),
+        ...pluginContexts.data.init(activeProject._id),
+        ...(pluginContexts.store.init(plugin)),
+        ...(pluginContexts.network.init(activeEnvironmentId)),
+      };
+      await action(context, {
+        request,
+        requestGroup,
+      });
+    } catch (error) {
+      showError({
+        title: 'Plugin Action Failed',
+        error,
+      });
+    }
+    setLoadingActions({ ...loadingActions, [label]: false });
+    if (ref && 'current' in ref) { // this `in` operator statement type-narrows to `MutableRefObject`
+      ref.current?.hide();
+    }
   }, [request, activeEnvironment, requestGroup, loadingActions, activeProject._id, ref]);
 
   const duplicate = useCallback(() => {

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -121,7 +121,9 @@ export const ResponseHistoryDropdown: FC<Props> = ({
     );
   };
 
-  const handleKeydown = useCallback((event: KeyboardEvent) => executeHotKey(event, hotKeyRefs.REQUEST_TOGGLE_HISTORY, () => dropdownRef.current?.toggle(true)), []);
+  const handleKeydown = useCallback((event: KeyboardEvent) => {
+    executeHotKey(event, hotKeyRefs.REQUEST_TOGGLE_HISTORY, () => dropdownRef.current?.toggle(true));
+  }, []);
   const environmentName = activeEnvironment ? activeEnvironment.name : 'Base';
   const isLatestResponseActive = !responses.length || activeResponse._id === responses[0]._id;
   return (

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -92,15 +92,12 @@ const useDesignEmptyState = () => {
     }
   }, [contents, shouldIncrementCounter]);
 
-  const onUpdateContents = useCallback((value: string) => {
+  const onUpdateContents = useCallback(async (value: string) => {
     if (!activeApiSpec) {
       return;
     }
 
-    const fn = async () => {
-      await models.apiSpec.update({ ...activeApiSpec, contents: value });
-    };
-    fn();
+    await models.apiSpec.update({ ...activeApiSpec, contents: value });
 
     // Because we can't await activeApiSpec.contents to have propageted to redux, we flip a toggle to decide if we should do something when redux does eventually change
     setShouldIncrementCounter(true);
@@ -124,15 +121,12 @@ const RenderEditor: FC<{ editor: RefObject<UnconnectedCodeEditor> }> = ({ editor
   const { uniquenessKey, emptyStateNode } = useDesignEmptyState();
 
   const onCodeEditorChange = useMemo(() => {
-    const handler = (contents: string) => {
-      const fn = async () => {
-        if (!activeApiSpec) {
-          return;
-        }
+    const handler = async (contents: string) => {
+      if (!activeApiSpec) {
+        return;
+      }
 
-        await models.apiSpec.update({ ...activeApiSpec, contents });
-      };
-      fn();
+      await models.apiSpec.update({ ...activeApiSpec, contents });
     };
 
     return debounce(handler, 500);


### PR DESCRIPTION
in https://github.com/Kong/insomnia/pull/4904#discussion_r909461737 I had changed some useCallback calls to not use `async`.  Turns out I was overgeneralizing a rule that _is_ legit about `useEffect`, but doesn't apply to useCallback.  Oh well.  This PR fixes it to be more idiomatic and read more clearly.

The scope was restrained pretty far, so the scope should be nice and contained (with no logical changes).