### PR TITLE
Fix Request Switcher Auto-Focus from CodeMirror

### DIFF
--- a/packages/insomnia/src/ui/components/base/modal.tsx
+++ b/packages/insomnia/src/ui/components/base/modal.tsx
@@ -16,7 +16,6 @@ export interface ModalProps {
   wide?: boolean;
   skinny?: boolean;
   noEscape?: boolean;
-  dontFocus?: boolean;
   closeOnKeyCodes?: any[];
   onShow?: Function;
   onHide?: Function;
@@ -117,10 +116,6 @@ export class Modal extends PureComponent<ModalProps, State> {
     });
 
     this.props.onShow?.();
-
-    if (this.props.dontFocus) {
-      return;
-    }
 
     // Allow instance-based onHide method
     this.onHide = options?.onHide ?? null;

--- a/packages/insomnia/src/ui/components/modals/request-switcher-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-switcher-modal.tsx
@@ -412,7 +412,6 @@ class RequestSwitcherModal extends PureComponent<ReduxProps, State> {
       <KeydownBinder onKeydown={this._handleKeydown} onKeyup={this._handleKeyup}>
         <Modal
           ref={this._setModalRef}
-          dontFocus={!disableInput}
           className={isModalVisible ? '' : 'hide'}
         >
           <ModalHeader hideCloseButton>


### PR DESCRIPTION
changelog(Fixes): Fixed an edge-case issue where Request Switcher search input would not auto-focus

Fixes the input `.focus()` method call. The simplest fix I found was to revert the change in 3cf464d0593f4359c56e6443b8a6d19831b73127.

There don't seem to be any new problems in the current application from reverting this commit's relevant changes. The original source of the bug may no longer be present.

Closes #4797