### PR TITLE
[INS-1784] Restore previous build behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "publish": "lerna publish from-package",
     "clean": "lerna run clean --parallel --stream && lerna clean --yes && rimraf node_modules **/*.tsbuildinfo",
     "test": "lerna run --stream --parallel test",
-    "inso-start": "npm run build:sr --prefix packages/insomnia && npm start --prefix packages/insomnia-inso",
+    "inso-start": "npm start --prefix packages/insomnia-inso",
     "inso-package": "npm run build:sr --prefix packages/insomnia && npm run package --prefix packages/insomnia-inso",
     "inso-package:artifacts": "npm run artifacts --prefix packages/insomnia-inso",
     "watch:app": "npm run build:main.min.js --prefix packages/insomnia && npm run start:dev-server --prefix packages/insomnia",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -17,8 +17,9 @@
   "author": "Kong <office@konghq.com>",
   "main": "src/main.min.js",
   "scripts": {
+    "bootstrap": "npm run build:sr",
     "prebuild": "npm run clean",
-    "build": "npm run build:app",
+    "build": "npm run build:sr && npm run build:app",
     "build:app": "esr --cache ./scripts/build.ts --noErrorTruncation",
     "build:main.min.js": "cross-env NODE_ENV=development esr esbuild.main.ts",
     "build:sr": "concurrently --names sr:source,sr:types \"npm run build:sr:source\" \"npm run build:sr:types\"",


### PR DESCRIPTION
This changeset reverts #4772, which broke the `insomnia-inso` NPM package due to a build error in one of its dependencies, `insomnia-send-request`.

The GitHub action to build and publish our NPM packages runs `npm run bootstrap`, which used to run `build:sr`, but now skips it entirely. `build:sr` used to build `send-request` and shuffled the `dist/` output into `packages/insomnia-send-request`. As a result, all versions of `insomnia-inso` between `3.1.0-beta.4` and the current beta, `3.4.1-beta.0`, do not run correctly, and will produce something resembling the following error:

```
 ERROR  Cannot find module '<redacted>/insomnia-inso@3.4.1-beta.0/node_modules/insomnia-send-request/dist/index.js'. Please verify that the package.json has a valid "main" entry
```

Since the original PR seems like a quality-of-life change, I decided to temporarily restore the previous run script behavior to fix the build until we can come up with a better solution. Similarly, I'll make a separate ticket and submit a separate PR to add a test somewhere to make sure Inso, when installed from the NPM `insomnia-inso` package, runs correctly.


changelog(Inso CLI): Fixed the broken `run test` command when using Inso CLI installed from NPM. This issue affected all versions of the `insomnia-inso` npm package between `3.1.0-beta.4` and the current beta, `3.4.1-beta.0`.