### PR TITLE
[INS-1712] hotfix: fixes duplicate request from dropdown

### DIFF
--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -320,6 +320,7 @@ export class WrapperClass extends PureComponent<Props, State> {
       handleUpdateRequestMimeType,
       gitVCS,
       vcs,
+      handleDuplicateRequest,
     } = this.props;
 
     // Setup git sync dropdown for use in Design/Debug pages
@@ -497,6 +498,7 @@ export class WrapperClass extends PureComponent<Props, State> {
                   handleSetResponseFilter={this._handleSetResponseFilter}
                   handleUpdateRequestMimeType={handleUpdateRequestMimeType}
                   handleSetActiveResponse={this.handleSetActiveResponse}
+                  handleDuplicateRequest={handleDuplicateRequest}
                 />
               </Suspense>
             }

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -236,8 +236,8 @@ class App extends PureComponent<AppProps, State> {
       ],
       [
         hotKeyRefs.REQUEST_SHOW_DUPLICATE,
-        async () => {
-          await this._requestDuplicate(this.props.activeRequest || undefined);
+        () => {
+          this._requestDuplicate(this.props.activeRequest || undefined);
         },
       ],
       [


### PR DESCRIPTION
closes INS-1712

Prior to this PR, handling duplicate requests was broken (not via the shortcut, but via the dropdown):

![Screenshot_20220729_090117](https://user-images.githubusercontent.com/15232461/181769610-c3d64534-146c-476f-bff4-0b92cdf29cf1.png)

After this PR, it works as before.

(this was broken in https://github.com/Kong/insomnia/pull/4979)