### PR TITLE
[INS-1711] regression: fixes lazyWithPreload types

### DIFF
--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import * as importers from 'insomnia-importers';
-import React, { Fragment, lazy, PureComponent, Suspense } from 'react';
+import React, { FC, Fragment, lazy, PureComponent, Suspense } from 'react';
 import { connect, useSelector } from 'react-redux';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import { AnyAction, bindActionCreators, Dispatch } from 'redux';
@@ -73,18 +73,13 @@ import { WorkspaceEnvironmentsEditModal } from './modals/workspace-environments-
 import { WorkspaceSettingsModal } from './modals/workspace-settings-modal';
 import { WrapperModal } from './modals/wrapper-modal';
 
-const lazyWithPreload = (
-  importFn: () => Promise<{ default: React.ComponentType<any> }>
-): [
-    React.LazyExoticComponent<React.ComponentType<any>>,
-    () => Promise<{
-      default: React.ComponentType<any>;
-    }>
-  ] => {
+const lazyWithPreload = <T extends FC<any>>(
+  importFn: () => Promise<{ default: T }>
+) => {
   const LazyComponent = lazy(importFn);
   const preload = () => importFn();
 
-  return [LazyComponent, preload];
+  return [LazyComponent, preload] as const;
 };
 
 const [WrapperHome, preloadWrapperHome] = lazyWithPreload(


### PR DESCRIPTION
the regression in this case was that we lost all typechecking for WrapperDebug, WrapperDesign, WrapperHome, WrapperUnitTest.

This occurred in https://github.com/Kong/insomnia/commit/34aa27a5fd2b60be4d217a4080fc13118955ae89#diff-9f799d44f6ba2340509075861e50905a4987c9e485cbc6e774b9dc403c47dfc5R79

and caused https://github.com/Kong/insomnia/pull/5023, https://github.com/Kong/insomnia/pull/5022, and https://github.com/Kong/insomnia/pull/5024

The fix is to provide a generic to `lazyWithPreload` that, thankfully, the dynamic `import` promise does infer (!that's cool!)