### PR TITLE
gutter boundary marking

### DIFF
--- a/packages/insomnia/src/ui/css/editor/theme.less
+++ b/packages/insomnia/src/ui/css/editor/theme.less
@@ -10,7 +10,7 @@
   }
 
   .CodeMirror-gutters {
-    border-right: 0;
+    border-right: 1px solid var(--hl-sm);
   }
 
   .CodeMirror-guttermarker {


### PR DESCRIPTION
Hello! I've added a visible right-hand edge to the gutter in the designer editor, due to the fact that it's not always clear that the cursor is at the start of the line. Especially when deleting characters using backspace.

Before:
![Снимок экрана от 2022-08-01 22-55-53](https://user-images.githubusercontent.com/9607501/182191686-003c8280-f8a4-4acf-bd42-8a766373b725.png)
After:
![Снимок экрана от 2022-08-01 22-55-16](https://user-images.githubusercontent.com/9607501/182191677-8c54c39a-6120-4242-a8ff-b40a2afdbb03.png)

 