### PR TITLE
[INS-1517] adds GitHubStarsButton

### DIFF
--- a/packages/insomnia/src/ui/components/app-header.tsx
+++ b/packages/insomnia/src/ui/components/app-header.tsx
@@ -5,6 +5,11 @@ import styled from 'styled-components';
 import coreLogo from '../images/insomnia-logo.svg';
 import { SettingsButton } from './buttons/settings-button';
 import { AccountDropdownButton } from './dropdowns/account-dropdown/account-dropdown';
+import { GitHubStarsButton } from './github-stars-button';
+
+const LogoWraper = styled.div({
+  display: 'flex',
+});
 
 const Header =  styled(_Header)({
   '&&': {
@@ -39,7 +44,10 @@ export const AppHeader: FC<AppHeaderProps> = ({
     <Header
       gridLeft={(
         <Fragment>
-          <img src={coreLogo} alt="Insomnia" width="28" height="28" />
+          <LogoWraper>
+            <img style={{ zIndex: 1 }} src={coreLogo} alt="Insomnia" width="28" height="28" />
+            <GitHubStarsButton />
+          </LogoWraper>
           <Breadcrumb {...breadcrumbProps} />
         </Fragment>
       )}

--- a/packages/insomnia/src/ui/components/app-header.tsx
+++ b/packages/insomnia/src/ui/components/app-header.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import coreLogo from '../images/insomnia-logo.svg';
 import { SettingsButton } from './buttons/settings-button';
 import { AccountDropdownButton } from './dropdowns/account-dropdown/account-dropdown';
-import { GitHubStarsButton } from './github-stars-button';
 
 const Header =  styled(_Header)({
   '&&': {
@@ -48,7 +47,6 @@ export const AppHeader: FC<AppHeaderProps> = ({
       gridRight={(
         <RightWrapper>
           {gridRight}
-          <GitHubStarsButton />
           <SettingsButton />
           <AccountDropdownButton />
         </RightWrapper>

--- a/packages/insomnia/src/ui/components/app-header.tsx
+++ b/packages/insomnia/src/ui/components/app-header.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import coreLogo from '../images/insomnia-logo.svg';
 import { SettingsButton } from './buttons/settings-button';
 import { AccountDropdownButton } from './dropdowns/account-dropdown/account-dropdown';
+import { GitHubStarsButton } from './github-stars-button';
 
 const Header =  styled(_Header)({
   '&&': {
@@ -47,6 +48,7 @@ export const AppHeader: FC<AppHeaderProps> = ({
       gridRight={(
         <RightWrapper>
           {gridRight}
+          <GitHubStarsButton />
           <SettingsButton />
           <AccountDropdownButton />
         </RightWrapper>

--- a/packages/insomnia/src/ui/components/github-stars-button.tsx
+++ b/packages/insomnia/src/ui/components/github-stars-button.tsx
@@ -8,8 +8,12 @@ import { SegmentEvent, trackSegmentEvent } from '../../common/analytics';
 import { selectSettings } from '../redux/selectors';
 
 const Wrapper = styled.div({
-  marginLeft: 'var(--padding-md)',
+  fontSize: 'var(--font-size-xs)',
+  zIndex: 0,
+  marginLeft: -10,
   display: 'flex',
+  height: '16px',
+  alignSelf: 'center',
   '& a': {
     textDecoration: 'none !important',
     fontWeight: 'normal !important',
@@ -22,10 +26,11 @@ const Wrapper = styled.div({
 });
 
 const Star = styled.a({
-  backgroundColor: 'var(--hl-sm)',
-  padding: 'var(--padding-xxs)',
+  width: 42,
+  justifyContent: 'flex-end',
+  backgroundColor: 'var(--hl-xs)',
+  padding: '2px',
   alignItems: 'center',
-  height: '100%',
   display: 'flex',
   border: '1px solid var(--hl-sm)',
   color: 'var(--hl) !important',
@@ -40,11 +45,14 @@ const Icon = styled(SvgIcon)({
 
 const Counter = styled.a({
   alignItems: 'center',
-  padding: '0 var(--padding-xs)',
+  paddingLeft: 4,
+  paddingRight: 5,
+  padding: '0 3px',
   display: 'flex',
   fontVariantNumeric: 'tabular-nums',
   border: '1px solid var(--hl-sm)',
   borderLeft: 'none',
+  borderRadius: '0 10px 10px 0',
   ':hover': {
     color: 'var(--color-surprise) !important',
   },

--- a/packages/insomnia/src/ui/components/github-stars-button.tsx
+++ b/packages/insomnia/src/ui/components/github-stars-button.tsx
@@ -1,0 +1,87 @@
+import { SvgIcon } from 'insomnia-components';
+import React, { useState } from 'react';
+import { useMount } from 'react-use';
+import styled from 'styled-components';
+
+const Wrapper = styled.div({
+  marginLeft: 'var(--padding-md)',
+  display: 'flex',
+  '& a': {
+    textDecoration: 'none !important',
+    fontWeight: 'normal !important',
+    color: 'var(--hl) !important',
+  },
+  ':hover': {
+    color: 'var(--color-font) !important',
+    cursor: 'pointer',
+  },
+});
+
+const Star = styled.a({
+  backgroundColor: 'var(--hl-sm)',
+  padding: 'var(--padding-xxs)',
+  alignItems: 'center',
+  height: '100%',
+  display: 'flex',
+  border: '1px solid var(--hl-sm)',
+  color: 'var(--hl) !important',
+  ':hover': {
+    borderColor: 'var(--hl-xl)',
+  },
+});
+
+const Icon = styled(SvgIcon)({
+  marginRight: 'var(--padding-xxs)',
+});
+
+const Counter = styled.a({
+  alignItems: 'center',
+  padding: '0 var(--padding-xs)',
+  display: 'flex',
+  fontVariantNumeric: 'tabular-nums',
+  border: '1px solid var(--hl-sm)',
+  borderLeft: 'none',
+  ':hover': {
+    color: 'var(--color-surprise) !important',
+  },
+});
+
+export const GitHubStarsButton = () => {
+  const [starCount, setStarCount] = useState(21700);
+  const [error, setError] = useState<Error | null>(null);
+  const org = 'Kong';
+  const repo = 'insomnia';
+
+  useMount(() => {
+    fetch(`https://api.github.com/repos/${org}/${repo}`)
+      .then(data => data.json())
+      .then(info => {
+        if (!('watchers' in info)) {
+          throw new Error('unable to get stars from GitHub API');
+        }
+        setStarCount(info.watchers);
+        setError(null);
+      })
+      .catch(error => {
+        console.error('error fetching GitHub stars', error);
+        setError(error);
+      });
+  });
+
+  const shouldShowCount = !Boolean(error);
+
+  return (
+    <Wrapper>
+      <Star href={`https://github.com/${org}/${repo}`}>
+        <Icon icon="github" />
+        Star
+      </Star>
+
+      {shouldShowCount ? (
+        <Counter href={`https://github.com/${org}/${repo}/stargazers`}>
+          {starCount.toLocaleString()}
+        </Counter>
+      ) : null}
+    </Wrapper>
+  );
+};

--- a/packages/insomnia/src/ui/components/github-stars-button.tsx
+++ b/packages/insomnia/src/ui/components/github-stars-button.tsx
@@ -1,7 +1,7 @@
 import { SvgIcon } from 'insomnia-components';
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useMount } from 'react-use';
+import { useMount, useMountedState } from 'react-use';
 import styled from 'styled-components';
 
 import { SegmentEvent, trackSegmentEvent } from '../../common/analytics';
@@ -51,6 +51,7 @@ const Counter = styled.a({
 });
 
 export const GitHubStarsButton = () => {
+  const isMounted = useMountedState();
   const { incognitoMode } = useSelector(selectSettings);
   const [starCount, setStarCount] = useState(21700);
   const [error, setError] = useState<Error | null>(null);
@@ -62,16 +63,29 @@ export const GitHubStarsButton = () => {
       return;
     }
 
+    if (!isMounted()) {
+      return;
+    }
+
     fetch(`https://api.github.com/repos/${org}/${repo}`)
       .then(data => data.json())
       .then(info => {
         if (!('watchers' in info)) {
           throw new Error('unable to get stars from GitHub API');
         }
+
+        if (!isMounted()) {
+          return;
+        }
+
         setStarCount(info.watchers);
         setError(null);
       })
       .catch(error => {
+        if (!isMounted()) {
+          return;
+        }
+
         console.error('error fetching GitHub stars', error);
         setError(error);
       });

--- a/packages/insomnia/src/ui/components/github-stars-button.tsx
+++ b/packages/insomnia/src/ui/components/github-stars-button.tsx
@@ -1,5 +1,5 @@
 import { SvgIcon } from 'insomnia-components';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useMount, useMountedState } from 'react-use';
 import styled from 'styled-components';
@@ -58,10 +58,19 @@ const Counter = styled.a({
   },
 });
 
+const LOCALSTORAGE_GITHUB_STARS_KEY = 'insomnia:github-stars';
+
 export const GitHubStarsButton = () => {
   const isMounted = useMountedState();
   const { incognitoMode } = useSelector(selectSettings);
-  const [starCount, setStarCount] = useState(21700);
+  const localStorageStars = localStorage.getItem(LOCALSTORAGE_GITHUB_STARS_KEY);
+  const initialState = parseInt(localStorageStars || '21700', 10);
+  const [starCount, setStarCount] = useState(initialState);
+
+  useEffect(() => {
+    localStorage.setItem(LOCALSTORAGE_GITHUB_STARS_KEY, String(starCount));
+  }, [starCount]);
+
   const [error, setError] = useState<Error | null>(null);
 
   useMount(() => {

--- a/packages/insomnia/src/ui/components/github-stars-button.tsx
+++ b/packages/insomnia/src/ui/components/github-stars-button.tsx
@@ -1,9 +1,10 @@
 import { SvgIcon } from 'insomnia-components';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useMount } from 'react-use';
 import styled from 'styled-components';
 
+import { SegmentEvent, trackSegmentEvent } from '../../common/analytics';
 import { selectSettings } from '../redux/selectors';
 
 const Wrapper = styled.div({
@@ -76,17 +77,31 @@ export const GitHubStarsButton = () => {
       });
   });
 
+  const starClick = useCallback(() => {
+    trackSegmentEvent(SegmentEvent.buttonClick, {
+      type: 'GitHub stars',
+      action: 'clicked star',
+    });
+  }, []);
+
+  const counterClick = useCallback(() => {
+    trackSegmentEvent(SegmentEvent.buttonClick, {
+      type: 'GitHub stars',
+      action: 'clicked stargazers',
+    });
+  }, []);
+
   const shouldShowCount = !Boolean(error) && !incognitoMode;
 
   return (
     <Wrapper>
-      <Star href={`https://github.com/${org}/${repo}`}>
+      <Star onClick={starClick} href={`https://github.com/${org}/${repo}`}>
         <Icon icon="github" />
         Star
       </Star>
 
       {shouldShowCount ? (
-        <Counter href={`https://github.com/${org}/${repo}/stargazers`}>
+        <Counter onClick={counterClick} href={`https://github.com/${org}/${repo}/stargazers`}>
           {starCount.toLocaleString()}
         </Counter>
       ) : null}

--- a/packages/insomnia/src/ui/components/github-stars-button.tsx
+++ b/packages/insomnia/src/ui/components/github-stars-button.tsx
@@ -1,7 +1,10 @@
 import { SvgIcon } from 'insomnia-components';
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import { useMount } from 'react-use';
 import styled from 'styled-components';
+
+import { selectSettings } from '../redux/selectors';
 
 const Wrapper = styled.div({
   marginLeft: 'var(--padding-md)',
@@ -47,12 +50,17 @@ const Counter = styled.a({
 });
 
 export const GitHubStarsButton = () => {
+  const { incognitoMode } = useSelector(selectSettings);
   const [starCount, setStarCount] = useState(21700);
   const [error, setError] = useState<Error | null>(null);
   const org = 'Kong';
   const repo = 'insomnia';
 
   useMount(() => {
+    if (incognitoMode) {
+      return;
+    }
+
     fetch(`https://api.github.com/repos/${org}/${repo}`)
       .then(data => data.json())
       .then(info => {
@@ -68,7 +76,7 @@ export const GitHubStarsButton = () => {
       });
   });
 
-  const shouldShowCount = !Boolean(error);
+  const shouldShowCount = !Boolean(error) && !incognitoMode;
 
   return (
     <Wrapper>

--- a/packages/insomnia/src/ui/components/github-stars-button.tsx
+++ b/packages/insomnia/src/ui/components/github-stars-button.tsx
@@ -63,8 +63,6 @@ export const GitHubStarsButton = () => {
   const { incognitoMode } = useSelector(selectSettings);
   const [starCount, setStarCount] = useState(21700);
   const [error, setError] = useState<Error | null>(null);
-  const org = 'Kong';
-  const repo = 'insomnia';
 
   useMount(() => {
     if (incognitoMode) {
@@ -75,7 +73,7 @@ export const GitHubStarsButton = () => {
       return;
     }
 
-    fetch(`https://api.github.com/repos/${org}/${repo}`)
+    fetch('https://api.github.com/repos/Kong/insomnia')
       .then(data => data.json())
       .then(info => {
         if (!('watchers' in info)) {
@@ -117,13 +115,13 @@ export const GitHubStarsButton = () => {
 
   return (
     <Wrapper>
-      <Star onClick={starClick} href={`https://github.com/${org}/${repo}`}>
+      <Star onClick={starClick} href="https://github.com/Kong/insomnia">
         <Icon icon="github" />
         Star
       </Star>
 
       {shouldShowCount ? (
-        <Counter onClick={counterClick} href={`https://github.com/${org}/${repo}/stargazers`}>
+        <Counter onClick={counterClick} href="https://github.com/Kong/insomnia/stargazers">
           {starCount.toLocaleString()}
         </Counter>
       ) : null}

--- a/packages/insomnia/src/ui/components/wrapper-home.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-home.tsx
@@ -346,7 +346,7 @@ const WrapperHome: FC<Props> = (({ wrapperProps }) => {
             )}
           </div>
           <div className="document-listing__footer vertically-center">
-            <a className="made-with-love" href="https://github.com/Kong/insomnia">
+            <a className="made-with-love" href="https://konghq.com/">
               Made with&nbsp;<SvgIcon icon="heart" />&nbsp;by Kong
             </a>
           </div>

--- a/packages/insomnia/src/ui/components/wrapper-home.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-home.tsx
@@ -37,7 +37,6 @@ import { AppHeader } from './app-header';
 import { DashboardSortDropdown } from './dropdowns/dashboard-sort-dropdown';
 import { ProjectDropdown } from './dropdowns/project-dropdown';
 import { RemoteWorkspacesDropdown } from './dropdowns/remote-workspaces-dropdown';
-import { GitHubStarsButton } from './github-stars-button';
 import { KeydownBinder } from './keydown-binder';
 import { showPrompt } from './modals';
 import { PageLayout } from './page-layout';
@@ -266,7 +265,6 @@ const WrapperHome: FC<Props> = (({ wrapperProps }) => {
             ],
             isLoading,
           }}
-          gridRight={<GitHubStarsButton />}
         />
       }
       renderPageBody={

--- a/packages/insomnia/src/ui/components/wrapper-home.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-home.tsx
@@ -37,6 +37,7 @@ import { AppHeader } from './app-header';
 import { DashboardSortDropdown } from './dropdowns/dashboard-sort-dropdown';
 import { ProjectDropdown } from './dropdowns/project-dropdown';
 import { RemoteWorkspacesDropdown } from './dropdowns/remote-workspaces-dropdown';
+import { GitHubStarsButton } from './github-stars-button';
 import { KeydownBinder } from './keydown-binder';
 import { showPrompt } from './modals';
 import { PageLayout } from './page-layout';
@@ -265,6 +266,7 @@ const WrapperHome: FC<Props> = (({ wrapperProps }) => {
             ],
             isLoading,
           }}
+          gridRight={<GitHubStarsButton />}
         />
       }
       renderPageBody={


### PR DESCRIPTION
This PR adds a GitHub star tracker, as commonly seen in many applications.

<img width="50%" src="https://user-images.githubusercontent.com/15232461/181128170-078a9b1f-d7b7-419d-8c9d-975f74b83a3a.png" />

### Some notes
- if incognito mode is enabled, it will not make any network requests
- app-wide unnecessary rerendering influenced the design:
  - when using `useEffect` the component was benchmarked to rerender 8 times (despite no props changes)
  - when using `useMount` it is improved (as, it only fetches on mount) to when changing insomnia activities (broadly speaking)


### App Dashboard
| BEFORE | AFTER |
| - | - |
| ![Screenshot_20220726_192216](https://user-images.githubusercontent.com/15232461/181128705-16f68018-6565-4f31-8a6c-6225e5a15fc8.png) | ![Screenshot_20220726_191908](https://user-images.githubusercontent.com/15232461/181128416-f1d33abd-920f-40d3-b44b-5ec9bf92c356.png) |


### Request Collection
| BEFORE | AFTER |
| - | - |
| ![Screenshot_20220726_192705](https://user-images.githubusercontent.com/15232461/181129114-396a96e4-3776-4460-8587-a8028b5c33cf.png) | ![Screenshot_20220726_192634](https://user-images.githubusercontent.com/15232461/181129084-cf145eb2-f85e-4d7a-ba35-c1170933572c.png) |




### Design Document
| BEFORE | AFTER |
| - | - |
| ![Screenshot_20220726_192234](https://user-images.githubusercontent.com/15232461/181128752-72bacba5-dc12-438a-bba8-e1c8cbc1abe1.png) | ![Screenshot_20220726_192744](https://user-images.githubusercontent.com/15232461/181129176-4a3b5d1d-1d47-4b43-b4fa-f38f102674d7.png) |


### Unit Test
| BEFORE | AFTER |
| - | - |
| ![Screenshot_20220726_192322](https://user-images.githubusercontent.com/15232461/181128807-3a4098a5-d166-4ddc-89ed-bfdb06511833.png) | ![Screenshot_20220726_191938](https://user-images.githubusercontent.com/15232461/181128457-9a841915-f151-4650-bfc2-04e304659fb7.png) |

### Incognito Mode
<img width="50%" src="https://user-images.githubusercontent.com/15232461/181128508-1239a23a-ab97-4282-9110-8e7a425e9d95.png" />


### Also works well in themes
<img width="50%" src="https://user-images.githubusercontent.com/15232461/181128545-b0bd6bce-b344-4e73-ba07-3cd36542764d.png" />

<img width="50%" src="https://user-images.githubusercontent.com/15232461/181128606-026a3d34-75ed-421b-81e4-4d36f8634d18.png" />

<img width="50%" src="https://user-images.githubusercontent.com/15232461/181128633-ec3dd801-d827-445f-a0d4-4d2e7924275d.png" />

| state | |
| - | - |
| neutral state | ![Screenshot_20220726_192519](https://user-images.githubusercontent.com/15232461/181128967-51349dca-67ac-4fd3-b912-56451aa4a16f.png) |
| hover "Star" | ![Screenshot_20220726_192456](https://user-images.githubusercontent.com/15232461/181128935-490be4bb-1fe8-4b61-a70e-84419032267e.png) |
| hover count | ![Screenshot_20220726_192433](https://user-images.githubusercontent.com/15232461/181128900-53fb13e5-0d96-4591-b491-4cc52df6c564.png) |



### Segment
As with the rest of the application, segment events will not fire if "send usage statistics" is false (including by being set by incognito mode).  If true, here is what the events look like (cc: @wdawson):

<img width="50%" src="https://user-images.githubusercontent.com/15232461/181071595-66fcdb1a-bc4b-4c9a-8234-adc06cdc402e.png" />

<img width="50%" src="https://user-images.githubusercontent.com/15232461/181071668-c1eca8c4-c627-4165-8e57-b296963cc8ce.png" />

changelog(Improvements): Adds a GitHub stargazer button to the app header