### PR TITLE
Websockets IPC API

### DIFF
--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -13,6 +13,7 @@ import { validateInsomniaConfig } from './common/validate-insomnia-config';
 import { registerElectronHandlers } from './main/ipc/electron';
 import { registergRPCHandlers } from './main/ipc/grpc';
 import { registerMainHandlers } from './main/ipc/main';
+import { registerWebSocketHandlers } from './main/network/websocket';
 import { initializeSentry, sentryWatchAnalyticsEnabled } from './main/sentry';
 import { checkIfRestartNeeded } from './main/squirrel-startup';
 import * as updates from './main/updates';
@@ -70,6 +71,7 @@ app.on('ready', async () => {
   registerElectronHandlers();
   registerMainHandlers();
   registergRPCHandlers();
+  registerWebSocketHandlers();
 
   disableSpellcheckerDownload();
 

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -2,6 +2,7 @@ import { app, ipcMain, IpcRendererEvent } from 'electron';
 import { writeFile } from 'fs/promises';
 
 import { authorizeUserInWindow } from '../../network/o-auth-2/misc';
+import { WSConnection } from '../../preload';
 import installPlugin from '../install-plugin';
 import { cancelCurlRequest, curlRequest } from '../network/libcurl-promise';
 
@@ -14,6 +15,7 @@ export interface MainBridgeAPI {
   cancelCurlRequest: typeof cancelCurlRequest;
   curlRequest: typeof curlRequest;
   on: (channel: string, listener: (event: IpcRendererEvent, ...args: any[]) => void) => Function;
+  webSocketConnection: WSConnection;
 }
 export function registerMainHandlers() {
   ipcMain.handle('authorizeUserInWindow', (_, options: Parameters<typeof authorizeUserInWindow>[0]) => {

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -1,0 +1,199 @@
+import { ipcMain } from 'electron';
+import { v4 as uuidV4 } from 'uuid';
+import {
+  CloseEvent,
+  ErrorEvent,
+  Event as OpenEvent,
+  MessageEvent,
+  WebSocket,
+} from 'ws';
+
+import { websocketRequest } from '../../models';
+
+export interface WebSocketConnection extends WebSocket {
+  _id: string;
+  requestId: string;
+}
+
+export type WebsocketOpenEvent = Omit<OpenEvent, 'target'> & {
+  _id: string;
+  requestId: string;
+};
+
+export type WebsocketMessageEvent = Omit<MessageEvent, 'target'> & {
+  _id: string;
+  requestId: string;
+  direction: 'OUTGOING' | 'INCOMING';
+};
+
+export type WebsocketErrorEvent = Omit<ErrorEvent, 'target'> & {
+  _id: string;
+  requestId: string;
+};
+
+export type WebsocketCloseEvent = Omit<CloseEvent, 'target'> & {
+  _id: string;
+  requestId: string;
+};
+
+export type WebsocketEvent =
+  | WebsocketOpenEvent
+  | WebsocketMessageEvent
+  | WebsocketErrorEvent
+  | WebsocketCloseEvent;
+
+export type WebSocketEventLog = WebsocketEvent[];
+
+// @TODO: Volatile state for now, later we might want to persist event logs.
+const WebSocketConnections = new Map<string, WebSocket>();
+const WebSocketEventLogs = new Map<string, WebSocketEventLog>();
+
+async function createWebSocketConnection(
+  event: Electron.IpcMainInvokeEvent,
+  options: { requestId: string }
+) {
+  const existingConnection = WebSocketConnections.get(options.requestId);
+
+  if (existingConnection) {
+    console.warn('Connection still open to ' + existingConnection.url);
+    return;
+  }
+
+  try {
+    const request = await websocketRequest.getById(options.requestId);
+
+    if (!request?.url) {
+      throw new Error('No URL specified');
+    }
+
+    const eventChannel = `webSocketRequest.connection.${request._id}.event`;
+    const readyStateChannel = `webSocketRequest.connection.${request._id}.readyState`;
+
+    const ws = new WebSocket(request?.url);
+
+    event.sender.send(readyStateChannel, ws.readyState);
+    WebSocketConnections.set(options.requestId, ws);
+
+    ws.addEventListener('open', ({ type }) => {
+      const openEvent: WebsocketOpenEvent = {
+        _id: uuidV4(),
+        requestId: options.requestId,
+        type,
+      };
+
+      WebSocketEventLogs.set(options.requestId, [openEvent]);
+
+      event.sender.send(eventChannel, openEvent);
+      event.sender.send(readyStateChannel, ws.readyState);
+    });
+
+    ws.addEventListener('message', ({ data, type }) => {
+      const msgs = WebSocketEventLogs.get(options.requestId) || [];
+      const messageEvent: WebsocketMessageEvent = {
+        _id: uuidV4(),
+        requestId: options.requestId,
+        data,
+        type,
+        direction: 'INCOMING',
+      };
+
+      WebSocketEventLogs.set(options.requestId, [...msgs, messageEvent]);
+      event.sender.send(eventChannel, messageEvent);
+    });
+
+    ws.addEventListener('close', ({ code, reason, type, wasClean }) => {
+      const msgs = WebSocketEventLogs.get(options.requestId) || [];
+      const closeEvent: WebsocketCloseEvent = {
+        _id: uuidV4(),
+        requestId: options.requestId,
+        code,
+        reason,
+        type,
+        wasClean,
+      };
+
+      WebSocketEventLogs.set(options.requestId, [...msgs, closeEvent]);
+      WebSocketConnections.delete(options.requestId);
+
+      event.sender.send(eventChannel, closeEvent);
+      event.sender.send(readyStateChannel, ws.readyState);
+    });
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}
+
+function getWebSocketReadyState(
+  _event: Electron.IpcMainInvokeEvent,
+  options: { requestId: string }
+): WebSocketConnection['readyState'] {
+  return WebSocketConnections.get(options.requestId)?.readyState ?? 0;
+}
+
+async function sendWebSocketEvent(
+  event: Electron.IpcMainInvokeEvent,
+  options: { message: string; requestId: string }
+) {
+  const ws = WebSocketConnections.get(options.requestId);
+
+  if (!ws) {
+    console.warn('No websocket found for requestId: ' + options.requestId);
+    return;
+  }
+
+  ws.send(options.message, error => {
+    // @TODO: We might want to set a status in the WebsocketMessageEvent
+    // and update it here based on the error. e.g. status = 'sending' | 'sent' | 'error'
+    if (error) {
+      console.error(error);
+    } else {
+      console.log('Message sent');
+    }
+  });
+
+  const connectionMessages = WebSocketEventLogs.get(options.requestId) || [];
+
+  const lastMessage: WebsocketMessageEvent = {
+    _id: uuidV4(),
+    requestId: options.requestId,
+    data: options.message,
+    direction: 'OUTGOING',
+    type: 'message',
+  };
+
+  WebSocketEventLogs.set(options.requestId, [
+    ...connectionMessages,
+    lastMessage,
+  ]);
+  const eventChannel = `webSocketRequest.connection.${options.requestId}.event`;
+  event.sender.send(eventChannel, lastMessage);
+}
+
+async function closeWebSocketConnection(
+  _event: Electron.IpcMainInvokeEvent,
+  options: { requestId: string }
+) {
+  const ws = WebSocketConnections.get(options.requestId);
+  if (!ws) {
+    console.warn('No websocket found for requestId: ' + options.requestId);
+    return;
+  }
+  ws.close();
+}
+
+async function getWebSocketConnectionEvents(
+  _event: Electron.IpcMainInvokeEvent,
+  options: { requestId: string }
+) {
+  const connectionMessages = WebSocketEventLogs.get(options.requestId) || [];
+  return connectionMessages;
+}
+
+export function registerWebSocketHandlers() {
+  ipcMain.handle('webSocketRequest.connection.create', createWebSocketConnection);
+  ipcMain.handle('webSocketRequest.connection.readyState', getWebSocketReadyState);
+  ipcMain.handle('webSocketRequest.connection.event.send', sendWebSocketEvent);
+  ipcMain.handle('webSocketRequest.connection.close', closeWebSocketConnection);
+  ipcMain.handle('webSocketRequest.connection.event.findMany', getWebSocketConnectionEvents);
+}

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -13,7 +13,7 @@ export const canSync = false;
 
 export interface BaseWebSocketRequest {
   name: string;
-  url?: string;
+  url: string;
 }
 
 export type WebSocketRequest = BaseWebSocketRequest & BaseModel;
@@ -24,6 +24,7 @@ export const isWebSocketRequest = (model: Pick<BaseModel, 'type'>): model is Web
 
 export const init = (): BaseWebSocketRequest => ({
   name: 'New WebSocket Request',
+  url: '',
 });
 
 export const migrate = (doc: WebSocketRequest) => doc;

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -13,6 +13,7 @@ export const canSync = false;
 
 export interface BaseWebSocketRequest {
   name: string;
+  url?: string;
 }
 
 export type WebSocketRequest = BaseWebSocketRequest & BaseModel;
@@ -29,8 +30,9 @@ export const migrate = (doc: WebSocketRequest) => doc;
 
 export const create = (patch: Partial<WebSocketRequest> = {}) => {
   if (!patch.parentId) {
-    throw new Error('TODO');
+    throw new Error(`New WebSocketRequest missing \`parentId\`: ${JSON.stringify(patch)}`);
   }
+
   return database.docCreate<WebSocketRequest>(type, patch);
 };
 

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -68,7 +68,8 @@ const webSocketConnection = {
   },
 };
 
-const main: Window['main'] & { webSocketConnection: typeof webSocketConnection } = {
+export type WSConnection = typeof webSocketConnection; // using 'WS' because main/network/websocket.ts already has WebSocketConnection reserved.
+const main: Window['main'] & { webSocketConnection: WSConnection } = {
   restart: () => ipcRenderer.send('restart'),
   authorizeUserInWindow: options => ipcRenderer.invoke('authorizeUserInWindow', options),
   setMenuBarVisibility: options => ipcRenderer.send('setMenuBarVisibility', options),

--- a/packages/insomnia/src/ui/redux/modules/entities.ts
+++ b/packages/insomnia/src/ui/redux/modules/entities.ts
@@ -71,7 +71,7 @@ export interface EntitiesState {
   protoDirectories: EntityRecord<ProtoDirectory>;
   grpcRequests: EntityRecord<GrpcRequest>;
   grpcRequestMetas: EntityRecord<GrpcRequestMeta>;
-  websocketRequests: EntityRecord<WebSocketRequest>;
+  webSocketRequests: EntityRecord<WebSocketRequest>;
 }
 
 export const initialEntitiesState: EntitiesState = {
@@ -100,7 +100,7 @@ export const initialEntitiesState: EntitiesState = {
   protoDirectories: {},
   grpcRequests: {},
   grpcRequestMetas: {},
-  websocketRequests: {},
+  webSocketRequests: {},
 };
 
 export function reducer(state = initialEntitiesState, action: any) {

--- a/packages/insomnia/src/ui/redux/selectors.ts
+++ b/packages/insomnia/src/ui/redux/selectors.ts
@@ -311,7 +311,7 @@ export const selectActiveWorkspaceEntities = createSelector(
 
 export const selectPinnedRequests = createSelector(selectEntitiesLists, entities => {
   const pinned: Record<string, boolean> = {};
-  const requests = [...entities.requests, ...entities.grpcRequests, ...entities.websocketRequests];
+  const requests = [...entities.requests, ...entities.grpcRequests, ...entities.webSocketRequests];
   const requestMetas = [...entities.requestMetas, ...entities.grpcRequestMetas];
 
   // Default all to unpinned
@@ -350,8 +350,8 @@ export const selectActiveRequest = createSelector(
       return entities.grpcRequests[id];
     }
 
-    if (id in entities.websocketRequests) {
-      return entities.websocketRequests[id];
+    if (id in entities.webSocketRequests) {
+      return entities.webSocketRequests[id];
     }
 
     return null;


### PR DESCRIPTION
Adds an API for creating connections on WebSocket Requests.

Highlights:
- Uses [ws](https://www.npmjs.com/package/ws) for networking
- Provides an api over IPC through preload

API functionality:
- Create/Close connection
- Get/Send/Subscribe to events
- Get/Subscribe to connection readyState

Closes INS-1696