### PR TITLE
[INS-1776] adds `ws` dependency explicitly

### DIFF
--- a/packages/insomnia/package-lock.json
+++ b/packages/insomnia/package-lock.json
@@ -98,6 +98,7 @@
 				"@types/tough-cookie": "^2.3.7",
 				"@types/uuid": "^8.3.4",
 				"@types/vkbeautify": "^0.99.2",
+				"@types/ws": "^8.5.3",
 				"@types/yaml": "^1.9.7",
 				"@vitejs/plugin-react": "^1.2.0",
 				"buffer": "^6.0.3",
@@ -151,7 +152,8 @@
 				"typescript": "^4.5.5",
 				"vite": "^2.8.6",
 				"vite-plugin-commonjs-externals": "^0.1.1",
-				"vkbeautify": "^0.99.1"
+				"vkbeautify": "^0.99.1",
+				"ws": "^8.8.1"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -20379,9 +20381,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-			"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+			"integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
@@ -36425,9 +36427,9 @@
 			}
 		},
 		"ws": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-			"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+			"integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
 			"dev": true,
 			"requires": {}
 		},

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -152,6 +152,7 @@
     "@types/tough-cookie": "^2.3.7",
     "@types/uuid": "^8.3.4",
     "@types/vkbeautify": "^0.99.2",
+    "@types/ws": "^8.5.3",
     "@types/yaml": "^1.9.7",
     "@vitejs/plugin-react": "^1.2.0",
     "buffer": "^6.0.3",
@@ -206,7 +207,8 @@
     "typescript": "^4.5.5",
     "vite": "^2.8.6",
     "vite-plugin-commonjs-externals": "^0.1.1",
-    "vkbeautify": "^0.99.1"
+    "vkbeautify": "^0.99.1",
+    "ws": "^8.8.1"
   },
   "dev": {
     "dev-server-port": 3334


### PR DESCRIPTION
closes INS-1776

I noticed in https://github.com/Kong/insomnia/pull/5050 that the websocket npm we use, ws, is unspecified by the insomnia package.  This means we do not control the version of this critical package.  It's a very very simple fix: specify the dependency in our package.json for the insomnia package, just as we did for insomnia-smoke-test.

To demonstrate this: we were in fact actually getting version 8.5.0, when we want the latest, 8.8.1.

<details>
<summary>ticket 1776 woop woop</summary>

<img src="https://media0.giphy.com/media/XClPnuZtG2yPyqTI6R/giphy.gif"/>

</details>

To test this PR:
1. take note of the actual version of `ws` used in the `package-lock.json` of the `insomnia` package (and the dependency itself in the `node_modules` directory)
1. delete all your node_modules (you can accomplish this with `npm run clean`)
1. pull this PR
1. redownload all node_modules fresh (you can accomplish this with `npm run bootstrap`)
1. look again at the lockfile (and dependency itself) and see that the version is updated.