### PR TITLE
[INS-1713] hotfix content-type editor sync

### DIFF
--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -321,6 +321,7 @@ export class WrapperClass extends PureComponent<Props, State> {
       gitVCS,
       vcs,
       handleDuplicateRequest,
+      headerEditorKey,
     } = this.props;
 
     // Setup git sync dropdown for use in Design/Debug pages
@@ -500,6 +501,7 @@ export class WrapperClass extends PureComponent<Props, State> {
                   handleSetActiveResponse={this.handleSetActiveResponse}
                   handleDuplicateRequest={handleDuplicateRequest}
                   vcs={vcs}
+                  headerEditorKey={headerEditorKey}
                 />
               </Suspense>
             }


### PR DESCRIPTION
closes: INS-1713

In Insomnia, when you change the mimetype (the far left tab in the request pane) it updates the `Content-Type` header.

Prior to this fix, when you changed the mimetype the header would not update, resulting in sending a request with an incorrect `Content-Type` value.  This is demonstrated below, as `XML` is selected for the mime type, yet `application/json` is the header type.

![Screenshot_20220729_095909](https://user-images.githubusercontent.com/15232461/181776295-05758caf-9667-45ce-81e4-4dcbf3237f7f.png)

after this fix, it works as before and will sync the value.

(this was broken in #4979)