### PR TITLE
refactor: convert settings-modal to functional

### DIFF
--- a/packages/insomnia/src/ui/components/modals/index.ts
+++ b/packages/insomnia/src/ui/components/modals/index.ts
@@ -5,16 +5,17 @@ import { PromptModal, PromptModalOptions } from './prompt-modal';
 
 const modals: Record<string, any> = {};
 
-export function registerModal(instance: any) {
+export function registerModal(instance: any, modalName?: string) {
   if (instance === null) {
     // Modal was unmounted
     return;
   }
 
-  modals[instance.constructor.name] = instance;
+  modals[modalName ?? instance.constructor.name] = instance;
 }
 
 export function showModal(modalCls: any, ...args: any[]) {
+  console.log(modalCls);
   trackPageView(modalCls.name);
   return _getModal(modalCls).show(...args);
 }
@@ -43,7 +44,7 @@ export function hideAllModals() {
 }
 
 function _getModal(modalCls: any) {
-  const m = modals[modalCls.name || modalCls.WrappedComponent?.name];
+  const m = modals[modalCls.name || modalCls.WrappedComponent?.name || modalCls.displayName];
 
   if (!m) {
     throw new Error('Modal was not registered with the app');

--- a/packages/insomnia/src/ui/components/modals/index.ts
+++ b/packages/insomnia/src/ui/components/modals/index.ts
@@ -4,6 +4,10 @@ import { ErrorModal, ErrorModalOptions } from './error-modal';
 import { PromptModal, PromptModalOptions } from './prompt-modal';
 
 const modals: Record<string, any> = {};
+export interface ModalHandle {
+  hide(): void;
+  show(currentTabIndex: number): void;
+}
 
 export function registerModal(instance: any, modalName?: string) {
   if (instance === null) {
@@ -15,7 +19,6 @@ export function registerModal(instance: any, modalName?: string) {
 }
 
 export function showModal(modalCls: any, ...args: any[]) {
-  console.log(modalCls);
   trackPageView(modalCls.name);
   return _getModal(modalCls).show(...args);
 }

--- a/packages/insomnia/src/ui/components/modals/index.ts
+++ b/packages/insomnia/src/ui/components/modals/index.ts
@@ -6,7 +6,7 @@ import { PromptModal, PromptModalOptions } from './prompt-modal';
 const modals: Record<string, any> = {};
 export interface ModalHandle {
   hide(): void;
-  show(currentTabIndex: number): void;
+  show(): void;
 }
 
 export function registerModal(instance: any, modalName?: string) {

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -107,5 +107,5 @@ export const SettingsModal = forwardRef<ModalHandle, ModalProps>((props, ref) =>
     </Modal>
   );
 });
-SettingsModal.displayName = SETTINGS_MODAL_DISPLAYNAME;
+SettingsModal.displayName = SETTINGS_MODAL_DISPLAY_NAME;
 export const showSettingsModal = () => showModal(SettingsModal);

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -23,7 +23,7 @@ export const TAB_INDEX_EXPORT = 1;
 export const TAB_INDEX_SHORTCUTS = 3;
 export const TAB_INDEX_THEMES = 2;
 export const TAB_INDEX_PLUGINS = 5;
-export const SETTINGS_MODAL_DISPLAYNAME = 'SettingsModal';
+export const SETTINGS_MODAL_DISPLAY_NAME = 'SettingsModal';
 export const SettingsModal = forwardRef<ModalHandle, ModalProps>((props, ref) => {
   const settings = useSelector(selectSettings);
   const [currentTabIndex, setCurrentTabIndex] = useState<number | null>(null);

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -18,13 +18,17 @@ import { Plugins } from '../settings/plugins';
 import { Shortcuts } from '../settings/shortcuts';
 import { ThemePanel } from '../settings/theme-panel';
 import { ModalHandle, registerModal, showModal } from './index';
+export interface SettingsModalHandle extends ModalHandle {
+  show(): void;
+  show(currentTabIndex: number): void;
+}
 
 export const TAB_INDEX_EXPORT = 1;
 export const TAB_INDEX_SHORTCUTS = 3;
 export const TAB_INDEX_THEMES = 2;
 export const TAB_INDEX_PLUGINS = 5;
 export const SETTINGS_MODAL_DISPLAY_NAME = 'SettingsModal';
-export const SettingsModal = forwardRef<ModalHandle, ModalProps>((props, ref) => {
+export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props, ref) => {
   const settings = useSelector(selectSettings);
   const [currentTabIndex, setCurrentTabIndex] = useState<number | null>(null);
   const modalRef = useRef<Modal>(null);

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -1,16 +1,14 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import { HotKeyRegistry } from 'insomnia-common';
-import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
 import * as session from '../../../account/session';
-import { AUTOBIND_CFG, getAppVersion, getProductName } from '../../../common/constants';
+import { getAppVersion, getProductName } from '../../../common/constants';
 import * as models from '../../../models/index';
-import { RootState } from '../../redux/modules';
 import { selectSettings } from '../../redux/selectors';
 import { Button } from '../base/button';
-import { Modal } from '../base/modal';
+import { Modal, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { Account } from '../settings/account';
@@ -19,128 +17,101 @@ import { ImportExport } from '../settings/import-export';
 import { Plugins } from '../settings/plugins';
 import { Shortcuts } from '../settings/shortcuts';
 import { ThemePanel } from '../settings/theme-panel';
-import { showModal } from './index';
+import { registerModal, showModal } from './index';
 
 export const TAB_INDEX_EXPORT = 1;
 export const TAB_INDEX_SHORTCUTS = 3;
 export const TAB_INDEX_THEMES = 2;
 export const TAB_INDEX_PLUGINS = 5;
-
-type ReduxProps = ReturnType<typeof mapStateToProps>;
-
-interface Props extends ReduxProps {
+export interface ModalHandle {
+  hide(): void;
+  show(currentTabIndex: number): void;
 }
 
-interface State {
-  currentTabIndex: number | null;
-}
+export const SETTINGS_MODAL_DISPLAYNAME = 'SettingsModal';
+export const SettingsModal = forwardRef<ModalHandle, ModalProps>((props, ref) => {
+  const settings = useSelector(selectSettings);
+  const [currentTabIndex, setCurrentTabIndex] = useState<number | null>(null);
+  const modalRef = useRef<Modal>(null);
+  const email = session.isLoggedIn() ? session.getFullName() : null;
 
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class UnconnectedSettingsModal extends PureComponent<Props, State> {
-  state: State = {
-    currentTabIndex: null,
-  };
-
-  modal: Modal | null = null;
-
-  _setModalRef(modal: Modal) {
-    this.modal = modal;
-  }
-
-  async _handleUpdateKeyBindings(hotKeyRegistry: HotKeyRegistry) {
-    await models.settings.update(this.props.settings, {
+  const handleUpdateKeyBindings = async (hotKeyRegistry: HotKeyRegistry) => {
+    await models.settings.update(settings, {
       hotKeyRegistry,
     });
-  }
+  };
 
-  show(currentTabIndex = 0) {
-    if (typeof currentTabIndex !== 'number') {
-      currentTabIndex = 0;
-    }
+  useEffect(() => {
+    registerModal(modalRef.current, SETTINGS_MODAL_DISPLAYNAME);
+  }, []);
 
-    this.setState({
-      currentTabIndex,
-    });
-    this.modal?.show();
-  }
+  useImperativeHandle(ref, () => ({
+    hide(): void {
+      modalRef.current?.hide();
+    },
+    show(currentTabIndex = 0): void {
+      const tabIndex = typeof currentTabIndex !== 'number' ? 0 : currentTabIndex;
+      setCurrentTabIndex(tabIndex);
+      modalRef.current?.show();
+    },
+  }), []);
 
-  hide() {
-    this.modal?.hide();
-  }
-
-  render() {
-    const { settings } = this.props;
-    const { currentTabIndex } = this.state;
-    const email = session.isLoggedIn() ? session.getFullName() : null;
-    return (
-      <Modal ref={this._setModalRef} tall freshState {...this.props}>
-        <ModalHeader>
-          {getProductName()} Preferences
-          <span className="faint txt-sm">
+  return (
+    <Modal ref={modalRef} tall freshState {...props}>
+      <ModalHeader>
+        {getProductName()} Preferences
+        <span className="faint txt-sm">
             &nbsp;&nbsp;–&nbsp; v{getAppVersion()}
-            {email ? ` – ${email}` : null}
-          </span>
-        </ModalHeader>
-        <ModalBody noScroll>
-          <Tabs className="react-tabs" defaultIndex={currentTabIndex ?? undefined}>
-            <TabList>
-              <Tab tabIndex="-1">
-                <Button value="General">General</Button>
-              </Tab>
-              <Tab tabIndex="-1">
-                <Button value="Import/Export">Data</Button>
-              </Tab>
-              <Tab tabIndex="-1">
-                <Button value="Themes">Themes</Button>
-              </Tab>
-              <Tab tabIndex="-1">
-                <Button value="Shortcuts">Keyboard</Button>
-              </Tab>
-              <Tab tabIndex="-1">
-                <Button value="Account">Account</Button>
-              </Tab>
-              <Tab tabIndex="-1">
-                <Button value="Plugins">Plugins</Button>
-              </Tab>
-            </TabList>
-            <TabPanel className="react-tabs__tab-panel pad scrollable">
-              <General />
-            </TabPanel>
-            <TabPanel className="react-tabs__tab-panel pad scrollable">
-              <ImportExport
-                hideSettingsModal={this.hide}
-              />
-            </TabPanel>
-            <TabPanel className="react-tabs__tab-panel pad scrollable">
-              <ThemePanel />
-            </TabPanel>
-            <TabPanel className="react-tabs__tab-panel pad scrollable">
-              <Shortcuts
-                handleUpdateKeyBindings={this._handleUpdateKeyBindings}
-              />
-            </TabPanel>
-            <TabPanel className="react-tabs__tab-panel pad scrollable">
-              <Account />
-            </TabPanel>
-            <TabPanel className="react-tabs__tab-panel pad scrollable">
-              <Plugins settings={settings} />
-            </TabPanel>
-          </Tabs>
-        </ModalBody>
-      </Modal>
-    );
-  }
-}
+          {email ? ` – ${email}` : null}
+        </span>
+      </ModalHeader>
+      <ModalBody noScroll>
+        <Tabs className="react-tabs" defaultIndex={currentTabIndex ?? undefined}>
+          <TabList>
+            <Tab tabIndex="-1">
+              <Button value="General">General</Button>
+            </Tab>
+            <Tab tabIndex="-1">
+              <Button value="Import/Export">Data</Button>
+            </Tab>
+            <Tab tabIndex="-1">
+              <Button value="Themes">Themes</Button>
+            </Tab>
+            <Tab tabIndex="-1">
+              <Button value="Shortcuts">Keyboard</Button>
+            </Tab>
+            <Tab tabIndex="-1">
+              <Button value="Account">Account</Button>
+            </Tab>
+            <Tab tabIndex="-1">
+              <Button value="Plugins">Plugins</Button>
+            </Tab>
+          </TabList>
+          <TabPanel className="react-tabs__tab-panel pad scrollable">
+            <General />
+          </TabPanel>
+          <TabPanel className="react-tabs__tab-panel pad scrollable">
+            <ImportExport hideSettingsModal={() => modalRef.current?.hide()}/>
+          </TabPanel>
+          <TabPanel className="react-tabs__tab-panel pad scrollable">
+            <ThemePanel />
+          </TabPanel>
+          <TabPanel className="react-tabs__tab-panel pad scrollable">
+            <Shortcuts
+              handleUpdateKeyBindings={handleUpdateKeyBindings}
+            />
+          </TabPanel>
+          <TabPanel className="react-tabs__tab-panel pad scrollable">
+            <Account />
+          </TabPanel>
+          <TabPanel className="react-tabs__tab-panel pad scrollable">
+            <Plugins settings={settings} />
+          </TabPanel>
+        </Tabs>
+      </ModalBody>
+    </Modal>
+  );
+});
+SettingsModal.displayName = SETTINGS_MODAL_DISPLAYNAME;
 
 export const showSettingsModal = () => showModal(SettingsModal);
-
-const mapStateToProps = (state: RootState) => ({
-  settings: selectSettings(state),
-});
-
-export const SettingsModal = connect(
-  mapStateToProps,
-  null,
-  null,
-  { forwardRef: true },
-)(UnconnectedSettingsModal);

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -17,17 +17,12 @@ import { ImportExport } from '../settings/import-export';
 import { Plugins } from '../settings/plugins';
 import { Shortcuts } from '../settings/shortcuts';
 import { ThemePanel } from '../settings/theme-panel';
-import { registerModal, showModal } from './index';
+import { ModalHandle, registerModal, showModal } from './index';
 
 export const TAB_INDEX_EXPORT = 1;
 export const TAB_INDEX_SHORTCUTS = 3;
 export const TAB_INDEX_THEMES = 2;
 export const TAB_INDEX_PLUGINS = 5;
-export interface ModalHandle {
-  hide(): void;
-  show(currentTabIndex: number): void;
-}
-
 export const SETTINGS_MODAL_DISPLAYNAME = 'SettingsModal';
 export const SettingsModal = forwardRef<ModalHandle, ModalProps>((props, ref) => {
   const settings = useSelector(selectSettings);
@@ -113,5 +108,4 @@ export const SettingsModal = forwardRef<ModalHandle, ModalProps>((props, ref) =>
   );
 });
 SettingsModal.displayName = SETTINGS_MODAL_DISPLAYNAME;
-
 export const showSettingsModal = () => showModal(SettingsModal);

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -37,7 +37,7 @@ export const SettingsModal = forwardRef<ModalHandle, ModalProps>((props, ref) =>
   };
 
   useEffect(() => {
-    registerModal(modalRef.current, SETTINGS_MODAL_DISPLAYNAME);
+    registerModal(modalRef.current, SETTINGS_MODAL_DISPLAY_NAME);
   }, []);
 
   useImperativeHandle(ref, () => ({

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as importers from 'insomnia-importers';
-import React, { Fragment, lazy, PureComponent, Suspense } from 'react';
+import React, { createRef, Fragment, lazy, PureComponent, Ref, Suspense } from 'react';
 import { useSelector } from 'react-redux';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 
@@ -64,7 +64,7 @@ import { RequestSettingsModal } from './modals/request-settings-modal';
 import RequestSwitcherModal from './modals/request-switcher-modal';
 import { ResponseDebugModal } from './modals/response-debug-modal';
 import { SelectModal } from './modals/select-modal';
-import { SettingsModal } from './modals/settings-modal';
+import { ModalHandle, SettingsModal } from './modals/settings-modal';
 import { SyncBranchesModal } from './modals/sync-branches-modal';
 import { SyncDeleteModal } from './modals/sync-delete-modal';
 import { SyncHistoryModal } from './modals/sync-history-modal';
@@ -170,7 +170,9 @@ const requestUpdate = (request: Request, patch: Partial<Request>) => {
 };
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-export class Wrapper extends PureComponent<WrapperProps, State> {
+export class Wrapper extends PureComponent<WrapperProps
+, State> {
+  settingsModalRef = createRef<ModalHandle>();
   state: State = {
     forceRefreshKey: Date.now(),
     activeGitBranch: 'no-vcs',

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as importers from 'insomnia-importers';
-import React, { createRef, Fragment, lazy, PureComponent, Ref, Suspense } from 'react';
+import React, { Fragment, lazy, PureComponent, Ref, Suspense } from 'react';
 import { useSelector } from 'react-redux';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 
@@ -64,7 +64,7 @@ import { RequestSettingsModal } from './modals/request-settings-modal';
 import RequestSwitcherModal from './modals/request-switcher-modal';
 import { ResponseDebugModal } from './modals/response-debug-modal';
 import { SelectModal } from './modals/select-modal';
-import { ModalHandle, SettingsModal } from './modals/settings-modal';
+import { SettingsModal } from './modals/settings-modal';
 import { SyncBranchesModal } from './modals/sync-branches-modal';
 import { SyncDeleteModal } from './modals/sync-delete-modal';
 import { SyncHistoryModal } from './modals/sync-history-modal';
@@ -170,9 +170,7 @@ const requestUpdate = (request: Request, patch: Partial<Request>) => {
 };
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
-export class Wrapper extends PureComponent<WrapperProps
-, State> {
-  settingsModalRef = createRef<ModalHandle>();
+export class Wrapper extends PureComponent<WrapperProps, State> {
   state: State = {
     forceRefreshKey: Date.now(),
     activeGitBranch: 'no-vcs',
@@ -515,7 +513,7 @@ export class Wrapper extends PureComponent<WrapperProps
               environmentId={activeEnvironment ? activeEnvironment._id : 'n/a'}
             />
 
-            <SettingsModal ref={registerModal} />
+            <SettingsModal />
             <ResponseDebugModal ref={registerModal} />
 
             <RequestSwitcherModal

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as importers from 'insomnia-importers';
-import React, { Fragment, lazy, PureComponent, Ref, Suspense } from 'react';
+import React, { Fragment, lazy, PureComponent, Suspense } from 'react';
 import { useSelector } from 'react-redux';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Attempted to convert one of the modal components into a function component. There are some caveats;
- registerModal and getModal methods needed some workaround
- this show and close does not refresh the modal (existing behaviour)
- some values rendered on the UI are purely based on rendering but .show() will just control the style of <Modal /> instance instead of refreshing, so there is a chance that these values would not be up to date. However, this seems to be an existing behaviour.
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/103070941/180275684-86e0c0c0-bf72-4920-98b8-e471df60a4ff.png">
