### PR TITLE
Chore/response viewer fc

### DIFF
--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -25,7 +25,7 @@ import { TimeTag } from '../tags/time-tag';
 import { ResponseCookiesViewer } from '../viewers/response-cookies-viewer';
 import { ResponseHeadersViewer } from '../viewers/response-headers-viewer';
 import { ResponseTimelineViewer } from '../viewers/response-timeline-viewer';
-import { ResponseViewer } from '../viewers/response-viewer';
+import { ResponseViewer, ResponseViewerHandle } from '../viewers/response-viewer';
 import { BlankPane } from './blank-pane';
 import { Pane, paneBodyClasses, PaneHeader } from './pane';
 import { PlaceholderResponsePane } from './placeholder-response-pane';
@@ -49,7 +49,7 @@ export const ResponsePane: FC<Props> = ({
   const loadStartTime = useSelector(selectLoadStartTime);
   const previewMode = useSelector(selectResponsePreviewMode);
 
-  const responseViewerRef = useRef<ResponseViewer>(null);
+  const responseViewerRef = useRef<ResponseViewerHandle>(null);
   const handleGetResponseBody = useCallback(() => {
     if (!response) {
       return null;

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -3,7 +3,7 @@ import { clipboard } from 'electron';
 import fs from 'fs';
 import { json as jsonPrettify } from 'insomnia-prettify';
 import { extension as mimeExtension } from 'mime-types';
-import React, { FC, useCallback, useRef } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
@@ -25,7 +25,7 @@ import { TimeTag } from '../tags/time-tag';
 import { ResponseCookiesViewer } from '../viewers/response-cookies-viewer';
 import { ResponseHeadersViewer } from '../viewers/response-headers-viewer';
 import { ResponseTimelineViewer } from '../viewers/response-timeline-viewer';
-import { ResponseViewer, ResponseViewerHandle } from '../viewers/response-viewer';
+import { ResponseViewer } from '../viewers/response-viewer';
 import { BlankPane } from './blank-pane';
 import { Pane, paneBodyClasses, PaneHeader } from './pane';
 import { PlaceholderResponsePane } from './placeholder-response-pane';
@@ -49,7 +49,6 @@ export const ResponsePane: FC<Props> = ({
   const loadStartTime = useSelector(selectLoadStartTime);
   const previewMode = useSelector(selectResponsePreviewMode);
 
-  const responseViewerRef = useRef<ResponseViewerHandle>(null);
   const handleGetResponseBody = useCallback(() => {
     if (!response) {
       return null;
@@ -110,17 +109,6 @@ export const ResponsePane: FC<Props> = ({
     }
   }, [request, response]);
 
-  const handleTabSelect = (index: number, lastIndex: number) => {
-    if (responseViewerRef.current != null && index === 0 && index !== lastIndex) {
-      // Fix for CodeMirror editor not updating its content.
-      // Refresh must be called when the editor is visible,
-      // so use nextTick to give time for it to be visible.
-      process.nextTick(() => {
-        responseViewerRef.current?.refresh();
-      });
-    }
-  };
-
   if (!request) {
     return <BlankPane type="response" />;
   }
@@ -156,7 +144,6 @@ export const ResponsePane: FC<Props> = ({
       )}
       <Tabs
         className={classnames(paneBodyClasses, 'react-tabs')}
-        onSelect={handleTabSelect}
         forceRenderTabPanel
       >
         <TabList>
@@ -188,7 +175,7 @@ export const ResponsePane: FC<Props> = ({
         </TabList>
         <TabPanel className="react-tabs__tab-panel">
           <ResponseViewer
-            ref={responseViewerRef}
+            key={response._id}
             bytes={Math.max(response.bytesContent, response.bytesRead)}
             contentType={response.contentType || ''}
             disableHtmlPreviewJs={settings.disableHtmlPreviewJs}

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -1,9 +1,15 @@
-import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import iconv from 'iconv-lite';
-import React, { Component, Fragment } from 'react';
+import React, {
+  forwardRef,
+  Fragment,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 
 import {
-  AUTOBIND_CFG,
   HUGE_RESPONSE_MB,
   LARGE_RESPONSE_MB,
   PREVIEW_MODE_FRIENDLY,
@@ -14,7 +20,7 @@ import { hotKeyRefs } from '../../../common/hotkeys';
 import { executeHotKey } from '../../../common/hotkeys-listener';
 import { xmlDecode } from '../../../common/misc';
 import { CodeEditor, UnconnectedCodeEditor } from '../codemirror/code-editor';
-import { KeydownBinder } from '../keydown-binder';
+// import { KeydownBinder } from '../keydown-binder';
 import { ResponseCSVViewer } from './response-csv-viewer';
 import { ResponseErrorViewer } from './response-error-viewer';
 import { ResponseMultipartViewer } from './response-multipart-viewer';
@@ -23,6 +29,10 @@ import { ResponseRawViewer } from './response-raw-viewer';
 import { ResponseWebView } from './response-web-view';
 
 let alwaysShowLargeResponses = false;
+
+export interface ResponseViewerHandle {
+  refresh: () => void;
+}
 
 export interface ResponseViewerProps {
   bytes: number;
@@ -41,168 +51,121 @@ export interface ResponseViewerProps {
   error?: string | null;
 }
 
-interface State {
-  blockingBecauseTooLarge: boolean;
-  bodyBuffer: Buffer | null;
-  error: string;
-  hugeResponse: boolean;
-  largeResponse: boolean;
-}
+export const ResponseViewer = forwardRef<ResponseViewerHandle, ResponseViewerProps>(({
+  bytes,
+  getBody,
+  contentType: originalContentType,
+  disableHtmlPreviewJs,
+  disablePreviewLinks,
+  download,
+  editorFontSize,
+  error: responseError,
+  filter,
+  filterHistory,
+  previewMode,
+  responseId,
+  updateFilter,
+  url,
+}, ref) => {
+  const [largeResponse, setLargeResponse] = useState(false);
+  const [blockingBecauseTooLarge, setBlockingBecauseTooLarge] = useState(false);
+  const [bodyBuffer, setBodyBuffer] = useState<Buffer | null>(null);
+  const [parseError, setError] = useState('');
+  const [hugeResponse, setHugeResponse] = useState(false);
 
-@autoBindMethodsForReact(AUTOBIND_CFG)
-export class ResponseViewer extends Component<ResponseViewerProps, State> {
-  _selectableView: typeof ResponseRawViewer | UnconnectedCodeEditor | null = null;
+  const error = responseError || parseError;
 
-  state: State = {
-    blockingBecauseTooLarge: false,
-    bodyBuffer: null,
-    error: '',
-    hugeResponse: false,
-    largeResponse: false,
-  };
+  const _selectableViewRef = useRef<
+    typeof ResponseRawViewer | UnconnectedCodeEditor | null
+  >(null);
 
-  refresh() {
-    // @ts-expect-error -- TSCONVERSION refresh only exists on a code-editor, not response-raw
-    if (this._selectableView != null && typeof this._selectableView.refresh === 'function') {
-      // @ts-expect-error -- TSCONVERSION refresh only exists on a code-editor, not response-raw
-      this._selectableView.refresh();
+  function refresh() {
+    if (
+      _selectableViewRef.current &&
+      'refresh' in _selectableViewRef.current
+    ) {
+      _selectableViewRef.current.refresh();
     }
   }
 
-  _handleDismissBlocker() {
-    this.setState({
-      blockingBecauseTooLarge: false,
-    });
+  useImperativeHandle(ref, () => {
+    return {
+      refresh,
+    };
+  });
 
-    this._maybeLoadResponseBody(this.props, true);
+  function _handleDismissBlocker() {
+    setBlockingBecauseTooLarge(false);
+
+    _maybeLoadResponseBody(true);
   }
 
-  _handleDisableBlocker() {
+  function _handleDisableBlocker() {
     alwaysShowLargeResponses = true;
 
-    this._handleDismissBlocker();
+    _handleDismissBlocker();
   }
 
-  _maybeLoadResponseBody(props: ResponseViewerProps, forceShow?: boolean) {
-    const { bytes } = props;
-    const largeResponse = bytes > LARGE_RESPONSE_MB * 1024 * 1024;
-    const hugeResponse = bytes > HUGE_RESPONSE_MB * 1024 * 1024;
+  const _maybeLoadResponseBody = useCallback(
+    (forceShow?: boolean) => {
+      const largeResponse = bytes > LARGE_RESPONSE_MB * 1024 * 1024;
+      const hugeResponse = bytes > HUGE_RESPONSE_MB * 1024 * 1024;
 
-    this.setState({ largeResponse, hugeResponse });
+      setLargeResponse(largeResponse);
+      setHugeResponse(hugeResponse);
 
-    // Block the response if it's too large
-    if (!forceShow && !alwaysShowLargeResponses && largeResponse) {
-      this.setState({ blockingBecauseTooLarge: true });
-    } else {
-      try {
-        const bodyBuffer = props.getBody();
-        this.setState({
-          bodyBuffer,
-          blockingBecauseTooLarge: false,
-        });
-      } catch (err) {
-        this.setState({
-          error: `Failed reading response from filesystem: ${err.stack}`,
-        });
-      }
-    }
-  }
-
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillMount() {
-    this._maybeLoadResponseBody(this.props);
-  }
-
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps: ResponseViewerProps) {
-    this._maybeLoadResponseBody(nextProps);
-  }
-
-  shouldComponentUpdate(nextProps: ResponseViewerProps, nextState: State) {
-    for (const k of Object.keys(nextProps)) {
-      const next = nextProps[k as keyof ResponseViewerProps];
-      const current = this.props[k as keyof ResponseViewerProps];
-
-      if (typeof next === 'function') {
-        continue;
-      }
-
-      if (current instanceof Buffer && next instanceof Buffer) {
-        if (current.equals(next)) {
-          continue;
-        } else {
-          return true;
+      // Block the response if it's too large
+      if (!forceShow && !alwaysShowLargeResponses && largeResponse) {
+        setBlockingBecauseTooLarge(true);
+      } else {
+        try {
+          const bodyBuffer = getBody();
+          setBodyBuffer(bodyBuffer);
+          setBlockingBecauseTooLarge(false);
+        } catch (err) {
+          setError(`Failed reading response from filesystem: ${err.stack}`);
         }
       }
+    },
+    [bytes, getBody]
+  );
 
-      if (next !== current) {
-        return true;
-      }
-    }
+  useEffect(() => {
+    _maybeLoadResponseBody();
+  }, [_maybeLoadResponseBody]);
 
-    for (const k of Object.keys(nextState)) {
-      const next = nextState[k as keyof State];
-      const current = this.state[k as keyof State];
-
-      if (typeof next === 'function') {
-        continue;
-      }
-
-      if (current instanceof Buffer && next instanceof Buffer) {
-        if (current.equals(next)) {
-          continue;
-        } else {
-          return true;
-        }
-      }
-
-      if (next !== current) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  _setSelectableViewRef<T extends typeof ResponseRawViewer | UnconnectedCodeEditor | null>(selectableView: T) {
-    this._selectableView = selectableView;
-  }
-
-  _isViewSelectable() {
+  const _isViewSelectable = () => {
     return (
-      this._selectableView != null &&
-      'focus' in this._selectableView &&
-      typeof this._selectableView.focus === 'function' &&
-      typeof this._selectableView.selectAll === 'function'
+      _selectableViewRef.current != null &&
+      'focus' in _selectableViewRef.current &&
+      typeof _selectableViewRef.current.focus === 'function' &&
+      typeof _selectableViewRef.current.selectAll === 'function'
     );
-  }
+  };
 
-  _handleKeyDown(event: KeyboardEvent) {
-    if (!this._isViewSelectable()) {
+  function _handleKeyDown(event: KeyboardEvent) {
+    if (!_isViewSelectable()) {
       return;
     }
 
     executeHotKey(event, hotKeyRefs.RESPONSE_FOCUS, () => {
-      if (!this._isViewSelectable()) {
+      if (!_isViewSelectable()) {
         return;
       }
 
-      if (this._selectableView) {
-        if ('focus' in this._selectableView) {
-          this._selectableView.focus();
+      if (_selectableViewRef.current) {
+        if ('focus' in _selectableViewRef.current) {
+          _selectableViewRef.current.focus();
         }
 
-        if (!this.state.largeResponse && 'selectAll' in this._selectableView) {
-          this._selectableView.selectAll();
+        if (!largeResponse && 'selectAll' in _selectableViewRef.current) {
+          _selectableViewRef.current.selectAll();
         }
       }
     });
   }
 
-  _getContentType() {
-    const { contentType: originalContentType } = this.props;
-    const { bodyBuffer } = this.state;
-
+  function _getContentType() {
     const lowercasedOriginalContentType = originalContentType.toLowerCase();
 
     if (!bodyBuffer || bodyBuffer.length === 0) {
@@ -230,7 +193,10 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
         .trim()
         .match(/^<!doctype html.*>/i);
 
-      if (lowercasedOriginalContentType.indexOf('text/html') !== 0 && isProbablyHTML) {
+      if (
+        lowercasedOriginalContentType.indexOf('text/html') !== 0 &&
+        isProbablyHTML
+      ) {
         return 'text/html';
       }
     } catch (error) {
@@ -240,14 +206,13 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
     return lowercasedOriginalContentType;
   }
 
-  _getBody() {
-    const { bodyBuffer } = this.state;
+  function _getBody() {
     if (!bodyBuffer) {
       return '';
     }
 
     // Show everything else as "source"
-    const contentType = this._getContentType();
+    const contentType = _getContentType();
     const match = contentType.match(/charset=([\w-]+)/);
     const charset = match && match.length >= 2 ? match[1] : 'utf-8';
 
@@ -261,16 +226,16 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
   }
 
   /** Try to detect content-types if there isn't one */
-  _getMode() {
-    if (this._getBody()?.match(/^\s*<\?xml [^?]*\?>/)) {
+  function _getMode() {
+    if (_getBody()?.match(/^\s*<\?xml [^?]*\?>/)) {
       return 'application/xml';
     }
 
-    return this._getContentType();
+    return _getContentType();
   }
 
-  _handleClickLink(url: string) {
-    const mode = this._getMode();
+  function _handleClickLink(url: string) {
+    const mode = _getMode();
 
     if (mode === 'application/xml') {
       clickLink(xmlDecode(url));
@@ -280,193 +245,201 @@ export class ResponseViewer extends Component<ResponseViewerProps, State> {
     clickLink(url);
   }
 
-  _renderView() {
-    const {
-      disableHtmlPreviewJs,
-      disablePreviewLinks,
-      download,
-      editorFontSize,
-      error: responseError,
-      filter,
-      filterHistory,
-      previewMode,
-      responseId,
-      updateFilter,
-      url,
-    } = this.props;
-    const { bodyBuffer, error: parseError } = this.state;
-    const error = responseError || parseError;
-
-    if (error) {
-      return (
-        <div className="scrollable tall">
-          <ResponseErrorViewer url={url} error={error} />
-        </div>
-      );
-    }
-
-    const { blockingBecauseTooLarge, hugeResponse } = this.state;
-
-    if (blockingBecauseTooLarge) {
-      return (
-        <div className="response-pane__notify">
-          {hugeResponse ? (
-            <Fragment>
-              <p className="pad faint">Responses over {HUGE_RESPONSE_MB}MB cannot be shown</p>
-              <button onClick={download} className="inline-block btn btn--clicky">
-                Save Response To File
-              </button>
-            </Fragment>
-          ) : (
-            <Fragment>
-              <p className="pad faint">
-                Response over {LARGE_RESPONSE_MB}MB hidden for performance reasons
-              </p>
-              <div>
-                <button onClick={download} className="inline-block btn btn--clicky margin-xs">
-                  Save To File
-                </button>
-                <button
-                  onClick={this._handleDismissBlocker}
-                  disabled={hugeResponse}
-                  className=" inline-block btn btn--clicky margin-xs"
-                >
-                  Show Anyway
-                </button>
-              </div>
-              <div className="pad-top-sm">
-                <button
-                  className="faint inline-block btn btn--super-compact"
-                  onClick={this._handleDisableBlocker}
-                >
-                  Always Show
-                </button>
-              </div>
-            </Fragment>
-          )}
-        </div>
-      );
-    }
-
-    if (!bodyBuffer) {
-      return <div className="pad faint">Failed to read response body from filesystem</div>;
-    }
-
-    if (bodyBuffer.length === 0) {
-      return <div className="pad faint">No body returned for response</div>;
-    }
-
-    const contentType = this._getContentType();
-    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('image/') === 0) {
-      const justContentType = contentType.split(';')[0];
-      const base64Body = bodyBuffer.toString('base64');
-      return (
-        <div className="scrollable-container tall wide">
-          <div className="scrollable">
-            <img
-              src={`data:${justContentType};base64,${base64Body}`}
-              className="pad block"
-              style={{
-                maxWidth: '100%',
-                maxHeight: '100%',
-                margin: 'auto',
-              }}
-            />
-          </div>
-        </div>
-      );
-    }
-
-    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.includes('html')) {
-      return (
-        <ResponseWebView
-          body={this._getBody()}
-          contentType={contentType}
-          key={disableHtmlPreviewJs ? 'no-js' : 'yes-js'}
-          url={url}
-          webpreferences={`disableDialogs=true, javascript=${disableHtmlPreviewJs ? 'no' : 'yes'}`}
-        />
-      );
-    }
-
-    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('application/pdf') === 0) {
-      return (
-        <div className="tall wide scrollable">
-          <ResponsePDFViewer body={bodyBuffer} key={responseId} />
-        </div>
-      );
-    }
-
-    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('text/csv') === 0) {
-      return (
-        <div className="tall wide scrollable">
-          <ResponseCSVViewer body={bodyBuffer} key={responseId} />
-        </div>
-      );
-    }
-
-    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('multipart/') === 0) {
-      return (
-        <ResponseMultipartViewer
-          bodyBuffer={bodyBuffer}
-          contentType={contentType}
-          disableHtmlPreviewJs={disableHtmlPreviewJs}
-          disablePreviewLinks={disablePreviewLinks}
-          download={download}
-          editorFontSize={editorFontSize}
-          filter={filter}
-          filterHistory={filterHistory}
-          key={responseId}
-          responseId={responseId}
-          url={url}
-        />
-      );
-    }
-
-    if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.indexOf('audio/') === 0) {
-      const justContentType = contentType.split(';')[0];
-      const base64Body = bodyBuffer.toString('base64');
-      return (
-        <div className="vertically-center" key={responseId}>
-          <audio controls>
-            <source src={`data:${justContentType};base64,${base64Body}`} />
-          </audio>
-        </div>
-      );
-    }
-
-    if (previewMode === PREVIEW_MODE_RAW) {
-      return (
-        <ResponseRawViewer
-          key={responseId}
-          responseId={responseId}
-          ref={this._setSelectableViewRef}
-          value={this._getBody()}
-        />
-      );
-    }
-
-    // Show everything else as "source"
+  if (error) {
     return (
-      <CodeEditor
-        key={disablePreviewLinks ? 'links-disabled' : 'links-enabled'}
-        ref={this._setSelectableViewRef}
-        autoPrettify
-        defaultValue={this._getBody()}
-        filter={filter}
-        filterHistory={filterHistory}
-        mode={this._getMode()}
-        noMatchBrackets
-        onClickLink={disablePreviewLinks ? undefined : this._handleClickLink}
-        placeholder="..."
-        readOnly
-        uniquenessKey={responseId}
-        updateFilter={updateFilter}
+      <div className="scrollable tall">
+        <ResponseErrorViewer url={url} error={error} />
+      </div>
+    );
+  }
+
+  if (blockingBecauseTooLarge) {
+    return (
+      <div className="response-pane__notify">
+        {hugeResponse ? (
+          <Fragment>
+            <p className="pad faint">
+              Responses over {HUGE_RESPONSE_MB}MB cannot be shown
+            </p>
+            <button onClick={download} className="inline-block btn btn--clicky">
+              Save Response To File
+            </button>
+          </Fragment>
+        ) : (
+          <Fragment>
+            <p className="pad faint">
+              Response over {LARGE_RESPONSE_MB}MB hidden for performance reasons
+            </p>
+            <div>
+              <button
+                onClick={download}
+                className="inline-block btn btn--clicky margin-xs"
+              >
+                Save To File
+              </button>
+              <button
+                onClick={_handleDismissBlocker}
+                disabled={hugeResponse}
+                className=" inline-block btn btn--clicky margin-xs"
+              >
+                Show Anyway
+              </button>
+            </div>
+            <div className="pad-top-sm">
+              <button
+                className="faint inline-block btn btn--super-compact"
+                onClick={_handleDisableBlocker}
+              >
+                Always Show
+              </button>
+            </div>
+          </Fragment>
+        )}
+      </div>
+    );
+  }
+
+  if (!bodyBuffer) {
+    return (
+      <div className="pad faint">
+        Failed to read response body from filesystem
+      </div>
+    );
+  }
+
+  if (bodyBuffer.length === 0) {
+    return <div className="pad faint">No body returned for response</div>;
+  }
+
+  const contentType = _getContentType();
+  if (
+    previewMode === PREVIEW_MODE_FRIENDLY &&
+    contentType.indexOf('image/') === 0
+  ) {
+    const justContentType = contentType.split(';')[0];
+    const base64Body = bodyBuffer.toString('base64');
+    return (
+      <div className="scrollable-container tall wide">
+        <div className="scrollable">
+          <img
+            src={`data:${justContentType};base64,${base64Body}`}
+            className="pad block"
+            style={{
+              maxWidth: '100%',
+              maxHeight: '100%',
+              margin: 'auto',
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (previewMode === PREVIEW_MODE_FRIENDLY && contentType.includes('html')) {
+    return (
+      <ResponseWebView
+        body={_getBody()}
+        contentType={contentType}
+        key={disableHtmlPreviewJs ? 'no-js' : 'yes-js'}
+        url={url}
+        webpreferences={`disableDialogs=true, javascript=${
+          disableHtmlPreviewJs ? 'no' : 'yes'
+        }`}
       />
     );
   }
 
-  render() {
-    return <KeydownBinder onKeydown={this._handleKeyDown}>{this._renderView()}</KeydownBinder>;
+  if (
+    previewMode === PREVIEW_MODE_FRIENDLY &&
+    contentType.indexOf('application/pdf') === 0
+  ) {
+    return (
+      <div className="tall wide scrollable">
+        <ResponsePDFViewer body={bodyBuffer} key={responseId} />
+      </div>
+    );
   }
-}
+
+  if (
+    previewMode === PREVIEW_MODE_FRIENDLY &&
+    contentType.indexOf('text/csv') === 0
+  ) {
+    return (
+      <div className="tall wide scrollable">
+        <ResponseCSVViewer body={bodyBuffer} key={responseId} />
+      </div>
+    );
+  }
+
+  if (
+    previewMode === PREVIEW_MODE_FRIENDLY &&
+    contentType.indexOf('multipart/') === 0
+  ) {
+    return (
+      <ResponseMultipartViewer
+        bodyBuffer={bodyBuffer}
+        contentType={contentType}
+        disableHtmlPreviewJs={disableHtmlPreviewJs}
+        disablePreviewLinks={disablePreviewLinks}
+        download={download}
+        editorFontSize={editorFontSize}
+        filter={filter}
+        filterHistory={filterHistory}
+        key={responseId}
+        responseId={responseId}
+        url={url}
+      />
+    );
+  }
+
+  if (
+    previewMode === PREVIEW_MODE_FRIENDLY &&
+    contentType.indexOf('audio/') === 0
+  ) {
+    const justContentType = contentType.split(';')[0];
+    const base64Body = bodyBuffer.toString('base64');
+    return (
+      <div className="vertically-center" key={responseId}>
+        <audio controls>
+          <source src={`data:${justContentType};base64,${base64Body}`} />
+        </audio>
+      </div>
+    );
+  }
+
+  if (previewMode === PREVIEW_MODE_RAW) {
+    return (
+      <ResponseRawViewer
+        key={responseId}
+        responseId={responseId}
+        ref={_selectableViewRef}
+        value={_getBody()}
+      />
+    );
+  }
+
+  // Show everything else as "source"
+  return (
+    <CodeEditor
+      key={disablePreviewLinks ? 'links-disabled' : 'links-enabled'}
+      ref={_selectableViewRef}
+      autoPrettify
+      defaultValue={_getBody()}
+      filter={filter}
+      filterHistory={filterHistory}
+      mode={_getMode()}
+      noMatchBrackets
+      onClickLink={disablePreviewLinks ? undefined : _handleClickLink}
+      placeholder="..."
+      readOnly
+      uniquenessKey={responseId}
+      updateFilter={updateFilter}
+    />
+  );
+});
+
+ResponseViewer.displayName = 'ResponseViewer';
+
+// export const ResponseViewer = React.memo(
+//   _ResponseViewer
+// );


### PR DESCRIPTION
Updates the ResponseViewer to a function component.

Highlights:
- Removes the need for a ref (and process.nextTick hacks) to refresh the underlying components by using the key prop.
- `shouldComponentUpdate` was trying to check the equality of Buffers but we use getBody since a long time now so it became obsolete.
- Reading/parsing the data based on the type on the client side seems wrong and heavy. It could benefit from an api that allows us to handle this outside of the renderer process.