### PR TITLE
Fix an issue with URL encoding on cURL imports

### DIFF
--- a/packages/insomnia-importers/src/importers/curl.test.ts
+++ b/packages/insomnia-importers/src/importers/curl.test.ts
@@ -4,6 +4,11 @@ import { quote } from 'shell-quote';
 import { convert } from './curl';
 
 describe('curl', () => {
+  const url = 'http://example.com';
+  const method = '-X POST';
+  const mimeType = 'application/x-www-form-urlencoded';
+  const header = `-H 'Content-Type: ${mimeType}'`;
+
   describe('encoding', () => {
     it.each([
       { input: ' ', expected: ' ' },
@@ -16,13 +21,9 @@ describe('curl', () => {
       { input: '}', expected: '}' },
       { input: '|', expected: '|' },
       { input: '^', expected: '^' },
-      { input: '%', expected: '%' },
+      { input: '%3d', expected: '=' },
       { input: '"', expected: '"' },
     ])('encodes %p correctly', ({ input, expected }: { input: string; expected: string }) => {
-      const url = 'http://example.com';
-      const method = '-X POST';
-      const mimeType = 'application/x-www-form-urlencoded';
-      const header = `-H 'Content-Type: ${mimeType}'`;
       const quoted = quote([input]);
       const rawData = `curl ${method} ${url} ${header} --data ${quoted} --data-urlencode ${quoted}`;
 
@@ -30,10 +31,28 @@ describe('curl', () => {
         body: {
           params: [
             { name: expected, value: '' },
-            { name: expected, value: '' },
+            { name: input, value: '' },
           ],
         },
       }]);
+    });
+
+    it('handles & correctly', () => {
+      const rawData = `curl ${method} ${url} ${header} --data a=1\\&b=2 --data-urlencode c=3\\&d=4`;
+      expect(convert(rawData)).toMatchObject([{
+        body: {
+          params: [
+            { name: 'a', value: '1' },
+            { name: 'b', value: '2' },
+            { name: 'c=3&d=4', value: '' },
+          ],
+        },
+      }]);
+    });
+
+    it('throws on invalid url encoding', () => {
+      const rawData = `curl ${method} ${url} ${header} --data %`;
+      expect(() => convert(rawData)).toThrow('URI malformed');
     });
   });
 });

--- a/packages/insomnia-importers/src/importers/curl.test.ts
+++ b/packages/insomnia-importers/src/importers/curl.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from '@jest/globals';
+import { quote } from 'shell-quote';
+
+import { convert } from './curl';
+
+describe('curl', () => {
+  describe('encoding', () => {
+    it.each([
+      { input: ' ', expected: ' ' },
+      { input: 'a=', expected: 'a' }, // using `a` before `=` to disambiguate shell parameters
+      { input: '<', expected: '<' },
+      { input: '>', expected: '>' },
+      { input: '[', expected: '[' },
+      { input: ']', expected: ']' },
+      { input: '{', expected: '{' },
+      { input: '}', expected: '}' },
+      { input: '|', expected: '|' },
+      { input: '^', expected: '^' },
+      { input: '%', expected: '%' },
+      { input: '"', expected: '"' },
+    ])('encodes %p correctly', ({ input, expected }: { input: string; expected: string }) => {
+      const url = 'http://example.com';
+      const method = '-X POST';
+      const mimeType = 'application/x-www-form-urlencoded';
+      const header = `-H 'Content-Type: ${mimeType}'`;
+      const quoted = quote([input]);
+      const rawData = `curl ${method} ${url} ${header} --data ${quoted} --data-urlencode ${quoted}`;
+
+      expect(convert(rawData)).toMatchObject([{
+        body: {
+          params: [
+            { name: expected, value: '' },
+            { name: expected, value: '' },
+          ],
+        },
+      }]);
+    });
+  });
+});

--- a/packages/insomnia-importers/src/importers/curl.ts
+++ b/packages/insomnia-importers/src/importers/curl.ts
@@ -172,7 +172,7 @@ const importCommand = (parseEntries: ParseEntry[]): ImportRequest => {
     const pair = pairsByName[paramName];
 
     if (pair && pair.length) {
-      textBodyParams = textBodyParams.concat(paramName === 'data-urlencode' ? encodeURIComponent(pair) : pair);
+      textBodyParams = textBodyParams.concat(paramName === 'data-urlencode' ? pair.map(item => encodeURIComponent(item)) : pair);
     }
   }
 

--- a/packages/insomnia-importers/src/importers/curl.ts
+++ b/packages/insomnia-importers/src/importers/curl.ts
@@ -172,7 +172,7 @@ const importCommand = (parseEntries: ParseEntry[]): ImportRequest => {
     const pair = pairsByName[paramName];
 
     if (pair && pair.length) {
-      textBodyParams = textBodyParams.concat(pair);
+      textBodyParams = textBodyParams.concat(paramName === 'data-urlencode' ? encodeURIComponent(pair) : pair);
     }
   }
 

--- a/packages/insomnia-importers/src/importers/curl.ts
+++ b/packages/insomnia-importers/src/importers/curl.ts
@@ -223,8 +223,8 @@ const importCommand = (parseEntries: ParseEntry[]): ImportRequest => {
     body.params = textBody.split('&').map(v => {
       const [name, value] = v.split('=');
       return {
-        name: name || '',
-        value: value || '',
+        name: decodeURIComponent(name || ''),
+        value: decodeURIComponent(value || ''),
       };
     });
   } else if (textBody) {


### PR DESCRIPTION
Fixes an issue where `application/x-www-form-urlencoded` cURL body parameters are left URL encoded when being imported, causing them to be double-encoded (for example, body parameters that contain an encoded `=` were imported as `%3D`, which would be sent as `%253D` rather than just `%3D`).

This fix was implemented by using `decodeURIComponent` on the name/value pair since the insomnia form body expects it to be decoded and encodes the values when they are sent.

changelog(Fixes): Fixed an issue with cURL imports that caused URL-encoded parameters to be encoded twice