### PR TITLE
fix: return the input focus back after sending a request

### DIFF
--- a/packages/insomnia/src/ui/components/base/dropdown/dropdown-button.tsx
+++ b/packages/insomnia/src/ui/components/base/dropdown/dropdown-button.tsx
@@ -1,24 +1,31 @@
-import React, { ButtonHTMLAttributes, PureComponent, ReactNode } from 'react';
+import React, { ButtonHTMLAttributes, forwardRef, ReactNode, useImperativeHandle, useRef } from 'react';
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
   noWrap?: boolean;
   className?: string;
 }
-
-// eslint-disable-next-line react/prefer-stateless-function -- Dropdown's implementation makes changing this to a function component tricky.
-export class DropdownButton extends PureComponent<Props> {
-  render() {
-    const { children, noWrap, ...props } = this.props;
-
-    if (noWrap) {
-      return <>{children}</>;
-    }
-
-    return (
-      <button type="button" {...props}>
-        {children}
-      </button>
-    );
-  }
+export const DROPDOWN_BUTTON_DISPLAY_NAME = 'DropdownButton';
+export interface DropdownButtonHandle {
+  blur(): void;
 }
+export const DropdownButton = forwardRef<DropdownButtonHandle, Props>(({ noWrap, children, ...otherProps }, ref) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    blur(): void {
+      buttonRef.current?.blur();
+    },
+  }), []);
+
+  if (noWrap) {
+    return <>{children}</>;
+  }
+
+  return (
+    <button ref={buttonRef} type="button" {...otherProps}>
+      {children}
+    </button>
+  );
+});
+DropdownButton.displayName = DROPDOWN_BUTTON_DISPLAY_NAME;

--- a/packages/insomnia/src/ui/components/base/dropdown/dropdown-button.tsx
+++ b/packages/insomnia/src/ui/components/base/dropdown/dropdown-button.tsx
@@ -30,4 +30,4 @@ const DropdownButtonForwarded = forwardRef<DropdownButtonHandle, Props>(({ noWra
 });
 DropdownButtonForwarded.displayName = DROPDOWN_BUTTON_DISPLAY_NAME;
 
-export const DropdownButton = Object.assign(DropdownButtonForwarded, { name: 'DROPDOWN_BUTTON_DISPLAY_NAME' });
+export const DropdownButton = Object.assign(DropdownButtonForwarded, { name: DROPDOWN_BUTTON_DISPLAY_NAME });

--- a/packages/insomnia/src/ui/components/base/dropdown/dropdown-button.tsx
+++ b/packages/insomnia/src/ui/components/base/dropdown/dropdown-button.tsx
@@ -9,7 +9,7 @@ export const DROPDOWN_BUTTON_DISPLAY_NAME = 'DropdownButton';
 export interface DropdownButtonHandle {
   blur(): void;
 }
-export const DropdownButton = forwardRef<DropdownButtonHandle, Props>(({ noWrap, children, ...otherProps }, ref) => {
+const DropdownButtonForwarded = forwardRef<DropdownButtonHandle, Props>(({ noWrap, children, ...otherProps }, ref) => {
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   useImperativeHandle(ref, () => ({
@@ -28,4 +28,6 @@ export const DropdownButton = forwardRef<DropdownButtonHandle, Props>(({ noWrap,
     </button>
   );
 });
-DropdownButton.displayName = DROPDOWN_BUTTON_DISPLAY_NAME;
+DropdownButtonForwarded.displayName = DROPDOWN_BUTTON_DISPLAY_NAME;
+
+export const DropdownButton = Object.assign(DropdownButtonForwarded, { name: 'DROPDOWN_BUTTON_DISPLAY_NAME' });

--- a/packages/insomnia/src/ui/components/base/dropdown/dropdown.tsx
+++ b/packages/insomnia/src/ui/components/base/dropdown/dropdown.tsx
@@ -19,7 +19,7 @@ import { hotKeyRefs } from '../../../../common/hotkeys';
 import { executeHotKey } from '../../../../common/hotkeys-listener';
 import { fuzzyMatch } from '../../../../common/misc';
 import { KeydownBinder } from '../../keydown-binder';
-import { DropdownButton } from './dropdown-button';
+import { DROPDOWN_BUTTON_DISPLAY_NAME } from './dropdown-button';
 import { DropdownDivider } from './dropdown-divider';
 import { DropdownItem } from './dropdown-item';
 
@@ -46,7 +46,7 @@ const isComponent = (match: string) => (child: ReactNode) =>
   ]);
 
 const isDropdownItem = isComponent(DropdownItem.name);
-const isDropdownButton = isComponent(DropdownButton.name);
+const isDropdownButton = isComponent(DROPDOWN_BUTTON_DISPLAY_NAME);
 const isDropdownDivider = isComponent(DropdownDivider.name);
 
 // This walks the children tree and returns the dropdown specific components.

--- a/packages/insomnia/src/ui/components/base/dropdown/dropdown.tsx
+++ b/packages/insomnia/src/ui/components/base/dropdown/dropdown.tsx
@@ -19,7 +19,7 @@ import { hotKeyRefs } from '../../../../common/hotkeys';
 import { executeHotKey } from '../../../../common/hotkeys-listener';
 import { fuzzyMatch } from '../../../../common/misc';
 import { KeydownBinder } from '../../keydown-binder';
-import { DROPDOWN_BUTTON_DISPLAY_NAME } from './dropdown-button';
+import { DropdownButton } from './dropdown-button';
 import { DropdownDivider } from './dropdown-divider';
 import { DropdownItem } from './dropdown-item';
 
@@ -46,7 +46,7 @@ const isComponent = (match: string) => (child: ReactNode) =>
   ]);
 
 const isDropdownItem = isComponent(DropdownItem.name);
-const isDropdownButton = isComponent(DROPDOWN_BUTTON_DISPLAY_NAME);
+const isDropdownButton = isComponent(DropdownButton.name);
 const isDropdownDivider = isComponent(DropdownDivider.name);
 
 // This walks the children tree and returns the dropdown specific components.

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -212,14 +212,12 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
                 className="tall"
                 right
                 ref={dropdownRef}
-                onHide={() => {
-                  buttonRef.current?.blur();
-                }}
+                onHide={handleSendDropdownHide}
               >
                 <DropdownButton
                   ref={buttonRef}
                   className="urlbar__send-context"
-                  onClick={handleSendDropdownHide}
+                  onClick={() => dropdownRef.current?.show()}
                 >
                   <i className="fa fa-caret-down" />
                 </DropdownButton>

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -200,7 +200,6 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
           ) : (
             <>
               <button
-                ref={buttonRef}
                 type="button"
                 className="urlbar__send-btn"
                 onClick={send}

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -249,7 +249,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
                     <i className="fa fa-download" /> Download After Send
                   </DropdownItem>
                 )}
-                <DropdownItem onClick={handleSendAndDownload}>
+                <DropdownItem onClick={() => handleSendAndDownload()}>
                   <i className="fa fa-download" /> Send And Download
                 </DropdownItem>
               </Dropdown>

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -163,6 +163,10 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     setLastPastedText(event.clipboardData?.getData('text/plain'));
   }, []);
 
+  const handleSendDropdownHide = useCallback(() => {
+    buttonRef.current?.blur();
+  }, []);
+
   const { url, method } = request;
   const isCancellable = currentInterval || currentTimeout;
   return (
@@ -215,7 +219,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
                 <DropdownButton
                   ref={buttonRef}
                   className="urlbar__send-context"
-                  onClick={() => dropdownRef.current?.show()}
+                  onClick={handleSendDropdownHide}
                 >
                   <i className="fa fa-caret-down" />
                 </DropdownButton>

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -53,6 +53,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
   const methodDropdownRef = useRef<DropdownHandle>(null);
   const dropdownRef = useRef<DropdownHandle>(null);
   const inputRef = useRef<OneLineEditor>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const focusInput = useCallback(() => {
     if (inputRef.current) {
@@ -195,14 +196,24 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
           ) : (
             <>
               <button
+                ref={buttonRef}
                 type="button"
                 className="urlbar__send-btn"
                 onClick={send}
               >
                 {downloadPath ? 'Download' : 'Send'}
               </button>
-              <Dropdown key="dropdown" className="tall" right ref={dropdownRef}>
+              <Dropdown
+                key="dropdown"
+                className="tall"
+                right
+                ref={dropdownRef}
+                onHide={() => {
+                  buttonRef.current?.blur();
+                }}
+              >
                 <DropdownButton
+                  ref={buttonRef}
                   className="urlbar__send-context"
                   onClick={() => dropdownRef.current?.show()}
                 >

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -72,6 +72,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     } else {
       handleSend();
     }
+    inputRef.current?.focus(true);
   }, [downloadPath, handleSend, handleSendAndDownload]);
 
   useInterval(send, currentInterval ? currentInterval : null);
@@ -119,7 +120,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
   }, [handleUpdateDownloadPath, request._id]);
   const handleClearDownloadLocation = () => handleUpdateDownloadPath(request._id, null);
 
-  const handleKeyDown = useCallback(async (event: KeyboardEvent) => {
+  const handleKeyDown = useCallback((event: KeyboardEvent) => {
     if (event.code === 'Enter' && request.url) {
       send();
       return;


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
This PR closes [INS-1650](https://linear.app/insomnia/issue/INS-1650/regression-send-button-stays-pushed-in-after-clicking-figure-out-if) by adding focus back to the input when sending a request is executed as it was the original behaviour. We can discuss further on what we may find conforming to the accessibility standards in the followup discussion.

Before:
<img width="488" alt="image" src="https://user-images.githubusercontent.com/103070941/179608772-6bc91776-1fd4-40fb-886c-6b94c858a000.png">

After:
<img width="481" alt="image" src="https://user-images.githubusercontent.com/103070941/179608884-be31ce64-2f91-43d9-a517-920a6d7d96b5.png">
