### PR TITLE
response pane class->fc

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
@@ -1,6 +1,9 @@
 import React, { FC, useCallback } from 'react';
+import { useSelector } from 'react-redux';
 
 import { getPreviewModeName, PREVIEW_MODES, PreviewMode } from '../../../common/constants';
+import * as models from '../../../models';
+import { selectActiveRequest, selectResponsePreviewMode } from '../../redux/selectors';
 import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -11,23 +14,24 @@ interface Props {
   fullDownload: (pretty: boolean) => any;
   exportAsHAR: () => void;
   copyToClipboard: () => any;
-  updatePreviewMode: Function;
-  previewMode: PreviewMode;
   showPrettifyOption?: boolean;
 }
 
 export const PreviewModeDropdown: FC<Props> = ({
   fullDownload,
-  previewMode,
   showPrettifyOption,
   download,
   copyToClipboard,
   exportAsHAR,
-  updatePreviewMode,
 }) => {
+  const activeRequest = useSelector(selectActiveRequest);
+  const previewMode = useSelector(selectResponsePreviewMode);
 
-  const handleClick = async (previewMode: string) => {
-    await updatePreviewMode(previewMode);
+  const handleClick = async (previewMode: PreviewMode) => {
+    if (!activeRequest) {
+      return;
+    }
+    return models.requestMeta.updateOrCreateByParentId(activeRequest._id, { previewMode });
   };
   const handleDownloadPrettify = useCallback(() => {
     download(true);

--- a/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
@@ -61,7 +61,11 @@ export const PreviewModeDropdown: FC<Props> = ({
     if (!filePath) {
       return;
     }
-    window.main.writeFile({ path: filePath, content: har });
+    const to = fs.createWriteStream(filePath);
+    to.on('error', err => {
+      console.warn('Failed to export har', err);
+    });
+    to.end(har);
   };
 
   const exportDebugFile = async () => {

--- a/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
@@ -15,11 +15,9 @@ import { DropdownItem } from '../base/dropdown/dropdown-item';
 interface Props {
   download: (pretty: boolean) => any;
   copyToClipboard: () => any;
-  showPrettifyOption?: boolean;
 }
 
 export const PreviewModeDropdown: FC<Props> = ({
-  showPrettifyOption,
   download,
   copyToClipboard,
 }) => {
@@ -118,7 +116,7 @@ export const PreviewModeDropdown: FC<Props> = ({
       <i className="fa fa-save" />
       Export raw response
     </DropdownItem>
-    {showPrettifyOption && <DropdownItem onClick={handleDownloadPrettify}>
+    {response.contentType.includes('json') && <DropdownItem onClick={handleDownloadPrettify}>
       <i className="fa fa-save" />
       Export prettified response
     </DropdownItem>}

--- a/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
@@ -31,19 +31,11 @@ export const PreviewModeDropdown: FC<Props> = ({
     }
     return models.requestMeta.updateOrCreateByParentId(request._id, { previewMode });
   };
-  const handleDownloadPrettify = useCallback(() => {
-    download(true);
-  }, [download]);
+  const handleDownloadPrettify = useCallback(() => download(true), [download]);
 
-  const handleDownloadNormal = useCallback(() => {
-    download(false);
-  }, [download]);
+  const handleDownloadNormal = useCallback(() => download(false), [download]);
 
-  const handleCopyRawResponse = useCallback(() => {
-    copyToClipboard();
-  }, [copyToClipboard]);
-
-  const exportAsHAR = async () => {
+  const exportAsHAR = useCallback(async () => {
     if (!response || !request || !isRequest(request)) {
       console.warn('Nothing to download');
       return;
@@ -66,9 +58,9 @@ export const PreviewModeDropdown: FC<Props> = ({
       console.warn('Failed to export har', err);
     });
     to.end(har);
-  };
+  }, [request, response]);
 
-  const exportDebugFile = async () => {
+  const exportDebugFile = useCallback(async () => {
     if (!response || !request) {
       console.warn('Nothing to download');
       return;
@@ -99,8 +91,8 @@ export const PreviewModeDropdown: FC<Props> = ({
         console.warn('Failed to save full response', err);
       });
     }
-  };
-
+  }, [request, response]);
+  const shouldPrettifyOption = response.contentType.includes('json');
   return <Dropdown beside>
     <DropdownButton className="tall">
       {getPreviewModeName(previewMode)}
@@ -112,7 +104,7 @@ export const PreviewModeDropdown: FC<Props> = ({
       {getPreviewModeName(mode, true)}
     </DropdownItem>)}
     <DropdownDivider>Actions</DropdownDivider>
-    <DropdownItem onClick={handleCopyRawResponse}>
+    <DropdownItem onClick={copyToClipboard}>
       <i className="fa fa-copy" />
       Copy raw response
     </DropdownItem>
@@ -120,7 +112,7 @@ export const PreviewModeDropdown: FC<Props> = ({
       <i className="fa fa-save" />
       Export raw response
     </DropdownItem>
-    {response.contentType.includes('json') && <DropdownItem onClick={handleDownloadPrettify}>
+    {shouldPrettifyOption && <DropdownItem onClick={handleDownloadPrettify}>
       <i className="fa fa-save" />
       Export prettified response
     </DropdownItem>}

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -5,10 +5,9 @@ import { useSelector } from 'react-redux';
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
 import { decompressObject } from '../../../common/misc';
-import type { Environment } from '../../../models/environment';
 import * as models from '../../../models/index';
 import type { Response } from '../../../models/response';
-import { selectActiveRequest, selectActiveRequestResponses, selectRequestVersions } from '../../redux/selectors';
+import { selectActiveEnvironment, selectActiveRequest, selectActiveRequestResponses, selectRequestVersions } from '../../redux/selectors';
 import { type DropdownHandle, Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -22,7 +21,6 @@ import { URLTag } from '../tags/url-tag';
 import { TimeFromNow } from '../time-from-now';
 
 interface Props {
-  activeEnvironment?: Environment | null;
   activeResponse: Response;
   className?: string;
   handleSetActiveResponse: Function;
@@ -30,13 +28,13 @@ interface Props {
 }
 
 export const ResponseHistoryDropdown: FC<Props> = ({
-  activeEnvironment,
   activeResponse,
   className,
   handleSetActiveResponse,
   requestId,
 }) => {
   const dropdownRef = useRef<DropdownHandle>(null);
+  const activeEnvironment = useSelector(selectActiveEnvironment);
   const responses = useSelector(selectActiveRequestResponses);
   const activeRequest = useSelector(selectActiveRequest);
   const requestVersions = useSelector(selectRequestVersions);

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -55,16 +55,12 @@ export const ResponseHistoryDropdown: FC<Props> = ({
     }
   }, [activeRequest, handleSetActiveResponse]);
 
-  const handleDeleteResponse = useCallback(async (response: Response) => {
-    if (response) {
-      await models.response.remove(response);
+  const handleDeleteResponse = useCallback(async () => {
+    if (activeResponse) {
+      await models.response.remove(activeResponse);
     }
-
-    // Also unset active response it's the one we're deleting
-    if (activeResponse?._id === response._id) {
-      handleSetActiveResponse(null);
-    }
-  }, [activeResponse?._id, handleSetActiveResponse]);
+    handleSetActiveResponse(null);
+  }, [activeResponse, handleSetActiveResponse]);
 
   responses.forEach(response => {
     const responseTime = new Date(response.created);

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -47,13 +47,14 @@ export const ResponseHistoryDropdown: FC<Props> = ({
     other: [],
   };
 
-  const handleDeleteResponses = useCallback(async (requestId: string, environmentId: string | null) => {
+  const handleDeleteResponses = useCallback(async () => {
+    const environmentId = activeEnvironment ? activeEnvironment._id : null;
     await models.response.removeForRequest(requestId, environmentId);
 
     if (activeRequest && activeRequest._id === requestId) {
       await handleSetActiveResponse(requestId, null);
     }
-  }, [activeRequest, handleSetActiveResponse]);
+  }, [activeEnvironment, activeRequest, handleSetActiveResponse, requestId]);
 
   const handleDeleteResponse = useCallback(async () => {
     if (activeResponse) {
@@ -157,7 +158,7 @@ export const ResponseHistoryDropdown: FC<Props> = ({
           <i className="fa fa-trash-o" />
           Delete Current Response
         </DropdownItem>
-        <DropdownItem buttonClass={PromptButton} addIcon onClick={() => handleDeleteResponses(requestId, activeEnvironment ? activeEnvironment._id : null)}>
+        <DropdownItem buttonClass={PromptButton} addIcon onClick={handleDeleteResponses}>
           <i className="fa fa-trash-o" />
           Clear History
         </DropdownItem>

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -7,9 +7,8 @@ import { executeHotKey } from '../../../common/hotkeys-listener';
 import { decompressObject } from '../../../common/misc';
 import type { Environment } from '../../../models/environment';
 import * as models from '../../../models/index';
-import type { RequestVersion } from '../../../models/request-version';
 import type { Response } from '../../../models/response';
-import { selectActiveRequest, selectActiveRequestResponses } from '../../redux/selectors';
+import { selectActiveRequest, selectActiveRequestResponses, selectRequestVersions } from '../../redux/selectors';
 import { type DropdownHandle, Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -28,7 +27,6 @@ interface Props {
   className?: string;
   handleSetActiveResponse: Function;
   requestId: string;
-  requestVersions: RequestVersion[];
 }
 
 export const ResponseHistoryDropdown: FC<Props> = ({
@@ -37,11 +35,11 @@ export const ResponseHistoryDropdown: FC<Props> = ({
   className,
   handleSetActiveResponse,
   requestId,
-  requestVersions,
 }) => {
   const dropdownRef = useRef<DropdownHandle>(null);
   const responses = useSelector(selectActiveRequestResponses);
   const activeRequest = useSelector(selectActiveRequest);
+  const requestVersions = useSelector(selectRequestVersions);
   const now = new Date();
   const categories: Record<string, Response[]> = {
     minutes: [],

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -7,13 +7,13 @@ import React, { FC, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
-import { PREVIEW_MODE_SOURCE, PreviewMode } from '../../../common/constants';
+import { PREVIEW_MODE_SOURCE } from '../../../common/constants';
 import { exportHarCurrentRequest } from '../../../common/har';
 import { getSetCookieHeaders } from '../../../common/misc';
 import * as models from '../../../models';
 import type { Request } from '../../../models/request';
 import { cancelRequestById } from '../../../network/network';
-import { selectActiveResponse, selectResponseFilter, selectResponseFilterHistory } from '../../redux/selectors';
+import { selectActiveResponse, selectLoadStartTime, selectResponseFilter, selectResponseFilterHistory, selectResponsePreviewMode, selectSettings } from '../../redux/selectors';
 import { Button } from '../base/button';
 import { PreviewModeDropdown } from '../dropdowns/preview-mode-dropdown';
 import { ResponseHistoryDropdown } from '../dropdowns/response-history-dropdown';
@@ -32,32 +32,25 @@ import { Pane, paneBodyClasses, PaneHeader } from './pane';
 import { PlaceholderResponsePane } from './placeholder-response-pane';
 
 interface Props {
-  disableHtmlPreviewJs: boolean;
-  disableResponsePreviewLinks: boolean;
-  editorFontSize: number;
   handleSetActiveResponse: Function;
   handleSetFilter: (filter: string) => void;
   handleSetPreviewMode: Function;
   handleShowRequestSettings: Function;
-  loadStartTime: number;
-  previewMode: PreviewMode;
   request?: Request | null;
 }
 export const ResponsePane: FC<Props> = ({
-  disableHtmlPreviewJs,
-  disableResponsePreviewLinks,
-  editorFontSize,
   handleSetActiveResponse,
   handleSetFilter,
   handleSetPreviewMode,
   handleShowRequestSettings,
-  loadStartTime,
-  previewMode,
   request,
 }) => {
   const response = useSelector(selectActiveResponse);
   const filterHistory = useSelector(selectResponseFilterHistory);
   const filter = useSelector(selectResponseFilter);
+  const settings = useSelector(selectSettings);
+  const loadStartTime = useSelector(selectLoadStartTime);
+  const previewMode = useSelector(selectResponsePreviewMode);
 
   const responseViewerRef = useRef<ResponseViewer>(null);
   const handleGetResponseBody = (): Buffer | null => {
@@ -277,10 +270,10 @@ export const ResponsePane: FC<Props> = ({
             ref={responseViewerRef}
             bytes={Math.max(response.bytesContent, response.bytesRead)}
             contentType={response.contentType || ''}
-            disableHtmlPreviewJs={disableHtmlPreviewJs}
-            disablePreviewLinks={disableResponsePreviewLinks}
+            disableHtmlPreviewJs={settings.disableHtmlPreviewJs}
+            disablePreviewLinks={settings.disableResponsePreviewLinks}
             download={handleDownloadResponseBody}
-            editorFontSize={editorFontSize}
+            editorFontSize={settings.editorFontSize}
             error={response.error}
             filter={filter}
             filterHistory={filterHistory}

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -39,8 +39,6 @@ interface Props {
   environment?: Environment | null;
   filter: string;
   filterHistory: string[];
-  handleDeleteResponse: Function;
-  handleDeleteResponses: Function;
   handleSetActiveResponse: Function;
   handleSetFilter: (filter: string) => void;
   handleSetPreviewMode: Function;
@@ -59,8 +57,6 @@ export const ResponsePane: FC<Props> = ({
   filter,
   disableResponsePreviewLinks,
   filterHistory,
-  handleDeleteResponse,
-  handleDeleteResponses,
   handleSetActiveResponse,
   handleSetFilter,
   handleSetPreviewMode,
@@ -70,7 +66,6 @@ export const ResponsePane: FC<Props> = ({
   request,
   requestVersions,
   response,
-  responses,
 }) => {
 
   const responseViewerRef = useRef<ResponseViewer>(null);
@@ -246,12 +241,9 @@ export const ResponsePane: FC<Props> = ({
           <ResponseHistoryDropdown
             activeResponse={response}
             activeEnvironment={environment}
-            responses={responses}
             requestVersions={requestVersions}
             requestId={request._id}
             handleSetActiveResponse={handleSetActiveResponse}
-            handleDeleteResponses={handleDeleteResponses}
-            handleDeleteResponse={handleDeleteResponse}
             className="tall pane__header__right"
           />
         </PaneHeader>

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -14,7 +14,6 @@ import type { Environment } from '../../../models/environment';
 import type { Request } from '../../../models/request';
 import type { RequestVersion } from '../../../models/request-version';
 import type { Response } from '../../../models/response';
-import type { UnitTestResult } from '../../../models/unit-test-result';
 import { cancelRequestById } from '../../../network/network';
 import { Button } from '../base/button';
 import { PreviewModeDropdown } from '../dropdowns/preview-mode-dropdown';
@@ -52,41 +51,44 @@ interface Props {
   requestVersions: RequestVersion[];
   response?: Response | null;
   responses: Response[];
-  unitTestResult?: UnitTestResult | null;
 }
-export const ResponsePane: FC<Props> = props => {
-  const {
-    disableHtmlPreviewJs,
-    editorFontSize,
-    environment,
-    filter,
-    disableResponsePreviewLinks,
-    filterHistory,
-    handleDeleteResponse,
-    handleDeleteResponses,
-    handleSetActiveResponse,
-    handleSetFilter,
-    handleSetPreviewMode,
-    handleShowRequestSettings,
-    loadStartTime,
-    previewMode,
-    request,
-    requestVersions,
-    response,
-    responses,
-  } = props;
+export const ResponsePane: FC<Props> = ({
+  disableHtmlPreviewJs,
+  editorFontSize,
+  environment,
+  filter,
+  disableResponsePreviewLinks,
+  filterHistory,
+  handleDeleteResponse,
+  handleDeleteResponses,
+  handleSetActiveResponse,
+  handleSetFilter,
+  handleSetPreviewMode,
+  handleShowRequestSettings,
+  loadStartTime,
+  previewMode,
+  request,
+  requestVersions,
+  response,
+  responses,
+}) => {
+
   const responseViewerRef = useRef<ResponseViewer>(null);
   const _handleGetResponseBody = (): Buffer | null => {
-    if (!props.response) {
+    if (!response) {
       return null;
     }
 
-    return models.response.getBodyBuffer(props.response);
+    return models.response.getBodyBuffer(response);
   };
+  async function _handleCopyResponseToClipboard() {
+    const bodyBuffer = _handleGetResponseBody();
+    if (bodyBuffer) {
+      clipboard.writeText(bodyBuffer.toString('utf8'));
+    }
+  }
 
   async function _handleDownloadResponseBody(prettify: boolean) {
-    const { response, request } = props;
-
     if (!response || !request) {
       // Should never happen
       console.warn('No response to download');
@@ -136,8 +138,6 @@ export const ResponsePane: FC<Props> = props => {
   }
 
   async function _handleDownloadFullResponseBody() {
-    const { response, request } = props;
-
     if (!response || !request) {
       // Should never happen
       console.warn('No response to download');
@@ -173,20 +173,7 @@ export const ResponsePane: FC<Props> = props => {
     }
   }
 
-  async function _handleCopyResponseToClipboard() {
-    if (!props.response) {
-      return;
-    }
-
-    const bodyBuffer = models.response.getBodyBuffer(props.response);
-    if (bodyBuffer) {
-      clipboard.writeText(bodyBuffer.toString('utf8'));
-    }
-  }
-
   async function _handleExportAsHAR() {
-    const { response, request } = props;
-
     if (!response) {
       // Should never happen
       console.warn('No response to download');

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -34,14 +34,12 @@ import { PlaceholderResponsePane } from './placeholder-response-pane';
 interface Props {
   handleSetActiveResponse: Function;
   handleSetFilter: (filter: string) => void;
-  handleSetPreviewMode: Function;
   handleShowRequestSettings: Function;
   request?: Request | null;
 }
 export const ResponsePane: FC<Props> = ({
   handleSetActiveResponse,
   handleSetFilter,
-  handleSetPreviewMode,
   handleShowRequestSettings,
   request,
 }) => {
@@ -239,8 +237,6 @@ export const ResponsePane: FC<Props> = ({
               download={handleDownloadResponseBody}
               fullDownload={handleDownloadFullResponseBody}
               exportAsHAR={handleExportAsHAR}
-              previewMode={previewMode}
-              updatePreviewMode={handleSetPreviewMode}
               showPrettifyOption={response.contentType.includes('json')}
               copyToClipboard={handleCopyResponseToClipboard}
             />

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -8,7 +8,6 @@ import { useSelector } from 'react-redux';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
 import { PREVIEW_MODE_SOURCE } from '../../../common/constants';
-import { exportHarCurrentRequest } from '../../../common/har';
 import { getSetCookieHeaders } from '../../../common/misc';
 import * as models from '../../../models';
 import type { Request } from '../../../models/request';
@@ -149,39 +148,6 @@ export const ResponsePane: FC<Props> = ({
     }
   };
 
-  const handleExportAsHAR = async () => {
-    if (!response) {
-      // Should never happen
-      console.warn('No response to download');
-      return;
-    }
-
-    if (!request) {
-      // Should never happen
-      console.warn('No request to download');
-      return;
-    }
-
-    const data = await exportHarCurrentRequest(request, response);
-    const har = JSON.stringify(data, null, '\t');
-
-    const { filePath } = await window.dialog.showSaveDialog({
-      title: 'Export As HAR',
-      buttonLabel: 'Save',
-      defaultPath: `${request.name.replace(/ +/g, '_')}-${Date.now()}.har`,
-    });
-
-    if (!filePath) {
-      return;
-    }
-
-    const to = fs.createWriteStream(filePath);
-    to.on('error', err => {
-      console.warn('Failed to export har', err);
-    });
-    to.end(har);
-  };
-
   const handleTabSelect = (index: number, lastIndex: number) => {
     if (responseViewerRef.current != null && index === 0 && index !== lastIndex) {
       // Fix for CodeMirror editor not updating its content.
@@ -236,7 +202,6 @@ export const ResponsePane: FC<Props> = ({
             <PreviewModeDropdown
               download={handleDownloadResponseBody}
               fullDownload={handleDownloadFullResponseBody}
-              exportAsHAR={handleExportAsHAR}
               showPrettifyOption={response.contentType.includes('json')}
               copyToClipboard={handleCopyResponseToClipboard}
             />

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { json as jsonPrettify } from 'insomnia-prettify';
 import { extension as mimeExtension } from 'mime-types';
 import React, { FC, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
 import { PREVIEW_MODE_SOURCE, PreviewMode } from '../../../common/constants';
@@ -12,9 +13,8 @@ import { getSetCookieHeaders } from '../../../common/misc';
 import * as models from '../../../models';
 import type { Environment } from '../../../models/environment';
 import type { Request } from '../../../models/request';
-import type { RequestVersion } from '../../../models/request-version';
-import type { Response } from '../../../models/response';
 import { cancelRequestById } from '../../../network/network';
+import { selectActiveResponse } from '../../redux/selectors';
 import { Button } from '../base/button';
 import { PreviewModeDropdown } from '../dropdowns/preview-mode-dropdown';
 import { ResponseHistoryDropdown } from '../dropdowns/response-history-dropdown';
@@ -46,9 +46,6 @@ interface Props {
   loadStartTime: number;
   previewMode: PreviewMode;
   request?: Request | null;
-  requestVersions: RequestVersion[];
-  response?: Response | null;
-  responses: Response[];
 }
 export const ResponsePane: FC<Props> = ({
   disableHtmlPreviewJs,
@@ -64,9 +61,8 @@ export const ResponsePane: FC<Props> = ({
   loadStartTime,
   previewMode,
   request,
-  requestVersions,
-  response,
 }) => {
+  const response = useSelector(selectActiveResponse);
 
   const responseViewerRef = useRef<ResponseViewer>(null);
   const _handleGetResponseBody = (): Buffer | null => {
@@ -241,7 +237,6 @@ export const ResponsePane: FC<Props> = ({
           <ResponseHistoryDropdown
             activeResponse={response}
             activeEnvironment={environment}
-            requestVersions={requestVersions}
             requestId={request._id}
             handleSetActiveResponse={handleSetActiveResponse}
             className="tall pane__header__right"

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -3,7 +3,7 @@ import { clipboard } from 'electron';
 import fs from 'fs';
 import { json as jsonPrettify } from 'insomnia-prettify';
 import { extension as mimeExtension } from 'mime-types';
-import React, { FC, useRef } from 'react';
+import React, { FC, useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
@@ -50,20 +50,20 @@ export const ResponsePane: FC<Props> = ({
   const previewMode = useSelector(selectResponsePreviewMode);
 
   const responseViewerRef = useRef<ResponseViewer>(null);
-  const handleGetResponseBody = (): Buffer | null => {
+  const handleGetResponseBody = useCallback(() => {
     if (!response) {
       return null;
     }
     return models.response.getBodyBuffer(response);
-  };
-  const handleCopyResponseToClipboard = async () => {
+  }, [response]);
+  const handleCopyResponseToClipboard = useCallback(async () => {
     const bodyBuffer = handleGetResponseBody();
     if (bodyBuffer) {
       clipboard.writeText(bodyBuffer.toString('utf8'));
     }
-  };
+  }, [handleGetResponseBody]);
 
-  const handleDownloadResponseBody = async (prettify: boolean) => {
+  const handleDownloadResponseBody = useCallback(async (prettify: boolean) => {
     if (!response || !request) {
       console.warn('Nothing to download');
       return;
@@ -108,7 +108,7 @@ export const ResponsePane: FC<Props> = ({
         to.end();
       });
     }
-  };
+  }, [request, response]);
 
   const handleTabSelect = (index: number, lastIndex: number) => {
     if (responseViewerRef.current != null && index === 0 && index !== lastIndex) {

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -14,7 +14,7 @@ import * as models from '../../../models';
 import type { Environment } from '../../../models/environment';
 import type { Request } from '../../../models/request';
 import { cancelRequestById } from '../../../network/network';
-import { selectActiveResponse } from '../../redux/selectors';
+import { selectActiveResponse, selectResponseFilter, selectResponseFilterHistory } from '../../redux/selectors';
 import { Button } from '../base/button';
 import { PreviewModeDropdown } from '../dropdowns/preview-mode-dropdown';
 import { ResponseHistoryDropdown } from '../dropdowns/response-history-dropdown';
@@ -37,8 +37,6 @@ interface Props {
   disableResponsePreviewLinks: boolean;
   editorFontSize: number;
   environment?: Environment | null;
-  filter: string;
-  filterHistory: string[];
   handleSetActiveResponse: Function;
   handleSetFilter: (filter: string) => void;
   handleSetPreviewMode: Function;
@@ -49,11 +47,9 @@ interface Props {
 }
 export const ResponsePane: FC<Props> = ({
   disableHtmlPreviewJs,
+  disableResponsePreviewLinks,
   editorFontSize,
   environment,
-  filter,
-  disableResponsePreviewLinks,
-  filterHistory,
   handleSetActiveResponse,
   handleSetFilter,
   handleSetPreviewMode,
@@ -63,6 +59,8 @@ export const ResponsePane: FC<Props> = ({
   request,
 }) => {
   const response = useSelector(selectActiveResponse);
+  const filterHistory = useSelector(selectResponseFilterHistory);
+  const filter = useSelector(selectResponseFilter);
 
   const responseViewerRef = useRef<ResponseViewer>(null);
   const _handleGetResponseBody = (): Buffer | null => {

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -163,7 +163,6 @@ export const ResponsePane: FC<Props> = ({
           <Tab tabIndex="-1">
             <PreviewModeDropdown
               download={handleDownloadResponseBody}
-              showPrettifyOption={response.contentType.includes('json')}
               copyToClipboard={handleCopyResponseToClipboard}
             />
           </Tab>

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -60,21 +60,20 @@ export const ResponsePane: FC<Props> = ({
   const filter = useSelector(selectResponseFilter);
 
   const responseViewerRef = useRef<ResponseViewer>(null);
-  const _handleGetResponseBody = (): Buffer | null => {
+  const handleGetResponseBody = (): Buffer | null => {
     if (!response) {
       return null;
     }
-
     return models.response.getBodyBuffer(response);
   };
-  async function _handleCopyResponseToClipboard() {
-    const bodyBuffer = _handleGetResponseBody();
+  const handleCopyResponseToClipboard = async () => {
+    const bodyBuffer = handleGetResponseBody();
     if (bodyBuffer) {
       clipboard.writeText(bodyBuffer.toString('utf8'));
     }
-  }
+  };
 
-  async function _handleDownloadResponseBody(prettify: boolean) {
+  const handleDownloadResponseBody = async (prettify: boolean) => {
     if (!response || !request) {
       // Should never happen
       console.warn('No response to download');
@@ -121,9 +120,9 @@ export const ResponsePane: FC<Props> = ({
         to.end();
       });
     }
-  }
+  };
 
-  async function _handleDownloadFullResponseBody() {
+  const handleDownloadFullResponseBody = async () => {
     if (!response || !request) {
       // Should never happen
       console.warn('No response to download');
@@ -157,9 +156,9 @@ export const ResponsePane: FC<Props> = ({
         console.warn('Failed to save full response', err);
       });
     }
-  }
+  };
 
-  async function _handleExportAsHAR() {
+  const handleExportAsHAR = async () => {
     if (!response) {
       // Should never happen
       console.warn('No response to download');
@@ -190,19 +189,18 @@ export const ResponsePane: FC<Props> = ({
       console.warn('Failed to export har', err);
     });
     to.end(har);
-  }
+  };
 
-  function _handleTabSelect(index: number, lastIndex: number) {
+  const handleTabSelect = (index: number, lastIndex: number) => {
     if (responseViewerRef.current != null && index === 0 && index !== lastIndex) {
       // Fix for CodeMirror editor not updating its content.
       // Refresh must be called when the editor is visible,
       // so use nextTick to give time for it to be visible.
       process.nextTick(() => {
-        // @ts-expect-error -- TSCONVERSION
-        responseViewerRef.current.refresh();
+        responseViewerRef.current?.refresh();
       });
     }
-  }
+  };
 
   if (!request) {
     return <BlankPane type="response" />;
@@ -239,19 +237,19 @@ export const ResponsePane: FC<Props> = ({
       )}
       <Tabs
         className={classnames(paneBodyClasses, 'react-tabs')}
-        onSelect={_handleTabSelect}
+        onSelect={handleTabSelect}
         forceRenderTabPanel
       >
         <TabList>
           <Tab tabIndex="-1">
             <PreviewModeDropdown
-              download={_handleDownloadResponseBody}
-              fullDownload={_handleDownloadFullResponseBody}
-              exportAsHAR={_handleExportAsHAR}
+              download={handleDownloadResponseBody}
+              fullDownload={handleDownloadFullResponseBody}
+              exportAsHAR={handleExportAsHAR}
               previewMode={previewMode}
               updatePreviewMode={handleSetPreviewMode}
               showPrettifyOption={response.contentType.includes('json')}
-              copyToClipboard={_handleCopyResponseToClipboard}
+              copyToClipboard={handleCopyResponseToClipboard}
             />
           </Tab>
           <Tab tabIndex="-1">
@@ -281,12 +279,12 @@ export const ResponsePane: FC<Props> = ({
             contentType={response.contentType || ''}
             disableHtmlPreviewJs={disableHtmlPreviewJs}
             disablePreviewLinks={disableResponsePreviewLinks}
-            download={_handleDownloadResponseBody}
+            download={handleDownloadResponseBody}
             editorFontSize={editorFontSize}
             error={response.error}
             filter={filter}
             filterHistory={filterHistory}
-            getBody={_handleGetResponseBody}
+            getBody={handleGetResponseBody}
             previewMode={response.error ? PREVIEW_MODE_SOURCE : previewMode}
             responseId={response._id}
             updateFilter={response.error ? undefined : handleSetFilter}

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -11,7 +11,6 @@ import { PREVIEW_MODE_SOURCE, PreviewMode } from '../../../common/constants';
 import { exportHarCurrentRequest } from '../../../common/har';
 import { getSetCookieHeaders } from '../../../common/misc';
 import * as models from '../../../models';
-import type { Environment } from '../../../models/environment';
 import type { Request } from '../../../models/request';
 import { cancelRequestById } from '../../../network/network';
 import { selectActiveResponse, selectResponseFilter, selectResponseFilterHistory } from '../../redux/selectors';
@@ -36,7 +35,6 @@ interface Props {
   disableHtmlPreviewJs: boolean;
   disableResponsePreviewLinks: boolean;
   editorFontSize: number;
-  environment?: Environment | null;
   handleSetActiveResponse: Function;
   handleSetFilter: (filter: string) => void;
   handleSetPreviewMode: Function;
@@ -49,7 +47,6 @@ export const ResponsePane: FC<Props> = ({
   disableHtmlPreviewJs,
   disableResponsePreviewLinks,
   editorFontSize,
-  environment,
   handleSetActiveResponse,
   handleSetFilter,
   handleSetPreviewMode,
@@ -234,7 +231,6 @@ export const ResponsePane: FC<Props> = ({
           </div>
           <ResponseHistoryDropdown
             activeResponse={response}
-            activeEnvironment={environment}
             requestId={request._id}
             handleSetActiveResponse={handleSetActiveResponse}
             className="tall pane__header__right"

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -113,8 +113,6 @@ export const WrapperDebug: FC<Props> = ({
   const loadStartTime = useSelector(selectLoadStartTime);
 
   const responseDownloadPath = useSelector(selectResponseDownloadPath);
-  const responseFilter = useSelector(selectResponseFilter);
-  const responseFilterHistory = useSelector(selectResponseFilterHistory);
   const responsePreviewMode = useSelector(selectResponsePreviewMode);
   const settings = useSelector(selectSettings);
   const sidebarChildren = useSelector(selectSidebarChildren);
@@ -224,8 +222,6 @@ export const WrapperDebug: FC<Props> = ({
               disableResponsePreviewLinks={settings.disableResponsePreviewLinks}
               editorFontSize={settings.editorFontSize}
               environment={activeEnvironment}
-              filter={responseFilter}
-              filterHistory={responseFilterHistory}
               handleSetActiveResponse={handleSetActiveResponse}
               handleSetFilter={handleSetResponseFilter}
               handleSetPreviewMode={handleSetPreviewMode}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -10,11 +10,9 @@ import { isCollection, isDesign } from '../../models/workspace';
 import {
   selectActiveEnvironment,
   selectActiveRequest,
-  selectActiveResponse,
   selectActiveWorkspace,
   selectEnvironments,
   selectLoadStartTime,
-  selectRequestVersions,
   selectResponseDownloadPath,
   selectResponseFilter,
   selectResponseFilterHistory,
@@ -110,11 +108,10 @@ export const WrapperDebug: FC<Props> = ({
   const activeEnvironment = useSelector(selectActiveEnvironment);
   const activeRequest = useSelector(selectActiveRequest);
 
-  const activeResponse = useSelector(selectActiveResponse);
   const activeWorkspace = useSelector(selectActiveWorkspace);
   const environments = useSelector(selectEnvironments);
   const loadStartTime = useSelector(selectLoadStartTime);
-  const requestVersions = useSelector(selectRequestVersions);
+
   const responseDownloadPath = useSelector(selectResponseDownloadPath);
   const responseFilter = useSelector(selectResponseFilter);
   const responseFilterHistory = useSelector(selectResponseFilterHistory);
@@ -236,8 +233,6 @@ export const WrapperDebug: FC<Props> = ({
               loadStartTime={loadStartTime}
               previewMode={responsePreviewMode}
               request={activeRequest}
-              requestVersions={requestVersions}
-              response={activeResponse}
             />}
         </ErrorBoundary>}
     />

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -14,8 +14,6 @@ import {
   selectEnvironments,
   selectLoadStartTime,
   selectResponseDownloadPath,
-  selectResponseFilter,
-  selectResponseFilterHistory,
   selectResponsePreviewMode,
   selectSettings,
 } from '../redux/selectors';
@@ -221,7 +219,6 @@ export const WrapperDebug: FC<Props> = ({
               disableHtmlPreviewJs={settings.disableHtmlPreviewJs}
               disableResponsePreviewLinks={settings.disableResponsePreviewLinks}
               editorFontSize={settings.editorFontSize}
-              environment={activeEnvironment}
               handleSetActiveResponse={handleSetActiveResponse}
               handleSetFilter={handleSetResponseFilter}
               handleSetPreviewMode={handleSetPreviewMode}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -7,7 +7,20 @@ import { isRemoteProject } from '../../models/project';
 import { Request, RequestAuthentication, RequestBody, RequestHeader, RequestParameter } from '../../models/request';
 import { Settings } from '../../models/settings';
 import { isCollection, isDesign } from '../../models/workspace';
-import { selectActiveEnvironment, selectActiveRequest, selectActiveRequestResponses, selectActiveResponse, selectActiveUnitTestResult, selectActiveWorkspace, selectEnvironments, selectLoadStartTime, selectRequestVersions, selectResponseDownloadPath, selectResponseFilter, selectResponseFilterHistory, selectResponsePreviewMode, selectSettings } from '../redux/selectors';
+import {
+  selectActiveEnvironment,
+  selectActiveRequest,
+  selectActiveResponse,
+  selectActiveWorkspace,
+  selectEnvironments,
+  selectLoadStartTime,
+  selectRequestVersions,
+  selectResponseDownloadPath,
+  selectResponseFilter,
+  selectResponseFilterHistory,
+  selectResponsePreviewMode,
+  selectSettings,
+} from '../redux/selectors';
 import { selectSidebarChildren, selectSidebarFilter } from '../redux/sidebar-selectors';
 import { EnvironmentsDropdown } from './dropdowns/environments-dropdown';
 import { SyncDropdown } from './dropdowns/sync-dropdown';
@@ -28,8 +41,6 @@ interface Props {
   gitSyncDropdown: ReactNode;
   handleActivityChange: HandleActivityChange;
   handleChangeEnvironment: Function;
-  handleDeleteResponse: Function;
-  handleDeleteResponses: Function;
   handleForceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
   handleForceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleImport: Function;
@@ -55,8 +66,6 @@ export const WrapperDebug: FC<Props> = ({
   gitSyncDropdown,
   handleActivityChange,
   handleChangeEnvironment,
-  handleDeleteResponse,
-  handleDeleteResponses,
   handleForceUpdateRequest,
   handleForceUpdateRequestHeaders,
   handleImport,
@@ -100,9 +109,8 @@ export const WrapperDebug: FC<Props> = ({
 
   const activeEnvironment = useSelector(selectActiveEnvironment);
   const activeRequest = useSelector(selectActiveRequest);
-  const activeRequestResponses = useSelector(selectActiveRequestResponses);
+
   const activeResponse = useSelector(selectActiveResponse);
-  const activeUnitTestResult = useSelector(selectActiveUnitTestResult);
   const activeWorkspace = useSelector(selectActiveWorkspace);
   const environments = useSelector(selectEnvironments);
   const loadStartTime = useSelector(selectLoadStartTime);
@@ -221,8 +229,6 @@ export const WrapperDebug: FC<Props> = ({
               environment={activeEnvironment}
               filter={responseFilter}
               filterHistory={responseFilterHistory}
-              handleDeleteResponse={handleDeleteResponse}
-              handleDeleteResponses={handleDeleteResponses}
               handleSetActiveResponse={handleSetActiveResponse}
               handleSetFilter={handleSetResponseFilter}
               handleSetPreviewMode={handleSetPreviewMode}
@@ -232,8 +238,6 @@ export const WrapperDebug: FC<Props> = ({
               request={activeRequest}
               requestVersions={requestVersions}
               response={activeResponse}
-              responses={activeRequestResponses}
-              unitTestResult={activeUnitTestResult}
             />}
         </ErrorBoundary>}
     />

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -12,9 +12,7 @@ import {
   selectActiveRequest,
   selectActiveWorkspace,
   selectEnvironments,
-  selectLoadStartTime,
   selectResponseDownloadPath,
-  selectResponsePreviewMode,
   selectSettings,
 } from '../redux/selectors';
 import { selectSidebarChildren, selectSidebarFilter } from '../redux/sidebar-selectors';
@@ -108,10 +106,8 @@ export const WrapperDebug: FC<Props> = ({
 
   const activeWorkspace = useSelector(selectActiveWorkspace);
   const environments = useSelector(selectEnvironments);
-  const loadStartTime = useSelector(selectLoadStartTime);
 
   const responseDownloadPath = useSelector(selectResponseDownloadPath);
-  const responsePreviewMode = useSelector(selectResponsePreviewMode);
   const settings = useSelector(selectSettings);
   const sidebarChildren = useSelector(selectSidebarChildren);
   const sidebarFilter = useSelector(selectSidebarFilter);
@@ -216,15 +212,10 @@ export const WrapperDebug: FC<Props> = ({
             />
             :
             <ResponsePane
-              disableHtmlPreviewJs={settings.disableHtmlPreviewJs}
-              disableResponsePreviewLinks={settings.disableResponsePreviewLinks}
-              editorFontSize={settings.editorFontSize}
               handleSetActiveResponse={handleSetActiveResponse}
               handleSetFilter={handleSetResponseFilter}
               handleSetPreviewMode={handleSetPreviewMode}
               handleShowRequestSettings={handleShowRequestSettingsModal}
-              loadStartTime={loadStartTime}
-              previewMode={responsePreviewMode}
               request={activeRequest}
             />}
         </ErrorBoundary>}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -41,7 +41,6 @@ interface Props {
   handleSendAndDownloadRequestWithActiveEnvironment: (filepath?: string) => Promise<void>;
   handleSendRequestWithActiveEnvironment: () => void;
   handleSetActiveResponse: Function;
-  handleSetPreviewMode: Function;
   handleSetResponseFilter: (filter: string) => void;
   handleShowRequestSettingsModal: Function;
   handleSidebarSort: (sortOrder: SortOrder) => void;
@@ -66,7 +65,6 @@ export const WrapperDebug: FC<Props> = ({
   handleSendAndDownloadRequestWithActiveEnvironment,
   handleSendRequestWithActiveEnvironment,
   handleSetActiveResponse,
-  handleSetPreviewMode,
   handleSetResponseFilter,
   handleShowRequestSettingsModal,
   handleSidebarSort,
@@ -214,7 +212,6 @@ export const WrapperDebug: FC<Props> = ({
             <ResponsePane
               handleSetActiveResponse={handleSetActiveResponse}
               handleSetFilter={handleSetResponseFilter}
-              handleSetPreviewMode={handleSetPreviewMode}
               handleShowRequestSettings={handleShowRequestSettingsModal}
               request={activeRequest}
             />}

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -27,7 +27,6 @@ import {
   RequestParameter,
 } from '../../models/request';
 import { RequestGroup } from '../../models/request-group';
-import type { Response } from '../../models/response';
 import { GitVCS } from '../../sync/git/git-vcs';
 import { VCS } from '../../sync/vcs/vcs';
 import { CookieModifyModal } from '../components/modals/cookie-modify-modal';

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -350,26 +350,6 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
     showModal(RequestSettingsModal, { request: this.props.activeRequest });
   }
 
-  async _handleDeleteResponses(requestId: string, environmentId: string | null) {
-    const { handleSetActiveResponse, activeRequest } = this.props;
-    await models.response.removeForRequest(requestId, environmentId);
-
-    if (activeRequest && activeRequest._id === requestId) {
-      await handleSetActiveResponse(requestId, null);
-    }
-  }
-
-  async _handleDeleteResponse(response: Response) {
-    if (response) {
-      await models.response.remove(response);
-    }
-
-    // Also unset active response it's the one we're deleting
-    if (this.props.activeResponse?._id === response._id) {
-      this._handleSetActiveResponse(null);
-    }
-  }
-
   async _handleRemoveActiveWorkspace() {
     const { activeWorkspace, handleSetActiveActivity } = this.props;
 
@@ -654,8 +634,6 @@ export class Wrapper extends PureComponent<WrapperProps, State> {
                   gitSyncDropdown={gitSyncDropdown}
                   handleActivityChange={this._handleWorkspaceActivityChange}
                   handleChangeEnvironment={this._handleChangeEnvironment}
-                  handleDeleteResponse={this._handleDeleteResponse}
-                  handleDeleteResponses={this._handleDeleteResponses}
                   handleForceUpdateRequest={this._handleForceUpdateRequest}
                   handleForceUpdateRequestHeaders={this._handleForceUpdateRequestHeaders}
                   handleImport={this._handleImport}


### PR DESCRIPTION
highlights
- lots of prop drills removed, but a little more tricky to test
- impacts preview tab popover and response history actions
- removes 15 wrapper drills by using redux selector hooks


scoped out
- download http debug and export har could use ipc writeFile instead of fs in the renderer
- would be great to also move file download methods over ipc to main, involves some ipc api decisions.
- handleTabSelect has a nasty legacy hack here for codededitor refresh on tab change

<img width="213" alt="image" src="https://user-images.githubusercontent.com/3679927/180165311-ec969a33-002c-4f9f-8ff9-cf9b210e9287.png">

<img width="845" alt="image" src="https://user-images.githubusercontent.com/3679927/180165150-6c01aab2-0651-4224-8092-d7426623d106.png">

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
