### PR TITLE
Eliminate wrapperProps

### DIFF
--- a/packages/insomnia/src/ui/components/cookie-list.tsx
+++ b/packages/insomnia/src/ui/components/cookie-list.tsx
@@ -8,6 +8,8 @@ import { Dropdown } from './base/dropdown/dropdown';
 import { DropdownButton } from './base/dropdown/dropdown-button';
 import { DropdownItem } from './base/dropdown/dropdown-item';
 import { PromptButton } from './base/prompt-button';
+import { showModal } from './modals';
+import { CookieModifyModal } from './modals/cookie-modify-modal';
 import { RenderedText } from './rendered-text';
 
 export interface CookieListProps {
@@ -16,7 +18,6 @@ export interface CookieListProps {
   handleDeleteAll: Function;
   cookies: Cookie[];
   newCookieDomainName: string;
-  handleShowModifyCookieModal: (cookie: Cookie) => void;
 }
 
 // Use tough-cookie MAX_DATE value
@@ -27,16 +28,15 @@ const CookieRow: FC<{
   cookie: Cookie;
   index: number;
   deleteCookie: (cookie: Cookie) => void;
-  showModal: (cookie: Cookie) => void;
-}> = ({ cookie, index, deleteCookie, showModal }) => {
+}> = ({ cookie, index, deleteCookie }) => {
 
   const handleDeleteCookie = useCallback(() => {
     deleteCookie(cookie);
   }, [deleteCookie, cookie]);
 
   const handleShowModal = useCallback(() => {
-    showModal(cookie);
-  }, [showModal, cookie]);
+    showModal(CookieModifyModal, cookie);
+  }, [cookie]);
 
   const cookieString = cookieToString(ToughCookie.fromJSON(cookie));
   return <tr className="selectable" key={index}>
@@ -71,7 +71,6 @@ const CookieRow: FC<{
 export const CookieList: FC<CookieListProps> = ({
   cookies,
   handleDeleteAll,
-  handleShowModifyCookieModal,
   handleCookieAdd,
   newCookieDomainName,
   handleCookieDelete,
@@ -132,7 +131,6 @@ export const CookieList: FC<CookieListProps> = ({
             index={i}
             key={i}
             deleteCookie={handleCookieDelete}
-            showModal={handleShowModifyCookieModal}
           />
         ))}
       </tbody>

--- a/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
@@ -16,7 +16,7 @@ import {
   getAuthTypeName,
 } from '../../../common/constants';
 import * as models from '../../../models';
-import type { Request, RequestAuthentication } from '../../../models/request';
+import { update } from '../../../models/helpers/request-operations';
 import { selectActiveRequest } from '../../redux/selectors';
 import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
@@ -38,11 +38,7 @@ const AuthItem: FC<{
 );
 AuthItem.displayName = DropdownItem.name;
 
-interface Props {
-  onChange: (request: Request, arg1: RequestAuthentication) => Promise<Request>;
-}
-
-export const AuthDropdown: FC<Props> = ({ onChange }) => {
+export const AuthDropdown: FC = () => {
   const activeRequest = useSelector(selectActiveRequest);
 
   const onClick = useCallback(async (type: string) => {
@@ -84,9 +80,8 @@ export const AuthDropdown: FC<Props> = ({ onChange }) => {
         break;
       }
     }
-    onChange(activeRequest, newAuthentication);
-  }, [onChange, activeRequest]);
-
+    update(activeRequest, { authentication:newAuthentication });
+  }, [activeRequest]);
   const isCurrent = useCallback((type: string) => {
     if (!activeRequest) {
       return false;

--- a/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
@@ -6,7 +6,7 @@ import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
 import type { Environment } from '../../../models/environment';
 import type { Workspace } from '../../../models/workspace';
-import { selectHotKeyRegistry } from '../../redux/selectors';
+import { selectEnvironments, selectHotKeyRegistry } from '../../redux/selectors';
 import { type DropdownHandle, Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -20,7 +20,6 @@ import { Tooltip } from '../tooltip';
 interface Props {
   activeEnvironment?: Environment | null;
   environmentHighlightColorStyle: EnvironmentHighlightColorStyle;
-  environments: Environment[];
   handleSetActiveEnvironment: Function;
   workspace: Workspace;
 }
@@ -28,10 +27,10 @@ interface Props {
 export const EnvironmentsDropdown: FC<Props> = ({
   activeEnvironment,
   environmentHighlightColorStyle,
-  environments,
   handleSetActiveEnvironment,
   workspace,
 }) => {
+  const environments = useSelector(selectEnvironments);
   const hotKeyRegistry = useSelector(selectHotKeyRegistry);
   const dropdownRef = useRef<DropdownHandle>(null);
   const handleShowEnvironmentModal = useCallback(() => {

--- a/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
@@ -21,7 +21,7 @@ interface Props {
   activeEnvironment?: Environment | null;
   environmentHighlightColorStyle: EnvironmentHighlightColorStyle;
   environments: Environment[];
-  handleChangeEnvironment: Function;
+  handleSetActiveEnvironment: Function;
   workspace: Workspace;
 }
 
@@ -29,7 +29,7 @@ export const EnvironmentsDropdown: FC<Props> = ({
   activeEnvironment,
   environmentHighlightColorStyle,
   environments,
-  handleChangeEnvironment,
+  handleSetActiveEnvironment,
   workspace,
 }) => {
   const hotKeyRegistry = useSelector(selectHotKeyRegistry);
@@ -85,7 +85,7 @@ export const EnvironmentsDropdown: FC<Props> = ({
           <DropdownItem
             key={environment._id}
             value={environment._id}
-            onClick={handleChangeEnvironment}
+            onClick={handleSetActiveEnvironment}
           >
             <i
               className="fa fa-random"
@@ -97,7 +97,7 @@ export const EnvironmentsDropdown: FC<Props> = ({
           </DropdownItem>
         ))}
 
-        <DropdownItem onClick={handleChangeEnvironment}>
+        <DropdownItem onClick={handleSetActiveEnvironment}>
           <i className="fa fa-empty" /> No Environment
         </DropdownItem>
 

--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -16,10 +16,6 @@ import type { GitLogEntry, GitVCS } from '../../../sync/git/git-vcs';
 import { MemClient } from '../../../sync/git/mem-client';
 import { getOauth2FormatName } from '../../../sync/git/utils';
 import { initialize as initializeEntities } from '../../redux/modules/entities';
-import type {
-  SetupGitRepositoryCallback,
-  UpdateGitRepositoryCallback,
-} from '../../redux/modules/git';
 import * as gitActions from '../../redux/modules/git';
 import { type DropdownHandle, Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
@@ -32,17 +28,14 @@ import { GitBranchesModal } from '../modals/git-branches-modal';
 import { GitLogModal } from '../modals/git-log-modal';
 import { GitStagingModal } from '../modals/git-staging-modal';
 
-interface Props {
-  handleInitializeEntities: typeof initializeEntities;
+type Props = ReturnType<typeof mapDispatchToProps> & {
   handleGitBranchChanged: (branch: string) => void;
   workspace: Workspace;
   vcs: GitVCS;
   gitRepository: GitRepository | null;
-  setupGitRepository: SetupGitRepositoryCallback;
-  updateGitRepository: UpdateGitRepositoryCallback;
   className?: string;
   renderDropdownButton?: (children: ReactNode) => ReactNode;
-}
+};
 
 interface State {
   initializing: boolean;
@@ -416,10 +409,11 @@ class GitSyncDropdown extends PureComponent<Props, State> {
 }
 
 function mapDispatchToProps(dispatch: Dispatch<AnyAction>) {
-  const boundGitActions = bindActionCreators(gitActions, dispatch);
+  const boundGitActions = bindActionCreators({ ...gitActions, initializeEntities }, dispatch);
   return {
     setupGitRepository: boundGitActions.setupGitRepository,
     updateGitRepository: boundGitActions.updateGitRepository,
+    handleInitializeEntities: boundGitActions.initializeEntities,
   };
 }
 

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -103,7 +103,7 @@ export const RequestActionsDropdown = forwardRef<DropdownHandle, Props>(({
     if (cmd) {
       clipboard.writeText(cmd);
     }
-  }, []);
+  }, [activeEnvironment, request._id]);
 
   const togglePin = useCallback(() => {
     updateRequestMetaByParentId(request._id, { pinned: !isPinned });

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -23,13 +23,13 @@ import { DropdownDivider } from '../base/dropdown/dropdown-divider';
 import { DropdownHint } from '../base/dropdown/dropdown-hint';
 import { DropdownItem } from '../base/dropdown/dropdown-item';
 import { PromptButton } from '../base/prompt-button';
-import { showError } from '../modals';
+import { showError, showModal } from '../modals';
+import { GenerateCodeModal } from '../modals/generate-code-modal';
 
 interface Props extends Pick<DropdownProps, 'right'> {
   activeEnvironment?: Environment | null;
   activeProject: Project;
   handleDuplicateRequest: Function;
-  handleGenerateCode: Function;
   handleCopyAsCurl: Function;
   handleShowSettings: () => void;
   isPinned: Boolean;
@@ -42,7 +42,6 @@ export const RequestActionsDropdown = forwardRef<DropdownHandle, Props>(({
   activeProject,
   handleCopyAsCurl,
   handleDuplicateRequest,
-  handleGenerateCode,
   handleShowSettings,
   isPinned,
   request,
@@ -90,8 +89,8 @@ export const RequestActionsDropdown = forwardRef<DropdownHandle, Props>(({
   }, [handleDuplicateRequest, request]);
 
   const generateCode = useCallback(() => {
-    handleGenerateCode(request);
-  }, [handleGenerateCode, request]);
+    showModal(GenerateCodeModal, request);
+  }, [request]);
 
   const copyAsCurl = useCallback(() => {
     handleCopyAsCurl(request);

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -15,6 +15,7 @@ import { incrementDeletedRequests } from '../../../models/stats';
 import type { RequestAction } from '../../../plugins';
 import { getRequestActions } from '../../../plugins';
 import * as pluginContexts from '../../../plugins/context/index';
+import { updateRequestMetaByParentId } from '../../hooks/create-request';
 import { selectHotKeyRegistry } from '../../redux/selectors';
 import { type DropdownHandle, type DropdownProps, Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
@@ -27,7 +28,6 @@ import { showError } from '../modals';
 interface Props extends Pick<DropdownProps, 'right'> {
   activeEnvironment?: Environment | null;
   activeProject: Project;
-  handleSetRequestPinned: Function;
   handleDuplicateRequest: Function;
   handleGenerateCode: Function;
   handleCopyAsCurl: Function;
@@ -43,7 +43,6 @@ export const RequestActionsDropdown = forwardRef<DropdownHandle, Props>(({
   handleCopyAsCurl,
   handleDuplicateRequest,
   handleGenerateCode,
-  handleSetRequestPinned,
   handleShowSettings,
   isPinned,
   request,
@@ -99,8 +98,8 @@ export const RequestActionsDropdown = forwardRef<DropdownHandle, Props>(({
   }, [handleCopyAsCurl, request]);
 
   const togglePin = useCallback(() => {
-    handleSetRequestPinned(request, !isPinned);
-  }, [handleSetRequestPinned, isPinned, request]);
+    updateRequestMetaByParentId(request._id, { pinned:!isPinned });
+  }, [isPinned, request]);
 
   const deleteRequest = useCallback(() => {
     incrementDeletedRequests();

--- a/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -18,12 +18,11 @@ import { DropdownDivider } from '../base/dropdown/dropdown-divider';
 import { DropdownHint } from '../base/dropdown/dropdown-hint';
 import { DropdownItem } from '../base/dropdown/dropdown-item';
 import { PromptButton } from '../base/prompt-button';
-import { showError, showModal } from '../modals';
+import { showError, showModal, showPrompt } from '../modals';
 import { EnvironmentEditModal } from '../modals/environment-edit-modal';
 
 interface Props extends Partial<DropdownProps> {
   requestGroup: RequestGroup;
-  handleDuplicateRequestGroup: (requestGroup: RequestGroup) => any;
   handleShowSettings: (requestGroup: RequestGroup) => any;
 }
 
@@ -34,7 +33,6 @@ interface RequestGroupActionsDropdownHandle {
 export const RequestGroupActionsDropdown = forwardRef<RequestGroupActionsDropdownHandle, Props>(({
   requestGroup,
   handleShowSettings,
-  handleDuplicateRequestGroup,
   ...other
 }, ref) => {
   const hotKeyRegistry = useSelector(selectHotKeyRegistry);
@@ -65,8 +63,20 @@ export const RequestGroupActionsDropdown = forwardRef<RequestGroupActionsDropdow
   }, []);
 
   const handleRequestGroupDuplicate = useCallback(() => {
-    handleDuplicateRequestGroup(requestGroup);
-  }, [requestGroup, handleDuplicateRequestGroup]);
+    showPrompt({
+      title: 'Duplicate Folder',
+      defaultValue: requestGroup.name,
+      submitName: 'Create',
+      label: 'New Name',
+      selectText: true,
+      onComplete: async (name: string) => {
+        const newRequestGroup = await models.requestGroup.duplicate(requestGroup, {
+          name,
+        });
+        models.stats.incrementCreatedRequestsForDescendents(newRequestGroup);
+      },
+    });
+  }, [requestGroup]);
 
   const createGroup = useCallback(() => {
     createRequestGroup(requestGroup._id);

--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -22,7 +22,7 @@ import { interceptAccessError } from '../../../sync/vcs/util';
 import { VCS } from '../../../sync/vcs/vcs';
 import { RootState } from '../../redux/modules';
 import { activateWorkspace } from '../../redux/modules/workspace';
-import { selectRemoteProjects } from '../../redux/selectors';
+import { selectRemoteProjects, selectSyncItems } from '../../redux/selectors';
 import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -47,6 +47,7 @@ type ReduxProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDisp
 
 const mapStateToProps = (state: RootState) => ({
   remoteProjects: selectRemoteProjects(state),
+  syncItems: selectSyncItems(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {

--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -12,7 +12,6 @@ import { strings } from '../../../common/strings';
 import * as models from '../../../models';
 import { isRemoteProject, Project } from '../../../models/project';
 import type { Workspace } from '../../../models/workspace';
-import { WorkspaceMeta } from '../../../models/workspace-meta';
 import { Snapshot, Status, StatusCandidate } from '../../../sync/types';
 import { pushSnapshotOnInitialize } from '../../../sync/vcs/initialize-backend-project';
 import { logCollectionMovedToProject } from '../../../sync/vcs/migrate-collections';
@@ -22,7 +21,7 @@ import { interceptAccessError } from '../../../sync/vcs/util';
 import { VCS } from '../../../sync/vcs/vcs';
 import { RootState } from '../../redux/modules';
 import { activateWorkspace } from '../../redux/modules/workspace';
-import { selectRemoteProjects, selectSyncItems } from '../../redux/selectors';
+import { selectActiveWorkspaceMeta, selectRemoteProjects, selectSyncItems } from '../../redux/selectors';
 import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -48,6 +47,7 @@ type ReduxProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDisp
 const mapStateToProps = (state: RootState) => ({
   remoteProjects: selectRemoteProjects(state),
   syncItems: selectSyncItems(state),
+  workspaceMeta: selectActiveWorkspaceMeta(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
@@ -59,7 +59,6 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
 
 interface Props extends ReduxProps {
   workspace: Workspace;
-  workspaceMeta?: WorkspaceMeta;
   project: Project;
   vcs: VCS;
   syncItems: StatusCandidate[];

--- a/packages/insomnia/src/ui/components/editors/body/body-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/body-editor.tsx
@@ -12,9 +12,9 @@ import {
 } from '../../../../common/constants';
 import { documentationLinks } from '../../../../common/documentation';
 import { getContentTypeHeader } from '../../../../common/misc';
+import { update } from '../../../../models/helpers/request-operations';
 import type {
   Request,
-  RequestBody,
   RequestBodyParameter,
   RequestHeader,
 } from '../../../../models/request';
@@ -37,9 +37,7 @@ import { RawEditor } from './raw-editor';
 import { UrlEncodedEditor } from './url-encoded-editor';
 
 interface Props {
-  onChange: (r: Request, body: RequestBody) => Promise<Request>;
   onChangeHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
-  handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   request: Request;
   workspace: Workspace;
   settings: Settings;
@@ -47,7 +45,6 @@ interface Props {
 }
 
 export const BodyEditor: FC<Props> = ({
-  onChange,
   onChangeHeaders,
   request,
   workspace,
@@ -56,29 +53,29 @@ export const BodyEditor: FC<Props> = ({
 }) => {
   const handleRawChange = useCallback((rawValue: string) => {
     const oldContentType = request.body.mimeType || '';
-    const newBody = newBodyRaw(rawValue, oldContentType);
-    onChange(request, newBody);
-  }, [onChange, request]);
+    const body = newBodyRaw(rawValue, oldContentType);
+    update(request, { body });
+  }, [request]);
 
   const handleGraphQLChange = useCallback((content: string) => {
-    const newBody = newBodyRaw(content, CONTENT_TYPE_GRAPHQL);
-    onChange(request, newBody);
-  }, [onChange, request]);
+    const body = newBodyRaw(content, CONTENT_TYPE_GRAPHQL);
+    update(request, { body });
+  }, [request]);
 
   const handleFormUrlEncodedChange = useCallback((parameters: RequestBodyParameter[]) => {
-    const newBody = newBodyFormUrlEncoded(parameters);
-    onChange(request, newBody);
-  }, [onChange, request]);
+    const body = newBodyFormUrlEncoded(parameters);
+    update(request, { body });
+  }, [request]);
 
   const handleFormChange = useCallback((parameters: RequestBodyParameter[]) => {
-    const newBody = newBodyForm(parameters);
-    onChange(request, newBody);
-  }, [onChange, request]);
+    const body = newBodyForm(parameters);
+    update(request, { body });
+  }, [request]);
 
   const handleFileChange = async (path: string) => {
     const headers = clone(request.headers);
-    const newBody = newBodyFile(path);
-    const newRequest = await onChange(request, newBody);
+    const body = newBodyFile(path);
+    const newRequest = await update(request, { body });
     let contentTypeHeader = getContentTypeHeader(headers);
 
     if (!contentTypeHeader) {

--- a/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
@@ -1,18 +1,17 @@
 import React, { FC, useCallback } from 'react';
 
 import { getCommonHeaderNames, getCommonHeaderValues } from '../../../common/common-headers';
+import { update } from '../../../models/helpers/request-operations';
 import type { Request, RequestHeader } from '../../../models/request';
 import { CodeEditor } from '../codemirror/code-editor';
 import { KeyValueEditor } from '../key-value-editor/key-value-editor';
 
 interface Props {
-  onChange: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   bulk: boolean;
   request: Request;
 }
 
 export const RequestHeadersEditor: FC<Props> = ({
-  onChange,
   request,
   bulk,
 }) => {
@@ -38,8 +37,8 @@ export const RequestHeadersEditor: FC<Props> = ({
       });
     }
 
-    onChange(request, headers);
-  }, [onChange, request]);
+    update(request, { headers });
+  }, [request]);
 
   let headersString = '';
   for (const header of request.headers) {
@@ -56,8 +55,8 @@ export const RequestHeadersEditor: FC<Props> = ({
   }
 
   const onChangeHeaders = useCallback((headers: RequestHeader[]) => {
-    onChange(request, headers);
-  }, [onChange, request]);
+    update(request, { headers });
+  }, [request]);
 
   if (bulk) {
     return (

--- a/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
@@ -1,22 +1,21 @@
 import React, { FC, useCallback } from 'react';
 
+import { update } from '../../../models/helpers/request-operations';
 import type { Request, RequestParameter } from '../../../models/request';
 import { CodeEditor } from '../codemirror/code-editor';
 import { KeyValueEditor } from '../key-value-editor/key-value-editor';
 
 interface Props {
-  onChange: (r: Request, parameters: RequestParameter[]) => Promise<Request>;
   bulk: boolean;
   request: Request;
 }
 
 export const RequestParametersEditor: FC<Props> = ({
-  onChange,
   request,
   bulk,
 }) => {
   const handleBulkUpdate = useCallback((paramsString: string) => {
-    const params: {
+    const parameters: {
       name: string;
       value: string;
     }[] = [];
@@ -31,14 +30,13 @@ export const RequestParametersEditor: FC<Props> = ({
         continue;
       }
 
-      params.push({
+      parameters.push({
         name,
         value,
       });
     }
-
-    onChange(request, params);
-  }, [onChange, request]);
+    update(request, { parameters });
+  }, [request]);
 
   let paramsString = '';
   for (const param of request.parameters) {
@@ -55,8 +53,8 @@ export const RequestParametersEditor: FC<Props> = ({
   }
 
   const onChangeParameter = useCallback((parameters: RequestParameter[]) => {
-    onChange(request, parameters);
-  }, [onChange, request]);
+    update(request, { parameters });
+  }, [request]);
 
   if (bulk) {
     return (

--- a/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
@@ -14,11 +14,10 @@ import { Modal, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
-import { CookieList, CookieListProps } from '../cookie-list';
+import { CookieList } from '../cookie-list';
 import { showModal } from '.';
 
 interface Props extends ModalProps {
-  handleShowModifyCookieModal: CookieListProps['handleShowModifyCookieModal'];
   handleRender: HandleRender;
   activeCookieJar: CookieJar | null;
 }
@@ -183,7 +182,7 @@ class CookiesModal extends PureComponent<Props, State> {
   }
 
   render() {
-    const { handleShowModifyCookieModal, activeCookieJar } = this.props;
+    const { activeCookieJar } = this.props;
     const { filter } = this.state;
 
     const cookies = this._getVisibleCookies();
@@ -211,7 +210,6 @@ class CookiesModal extends PureComponent<Props, State> {
               <div className="cookie-list__list border-tops pad">
                 <CookieList
                   cookies={cookies}
-                  handleShowModifyCookieModal={handleShowModifyCookieModal}
                   handleDeleteAll={this._handleDeleteAllCookies}
                   handleCookieAdd={this._handleCookieAdd}
                   handleCookieDelete={this._handleCookieDelete} // Set the domain to the filter so that it shows up if we're filtering

--- a/packages/insomnia/src/ui/components/modals/export-requests-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/export-requests-modal.tsx
@@ -254,4 +254,4 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
   };
 };
 
-export const ExportRequestsModal = connect(mapStateToProps, mapDispatchToProps)(ExportRequestsModalClass);
+export const ExportRequestsModal = connect(mapStateToProps, mapDispatchToProps, null, { forwardRef:true })(ExportRequestsModalClass);

--- a/packages/insomnia/src/ui/components/modals/export-requests-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/export-requests-modal.tsx
@@ -8,13 +8,14 @@ import * as models from '../../../models';
 import { GrpcRequest, isGrpcRequest } from '../../../models/grpc-request';
 import { isRequest, Request } from '../../../models/request';
 import { isRequestGroup, RequestGroup } from '../../../models/request-group';
+import { RootState } from '../../redux/modules';
 import { exportRequestsToFile } from '../../redux/modules/global';
+import { selectSidebarChildren } from '../../redux/sidebar-selectors';
 import { Modal, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
 import { Tree } from '../export-requests/tree';
-import { Child } from '../sidebar/sidebar-children';
 
 export interface Node {
   doc: Request | GrpcRequest | RequestGroup;
@@ -24,9 +25,7 @@ export interface Node {
   selectedRequests: number;
 }
 
-type Props = ModalProps & ReturnType<typeof mapDispatchToProps> & {
-  childObjects: Child[];
-};
+type Props = ModalProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
 
 interface State {
   treeRoot: Node | null;
@@ -85,7 +84,8 @@ export class ExportRequestsModalClass extends PureComponent<Props, State> {
   }
 
   createTree() {
-    const { childObjects } = this.props;
+    const { sidebarChildren } = this.props;
+    const childObjects = sidebarChildren.all;
     const children: Node[] = childObjects.map(child => this.createNode(child));
     const totalRequests = children
       .map(child => child.totalRequests)
@@ -244,6 +244,9 @@ export class ExportRequestsModalClass extends PureComponent<Props, State> {
   }
 }
 
+const mapStateToProps = (state: RootState) => ({
+  sidebarChildren: selectSidebarChildren(state),
+});
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
   const bound = bindActionCreators({ exportRequestsToFile }, dispatch);
   return {
@@ -251,4 +254,4 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
   };
 };
 
-export const ExportRequestsModal = connect(null, mapDispatchToProps)(ExportRequestsModalClass);
+export const ExportRequestsModal = connect(mapStateToProps, mapDispatchToProps)(ExportRequestsModalClass);

--- a/packages/insomnia/src/ui/components/modals/export-requests-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/export-requests-modal.tsx
@@ -1,11 +1,14 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { AnyAction, bindActionCreators, Dispatch } from 'redux';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
 import * as models from '../../../models';
 import { GrpcRequest, isGrpcRequest } from '../../../models/grpc-request';
 import { isRequest, Request } from '../../../models/request';
 import { isRequestGroup, RequestGroup } from '../../../models/request-group';
+import { exportRequestsToFile } from '../../redux/modules/global';
 import { Modal, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
@@ -21,17 +24,16 @@ export interface Node {
   selectedRequests: number;
 }
 
-interface Props extends ModalProps {
+type Props = ModalProps & ReturnType<typeof mapDispatchToProps> & {
   childObjects: Child[];
-  handleExportRequestsToFile: Function;
-}
+};
 
 interface State {
   treeRoot: Node | null;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-export class ExportRequestsModal extends PureComponent<Props, State> {
+export class ExportRequestsModalClass extends PureComponent<Props, State> {
   modal: Modal | null = null;
 
   state: State = {
@@ -241,3 +243,12 @@ export class ExportRequestsModal extends PureComponent<Props, State> {
     );
   }
 }
+
+const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
+  const bound = bindActionCreators({ exportRequestsToFile }, dispatch);
+  return {
+    handleExportRequestsToFile: bound.exportRequestsToFile,
+  };
+};
+
+export const ExportRequestsModal = connect(null, mapDispatchToProps)(ExportRequestsModalClass);

--- a/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
@@ -317,4 +317,4 @@ function mapDispatchToProps(dispatch: Dispatch<AnyAction>) {
   };
 }
 
-export const GitBranchesModal = connect(null, mapDispatchToProps)(GitBranchesModalClass);
+export const GitBranchesModal = connect(null, mapDispatchToProps, null, { forwardRef: true })(GitBranchesModalClass);

--- a/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
@@ -1,6 +1,8 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import React, { Fragment, PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { AnyAction, bindActionCreators, Dispatch } from 'redux';
 
 import { SegmentEvent, trackSegmentEvent, vcsSegmentEventProperties } from '../../../common/analytics';
 import { AUTOBIND_CFG } from '../../../common/constants';
@@ -15,12 +17,11 @@ import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
 import { PromptButton } from '../base/prompt-button';
 
-interface Props {
+type Props = ReturnType<typeof mapDispatchToProps> & {
   vcs: GitVCS;
   gitRepository: GitRepository;
-  handleInitializeEntities: typeof initializeEntities;
   handleGitBranchChanged: (branch: string) => void;
-}
+};
 
 interface State {
   error: string;
@@ -31,7 +32,7 @@ interface State {
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-export class GitBranchesModal extends PureComponent<Props, State> {
+class GitBranchesModalClass extends PureComponent<Props, State> {
   modal: Modal | null = null;
   input: HTMLInputElement | null = null;
   _onHide?: (() => void) | null;
@@ -309,3 +310,11 @@ export class GitBranchesModal extends PureComponent<Props, State> {
     );
   }
 }
+function mapDispatchToProps(dispatch: Dispatch<AnyAction>) {
+  const boundGitActions = bindActionCreators({ initializeEntities }, dispatch);
+  return {
+    handleInitializeEntities: boundGitActions.initializeEntities,
+  };
+}
+
+export const GitBranchesModal = connect(null, mapDispatchToProps)(GitBranchesModalClass);

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -26,7 +26,7 @@ import { Tooltip } from '../tooltip';
 const ROOT_ENVIRONMENT_NAME = 'Base Environment';
 
 interface Props extends ModalProps {
-  handleChangeEnvironment: (id: string | null) => void;
+  handleSetActiveEnvironment: (id: string | null) => void;
   activeEnvironmentId: string | null;
 }
 
@@ -243,7 +243,7 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
   }
 
   async _handleDeleteEnvironment(_event: React.MouseEvent, environment?: Environment) {
-    const { handleChangeEnvironment, activeEnvironmentId } = this.props;
+    const { handleSetActiveEnvironment, activeEnvironmentId } = this.props;
     const { rootEnvironment, workspace } = this.state;
 
     // Don't delete the root environment
@@ -255,7 +255,7 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
     // TODO: unsound non-null assertion
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     if (activeEnvironmentId === environment!._id) {
-      handleChangeEnvironment(null);
+      handleSetActiveEnvironment(null);
     }
 
     // Delete the current one
@@ -417,7 +417,7 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
   }
 
   _handleActivateEnvironment: ButtonProps<Environment>['onClick'] = (event, environment) => {
-    const { handleChangeEnvironment, activeEnvironmentId } = this.props;
+    const { handleSetActiveEnvironment, activeEnvironmentId } = this.props;
 
     if (!environment) {
       return;
@@ -427,7 +427,7 @@ export class WorkspaceEnvironmentsEditModal extends PureComponent<Props, State> 
       return;
     }
 
-    handleChangeEnvironment(environment._id);
+    handleSetActiveEnvironment(environment._id);
     this._handleShowEnvironment(event, environment);
   };
 

--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -12,7 +12,7 @@ import * as workspaceOperations from '../../../models/helpers/workspace-operatio
 import * as models from '../../../models/index';
 import type { Workspace } from '../../../models/workspace';
 import { RootState } from '../../redux/modules';
-import { selectActiveWorkspaceName } from '../../redux/selectors';
+import { selectActiveWorkspaceClientCertificates, selectActiveWorkspaceName } from '../../redux/selectors';
 import { DebouncedInput } from '../base/debounced-input';
 import { FileInputButton } from '../base/file-input-button';
 import { Modal } from '../base/modal';
@@ -62,7 +62,6 @@ const CertificateField: FC<{
 type ReduxProps = ReturnType<typeof mapStateToProps>;
 
 interface Props extends ReduxProps {
-  clientCertificates: ClientCertificate[];
   workspace: Workspace;
   apiSpec: ApiSpec;
   handleRemoveWorkspace: Function;
@@ -521,6 +520,7 @@ export class UnconnectedWorkspaceSettingsModal extends PureComponent<Props, Stat
 
 const mapStateToProps = (state: RootState) => ({
   activeWorkspaceName: selectActiveWorkspaceName(state),
+  clientCertificates: selectActiveWorkspaceClientCertificates(state),
 });
 
 export const WorkspaceSettingsModal = connect(mapStateToProps, null, null, { forwardRef: true })(UnconnectedWorkspaceSettingsModal);

--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -2,17 +2,21 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import React, { FC, PureComponent, ReactNode } from 'react';
 import { connect } from 'react-redux';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
+import { AnyAction, bindActionCreators, Dispatch } from 'redux';
 import styled from 'styled-components';
 
-import { AUTOBIND_CFG } from '../../../common/constants';
+import { ACTIVITY_HOME, AUTOBIND_CFG } from '../../../common/constants';
+import { database as db } from '../../../common/database';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
 import type { ApiSpec } from '../../../models/api-spec';
 import type { ClientCertificate } from '../../../models/client-certificate';
 import * as workspaceOperations from '../../../models/helpers/workspace-operations';
 import * as models from '../../../models/index';
+import { isRequest } from '../../../models/request';
 import type { Workspace } from '../../../models/workspace';
 import { RootState } from '../../redux/modules';
-import { selectActiveWorkspaceClientCertificates, selectActiveWorkspaceName } from '../../redux/selectors';
+import { setActiveActivity } from '../../redux/modules/global';
+import { selectActiveWorkspace, selectActiveWorkspaceClientCertificates, selectActiveWorkspaceName } from '../../redux/selectors';
 import { DebouncedInput } from '../base/debounced-input';
 import { FileInputButton } from '../base/file-input-button';
 import { Modal } from '../base/modal';
@@ -59,13 +63,11 @@ const CertificateField: FC<{
   );
 };
 
-type ReduxProps = ReturnType<typeof mapStateToProps>;
+type ReduxProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
 
 interface Props extends ReduxProps {
   workspace: Workspace;
   apiSpec: ApiSpec;
-  handleRemoveWorkspace: Function;
-  handleClearAllResponses: Function;
 }
 
 interface State {
@@ -110,13 +112,33 @@ export class UnconnectedWorkspaceSettingsModal extends PureComponent<Props, Stat
     this.modal = modal;
   }
 
-  _handleRemoveWorkspace() {
-    this.props.handleRemoveWorkspace();
+  async _handleRemoveWorkspace() {
+    const { activeWorkspace, handleSetActiveActivity } = this.props;
+
+    if (!activeWorkspace) {
+      return;
+    }
+
+    await models.stats.incrementDeletedRequestsForDescendents(activeWorkspace);
+    await models.workspace.remove(activeWorkspace);
+
+    handleSetActiveActivity(ACTIVITY_HOME);
     this.hide();
   }
 
-  _handleClearAllResponses() {
-    this.props.handleClearAllResponses();
+  async _handleClearAllResponses() {
+    const { activeWorkspace } = this.props;
+
+    if (!activeWorkspace) {
+      return;
+    }
+
+    const docs = await db.withDescendants(activeWorkspace, models.request.type);
+    const requests = docs.filter(isRequest);
+
+    for (const req of requests) {
+      await models.response.removeForRequest(req._id);
+    }
     this.hide();
   }
 
@@ -519,8 +541,16 @@ export class UnconnectedWorkspaceSettingsModal extends PureComponent<Props, Stat
 }
 
 const mapStateToProps = (state: RootState) => ({
+  activeWorkspace: selectActiveWorkspace(state),
   activeWorkspaceName: selectActiveWorkspaceName(state),
   clientCertificates: selectActiveWorkspaceClientCertificates(state),
 });
 
-export const WorkspaceSettingsModal = connect(mapStateToProps, null, null, { forwardRef: true })(UnconnectedWorkspaceSettingsModal);
+const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
+  const bound = bindActionCreators({ setActiveActivity }, dispatch);
+  return {
+    handleSetActiveActivity: bound.setActiveActivity,
+  };
+};
+
+export const WorkspaceSettingsModal = connect(mapStateToProps, mapDispatchToProps, null, { forwardRef: true })(UnconnectedWorkspaceSettingsModal);

--- a/packages/insomnia/src/ui/components/page-layout.tsx
+++ b/packages/insomnia/src/ui/components/page-layout.tsx
@@ -5,12 +5,10 @@ import { useSelector } from 'react-redux';
 import { COLLAPSE_SIDEBAR_REMS, DEFAULT_PANE_HEIGHT, DEFAULT_PANE_WIDTH, DEFAULT_SIDEBAR_WIDTH, MAX_PANE_HEIGHT, MAX_PANE_WIDTH, MAX_SIDEBAR_REMS, MIN_PANE_HEIGHT, MIN_PANE_WIDTH, MIN_SIDEBAR_REMS } from '../../common/constants';
 import { debounce } from '../../common/misc';
 import * as models from '../../models';
-import { selectIsLoading } from '../redux/modules/global';
-import { selectActiveEnvironment, selectActiveWorkspaceMeta, selectSettings, selectUnseenWorkspaces, selectWorkspacesForActiveProject } from '../redux/selectors';
+import { selectActiveEnvironment, selectActiveWorkspaceMeta, selectSettings } from '../redux/selectors';
 import { selectPaneHeight, selectPaneWidth, selectSidebarWidth } from '../redux/sidebar-selectors';
 import { ErrorBoundary } from './error-boundary';
 import { Sidebar } from './sidebar/sidebar';
-import type { WrapperProps } from './wrapper';
 
 const Pane = forwardRef<HTMLElement, { position: string; children: ReactNode }>(
   function Pane({ children, position }, ref) {
@@ -23,7 +21,6 @@ const Pane = forwardRef<HTMLElement, { position: string; children: ReactNode }>(
 );
 
 interface Props {
-  wrapperProps: WrapperProps;
   renderPageSidebar?: ReactNode;
   renderPageHeader?: ReactNode;
   renderPageBody?: ReactNode;
@@ -37,20 +34,13 @@ export const PageLayout: FC<Props> = ({
   renderPageBody,
   renderPageHeader,
   renderPageSidebar,
-  wrapperProps,
 }) => {
   const activeEnvironment = useSelector(selectActiveEnvironment);
-  const isLoading = useSelector(selectIsLoading);
   const settings = useSelector(selectSettings);
-  const unseenWorkspaces = useSelector(selectUnseenWorkspaces);
-  const workspacesForActiveProject = useSelector(selectWorkspacesForActiveProject);
   const activeWorkspaceMeta = useSelector(selectActiveWorkspaceMeta);
   const reduxPaneHeight = useSelector(selectPaneHeight);
   const reduxPaneWidth = useSelector(selectPaneWidth);
   const reduxSidebarWidth = useSelector(selectSidebarWidth);
-  const {
-    handleSetActiveEnvironment,
-  } = wrapperProps;
 
   const requestPaneRef = useRef<HTMLElement>(null);
   const responsePaneRef = useRef<HTMLElement>(null);
@@ -253,12 +243,8 @@ export const PageLayout: FC<Props> = ({
             ref={sidebarRef}
             activeEnvironment={activeEnvironment}
             environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
-            handleSetActiveEnvironment={handleSetActiveEnvironment}
             hidden={activeWorkspaceMeta?.sidebarHidden || false}
-            isLoading={isLoading}
-            unseenWorkspaces={unseenWorkspaces}
             width={sidebarWidth}
-            workspacesForActiveProject={workspacesForActiveProject}
           >
             {renderPageSidebar}
           </Sidebar>

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -6,6 +6,7 @@ import { useMount } from 'react-use';
 
 import * as models from '../../../models';
 import { queryAllWorkspaceUrls } from '../../../models/helpers/query-all-workspace-urls';
+import { update } from '../../../models/helpers/request-operations';
 import type {
   Request,
   RequestAuthentication,
@@ -44,13 +45,7 @@ interface Props {
   headerEditorKey: string;
   request?: Request | null;
   settings: Settings;
-  updateRequestAuthentication: (r: Request, auth: RequestAuthentication) => Promise<Request>;
-  updateRequestBody: (r: Request, body: RequestBody) => Promise<Request>;
-  updateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
-  updateRequestMethod: (r: Request, method: string) => Promise<Request>;
   updateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
-  updateRequestParameters: (r: Request, params: RequestParameter[]) => Promise<Request>;
-  updateRequestUrl: (r: Request, url: string) => Promise<Request>;
   updateSettingsUseBulkHeaderEditor: Function;
   updateSettingsUseBulkParametersEditor: (useBulkParametersEditor: boolean) => Promise<Settings>;
   workspace: Workspace;
@@ -70,17 +65,37 @@ export const RequestPane: FC<Props> = ({
   headerEditorKey,
   request,
   settings,
-  updateRequestAuthentication,
-  updateRequestBody,
-  updateRequestHeaders,
-  updateRequestMethod,
   updateRequestMimeType,
-  updateRequestParameters,
-  updateRequestUrl,
   updateSettingsUseBulkHeaderEditor,
   updateSettingsUseBulkParametersEditor,
   workspace,
 }) => {
+  const updateRequestBody = (request: Request, body: RequestBody) => {
+    return update(request, { body });
+  };
+
+  const updateRequestParameters = (request: Request, parameters: RequestParameter[]) => {
+    return update(request, { parameters });
+  };
+
+  const updateRequestAuthentication = (request: Request, authentication: RequestAuthentication) => {
+    return update(request, { authentication });
+  };
+
+  const updateRequestHeaders = (request: Request, headers: RequestHeader[]) => {
+    return update(request, { headers });
+  };
+
+  const updateRequestMethod = (request: Request, method: string) => {
+    return update(request, { method });
+  };
+  const updateRequestUrl = (request: Request, url: string) => {
+    if (request.url === url) {
+      return Promise.resolve(request);
+    }
+    return update(request, { url });
+  };
+
   const handleEditDescription = useCallback((forceEditMode: boolean) => {
     showModal(RequestSettingsModal, { request, forceEditMode });
   }, [request]);

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -29,7 +29,6 @@ import { Pane, paneBodyClasses, PaneHeader } from './pane';
 import { PlaceholderRequestPane } from './placeholder-request-pane';
 
 interface Props {
-  downloadPath: string | null;
   environmentId: string;
   forceRefreshCounter: number;
   forceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
@@ -43,7 +42,6 @@ interface Props {
 }
 
 export const RequestPane: FC<Props> = ({
-  downloadPath,
   environmentId,
   forceRefreshCounter,
   forceUpdateRequest,
@@ -146,7 +144,6 @@ export const RequestPane: FC<Props> = ({
             handleImport={handleImport}
             nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             request={request}
-            downloadPath={downloadPath}
           />
         </ErrorBoundary>
       </PaneHeader>

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -40,7 +40,6 @@ interface Props {
   handleImport: Function;
   handleSend: () => void;
   handleSendAndDownload: (filepath?: string) => Promise<void>;
-  handleUpdateDownloadPath: Function;
   headerEditorKey: string;
   request?: Request | null;
   settings: Settings;
@@ -59,7 +58,6 @@ export const RequestPane: FC<Props> = ({
   handleImport,
   handleSend,
   handleSendAndDownload,
-  handleUpdateDownloadPath,
   headerEditorKey,
   request,
   settings,
@@ -181,7 +179,6 @@ export const RequestPane: FC<Props> = ({
             handleSendAndDownload={handleSendAndDownload}
             nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             request={request}
-            handleUpdateDownloadPath={handleUpdateDownloadPath}
             downloadPath={downloadPath}
           />
         </ErrorBoundary>

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -9,7 +9,6 @@ import { queryAllWorkspaceUrls } from '../../../models/helpers/query-all-workspa
 import { update } from '../../../models/helpers/request-operations';
 import type {
   Request,
-  RequestBody,
   RequestHeader,
   RequestParameter,
 } from '../../../models/request';
@@ -57,10 +56,6 @@ export const RequestPane: FC<Props> = ({
   updateRequestMimeType,
   workspace,
 }) => {
-
-  const updateRequestBody = (request: Request, body: RequestBody) => {
-    return update(request, { body });
-  };
 
   const updateRequestParameters = (request: Request, parameters: RequestParameter[]) => {
     return update(request, { parameters });

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -37,7 +37,6 @@ interface Props {
   forceRefreshCounter: number;
   forceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
   forceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
-  handleGenerateCode: Function;
   handleImport: Function;
   handleSend: () => void;
   handleSendAndDownload: (filepath?: string) => Promise<void>;
@@ -57,7 +56,6 @@ export const RequestPane: FC<Props> = ({
   forceRefreshCounter,
   forceUpdateRequest,
   forceUpdateRequestHeaders,
-  handleGenerateCode,
   handleImport,
   handleSend,
   handleSendAndDownload,
@@ -70,6 +68,7 @@ export const RequestPane: FC<Props> = ({
   updateSettingsUseBulkParametersEditor,
   workspace,
 }) => {
+
   const updateRequestBody = (request: Request, body: RequestBody) => {
     return update(request, { body });
   };
@@ -178,7 +177,6 @@ export const RequestPane: FC<Props> = ({
             onUrlChange={updateRequestUrl}
             handleAutocompleteUrls={autocompleteUrls}
             handleImport={handleImport}
-            handleGenerateCode={handleGenerateCode}
             handleSend={handleSend}
             handleSendAndDownload={handleSendAndDownload}
             nunjucksPowerUserMode={settings.nunjucksPowerUserMode}

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -10,7 +10,6 @@ import { update } from '../../../models/helpers/request-operations';
 import type {
   Request,
   RequestHeader,
-  RequestParameter,
 } from '../../../models/request';
 import type { Settings } from '../../../models/settings';
 import type { Workspace } from '../../../models/workspace';
@@ -57,17 +56,6 @@ export const RequestPane: FC<Props> = ({
   workspace,
 }) => {
 
-  const updateRequestParameters = (request: Request, parameters: RequestParameter[]) => {
-    return update(request, { parameters });
-  };
-
-  const updateRequestHeaders = (request: Request, headers: RequestHeader[]) => {
-    return update(request, { headers });
-  };
-
-  const updateRequestMethod = (request: Request, method: string) => {
-    return update(request, { method });
-  };
   const updateRequestUrl = (request: Request, url: string) => {
     if (request.url === url) {
       return Promise.resolve(request);
@@ -153,7 +141,6 @@ export const RequestPane: FC<Props> = ({
             key={request._id}
             ref={requestUrlBarRef}
             uniquenessKey={uniqueKey}
-            onMethodChange={updateRequestMethod}
             onUrlChange={updateRequestUrl}
             handleAutocompleteUrls={autocompleteUrls}
             handleImport={handleImport}
@@ -232,7 +219,6 @@ export const RequestPane: FC<Props> = ({
             >
               <RequestParametersEditor
                 key={headerEditorKey}
-                onChange={updateRequestParameters}
                 request={request}
                 bulk={settings.useBulkParametersEditor}
               />
@@ -258,7 +244,6 @@ export const RequestPane: FC<Props> = ({
           <ErrorBoundary key={uniqueKey} errorClassName="font-error pad text-center">
             <RequestHeadersEditor
               key={headerEditorKey}
-              onChange={updateRequestHeaders}
               request={request}
               bulk={settings.useBulkHeaderEditor}
             />

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -9,7 +9,6 @@ import { queryAllWorkspaceUrls } from '../../../models/helpers/query-all-workspa
 import { update } from '../../../models/helpers/request-operations';
 import type {
   Request,
-  RequestAuthentication,
   RequestBody,
   RequestHeader,
   RequestParameter,
@@ -205,12 +204,10 @@ export const RequestPane: FC<Props> = ({
         <TabPanel key={uniqueKey} className="react-tabs__tab-panel editor-wrapper">
           <BodyEditor
             key={uniqueKey}
-            handleUpdateRequestMimeType={updateRequestMimeType}
             request={request}
             workspace={workspace}
             environmentId={environmentId}
             settings={settings}
-            onChange={updateRequestBody}
             onChangeHeaders={forceUpdateRequestHeaders}
           />
         </TabPanel>

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -44,8 +44,6 @@ interface Props {
   request?: Request | null;
   settings: Settings;
   updateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
-  updateSettingsUseBulkHeaderEditor: Function;
-  updateSettingsUseBulkParametersEditor: (useBulkParametersEditor: boolean) => Promise<Settings>;
   workspace: Workspace;
 }
 
@@ -62,8 +60,6 @@ export const RequestPane: FC<Props> = ({
   request,
   settings,
   updateRequestMimeType,
-  updateSettingsUseBulkHeaderEditor,
-  updateSettingsUseBulkParametersEditor,
   workspace,
 }) => {
 
@@ -106,12 +102,12 @@ export const RequestPane: FC<Props> = ({
   }, [workspace, request]);
 
   const handleUpdateSettingsUseBulkHeaderEditor = useCallback(() => {
-    updateSettingsUseBulkHeaderEditor(!settings.useBulkHeaderEditor);
-  }, [settings, updateSettingsUseBulkHeaderEditor]);
+    models.settings.update(settings, { useBulkHeaderEditor:!settings.useBulkHeaderEditor });
+  }, [settings]);
 
   const handleUpdateSettingsUseBulkParametersEditor = useCallback(() => {
-    updateSettingsUseBulkParametersEditor(!settings.useBulkParametersEditor);
-  }, [settings, updateSettingsUseBulkParametersEditor]);
+    models.settings.update(settings, { useBulkParametersEditor:!settings.useBulkParametersEditor });
+  }, [settings]);
 
   const handleImportQueryFromUrl = useCallback(() => {
     if (!request) {

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -38,8 +38,6 @@ interface Props {
   forceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
   forceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleImport: Function;
-  handleSend: () => void;
-  handleSendAndDownload: (filepath?: string) => Promise<void>;
   headerEditorKey: string;
   request?: Request | null;
   settings: Settings;
@@ -54,8 +52,6 @@ export const RequestPane: FC<Props> = ({
   forceUpdateRequest,
   forceUpdateRequestHeaders,
   handleImport,
-  handleSend,
-  handleSendAndDownload,
   headerEditorKey,
   request,
   settings,
@@ -69,10 +65,6 @@ export const RequestPane: FC<Props> = ({
 
   const updateRequestParameters = (request: Request, parameters: RequestParameter[]) => {
     return update(request, { parameters });
-  };
-
-  const updateRequestAuthentication = (request: Request, authentication: RequestAuthentication) => {
-    return update(request, { authentication });
   };
 
   const updateRequestHeaders = (request: Request, headers: RequestHeader[]) => {
@@ -171,8 +163,6 @@ export const RequestPane: FC<Props> = ({
             onUrlChange={updateRequestUrl}
             handleAutocompleteUrls={autocompleteUrls}
             handleImport={handleImport}
-            handleSend={handleSend}
-            handleSendAndDownload={handleSendAndDownload}
             nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             request={request}
             downloadPath={downloadPath}
@@ -187,9 +177,7 @@ export const RequestPane: FC<Props> = ({
             />
           </Tab>
           <Tab tabIndex="-1">
-            <AuthDropdown
-              onChange={updateRequestAuthentication}
-            />
+            <AuthDropdown />
           </Tab>
           <Tab tabIndex="-1">
             <button>

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -32,12 +32,10 @@ import { PlaceholderResponsePane } from './placeholder-response-pane';
 
 interface Props {
   handleSetFilter: (filter: string) => void;
-  handleShowRequestSettings: Function;
   request?: Request | null;
 }
 export const ResponsePane: FC<Props> = ({
   handleSetFilter,
-  handleShowRequestSettings,
   request,
 }) => {
   const response = useSelector(selectActiveResponse);
@@ -200,7 +198,6 @@ export const ResponsePane: FC<Props> = ({
           <div className="scrollable pad">
             <ErrorBoundary key={response._id} errorClassName="font-error pad text-center">
               <ResponseCookiesViewer
-                handleShowRequestSettings={handleShowRequestSettings}
                 cookiesSent={response.settingSendCookies}
                 cookiesStored={response.settingStoreCookies}
                 headers={cookieHeaders}

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -31,13 +31,11 @@ import { Pane, paneBodyClasses, PaneHeader } from './pane';
 import { PlaceholderResponsePane } from './placeholder-response-pane';
 
 interface Props {
-  handleSetActiveResponse: Function;
   handleSetFilter: (filter: string) => void;
   handleShowRequestSettings: Function;
   request?: Request | null;
 }
 export const ResponsePane: FC<Props> = ({
-  handleSetActiveResponse,
   handleSetFilter,
   handleShowRequestSettings,
   request,
@@ -137,7 +135,6 @@ export const ResponsePane: FC<Props> = ({
           <ResponseHistoryDropdown
             activeResponse={response}
             requestId={request._id}
-            handleSetActiveResponse={handleSetActiveResponse}
             className="tall pane__header__right"
           />
         </PaneHeader>

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -11,6 +11,7 @@ import { PREVIEW_MODE_SOURCE } from '../../../common/constants';
 import { getSetCookieHeaders } from '../../../common/misc';
 import * as models from '../../../models';
 import type { Request } from '../../../models/request';
+import type { Response } from '../../../models/response';
 import { cancelRequestById } from '../../../network/network';
 import { selectActiveResponse, selectLoadStartTime, selectResponseFilter, selectResponseFilterHistory, selectResponsePreviewMode, selectSettings } from '../../redux/selectors';
 import { Button } from '../base/button';
@@ -32,10 +33,12 @@ import { PlaceholderResponsePane } from './placeholder-response-pane';
 
 interface Props {
   handleSetFilter: (filter: string) => void;
+  handleSetActiveResponse: (requestId: string, activeResponse: Response | null) => void;
   request?: Request | null;
 }
 export const ResponsePane: FC<Props> = ({
   handleSetFilter,
+  handleSetActiveResponse,
   request,
 }) => {
   const response = useSelector(selectActiveResponse);
@@ -132,6 +135,7 @@ export const ResponsePane: FC<Props> = ({
           </div>
           <ResponseHistoryDropdown
             activeResponse={response}
+            handleSetActiveResponse={handleSetActiveResponse}
             requestId={request._id}
             className="tall pane__header__right"
           />

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -181,7 +181,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
   }, [activeEnvironment, dispatch, request, settings.maxHistoryResponses, settings.preferredHttpVersion]);
 
   const handleSend = useCallback(async () => {
-    if (!request || !activeEnvironment) {
+    if (!request) {
       return;
     }
     // Update request stats
@@ -193,9 +193,8 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     });
     dispatch(loadRequestStart(request._id));
     try {
-      const responsePatch = await network.send(request._id, activeEnvironment._id);
+      const responsePatch = await network.send(request._id, activeEnvironment?._id);
       await models.response.create(responsePatch, settings.maxHistoryResponses);
-
     } catch (err) {
       if (err.type === 'render') {
         showModal(RequestRenderErrorModal, {

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -298,6 +298,11 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
       send();
     });
   }, [request.url, send]);
+  const handleGlobalKeyDown = useCallback(async (event: KeyboardEvent) => {
+    executeHotKey(event, hotKeyRefs.REQUEST_SEND, () => {
+      send();
+    });
+  }, [send]);
 
   const [lastPastedText, setLastPastedText] = useState<string>();
   const handleUrlChange = useCallback(async (url: string) => {
@@ -329,93 +334,88 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
   const { url, method } = request;
   const isCancellable = currentInterval || currentTimeout;
   return (
-    <KeydownBinder onKeydown={handleKeyDown} scoped>
-      <div className="urlbar">
-        <MethodDropdown
-          ref={methodDropdownRef}
-          onChange={methodValue => onMethodChange(methodValue)}
-          method={method}
-        />
-        <div className="urlbar__flex__right">
-          <OneLineEditor
-            key={uniquenessKey}
-            ref={inputRef}
-            onPaste={handleUrlPaste}
-            forceEditor
-            type="text"
-            getAutocompleteConstants={handleAutocompleteUrls}
-            placeholder="https://api.myproduct.com/v1/users"
-            defaultValue={url}
-            onChange={handleUrlChange}
+    <KeydownBinder onKeydown={handleGlobalKeyDown}>
+      <KeydownBinder onKeydown={handleKeyDown} scoped>
+        <div className="urlbar">
+          <MethodDropdown
+            ref={methodDropdownRef}
+            onChange={methodValue => onMethodChange(methodValue)}
+            method={method}
           />
-          {isCancellable ? (
-            <button
-              type="button"
-              className="urlbar__send-btn danger"
-              onClick={handleStop}
-            >
-              Cancel
-            </button>
-          ) : (
-            <>
+          <div className="urlbar__flex__right">
+            <OneLineEditor
+              key={uniquenessKey}
+              ref={inputRef}
+              onPaste={handleUrlPaste}
+              forceEditor
+              type="text"
+              getAutocompleteConstants={handleAutocompleteUrls}
+              placeholder="https://api.myproduct.com/v1/users"
+              defaultValue={url}
+              onChange={handleUrlChange}
+            />
+            {isCancellable ? (
               <button
                 type="button"
-                className="urlbar__send-btn"
-                onClick={send}
+                className="urlbar__send-btn danger"
+                onClick={handleStop}
               >
-                {downloadPath ? 'Download' : 'Send'}
+                Cancel
               </button>
-              <Dropdown
-                key="dropdown"
-                className="tall"
-                right
-                ref={dropdownRef}
-                onHide={handleSendDropdownHide}
-              >
-                <DropdownButton
-                  ref={buttonRef}
-                  className="urlbar__send-context"
-                  onClick={() => dropdownRef.current?.show()}
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="urlbar__send-btn"
+                  onClick={send}
                 >
-                  <i className="fa fa-caret-down" />
-                </DropdownButton>
-                <DropdownDivider>Basic</DropdownDivider>
-                <DropdownItem onClick={send}>
-                  <i className="fa fa-arrow-circle-o-right" /> Send Now
-                  <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SEND.id]} />
-                </DropdownItem>
-                <DropdownItem onClick={handleGenerateCode}>
-                  <i className="fa fa-code" /> Generate Client Code
-                </DropdownItem>
-                <DropdownDivider>Advanced</DropdownDivider>
-                <DropdownItem onClick={handleSendAfterDelay}>
-                  <i className="fa fa-clock-o" /> Send After Delay
-                </DropdownItem>
-                <DropdownItem onClick={handleSendOnInterval}>
-                  <i className="fa fa-repeat" /> Repeat on Interval
-                </DropdownItem>
-                {downloadPath ? (
-                  <DropdownItem
-                    stayOpenAfterClick
-                    addIcon
-                    buttonClass={PromptButton}
-                    onClick={handleClearDownloadLocation}
+                  {downloadPath ? 'Download' : 'Send'}
+                </button>
+                <Dropdown key="dropdown" className="tall" right ref={dropdownRef}>
+                  <DropdownButton
+                    className="urlbar__send-context"
+                    onClick={() => dropdownRef.current?.show()}
                   >
-                    <i className="fa fa-stop-circle" /> Stop Auto-Download
+                    <i className="fa fa-caret-down" />
+                  </DropdownButton>
+                  <DropdownDivider>Basic</DropdownDivider>
+                  <DropdownItem onClick={send}>
+                    <i className="fa fa-arrow-circle-o-right" /> Send Now
+                    <DropdownHint keyBindings={hotKeyRegistry[hotKeyRefs.REQUEST_SEND.id]} />
                   </DropdownItem>
-                ) : (
-                  <DropdownItem onClick={handleSetDownloadLocation}>
-                    <i className="fa fa-download" /> Download After Send
+                  <DropdownItem onClick={handleGenerateCode}>
+                    <i className="fa fa-code" /> Generate Client Code
                   </DropdownItem>
-                )}
-                <DropdownItem onClick={() => handleSendAndDownload()}>
-                  <i className="fa fa-download" /> Send And Download
-                </DropdownItem>
-              </Dropdown>
-            </>
-          )}
+                  <DropdownDivider>Advanced</DropdownDivider>
+                  <DropdownItem onClick={handleSendAfterDelay}>
+                    <i className="fa fa-clock-o" /> Send After Delay
+                  </DropdownItem>
+                  <DropdownItem onClick={handleSendOnInterval}>
+                    <i className="fa fa-repeat" /> Repeat on Interval
+                  </DropdownItem>
+                  {downloadPath ? (
+                    <DropdownItem
+                      stayOpenAfterClick
+                      addIcon
+                      buttonClass={PromptButton}
+                      onClick={handleClearDownloadLocation}
+                    >
+                      <i className="fa fa-stop-circle" /> Stop Auto-Download
+                    </DropdownItem>
+                  ) : (
+                    <DropdownItem onClick={handleSetDownloadLocation}>
+                      <i className="fa fa-download" /> Download After Send
+                    </DropdownItem>
+                  )}
+                  <DropdownItem onClick={handleSendAndDownload}>
+                    <i className="fa fa-download" /> Send And Download
+                  </DropdownItem>
+                </Dropdown>
+              </>
+            )}
+          </div>
         </div>
-      </div>
+      </KeydownBinder>
     </KeydownBinder>
   );
 });

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -17,7 +17,7 @@ import * as network from '../../network/network';
 import { updateRequestMetaByParentId } from '../hooks/create-request';
 import { useTimeoutWhen } from '../hooks/useTimeoutWhen';
 import { loadRequestStart, loadRequestStop } from '../redux/modules/global';
-import { selectActiveEnvironment, selectHotKeyRegistry, selectSettings } from '../redux/selectors';
+import { selectActiveEnvironment, selectHotKeyRegistry, selectResponseDownloadPath, selectSettings } from '../redux/selectors';
 import { type DropdownHandle, Dropdown } from './base/dropdown/dropdown';
 import { DropdownButton } from './base/dropdown/dropdown-button';
 import { DropdownDivider } from './base/dropdown/dropdown-divider';
@@ -38,20 +38,19 @@ interface Props {
   onUrlChange: (r: Request, url: string) => Promise<Request>;
   request: Request;
   uniquenessKey: string;
-  downloadPath: string | null;
 }
 
 export interface RequestUrlBarHandle {
   focusInput: () => void;
 }
 export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
-  downloadPath,
   handleAutocompleteUrls,
   handleImport,
   onUrlChange,
   request,
   uniquenessKey,
 }, ref) => {
+  const downloadPath = useSelector(selectResponseDownloadPath);
   const hotKeyRegistry = useSelector(selectHotKeyRegistry);
   const activeEnvironment = useSelector(selectActiveEnvironment);
   const settings = useSelector(selectSettings);

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -5,6 +5,7 @@ import { useInterval } from 'react-use';
 import { hotKeyRefs } from '../../common/hotkeys';
 import { executeHotKey } from '../../common/hotkeys-listener';
 import type { Request } from '../../models/request';
+import { updateRequestMetaByParentId } from '../hooks/create-request';
 import { useTimeoutWhen } from '../hooks/useTimeoutWhen';
 import { selectHotKeyRegistry } from '../redux/selectors';
 import { type DropdownHandle, Dropdown } from './base/dropdown/dropdown';
@@ -24,7 +25,6 @@ interface Props {
   handleImport: Function;
   handleSend: () => void;
   handleSendAndDownload: (filepath?: string) => Promise<void>;
-  handleUpdateDownloadPath: Function;
   nunjucksPowerUserMode: boolean;
   onMethodChange: (r: Request, method: string) => Promise<Request>;
   onUrlChange: (r: Request, url: string) => Promise<Request>;
@@ -42,7 +42,6 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
   handleImport,
   handleSend,
   handleSendAndDownload,
-  handleUpdateDownloadPath,
   onMethodChange,
   onUrlChange,
   request,
@@ -119,9 +118,9 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     if (canceled) {
       return;
     }
-    handleUpdateDownloadPath(request._id, filePaths[0]);
-  }, [handleUpdateDownloadPath, request._id]);
-  const handleClearDownloadLocation = () => handleUpdateDownloadPath(request._id, null);
+    updateRequestMetaByParentId(request._id, { downloadPath: filePaths[0] });
+  }, [request._id]);
+  const handleClearDownloadLocation = () => updateRequestMetaByParentId(request._id, { downloadPath: null });
 
   const handleKeyDown = useCallback((event: KeyboardEvent) => {
     if (event.code === 'Enter' && request.url) {

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -11,6 +11,7 @@ import { hotKeyRefs } from '../../common/hotkeys';
 import { executeHotKey } from '../../common/hotkeys-listener';
 import { getContentDispositionHeader } from '../../common/misc';
 import * as models from '../../models';
+import { update } from '../../models/helpers/request-operations';
 import type { Request } from '../../models/request';
 import * as network from '../../network/network';
 import { updateRequestMetaByParentId } from '../hooks/create-request';
@@ -34,7 +35,6 @@ interface Props {
   handleAutocompleteUrls: () => Promise<string[]>;
   handleImport: Function;
   nunjucksPowerUserMode: boolean;
-  onMethodChange: (r: Request, method: string) => Promise<Request>;
   onUrlChange: (r: Request, url: string) => Promise<Request>;
   request: Request;
   uniquenessKey: string;
@@ -48,7 +48,6 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
   downloadPath,
   handleAutocompleteUrls,
   handleImport,
-  onMethodChange,
   onUrlChange,
   request,
   uniquenessKey,
@@ -321,6 +320,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     // NOTE: We're not actually doing the import here to avoid races with onChange
     setLastPastedText(event.clipboardData?.getData('text/plain'));
   }, []);
+  const onMethodChange = useCallback((method: string) => update(request, { method }), [request]);
 
   const handleSendDropdownHide = useCallback(() => {
     buttonRef.current?.blur();
@@ -333,7 +333,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
       <div className="urlbar">
         <MethodDropdown
           ref={methodDropdownRef}
-          onChange={(methodValue: string) => onMethodChange(request, methodValue)}
+          onChange={methodValue => onMethodChange(methodValue)}
           method={method}
         />
         <div className="urlbar__flex__right">

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -92,7 +92,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     return filePath || null;
   }
 
-  const handleSendAndDownload = useCallback(async (filePath: string) => {
+  const handleSendAndDownload = useCallback(async (filePath?: string) => {
     if (!request || !activeEnvironment) {
       return;
     }
@@ -370,8 +370,15 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
                 >
                   {downloadPath ? 'Download' : 'Send'}
                 </button>
-                <Dropdown key="dropdown" className="tall" right ref={dropdownRef}>
+                <Dropdown
+                  key="dropdown"
+                  className="tall"
+                  right
+                  ref={dropdownRef}
+                  onHide={handleSendDropdownHide}
+                >
                   <DropdownButton
+                    ref={buttonRef}
                     className="urlbar__send-context"
                     onClick={() => dropdownRef.current?.show()}
                   >
@@ -406,7 +413,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
                       <i className="fa fa-download" /> Download After Send
                     </DropdownItem>
                   )}
-                  <DropdownItem onClick={handleSendAndDownload}>
+                  <DropdownItem onClick={() => handleSendAndDownload()}>
                     <i className="fa fa-download" /> Send And Download
                   </DropdownItem>
                 </Dropdown>

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -16,11 +16,11 @@ import { PromptButton } from './base/prompt-button';
 import { OneLineEditor } from './codemirror/one-line-editor';
 import { MethodDropdown } from './dropdowns/method-dropdown';
 import { KeydownBinder } from './keydown-binder';
-import { showPrompt } from './modals/index';
+import { GenerateCodeModal } from './modals/generate-code-modal';
+import { showModal, showPrompt } from './modals/index';
 
 interface Props {
   handleAutocompleteUrls: () => Promise<string[]>;
-  handleGenerateCode: Function;
   handleImport: Function;
   handleSend: () => void;
   handleSendAndDownload: (filepath?: string) => Promise<void>;
@@ -40,7 +40,6 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
   downloadPath,
   handleAutocompleteUrls,
   handleImport,
-  handleGenerateCode,
   handleSend,
   handleSendAndDownload,
   handleUpdateDownloadPath,
@@ -55,6 +54,9 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
   const inputRef = useRef<OneLineEditor>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
+  const handleGenerateCode = () => {
+    showModal(GenerateCodeModal, request);
+  };
   const focusInput = useCallback(() => {
     if (inputRef.current) {
       inputRef.current.focus(true);

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
@@ -35,13 +35,11 @@ interface RecursiveSidebarRowsProps {
 interface Props {
   childObjects: SidebarChildObjects;
   filter: string;
-  handleCopyAsCurl: Function;
   handleDuplicateRequest: Function;
 }
 export const SidebarChildren: FC<Props> = ({
   childObjects,
   filter,
-  handleCopyAsCurl,
   handleDuplicateRequest,
 }) => {
   const activeWorkspaceMeta = useSelector(selectActiveWorkspaceMeta);
@@ -67,7 +65,6 @@ export const SidebarChildren: FC<Props> = ({
                 filter={isInPinnedList ? '' : filter || ''}
                 handleSetActiveRequest={setActiveRequest}
                 handleDuplicateRequest={handleDuplicateRequest}
-                handleCopyAsCurl={handleCopyAsCurl}
                 isActive={row.doc._id === activeRequestId}
                 isPinned={row.pinned}
                 disableDragAndDrop={isInPinnedList}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
@@ -8,6 +8,7 @@ import { isRequest, Request } from '../../../models/request';
 import type { RequestGroup } from '../../../models/request-group';
 import { updateRequestMetaByParentId } from '../../hooks/create-request';
 import { selectActiveRequest, selectActiveWorkspaceMeta } from '../../redux/selectors';
+import { selectSidebarChildren } from '../../redux/sidebar-selectors';
 import { SidebarCreateDropdown } from './sidebar-create-dropdown';
 import { SidebarRequestGroupRow } from './sidebar-request-group-row';
 import { SidebarRequestRow } from './sidebar-request-row';
@@ -33,15 +34,14 @@ interface RecursiveSidebarRowsProps {
 }
 
 interface Props {
-  childObjects: SidebarChildObjects;
   filter: string;
   handleDuplicateRequest: Function;
 }
 export const SidebarChildren: FC<Props> = ({
-  childObjects,
   filter,
   handleDuplicateRequest,
 }) => {
+  const sidebarChildren = useSelector(selectSidebarChildren);
   const activeWorkspaceMeta = useSelector(selectActiveWorkspaceMeta);
   const setActiveRequest = (requestId: string) => {
     if (activeWorkspaceMeta) {
@@ -83,8 +83,8 @@ export const SidebarChildren: FC<Props> = ({
             ))}
       </>);
   };
-  const { all, pinned } = childObjects;
-  const showSeparator = childObjects.pinned.length > 0;
+  const { all, pinned } = sidebarChildren;
+  const showSeparator = sidebarChildren.pinned.length > 0;
   const contextMenuPortal = ReactDOM.createPortal(
     <div className="hide">
       <SidebarCreateDropdown />

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
@@ -36,9 +36,7 @@ interface Props {
   handleActivateRequest: Function;
   handleCopyAsCurl: Function;
   handleDuplicateRequest: Function;
-  handleDuplicateRequestGroup: (requestGroup: RequestGroup) => any;
   handleGenerateCode: Function;
-  handleSetRequestGroupCollapsed: Function;
   handleSetRequestPinned: Function;
 }
 export const SidebarChildren: FC<Props> = ({
@@ -47,9 +45,7 @@ export const SidebarChildren: FC<Props> = ({
   handleActivateRequest,
   handleCopyAsCurl,
   handleDuplicateRequest,
-  handleDuplicateRequestGroup,
   handleGenerateCode,
-  handleSetRequestGroupCollapsed,
   handleSetRequestPinned,
 }) => {
   const RecursiveSidebarRows: FC<RecursiveSidebarRowsProps> = ({ rows, isInPinnedList }) => {
@@ -80,8 +76,6 @@ export const SidebarChildren: FC<Props> = ({
                 filter={filter || ''}
                 isActive={hasActiveChild(row.children, activeRequestId)}
                 handleActivateRequest={handleActivateRequest}
-                handleSetRequestGroupCollapsed={handleSetRequestGroupCollapsed}
-                handleDuplicateRequestGroup={handleDuplicateRequestGroup}
                 isCollapsed={row.collapsed}
                 requestGroup={row.doc}
               >

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
@@ -37,7 +37,6 @@ interface Props {
   handleCopyAsCurl: Function;
   handleDuplicateRequest: Function;
   handleGenerateCode: Function;
-  handleSetRequestPinned: Function;
 }
 export const SidebarChildren: FC<Props> = ({
   childObjects,
@@ -46,7 +45,6 @@ export const SidebarChildren: FC<Props> = ({
   handleCopyAsCurl,
   handleDuplicateRequest,
   handleGenerateCode,
-  handleSetRequestPinned,
 }) => {
   const RecursiveSidebarRows: FC<RecursiveSidebarRowsProps> = ({ rows, isInPinnedList }) => {
     const activeRequest = useSelector(selectActiveRequest);
@@ -61,7 +59,6 @@ export const SidebarChildren: FC<Props> = ({
                 key={row.doc._id}
                 filter={isInPinnedList ? '' : filter || ''}
                 handleActivateRequest={handleActivateRequest}
-                handleSetRequestPinned={handleSetRequestPinned}
                 handleDuplicateRequest={handleDuplicateRequest}
                 handleGenerateCode={handleGenerateCode}
                 handleCopyAsCurl={handleCopyAsCurl}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
@@ -36,7 +36,6 @@ interface Props {
   handleActivateRequest: Function;
   handleCopyAsCurl: Function;
   handleDuplicateRequest: Function;
-  handleGenerateCode: Function;
 }
 export const SidebarChildren: FC<Props> = ({
   childObjects,
@@ -44,7 +43,6 @@ export const SidebarChildren: FC<Props> = ({
   handleActivateRequest,
   handleCopyAsCurl,
   handleDuplicateRequest,
-  handleGenerateCode,
 }) => {
   const RecursiveSidebarRows: FC<RecursiveSidebarRowsProps> = ({ rows, isInPinnedList }) => {
     const activeRequest = useSelector(selectActiveRequest);
@@ -60,7 +58,6 @@ export const SidebarChildren: FC<Props> = ({
                 filter={isInPinnedList ? '' : filter || ''}
                 handleActivateRequest={handleActivateRequest}
                 handleDuplicateRequest={handleDuplicateRequest}
-                handleGenerateCode={handleGenerateCode}
                 handleCopyAsCurl={handleCopyAsCurl}
                 isActive={row.doc._id === activeRequestId}
                 isPinned={row.pinned}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-filter.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-filter.tsx
@@ -8,29 +8,34 @@ import { executeHotKey } from '../../../common/hotkeys-listener';
 import { sortMethodMap } from '../../../common/sorting';
 import * as models from '../../../models';
 import { isRequestGroup } from '../../../models/request-group';
-import { selectActiveWorkspace } from '../../redux/selectors';
+import { selectActiveWorkspace, selectActiveWorkspaceMeta } from '../../redux/selectors';
 import { KeydownBinder } from '../keydown-binder';
 import { SidebarCreateDropdown } from './sidebar-create-dropdown';
 import { SidebarSortDropdown } from './sidebar-sort-dropdown';
 
 interface Props {
-  onChange: (value: string) => Promise<void>;
   filter: string;
 }
-export const SidebarFilter: FC<Props> = ({ filter, onChange }) => {
+export const SidebarFilter: FC<Props> = ({ filter }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const activeWorkspace = useSelector(selectActiveWorkspace);
+  const activeWorkspaceMeta = useSelector(selectActiveWorkspaceMeta);
 
-  const handleClearFilter = useCallback(() => {
-    onChange('');
+  const handleClearFilter = useCallback(async () => {
+    if (activeWorkspaceMeta) {
+      await models.workspaceMeta.update(activeWorkspaceMeta, { sidebarFilter: '' });
+    }
     if (inputRef.current) {
       inputRef.current.value = '';
       inputRef.current.focus();
     }
-  }, [onChange]);
-  const handleOnChange = useCallback((event: React.SyntheticEvent<HTMLInputElement>) => {
-    onChange(event.currentTarget.value);
-  }, [onChange]);
+  }, [activeWorkspaceMeta]);
+
+  const handleOnChange = useCallback(async (event: React.SyntheticEvent<HTMLInputElement>) => {
+    if (activeWorkspaceMeta) {
+      await models.workspaceMeta.update(activeWorkspaceMeta, { sidebarFilter: event.currentTarget.value });
+    }
+  }, [activeWorkspaceMeta]);
   const handleKeydown = useCallback((event: KeyboardEvent) => {
     executeHotKey(event, hotKeyRefs.SIDEBAR_FOCUS_FILTER, () => {
       inputRef.current?.focus();

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
@@ -173,7 +173,6 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
             <SidebarRequestRow
               handleActivateRequest={noop}
               handleDuplicateRequest={noop}
-              handleGenerateCode={noop}
               handleCopyAsCurl={noop}
               isActive={false}
               requestGroup={requestGroup}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
@@ -175,7 +175,6 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
               handleDuplicateRequest={noop}
               handleGenerateCode={noop}
               handleCopyAsCurl={noop}
-              handleSetRequestPinned={noop}
               isActive={false}
               requestGroup={requestGroup}
               filter={filter}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
@@ -8,6 +8,7 @@ import { DragSource, DragSourceSpec, DropTarget, DropTargetMonitor, DropTargetSp
 import { connect } from 'react-redux';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
+import * as models from '../../../models/index';
 import { RequestGroup } from '../../../models/request-group';
 import { RootState } from '../../redux/modules';
 import { selectActiveEnvironment, selectActiveRequest } from '../../redux/selectors';
@@ -26,8 +27,6 @@ const mapStateToProps = (state: RootState) => ({
 });
 
 interface Props extends DnDProps, ReduxProps, PropsWithChildren<{}> {
-  handleSetRequestGroupCollapsed: Function;
-  handleDuplicateRequestGroup: (requestGroup: RequestGroup) => any;
   handleActivateRequest: Function;
   filter: string;
   isActive: boolean;
@@ -53,8 +52,27 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
   }
 
   _handleCollapse() {
-    const { requestGroup, handleSetRequestGroupCollapsed, isCollapsed } = this.props;
-    handleSetRequestGroupCollapsed(requestGroup._id, !isCollapsed);
+    const { requestGroup, isCollapsed } = this.props;
+    this.handleSetRequestGroupCollapsed(requestGroup._id, !isCollapsed);
+  }
+  async handleSetRequestGroupCollapsed(requestGroupId: string, collapsed: boolean) {
+    const requestGroupMeta = await models.requestGroupMeta.getByParentId(requestGroupId);
+
+    if (requestGroupMeta) {
+      await models.requestGroupMeta.update(requestGroupMeta, {
+        collapsed,
+      });
+    } else {
+      const newPatch = Object.assign(
+        {
+          parentId: requestGroupId,
+        },
+        {
+          collapsed,
+        },
+      );
+      await models.requestGroupMeta.create(newPatch);
+    }
   }
 
   _handleShowActions(event: MouseEvent<HTMLButtonElement>) {
@@ -86,7 +104,6 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
       requestGroup,
       isCollapsed,
       isActive,
-      handleDuplicateRequestGroup,
       isDragging,
       isDraggingOver,
     } = this.props;
@@ -138,7 +155,6 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
           <div className="sidebar__actions">
             <RequestGroupActionsDropdown
               ref={this.dropdownRef}
-              handleDuplicateRequestGroup={handleDuplicateRequestGroup}
               handleShowSettings={this._handleShowRequestGroupSettings}
               requestGroup={requestGroup}
               right

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
@@ -27,7 +27,6 @@ const mapStateToProps = (state: RootState) => ({
 });
 
 interface Props extends DnDProps, ReduxProps, PropsWithChildren<{}> {
-  handleActivateRequest: Function;
   filter: string;
   isActive: boolean;
   isCollapsed: boolean;
@@ -171,7 +170,7 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
             children
           ) : (
             <SidebarRequestRow
-              handleActivateRequest={noop}
+              handleSetActiveRequest={noop}
               handleDuplicateRequest={noop}
               handleCopyAsCurl={noop}
               isActive={false}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
@@ -172,7 +172,6 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
             <SidebarRequestRow
               handleSetActiveRequest={noop}
               handleDuplicateRequest={noop}
-              handleCopyAsCurl={noop}
               isActive={false}
               requestGroup={requestGroup}
               filter={filter}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -28,7 +28,6 @@ interface RawProps {
   filter: string;
   handleSetActiveRequest: Function;
   handleDuplicateRequest: Function;
-  handleCopyAsCurl: Function;
   isActive: boolean;
   isPinned: boolean;
   request?: Request | GrpcRequest;
@@ -59,7 +58,6 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
   disableDragAndDrop,
   filter,
   handleSetActiveRequest,
-  handleCopyAsCurl,
   handleDuplicateRequest,
   isActive,
   isDragging,
@@ -249,7 +247,6 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
               right
               ref={requestActionsDropdown}
               handleDuplicateRequest={handleDuplicateRequest}
-              handleCopyAsCurl={handleCopyAsCurl}
               handleShowSettings={handleShowRequestSettings}
               request={request}
               isPinned={isPinned}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -26,7 +26,7 @@ import { DnDProps, DragObject, dropHandleCreator, hoverHandleCreator, sourceColl
 interface RawProps {
   disableDragAndDrop?: boolean;
   filter: string;
-  handleActivateRequest: Function;
+  handleSetActiveRequest: Function;
   handleDuplicateRequest: Function;
   handleCopyAsCurl: Function;
   isActive: boolean;
@@ -58,7 +58,7 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
   connectDropTarget,
   disableDragAndDrop,
   filter,
-  handleActivateRequest,
+  handleSetActiveRequest,
   handleCopyAsCurl,
   handleDuplicateRequest,
   isActive,
@@ -126,8 +126,8 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
       return;
     }
 
-    handleActivateRequest(request?._id);
-  }, [isActive, request?._id, handleActivateRequest]);
+    handleSetActiveRequest(request?._id);
+  }, [isActive, request?._id, handleSetActiveRequest]);
 
   const handleShowRequestSettings = useCallback(() => {
     showModal(RequestSettingsModal, { request });

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -27,7 +27,6 @@ interface RawProps {
   disableDragAndDrop?: boolean;
   filter: string;
   handleActivateRequest: Function;
-  handleSetRequestPinned: Function;
   handleDuplicateRequest: Function;
   handleGenerateCode: Function;
   handleCopyAsCurl: Function;
@@ -64,7 +63,6 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
   handleCopyAsCurl,
   handleDuplicateRequest,
   handleGenerateCode,
-  handleSetRequestPinned,
   isActive,
   isDragging,
   isDraggingOver,
@@ -253,7 +251,6 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
               right
               ref={requestActionsDropdown}
               handleDuplicateRequest={handleDuplicateRequest}
-              handleSetRequestPinned={handleSetRequestPinned}
               handleGenerateCode={handleGenerateCode}
               handleCopyAsCurl={handleCopyAsCurl}
               handleShowSettings={handleShowRequestSettings}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -28,7 +28,6 @@ interface RawProps {
   filter: string;
   handleActivateRequest: Function;
   handleDuplicateRequest: Function;
-  handleGenerateCode: Function;
   handleCopyAsCurl: Function;
   isActive: boolean;
   isPinned: boolean;
@@ -62,7 +61,6 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
   handleActivateRequest,
   handleCopyAsCurl,
   handleDuplicateRequest,
-  handleGenerateCode,
   isActive,
   isDragging,
   isDraggingOver,
@@ -251,7 +249,6 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
               right
               ref={requestActionsDropdown}
               handleDuplicateRequest={handleDuplicateRequest}
-              handleGenerateCode={handleGenerateCode}
               handleCopyAsCurl={handleCopyAsCurl}
               handleShowSettings={handleShowRequestSettings}
               request={request}

--- a/packages/insomnia/src/ui/components/sidebar/sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar.tsx
@@ -7,18 +7,13 @@ import {
   SIDEBAR_SKINNY_REMS,
 } from '../../../common/constants';
 import type { Environment } from '../../../models/environment';
-import type { Workspace } from '../../../models/workspace';
 
 interface Props {
   activeEnvironment: Environment | null;
   children: ReactNode;
   environmentHighlightColorStyle: EnvironmentHighlightColorStyle;
-  handleSetActiveEnvironment: (...args: any[]) => any;
   hidden: boolean;
-  isLoading: boolean;
-  unseenWorkspaces: Workspace[];
   width: number;
-  workspacesForActiveProject: Workspace[];
 }
 
 export const Sidebar = memo(

--- a/packages/insomnia/src/ui/components/viewers/response-cookies-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-cookies-viewer.tsx
@@ -7,7 +7,6 @@ interface Props {
   cookiesSent?: boolean | null;
   cookiesStored?: boolean | null;
   headers: any[];
-  handleShowRequestSettings: Function;
 }
 
 export const ResponseCookiesViewer: FC<Props> = props => {

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -19,7 +19,6 @@ import { executeHotKey } from '../../../common/hotkeys-listener';
 import { xmlDecode } from '../../../common/misc';
 import { CodeEditor, UnconnectedCodeEditor } from '../codemirror/code-editor';
 import { KeydownBinder } from '../keydown-binder';
-// import { KeydownBinder } from '../keydown-binder';
 import { ResponseCSVViewer } from './response-csv-viewer';
 import { ResponseErrorViewer } from './response-error-viewer';
 import { ResponseMultipartViewer } from './response-multipart-viewer';

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -4,9 +4,10 @@ import { useSelector } from 'react-redux';
 import { SortOrder } from '../../common/constants';
 import { isGrpcRequest } from '../../models/grpc-request';
 import { isRemoteProject } from '../../models/project';
-import { Request, RequestAuthentication, RequestBody, RequestHeader, RequestParameter } from '../../models/request';
+import { Request, RequestHeader } from '../../models/request';
 import { Settings } from '../../models/settings';
 import { isCollection, isDesign } from '../../models/workspace';
+import { VCS } from '../../sync/vcs/vcs';
 import {
   selectActiveEnvironment,
   selectActiveProject,
@@ -31,13 +32,13 @@ import { ResponsePane } from './panes/response-pane';
 import { SidebarChildren } from './sidebar/sidebar-children';
 import { SidebarFilter } from './sidebar/sidebar-filter';
 import { WorkspacePageHeader } from './workspace-page-header';
-import type { HandleActivityChange, WrapperProps } from './wrapper';
+import type { HandleActivityChange } from './wrapper';
 
 interface Props {
   forceRefreshKey: number;
   gitSyncDropdown: ReactNode;
   handleActivityChange: HandleActivityChange;
-  handleChangeEnvironment: Function;
+  handleSetActiveEnvironment: Function;
   handleForceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
   handleForceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleImport: Function;
@@ -47,21 +48,24 @@ interface Props {
   handleSetResponseFilter: (filter: string) => void;
   handleShowRequestSettingsModal: Function;
   handleSidebarSort: (sortOrder: SortOrder) => void;
-  handleUpdateRequestAuthentication: (r: Request, auth: RequestAuthentication) => Promise<Request>;
-  handleUpdateRequestBody: (r: Request, body: RequestBody) => Promise<Request>;
-  handleUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
-  handleUpdateRequestMethod: (r: Request, method: string) => Promise<Request>;
-  handleUpdateRequestParameters: (r: Request, params: RequestParameter[]) => Promise<Request>;
-  handleUpdateRequestUrl: (r: Request, url: string) => Promise<Request>;
   handleUpdateSettingsUseBulkHeaderEditor: Function;
   handleUpdateSettingsUseBulkParametersEditor: (useBulkParametersEditor: boolean) => Promise<Settings>;
-  wrapperProps: WrapperProps;
+  handleActivateRequest: (activeRequestId: string) => void;
+  handleCopyAsCurl: Function;
+  handleDuplicateRequest: Function;
+  handleGenerateCode: Function;
+  handleGenerateCodeForActiveRequest: Function;
+  handleSetSidebarFilter: (value: string) => Promise<void>;
+  handleUpdateDownloadPath: Function;
+  handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
+  headerEditorKey: string;
+  vcs: VCS | null;
 }
 export const WrapperDebug: FC<Props> = ({
   forceRefreshKey,
   gitSyncDropdown,
   handleActivityChange,
-  handleChangeEnvironment,
+  handleSetActiveEnvironment,
   handleForceUpdateRequest,
   handleForceUpdateRequestHeaders,
   handleImport,
@@ -71,29 +75,20 @@ export const WrapperDebug: FC<Props> = ({
   handleSetResponseFilter,
   handleShowRequestSettingsModal,
   handleSidebarSort,
-  handleUpdateRequestAuthentication,
-  handleUpdateRequestBody,
-  handleUpdateRequestHeaders,
-  handleUpdateRequestMethod,
-  handleUpdateRequestParameters,
-  handleUpdateRequestUrl,
   handleUpdateSettingsUseBulkHeaderEditor,
   handleUpdateSettingsUseBulkParametersEditor,
-  wrapperProps,
-
+  handleActivateRequest,
+  handleCopyAsCurl,
+  handleDuplicateRequest,
+  handleGenerateCode,
+  handleGenerateCodeForActiveRequest,
+  handleSetSidebarFilter,
+  handleUpdateDownloadPath,
+  handleUpdateRequestMimeType,
+  headerEditorKey,
+  vcs,
 }) => {
-  const {
-    handleActivateRequest,
-    handleCopyAsCurl,
-    handleDuplicateRequest,
-    handleGenerateCode,
-    handleGenerateCodeForActiveRequest,
-    handleSetSidebarFilter,
-    handleUpdateDownloadPath,
-    handleUpdateRequestMimeType,
-    headerEditorKey,
-    vcs,
-  } = wrapperProps;
+
   const activeProject = useSelector(selectActiveProject);
   const activeWorkspaceMeta = useSelector(selectActiveWorkspaceMeta);
   const isLoggedIn = useSelector(selectIsLoggedIn);
@@ -130,7 +125,7 @@ export const WrapperDebug: FC<Props> = ({
             activeEnvironment={activeEnvironment}
             environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
             environments={environments}
-            handleChangeEnvironment={handleChangeEnvironment}
+            handleChangeEnvironment={handleSetActiveEnvironment}
             workspace={activeWorkspace}
           />
           <button className="btn btn--super-compact" onClick={showCookiesModal}>
@@ -182,13 +177,7 @@ export const WrapperDebug: FC<Props> = ({
               headerEditorKey={headerEditorKey}
               request={activeRequest}
               settings={settings}
-              updateRequestAuthentication={handleUpdateRequestAuthentication}
-              updateRequestBody={handleUpdateRequestBody}
-              updateRequestHeaders={handleUpdateRequestHeaders}
-              updateRequestMethod={handleUpdateRequestMethod}
               updateRequestMimeType={handleUpdateRequestMimeType}
-              updateRequestParameters={handleUpdateRequestParameters}
-              updateRequestUrl={handleUpdateRequestUrl}
               updateSettingsUseBulkHeaderEditor={handleUpdateSettingsUseBulkHeaderEditor}
               updateSettingsUseBulkParametersEditor={handleUpdateSettingsUseBulkParametersEditor}
               workspace={activeWorkspace}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -43,7 +43,6 @@ interface Props {
   handleSendAndDownloadRequestWithActiveEnvironment: (filepath?: string) => Promise<void>;
   handleSendRequestWithActiveEnvironment: () => void;
   handleSetResponseFilter: (filter: string) => void;
-  handleShowRequestSettingsModal: Function;
   handleDuplicateRequest: Function;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   headerEditorKey: string;
@@ -60,7 +59,6 @@ export const WrapperDebug: FC<Props> = ({
   handleSendAndDownloadRequestWithActiveEnvironment,
   handleSendRequestWithActiveEnvironment,
   handleSetResponseFilter,
-  handleShowRequestSettingsModal,
   handleDuplicateRequest,
   handleUpdateRequestMimeType,
   headerEditorKey,
@@ -163,7 +161,6 @@ export const WrapperDebug: FC<Props> = ({
             :
             <ResponsePane
               handleSetFilter={handleSetResponseFilter}
-              handleShowRequestSettings={handleShowRequestSettingsModal}
               request={activeRequest}
             />}
         </ErrorBoundary>}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -1,7 +1,6 @@
 import React, { FC, Fragment, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
-import { SortOrder } from '../../common/constants';
 import { isGrpcRequest } from '../../models/grpc-request';
 import { isRemoteProject } from '../../models/project';
 import { Request, RequestHeader } from '../../models/request';
@@ -47,7 +46,6 @@ interface Props {
   handleSetActiveResponse: Function;
   handleSetResponseFilter: (filter: string) => void;
   handleShowRequestSettingsModal: Function;
-  handleSidebarSort: (sortOrder: SortOrder) => void;
   handleUpdateSettingsUseBulkHeaderEditor: Function;
   handleUpdateSettingsUseBulkParametersEditor: (useBulkParametersEditor: boolean) => Promise<Settings>;
   handleDuplicateRequest: Function;
@@ -69,7 +67,6 @@ export const WrapperDebug: FC<Props> = ({
   handleSetActiveResponse,
   handleSetResponseFilter,
   handleShowRequestSettingsModal,
-  handleSidebarSort,
   handleUpdateSettingsUseBulkHeaderEditor,
   handleUpdateSettingsUseBulkParametersEditor,
   handleDuplicateRequest,
@@ -128,7 +125,6 @@ export const WrapperDebug: FC<Props> = ({
         <SidebarFilter
           key={`${activeWorkspace._id}::filter`}
           onChange={handleSetSidebarFilter}
-          sidebarSort={handleSidebarSort}
           filter={sidebarFilter || ''}
         />
 

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -43,7 +43,6 @@ interface Props {
   handleImport: Function;
   handleSendAndDownloadRequestWithActiveEnvironment: (filepath?: string) => Promise<void>;
   handleSendRequestWithActiveEnvironment: () => void;
-  handleSetActiveResponse: Function;
   handleSetResponseFilter: (filter: string) => void;
   handleShowRequestSettingsModal: Function;
   handleUpdateSettingsUseBulkHeaderEditor: Function;
@@ -63,7 +62,6 @@ export const WrapperDebug: FC<Props> = ({
   handleImport,
   handleSendAndDownloadRequestWithActiveEnvironment,
   handleSendRequestWithActiveEnvironment,
-  handleSetActiveResponse,
   handleSetResponseFilter,
   handleShowRequestSettingsModal,
   handleUpdateSettingsUseBulkHeaderEditor,
@@ -171,7 +169,6 @@ export const WrapperDebug: FC<Props> = ({
             />
             :
             <ResponsePane
-              handleSetActiveResponse={handleSetActiveResponse}
               handleSetFilter={handleSetResponseFilter}
               handleShowRequestSettings={handleShowRequestSettingsModal}
               request={activeRequest}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -50,7 +50,6 @@ interface Props {
   handleSidebarSort: (sortOrder: SortOrder) => void;
   handleUpdateSettingsUseBulkHeaderEditor: Function;
   handleUpdateSettingsUseBulkParametersEditor: (useBulkParametersEditor: boolean) => Promise<Settings>;
-  handleActivateRequest: (activeRequestId: string) => void;
   handleCopyAsCurl: Function;
   handleDuplicateRequest: Function;
   handleSetSidebarFilter: (value: string) => Promise<void>;
@@ -75,7 +74,6 @@ export const WrapperDebug: FC<Props> = ({
   handleSidebarSort,
   handleUpdateSettingsUseBulkHeaderEditor,
   handleUpdateSettingsUseBulkParametersEditor,
-  handleActivateRequest,
   handleCopyAsCurl,
   handleDuplicateRequest,
   handleSetSidebarFilter,
@@ -140,7 +138,6 @@ export const WrapperDebug: FC<Props> = ({
 
         <SidebarChildren
           childObjects={sidebarChildren}
-          handleActivateRequest={handleActivateRequest}
           handleDuplicateRequest={handleDuplicateRequest}
           handleCopyAsCurl={handleCopyAsCurl}
           filter={sidebarFilter || ''}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -9,9 +9,12 @@ import { Settings } from '../../models/settings';
 import { isCollection, isDesign } from '../../models/workspace';
 import {
   selectActiveEnvironment,
+  selectActiveProject,
   selectActiveRequest,
   selectActiveWorkspace,
+  selectActiveWorkspaceMeta,
   selectEnvironments,
+  selectIsLoggedIn,
   selectResponseDownloadPath,
   selectSettings,
 } from '../redux/selectors';
@@ -80,8 +83,6 @@ export const WrapperDebug: FC<Props> = ({
 
 }) => {
   const {
-    activeProject,
-    activeWorkspaceMeta,
     handleActivateRequest,
     handleCopyAsCurl,
     handleDuplicateRequest,
@@ -91,9 +92,11 @@ export const WrapperDebug: FC<Props> = ({
     handleUpdateDownloadPath,
     handleUpdateRequestMimeType,
     headerEditorKey,
-    isLoggedIn,
     vcs,
   } = wrapperProps;
+  const activeProject = useSelector(selectActiveProject);
+  const activeWorkspaceMeta = useSelector(selectActiveWorkspaceMeta);
+  const isLoggedIn = useSelector(selectIsLoggedIn);
 
   const activeEnvironment = useSelector(selectActiveEnvironment);
   const activeRequest = useSelector(selectActiveRequest);
@@ -110,7 +113,6 @@ export const WrapperDebug: FC<Props> = ({
 
   return (
     <PageLayout
-      wrapperProps={wrapperProps}
       renderPageHeader={activeWorkspace ?
         <WorkspacePageHeader
           handleActivityChange={handleActivityChange}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -95,7 +95,6 @@ export const WrapperDebug: FC<Props> = ({
     handleUpdateRequestMimeType,
     headerEditorKey,
     isLoggedIn,
-    syncItems,
     vcs,
   } = wrapperProps;
 
@@ -123,7 +122,6 @@ export const WrapperDebug: FC<Props> = ({
             workspaceMeta={activeWorkspaceMeta}
             project={activeProject}
             vcs={vcs}
-            syncItems={syncItems}
           /> : isDesign(activeWorkspace) ? gitSyncDropdown : null}
         />
         : null}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -97,7 +97,7 @@ export const WrapperDebug: FC<Props> = ({
             activeEnvironment={activeEnvironment}
             environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
             environments={environments}
-            handleChangeEnvironment={handleSetActiveEnvironment}
+            handleSetActiveEnvironment={handleSetActiveEnvironment}
             workspace={activeWorkspace}
           />
           <button className="btn btn--super-compact" onClick={showCookiesModal}>

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -14,10 +14,9 @@ import {
   selectActiveWorkspaceMeta,
   selectEnvironments,
   selectIsLoggedIn,
-  selectResponseDownloadPath,
   selectSettings,
 } from '../redux/selectors';
-import { selectSidebarChildren, selectSidebarFilter } from '../redux/sidebar-selectors';
+import { selectSidebarFilter } from '../redux/sidebar-selectors';
 import { EnvironmentsDropdown } from './dropdowns/environments-dropdown';
 import { SyncDropdown } from './dropdowns/sync-dropdown';
 import { ErrorBoundary } from './error-boundary';
@@ -71,9 +70,7 @@ export const WrapperDebug: FC<Props> = ({
   const activeWorkspace = useSelector(selectActiveWorkspace);
   const environments = useSelector(selectEnvironments);
 
-  const responseDownloadPath = useSelector(selectResponseDownloadPath);
   const settings = useSelector(selectSettings);
-  const sidebarChildren = useSelector(selectSidebarChildren);
   const sidebarFilter = useSelector(selectSidebarFilter);
 
   const isTeamSync = isLoggedIn && activeWorkspace && isCollection(activeWorkspace) && isRemoteProject(activeProject) && vcs;
@@ -113,7 +110,6 @@ export const WrapperDebug: FC<Props> = ({
         />
 
         <SidebarChildren
-          childObjects={sidebarChildren}
           handleDuplicateRequest={handleDuplicateRequest}
           filter={sidebarFilter || ''}
         />
@@ -131,7 +127,6 @@ export const WrapperDebug: FC<Props> = ({
             />
             :
             <RequestPane
-              downloadPath={responseDownloadPath}
               environmentId={activeEnvironment ? activeEnvironment._id : ''}
               forceRefreshCounter={forceRefreshKey}
               forceUpdateRequest={handleForceUpdateRequest}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -40,8 +40,6 @@ interface Props {
   handleForceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
   handleForceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleImport: Function;
-  handleSendAndDownloadRequestWithActiveEnvironment: (filepath?: string) => Promise<void>;
-  handleSendRequestWithActiveEnvironment: () => void;
   handleSetResponseFilter: (filter: string) => void;
   handleDuplicateRequest: Function;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
@@ -56,8 +54,6 @@ export const WrapperDebug: FC<Props> = ({
   handleForceUpdateRequest,
   handleForceUpdateRequestHeaders,
   handleImport,
-  handleSendAndDownloadRequestWithActiveEnvironment,
-  handleSendRequestWithActiveEnvironment,
   handleSetResponseFilter,
   handleDuplicateRequest,
   handleUpdateRequestMimeType,
@@ -141,8 +137,6 @@ export const WrapperDebug: FC<Props> = ({
               forceUpdateRequest={handleForceUpdateRequest}
               forceUpdateRequestHeaders={handleForceUpdateRequestHeaders}
               handleImport={handleImport}
-              handleSend={handleSendRequestWithActiveEnvironment}
-              handleSendAndDownload={handleSendAndDownloadRequestWithActiveEnvironment}
               headerEditorKey={headerEditorKey}
               request={activeRequest}
               settings={settings}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { isGrpcRequest } from '../../models/grpc-request';
 import { isRemoteProject } from '../../models/project';
 import { Request, RequestHeader } from '../../models/request';
-import { Settings } from '../../models/settings';
 import { isCollection, isDesign } from '../../models/workspace';
 import { VCS } from '../../sync/vcs/vcs';
 import {
@@ -45,8 +44,6 @@ interface Props {
   handleSendRequestWithActiveEnvironment: () => void;
   handleSetResponseFilter: (filter: string) => void;
   handleShowRequestSettingsModal: Function;
-  handleUpdateSettingsUseBulkHeaderEditor: Function;
-  handleUpdateSettingsUseBulkParametersEditor: (useBulkParametersEditor: boolean) => Promise<Settings>;
   handleDuplicateRequest: Function;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   headerEditorKey: string;
@@ -64,8 +61,6 @@ export const WrapperDebug: FC<Props> = ({
   handleSendRequestWithActiveEnvironment,
   handleSetResponseFilter,
   handleShowRequestSettingsModal,
-  handleUpdateSettingsUseBulkHeaderEditor,
-  handleUpdateSettingsUseBulkParametersEditor,
   handleDuplicateRequest,
   handleUpdateRequestMimeType,
   headerEditorKey,
@@ -154,8 +149,6 @@ export const WrapperDebug: FC<Props> = ({
               request={activeRequest}
               settings={settings}
               updateRequestMimeType={handleUpdateRequestMimeType}
-              updateSettingsUseBulkHeaderEditor={handleUpdateSettingsUseBulkHeaderEditor}
-              updateSettingsUseBulkParametersEditor={handleUpdateSettingsUseBulkParametersEditor}
               workspace={activeWorkspace}
             />}
         </ErrorBoundary>

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -53,8 +53,6 @@ interface Props {
   handleActivateRequest: (activeRequestId: string) => void;
   handleCopyAsCurl: Function;
   handleDuplicateRequest: Function;
-  handleGenerateCode: Function;
-  handleGenerateCodeForActiveRequest: Function;
   handleSetSidebarFilter: (value: string) => Promise<void>;
   handleUpdateDownloadPath: Function;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
@@ -80,8 +78,6 @@ export const WrapperDebug: FC<Props> = ({
   handleActivateRequest,
   handleCopyAsCurl,
   handleDuplicateRequest,
-  handleGenerateCode,
-  handleGenerateCodeForActiveRequest,
   handleSetSidebarFilter,
   handleUpdateDownloadPath,
   handleUpdateRequestMimeType,
@@ -146,7 +142,6 @@ export const WrapperDebug: FC<Props> = ({
           childObjects={sidebarChildren}
           handleActivateRequest={handleActivateRequest}
           handleDuplicateRequest={handleDuplicateRequest}
-          handleGenerateCode={handleGenerateCode}
           handleCopyAsCurl={handleCopyAsCurl}
           filter={sidebarFilter || ''}
         />
@@ -169,7 +164,6 @@ export const WrapperDebug: FC<Props> = ({
               forceRefreshCounter={forceRefreshKey}
               forceUpdateRequest={handleForceUpdateRequest}
               forceUpdateRequestHeaders={handleForceUpdateRequestHeaders}
-              handleGenerateCode={handleGenerateCodeForActiveRequest}
               handleImport={handleImport}
               handleSend={handleSendRequestWithActiveEnvironment}
               handleSendAndDownload={handleSendAndDownloadRequestWithActiveEnvironment}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -11,8 +11,6 @@ import {
   selectActiveProject,
   selectActiveRequest,
   selectActiveWorkspace,
-  selectActiveWorkspaceMeta,
-  selectEnvironments,
   selectIsLoggedIn,
   selectSettings,
 } from '../redux/selectors';
@@ -61,14 +59,12 @@ export const WrapperDebug: FC<Props> = ({
 }) => {
 
   const activeProject = useSelector(selectActiveProject);
-  const activeWorkspaceMeta = useSelector(selectActiveWorkspaceMeta);
   const isLoggedIn = useSelector(selectIsLoggedIn);
 
   const activeEnvironment = useSelector(selectActiveEnvironment);
   const activeRequest = useSelector(selectActiveRequest);
 
   const activeWorkspace = useSelector(selectActiveWorkspace);
-  const environments = useSelector(selectEnvironments);
 
   const settings = useSelector(selectSettings);
   const sidebarFilter = useSelector(selectSidebarFilter);
@@ -82,7 +78,6 @@ export const WrapperDebug: FC<Props> = ({
           handleActivityChange={handleActivityChange}
           gridRight={isTeamSync ? <SyncDropdown
             workspace={activeWorkspace}
-            workspaceMeta={activeWorkspaceMeta}
             project={activeProject}
             vcs={vcs}
           /> : isDesign(activeWorkspace) ? gitSyncDropdown : null}
@@ -93,7 +88,6 @@ export const WrapperDebug: FC<Props> = ({
           <EnvironmentsDropdown
             activeEnvironment={activeEnvironment}
             environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
-            environments={environments}
             handleSetActiveEnvironment={handleSetActiveEnvironment}
             workspace={activeWorkspace}
           />

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -50,7 +50,6 @@ interface Props {
   handleSidebarSort: (sortOrder: SortOrder) => void;
   handleUpdateSettingsUseBulkHeaderEditor: Function;
   handleUpdateSettingsUseBulkParametersEditor: (useBulkParametersEditor: boolean) => Promise<Settings>;
-  handleCopyAsCurl: Function;
   handleDuplicateRequest: Function;
   handleSetSidebarFilter: (value: string) => Promise<void>;
   handleUpdateDownloadPath: Function;
@@ -74,7 +73,6 @@ export const WrapperDebug: FC<Props> = ({
   handleSidebarSort,
   handleUpdateSettingsUseBulkHeaderEditor,
   handleUpdateSettingsUseBulkParametersEditor,
-  handleCopyAsCurl,
   handleDuplicateRequest,
   handleSetSidebarFilter,
   handleUpdateDownloadPath,
@@ -139,7 +137,6 @@ export const WrapperDebug: FC<Props> = ({
         <SidebarChildren
           childObjects={sidebarChildren}
           handleDuplicateRequest={handleDuplicateRequest}
-          handleCopyAsCurl={handleCopyAsCurl}
           filter={sidebarFilter || ''}
         />
       </Fragment>

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -49,7 +49,6 @@ interface Props {
   handleUpdateSettingsUseBulkHeaderEditor: Function;
   handleUpdateSettingsUseBulkParametersEditor: (useBulkParametersEditor: boolean) => Promise<Settings>;
   handleDuplicateRequest: Function;
-  handleSetSidebarFilter: (value: string) => Promise<void>;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   headerEditorKey: string;
   vcs: VCS | null;
@@ -70,7 +69,6 @@ export const WrapperDebug: FC<Props> = ({
   handleUpdateSettingsUseBulkHeaderEditor,
   handleUpdateSettingsUseBulkParametersEditor,
   handleDuplicateRequest,
-  handleSetSidebarFilter,
   handleUpdateRequestMimeType,
   headerEditorKey,
   vcs,
@@ -124,7 +122,6 @@ export const WrapperDebug: FC<Props> = ({
 
         <SidebarFilter
           key={`${activeWorkspace._id}::filter`}
-          onChange={handleSetSidebarFilter}
           filter={sidebarFilter || ''}
         />
 

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -85,10 +85,8 @@ export const WrapperDebug: FC<Props> = ({
     handleActivateRequest,
     handleCopyAsCurl,
     handleDuplicateRequest,
-    handleDuplicateRequestGroup,
     handleGenerateCode,
     handleGenerateCodeForActiveRequest,
-    handleSetRequestGroupCollapsed,
     handleSetRequestPinned,
     handleSetSidebarFilter,
     handleUpdateDownloadPath,
@@ -151,10 +149,8 @@ export const WrapperDebug: FC<Props> = ({
         <SidebarChildren
           childObjects={sidebarChildren}
           handleActivateRequest={handleActivateRequest}
-          handleSetRequestGroupCollapsed={handleSetRequestGroupCollapsed}
           handleSetRequestPinned={handleSetRequestPinned}
           handleDuplicateRequest={handleDuplicateRequest}
-          handleDuplicateRequestGroup={handleDuplicateRequestGroup}
           handleGenerateCode={handleGenerateCode}
           handleCopyAsCurl={handleCopyAsCurl}
           filter={sidebarFilter || ''}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -52,7 +52,6 @@ interface Props {
   handleUpdateSettingsUseBulkParametersEditor: (useBulkParametersEditor: boolean) => Promise<Settings>;
   handleDuplicateRequest: Function;
   handleSetSidebarFilter: (value: string) => Promise<void>;
-  handleUpdateDownloadPath: Function;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   headerEditorKey: string;
   vcs: VCS | null;
@@ -75,7 +74,6 @@ export const WrapperDebug: FC<Props> = ({
   handleUpdateSettingsUseBulkParametersEditor,
   handleDuplicateRequest,
   handleSetSidebarFilter,
-  handleUpdateDownloadPath,
   handleUpdateRequestMimeType,
   headerEditorKey,
   vcs,
@@ -161,7 +159,6 @@ export const WrapperDebug: FC<Props> = ({
               handleImport={handleImport}
               handleSend={handleSendRequestWithActiveEnvironment}
               handleSendAndDownload={handleSendAndDownloadRequestWithActiveEnvironment}
-              handleUpdateDownloadPath={handleUpdateDownloadPath}
               headerEditorKey={headerEditorKey}
               request={activeRequest}
               settings={settings}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -87,7 +87,6 @@ export const WrapperDebug: FC<Props> = ({
     handleDuplicateRequest,
     handleGenerateCode,
     handleGenerateCodeForActiveRequest,
-    handleSetRequestPinned,
     handleSetSidebarFilter,
     handleUpdateDownloadPath,
     handleUpdateRequestMimeType,
@@ -149,7 +148,6 @@ export const WrapperDebug: FC<Props> = ({
         <SidebarChildren
           childObjects={sidebarChildren}
           handleActivateRequest={handleActivateRequest}
-          handleSetRequestPinned={handleSetRequestPinned}
           handleDuplicateRequest={handleDuplicateRequest}
           handleGenerateCode={handleGenerateCode}
           handleCopyAsCurl={handleCopyAsCurl}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { isGrpcRequest } from '../../models/grpc-request';
 import { isRemoteProject } from '../../models/project';
 import { Request, RequestHeader } from '../../models/request';
+import type { Response } from '../../models/response';
 import { isCollection, isDesign } from '../../models/workspace';
 import { VCS } from '../../sync/vcs/vcs';
 import {
@@ -34,6 +35,7 @@ interface Props {
   gitSyncDropdown: ReactNode;
   handleActivityChange: HandleActivityChange;
   handleSetActiveEnvironment: Function;
+  handleSetActiveResponse: (requestId: string, activeResponse: Response | null) => void;
   handleForceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
   handleForceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleImport: Function;
@@ -48,6 +50,7 @@ export const WrapperDebug: FC<Props> = ({
   gitSyncDropdown,
   handleActivityChange,
   handleSetActiveEnvironment,
+  handleSetActiveResponse,
   handleForceUpdateRequest,
   handleForceUpdateRequestHeaders,
   handleImport,
@@ -145,6 +148,7 @@ export const WrapperDebug: FC<Props> = ({
             <ResponsePane
               handleSetFilter={handleSetResponseFilter}
               request={activeRequest}
+              handleSetActiveResponse={handleSetActiveResponse}
             />}
         </ErrorBoundary>}
     />

--- a/packages/insomnia/src/ui/components/wrapper-design.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-design.tsx
@@ -20,7 +20,7 @@ import { ErrorBoundary } from './error-boundary';
 import { PageLayout } from './page-layout';
 import { SpecEditorSidebar } from './spec-editor/spec-editor-sidebar';
 import { WorkspacePageHeader } from './workspace-page-header';
-import type { HandleActivityChange, WrapperProps } from './wrapper';
+import type { HandleActivityChange } from './wrapper';
 
 const EmptySpaceHelper = styled.div({
   ...superFaint,
@@ -292,19 +292,16 @@ const RenderPageSidebar: FC<{ editor: RefObject<UnconnectedCodeEditor> }> = ({ e
 interface Props {
   gitSyncDropdown: ReactNode;
   handleActivityChange: HandleActivityChange;
-  wrapperProps: WrapperProps;
 }
 
 export const WrapperDesign: FC<Props> = ({
   gitSyncDropdown,
   handleActivityChange,
-  wrapperProps,
 }) => {
   const editor = createRef<UnconnectedCodeEditor>();
 
   return (
     <PageLayout
-      wrapperProps={wrapperProps}
       renderPageHeader={
         <RenderPageHeader
           gitSyncDropdown={gitSyncDropdown}

--- a/packages/insomnia/src/ui/components/wrapper-home.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-home.tsx
@@ -27,6 +27,7 @@ import { isDesign, Workspace, WorkspaceScopeKeys } from '../../models/workspace'
 import { WorkspaceMeta } from '../../models/workspace-meta';
 import { MemClient } from '../../sync/git/mem-client';
 import { initializeLocalBackendProjectAndMarkForSync } from '../../sync/vcs/initialize-backend-project';
+import { VCS } from '../../sync/vcs/vcs';
 import { cloneGitRepository } from '../redux/modules/git';
 import { selectIsLoading, setDashboardSortOrder } from '../redux/modules/global';
 import { ForceToWorkspace } from '../redux/modules/helpers';
@@ -41,7 +42,6 @@ import { KeydownBinder } from './keydown-binder';
 import { showPrompt } from './modals';
 import { PageLayout } from './page-layout';
 import { WorkspaceCard, WorkspaceCardProps } from './workspace-card';
-import type { WrapperProps } from './wrapper';
 
 const CreateButton = styled(Button)({
   '&&': {
@@ -50,7 +50,7 @@ const CreateButton = styled(Button)({
 });
 
 interface Props {
-  wrapperProps: WrapperProps;
+  vcs: VCS | null;
 }
 
 function orderDashboardCards(orderBy: DashboardSortOrder) {
@@ -145,7 +145,7 @@ const mapWorkspaceToWorkspaceCard = ({
   };
 };
 
-const WrapperHome: FC<Props> = (({ wrapperProps }) => {
+const WrapperHome: FC<Props> = (({ vcs }) => {
   const sortOrder = useSelector(selectDashboardSortOrder);
   const activeProject = useSelector(selectActiveProject);
   const isLoggedIn = useSelector(selectIsLoggedIn);
@@ -187,7 +187,6 @@ const WrapperHome: FC<Props> = (({ wrapperProps }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [filter, setFilter] = useState('');
 
-  const { vcs } = wrapperProps;
   // Render each card, removing all the ones that don't match the filter
   const cards = workspacesForActiveProject
     .map(mapWorkspaceToWorkspaceCard({ workspaceMetas, apiSpecs }))
@@ -253,7 +252,6 @@ const WrapperHome: FC<Props> = (({ wrapperProps }) => {
 
   return (
     <PageLayout
-      wrapperProps={wrapperProps}
       renderPageHeader={
         <AppHeader
           breadcrumbProps={{

--- a/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-unit-test.tsx
@@ -23,6 +23,7 @@ import type { UnitTest } from '../../models/unit-test';
 import type { UnitTestSuite } from '../../models/unit-test-suite';
 import { getSendRequestCallback } from '../../network/unit-test-feature';
 import { selectActiveEnvironment, selectActiveUnitTestResult, selectActiveUnitTests, selectActiveUnitTestSuite, selectActiveUnitTestSuites, selectActiveWorkspace } from '../redux/selectors';
+import { selectSidebarChildren } from '../redux/sidebar-selectors';
 import { Editable } from './base/editable';
 import { CodeEditor } from './codemirror/code-editor';
 import { ErrorBoundary } from './error-boundary';
@@ -30,10 +31,10 @@ import { showAlert, showModal, showPrompt } from './modals';
 import { SelectModal } from './modals/select-modal';
 import { PageLayout } from './page-layout';
 import { EmptyStatePane } from './panes/empty-state-pane';
-import type { Child, SidebarChildObjects } from './sidebar/sidebar-children';
+import type { Child } from './sidebar/sidebar-children';
 import { UnitTestEditable } from './unit-test-editable';
 import { WorkspacePageHeader } from './workspace-page-header';
-import type { HandleActivityChange, WrapperProps } from './wrapper';
+import type { HandleActivityChange } from './wrapper';
 
 const HeaderButton = styled(Button)({
   '&&': {
@@ -42,15 +43,11 @@ const HeaderButton = styled(Button)({
 });
 
 interface Props {
-  sidebarChildren: SidebarChildObjects;
   gitSyncDropdown: ReactNode;
   handleActivityChange: HandleActivityChange;
-  wrapperProps: WrapperProps;
 }
 
 const WrapperUnitTest: FC<Props> = ({
-  sidebarChildren,
-  wrapperProps,
   gitSyncDropdown,
   handleActivityChange,
 }) => {
@@ -72,6 +69,7 @@ const WrapperUnitTest: FC<Props> = ({
     // Enable NodeJS globals
     esversion: 8, // ES8 syntax (async/await, etc)
   };
+  const sidebarChildren = useSelector(selectSidebarChildren);
   const activeWorkspace = useSelector(selectActiveWorkspace);
   const activeUnitTestSuite = useSelector(selectActiveUnitTestSuite);
   const activeUnitTestSuites = useSelector(selectActiveUnitTestSuites);
@@ -302,7 +300,6 @@ const WrapperUnitTest: FC<Props> = ({
 
   return (
     <PageLayout
-      wrapperProps={wrapperProps}
       renderPageSidebar={
         <ErrorBoundary showAlert>
           <div className="unit-tests__sidebar">

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -16,7 +16,6 @@ import {
 import { database as db } from '../../common/database';
 import { importRaw } from '../../common/import';
 import { initializeSpectral, isLintError } from '../../common/spectral';
-import type { Cookie } from '../../models/cookie-jar';
 import { update } from '../../models/helpers/request-operations';
 import * as models from '../../models/index';
 import {
@@ -254,10 +253,6 @@ export class WrapperClass extends PureComponent<Props, State> {
     }, 1000);
   }
 
-  static _handleShowModifyCookieModal(cookie: Cookie) {
-    showModal(CookieModifyModal, cookie);
-  }
-
   async _handleRemoveActiveWorkspace() {
     const { activeWorkspace, handleSetActiveActivity } = this.props;
 
@@ -390,7 +385,6 @@ export class WrapperClass extends PureComponent<Props, State> {
               {activeCookieJar ? <>
                 <CookiesModalFC
                   ref={registerModal}
-                  handleShowModifyCookieModal={Wrapper._handleShowModifyCookieModal}
                 />
                 <CookieModifyModal ref={registerModal} />
               </> : null}

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -125,7 +125,6 @@ const ActivityRouter = () => {
 const spectral = initializeSpectral();
 
 export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps> & {
-  handleActivateRequest: (activeRequestId: string) => void;
   handleSetSidebarFilter: (value: string) => Promise<void>;
   handleSetActiveEnvironment: (environmentId: string | null) => Promise<void>;
   handleDuplicateRequest: Function;
@@ -382,7 +381,6 @@ export class WrapperClass extends PureComponent<Props, State> {
       activeWorkspace,
       activeApiSpec,
       gitVCS,
-      handleActivateRequest,
       handleSidebarSort,
       vcs,
     } = this.props;
@@ -463,7 +461,6 @@ export class WrapperClass extends PureComponent<Props, State> {
 
             <RequestSwitcherModal
               ref={registerModal}
-              activateRequest={handleActivateRequest}
             />
 
             <EnvironmentEditModal

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -128,7 +128,6 @@ export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDi
   handleSetSidebarFilter: (value: string) => Promise<void>;
   handleSetActiveEnvironment: (environmentId: string | null) => Promise<void>;
   handleDuplicateRequest: Function;
-  handleCopyAsCurl: Function;
   handleSetResponsePreviewMode: Function;
   handleSetResponseFilter: Function;
   handleSetActiveResponse: Function;

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -127,7 +127,6 @@ export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDi
   handleSetActiveEnvironment: (environmentId: string | null) => Promise<void>;
   handleDuplicateRequest: Function;
   handleSetResponseFilter: Function;
-  handleSetActiveResponse: Function;
   handleSendRequestWithEnvironment: Function;
   handleSendAndDownloadRequestWithEnvironment: Function;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
@@ -262,15 +261,6 @@ export class WrapperClass extends PureComponent<Props, State> {
 
   _handleUpdateSettingsUseBulkParametersEditor(useBulkParametersEditor: boolean) {
     return models.settings.update(this.props.settings, { useBulkParametersEditor });
-  }
-
-  _handleSetActiveResponse(responseId: string | null) {
-    if (!this.props.activeRequest) {
-      console.warn('Tried to set active response when request not active');
-      return;
-    }
-
-    this.props.handleSetActiveResponse(this.props.activeRequest._id, responseId);
   }
 
   _handleShowEnvironmentsModal() {
@@ -550,7 +540,6 @@ export class WrapperClass extends PureComponent<Props, State> {
                   handleImport={this._handleImport}
                   handleSendAndDownloadRequestWithActiveEnvironment={this._handleSendAndDownloadRequestWithActiveEnvironment}
                   handleSendRequestWithActiveEnvironment={this._handleSendRequestWithActiveEnvironment}
-                  handleSetActiveResponse={this._handleSetActiveResponse}
                   handleSetResponseFilter={this._handleSetResponseFilter}
                   handleShowRequestSettingsModal={this._handleShowRequestSettingsModal}
                   handleUpdateSettingsUseBulkHeaderEditor={this._handleUpdateSettingsUseBulkHeaderEditor}

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -254,16 +254,8 @@ export class WrapperClass extends PureComponent<Props, State> {
     }, 1000);
   }
 
-  _handleShowEnvironmentsModal() {
-    showModal(WorkspaceEnvironmentsEditModal, this.props.activeWorkspace);
-  }
-
   static _handleShowModifyCookieModal(cookie: Cookie) {
     showModal(CookieModifyModal, cookie);
-  }
-
-  _handleShowRequestSettingsModal() {
-    showModal(RequestSettingsModal, { request: this.props.activeRequest });
   }
 
   async _handleRemoveActiveWorkspace() {
@@ -532,7 +524,6 @@ export class WrapperClass extends PureComponent<Props, State> {
                   handleSendAndDownloadRequestWithActiveEnvironment={this._handleSendAndDownloadRequestWithActiveEnvironment}
                   handleSendRequestWithActiveEnvironment={this._handleSendRequestWithActiveEnvironment}
                   handleSetResponseFilter={this._handleSetResponseFilter}
-                  handleShowRequestSettingsModal={this._handleShowRequestSettingsModal}
                 />
               </Suspense>
             }

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -128,7 +128,6 @@ export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDi
   handleSetSidebarFilter: (value: string) => Promise<void>;
   handleSetActiveEnvironment: (environmentId: string | null) => Promise<void>;
   handleDuplicateRequest: Function;
-  handleSetResponsePreviewMode: Function;
   handleSetResponseFilter: Function;
   handleSetActiveResponse: Function;
   handleSidebarSort: (sortOrder: SortOrder) => void;
@@ -337,12 +336,6 @@ export class WrapperClass extends PureComponent<Props, State> {
       activeEnvironmentId,
       filename,
     );
-  }
-
-  _handleSetPreviewMode(previewMode: string) {
-    const activeRequest = this.props.activeRequest;
-    const activeRequestId = activeRequest ? activeRequest._id : 'n/a';
-    this.props.handleSetResponsePreviewMode(activeRequestId, previewMode);
   }
 
   _handleSetResponseFilter(filter: string) {
@@ -562,7 +555,6 @@ export class WrapperClass extends PureComponent<Props, State> {
                   handleSendAndDownloadRequestWithActiveEnvironment={this._handleSendAndDownloadRequestWithActiveEnvironment}
                   handleSendRequestWithActiveEnvironment={this._handleSendRequestWithActiveEnvironment}
                   handleSetActiveResponse={this._handleSetActiveResponse}
-                  handleSetPreviewMode={this._handleSetPreviewMode}
                   handleSetResponseFilter={this._handleSetResponseFilter}
                   handleShowRequestSettingsModal={this._handleShowRequestSettingsModal}
                   handleSidebarSort={handleSidebarSort}

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -129,8 +129,6 @@ export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDi
   handleSetSidebarFilter: (value: string) => Promise<void>;
   handleSetActiveEnvironment: (environmentId: string | null) => Promise<void>;
   handleDuplicateRequest: Function;
-  handleGenerateCodeForActiveRequest: Function;
-  handleGenerateCode: Function;
   handleCopyAsCurl: Function;
   handleSetResponsePreviewMode: Function;
   handleSetResponseFilter: Function;

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -27,7 +27,6 @@ import {
   RequestHeader,
   RequestParameter,
 } from '../../models/request';
-import { RequestGroup } from '../../models/request-group';
 import { GitVCS } from '../../sync/git/git-vcs';
 import { VCS } from '../../sync/vcs/vcs';
 import { CookieModifyModal } from '../components/modals/cookie-modify-modal';
@@ -133,7 +132,6 @@ export type WrapperProps = AppProps & ReturnType<typeof mapStateToProps> & Retur
   handleSetSidebarFilter: (value: string) => Promise<void>;
   handleSetActiveEnvironment: (environmentId: string | null) => Promise<void>;
   handleDuplicateRequest: Function;
-  handleDuplicateRequestGroup: (requestGroup: RequestGroup) => void;
   handleGenerateCodeForActiveRequest: Function;
   handleGenerateCode: Function;
   handleCopyAsCurl: Function;
@@ -141,7 +139,6 @@ export type WrapperProps = AppProps & ReturnType<typeof mapStateToProps> & Retur
   handleSetResponseFilter: Function;
   handleSetActiveResponse: Function;
   handleSidebarSort: (sortOrder: SortOrder) => void;
-  handleSetRequestGroupCollapsed: Function;
   handleSetRequestPinned: Function;
   handleSendRequestWithEnvironment: Function;
   handleSendAndDownloadRequestWithEnvironment: Function;

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -12,7 +12,6 @@ import {
   ACTIVITY_SPEC,
   ACTIVITY_UNIT_TEST,
   AUTOBIND_CFG,
-  SortOrder,
 } from '../../common/constants';
 import { database as db } from '../../common/database';
 import { importRaw } from '../../common/import';
@@ -130,7 +129,6 @@ export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDi
   handleDuplicateRequest: Function;
   handleSetResponseFilter: Function;
   handleSetActiveResponse: Function;
-  handleSidebarSort: (sortOrder: SortOrder) => void;
   handleSendRequestWithEnvironment: Function;
   handleSendAndDownloadRequestWithEnvironment: Function;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
@@ -371,7 +369,6 @@ export class WrapperClass extends PureComponent<Props, State> {
       activeWorkspace,
       activeApiSpec,
       gitVCS,
-      handleSidebarSort,
       vcs,
     } = this.props;
 
@@ -557,7 +554,6 @@ export class WrapperClass extends PureComponent<Props, State> {
                   handleSetActiveResponse={this._handleSetActiveResponse}
                   handleSetResponseFilter={this._handleSetResponseFilter}
                   handleShowRequestSettingsModal={this._handleShowRequestSettingsModal}
-                  handleSidebarSort={handleSidebarSort}
                   handleUpdateSettingsUseBulkHeaderEditor={this._handleUpdateSettingsUseBulkHeaderEditor}
                   handleUpdateSettingsUseBulkParametersEditor={this._handleUpdateSettingsUseBulkParametersEditor}
                 />

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -397,7 +397,7 @@ export class WrapperClass extends PureComponent<Props, State> {
 
             <WorkspaceEnvironmentsEditModal
               ref={registerModal}
-              handleChangeEnvironment={handleSetActiveEnvironment}
+              handleSetActiveEnvironment={handleSetActiveEnvironment}
               activeEnvironmentId={activeEnvironment ? activeEnvironment._id : null}
             />
 

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -254,15 +254,6 @@ export class WrapperClass extends PureComponent<Props, State> {
     }, 1000);
   }
 
-  // Settings updaters
-  _handleUpdateSettingsUseBulkHeaderEditor(useBulkHeaderEditor: boolean) {
-    return models.settings.update(this.props.settings, { useBulkHeaderEditor });
-  }
-
-  _handleUpdateSettingsUseBulkParametersEditor(useBulkParametersEditor: boolean) {
-    return models.settings.update(this.props.settings, { useBulkParametersEditor });
-  }
-
   _handleShowEnvironmentsModal() {
     showModal(WorkspaceEnvironmentsEditModal, this.props.activeWorkspace);
   }
@@ -542,8 +533,6 @@ export class WrapperClass extends PureComponent<Props, State> {
                   handleSendRequestWithActiveEnvironment={this._handleSendRequestWithActiveEnvironment}
                   handleSetResponseFilter={this._handleSetResponseFilter}
                   handleShowRequestSettingsModal={this._handleShowRequestSettingsModal}
-                  handleUpdateSettingsUseBulkHeaderEditor={this._handleUpdateSettingsUseBulkHeaderEditor}
-                  handleUpdateSettingsUseBulkParametersEditor={this._handleUpdateSettingsUseBulkParametersEditor}
                 />
               </Suspense>
             }

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -135,8 +135,6 @@ export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDi
   handleSendRequestWithEnvironment: Function;
   handleSendAndDownloadRequestWithEnvironment: Function;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
-  handleUpdateDownloadPath: Function;
-
   headerEditorKey: string;
   vcs: VCS | null;
   gitVCS: GitVCS | null;

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -436,9 +436,7 @@ export class WrapperClass extends PureComponent<Props, State> {
             />
 
             <AddKeyCombinationModal ref={registerModal} />
-            <ExportRequestsModal
-              ref={registerModal}
-            />
+            <ExportRequestsModal ref={registerModal} />
 
             <GrpcDispatchModalWrapper>
               {dispatch => (
@@ -528,4 +526,4 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => {
   };
 };
 
-export const Wrapper = connect(mapStateToProps, mapDispatchToProps)(WrapperClass);
+export const Wrapper = connect(mapStateToProps, mapDispatchToProps, null, { forwardRef: true })(WrapperClass);

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -124,7 +124,6 @@ const ActivityRouter = () => {
 const spectral = initializeSpectral();
 
 export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps> & {
-  handleSetSidebarFilter: (value: string) => Promise<void>;
   handleSetActiveEnvironment: (environmentId: string | null) => Promise<void>;
   handleDuplicateRequest: Function;
   handleSetResponseFilter: Function;

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -139,7 +139,6 @@ export type WrapperProps = AppProps & ReturnType<typeof mapStateToProps> & Retur
   handleSetResponseFilter: Function;
   handleSetActiveResponse: Function;
   handleSidebarSort: (sortOrder: SortOrder) => void;
-  handleSetRequestPinned: Function;
   handleSendRequestWithEnvironment: Function;
   handleSendAndDownloadRequestWithEnvironment: Function;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
@@ -432,7 +431,6 @@ export class WrapperClass extends PureComponent<WrapperProps, State> {
       gitVCS,
       handleActivateRequest,
       handleSidebarSort,
-      sidebarChildren,
       vcs,
     } = this.props;
 
@@ -556,7 +554,6 @@ export class WrapperClass extends PureComponent<WrapperProps, State> {
             <AddKeyCombinationModal ref={registerModal} />
             <ExportRequestsModal
               ref={registerModal}
-              childObjects={sidebarChildren.all}
             />
 
             <GrpcDispatchModalWrapper>
@@ -575,7 +572,9 @@ export class WrapperClass extends PureComponent<WrapperProps, State> {
             path="*"
             element={
               <Suspense fallback={<div />}>
-                <WrapperHome wrapperProps={this.props} />
+                <WrapperHome
+                  vcs={vcs}
+                />
               </Suspense>
             }
           />
@@ -585,9 +584,7 @@ export class WrapperClass extends PureComponent<WrapperProps, State> {
               <Suspense fallback={<div />}>
                 <WrapperUnitTest
                   gitSyncDropdown={gitSyncDropdown}
-                  wrapperProps={this.props}
                   handleActivityChange={this._handleWorkspaceActivityChange}
-                  sidebarChildren={sidebarChildren}
                 />
               </Suspense>
             }
@@ -599,7 +596,6 @@ export class WrapperClass extends PureComponent<WrapperProps, State> {
                 <WrapperDesign
                   gitSyncDropdown={gitSyncDropdown}
                   handleActivityChange={this._handleWorkspaceActivityChange}
-                  wrapperProps={this.props}
                 />
               </Suspense>
             }

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -125,8 +125,6 @@ export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDi
   handleSetActiveEnvironment: (environmentId: string | null) => Promise<void>;
   handleDuplicateRequest: Function;
   handleSetResponseFilter: Function;
-  handleSendRequestWithEnvironment: Function;
-  handleSendAndDownloadRequestWithEnvironment: Function;
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   headerEditorKey: string;
   vcs: VCS | null;
@@ -252,28 +250,6 @@ export class WrapperClass extends PureComponent<Props, State> {
     }, 1000);
   }
 
-  _handleSendRequestWithActiveEnvironment() {
-    const { activeRequest, activeEnvironment, handleSendRequestWithEnvironment } = this.props;
-    const activeRequestId = activeRequest ? activeRequest._id : 'n/a';
-    const activeEnvironmentId = activeEnvironment ? activeEnvironment._id : 'n/a';
-    handleSendRequestWithEnvironment(activeRequestId, activeEnvironmentId);
-  }
-
-  async _handleSendAndDownloadRequestWithActiveEnvironment(filename?: string) {
-    const {
-      activeRequest,
-      activeEnvironment,
-      handleSendAndDownloadRequestWithEnvironment,
-    } = this.props;
-    const activeRequestId = activeRequest ? activeRequest._id : 'n/a';
-    const activeEnvironmentId = activeEnvironment ? activeEnvironment._id : 'n/a';
-    await handleSendAndDownloadRequestWithEnvironment(
-      activeRequestId,
-      activeEnvironmentId,
-      filename,
-    );
-  }
-
   _handleSetResponseFilter(filter: string) {
     const activeRequest = this.props.activeRequest;
     const activeRequestId = activeRequest ? activeRequest._id : 'n/a';
@@ -306,6 +282,8 @@ export class WrapperClass extends PureComponent<Props, State> {
       activeGitRepository,
       activeWorkspace,
       activeApiSpec,
+      handleUpdateRequestMimeType,
+      handleSetActiveEnvironment,
       gitVCS,
       vcs,
     } = this.props;
@@ -419,7 +397,7 @@ export class WrapperClass extends PureComponent<Props, State> {
 
             <WorkspaceEnvironmentsEditModal
               ref={registerModal}
-              handleChangeEnvironment={this.props.handleSetActiveEnvironment}
+              handleChangeEnvironment={handleSetActiveEnvironment}
               activeEnvironmentId={activeEnvironment ? activeEnvironment._id : null}
             />
 
@@ -480,13 +458,12 @@ export class WrapperClass extends PureComponent<Props, State> {
                   forceRefreshKey={this.state.forceRefreshKey}
                   gitSyncDropdown={gitSyncDropdown}
                   handleActivityChange={this._handleWorkspaceActivityChange}
-                  handleSetActiveEnvironment={this.props.handleSetActiveEnvironment}
+                  handleSetActiveEnvironment={handleSetActiveEnvironment}
                   handleForceUpdateRequest={this._handleForceUpdateRequest}
                   handleForceUpdateRequestHeaders={this._handleForceUpdateRequestHeaders}
                   handleImport={this._handleImport}
-                  handleSendAndDownloadRequestWithActiveEnvironment={this._handleSendAndDownloadRequestWithActiveEnvironment}
-                  handleSendRequestWithActiveEnvironment={this._handleSendRequestWithActiveEnvironment}
                   handleSetResponseFilter={this._handleSetResponseFilter}
+                  handleUpdateRequestMimeType={handleUpdateRequestMimeType}
                 />
               </Suspense>
             }

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -13,7 +13,6 @@ import {
   ACTIVITY_UNIT_TEST,
   AUTOBIND_CFG,
 } from '../../common/constants';
-import { database as db } from '../../common/database';
 import { importRaw } from '../../common/import';
 import { initializeSpectral, isLintError } from '../../common/spectral';
 import { update } from '../../models/helpers/request-operations';
@@ -253,34 +252,6 @@ export class WrapperClass extends PureComponent<Props, State> {
     }, 1000);
   }
 
-  async _handleRemoveActiveWorkspace() {
-    const { activeWorkspace, handleSetActiveActivity } = this.props;
-
-    if (!activeWorkspace) {
-      return;
-    }
-
-    await models.stats.incrementDeletedRequestsForDescendents(activeWorkspace);
-    await models.workspace.remove(activeWorkspace);
-
-    handleSetActiveActivity(ACTIVITY_HOME);
-  }
-
-  async _handleActiveWorkspaceClearAllResponses() {
-    const { activeWorkspace } = this.props;
-
-    if (!activeWorkspace) {
-      return;
-    }
-
-    const docs = await db.withDescendants(activeWorkspace, models.request.type);
-    const requests = docs.filter(isRequest);
-
-    for (const req of requests) {
-      await models.response.removeForRequest(req._id);
-    }
-  }
-
   _handleSendRequestWithActiveEnvironment() {
     const { activeRequest, activeEnvironment, handleSendRequestWithEnvironment } = this.props;
     const activeRequestId = activeRequest ? activeRequest._id : 'n/a';
@@ -399,8 +370,6 @@ export class WrapperClass extends PureComponent<Props, State> {
                 ref={registerModal}
                 workspace={activeWorkspace}
                 apiSpec={activeApiSpec}
-                handleRemoveWorkspace={this._handleRemoveActiveWorkspace}
-                handleClearAllResponses={this._handleActiveWorkspaceClearAllResponses}
               /> : null}
             </> : null}
 

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -96,7 +96,6 @@ import {
   selectIsLoggedIn,
   selectSettings,
 } from '../redux/selectors';
-import { selectSidebarChildren } from '../redux/sidebar-selectors';
 import { AppHooks } from './app-hooks';
 
 export type AppProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
@@ -1134,7 +1133,6 @@ class App extends PureComponent<AppProps, State> {
                 <Wrapper
                   ref={this._setWrapperRef}
                   {...this.props}
-                  handleSetRequestPinned={this._handleSetRequestPinned}
                   handleActivateRequest={this._handleSetActiveRequest}
                   handleDuplicateRequest={this._requestDuplicate}
                   handleGenerateCode={App._handleGenerateCode}
@@ -1184,7 +1182,6 @@ const mapStateToProps = (state: RootState) => ({
   isLoggedIn: selectIsLoggedIn(state),
   isFinishedBooting: selectIsFinishedBooting(state),
   settings: selectSettings(state),
-  sidebarChildren: selectSidebarChildren(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<Action<any>>) => {

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -1132,7 +1132,6 @@ class App extends PureComponent<AppProps, State> {
               <ErrorBoundary showAlert>
                 <Wrapper
                   ref={this._setWrapperRef}
-                  {...this.props}
                   handleActivateRequest={this._handleSetActiveRequest}
                   handleDuplicateRequest={this._requestDuplicate}
                   handleGenerateCode={App._handleGenerateCode}

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -40,7 +40,6 @@ import { type RequestGroupMeta } from '../../models/request-group-meta';
 import { RequestMeta } from '../../models/request-meta';
 import { Response } from '../../models/response';
 import { isWorkspace } from '../../models/workspace';
-import { WorkspaceMeta } from '../../models/workspace-meta';
 import * as network from '../../network/network';
 import * as plugins from '../../plugins';
 import * as themes from '../../plugins/misc';
@@ -382,32 +381,24 @@ class App extends PureComponent<AppProps, State> {
     }
   }
 
-  async _updateActiveWorkspaceMeta(patch: Partial<WorkspaceMeta>) {
-    const { activeWorkspaceMeta } = this.props;
-
-    if (activeWorkspaceMeta) {
-      await models.workspaceMeta.update(activeWorkspaceMeta, patch);
-    }
-  }
-
   async _updateShowVariableSourceAndValue() {
     const { settings } = this.props;
     await models.settings.update(settings, { showVariableSourceAndValue: !settings.showVariableSourceAndValue });
   }
 
   async _handleSetActiveRequest(activeRequestId: string) {
-    await this._updateActiveWorkspaceMeta({
-      activeRequestId,
-    });
+    if (this.props.activeWorkspaceMeta) {
+      await models.workspaceMeta.update(this.props.activeWorkspaceMeta, { activeRequestId });
+    }
     await updateRequestMetaByParentId(activeRequestId, {
       lastActive: Date.now(),
     });
   }
 
   async _handleSetActiveEnvironment(activeEnvironmentId: string | null) {
-    await this._updateActiveWorkspaceMeta({
-      activeEnvironmentId,
-    });
+    if (this.props.activeWorkspaceMeta) {
+      await models.workspaceMeta.update(this.props.activeWorkspaceMeta, { activeEnvironmentId });
+    }
     // Give it time to update and re-render
     setTimeout(() => {
       this._wrapper?._forceRequestPaneRefresh();
@@ -415,9 +406,9 @@ class App extends PureComponent<AppProps, State> {
   }
 
   async _handleSetSidebarFilter(sidebarFilter: string) {
-    await this._updateActiveWorkspaceMeta({
-      sidebarFilter,
-    });
+    if (this.props.activeWorkspaceMeta) {
+      await models.workspaceMeta.update(this.props.activeWorkspaceMeta, { sidebarFilter });
+    }
   }
 
   _handleSetResponsePreviewMode(requestId: string, previewMode: PreviewMode) {
@@ -1123,7 +1114,6 @@ class App extends PureComponent<AppProps, State> {
               <ErrorBoundary showAlert>
                 <Wrapper
                   ref={this._setWrapperRef}
-                  handleActivateRequest={this._handleSetActiveRequest}
                   handleDuplicateRequest={this._requestDuplicate}
                   handleCopyAsCurl={this._handleCopyAsCurl}
                   handleSetResponsePreviewMode={this._handleSetResponsePreviewMode}

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -348,12 +348,6 @@ class App extends PureComponent<AppProps, State> {
     }, 300);
   }
 
-  async _handleSetSidebarFilter(sidebarFilter: string) {
-    if (this.props.activeWorkspaceMeta) {
-      await models.workspaceMeta.update(this.props.activeWorkspaceMeta, { sidebarFilter });
-    }
-  }
-
   async _handleSetResponseFilter(requestId: string, responseFilter: string) {
     await updateRequestMetaByParentId(requestId, {
       responseFilter,
@@ -1053,7 +1047,6 @@ class App extends PureComponent<AppProps, State> {
                   }
                   handleSetActiveResponse={this._handleSetActiveResponse}
                   handleSetActiveEnvironment={this._handleSetActiveEnvironment}
-                  handleSetSidebarFilter={this._handleSetSidebarFilter}
                   handleUpdateRequestMimeType={this._handleUpdateRequestMimeType}
                   headerEditorKey={forceRefreshHeaderCounter + ''}
                   vcs={vcs}

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -321,16 +321,6 @@ class App extends PureComponent<AppProps, State> {
     });
   }
 
-  async _handleSetActiveEnvironment(activeEnvironmentId: string | null) {
-    if (this.props.activeWorkspaceMeta) {
-      await models.workspaceMeta.update(this.props.activeWorkspaceMeta, { activeEnvironmentId });
-    }
-    // Give it time to update and re-render
-    setTimeout(() => {
-      this._wrapper?._forceRequestPaneRefresh();
-    }, 300);
-  }
-
   async _handleSetResponseFilter(requestId: string, responseFilter: string) {
     await updateRequestMetaByParentId(requestId, {
       responseFilter,
@@ -833,7 +823,6 @@ class App extends PureComponent<AppProps, State> {
                   ref={this._setWrapperRef}
                   handleDuplicateRequest={this._requestDuplicate}
                   handleSetResponseFilter={this._handleSetResponseFilter}
-                  handleSetActiveEnvironment={this._handleSetActiveEnvironment}
                   handleUpdateRequestMimeType={this._handleUpdateRequestMimeType}
                   headerEditorKey={forceRefreshHeaderCounter + ''}
                   vcs={vcs}

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -345,22 +345,6 @@ class App extends PureComponent<AppProps, State> {
     }
   }
 
-  static async _requestGroupDuplicate(requestGroup: RequestGroup) {
-    showPrompt({
-      title: 'Duplicate Folder',
-      defaultValue: requestGroup.name,
-      submitName: 'Create',
-      label: 'New Name',
-      selectText: true,
-      onComplete: async (name: string) => {
-        const newRequestGroup = await models.requestGroup.duplicate(requestGroup, {
-          name,
-        });
-        models.stats.incrementCreatedRequestsForDescendents(newRequestGroup);
-      },
-    });
-  }
-
   _requestDuplicate(request?: Request | GrpcRequest) {
     if (!request) {
       return;
@@ -455,12 +439,6 @@ class App extends PureComponent<AppProps, State> {
   async _handleSetSidebarFilter(sidebarFilter: string) {
     await this._updateActiveWorkspaceMeta({
       sidebarFilter,
-    });
-  }
-
-  _handleSetRequestGroupCollapsed(requestGroupId: string, collapsed: boolean) {
-    App._updateRequestGroupMetaByParentId(requestGroupId, {
-      collapsed,
     });
   }
 
@@ -1175,10 +1153,8 @@ class App extends PureComponent<AppProps, State> {
                   ref={this._setWrapperRef}
                   {...this.props}
                   handleSetRequestPinned={this._handleSetRequestPinned}
-                  handleSetRequestGroupCollapsed={this._handleSetRequestGroupCollapsed}
                   handleActivateRequest={this._handleSetActiveRequest}
                   handleDuplicateRequest={this._requestDuplicate}
-                  handleDuplicateRequestGroup={App._requestGroupDuplicate}
                   handleGenerateCode={App._handleGenerateCode}
                   handleGenerateCodeForActiveRequest={this._handleGenerateCodeForActiveRequest}
                   handleCopyAsCurl={this._handleCopyAsCurl}

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -14,7 +14,6 @@ import {
   AUTOBIND_CFG,
   getProductName,
   isDevelopment,
-  PreviewMode,
   SortOrder,
 } from '../../common/constants';
 import { type ChangeBufferEvent, database as db } from '../../common/database';
@@ -394,12 +393,6 @@ class App extends PureComponent<AppProps, State> {
     if (this.props.activeWorkspaceMeta) {
       await models.workspaceMeta.update(this.props.activeWorkspaceMeta, { sidebarFilter });
     }
-  }
-
-  _handleSetResponsePreviewMode(requestId: string, previewMode: PreviewMode) {
-    updateRequestMetaByParentId(requestId, {
-      previewMode,
-    });
   }
 
   async _handleSetResponseFilter(requestId: string, responseFilter: string) {
@@ -1094,7 +1087,6 @@ class App extends PureComponent<AppProps, State> {
                 <Wrapper
                   ref={this._setWrapperRef}
                   handleDuplicateRequest={this._requestDuplicate}
-                  handleSetResponsePreviewMode={this._handleSetResponsePreviewMode}
                   handleSetResponseFilter={this._handleSetResponseFilter}
                   handleSendRequestWithEnvironment={this._handleSendRequestWithEnvironment}
                   handleSendAndDownloadRequestWithEnvironment={

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -1,7 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
-import { clipboard, ipcRenderer, SaveDialogOptions } from 'electron';
+import { ipcRenderer, SaveDialogOptions } from 'electron';
 import fs from 'fs';
-import HTTPSnippet from 'httpsnippet';
 import { extension as mimeExtension } from 'mime-types';
 import * as path from 'path';
 import React, { PureComponent } from 'react';
@@ -20,7 +19,6 @@ import {
 } from '../../common/constants';
 import { type ChangeBufferEvent, database as db } from '../../common/database';
 import { getDataDirectory } from '../../common/electron-helpers';
-import { exportHarRequest } from '../../common/har';
 import { hotKeyRefs } from '../../common/hotkeys';
 import { executeHotKey } from '../../common/hotkeys-listener';
 import {
@@ -350,19 +348,6 @@ class App extends PureComponent<AppProps, State> {
         models.stats.incrementCreatedRequests();
       },
     });
-  }
-
-  async _handleCopyAsCurl(request: Request) {
-    const { activeEnvironment } = this.props;
-    const environmentId = activeEnvironment ? activeEnvironment._id : 'n/a';
-    const har = await exportHarRequest(request._id, environmentId);
-    const snippet = new HTTPSnippet(har);
-    const cmd = snippet.convert('shell', 'curl');
-
-    // @TODO Should we throw otherwise? What should happen if we cannot find cmd?
-    if (cmd) {
-      clipboard.writeText(cmd);
-    }
   }
 
   static async _updateRequestGroupMetaByParentId(requestGroupId: string, patch: Partial<RequestGroupMeta>) {
@@ -1115,7 +1100,6 @@ class App extends PureComponent<AppProps, State> {
                 <Wrapper
                   ref={this._setWrapperRef}
                   handleDuplicateRequest={this._requestDuplicate}
-                  handleCopyAsCurl={this._handleCopyAsCurl}
                   handleSetResponsePreviewMode={this._handleSetResponsePreviewMode}
                   handleSetResponseFilter={this._handleSetResponseFilter}
                   handleSendRequestWithEnvironment={this._handleSendRequestWithEnvironment}

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -353,15 +353,6 @@ class App extends PureComponent<AppProps, State> {
     });
   }
 
-  _handleGenerateCodeForActiveRequest() {
-    // @ts-expect-error -- TSCONVERSION should skip this if active request is grpc request
-    App._handleGenerateCode(this.props.activeRequest);
-  }
-
-  static _handleGenerateCode(request: Request) {
-    showModal(GenerateCodeModal, request);
-  }
-
   async _handleCopyAsCurl(request: Request) {
     const { activeEnvironment } = this.props;
     const environmentId = activeEnvironment ? activeEnvironment._id : 'n/a';
@@ -1134,8 +1125,6 @@ class App extends PureComponent<AppProps, State> {
                   ref={this._setWrapperRef}
                   handleActivateRequest={this._handleSetActiveRequest}
                   handleDuplicateRequest={this._requestDuplicate}
-                  handleGenerateCode={App._handleGenerateCode}
-                  handleGenerateCodeForActiveRequest={this._handleGenerateCodeForActiveRequest}
                   handleCopyAsCurl={this._handleCopyAsCurl}
                   handleSetResponsePreviewMode={this._handleSetResponsePreviewMode}
                   handleSetResponseFilter={this._handleSetResponseFilter}

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -67,23 +67,18 @@ import { SyncMergeModal } from '../components/modals/sync-merge-modal';
 import { WorkspaceEnvironmentsEditModal } from '../components/modals/workspace-environments-edit-modal';
 import { WorkspaceSettingsModal } from '../components/modals/workspace-settings-modal';
 import { Toast } from '../components/toast';
-import { Wrapper } from '../components/wrapper';
+import { type WrapperClass, Wrapper } from '../components/wrapper';
 import withDragDropContext from '../context/app/drag-drop-context';
 import { GrpcProvider } from '../context/grpc';
 import { NunjucksEnabledProvider } from '../context/nunjucks/nunjucks-enabled-context';
 import { createRequestGroup } from '../hooks/create-request-group';
 import { RootState } from '../redux/modules';
-import { initialize } from '../redux/modules/entities';
 import {
-  exportRequestsToFile,
   loadRequestStart,
   loadRequestStop,
   newCommand,
-  selectIsLoading,
-  setActiveActivity,
 } from '../redux/modules/global';
 import { importUri } from '../redux/modules/import';
-import { activateWorkspace } from '../redux/modules/workspace';
 import {
   selectActiveActivity,
   selectActiveApiSpec,
@@ -92,38 +87,15 @@ import {
   selectActiveGitRepository,
   selectActiveProject,
   selectActiveRequest,
-  selectActiveRequestResponses,
-  selectActiveResponse,
-  selectActiveUnitTestResult,
-  selectActiveUnitTests,
-  selectActiveUnitTestSuite,
-  selectActiveUnitTestSuites,
   selectActiveWorkspace,
-  selectActiveWorkspaceClientCertificates,
   selectActiveWorkspaceMeta,
   selectActiveWorkspaceName,
-  selectApiSpecs,
   selectEnvironments,
-  selectGitRepositories,
   selectIsFinishedBooting,
   selectIsLoggedIn,
-  selectLoadStartTime,
-  selectRequestGroups,
-  selectRequestMetas,
-  selectRequests,
-  selectRequestVersions,
-  selectResponseDownloadPath,
-  selectResponseFilter,
-  selectResponseFilterHistory,
-  selectResponsePreviewMode,
   selectSettings,
-  selectStats,
-  selectSyncItems,
-  selectUnseenWorkspaces,
-  selectWorkspaceMetas,
-  selectWorkspacesForActiveProject,
 } from '../redux/selectors';
-import { selectSidebarChildren, selectSidebarFilter } from '../redux/sidebar-selectors';
+import { selectSidebarChildren } from '../redux/sidebar-selectors';
 import { AppHooks } from './app-hooks';
 
 const updateRequestMetaByParentId = async (
@@ -153,7 +125,7 @@ interface State {
 class App extends PureComponent<AppProps, State> {
   private _globalKeyMap: any;
   private _updateVCSLock: any;
-  private _wrapper: Wrapper | null = null;
+  private _wrapper: WrapperClass | null = null;
   private _responseFilterHistorySaveTimeout: NodeJS.Timeout | null = null;
 
   constructor(props: AppProps) {
@@ -771,7 +743,7 @@ class App extends PureComponent<AppProps, State> {
     showModal(SettingsModal, tabIndex);
   }
 
-  _setWrapperRef(wrapper: Wrapper) {
+  _setWrapperRef(wrapper: WrapperClass) {
     this._wrapper = wrapper;
   }
 
@@ -1220,7 +1192,6 @@ class App extends PureComponent<AppProps, State> {
                   handleSetActiveEnvironment={this._handleSetActiveEnvironment}
                   handleSetSidebarFilter={this._handleSetSidebarFilter}
                   handleUpdateRequestMimeType={this._handleUpdateRequestMimeType}
-                  handleShowSettingsModal={App._handleShowSettingsModal}
                   handleUpdateDownloadPath={this._handleUpdateDownloadPath}
                   headerEditorKey={forceRefreshHeaderCounter + ''}
                   handleSidebarSort={this._sortSidebar}
@@ -1249,38 +1220,13 @@ const mapStateToProps = (state: RootState) => ({
   activeEnvironment: selectActiveEnvironment(state),
   activeGitRepository: selectActiveGitRepository(state),
   activeRequest: selectActiveRequest(state),
-  activeRequestResponses: selectActiveRequestResponses(state),
-  activeResponse: selectActiveResponse(state),
-  activeUnitTestResult: selectActiveUnitTestResult(state),
-  activeUnitTestSuite: selectActiveUnitTestSuite(state),
-  activeUnitTestSuites: selectActiveUnitTestSuites(state),
-  activeUnitTests: selectActiveUnitTests(state),
   activeWorkspace: selectActiveWorkspace(state),
-  activeWorkspaceClientCertificates: selectActiveWorkspaceClientCertificates(state),
   activeWorkspaceMeta: selectActiveWorkspaceMeta(state),
-  apiSpecs: selectApiSpecs(state),
   environments: selectEnvironments(state),
-  gitRepositories: selectGitRepositories(state),
-  isLoading: selectIsLoading(state),
   isLoggedIn: selectIsLoggedIn(state),
   isFinishedBooting: selectIsFinishedBooting(state),
-  loadStartTime: selectLoadStartTime(state),
-  requestGroups: selectRequestGroups(state),
-  requestMetas: selectRequestMetas(state),
-  requestVersions: selectRequestVersions(state),
-  requests: selectRequests(state),
-  responseDownloadPath: selectResponseDownloadPath(state),
-  responseFilter: selectResponseFilter(state),
-  responseFilterHistory: selectResponseFilterHistory(state),
-  responsePreviewMode: selectResponsePreviewMode(state),
   settings: selectSettings(state),
   sidebarChildren: selectSidebarChildren(state),
-  sidebarFilter: selectSidebarFilter(state),
-  stats: selectStats(state),
-  syncItems: selectSyncItems(state),
-  unseenWorkspaces: selectUnseenWorkspaces(state),
-  workspacesForActiveProject: selectWorkspacesForActiveProject(state),
-  workspaceMetas: selectWorkspaceMetas(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<Action<any>>) => {
@@ -1289,29 +1235,17 @@ const mapDispatchToProps = (dispatch: Dispatch<Action<any>>) => {
     loadRequestStart: handleStartLoading,
     loadRequestStop: handleStopLoading,
     newCommand: handleCommand,
-    setActiveActivity: handleSetActiveActivity,
-    activateWorkspace: handleActivateWorkspace,
-    exportRequestsToFile: handleExportRequestsToFile,
-    initialize: handleInitializeEntities,
   } = bindActionCreators({
     importUri,
     loadRequestStart,
     loadRequestStop,
     newCommand,
-    setActiveActivity,
-    activateWorkspace,
-    exportRequestsToFile,
-    initialize,
   }, dispatch);
   return {
     handleCommand,
     handleImportUri,
-    handleSetActiveActivity,
-    handleActivateWorkspace,
     handleStartLoading,
     handleStopLoading,
-    handleExportRequestsToFile,
-    handleInitializeEntities,
   };
 };
 

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -402,12 +402,6 @@ class App extends PureComponent<AppProps, State> {
     });
   }
 
-  _handleUpdateDownloadPath(requestId: string, downloadPath: string) {
-    updateRequestMetaByParentId(requestId, {
-      downloadPath,
-    });
-  }
-
   async _handleSetResponseFilter(requestId: string, responseFilter: string) {
     await updateRequestMetaByParentId(requestId, {
       responseFilter,
@@ -1110,7 +1104,6 @@ class App extends PureComponent<AppProps, State> {
                   handleSetActiveEnvironment={this._handleSetActiveEnvironment}
                   handleSetSidebarFilter={this._handleSetSidebarFilter}
                   handleUpdateRequestMimeType={this._handleUpdateRequestMimeType}
-                  handleUpdateDownloadPath={this._handleUpdateDownloadPath}
                   headerEditorKey={forceRefreshHeaderCounter + ''}
                   handleSidebarSort={this._sortSidebar}
                   vcs={vcs}


### PR DESCRIPTION
this is a pre-fc pass to cut some  700 lines, from app and props of yesteryear, @gatzjames is working on a FC pass on app.tsx so hoping this will help. Related #4937

~~next step would be to rethink the pagelayout component and try to nest the mouse handlers and pan height and width story within rather than drilling from app.tsx through wrapperProps. #4994~~

highlights
- moved each function from app.tsx and wrapper.tsx to "appropriate" place in component tree.
- I exercised some discretion about where is appropriate based on props and selectors available in a given context.
- avoided any which involved react rendering hacks.
- curiously send and download request behaviour  is coupled to redux state.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
