### PR TITLE
[INS-1693] Add WS echo server for smoke tests

### DIFF
--- a/packages/insomnia-smoke-test/package-lock.json
+++ b/packages/insomnia-smoke-test/package-lock.json
@@ -22,6 +22,7 @@
 				"@types/oidc-provider": "^7.8.1",
 				"@types/ramda": "^0.27.45",
 				"@types/uuid": "^8.3.4",
+				"@types/ws": "^8.5.3",
 				"concurrently": "^7.0.0",
 				"cross-env": "^7.0.3",
 				"execa": "^5.0.0",
@@ -38,6 +39,7 @@
 				"ramda-adjunct": "^2.34.0",
 				"ts-node": "^9.1.1",
 				"uuid": "^8.3.2",
+				"ws": "^8.8.1",
 				"xvfb-maybe": "^0.2.1"
 			}
 		},
@@ -1452,6 +1454,15 @@
 			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
 			"integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
 			"dev": true
+		},
+		"node_modules/@types/ws": {
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+			"integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.10",
@@ -5644,6 +5655,27 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
+		"node_modules/ws": {
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+			"integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/xvfb-maybe": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/xvfb-maybe/-/xvfb-maybe-0.2.1.tgz",
@@ -6956,6 +6988,15 @@
 			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
 			"integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
 			"dev": true
+		},
+		"@types/ws": {
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+			"integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/yargs": {
 			"version": "17.0.10",
@@ -10191,6 +10232,13 @@
 				"imurmurhash": "^0.1.4",
 				"signal-exit": "^3.0.7"
 			}
+		},
+		"ws": {
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+			"integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+			"dev": true,
+			"requires": {}
 		},
 		"xvfb-maybe": {
 			"version": "0.2.1",

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -41,6 +41,7 @@
     "@types/oidc-provider": "^7.8.1",
     "@types/ramda": "^0.27.45",
     "@types/uuid": "^8.3.4",
+    "@types/ws": "^8.5.3",
     "concurrently": "^7.0.0",
     "cross-env": "^7.0.3",
     "execa": "^5.0.0",
@@ -57,6 +58,7 @@
     "ramda-adjunct": "^2.34.0",
     "ts-node": "^9.1.1",
     "uuid": "^8.3.2",
+    "ws": "^8.8.1",
     "xvfb-maybe": "^0.2.1"
   }
 }

--- a/packages/insomnia-smoke-test/server/index.ts
+++ b/packages/insomnia-smoke-test/server/index.ts
@@ -7,6 +7,7 @@ import gitlabApi from './gitlab-api';
 import { root, schema } from './graphql';
 import { startGRPCServer } from './grpc';
 import { oauthRoutes } from './oauth';
+import { startWebsocketServer } from './websocket';
 
 const app = express();
 const port = 4010;
@@ -55,7 +56,9 @@ app.use('/graphql', graphqlHTTP({
 }));
 
 startGRPCServer(grpcPort).then(() => {
-  app.listen(port, () => {
+  const server = app.listen(port, () => {
     console.log(`Listening at http://localhost:${port}`);
+    console.log(`Listening at ws://localhost:${port}`);
   });
+  startWebsocketServer(server);
 });

--- a/packages/insomnia-smoke-test/server/websocket.ts
+++ b/packages/insomnia-smoke-test/server/websocket.ts
@@ -1,17 +1,22 @@
 import { Server } from 'http';
-import { WebSocket, WebSocketServer } from 'ws';
+import { WebSocketServer } from 'ws';
 
 /**
  * Starts an echo WebSocket server that receives messages from a client and echoes them back.
  */
 export function startWebsocketServer(server: Server) {
-  const wsServer = new WebSocketServer({ server: server });
+  const wsServer = new WebSocketServer({ server });
 
-  wsServer.on('connection', (ws: WebSocket) => {
+  wsServer.on('connection', ws => {
     console.log('WebSocket connection was opened');
 
-    ws.on('message', (message: string) => {
-      ws.send(message);
+    ws.on('message', (message, isBinary) => {
+      if (isBinary) {
+        ws.send(message);
+        return;
+      }
+
+      ws.send(message.toString());
     });
 
     ws.on('close', () => {

--- a/packages/insomnia-smoke-test/server/websocket.ts
+++ b/packages/insomnia-smoke-test/server/websocket.ts
@@ -1,0 +1,23 @@
+import { Server } from 'http';
+import { WebSocket, WebSocketServer } from 'ws';
+
+/**
+ * Starts an echo WebSocket server that receives messages from a client and echoes them back.
+ */
+export function startWebsocketServer(server: Server) {
+  const wsServer = new WebSocketServer({ server: server });
+
+  wsServer.on('connection', (ws: WebSocket) => {
+    console.log('WebSocket connection was opened');
+
+    ws.on('message', (message: string) => {
+      ws.send(message);
+    });
+
+    ws.on('close', () => {
+      console.log('WebSocket connection was closed');
+    });
+  });
+
+  return wsServer;
+}


### PR DESCRIPTION
Closes INS-1693

This PR adds a simple WS echo server for smoke tests into our existing express server. 
It's available behind `ws://localhost:4010` and any other dummy path, e.g. you can start a connection to `ws://localhost:4010/echo` and it will still work.
