### PR TITLE
undoes hotKeyRegistry prop drilling

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
@@ -1,10 +1,12 @@
-import { EnvironmentHighlightColorStyle, HotKeyRegistry } from 'insomnia-common';
+import { EnvironmentHighlightColorStyle } from 'insomnia-common';
 import React, { FC, useCallback, useRef } from 'react';
+import { useSelector } from 'react-redux';
 
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
 import type { Environment } from '../../../models/environment';
 import type { Workspace } from '../../../models/workspace';
+import { selectHotKeyRegistry } from '../../redux/selectors';
 import { type DropdownHandle, Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -20,7 +22,6 @@ interface Props {
   environmentHighlightColorStyle: EnvironmentHighlightColorStyle;
   environments: Environment[];
   handleChangeEnvironment: Function;
-  hotKeyRegistry: HotKeyRegistry;
   workspace: Workspace;
 }
 
@@ -29,9 +30,9 @@ export const EnvironmentsDropdown: FC<Props> = ({
   environmentHighlightColorStyle,
   environments,
   handleChangeEnvironment,
-  hotKeyRegistry,
   workspace,
 }) => {
+  const hotKeyRegistry = useSelector(selectHotKeyRegistry);
   const dropdownRef = useRef<DropdownHandle>(null);
   const handleShowEnvironmentModal = useCallback(() => {
     showModal(WorkspaceEnvironmentsEditModal, workspace);

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
-import { HotKeyRegistry } from 'insomnia-common';
 import React, { forwardRef, useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { RENDER_PURPOSE_NO_RENDER } from '../../../common/render';
@@ -15,6 +15,7 @@ import { incrementDeletedRequests } from '../../../models/stats';
 import type { RequestAction } from '../../../plugins';
 import { getRequestActions } from '../../../plugins';
 import * as pluginContexts from '../../../plugins/context/index';
+import { selectHotKeyRegistry } from '../../redux/selectors';
 import { type DropdownHandle, type DropdownProps, Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -31,7 +32,6 @@ interface Props extends Pick<DropdownProps, 'right'> {
   handleGenerateCode: Function;
   handleCopyAsCurl: Function;
   handleShowSettings: () => void;
-  hotKeyRegistry: HotKeyRegistry;
   isPinned: Boolean;
   request: Request | GrpcRequest;
   requestGroup?: RequestGroup;
@@ -45,12 +45,12 @@ export const RequestActionsDropdown = forwardRef<DropdownHandle, Props>(({
   handleGenerateCode,
   handleSetRequestPinned,
   handleShowSettings,
-  hotKeyRegistry,
   isPinned,
   request,
   requestGroup,
   right,
 }, ref) => {
+  const hotKeyRegistry = useSelector(selectHotKeyRegistry);
   const [actionPlugins, setActionPlugins] = useState<RequestAction[]>([]);
   const [loadingActions, setLoadingActions] = useState<Record<string, boolean>>({});
 

--- a/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { HotKeyRegistry } from 'insomnia-common';
 import React, { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -12,7 +11,7 @@ import { getRequestGroupActions } from '../../../plugins';
 import * as pluginContexts from '../../../plugins/context/index';
 import { createRequest, CreateRequestType } from '../../hooks/create-request';
 import { createRequestGroup } from '../../hooks/create-request-group';
-import { selectActiveEnvironment, selectActiveProject, selectActiveWorkspace } from '../../redux/selectors';
+import { selectActiveEnvironment, selectActiveProject, selectActiveWorkspace, selectHotKeyRegistry } from '../../redux/selectors';
 import { type DropdownHandle, type DropdownProps, Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -24,7 +23,6 @@ import { EnvironmentEditModal } from '../modals/environment-edit-modal';
 
 interface Props extends Partial<DropdownProps> {
   requestGroup: RequestGroup;
-  hotKeyRegistry: HotKeyRegistry;
   handleDuplicateRequestGroup: (requestGroup: RequestGroup) => any;
   handleShowSettings: (requestGroup: RequestGroup) => any;
 }
@@ -35,11 +33,11 @@ interface RequestGroupActionsDropdownHandle {
 
 export const RequestGroupActionsDropdown = forwardRef<RequestGroupActionsDropdownHandle, Props>(({
   requestGroup,
-  hotKeyRegistry,
   handleShowSettings,
   handleDuplicateRequestGroup,
   ...other
 }, ref) => {
+  const hotKeyRegistry = useSelector(selectHotKeyRegistry);
   const [actionPlugins, setActionPlugins] = useState<RequestGroupAction[]>([]);
   const [loadingActions, setLoadingActions] = useState< Record<string, boolean>>({});
   const dropdownRef = useRef<DropdownHandle>(null);

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -116,7 +116,6 @@ export class UnconnectedSettingsModal extends PureComponent<Props, State> {
             </TabPanel>
             <TabPanel className="react-tabs__tab-panel pad scrollable">
               <Shortcuts
-                hotKeyRegistry={settings.hotKeyRegistry}
                 handleUpdateKeyBindings={this._handleUpdateKeyBindings}
               />
             </TabPanel>

--- a/packages/insomnia/src/ui/components/page-layout.tsx
+++ b/packages/insomnia/src/ui/components/page-layout.tsx
@@ -118,7 +118,6 @@ export const PageLayout: FC<Props> = ({
             environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
             handleSetActiveEnvironment={handleSetActiveEnvironment}
             hidden={sidebarHidden || false}
-            hotKeyRegistry={settings.hotKeyRegistry}
             isLoading={isLoading}
             unseenWorkspaces={unseenWorkspaces}
             width={sidebarWidth}

--- a/packages/insomnia/src/ui/components/panes/placeholder-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/placeholder-response-pane.tsx
@@ -1,8 +1,9 @@
-import { HotKeyRegistry } from 'insomnia-common';
-import React, { FunctionComponent } from 'react';
+import React, { FC } from 'react';
+import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import { hotKeyRefs } from '../../../common/hotkeys';
+import { selectHotKeyRegistry } from '../../redux/selectors';
 import { Hotkey } from '../hotkey';
 import { Pane, PaneBody, PaneHeader } from './pane';
 
@@ -26,36 +27,34 @@ const Description = styled.div({
   marginRight: '2em',
 });
 
-interface Props {
-  hotKeyRegistry: HotKeyRegistry;
-}
+export const PlaceholderResponsePane: FC = ({ children }) => {
+  const hotKeyRegistry = useSelector(selectHotKeyRegistry);
+  return (
+    <Pane type="response">
+      <PaneHeader />
+      <PaneBody placeholder>
+        <Wrapper>
+          {[
+            hotKeyRefs.REQUEST_SEND,
+            hotKeyRefs.REQUEST_FOCUS_URL,
+            hotKeyRefs.SHOW_COOKIES_EDITOR,
+            hotKeyRefs.ENVIRONMENT_SHOW_EDITOR,
+            hotKeyRefs.PREFERENCES_SHOW_KEYBOARD_SHORTCUTS,
+          ].map(({ description, id }) => (
+            <Item key={id}>
+              <Description>{description}</Description>
+              <code>
+                <Hotkey
+                  keyBindings={hotKeyRegistry[id]}
+                  useFallbackMessage
+                />
+              </code>
 
-// TODO: get hotKeyRegistry from redux
-export const PlaceholderResponsePane: FunctionComponent<Props> = ({ hotKeyRegistry, children }) => (
-  <Pane type="response">
-    <PaneHeader />
-    <PaneBody placeholder>
-      <Wrapper>
-        {[
-          hotKeyRefs.REQUEST_SEND,
-          hotKeyRefs.REQUEST_FOCUS_URL,
-          hotKeyRefs.SHOW_COOKIES_EDITOR,
-          hotKeyRefs.ENVIRONMENT_SHOW_EDITOR,
-          hotKeyRefs.PREFERENCES_SHOW_KEYBOARD_SHORTCUTS,
-        ].map(({ description, id }) => (
-          <Item key={id}>
-            <Description>{description}</Description>
-            <code>
-              <Hotkey
-                keyBindings={hotKeyRegistry[id]}
-                useFallbackMessage
-              />
-            </code>
-
-          </Item>
-        ))}
-      </Wrapper>
-    </PaneBody>
-    {children}
-  </Pane>
-);
+            </Item>
+          ))}
+        </Wrapper>
+      </PaneBody>
+      {children}
+    </Pane>
+  );
+};

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -168,7 +168,6 @@ export const RequestPane: FC<Props> = ({
             handleSendAndDownload={handleSendAndDownload}
             nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             request={request}
-            hotKeyRegistry={settings.hotKeyRegistry}
             handleUpdateDownloadPath={handleUpdateDownloadPath}
             downloadPath={downloadPath}
           />

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -2,10 +2,10 @@ import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
 import { clipboard } from 'electron';
 import fs from 'fs';
-import { HotKeyRegistry } from 'insomnia-common';
 import { json as jsonPrettify } from 'insomnia-prettify';
 import { extension as mimeExtension } from 'mime-types';
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
 import { AUTOBIND_CFG, PREVIEW_MODE_SOURCE, PreviewMode } from '../../../common/constants';
@@ -18,6 +18,8 @@ import type { RequestVersion } from '../../../models/request-version';
 import type { Response } from '../../../models/response';
 import type { UnitTestResult } from '../../../models/unit-test-result';
 import { cancelRequestById } from '../../../network/network';
+import { RootState } from '../../redux/modules';
+import { selectHotKeyRegistry } from '../../redux/selectors';
 import { Button } from '../base/button';
 import { PreviewModeDropdown } from '../dropdowns/preview-mode-dropdown';
 import { ResponseHistoryDropdown } from '../dropdowns/response-history-dropdown';
@@ -35,7 +37,7 @@ import { BlankPane } from './blank-pane';
 import { Pane, paneBodyClasses, PaneHeader } from './pane';
 import { PlaceholderResponsePane } from './placeholder-response-pane';
 
-interface Props {
+interface OwnProps {
   handleSetFilter: (filter: string) => void;
   handleSetPreviewMode: Function;
   handleSetActiveResponse: Function;
@@ -49,7 +51,6 @@ interface Props {
   editorFontSize: number;
   loadStartTime: number;
   responses: Response[];
-  hotKeyRegistry: HotKeyRegistry;
   disableResponsePreviewLinks: boolean;
   requestVersions: RequestVersion[];
   request?: Request | null;
@@ -58,8 +59,16 @@ interface Props {
   unitTestResult?: UnitTestResult | null;
 }
 
+const mapStateToProps = (state: RootState) => ({
+  hotKeyRegistry: selectHotKeyRegistry(state),
+});
+
+type ReduxProps = ReturnType<typeof mapStateToProps>;
+
+type Props = OwnProps & ReduxProps;
+
 @autoBindMethodsForReact(AUTOBIND_CFG)
-export class ResponsePane extends PureComponent<Props> {
+class UnconnectedResponsePane extends PureComponent<Props> {
   _responseViewer: ResponseViewer | null = null;
 
   _setResponseViewerRef(responseViewer: ResponseViewer) {
@@ -235,7 +244,6 @@ export class ResponsePane extends PureComponent<Props> {
       handleSetFilter,
       handleSetPreviewMode,
       handleShowRequestSettings,
-      hotKeyRegistry,
       loadStartTime,
       previewMode,
       request,
@@ -250,7 +258,7 @@ export class ResponsePane extends PureComponent<Props> {
 
     if (!response) {
       return (
-        <PlaceholderResponsePane hotKeyRegistry={hotKeyRegistry}>
+        <PlaceholderResponsePane>
           <ResponseTimer
             handleCancel={() => cancelRequestById(request._id)}
             loadStartTime={loadStartTime}
@@ -375,3 +383,5 @@ export class ResponsePane extends PureComponent<Props> {
     );
   }
 }
+
+export const ResponsePane = connect(mapStateToProps)(UnconnectedResponsePane);

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -1,11 +1,12 @@
-import { HotKeyRegistry } from 'insomnia-common';
 import React, { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { useInterval } from 'react-use';
 
 import { hotKeyRefs } from '../../common/hotkeys';
 import { executeHotKey } from '../../common/hotkeys-listener';
 import type { Request } from '../../models/request';
 import { useTimeoutWhen } from '../hooks/useTimeoutWhen';
+import { selectHotKeyRegistry } from '../redux/selectors';
 import { type DropdownHandle, Dropdown } from './base/dropdown/dropdown';
 import { DropdownButton } from './base/dropdown/dropdown-button';
 import { DropdownDivider } from './base/dropdown/dropdown-divider';
@@ -29,7 +30,6 @@ interface Props {
   onUrlChange: (r: Request, url: string) => Promise<Request>;
   request: Request;
   uniquenessKey: string;
-  hotKeyRegistry: HotKeyRegistry;
   downloadPath: string | null;
 }
 
@@ -44,13 +44,12 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
   handleSend,
   handleSendAndDownload,
   handleUpdateDownloadPath,
-  hotKeyRegistry,
   onMethodChange,
   onUrlChange,
   request,
   uniquenessKey,
 }, ref) => {
-
+  const hotKeyRegistry = useSelector(selectHotKeyRegistry);
   const methodDropdownRef = useRef<DropdownHandle>(null);
   const dropdownRef = useRef<DropdownHandle>(null);
   const inputRef = useRef<OneLineEditor>(null);

--- a/packages/insomnia/src/ui/components/settings/shortcuts.tsx
+++ b/packages/insomnia/src/ui/components/settings/shortcuts.tsx
@@ -1,6 +1,7 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { HotKeyRegistry, KeyCombination } from 'insomnia-common';
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
 import {
@@ -13,6 +14,8 @@ import {
   newDefaultKeyBindings,
   newDefaultRegistry,
 } from '../../../common/hotkeys';
+import { RootState } from '../../redux/modules';
+import { selectHotKeyRegistry } from '../../redux/selectors';
 import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../base/dropdown/dropdown-divider';
@@ -22,15 +25,22 @@ import { Hotkey } from '../hotkey';
 import { showModal } from '../modals';
 import { AddKeyCombinationModal } from '../modals/add-key-combination-modal';
 
-interface Props {
-  hotKeyRegistry: HotKeyRegistry;
+interface OwnProps {
   handleUpdateKeyBindings: (keyBindings: HotKeyRegistry) => void;
 }
+
+const mapStateToProps = (state: RootState) => ({
+  hotKeyRegistry: selectHotKeyRegistry(state),
+});
+
+type ReduxProps = ReturnType<typeof mapStateToProps>;
+
+type Props = OwnProps & ReduxProps;
 
 const HOT_KEY_DEFS: HotKeyDefinition[] = Object.keys(hotKeyRefs).map(k => hotKeyRefs[k]);
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-export class Shortcuts extends PureComponent<Props> {
+export class UnconnectedShortcuts extends PureComponent<Props> {
   /**
    * Checks whether the given key combination already existed.
    * @param newKeyComb the key combination to be checked.
@@ -190,3 +200,5 @@ export class Shortcuts extends PureComponent<Props> {
     );
   }
 }
+
+export const Shortcuts = connect(mapStateToProps)(UnconnectedShortcuts);

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-children.tsx
@@ -1,4 +1,3 @@
-import { HotKeyRegistry } from 'insomnia-common';
 import React, { FC, Fragment } from 'react';
 import ReactDOM from 'react-dom';
 import { useSelector } from 'react-redux';
@@ -41,7 +40,6 @@ interface Props {
   handleGenerateCode: Function;
   handleSetRequestGroupCollapsed: Function;
   handleSetRequestPinned: Function;
-  hotKeyRegistry: HotKeyRegistry;
 }
 export const SidebarChildren: FC<Props> = ({
   childObjects,
@@ -53,7 +51,6 @@ export const SidebarChildren: FC<Props> = ({
   handleGenerateCode,
   handleSetRequestGroupCollapsed,
   handleSetRequestPinned,
-  hotKeyRegistry,
 }) => {
   const RecursiveSidebarRows: FC<RecursiveSidebarRowsProps> = ({ rows, isInPinnedList }) => {
     const activeRequest = useSelector(selectActiveRequest);
@@ -76,7 +73,6 @@ export const SidebarChildren: FC<Props> = ({
                 isPinned={row.pinned}
                 disableDragAndDrop={isInPinnedList}
                 request={row.doc}
-                hotKeyRegistry={hotKeyRegistry} // Necessary for plugin actions on requests
               />
             ) : (
               <SidebarRequestGroupRow
@@ -88,7 +84,6 @@ export const SidebarChildren: FC<Props> = ({
                 handleDuplicateRequestGroup={handleDuplicateRequestGroup}
                 isCollapsed={row.collapsed}
                 requestGroup={row.doc}
-                hotKeyRegistry={hotKeyRegistry}
               >
                 {row.children.filter(Boolean).length > 0 ? <RecursiveSidebarRows isInPinnedList={isInPinnedList} rows={row.children} /> : null}
               </SidebarRequestGroupRow>
@@ -99,9 +94,7 @@ export const SidebarChildren: FC<Props> = ({
   const showSeparator = childObjects.pinned.length > 0;
   const contextMenuPortal = ReactDOM.createPortal(
     <div className="hide">
-      <SidebarCreateDropdown
-        hotKeyRegistry={hotKeyRegistry}
-      />
+      <SidebarCreateDropdown />
     </div>,
     document.querySelector('#dropdowns-container') as any,
   );

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-create-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-create-dropdown.tsx
@@ -1,25 +1,21 @@
-import { HotKeyRegistry } from 'insomnia-common';
 import React, { FC, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import { hotKeyRefs } from '../../../common/hotkeys';
 import { createRequest, CreateRequestType } from '../../hooks/create-request';
 import { createRequestGroup } from '../../hooks/create-request-group';
-import { selectActiveWorkspace } from '../../redux/selectors';
+import { selectActiveWorkspace, selectHotKeyRegistry } from '../../redux/selectors';
 import { Dropdown } from '../base/dropdown/dropdown';
 import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownHint } from '../base/dropdown/dropdown-hint';
 import { DropdownItem } from '../base/dropdown/dropdown-item';
 
 interface Props {
-  hotKeyRegistry: HotKeyRegistry;
   right?: boolean;
 }
 
-export const SidebarCreateDropdown: FC<Props> = ({
-  hotKeyRegistry,
-  right,
-}) => {
+export const SidebarCreateDropdown: FC<Props> = ({ right }) => {
+  const hotKeyRegistry = useSelector(selectHotKeyRegistry);
   const activeWorkspace = useSelector(selectActiveWorkspace);
   const activeWorkspaceId = activeWorkspace?._id;
   const create = useCallback((value: CreateRequestType) => {

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-filter.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-filter.tsx
@@ -1,4 +1,3 @@
-import { HotKeyRegistry } from 'insomnia-common';
 import React, { FC, useCallback, useRef } from 'react';
 
 import { SortOrder } from '../../../common/constants';
@@ -12,9 +11,8 @@ interface Props {
   onChange: (value: string) => Promise<void>;
   sidebarSort: (sortOrder: SortOrder) => void;
   filter: string;
-  hotKeyRegistry: HotKeyRegistry;
 }
-export const SidebarFilter: FC<Props> = ({ filter, hotKeyRegistry, sidebarSort, onChange }) => {
+export const SidebarFilter: FC<Props> = ({ filter, sidebarSort, onChange }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const handleClearFilter = useCallback(() => {
     onChange('');
@@ -49,9 +47,7 @@ export const SidebarFilter: FC<Props> = ({ filter, hotKeyRegistry, sidebarSort, 
           )}
         </div>
         <SidebarSortDropdown handleSort={sidebarSort} />
-        <SidebarCreateDropdown
-          hotKeyRegistry={hotKeyRegistry}
-        />
+        <SidebarCreateDropdown />
       </div>
     </KeydownBinder>
   );

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-group-row.tsx
@@ -1,6 +1,5 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
-import { HotKeyRegistry } from 'insomnia-common';
 import { noop } from 'ramda-adjunct';
 import React, { ElementRef, MouseEvent, PureComponent } from 'react';
 import { PropsWithChildren } from 'react';
@@ -34,7 +33,6 @@ interface Props extends DnDProps, ReduxProps, PropsWithChildren<{}> {
   isActive: boolean;
   isCollapsed: boolean;
   requestGroup: RequestGroup;
-  hotKeyRegistry: HotKeyRegistry;
 }
 
 interface State {
@@ -91,7 +89,6 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
       handleDuplicateRequestGroup,
       isDragging,
       isDraggingOver,
-      hotKeyRegistry,
     } = this.props;
     const { dragDirection } = this.state;
     let folderIconClass = 'fa-folder';
@@ -144,7 +141,6 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
               handleDuplicateRequestGroup={handleDuplicateRequestGroup}
               handleShowSettings={this._handleShowRequestGroupSettings}
               requestGroup={requestGroup}
-              hotKeyRegistry={hotKeyRegistry}
               right
             />
           </div>
@@ -167,8 +163,7 @@ class UnconnectedSidebarRequestGroupRow extends PureComponent<Props, State> {
               isActive={false}
               requestGroup={requestGroup}
               filter={filter}
-              hotKeyRegistry={hotKeyRegistry}
-              isPinned={false} // Necessary so that plugin actions work
+              isPinned={false}
             />
           )}
         </ul>

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -1,5 +1,4 @@
 import classnames from 'classnames';
-import { HotKeyRegistry } from 'insomnia-common';
 import React, { FC, forwardRef, MouseEvent, ReactElement, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { DragSource, DragSourceSpec, DropTarget, DropTargetSpec } from 'react-dnd';
 import { useSelector } from 'react-redux';
@@ -32,7 +31,6 @@ interface RawProps {
   handleDuplicateRequest: Function;
   handleGenerateCode: Function;
   handleCopyAsCurl: Function;
-  hotKeyRegistry: HotKeyRegistry;
   isActive: boolean;
   isPinned: boolean;
   request?: Request | GrpcRequest;
@@ -67,7 +65,6 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
   handleDuplicateRequest,
   handleGenerateCode,
   handleSetRequestPinned,
-  hotKeyRegistry,
   isActive,
   isDragging,
   isDraggingOver,
@@ -263,7 +260,6 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
               request={request}
               isPinned={isPinned}
               requestGroup={requestGroup}
-              hotKeyRegistry={hotKeyRegistry} // Necessary for plugin actions to have network capabilities
               activeEnvironment={activeEnvironment}
               activeProject={activeProject}
             />

--- a/packages/insomnia/src/ui/components/sidebar/sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { EnvironmentHighlightColorStyle, HotKeyRegistry } from 'insomnia-common';
+import { EnvironmentHighlightColorStyle } from 'insomnia-common';
 import React, { forwardRef, memo, ReactNode } from 'react';
 
 import {
@@ -15,7 +15,6 @@ interface Props {
   environmentHighlightColorStyle: EnvironmentHighlightColorStyle;
   handleSetActiveEnvironment: (...args: any[]) => any;
   hidden: boolean;
-  hotKeyRegistry: HotKeyRegistry;
   isLoading: boolean;
   unseenWorkspaces: Workspace[];
   width: number;
@@ -23,15 +22,13 @@ interface Props {
 }
 
 export const Sidebar = memo(
-  forwardRef<HTMLElement, Props>((props, ref) => {
-    const {
-      activeEnvironment,
-      children,
-      environmentHighlightColorStyle,
-      hidden,
-      width,
-    } = props;
-
+  forwardRef<HTMLElement, Props>(({
+    activeEnvironment,
+    children,
+    environmentHighlightColorStyle,
+    hidden,
+    width,
+  }, ref) => {
     return (
       <aside
         ref={ref}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -139,7 +139,6 @@ export const WrapperDebug: FC<Props> = ({
             environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
             environments={environments}
             handleChangeEnvironment={handleChangeEnvironment}
-            hotKeyRegistry={settings.hotKeyRegistry}
             workspace={activeWorkspace}
           />
           <button className="btn btn--super-compact" onClick={showCookiesModal}>
@@ -154,7 +153,6 @@ export const WrapperDebug: FC<Props> = ({
           onChange={handleSetSidebarFilter}
           sidebarSort={handleSidebarSort}
           filter={sidebarFilter || ''}
-          hotKeyRegistry={settings.hotKeyRegistry}
         />
 
         <SidebarChildren
@@ -167,7 +165,6 @@ export const WrapperDebug: FC<Props> = ({
           handleGenerateCode={handleGenerateCode}
           handleCopyAsCurl={handleCopyAsCurl}
           filter={sidebarFilter || ''}
-          hotKeyRegistry={settings.hotKeyRegistry}
         />
       </Fragment>
         : null}
@@ -230,7 +227,6 @@ export const WrapperDebug: FC<Props> = ({
               handleSetFilter={handleSetResponseFilter}
               handleSetPreviewMode={handleSetPreviewMode}
               handleShowRequestSettings={handleShowRequestSettingsModal}
-              hotKeyRegistry={settings.hotKeyRegistry}
               loadStartTime={loadStartTime}
               previewMode={responsePreviewMode}
               request={activeRequest}

--- a/packages/insomnia/src/ui/redux/selectors.ts
+++ b/packages/insomnia/src/ui/redux/selectors.ts
@@ -419,6 +419,11 @@ export const selectResponseDownloadPath = createSelector(
   requestMeta => requestMeta?.downloadPath || null,
 );
 
+export const selectHotKeyRegistry = createSelector(
+  selectSettings,
+  settings => settings.hotKeyRegistry,
+);
+
 export const selectActiveRequestResponses = createSelector(
   selectActiveRequest,
   selectEntitiesLists,


### PR DESCRIPTION
as part of another spike, I happened across a stumbling block: we haven't gotten around to un-prop-drilling hotKeyRegistry yet.

I pulled this out of another PR where it complicated the diff.  I thought it'd be great to restrict the scope to just this one change and make a separate PR (this one).