### PR TITLE
[INS-1724] creating a gRPC request should activate that request

### DIFF
--- a/packages/insomnia/src/ui/hooks/create-request.ts
+++ b/packages/insomnia/src/ui/hooks/create-request.ts
@@ -62,19 +62,17 @@ export const createRequest: RequestCreator = async ({
   requestType,
   workspaceId,
 }) => {
-  let requestId = '';
-
   switch (requestType) {
     case 'gRPC': {
       showModal(ProtoFilesModal, {
         onSave: async (protoFileId: string) => {
-          const createdRequest = await models.grpcRequest.create({
+          const request = await models.grpcRequest.create({
             parentId,
             name: 'New Request',
             protoFileId,
           });
           models.stats.incrementCreatedRequests();
-          requestId = createdRequest._id;
+          setActiveRequest(request._id, workspaceId);
         },
       });
       break;
@@ -97,7 +95,7 @@ export const createRequest: RequestCreator = async ({
         name: 'New Request',
       });
       models.stats.incrementCreatedRequests();
-      requestId = request._id;
+      setActiveRequest(request._id, workspaceId);
       break;
     }
 
@@ -108,7 +106,7 @@ export const createRequest: RequestCreator = async ({
         name: 'New Request',
       });
       models.stats.incrementCreatedRequests();
-      requestId = request._id;
+      setActiveRequest(request._id, workspaceId);
       break;
     }
 
@@ -120,5 +118,4 @@ export const createRequest: RequestCreator = async ({
   }
 
   trackSegmentEvent(SegmentEvent.requestCreate, { requestType });
-  setActiveRequest(requestId, workspaceId);
 };


### PR DESCRIPTION
### Expected behavior

When creating a new request of any type, Insomnia will active that request upon creation.

### Current behavior

When creating a gRPC request, this error is reported, and upon completing the schema select modal the request is not activated: instead no request is activated (which is not considered a valid state of the app after the first request has been created in a workspace).

![Screenshot_20220802_084215](https://user-images.githubusercontent.com/15232461/182378170-47f42748-354a-4098-b9ef-b51db882eadd.png)



https://user-images.githubusercontent.com/15232461/182378131-55daf5b9-c393-4c45-8e7c-bddaa0cc1b35.mp4


