### PR TITLE
fix: (first pass) clear token with flush listener

### DIFF
--- a/packages/insomnia/src/models/o-auth-2-token.ts
+++ b/packages/insomnia/src/models/o-auth-2-token.ts
@@ -69,6 +69,10 @@ export function remove(token: OAuth2Token) {
   return db.remove(token);
 }
 
+export function removeAsync(token: OAuth2Token) {
+  return db.remove(token);
+}
+
 export function getByParentId(parentId: string) {
   return db.getWhere<OAuth2Token>(type, { parentId });
 }

--- a/packages/insomnia/src/models/o-auth-2-token.ts
+++ b/packages/insomnia/src/models/o-auth-2-token.ts
@@ -69,10 +69,6 @@ export function remove(token: OAuth2Token) {
   return db.remove(token);
 }
 
-export function removeAsync(token: OAuth2Token) {
-  return db.remove(token);
-}
-
 export function getByParentId(parentId: string) {
   return db.getWhere<OAuth2Token>(type, { parentId });
 }

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -1,5 +1,5 @@
 import { Button } from 'insomnia-components';
-import React, { ChangeEvent, FC, ReactNode, useCallback, useMemo, useState } from 'react';
+import React, { ChangeEvent, FC, ReactElement, ReactNode, useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { convertEpochToMilliseconds, toKebabCase } from '../../../../common/misc';
@@ -449,8 +449,8 @@ const useActiveOAuth2Token = () => {
 };
 
 const OAuth2Tokens: FC = () => {
-  const { refreshToken, loading, error } = useActiveOAuth2Token();
-  const [{ token, loading: tokenClearLoading }, clearTokens] = useOauth2TokenClear();
+  const { error } = useActiveOAuth2Token();
+  const [{ token }, clearTokens] = useOauth2TokenClear();
 
   return (
     <div className='notice subtle text-left'>
@@ -464,26 +464,45 @@ const OAuth2Tokens: FC = () => {
       <OAuth2TokenInput label='Identity Token' property='identityToken' />
       <OAuth2TokenInput label='Access Token' property='accessToken' />
       <div className='pad-top text-right'>
-        {token ? (
-          <PromptButton className="btn btn--clicky" onClick={clearTokens}>
-            Clear
-          </PromptButton>
-        ) : null}
+        {token && <PromptButton className="btn btn--clicky" onClick={clearTokens}>
+          Clear
+        </PromptButton>}
         &nbsp;&nbsp;
-        <button
-          className="btn btn--clicky"
-          onClick={refreshToken}
-          disabled={loading || tokenClearLoading}
-        >
-          {loading || tokenClearLoading
-            ? token
-              ? 'Refreshing...'
-              : 'Fetching...'
-            : token
-              ? 'Refresh Token'
-              : 'Fetch Tokens'}
-        </button>
+        <TokenRefreshButton />
       </div>
     </div>
+  );
+};
+
+function getLabel(loading: boolean, token?: OAuth2Token): string {
+  if (!loading) {
+    if (!token) {
+      return 'Fetch Tokens';
+    }
+
+    return 'Refresh Token';
+  }
+
+  if (!token) {
+    return 'Fetching...';
+  }
+
+  return 'Refreshing...';
+}
+
+const TokenRefreshButton = (): ReactElement => {
+  const { refreshToken, loading: refreshLoading } = useActiveOAuth2Token();
+  const [{ token, loading: clearLoading }] = useOauth2TokenClear();
+  const loading = refreshLoading || clearLoading;
+  const label = getLabel(loading, token);
+
+  return (
+    <button
+      className="btn btn--clicky"
+      onClick={refreshToken}
+      disabled={loading}
+    >
+      {label}
+    </button>
   );
 };

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -53,8 +53,7 @@ const useOauthToken = (): [{ token: OAuth2Token | undefined; loading: boolean },
   useEffect(() => {
     function listener(changes: ChangeBufferEvent[]): void {
       for (const change of changes) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const [operationEvent, entity, _fromSync] = change;
+        const [operationEvent, entity] = change;
         if (entity.type === type && operationEvent === database.CHANGE_REMOVE) {
           setLoading(false);
         }
@@ -451,8 +450,7 @@ const OAuth2Error: FC = () => {
 };
 
 const useActiveOAuth2Token = () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_, clearTokens] = useOauthToken();
+  const [, clearTokens] = useOauthToken();
   const { activeRequest: { authentication, _id: requestId } } = useActiveRequest();
   const { handleRender } = useNunjucks();
 

--- a/packages/insomnia/src/ui/components/editors/auth/use-oauth2-token.ts
+++ b/packages/insomnia/src/ui/components/editors/auth/use-oauth2-token.ts
@@ -15,13 +15,13 @@ export function useOauth2TokenClear(): UseOauth2TokenClear {
   const token = useSelector(selectActiveOAuth2Token);
   const [loading, setLoading] = useState(false);
 
-  const clearTokens = useCallback(() => {
+  const clearTokens = useCallback(async () => {
     if (!token) {
       return;
     }
 
     setLoading(true);
-    models.oAuth2Token.remove(token);
+    await models.oAuth2Token.remove(token);
   }, [token]);
 
   useEffect(() => {

--- a/packages/insomnia/src/ui/components/editors/auth/use-oauth2-token.ts
+++ b/packages/insomnia/src/ui/components/editors/auth/use-oauth2-token.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { ChangeBufferEvent, database } from '../../../../common/database';
+import * as models from '../../../../models';
+import { OAuth2Token, type } from '../../../../models/o-auth-2-token';
+import { selectActiveOAuth2Token } from '../../../redux/selectors';
+
+interface Oauth2TokenData {
+  token: OAuth2Token | undefined;
+  loading: boolean;
+}
+type UseOauth2TokenClear  = [Oauth2TokenData, () => void];
+export function useOauth2TokenClear(): UseOauth2TokenClear {
+  const token = useSelector(selectActiveOAuth2Token);
+  const [loading, setLoading] = useState(false);
+
+  const clearTokens = useCallback(() => {
+    if (!token) {
+      return;
+    }
+
+    setLoading(true);
+    models.oAuth2Token.remove(token);
+  }, [token]);
+
+  useEffect(() => {
+    function listener(changes: ChangeBufferEvent[]): void {
+      for (const change of changes) {
+        const [operationEvent, entity] = change;
+        if (entity.type === type && operationEvent === database.CHANGE_REMOVE) {
+          setLoading(false);
+        }
+      }
+    }
+
+    database.onChange(listener);
+    return () => database.offChange(listener);
+  }, [token]);
+
+  return [{ token, loading }, clearTokens];
+}


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

First pass to solve the oauth e2e test failure
- Added an event listener to the db changes to set loading false. This is a workaround.
