### PR TITLE
feat: add link to Azure DevOps access token docs

### DIFF
--- a/packages/insomnia/src/common/documentation.ts
+++ b/packages/insomnia/src/common/documentation.ts
@@ -17,7 +17,7 @@ export const docsGitAccessToken = {
   gitlab: 'https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html',
   bitbucket: 'https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/',
   bitbucketServer: 'https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html',
-  azureDevOps: "https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate",
+  azureDevOps: 'https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate',
 };
 
 export const documentationLinks = {

--- a/packages/insomnia/src/common/documentation.ts
+++ b/packages/insomnia/src/common/documentation.ts
@@ -17,6 +17,7 @@ export const docsGitAccessToken = {
   gitlab: 'https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html',
   bitbucket: 'https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/',
   bitbucketServer: 'https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html',
+  azureDevOps: "https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate",
 };
 
 export const documentationLinks = {

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/custom-repository-settings-form-group.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/custom-repository-settings-form-group.tsx
@@ -108,6 +108,10 @@ export const CustomRepositorySettingsFormGroup: FunctionComponent<Props> = ({
               <Link href={docsGitAccessToken.bitbucketServer}>
                 Bitbucket Server {linkIcon}
               </Link>
+              {' | '}
+              <Link href={docsGitAccessToken.azureDevOps}>
+                Azure DevOps {linkIcon}
+              </Link>
             </HelpTooltip>
             <input
               required


### PR DESCRIPTION
Add a new link to the help tool tip of the git access token that points to the help page for Azure DevOps.
