### PR TITLE
WrapperProps: decouple page layout

### DIFF
--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain } from 'electron';
+import { app, ipcMain, IpcRendererEvent } from 'electron';
 import { writeFile } from 'fs/promises';
 
 import { authorizeUserInWindow } from '../../network/o-auth-2/misc';
@@ -13,6 +13,7 @@ export interface MainBridgeAPI {
   writeFile: (options: { path: string; content: string }) => Promise<string>;
   cancelCurlRequest: typeof cancelCurlRequest;
   curlRequest: typeof curlRequest;
+  on: (channel: string, listener: (event: IpcRendererEvent, ...args: any[]) => void) => Function;
 }
 export function registerMainHandlers() {
   ipcMain.handle('authorizeUserInWindow', (_, options: Parameters<typeof authorizeUserInWindow>[0]) => {

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -8,6 +8,10 @@ const main: Window['main'] = {
   curlRequest: options => ipcRenderer.invoke('curlRequest', options),
   cancelCurlRequest: options => ipcRenderer.send('cancelCurlRequest', options),
   writeFile: options => ipcRenderer.invoke('writeFile', options),
+  on: (channel, listener) => {
+    ipcRenderer.on(channel, listener);
+    return () => ipcRenderer.removeListener(channel, listener);
+  },
 };
 const dialog: Window['dialog'] = {
   showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),

--- a/packages/insomnia/src/ui/components/page-layout.tsx
+++ b/packages/insomnia/src/ui/components/page-layout.tsx
@@ -1,9 +1,13 @@
 import classnames from 'classnames';
-import React, { FC, forwardRef, ReactNode, useCallback } from 'react';
+import React, { FC, forwardRef, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { COLLAPSE_SIDEBAR_REMS, DEFAULT_PANE_HEIGHT, DEFAULT_PANE_WIDTH, DEFAULT_SIDEBAR_WIDTH, MAX_PANE_HEIGHT, MAX_PANE_WIDTH, MAX_SIDEBAR_REMS, MIN_PANE_HEIGHT, MIN_PANE_WIDTH, MIN_SIDEBAR_REMS } from '../../common/constants';
+import { debounce } from '../../common/misc';
+import * as models from '../../models';
 import { selectIsLoading } from '../redux/modules/global';
-import { selectActiveEnvironment, selectSettings, selectUnseenWorkspaces, selectWorkspacesForActiveProject } from '../redux/selectors';
+import { selectActiveEnvironment, selectActiveWorkspaceMeta, selectSettings, selectUnseenWorkspaces, selectWorkspacesForActiveProject } from '../redux/selectors';
+import { selectPaneHeight, selectPaneWidth, selectSidebarWidth } from '../redux/sidebar-selectors';
 import { ErrorBoundary } from './error-boundary';
 import { Sidebar } from './sidebar/sidebar';
 import type { WrapperProps } from './wrapper';
@@ -40,29 +44,154 @@ export const PageLayout: FC<Props> = ({
   const settings = useSelector(selectSettings);
   const unseenWorkspaces = useSelector(selectUnseenWorkspaces);
   const workspacesForActiveProject = useSelector(selectWorkspacesForActiveProject);
-
+  const activeWorkspaceMeta = useSelector(selectActiveWorkspaceMeta);
+  const reduxPaneHeight = useSelector(selectPaneHeight);
+  const reduxPaneWidth = useSelector(selectPaneWidth);
+  const reduxSidebarWidth = useSelector(selectSidebarWidth);
   const {
-    handleResetDragSidebar,
-    handleStartDragSidebar,
     handleSetActiveEnvironment,
-    sidebarRef,
-    requestPaneRef,
-    responsePaneRef,
-    handleStartDragPaneHorizontal,
-    handleResetDragPaneHorizontal,
-    handleStartDragPaneVertical,
-    handleResetDragPaneVertical,
-    paneHeight,
-    paneWidth,
     sidebarHidden,
-    sidebarWidth,
   } = wrapperProps;
+
+  const requestPaneRef = useRef<HTMLElement>(null);
+  const responsePaneRef = useRef<HTMLElement>(null);
+  const sidebarRef = useRef<HTMLElement>(null);
+  const [showDragOverlay, setShowDragOverlay] = useState(false);
+  const [draggingSidebar, setDraggingSidebar] = useState(false);
+  const [draggingPaneHorizontal, setDraggingPaneHorizontal] = useState(false);
+  const [draggingPaneVertical, setDraggingPaneVertical] = useState(false);
+  const [sidebarWidth, setSidebarWidth] = useState(reduxSidebarWidth || DEFAULT_SIDEBAR_WIDTH);
+  const [paneWidth, setPaneWidth] = useState(reduxPaneWidth || DEFAULT_PANE_WIDTH);
+  const [paneHeight, setPaneHeight] = useState(reduxPaneHeight || DEFAULT_PANE_HEIGHT);
+
+  const handleSetPaneWidth = useCallback((paneWidth: number) => {
+    setPaneWidth(paneWidth);
+    if (activeWorkspaceMeta) {
+      debounce(() => models.workspaceMeta.update(activeWorkspaceMeta, { paneWidth }));
+    }
+  }, [activeWorkspaceMeta]);
+  const handleSetPaneHeight = useCallback((paneHeight: number) => {
+    setPaneHeight(paneHeight);
+    if (activeWorkspaceMeta) {
+      debounce(() => models.workspaceMeta.update(activeWorkspaceMeta, { paneHeight }));
+    }
+  }, [activeWorkspaceMeta]);
+  const handleSetSidebarWidth = useCallback((sidebarWidth: number) => {
+    setSidebarWidth(sidebarWidth);
+    if (activeWorkspaceMeta) {
+      debounce(() => models.workspaceMeta.update(activeWorkspaceMeta, { sidebarWidth }));
+    }
+  }, [activeWorkspaceMeta]);
+
+  const handleMouseUp = useCallback(() => {
+    if (draggingSidebar) {
+      setDraggingSidebar(false);
+      setShowDragOverlay(false);
+    }
+    if (draggingPaneHorizontal) {
+      setDraggingPaneHorizontal(false);
+      setShowDragOverlay(false);
+    }
+    if (draggingPaneVertical) {
+      setDraggingPaneVertical(false);
+      setShowDragOverlay(false);
+    }
+  }, [draggingPaneHorizontal, draggingPaneVertical, draggingSidebar]);
+
+  const handleMouseMove = useCallback((event: MouseEvent) => {
+    if (draggingPaneHorizontal) {
+      // Only pop the overlay after we've moved it a bit (so we don't block doubleclick);
+      const distance = reduxPaneWidth - paneWidth;
+
+      if (!showDragOverlay && Math.abs(distance) > 0.02) {
+        setShowDragOverlay(true);
+      }
+
+      if (requestPaneRef.current && responsePaneRef.current) {
+        const requestPaneWidth = requestPaneRef.current.offsetWidth;
+        const responsePaneWidth = responsePaneRef.current.offsetWidth;
+
+        const pixelOffset = event.clientX - requestPaneRef.current.offsetLeft;
+        let paneWidth = pixelOffset / (requestPaneWidth + responsePaneWidth);
+        paneWidth = Math.min(Math.max(paneWidth, MIN_PANE_WIDTH), MAX_PANE_WIDTH);
+
+        handleSetPaneWidth(paneWidth);
+      }
+    } else if (draggingPaneVertical) {
+      // Only pop the overlay after we've moved it a bit (so we don't block doubleclick);
+      const distance = reduxPaneHeight - paneHeight;
+      /* % */
+      if (!showDragOverlay && Math.abs(distance) > 0.02) {
+        setShowDragOverlay(true);
+      }
+
+      if (requestPaneRef.current && responsePaneRef.current) {
+        const requestPaneHeight = requestPaneRef.current.offsetHeight;
+        const responsePaneHeight = responsePaneRef.current.offsetHeight;
+        const pixelOffset = event.clientY - requestPaneRef.current.offsetTop;
+        let paneHeight = pixelOffset / (requestPaneHeight + responsePaneHeight);
+        paneHeight = Math.min(Math.max(paneHeight, MIN_PANE_HEIGHT), MAX_PANE_HEIGHT);
+
+        handleSetPaneHeight(paneHeight);
+      }
+    } else if (draggingSidebar) {
+      // Only pop the overlay after we've moved it a bit (so we don't block doubleclick);
+      const distance = reduxSidebarWidth - sidebarWidth;
+      /* ems */
+      if (!showDragOverlay && Math.abs(distance) > 2) {
+        setShowDragOverlay(true);
+      }
+
+      if (sidebarRef.current) {
+        const currentPixelWidth = sidebarRef.current.offsetWidth;
+        const ratio = (event.clientX - sidebarRef.current.offsetLeft) / currentPixelWidth;
+        const width = sidebarWidth * ratio;
+        let localSidebarWidth = Math.min(width, MAX_SIDEBAR_REMS);
+        if (localSidebarWidth < COLLAPSE_SIDEBAR_REMS) {
+          localSidebarWidth = MIN_SIDEBAR_REMS;
+        }
+        handleSetSidebarWidth(localSidebarWidth);
+      }
+    }
+  }, [draggingPaneHorizontal, draggingPaneVertical, draggingSidebar, handleSetPaneHeight, handleSetPaneWidth, handleSetSidebarWidth, paneHeight, paneWidth, reduxPaneHeight, reduxPaneWidth, reduxSidebarWidth, showDragOverlay, sidebarWidth]);
+
+  useEffect(() => {
+    document.addEventListener('mouseup', handleMouseUp);
+    document.addEventListener('mousemove', handleMouseMove);
+    return () => {
+      document.removeEventListener('mouseup', handleMouseUp);
+      document.removeEventListener('mousemove', handleMouseMove);
+    };
+  }, [handleMouseMove, handleMouseUp]);
+
+  function handleResetDragSidebar() {
+    // TODO: Remove setTimeout need be not triggering drag on double click
+    setTimeout(() => handleSetSidebarWidth(DEFAULT_SIDEBAR_WIDTH), 50);
+  }
+
+  function handleStartDragPaneHorizontal() {
+    setDraggingPaneHorizontal(true);
+  }
+
+  function handleStartDragPaneVertical() {
+    setDraggingPaneVertical(true);
+  }
+
+  function handleResetDragPaneHorizontal() {
+    // TODO: Remove setTimeout need be not triggering drag on double click
+    setTimeout(() => handleSetPaneWidth(DEFAULT_PANE_WIDTH), 50);
+  }
+
+  function handleResetDragPaneVertical() {
+    // TODO: Remove setTimeout need be not triggering drag on double click
+    setTimeout(() => handleSetPaneHeight(DEFAULT_PANE_HEIGHT), 50);
+  }
 
   // Special request updaters
   const startDragSidebar = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
-    handleStartDragSidebar(event);
-  }, [handleStartDragSidebar]);
+    setDraggingSidebar(true);
+  }, []);
 
   const realSidebarWidth = sidebarHidden ? 0 : sidebarWidth;
   const gridRows = renderPaneTwo
@@ -176,6 +305,8 @@ export const PageLayout: FC<Props> = ({
           )}
         </>
       )}
+      {/* Block all mouse activity by showing an overlay while dragging */}
+      {showDragOverlay ? <div className="blocker-overlay" /> : null}
     </div>
   );
 };

--- a/packages/insomnia/src/ui/components/page-layout.tsx
+++ b/packages/insomnia/src/ui/components/page-layout.tsx
@@ -50,7 +50,6 @@ export const PageLayout: FC<Props> = ({
   const reduxSidebarWidth = useSelector(selectSidebarWidth);
   const {
     handleSetActiveEnvironment,
-    sidebarHidden,
   } = wrapperProps;
 
   const requestPaneRef = useRef<HTMLElement>(null);
@@ -63,6 +62,15 @@ export const PageLayout: FC<Props> = ({
   const [sidebarWidth, setSidebarWidth] = useState(reduxSidebarWidth || DEFAULT_SIDEBAR_WIDTH);
   const [paneWidth, setPaneWidth] = useState(reduxPaneWidth || DEFAULT_PANE_WIDTH);
   const [paneHeight, setPaneHeight] = useState(reduxPaneHeight || DEFAULT_PANE_HEIGHT);
+
+  useEffect(() => {
+    const unsubscribe = window.main.on('toggle-sidebar', () => {
+      if (activeWorkspaceMeta) {
+        models.workspaceMeta.update(activeWorkspaceMeta, { sidebarHidden: !activeWorkspaceMeta.sidebarHidden });
+      }
+    });
+    return () => unsubscribe();
+  }, [activeWorkspaceMeta]);
 
   const handleSetPaneWidth = useCallback((paneWidth: number) => {
     setPaneWidth(paneWidth);
@@ -193,7 +201,7 @@ export const PageLayout: FC<Props> = ({
     setDraggingSidebar(true);
   }, []);
 
-  const realSidebarWidth = sidebarHidden ? 0 : sidebarWidth;
+  const realSidebarWidth = activeWorkspaceMeta?.sidebarHidden ? 0 : sidebarWidth;
   const gridRows = renderPaneTwo
     ? `auto minmax(0, ${paneHeight}fr) 0 minmax(0, ${1 - paneHeight}fr)`
     : 'auto 1fr';
@@ -246,7 +254,7 @@ export const PageLayout: FC<Props> = ({
             activeEnvironment={activeEnvironment}
             environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
             handleSetActiveEnvironment={handleSetActiveEnvironment}
-            hidden={sidebarHidden || false}
+            hidden={activeWorkspaceMeta?.sidebarHidden || false}
             isLoading={isLoading}
             unseenWorkspaces={unseenWorkspaces}
             width={sidebarWidth}

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as importers from 'insomnia-importers';
-import React, { Fragment, lazy, PureComponent, Ref, Suspense } from 'react';
+import React, { Fragment, lazy, PureComponent, Suspense } from 'react';
 import { useSelector } from 'react-redux';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 
@@ -135,19 +135,10 @@ export type WrapperProps = AppProps & {
   handleGenerateCodeForActiveRequest: Function;
   handleGenerateCode: Function;
   handleCopyAsCurl: Function;
-  requestPaneRef: Ref<HTMLElement>;
-  responsePaneRef: Ref<HTMLElement>;
   handleSetResponsePreviewMode: Function;
   handleSetResponseFilter: Function;
   handleSetActiveResponse: Function;
-  sidebarRef: Ref<HTMLElement>;
   handleSidebarSort: (sortOrder: SortOrder) => void;
-  handleStartDragSidebar: React.MouseEventHandler;
-  handleResetDragSidebar: React.MouseEventHandler;
-  handleStartDragPaneHorizontal: React.MouseEventHandler;
-  handleStartDragPaneVertical: React.MouseEventHandler;
-  handleResetDragPaneHorizontal: React.MouseEventHandler;
-  handleResetDragPaneVertical: React.MouseEventHandler;
   handleSetRequestGroupCollapsed: Function;
   handleSetRequestPinned: Function;
   handleSendRequestWithEnvironment: Function;
@@ -155,9 +146,6 @@ export type WrapperProps = AppProps & {
   handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   handleUpdateDownloadPath: Function;
 
-  paneWidth: number;
-  paneHeight: number;
-  sidebarWidth: number;
   headerEditorKey: string;
   vcs: VCS | null;
   gitVCS: GitVCS | null;

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -123,7 +123,7 @@ import {
   selectWorkspaceMetas,
   selectWorkspacesForActiveProject,
 } from '../redux/selectors';
-import { selectSidebarChildren, selectSidebarFilter, selectSidebarHidden } from '../redux/sidebar-selectors';
+import { selectSidebarChildren, selectSidebarFilter } from '../redux/sidebar-selectors';
 import { AppHooks } from './app-hooks';
 
 const updateRequestMetaByParentId = async (
@@ -319,7 +319,9 @@ class App extends PureComponent<AppProps, State> {
       [
         hotKeyRefs.SIDEBAR_TOGGLE,
         () => {
-          this._handleToggleSidebar();
+          if (this.props.activeWorkspaceMeta) {
+            models.workspaceMeta.update(this.props.activeWorkspaceMeta, { sidebarHidden: !this.props.activeWorkspaceMeta.sidebarHidden });
+          }
         },
       ],
     ];
@@ -764,15 +766,6 @@ class App extends PureComponent<AppProps, State> {
       executeHotKey(event, definition, callback);
     }
   }
-  async _handleSetSidebarHidden(sidebarHidden: boolean) {
-    await this._updateActiveWorkspaceMeta({
-      sidebarHidden,
-    });
-  }
-  async _handleToggleSidebar() {
-    const sidebarHidden = !this.props.sidebarHidden;
-    await this._handleSetSidebarHidden(sidebarHidden);
-  }
 
   static _handleShowSettingsModal(tabIndex?: number) {
     showModal(SettingsModal, tabIndex);
@@ -1116,7 +1109,6 @@ class App extends PureComponent<AppProps, State> {
       },
       false,
     );
-    ipcRenderer.on('toggle-sidebar', this._handleToggleSidebar);
 
     // Give it a bit before letting the backend know it's ready
     setTimeout(() => ipcRenderer.send('window-ready'), 500);
@@ -1284,7 +1276,6 @@ const mapStateToProps = (state: RootState) => ({
   settings: selectSettings(state),
   sidebarChildren: selectSidebarChildren(state),
   sidebarFilter: selectSidebarFilter(state),
-  sidebarHidden: selectSidebarHidden(state),
   stats: selectStats(state),
   syncItems: selectSyncItems(state),
   unseenWorkspaces: selectUnseenWorkspaces(state),

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -4,27 +4,17 @@ import fs from 'fs';
 import HTTPSnippet from 'httpsnippet';
 import { extension as mimeExtension } from 'mime-types';
 import * as path from 'path';
-import React, { createRef, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { Action, bindActionCreators, Dispatch } from 'redux';
 import { parse as urlParse } from 'url';
 
-import {  SegmentEvent, trackSegmentEvent } from '../../common/analytics';
+import { SegmentEvent, trackSegmentEvent } from '../../common/analytics';
 import {
   ACTIVITY_HOME,
   AUTOBIND_CFG,
-  COLLAPSE_SIDEBAR_REMS,
-  DEFAULT_PANE_HEIGHT,
-  DEFAULT_PANE_WIDTH,
-  DEFAULT_SIDEBAR_WIDTH,
   getProductName,
   isDevelopment,
-  MAX_PANE_HEIGHT,
-  MAX_PANE_WIDTH,
-  MAX_SIDEBAR_REMS,
-  MIN_PANE_HEIGHT,
-  MIN_PANE_WIDTH,
-  MIN_SIDEBAR_REMS,
   PreviewMode,
   SortOrder,
 } from '../../common/constants';
@@ -34,7 +24,6 @@ import { exportHarRequest } from '../../common/har';
 import { hotKeyRefs } from '../../common/hotkeys';
 import { executeHotKey } from '../../common/hotkeys-listener';
 import {
-  debounce,
   generateId,
   getContentDispositionHeader,
 } from '../../common/misc';
@@ -134,7 +123,7 @@ import {
   selectWorkspaceMetas,
   selectWorkspacesForActiveProject,
 } from '../redux/selectors';
-import { selectPaneHeight, selectPaneWidth, selectSidebarChildren, selectSidebarFilter, selectSidebarHidden, selectSidebarWidth } from '../redux/sidebar-selectors';
+import { selectSidebarChildren, selectSidebarFilter, selectSidebarHidden } from '../redux/sidebar-selectors';
 import { AppHooks } from './app-hooks';
 
 const updateRequestMetaByParentId = async (
@@ -153,13 +142,6 @@ const updateRequestMetaByParentId = async (
 export type AppProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
 
 interface State {
-  showDragOverlay: boolean;
-  draggingSidebar: boolean;
-  draggingPaneHorizontal: boolean;
-  draggingPaneVertical: boolean;
-  sidebarWidth: number;
-  paneWidth: number;
-  paneHeight: number;
   vcs: VCS | null;
   gitVCS: GitVCS | null;
   forceRefreshCounter: number;
@@ -169,14 +151,8 @@ interface State {
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
 class App extends PureComponent<AppProps, State> {
-  private _savePaneWidth: (paneWidth: number) => void;
-  private _savePaneHeight: (paneWidth: number) => void;
-  private _saveSidebarWidth: (paneWidth: number) => void;
   private _globalKeyMap: any;
   private _updateVCSLock: any;
-  private _requestPaneRef = createRef<HTMLElement>();
-  private _responsePaneRef = createRef<HTMLElement>();
-  private _sidebarRef = createRef<HTMLElement>();
   private _wrapper: Wrapper | null = null;
   private _responseFilterHistorySaveTimeout: NodeJS.Timeout | null = null;
 
@@ -184,13 +160,6 @@ class App extends PureComponent<AppProps, State> {
     super(props);
 
     this.state = {
-      showDragOverlay: false,
-      draggingSidebar: false,
-      draggingPaneHorizontal: false,
-      draggingPaneVertical: false,
-      sidebarWidth: props.sidebarWidth || DEFAULT_SIDEBAR_WIDTH,
-      paneWidth: props.paneWidth || DEFAULT_PANE_WIDTH,
-      paneHeight: props.paneHeight || DEFAULT_PANE_HEIGHT,
       vcs: null,
       gitVCS: null,
       forceRefreshCounter: 0,
@@ -198,15 +167,6 @@ class App extends PureComponent<AppProps, State> {
       isMigratingChildren: false,
     };
 
-    this._savePaneWidth = debounce(paneWidth =>
-      this._updateActiveWorkspaceMeta({ paneWidth }),
-    );
-    this._savePaneHeight = debounce(paneHeight =>
-      this._updateActiveWorkspaceMeta({ paneHeight }),
-    );
-    this._saveSidebarWidth = debounce(sidebarWidth =>
-      this._updateActiveWorkspaceMeta({ sidebarWidth }),
-    );
     this._globalKeyMap = null;
     this._updateVCSLock = null;
   }
@@ -499,22 +459,6 @@ class App extends PureComponent<AppProps, State> {
     await models.settings.update(settings, { showVariableSourceAndValue: !settings.showVariableSourceAndValue });
   }
 
-  _handleSetPaneWidth(paneWidth: number) {
-    this.setState({
-      paneWidth,
-    });
-
-    this._savePaneWidth(paneWidth);
-  }
-
-  _handleSetPaneHeight(paneHeight: number) {
-    this.setState({
-      paneHeight,
-    });
-
-    this._savePaneHeight(paneHeight);
-  }
-
   async _handleSetActiveRequest(activeRequestId: string) {
     await this._updateActiveWorkspaceMeta({
       activeRequestId,
@@ -532,20 +476,6 @@ class App extends PureComponent<AppProps, State> {
     setTimeout(() => {
       this._wrapper?._forceRequestPaneRefresh();
     }, 300);
-  }
-
-  _handleSetSidebarWidth(sidebarWidth: number) {
-    this.setState({
-      sidebarWidth,
-    });
-
-    this._saveSidebarWidth(sidebarWidth);
-  }
-
-  async _handleSetSidebarHidden(sidebarHidden: boolean) {
-    await this._updateActiveWorkspaceMeta({
-      sidebarHidden,
-    });
   }
 
   async _handleSetSidebarFilter(sidebarFilter: string) {
@@ -829,154 +759,16 @@ class App extends PureComponent<AppProps, State> {
     }
   }
 
-  _startDragSidebar() {
-    this.setState({
-      draggingSidebar: true,
-    });
-  }
-
-  _resetDragSidebar() {
-    // TODO: Remove setTimeout need be not triggering drag on double click
-    setTimeout(() => this._handleSetSidebarWidth(DEFAULT_SIDEBAR_WIDTH), 50);
-  }
-
-  _startDragPaneHorizontal() {
-    this.setState({
-      draggingPaneHorizontal: true,
-    });
-  }
-
-  _startDragPaneVertical() {
-    this.setState({
-      draggingPaneVertical: true,
-    });
-  }
-
-  _resetDragPaneHorizontal() {
-    // TODO: Remove setTimeout need be not triggering drag on double click
-    setTimeout(() => this._handleSetPaneWidth(DEFAULT_PANE_WIDTH), 50);
-  }
-
-  _resetDragPaneVertical() {
-    // TODO: Remove setTimeout need be not triggering drag on double click
-    setTimeout(() => this._handleSetPaneHeight(DEFAULT_PANE_HEIGHT), 50);
-  }
-
-  _handleMouseMove(event: MouseEvent) {
-    if (this.state.draggingPaneHorizontal) {
-      // Only pop the overlay after we've moved it a bit (so we don't block doubleclick);
-      const distance = this.props.paneWidth - this.state.paneWidth;
-
-      if (
-        !this.state.showDragOverlay &&
-        Math.abs(distance) > 0.02
-        /* % */
-      ) {
-        this.setState({
-          showDragOverlay: true,
-        });
-      }
-
-      const requestPane = this._requestPaneRef.current;
-      const responsePane = this._responsePaneRef.current;
-
-      if (requestPane && responsePane) {
-        const requestPaneWidth = requestPane.offsetWidth;
-        const responsePaneWidth = responsePane.offsetWidth;
-
-        const pixelOffset = event.clientX - requestPane.offsetLeft;
-        let paneWidth = pixelOffset / (requestPaneWidth + responsePaneWidth);
-        paneWidth = Math.min(Math.max(paneWidth, MIN_PANE_WIDTH), MAX_PANE_WIDTH);
-
-        this._handleSetPaneWidth(paneWidth);
-      }
-    } else if (this.state.draggingPaneVertical) {
-      // Only pop the overlay after we've moved it a bit (so we don't block doubleclick);
-      const distance = this.props.paneHeight - this.state.paneHeight;
-
-      if (
-        !this.state.showDragOverlay &&
-        Math.abs(distance) > 0.02
-        /* % */
-      ) {
-        this.setState({
-          showDragOverlay: true,
-        });
-      }
-
-      const requestPane = this._requestPaneRef.current;
-      const responsePane = this._responsePaneRef.current;
-
-      if (requestPane && responsePane) {
-        const requestPaneHeight = requestPane.offsetHeight;
-        const responsePaneHeight = responsePane.offsetHeight;
-        const pixelOffset = event.clientY - requestPane.offsetTop;
-        let paneHeight = pixelOffset / (requestPaneHeight + responsePaneHeight);
-        paneHeight = Math.min(Math.max(paneHeight, MIN_PANE_HEIGHT), MAX_PANE_HEIGHT);
-
-        this._handleSetPaneHeight(paneHeight);
-      }
-    } else if (this.state.draggingSidebar) {
-      // Only pop the overlay after we've moved it a bit (so we don't block doubleclick);
-      const distance = this.props.sidebarWidth - this.state.sidebarWidth;
-
-      if (
-        !this.state.showDragOverlay &&
-        Math.abs(distance) > 2
-        /* ems */
-      ) {
-        this.setState({
-          showDragOverlay: true,
-        });
-      }
-
-      const sidebar = this._sidebarRef.current;
-
-      if (sidebar) {
-        const currentPixelWidth = sidebar.offsetWidth;
-
-        const ratio = (event.clientX - sidebar.offsetLeft) / currentPixelWidth;
-        const width = this.state.sidebarWidth * ratio;
-        let sidebarWidth = Math.min(width, MAX_SIDEBAR_REMS);
-
-        if (sidebarWidth < COLLAPSE_SIDEBAR_REMS) {
-          sidebarWidth = MIN_SIDEBAR_REMS;
-        }
-
-        this._handleSetSidebarWidth(sidebarWidth);
-      }
-    }
-  }
-
-  _handleMouseUp() {
-    if (this.state.draggingSidebar) {
-      this.setState({
-        draggingSidebar: false,
-        showDragOverlay: false,
-      });
-    }
-
-    if (this.state.draggingPaneHorizontal) {
-      this.setState({
-        draggingPaneHorizontal: false,
-        showDragOverlay: false,
-      });
-    }
-
-    if (this.state.draggingPaneVertical) {
-      this.setState({
-        draggingPaneVertical: false,
-        showDragOverlay: false,
-      });
-    }
-  }
-
   _handleKeyDown(event: KeyboardEvent) {
     for (const [definition, callback] of this._globalKeyMap) {
       executeHotKey(event, definition, callback);
     }
   }
-
+  async _handleSetSidebarHidden(sidebarHidden: boolean) {
+    await this._updateActiveWorkspaceMeta({
+      sidebarHidden,
+    });
+  }
   async _handleToggleSidebar() {
     const sidebarHidden = !this.props.sidebarHidden;
     await this._handleSetSidebarHidden(sidebarHidden);
@@ -1205,10 +997,7 @@ class App extends PureComponent<AppProps, State> {
   }
 
   async componentDidMount() {
-    // Bind mouse and key handlers
-    document.addEventListener('mouseup', this._handleMouseUp);
-    document.addEventListener('mousemove', this._handleMouseMove);
-
+    // Bind key handlers
     this._setGlobalKeyMap();
 
     // Update title
@@ -1337,9 +1126,6 @@ class App extends PureComponent<AppProps, State> {
   }
 
   componentWillUnmount() {
-    // Remove mouse and key handlers
-    document.removeEventListener('mouseup', this._handleMouseUp);
-    document.removeEventListener('mousemove', this._handleMouseMove);
     db.offChange(this._handleDbChange);
   }
 
@@ -1407,9 +1193,6 @@ class App extends PureComponent<AppProps, State> {
 
     const { activeWorkspace } = this.props;
     const {
-      paneWidth,
-      paneHeight,
-      sidebarWidth,
       gitVCS,
       vcs,
       forceRefreshCounter,
@@ -1427,21 +1210,9 @@ class App extends PureComponent<AppProps, State> {
                 <Wrapper
                   ref={this._setWrapperRef}
                   {...this.props}
-                  paneWidth={paneWidth}
-                  paneHeight={paneHeight}
-                  sidebarWidth={sidebarWidth}
                   handleSetRequestPinned={this._handleSetRequestPinned}
                   handleSetRequestGroupCollapsed={this._handleSetRequestGroupCollapsed}
                   handleActivateRequest={this._handleSetActiveRequest}
-                  requestPaneRef={this._requestPaneRef}
-                  responsePaneRef={this._responsePaneRef}
-                  sidebarRef={this._sidebarRef}
-                  handleStartDragSidebar={this._startDragSidebar}
-                  handleResetDragSidebar={this._resetDragSidebar}
-                  handleStartDragPaneHorizontal={this._startDragPaneHorizontal}
-                  handleStartDragPaneVertical={this._startDragPaneVertical}
-                  handleResetDragPaneHorizontal={this._resetDragPaneHorizontal}
-                  handleResetDragPaneVertical={this._resetDragPaneVertical}
                   handleDuplicateRequest={this._requestDuplicate}
                   handleDuplicateRequestGroup={App._requestGroupDuplicate}
                   handleGenerateCode={App._handleGenerateCode}
@@ -1469,9 +1240,6 @@ class App extends PureComponent<AppProps, State> {
               <ErrorBoundary showAlert>
                 <Toast />
               </ErrorBoundary>
-
-              {/* Block all mouse activity by showing an overlay while dragging */}
-              {this.state.showDragOverlay ? <div className="blocker-overlay" /> : null}
             </div>
           </NunjucksEnabledProvider>
         </GrpcProvider>
@@ -1505,8 +1273,6 @@ const mapStateToProps = (state: RootState) => ({
   isLoggedIn: selectIsLoggedIn(state),
   isFinishedBooting: selectIsFinishedBooting(state),
   loadStartTime: selectLoadStartTime(state),
-  paneHeight: selectPaneHeight(state),
-  paneWidth: selectPaneWidth(state),
   requestGroups: selectRequestGroups(state),
   requestMetas: selectRequestMetas(state),
   requestVersions: selectRequestVersions(state),
@@ -1519,7 +1285,6 @@ const mapStateToProps = (state: RootState) => ({
   sidebarChildren: selectSidebarChildren(state),
   sidebarFilter: selectSidebarFilter(state),
   sidebarHidden: selectSidebarHidden(state),
-  sidebarWidth: selectSidebarWidth(state),
   stats: selectStats(state),
   syncItems: selectSyncItems(state),
   unseenWorkspaces: selectUnseenWorkspaces(state),

--- a/packages/insomnia/src/ui/redux/sidebar-selectors.ts
+++ b/packages/insomnia/src/ui/redux/sidebar-selectors.ts
@@ -43,11 +43,6 @@ export interface SidebarChildren {
   pinned: Child[];
 }
 
-export const selectSidebarHidden = createSelector(
-  selectActiveWorkspaceMeta,
-  activeWorkspaceMeta => activeWorkspaceMeta?.sidebarHidden || false,
-);
-
 export const selectSidebarWidth = createSelector(
   selectActiveWorkspaceMeta,
   activeWorkspaceMeta =>  activeWorkspaceMeta?.sidebarWidth || DEFAULT_SIDEBAR_WIDTH,


### PR DESCRIPTION
highlights
- moves control over paneHeight/Width and sidebar width from app.tsx and places it within the page layout component
- enables us to remove the rest of the wrapper props with redux hooks. #4979

could do/scoped out
- decouple dragging behaviour from redux
- come up with a more sensible way to do this kind of thing

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
