### PR TITLE
[INS-1668] handle multiple security requirement objects

### DIFF
--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/multiple-api-keys-input.yml
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/multiple-api-keys-input.yml
@@ -1,0 +1,162 @@
+openapi: 3.0.3
+info:
+  description: "This is a sample server Petstore server."
+  version: 1.0.2
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ""
+      operationId: addPet
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+      security:
+        - apiKey: []
+          appId:  []
+        - appSecret: []
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid status value
+      security:
+        - apiKey: []
+        - appId:  []
+        - appSecret: []
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore.swagger.io/v2
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-KEY
+    appId:
+      type: apiKey
+      in: header
+      name: X-APP-ID
+    appSecret:
+      type: apiKey
+      in: header
+      name: X-APP-SECRET
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          $ref: "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/multiple-api-keys-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/multiple-api-keys-output.json
@@ -1,0 +1,108 @@
+{
+  "__export_date": "2022-08-05T10:38:46.184Z",
+  "__export_format": 4,
+  "__export_source": "insomnia.importers:v0.1.0",
+  "_type": "export",
+  "resources": [
+    {
+      "_id": "__WORKSPACE_ID__",
+      "_type": "workspace",
+      "description": "This is a sample server Petstore server.",
+      "name": "Swagger Petstore 1.0.2",
+      "parentId": null
+    },
+    {
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
+      "data": {
+        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+      },
+      "name": "Base environment",
+      "parentId": "__WORKSPACE_ID__"
+    },
+    {
+      "_id": "env___BASE_ENVIRONMENT_ID___sub",
+      "_type": "environment",
+      "data": {
+        "base_path": "/v2",
+        "host": "petstore.swagger.io",
+        "scheme": "https",
+        "xApiKey": "xApiKey",
+        "xAppId": "xAppId",
+        "xAppSecret": "xAppSecret"
+      },
+      "name": "OpenAPI env",
+      "parentId": "__BASE_ENVIRONMENT_ID__"
+    },
+    {
+      "_id": "fld___WORKSPACE_ID__1b034c38",
+      "_type": "request_group",
+      "description": "Everything about your Pets",
+      "environment": {},
+      "name": "pet",
+      "parentId": "__WORKSPACE_ID__"
+    },
+    {
+      "_id": "req___WORKSPACE_ID__23acbe44",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [
+        {
+          "disabled": false,
+          "name": "X-API-KEY",
+          "value": "{{ xApiKey }}"
+        },
+        {
+          "disabled": false,
+          "name": "X-APP-ID",
+          "value": "{{ xAppId }}"
+        },
+        {
+          "disabled": false,
+          "name": "X-APP-SECRET",
+          "value": "{{ xAppSecret }}"
+        }
+      ],
+      "method": "POST",
+      "name": "Add a new pet to the store",
+      "parameters": [],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet"
+    },
+    {
+      "_id": "req___WORKSPACE_ID__80ab0d08",
+      "_type": "request",
+      "authentication": {},
+      "body": {},
+      "headers": [
+        {
+          "disabled": false,
+          "name": "X-API-KEY",
+          "value": "{{ xApiKey }}"
+        },
+        {
+          "disabled": false,
+          "name": "X-APP-ID",
+          "value": "{{ xAppId }}"
+        },
+        {
+          "disabled": false,
+          "name": "X-APP-SECRET",
+          "value": "{{ xAppSecret }}"
+        }
+      ],
+      "method": "GET",
+      "name": "Finds Pets by status",
+      "parameters": [
+        {
+          "disabled": false,
+          "name": "status",
+          "value": "available"
+        }
+      ],
+      "parentId": "fld___WORKSPACE_ID__1b034c38",
+      "url": "{{ base_url }}/pet/findByStatus"
+    }
+  ]
+}

--- a/packages/insomnia-importers/src/importers/openapi-3.ts
+++ b/packages/insomnia-importers/src/importers/openapi-3.ts
@@ -288,13 +288,14 @@ const parseSecurity = (
   }
 
   const supportedSchemes = security
-    .map(securityPolicy => {
-      const securityName = Object.keys(securityPolicy)[0];
-      return {
-        // @ts-expect-error the base types do not include an index but from what I can tell, they should
-        schemeDetails: securitySchemes[securityName],
-        securityScopes: securityPolicy[securityName],
-      };
+    .flatMap(securityPolicy => {
+      return Object.keys(securityPolicy).map((securityRequirement: string | number) => {
+        return {
+          // @ts-expect-error the base types do not include an index but from what I can tell, they should
+          schemeDetails: securitySchemes[securityRequirement],
+          securityScopes: securityPolicy[securityRequirement],
+        };
+      });
     })
     .filter(({ schemeDetails }) => (
       schemeDetails && SUPPORTED_SECURITY_TYPES.includes(schemeDetails.type)


### PR DESCRIPTION
Closes #INS-1668
Closes #4454

> TL;DR: in the past we already added all the auth methods for the `OR` case, according to [spec](https://swagger.io/docs/specification/authentication/#multiple),  but we didn’t handle the `AND` case because we just picked the first key out of a pair of Api Keys, for example.

## Investigation 

According to [spec](https://swagger.io/docs/specification/authentication/#multiple) there is logic defined when handling [multiple security requirement objects](https://swagger.io/docs/specification/authentication/#multiple):

> Security schemes combined via OR are alternatives – any one can be used in the given context. Security schemes combined via AND must be used simultaneously in the same request.

What this means in practices is, again, according to spec:

> Here, the API requires a pair of API keys to be included in requests:
> ```yaml
> security:
>   - apiKey1: []
>     apiKey2: []
> ```
> Here, we can use either OAuth 2 or a pair of API keys:
> ```yaml
> security:
>   - oauth2: [scope1, scope2]
>   - apiKey1: []
>     apiKey2: []
> ```


The problem on Insomnia happened when we would define what by spec is a pair of security api keys to a given request, if we did it like this:

```yaml
security:
    - apiKey: []
      appSecret:  []
```

Insomnia **would (wrongly) consider the first part of the pair and ignore the rest**, resulting in only one of the variables being generated when interpreting the OpenAPI spec:
![image](https://user-images.githubusercontent.com/11976836/182883970-8a5bc8b0-b05d-4804-9507-a190f786bc0b.png)

Which caused the symptoms we see in #4454. This wasn't reproducible if we didn't define a pair by spec:
```yaml
security:
    - apiKey: []
    - appSecret:  []
```
since each would get handled as an 'OR',  and would translate into this on the App:
![image](https://user-images.githubusercontent.com/11976836/182883782-66ebcadb-4bc3-4165-b753-bd06fc8de3d9.png)
 

### After this PR

Now both approaches translate into:
![image](https://user-images.githubusercontent.com/11976836/182883782-66ebcadb-4bc3-4165-b753-bd06fc8de3d9.png)

And we leave out to the user to afterwards disable and pick whichever api key or security scheme they want to use in a particular request.

changelog(OpenAPI-2-Kong): Fixed an issue where multiple security requirement objects, like pairs of API keys, were not properly handled when generating requests from an OpenAPI spec  