### PR TITLE
speceditor-sidebar class->fc

### DIFF
--- a/packages/insomnia/src/ui/components/spec-editor/spec-editor-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/spec-editor/spec-editor-sidebar.tsx
@@ -1,11 +1,9 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { Sidebar } from 'insomnia-components';
-import React, { Component } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import YAML from 'yaml';
 import YAMLSourceMap from 'yaml-source-map';
 
-import { AUTOBIND_CFG } from '../../../common/constants';
 import type { ApiSpec } from '../../../models/api-spec';
 
 interface Props {
@@ -13,42 +11,26 @@ interface Props {
   handleSetSelection: (chStart: number, chEnd: number, lineStart: number, lineEnd: number) => void;
 }
 
-interface State {
-  error: string;
-  specContentJSON: boolean;
-}
-
 const StyledSpecEditorSidebar = styled.div`
   overflow: hidden;
   overflow-y: auto;
 `;
+export const SpecEditorSidebar: FC<Props> = ({ apiSpec, handleSetSelection }) => {
+  const [specContentJSON, setSpecContentJSON] = useState(false);
 
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class SpecEditorSidebar extends Component<Props, State> {
-  state: State = {
-    error: '',
-    specContentJSON: false,
-  };
+  useEffect(() => {
+    try {
+      JSON.parse(apiSpec.contents);
+    } catch (error) {
+      setSpecContentJSON(false);
+      return;
+    }
+    setSpecContentJSON(true);
+  }, [apiSpec.contents]);
 
-  _handleScrollEditor(pos: {
-    start: {
-      line: number;
-      col: number;
-    };
-    end: {
-      line: number;
-      col: number;
-    };
-  }) {
-    const { handleSetSelection } = this.props;
-    // NOTE: We're subtracting 1 from everything because YAML CST uses
-    //   1-based indexing and we use 0-based.
-    handleSetSelection(pos.start.col - 1, pos.end.col - 1, pos.start.line - 1, pos.end.line - 1);
-  }
-
-  _mapPosition(itemPath: any[]) {
+  const onClick = (...itemPath: any[]): void => {
     const sourceMap = new YAMLSourceMap();
-    const { contents } = this.props.apiSpec;
+    const { contents } = apiSpec;
     const scrollPosition = {
       start: {
         line: 0,
@@ -61,7 +43,7 @@ export class SpecEditorSidebar extends Component<Props, State> {
     };
 
     // Account for JSON (as string) line number shift
-    if (this.state.specContentJSON) {
+    if (specContentJSON) {
       scrollPosition.start.line = 1;
     }
 
@@ -81,43 +63,15 @@ export class SpecEditorSidebar extends Component<Props, State> {
     }
 
     scrollPosition.end.line = scrollPosition.start.line;
-
-    this._handleScrollEditor(scrollPosition);
-  }
-
-  _handleItemClick = (...itemPath: any[]): void => {
-    this._mapPosition(itemPath);
+    // NOTE: We're subtracting 1 from everything because YAML CST uses
+    //   1-based indexing and we use 0-based.
+    handleSetSelection(scrollPosition.start.col - 1, scrollPosition.end.col - 1, scrollPosition.start.line - 1, scrollPosition.end.line - 1);
   };
 
-  componentDidMount() {
-    const { contents } = this.props.apiSpec;
-
-    try {
-      JSON.parse(contents);
-    } catch (error) {
-      this.setState({
-        specContentJSON: false,
-      });
-      return;
-    }
-
-    this.setState({
-      specContentJSON: true,
-    });
-  }
-
-  render() {
-    const { error } = this.state;
-
-    if (error) {
-      return <p className="notice error margin-sm">{error}</p>;
-    }
-
-    const specJSON = YAML.parse(this.props.apiSpec.contents);
-    return (
-      <StyledSpecEditorSidebar>
-        <Sidebar jsonData={specJSON} onClick={this._handleItemClick} />
-      </StyledSpecEditorSidebar>
-    );
-  }
-}
+  const specJSON = YAML.parse(apiSpec.contents);
+  return (
+    <StyledSpecEditorSidebar>
+      <Sidebar jsonData={specJSON} onClick={onClick} />
+    </StyledSpecEditorSidebar>
+  );
+};

--- a/packages/insomnia/src/ui/components/spec-editor/spec-editor-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/spec-editor/spec-editor-sidebar.tsx
@@ -1,5 +1,5 @@
 import { Sidebar } from 'insomnia-components';
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC } from 'react';
 import styled from 'styled-components';
 import YAML from 'yaml';
 import YAMLSourceMap from 'yaml-source-map';
@@ -17,34 +17,14 @@ const StyledSpecEditorSidebar = styled.div`
 `;
 
 export const SpecEditorSidebar: FC<Props> = ({ apiSpec, handleSetSelection }) => {
-  const [isSpecJSONParsable, setIsSpecJSONParsable] = useState(false);
+  const onClick = (...itemPath: any[]): void => {
+    const scrollPosition = { start: { line: 0, col: 0 }, end: { line: 0, col: 200 } };
 
-  useEffect(() => {
     try {
       JSON.parse(apiSpec.contents);
-    } catch (error) {
-      setIsSpecJSONParsable(false);
-      return;
-    }
-    setIsSpecJSONParsable(true);
-  }, [apiSpec.contents]);
-
-  const onClick = (...itemPath: any[]): void => {
-    const scrollPosition = {
-      start: {
-        line: 0,
-        col: 0,
-      },
-      end: {
-        line: 0,
-        col: 200,
-      },
-    };
-
-    // Account for JSON (as string) line number shift
-    if (isSpecJSONParsable) {
+      // Account for JSON (as string) line number shift
       scrollPosition.start.line = 1;
-    }
+    } catch  {}
 
     const sourceMap = new YAMLSourceMap();
     const specMap = sourceMap.index(


### PR DESCRIPTION
highlights
- refactored out the state that would initialise scroll to line 1 on successful json parse 

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
