### PR TITLE
INS-1692 removes document preview toggle

### DIFF
--- a/packages/insomnia/src/models/workspace-meta.ts
+++ b/packages/insomnia/src/models/workspace-meta.ts
@@ -25,7 +25,6 @@ export interface BaseWorkspaceMeta {
   paneHeight: number;
   paneWidth: number;
   parentId: string | null;
-  previewHidden: boolean;
   sidebarFilter: string;
   sidebarHidden: boolean;
   sidebarWidth: number;
@@ -52,7 +51,6 @@ export function init(): BaseWorkspaceMeta {
     paneHeight: DEFAULT_PANE_HEIGHT,
     paneWidth: DEFAULT_PANE_WIDTH,
     parentId: null,
-    previewHidden: false,
     sidebarFilter: '',
     sidebarHidden: false,
     sidebarWidth: DEFAULT_SIDEBAR_WIDTH,


### PR DESCRIPTION
This PR removes the preview button for the swagger-ui viewer:

| BEFORE | AFTER |
| - | - |
| ![Screenshot_20220728_153010](https://user-images.githubusercontent.com/15232461/181621781-45a570e1-d7dc-453f-82f6-65d3a151fa11.png) | ![Screenshot_20220728_152710](https://user-images.githubusercontent.com/15232461/181621672-d1bf0784-26c1-46f9-b9fd-621d28a07da6.png) |

Note, that the prior behavior when clicking this button was to just have an empty/blank screen in place of the swagger-ui:

![Screenshot_20220728_153524](https://user-images.githubusercontent.com/15232461/181622644-50f2537e-7a0b-49fa-ba94-ac9c8875c8fa.png)

Back in May, we added analytics to this in https://github.com/Kong/insomnia/pull/4761 to make sure that it is not a widely used feature of the app, and since then we have determined that it is not.

From the product discovery we've done on this, we've concluded that it is not altogether very useful to users to have this button, and it clutters up the app bar at the top of the application.

____

As always with Insomnia, we're aiming for a sleek user experience.  If you are reading this some time in the future and you have a critical use-case that involved hiding the spec generation, please let us know.