### PR TITLE
Support for client certificate authentication during OAuth 2.0

### DIFF
--- a/packages/insomnia/src/network/o-auth-2/misc.ts
+++ b/packages/insomnia/src/network/o-auth-2/misc.ts
@@ -121,6 +121,44 @@ export function authorizeUserInWindow({
         reject(new Error(errorDescription));
       }
     });
+
+    // Select client certificate during login if needed.
+    // More Info: https://textslashplain.com/2020/05/04/client-certificate-authentication/
+    child.webContents.on('select-client-certificate', (event, url, certificateList, callback) => {
+      event.preventDefault();
+
+      // There is only a single certificate so just use
+      // that certificate without prompting user.
+      // In the future maybe this could be a setting?
+      if (certificateList.length === 1) {
+        callback(certificateList[0]);
+        return;
+      }
+
+      const buttonLabels = certificateList.map(c => `${c.subjectName} (${c.issuerName})`);
+      const cancelId = buttonLabels.length;
+      const options = {
+        type: 'none',
+        buttons: [...buttonLabels, 'Cancel'],
+        cancelId: cancelId,
+        message: `The website\n"${url}"\nrequires a client certificate.`,
+        detail: 'This website requires a certificate to validate your identity. Select the certificate to use when you connect to this website.',
+        textWidth: 300,
+      };
+
+      // Prompt the user to select a certificate to use.
+      electron.dialog.showMessageBox(child, options).then(r => {
+        const selectedButtonIndex = r.response;
+        // Cancel button clicked
+        if (r.response === cancelId) {
+          child.close();
+          return;
+        }
+        const selectedCertificate = certificateList[selectedButtonIndex];
+        callback(selectedCertificate);
+      });
+    });
+
     // Catch the redirect after login
     child.webContents.on('did-navigate', () => {
       // Be sure to resolve URL so that we can handle redirects with no host like /foo/bar


### PR DESCRIPTION
changelog(Improvements): Added support for Client Certificate Authentication during OAuth 2 fetch token

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Adds support for [Client Certificate Authentication](https://textslashplain.com/2020/05/04/client-certificate-authentication) during the OAuth 2 browser popup. This form for authentication is well known and supported by all major browsers (Safari, Chrome, Edge, etc)

This fix will automatically select the first certificate if there is only a single certificate. If there are multiple valid certificates it will prompt the user to select one.

<img width="801" alt="Screen Shot 2022-07-15 at 2 03 58 AM" src="https://user-images.githubusercontent.com/8304095/179191969-0cdbb05c-9618-4063-b0d1-07aff5a92020.png">

Closes #4960 and possibly #1250