### PR TITLE
modal class->fc

### DIFF
--- a/packages/insomnia/src/ui/components/modals/add-key-combination-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/add-key-combination-modal.tsx
@@ -7,7 +7,7 @@ import React, { PureComponent } from 'react';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { constructKeyCombinationDisplay, isModifierKeyCode } from '../../../common/hotkeys';
 import { keyboardKeys } from '../../../common/keyboard-keys';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 
@@ -20,7 +20,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class AddKeyCombinationModal extends PureComponent<{}, State> {
-  _modal: Modal | null = null;
+  _modal: ModalHandle | null = null;
 
   state: State = {
     hotKeyRefId: null,
@@ -29,7 +29,7 @@ export class AddKeyCombinationModal extends PureComponent<{}, State> {
     pressedKeyCombination: null,
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this._modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/alert-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/alert-modal.tsx
@@ -2,7 +2,7 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import React, { PureComponent, ReactNode } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -26,14 +26,14 @@ export class AlertModal extends PureComponent<{}, State> {
     okLabel: '',
   };
 
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _cancel: HTMLButtonElement | null = null;
   _ok: HTMLButtonElement | null = null;
 
   _okCallback?: (value: void | PromiseLike<void>) => void;
   _okCallback2: AlertModalOptions['onConfirm'];
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/analytics-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/analytics-modal.tsx
@@ -8,7 +8,7 @@ import * as models from '../../../models';
 import chartSrc from '../../images/chart.svg';
 import coreLogo from '../../images/insomnia-logo.svg';
 import { selectSettings } from '../../redux/selectors';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 
 const Wrapper = styled.div({
   position: 'relative',
@@ -74,7 +74,7 @@ const ActionButtons = styled.div({
 
 export const AnalyticsModal: FC = () => {
   const { hasPromptedAnalytics } = useSelector(selectSettings);
-  const ref = useRef<Modal>(null);
+  const ref = useRef<ModalHandle>(null);
 
   const onEnable = useCallback(async () => {
     await models.settings.patch({

--- a/packages/insomnia/src/ui/components/modals/ask-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/ask-modal.tsx
@@ -2,7 +2,7 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import React, { PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -33,13 +33,13 @@ export class AskModal extends PureComponent<{}, State> {
     loading: false,
   };
 
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   yesButton: HTMLButtonElement | null = null;
 
   _doneCallback: AskModalOptions['onDone'];
   _promiseCallback: (value: boolean | PromiseLike<boolean>) => void = () => {};
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/code-prompt-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/code-prompt-modal.tsx
@@ -8,7 +8,7 @@ import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
 import { DropdownItem } from '../base/dropdown/dropdown-item';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -50,11 +50,11 @@ export class CodePromptModal extends PureComponent<{}, State> {
     showCopyButton: false,
   };
 
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _onModeChange: Function = () => {};
   _onChange: Function = () => {};
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/cookie-modify-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookie-modify-modal.tsx
@@ -13,7 +13,7 @@ import * as models from '../../../models';
 import type { Cookie, CookieJar } from '../../../models/cookie-jar';
 import { RootState } from '../../redux/modules';
 import { selectActiveCookieJar } from '../../redux/selectors';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -31,7 +31,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class UnconnectedCookieModifyModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _rawTimeout: NodeJS.Timeout | null = null;
   _cookieUpdateTimeout: NodeJS.Timeout | null = null;
 
@@ -40,7 +40,7 @@ export class UnconnectedCookieModifyModal extends PureComponent<Props, State> {
     rawValue: '',
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
@@ -10,7 +10,7 @@ import * as models from '../../../models';
 import type { Cookie, CookieJar } from '../../../models/cookie-jar';
 import { useNunjucks } from '../../context/nunjucks/use-nunjucks';
 import { selectActiveCookieJar } from '../../redux/selectors';
-import { Modal, ModalProps } from '../base/modal';
+import { type ModalHandle, Modal, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -29,7 +29,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class CookiesModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   filterInput: HTMLInputElement | null = null;
 
   state: State = {
@@ -37,7 +37,7 @@ class CookiesModal extends PureComponent<Props, State> {
     visibleCookieIndexes: null,
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/environment-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/environment-edit-modal.tsx
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { RequestGroup } from '../../../models/request-group';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -25,10 +25,10 @@ export class EnvironmentEditModal extends PureComponent<Props, State> {
     isValid: true,
   };
 
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _envEditor: EnvironmentEditor | null = null;
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/error-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/error-modal.tsx
@@ -2,7 +2,7 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import React, { PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -16,7 +16,7 @@ export interface ErrorModalOptions {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class ErrorModal extends PureComponent<{}, ErrorModalOptions> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _okCallback: (value?: unknown) => void = () => {};
 
   state: ErrorModalOptions = {
@@ -26,7 +26,7 @@ export class ErrorModal extends PureComponent<{}, ErrorModalOptions> {
     addCancel: false,
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/export-requests-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/export-requests-modal.tsx
@@ -11,7 +11,7 @@ import { isRequestGroup, RequestGroup } from '../../../models/request-group';
 import { RootState } from '../../redux/modules';
 import { exportRequestsToFile } from '../../redux/modules/global';
 import { selectSidebarChildren } from '../../redux/sidebar-selectors';
-import { Modal, ModalProps } from '../base/modal';
+import { type ModalHandle, Modal, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -33,13 +33,13 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class ExportRequestsModalClass extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
 
   state: State = {
     treeRoot: null,
   };
 
-  setModalRef(modal: Modal) {
+  setModalRef(modal: ModalHandle) {
     if (modal != null) {
       this.modal = modal;
     }

--- a/packages/insomnia/src/ui/components/modals/filter-help-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/filter-help-modal.tsx
@@ -3,7 +3,7 @@ import React, { FC, PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { Link } from '../base/link';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 
@@ -72,9 +72,9 @@ export class FilterHelpModal extends PureComponent<{}, State> {
     isJSON: true,
   };
 
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/generate-code-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/generate-code-modal.tsx
@@ -10,7 +10,7 @@ import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownItem } from '../base/dropdown/dropdown-item';
 import { Link } from '../base/link';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -65,10 +65,10 @@ export class GenerateCodeModal extends PureComponent<Props, State> {
     };
   }
 
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _editor: UnconnectedCodeEditor | null = null;
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/generate-config-modal.tsx
@@ -9,7 +9,7 @@ import type { ConfigGenerator } from '../../../plugins';
 import * as plugins from '../../../plugins';
 import { CopyButton } from '../base/copy-button';
 import { Link } from '../base/link';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -37,14 +37,14 @@ interface ShowOptions {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class GenerateConfigModal extends PureComponent<{}, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
 
   state: State = {
     configs: [],
     activeTab: 0,
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
@@ -11,7 +11,7 @@ import type { GitRepository } from '../../../models/git-repository';
 import { GitVCS } from '../../../sync/git/git-vcs';
 import { getOauth2FormatName } from '../../../sync/git/utils';
 import { initialize as initializeEntities } from '../../redux/modules/entities';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -32,8 +32,8 @@ interface State {
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-class GitBranchesModalClass extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+export class GitBranchesModalClass extends PureComponent<Props, State> {
+  modal: ModalHandle | null = null;
   input: HTMLInputElement | null = null;
   _onHide?: (() => void) | null;
 
@@ -45,7 +45,7 @@ class GitBranchesModalClass extends PureComponent<Props, State> {
     newBranchName: '',
   };
 
-  _setModalRef(ref: Modal) {
+  _setModalRef(ref: ModalHandle) {
     this.modal = ref;
   }
 

--- a/packages/insomnia/src/ui/components/modals/git-log-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-log-modal.tsx
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
 import type { GitLogEntry, GitVCS } from '../../../sync/git/git-vcs';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -21,14 +21,14 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class GitLogModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
 
   state: State = {
     logs: [],
     branch: '??',
   };
 
-  _setModalRef(ref: Modal) {
+  _setModalRef(ref: ModalHandle) {
     this.modal = ref;
   }
 

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
@@ -7,7 +7,7 @@ import { docsGitSync } from '../../../../common/documentation';
 import type { GitRepository, OauthProviderName } from '../../../../models/git-repository';
 import { deleteGitRepository } from '../../../../models/helpers/git-repository-operations';
 import { Link } from '../../base/link';
-import { Modal } from '../../base/modal';
+import { type ModalHandle, Modal } from '../../base/modal';
 import { ModalBody } from '../../base/modal-body';
 import { ModalFooter } from '../../base/modal-footer';
 import { ModalHeader } from '../../base/modal-header';
@@ -23,14 +23,14 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class GitRepositorySettingsModal extends PureComponent<{}, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _onSubmitEdits?: ((repo: Partial<GitRepository>) => any) | null;
 
   state: State = {
     gitRepository: null,
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
@@ -17,7 +17,7 @@ import { GIT_INSOMNIA_DIR, GIT_INSOMNIA_DIR_NAME, GitVCS } from '../../../sync/g
 import parseGitPath from '../../../sync/git/parse-git-path';
 import { getOauth2FormatName } from '../../../sync/git/utils';
 import { IndeterminateCheckbox } from '../base/indeterminate-checkbox';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -55,7 +55,7 @@ const INITIAL_STATE: State = {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class GitStagingModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   statusNames?: Record<string, string>;
   textarea: HTMLTextAreaElement | null = null;
   onCommit: null | (() => void);
@@ -66,7 +66,7 @@ export class GitStagingModal extends PureComponent<Props, State> {
     this.onCommit = null;
   }
 
-  _setModalRef(ref: Modal) {
+  _setModalRef(ref: ModalHandle) {
     this.modal = ref;
   }
 

--- a/packages/insomnia/src/ui/components/modals/login-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/login-modal.tsx
@@ -7,7 +7,7 @@ import React, { Dispatch, FormEvent, forwardRef, memo, RefObject, SetStateAction
 import * as session from '../../../account/session';
 import { getAppWebsiteBaseURL } from '../../../common/constants';
 import { clickLink } from '../../../common/electron-helpers';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -47,7 +47,7 @@ interface AuthBox {
 
 export class LoginModalHandle {
   constructor(
-    private readonly modalRef: RefObject<Modal>,
+    private readonly modalRef: RefObject<ModalHandle>,
     private readonly setState: Dispatch<SetStateAction<State & Options>>,
   ) {}
 
@@ -99,7 +99,7 @@ export class LoginModalHandle {
 }
 
 export const LoginModal = memo(forwardRef<LoginModalHandle, {}>(function LoginModal({ ...props }, ref) {
-  const modalRef = useRef<Modal>(null);
+  const modalRef = useRef<ModalHandle>(null);
   const tokenInputRef = useRef<HTMLInputElement>(null);
 
   const [state, setState] = useState<State & Options>({

--- a/packages/insomnia/src/ui/components/modals/nunjucks-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/nunjucks-modal.tsx
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { Workspace } from '../../../models/workspace';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -27,9 +27,9 @@ export class NunjucksModal extends PureComponent<Props, State> {
 
   _onDone: Function | null = null;
   _currentTemplate: string | null = null;
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/project-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/project-settings-modal.tsx
@@ -11,7 +11,7 @@ import { RootState } from '../../redux/modules';
 import * as projectActions from '../../redux/modules/project';
 import { selectActiveProject } from '../../redux/selectors';
 import { DebouncedInput } from '../base/debounced-input';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { PromptButton } from '../base/prompt-button';
@@ -23,9 +23,9 @@ type Props = ReduxProps;
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class ProjectSettingsModal extends PureComponent<Props> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
 
-  _handleSetModalRef(modal: Modal) {
+  _handleSetModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/prompt-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/prompt-modal.tsx
@@ -4,7 +4,7 @@ import React, { PureComponent, ReactNode } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { Button } from '../base/button';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -52,7 +52,7 @@ export interface PromptModalOptions {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class PromptModal extends PureComponent<{}, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _input: HTMLInputElement | null = null;
 
   state: State = {
@@ -100,7 +100,7 @@ export class PromptModal extends PureComponent<{}, State> {
     this._input = input;
   }
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
@@ -13,7 +13,7 @@ import { grpcActions, sendGrpcIpcMultiple } from '../../context/grpc';
 import { RootState } from '../../redux/modules';
 import { selectExpandedActiveProtoDirectories } from '../../redux/proto-selectors';
 import { selectActiveWorkspace } from '../../redux/selectors';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -42,7 +42,7 @@ const spinner = <i className="fa fa-spin fa-refresh" />;
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class ProtoFilesModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   onSave: ((arg0: string) => Promise<void>) | null;
 
   constructor(props: Props) {
@@ -51,7 +51,7 @@ class ProtoFilesModal extends PureComponent<Props, State> {
     this.onSave = null;
   }
 
-  _setModalRef(ref: Modal) {
+  _setModalRef(ref: ModalHandle) {
     this.modal = ref;
   }
 

--- a/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
@@ -10,7 +10,7 @@ import type { Workspace } from '../../../models/workspace';
 import { RootState } from '../../redux/modules';
 import { selectWorkspacesForActiveProject } from '../../redux/selectors';
 import { DebouncedInput } from '../base/debounced-input';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { UnconnectedCodeEditor } from '../codemirror/code-editor';
@@ -40,7 +40,7 @@ interface RequestGroupSettingsModalOptions {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class UnconnectedRequestGroupSettingsModal extends React.PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _editorRef = createRef<UnconnectedCodeEditor>();
 
   state: State = {
@@ -54,7 +54,7 @@ export class UnconnectedRequestGroupSettingsModal extends React.PureComponent<Pr
     justMoved: false,
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/request-render-error-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-render-error-modal.tsx
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { docsTemplateTags } from '../../../common/documentation';
 import { Link } from '../base/link';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { RequestSettingsModal } from '../modals/request-settings-modal';
@@ -23,9 +23,9 @@ export class RequestRenderErrorModal extends PureComponent<{}, State> {
     request: null,
   };
 
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -12,7 +12,7 @@ import { isWorkspace, Workspace } from '../../../models/workspace';
 import { RootState } from '../../redux/modules';
 import { selectWorkspacesForActiveProject } from '../../redux/selectors';
 import { DebouncedInput } from '../base/debounced-input';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { UnconnectedCodeEditor } from '../codemirror/code-editor';
@@ -42,7 +42,7 @@ interface RequestSettingsModalOptions {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class UnconnectedRequestSettingsModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _editorRef = createRef<UnconnectedCodeEditor>();
 
   state: State = {
@@ -56,7 +56,7 @@ export class UnconnectedRequestSettingsModal extends PureComponent<Props, State>
     justMoved: false,
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/request-switcher-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-switcher-modal.tsx
@@ -21,7 +21,7 @@ import { activateWorkspace } from '../../redux/modules/workspace';
 import { selectActiveRequest, selectActiveWorkspace, selectActiveWorkspaceMeta, selectGrpcRequestMetas, selectRequestMetas, selectWorkspaceRequestsAndRequestGroups, selectWorkspacesForActiveProject } from '../../redux/selectors';
 import { Button } from '../base/button';
 import { Highlight } from '../base/highlight';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { KeydownBinder } from '../keydown-binder';
@@ -65,7 +65,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class RequestSwitcherModal extends PureComponent<ReduxProps, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _input: HTMLInputElement | null = null;
   _openTimeout: NodeJS.Timeout | null = null;
 
@@ -99,7 +99,7 @@ class RequestSwitcherModal extends PureComponent<ReduxProps, State> {
     event.preventDefault();
   }
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/response-debug-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/response-debug-modal.tsx
@@ -5,7 +5,7 @@ import { AUTOBIND_CFG } from '../../../common/constants';
 import * as models from '../../../models/index';
 import type { Response } from '../../../models/response';
 import { ResponseTimelineViewer } from '../../components/viewers/response-timeline-viewer';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 
@@ -17,7 +17,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class ResponseDebugModal extends PureComponent<{}, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
 
   state: State = {
     response: null,
@@ -25,7 +25,7 @@ export class ResponseDebugModal extends PureComponent<{}, State> {
     title: '',
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/select-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/select-modal.tsx
@@ -2,7 +2,7 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import React, { createRef, PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -30,7 +30,7 @@ const initialState: SelectModalShowOptions = {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class SelectModal extends PureComponent<{}, SelectModalShowOptions> {
-  modal = createRef<Modal>();
+  modal = createRef<ModalHandle>();
   doneButton = createRef<HTMLButtonElement>();
   state: SelectModalShowOptions = initialState;
 

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -8,7 +8,7 @@ import { getAppVersion, getProductName } from '../../../common/constants';
 import * as models from '../../../models/index';
 import { selectSettings } from '../../redux/selectors';
 import { Button } from '../base/button';
-import { Modal, ModalProps } from '../base/modal';
+import { type ModalHandle, Modal, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { Account } from '../settings/account';
@@ -31,7 +31,7 @@ export const displayName = 'SettingsModal';
 export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props, ref) => {
   const settings = useSelector(selectSettings);
   const [currentTabIndex, setCurrentTabIndex] = useState<number | null>(null);
-  const modalRef = useRef<Modal>(null);
+  const modalRef = useRef<ModalHandle>(null);
   const email = session.isLoggedIn() ? session.getFullName() : null;
 
   const handleUpdateKeyBindings = async (hotKeyRegistry: HotKeyRegistry) => {

--- a/packages/insomnia/src/ui/components/modals/sync-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-branches-modal.tsx
@@ -9,7 +9,7 @@ import { interceptAccessError } from '../../../sync/vcs/util';
 import { VCS } from '../../../sync/vcs/vcs';
 import { RootState } from '../../redux/modules';
 import { selectSyncItems } from '../../redux/selectors';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { PromptButton } from '../base/prompt-button';
@@ -31,7 +31,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class UnconnectedSyncBranchesModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
 
   state: State = {
     error: '',
@@ -41,7 +41,7 @@ export class UnconnectedSyncBranchesModal extends PureComponent<Props, State> {
     currentBranch: '',
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 
@@ -171,11 +171,8 @@ export class UnconnectedSyncBranchesModal extends PureComponent<Props, State> {
     this.modal?.hide();
   }
 
-  async show(options: { onHide: (...args: any[]) => any }) {
-    this.modal &&
-      this.modal.show({
-        onHide: options.onHide,
-      });
+  async show() {
+    this.modal && this.modal.show();
     await this.refreshState();
   }
 

--- a/packages/insomnia/src/ui/components/modals/sync-delete-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-delete-modal.tsx
@@ -9,7 +9,7 @@ import { interceptAccessError } from '../../../sync/vcs/util';
 import { VCS } from '../../../sync/vcs/vcs';
 import { RootState } from '../../redux/modules';
 import { selectActiveWorkspace } from '../../redux/selectors';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 
@@ -31,7 +31,7 @@ const INITIAL_STATE: State = {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class UnconnectedSyncDeleteModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   input: HTMLInputElement | null = null;
 
   constructor(props: Props) {
@@ -39,7 +39,7 @@ export class UnconnectedSyncDeleteModal extends PureComponent<Props, State> {
     this.state = INITIAL_STATE;
   }
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 
@@ -73,11 +73,8 @@ export class UnconnectedSyncDeleteModal extends PureComponent<Props, State> {
     }
   }
 
-  async show(options: { onHide: (...args: any[]) => any }) {
-    this.modal &&
-      this.modal.show({
-        onHide: options.onHide,
-      });
+  async show() {
+    this.modal && this.modal.show();
     // Reset state
     this.setState(INITIAL_STATE);
     // Focus input when modal shows

--- a/packages/insomnia/src/ui/components/modals/sync-history-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-history-modal.tsx
@@ -5,7 +5,7 @@ import * as session from '../../../account/session';
 import { AUTOBIND_CFG } from '../../../common/constants';
 import type { Snapshot } from '../../../sync/types';
 import { VCS } from '../../../sync/vcs/vcs';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { PromptButton } from '../base/prompt-button';
@@ -24,7 +24,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class SyncHistoryModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   handleRollback?: (arg0: Snapshot) => Promise<void>;
 
   state: State = {
@@ -32,7 +32,7 @@ export class SyncHistoryModal extends PureComponent<Props, State> {
     history: [],
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/sync-merge-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-merge-modal.tsx
@@ -7,7 +7,7 @@ import type { DocumentKey, MergeConflict } from '../../../sync/types';
 import { VCS } from '../../../sync/vcs/vcs';
 import { RootState } from '../../redux/modules';
 import { selectSyncItems } from '../../redux/selectors';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -24,14 +24,14 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class UnconnectedSyncMergeModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _handleDone?: (arg0: MergeConflict[]) => void;
 
   state: State = {
     conflicts: [],
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/sync-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-staging-modal.tsx
@@ -12,7 +12,7 @@ import { VCS } from '../../../sync/vcs/vcs';
 import { RootState } from '../../redux/modules';
 import { selectSyncItems } from '../../redux/selectors';
 import { IndeterminateCheckbox } from '../base/indeterminate-checkbox';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -53,13 +53,13 @@ const _initialState: State = {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class UnconnectedSyncStagingModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   _onSnapshot: (() => void) | null = null;
   _handlePush: (() => Promise<void>) | null = null;
   textarea: HTMLTextAreaElement | null = null;
   state = _initialState;
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/workspace-duplicate-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-duplicate-modal.tsx
@@ -17,7 +17,7 @@ import { initializeLocalBackendProjectAndMarkForSync } from '../../../sync/vcs/i
 import { VCS } from '../../../sync/vcs/vcs';
 import { activateWorkspace } from '../../redux/modules/workspace';
 import { selectActiveProject, selectIsLoggedIn, selectProjects } from '../../redux/selectors';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -44,7 +44,7 @@ const ProjectOption: FC<Project> = project => (
   </option>
 );
 
-const WorkspaceDuplicateModalInternalWithRef: ForwardRefRenderFunction<Modal, InnerProps> = ({ workspace, apiSpec, onDone, hide, vcs }, ref) => {
+const WorkspaceDuplicateModalInternalWithRef: ForwardRefRenderFunction<ModalHandle, InnerProps> = ({ workspace, apiSpec, onDone, hide, vcs }, ref) => {
   const dispatch = useDispatch();
 
   const projects = useSelector(selectProjects);
@@ -128,7 +128,7 @@ interface State {
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class WorkspaceDuplicateModal extends PureComponent<Props, State> {
   state: State = { };
-  modal = createRef<Modal>();
+  modal = createRef<ModalHandle>();
 
   show(options: Options) {
     this.setState({ options }, () => {

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -15,7 +15,7 @@ import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownItem } from '../base/dropdown/dropdown-item';
 import { Editable } from '../base/editable';
 import { Link } from '../base/link';
-import { Modal, ModalProps } from '../base/modal';
+import { type ModalHandle, Modal, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
@@ -136,7 +136,7 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
   environmentEditorRef: EnvironmentEditor | null = null;
   environmentColorInputRef: HTMLInputElement | null = null;
   saveTimeout: NodeJS.Timeout | null = null;
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
   editorKey = 0;
 
   state: State = {
@@ -157,7 +157,7 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
     this.environmentEditorRef = environmentEditor;
   }
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -19,7 +19,7 @@ import { setActiveActivity } from '../../redux/modules/global';
 import { selectActiveWorkspace, selectActiveWorkspaceClientCertificates, selectActiveWorkspaceName } from '../../redux/selectors';
 import { DebouncedInput } from '../base/debounced-input';
 import { FileInputButton } from '../base/file-input-button';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { PromptButton } from '../base/prompt-button';
@@ -84,7 +84,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class UnconnectedWorkspaceSettingsModal extends PureComponent<Props, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
 
   state: State = {
     showAddCertificateForm: false,
@@ -108,7 +108,7 @@ export class UnconnectedWorkspaceSettingsModal extends PureComponent<Props, Stat
     });
   }
 
-  _handleSetModalRef(modal: Modal) {
+  _handleSetModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 

--- a/packages/insomnia/src/ui/components/modals/wrapper-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/wrapper-modal.tsx
@@ -2,7 +2,7 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import React, { PureComponent, ReactNode } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
-import { Modal } from '../base/modal';
+import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 
@@ -17,7 +17,7 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 export class WrapperModal extends PureComponent<{}, State> {
-  modal: Modal | null = null;
+  modal: ModalHandle | null = null;
 
   state: State = {
     title: '',
@@ -28,7 +28,7 @@ export class WrapperModal extends PureComponent<{}, State> {
     wide: false,
   };
 
-  _setModalRef(modal: Modal) {
+  _setModalRef(modal: ModalHandle) {
     this.modal = modal;
   }
 


### PR DESCRIPTION
Highlights
- modal.show() had args but they didn't do anything, however modal classes using `<Modal` have a show function with args
38 of the file changes are introducing the type ModalHandle to the 38 files that use the modal ref.

Uncertainties
- there's an onHide function on the Modal class that doesn't appear to do anything - removed
- theres a dom walker that searches up 5 parent elements to find the close button attribute
- there a force refresh that could probably be removed with some experimentation
- theres a an one-off option isOpen that could be removed if request switcher modal used isModalVisible rather than this one-off

EDIT: onHide may still have a purpose. Considering back out of this change.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
