### PR TITLE
fix e2e test/consistent buttons

### DIFF
--- a/packages/insomnia-smoke-test/tests/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/oauth.test.ts
@@ -53,7 +53,6 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await page.locator('text=Advanced Options').click();
   await page.locator('button:has-text("Clear OAuth 2 session")').click();
   await page.locator('button:text-is("Clear")').click();
-  await page.locator('button:has-text("Click to confirm")').click();
 
   const [refreshPage] = await Promise.all([
     app.waitForEvent('window'),

--- a/packages/insomnia-smoke-test/tests/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/oauth.test.ts
@@ -4,7 +4,11 @@ import { loadFixture } from '../playwright/paths';
 import { test } from '../playwright/test';
 
 test('can make oauth2 requests', async ({ app, page }) => {
-  test.slow();
+  if (process.platform === 'darwin') {
+    test.setTimeout(6 * 60 * 1000);
+  } else {
+    test.slow();
+  }
 
   const sendButton = page.locator('[data-testid="request-pane"] button:has-text("Send")');
   const statusTag = page.locator('[data-testid="response-status-tag"]:visible');

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -25,7 +25,6 @@ import { useNunjucks } from '../../../context/nunjucks/use-nunjucks';
 import { useActiveRequest } from '../../../hooks/use-active-request';
 import { selectActiveOAuth2Token } from '../../../redux/selectors';
 import { Link } from '../../base/link';
-import { PromptButton } from '../../base/prompt-button';
 import { showModal } from '../../modals';
 import { ResponseDebugModal } from '../../modals/response-debug-modal';
 import { TimeFromNow } from '../../time-from-now';

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -469,9 +469,9 @@ const OAuth2Tokens: FC = () => {
       <OAuth2TokenInput label='Access Token' property='accessToken' />
       <div className='pad-top text-right'>
         {token ? (
-          <PromptButton className="btn btn--clicky" onClick={clearTokens}>
+          <button className="btn btn--clicky" onClick={clearTokens}>
             Clear
-          </PromptButton>
+          </button>
         ) : null}
         &nbsp;&nbsp;
         <button


### PR DESCRIPTION
The clear oauth2 session button and clear token buttons were inconsistent and causing playwright e2e test flake because of prompt button's instability.

We hypothesise that macos github runners have tight resource constraints that cause some of the more intensive tasks to return slowly, thus we hope that doubling the timeout for this one long running test case will help to avoid this issue.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
