### PR TITLE
Fix signing out when pressing enter on the git form

### DIFF
--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/github-repository-settings-form-group.tsx
@@ -304,7 +304,7 @@ const GitHubRepositoryForm = ({
             </span>
           </Details>
         </AccountDetails>
-        <Button onClick={handleSignOut}>
+        <Button type="button" onClick={handleSignOut}>
           Sign out
         </Button>
       </AccountViewContainer>

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/gitlab-repository-settings-form-group.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/gitlab-repository-settings-form-group.tsx
@@ -242,6 +242,7 @@ const GitLabRepositoryForm = ({
           </Details>
         </AccountDetails>
         <Button
+          type="button"
           onClick={event => {
             event.preventDefault();
             event.stopPropagation();


### PR DESCRIPTION
Closes INS-1607


changelog(Fixes): Fixed an edge-case issue where the user would get a signing out suggestion instead of proceeding with GitHub/GitLab Sync