### PR TITLE
[INS-1786] WebSocket headers tab

### DIFF
--- a/packages/insomnia-smoke-test/server/websocket.ts
+++ b/packages/insomnia-smoke-test/server/websocket.ts
@@ -7,9 +7,9 @@ import { WebSocketServer } from 'ws';
 export function startWebsocketServer(server: Server) {
   const wsServer = new WebSocketServer({ server });
 
-  wsServer.on('connection', ws => {
+  wsServer.on('connection', (ws, req) => {
     console.log('WebSocket connection was opened');
-
+    console.log('Upgrade headers:', req.headers);
     ws.on('message', (message, isBinary) => {
       if (isBinary) {
         ws.send(message);

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -78,6 +78,7 @@ async function createWebSocketConnection(
     const eventChannel = `webSocketRequest.connection.${request._id}.event`;
     const readyStateChannel = `webSocketRequest.connection.${request._id}.readyState`;
 
+    // @TODO: Render nunjucks tags in these headers
     const reduceArrayToLowerCaseKeyedDictionary = (acc: { [key: string]: string }, { name, value }: BaseWebSocketRequest['headers'][0]) =>
       ({ ...acc, [name.toLowerCase() || '']: value || '' });
     const headers = request.headers.filter(({ value, disabled, readOnly }) => !!value && !disabled && !readOnly)
@@ -176,6 +177,7 @@ async function sendWebSocketEvent(
   }
 
   ws.send(options.message, error => {
+    // @TODO: Render nunjucks tags in these messages
     // @TODO: We might want to set a status in the WebsocketMessageEvent
     // and update it here based on the error. e.g. status = 'sending' | 'sent' | 'error'
     if (error) {

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -212,7 +212,6 @@ async function closeWebSocketConnection(
 ) {
   const ws = WebSocketConnections.get(options.requestId);
   if (!ws) {
-    console.warn('No websocket found for requestId: ' + options.requestId);
     return;
   }
   ws.close();

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -29,7 +29,10 @@ export type WebsocketUpgradeEvent = Omit<Event, 'target'> & {
   requestId: string;
   type: 'upgrade';
   timestamp: number;
-  headers: IncomingMessage['headers'];
+  incomingHeaders: IncomingMessage['headers'];
+  statusCode?: number;
+  statusMessage?: string;
+  httpVersion?: string;
 };
 
 export type WebsocketMessageEvent = Omit<MessageEvent, 'target'> & {
@@ -110,13 +113,17 @@ async function createWebSocketConnection(
       event.sender.send(readyStateChannel, ws.readyState);
     });
 
-    ws.on('upgrade', request => {
+    ws.on('upgrade', incoming => {
+      // @TODO: We may want to add set-cookie handling here.
       const upgradeEvent: WebsocketUpgradeEvent = {
         _id: uuidV4(),
         requestId: options.requestId,
         type: 'upgrade',
         timestamp: Date.now(),
-        headers: request.headers,
+        incomingHeaders: incoming.headers,
+        statusCode: incoming.statusCode,
+        statusMessage: incoming.statusMessage,
+        httpVersion: incoming.httpVersion,
       };
 
       WebSocketEventLogs.set(options.requestId, [upgradeEvent]);

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -9,6 +9,8 @@ import {
 } from 'ws';
 
 import { websocketRequest } from '../../models';
+import { RequestHeader } from '../../models/request';
+import { DISABLE_HEADER_VALUE } from './parse-header-strings';
 
 export interface WebSocketConnection extends WebSocket {
   _id: string;
@@ -76,8 +78,11 @@ async function createWebSocketConnection(
 
     const eventChannel = `webSocketRequest.connection.${request._id}.event`;
     const readyStateChannel = `webSocketRequest.connection.${request._id}.readyState`;
-
-    const ws = new WebSocket(request?.url);
+    const reduceArrayToLowerCaseKeyedDictionary = (acc: { [key: string]: string }, { name, value }: RequestHeader) =>
+      ({ ...acc, [name.toLowerCase() || '']: value || '' });
+    const headers = request.headers.filter(({ value, disabled }) => !!value && !disabled)
+      .reduce(reduceArrayToLowerCaseKeyedDictionary, {});
+    const ws = new WebSocket(request?.url, { headers });
     WebSocketConnections.set(options.requestId, ws);
 
     ws.addEventListener('open', () => {

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -81,7 +81,7 @@ async function createWebSocketConnection(
     // @TODO: Render nunjucks tags in these headers
     const reduceArrayToLowerCaseKeyedDictionary = (acc: { [key: string]: string }, { name, value }: BaseWebSocketRequest['headers'][0]) =>
       ({ ...acc, [name.toLowerCase() || '']: value || '' });
-    const headers = request.headers.filter(({ value, disabled, readOnly }) => !!value && !disabled && !readOnly)
+    const headers = request.headers.filter(({ value, disabled }) => !!value && !disabled)
       .reduce(reduceArrayToLowerCaseKeyedDictionary, {});
 
     const ws = new WebSocket(request?.url, { headers });

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -1,9 +1,10 @@
 import { ipcMain } from 'electron';
+import { IncomingMessage } from 'http';
 import { v4 as uuidV4 } from 'uuid';
 import {
   CloseEvent,
   ErrorEvent,
-  Event as OpenEvent,
+  Event,
   MessageEvent,
   WebSocket,
 } from 'ws';
@@ -16,11 +17,19 @@ export interface WebSocketConnection extends WebSocket {
   requestId: string;
 }
 
-export type WebsocketOpenEvent = Omit<OpenEvent, 'target'> & {
+export type WebsocketOpenEvent = Omit<Event, 'target'> & {
   _id: string;
   requestId: string;
   type: 'open';
   timestamp: number;
+};
+
+export type WebsocketUpgradeEvent = Omit<Event, 'target'> & {
+  _id: string;
+  requestId: string;
+  type: 'upgrade';
+  timestamp: number;
+  headers: IncomingMessage['headers'];
 };
 
 export type WebsocketMessageEvent = Omit<MessageEvent, 'target'> & {
@@ -47,6 +56,7 @@ export type WebsocketCloseEvent = Omit<CloseEvent, 'target'> & {
 
 export type WebsocketEvent =
   | WebsocketOpenEvent
+  | WebsocketUpgradeEvent
   | WebsocketMessageEvent
   | WebsocketErrorEvent
   | WebsocketCloseEvent;
@@ -100,8 +110,18 @@ async function createWebSocketConnection(
       event.sender.send(readyStateChannel, ws.readyState);
     });
 
-    ws.on('upgrade', response => {
-      console.log(response.headers);
+    ws.on('upgrade', request => {
+      const upgradeEvent: WebsocketUpgradeEvent = {
+        _id: uuidV4(),
+        requestId: options.requestId,
+        type: 'upgrade',
+        timestamp: Date.now(),
+        headers: request.headers,
+      };
+
+      WebSocketEventLogs.set(options.requestId, [upgradeEvent]);
+
+      event.sender.send(eventChannel, upgradeEvent);
     });
 
     ws.addEventListener('message', ({ data }: MessageEvent) => {

--- a/packages/insomnia/src/models/helpers/request-operations.ts
+++ b/packages/insomnia/src/models/helpers/request-operations.ts
@@ -6,11 +6,11 @@ import { isWebSocketRequest, isWebSocketRequestId, WebSocketRequest } from '../w
 export function getById(requestId: string): Promise<Request | GrpcRequest | WebSocketRequest | null> {
   if (isGrpcRequestId(requestId)) {
     return models.grpcRequest.getById(requestId);
-  } else if (isWebSocketRequestId(requestId)) {
-    return models.websocketRequest.getById(requestId);
-  } else {
-    return models.request.getById(requestId);
   }
+  if (isWebSocketRequestId(requestId)) {
+    return models.websocketRequest.getById(requestId);
+  }
+  return models.request.getById(requestId);
 }
 
 export function remove(request: Request | GrpcRequest | WebSocketRequest) {
@@ -19,9 +19,8 @@ export function remove(request: Request | GrpcRequest | WebSocketRequest) {
   }
   if (isWebSocketRequest(request)) {
     return models.websocketRequest.remove(request);
-  } else {
-    return models.request.remove(request);
   }
+  return models.request.remove(request);
 }
 
 export function update<T extends object>(request: T, patch: Partial<T> = {}): Promise<T> {
@@ -34,10 +33,9 @@ export function update<T extends object>(request: T, patch: Partial<T> = {}): Pr
   if (isWebSocketRequest(request)) {
     // @ts-expect-error -- TSCONVERSION
     return models.websocketRequest.update(request, patch);
-  } else {
-    // @ts-expect-error -- TSCONVERSION
-    return models.request.update(request, patch);
   }
+  // @ts-expect-error -- TSCONVERSION
+  return models.request.update(request, patch);
 }
 
 export function duplicate<T extends object>(request: T, patch: Partial<T> = {}): Promise<T> {
@@ -50,8 +48,7 @@ export function duplicate<T extends object>(request: T, patch: Partial<T> = {}):
   if (isWebSocketRequest(request)) {
     // @ts-expect-error -- TSCONVERSION
     return models.websocketRequest.duplicate(request, patch);
-  } else {
-    // @ts-expect-error -- TSCONVERSION
-    return models.request.duplicate(request, patch);
   }
+  // @ts-expect-error -- TSCONVERSION
+  return models.request.duplicate(request, patch);
 }

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -17,7 +17,7 @@ export interface BaseWebSocketRequest {
   name: string;
   url: string;
   metaSortKey: number;
-  headers: (RequestHeader & {readOnly?:boolean})[];
+  headers: RequestHeader[];
 }
 
 export type WebSocketRequest = BaseModel & BaseWebSocketRequest & { type: typeof type };

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -10,6 +10,7 @@ export const prefix = 'ws-req';
 
 export const canDuplicate = true;
 
+// @TODO: enable this at some point
 export const canSync = false;
 
 export interface BaseWebSocketRequest {

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -1,5 +1,6 @@
 import { database } from '../common/database';
 import type { BaseModel } from '.';
+import { RequestHeader } from './request';
 
 export const name = 'WebSocket Request';
 
@@ -15,6 +16,7 @@ export interface BaseWebSocketRequest {
   name: string;
   url: string;
   metaSortKey: number;
+  headers: RequestHeader[];
 }
 
 export type WebSocketRequest = BaseModel & BaseWebSocketRequest & { type: typeof type };
@@ -31,6 +33,14 @@ export const init = (): BaseWebSocketRequest => ({
   name: 'New WebSocket Request',
   url: '',
   metaSortKey: -1 * Date.now(),
+  headers: [
+    { name: 'Host', value: '' },
+    { name: 'Connection', value: 'Upgrade' },
+    { name: 'Upgrade', value: 'websocket' },
+    { name: 'Sec-WebSocket-Key', value: '' },
+    { name: 'Sec-WebSocket-Version', value: '' },
+    { name: 'Sec-WebSocket-Extensions', value: '' },
+    { name: 'Sec-WebSocket-Protocol', value: '' }],
 });
 
 export const migrate = (doc: WebSocketRequest) => doc;

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -16,7 +16,7 @@ export interface BaseWebSocketRequest {
   name: string;
   url: string;
   metaSortKey: number;
-  headers: RequestHeader[];
+  headers: (RequestHeader & {readOnly?:boolean})[];
 }
 
 export type WebSocketRequest = BaseModel & BaseWebSocketRequest & { type: typeof type };
@@ -34,12 +34,12 @@ export const init = (): BaseWebSocketRequest => ({
   url: '',
   metaSortKey: -1 * Date.now(),
   headers: [
-    { name: 'Host', value: '' },
-    { name: 'Connection', value: 'Upgrade' },
-    { name: 'Upgrade', value: 'websocket' },
-    { name: 'Sec-WebSocket-Key', value: '' },
-    { name: 'Sec-WebSocket-Version', value: '' },
-    { name: 'Sec-WebSocket-Extensions', value: '' },
+    { name: 'Host', value: '<calculated at runtime>', readOnly: true },
+    { name: 'Connection', value: 'Upgrade', readOnly: true },
+    { name: 'Upgrade', value: 'websocket', readOnly: true },
+    { name: 'Sec-WebSocket-Key', value: '<calculated at runtime>', readOnly: true },
+    { name: 'Sec-WebSocket-Version', value: '13', readOnly: true },
+    { name: 'Sec-WebSocket-Extensions', value: 'permessage-deflate; client_max_window_bits', readOnly: true },
     { name: 'Sec-WebSocket-Protocol', value: '' }],
 });
 

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -33,14 +33,7 @@ export const init = (): BaseWebSocketRequest => ({
   name: 'New WebSocket Request',
   url: '',
   metaSortKey: -1 * Date.now(),
-  headers: [
-    { name: 'Host', value: '<calculated at runtime>', readOnly: true },
-    { name: 'Connection', value: 'Upgrade', readOnly: true },
-    { name: 'Upgrade', value: 'websocket', readOnly: true },
-    { name: 'Sec-WebSocket-Key', value: '<calculated at runtime>', readOnly: true },
-    { name: 'Sec-WebSocket-Version', value: '13', readOnly: true },
-    { name: 'Sec-WebSocket-Extensions', value: 'permessage-deflate; client_max_window_bits', readOnly: true },
-    { name: 'Sec-WebSocket-Protocol', value: '' }],
+  headers: [],
 });
 
 export const migrate = (doc: WebSocketRequest) => doc;

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -402,6 +402,7 @@ export class OneLineEditor extends PureComponent<Props, State> {
           }}
           placeholder={placeholder}
           defaultValue={defaultValue}
+          disabled={this.props.readOnly}
           onBlur={this._handleInputBlur}
           onChange={this._handleInputChange}
           onMouseEnter={this._handleInputMouseEnter}

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -385,6 +385,7 @@ export class OneLineEditor extends PureComponent<Props, State> {
             getAutocompleteConstants={getAutocompleteConstants}
             className={classnames('editor--single-line', className)}
             defaultValue={defaultValue}
+            readOnly={this.props.readOnly}
           />
         </Fragment>
       );

--- a/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
@@ -3,12 +3,13 @@ import React, { FC, useCallback } from 'react';
 import { getCommonHeaderNames, getCommonHeaderValues } from '../../../common/common-headers';
 import { update } from '../../../models/helpers/request-operations';
 import type { Request, RequestHeader } from '../../../models/request';
+import { WebSocketRequest } from '../../../models/websocket-request';
 import { CodeEditor } from '../codemirror/code-editor';
 import { KeyValueEditor } from '../key-value-editor/key-value-editor';
 
 interface Props {
   bulk: boolean;
-  request: Request;
+  request: Request | WebSocketRequest;
 }
 
 export const RequestHeadersEditor: FC<Props> = ({

--- a/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
@@ -72,16 +72,6 @@ export const RequestHeadersEditor: FC<Props> = ({
       </div>
     );
   }
-  const isWSRequest = isWebSocketRequest(request);
-  const wsHeaders = [
-    { name: 'Connection', value: 'Upgrade', readOnly: true },
-    { name: 'Upgrade', value: 'websocket', readOnly: true },
-    { name: 'Sec-WebSocket-Key', value: '<calculated at runtime>', readOnly: true },
-    { name: 'Sec-WebSocket-Version', value: '13', readOnly: true },
-    { name: 'Sec-WebSocket-Extensions', value: 'permessage-deflate; client_max_window_bits', readOnly: true },
-    ...request.headers,
-  ];
-  const headers = isWSRequest ? wsHeaders : request.headers;
 
   return (
     <div className="pad-bottom scrollable-container">
@@ -91,12 +81,12 @@ export const RequestHeadersEditor: FC<Props> = ({
           namePlaceholder="header"
           valuePlaceholder="value"
           descriptionPlaceholder="description"
-          pairs={headers}
+          pairs={request.headers}
           handleGetAutocompleteNameConstants={getCommonHeaderNames}
           handleGetAutocompleteValueConstants={getCommonHeaderValues}
           onChange={onChangeHeaders}
           isDisabled={isDisabled}
-          forceInput={isWSRequest}
+          isWebSocketRequest={isWebSocketRequest(request)}
         />
       </div>
     </div>

--- a/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
@@ -73,6 +73,16 @@ export const RequestHeadersEditor: FC<Props> = ({
     );
   }
   const isWSRequest = isWebSocketRequest(request);
+  const wsHeaders = [
+    { name: 'Connection', value: 'Upgrade', readOnly: true },
+    { name: 'Upgrade', value: 'websocket', readOnly: true },
+    { name: 'Sec-WebSocket-Key', value: '<calculated at runtime>', readOnly: true },
+    { name: 'Sec-WebSocket-Version', value: '13', readOnly: true },
+    { name: 'Sec-WebSocket-Extensions', value: 'permessage-deflate; client_max_window_bits', readOnly: true },
+    ...request.headers,
+  ];
+  const headers = isWSRequest ? wsHeaders : request.headers;
+
   return (
     <div className="pad-bottom scrollable-container">
       <div className="scrollable">
@@ -81,7 +91,7 @@ export const RequestHeadersEditor: FC<Props> = ({
           namePlaceholder="header"
           valuePlaceholder="value"
           descriptionPlaceholder="description"
-          pairs={request.headers}
+          pairs={headers}
           handleGetAutocompleteNameConstants={getCommonHeaderNames}
           handleGetAutocompleteValueConstants={getCommonHeaderValues}
           onChange={onChangeHeaders}

--- a/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
@@ -3,7 +3,7 @@ import React, { FC, useCallback } from 'react';
 import { getCommonHeaderNames, getCommonHeaderValues } from '../../../common/common-headers';
 import { update } from '../../../models/helpers/request-operations';
 import type { Request, RequestHeader } from '../../../models/request';
-import { WebSocketRequest } from '../../../models/websocket-request';
+import { isWebSocketRequest, WebSocketRequest } from '../../../models/websocket-request';
 import { CodeEditor } from '../codemirror/code-editor';
 import { KeyValueEditor } from '../key-value-editor/key-value-editor';
 
@@ -72,7 +72,7 @@ export const RequestHeadersEditor: FC<Props> = ({
       </div>
     );
   }
-
+  const isWSRequest = isWebSocketRequest(request);
   return (
     <div className="pad-bottom scrollable-container">
       <div className="scrollable">
@@ -86,6 +86,7 @@ export const RequestHeadersEditor: FC<Props> = ({
           handleGetAutocompleteValueConstants={getCommonHeaderValues}
           onChange={onChangeHeaders}
           isDisabled={isDisabled}
+          forceInput={isWSRequest}
         />
       </div>
     </div>

--- a/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
@@ -9,12 +9,14 @@ import { KeyValueEditor } from '../key-value-editor/key-value-editor';
 
 interface Props {
   bulk: boolean;
+  isDisabled?: boolean;
   request: Request | WebSocketRequest;
 }
 
 export const RequestHeadersEditor: FC<Props> = ({
   request,
   bulk,
+  isDisabled,
 }) => {
   const handleBulkUpdate = useCallback((headersString: string) => {
     const headers: {
@@ -83,6 +85,7 @@ export const RequestHeadersEditor: FC<Props> = ({
           handleGetAutocompleteNameConstants={getCommonHeaderNames}
           handleGetAutocompleteValueConstants={getCommonHeaderValues}
           onChange={onChangeHeaders}
+          isDisabled={isDisabled}
         />
       </div>
     </div>

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -458,6 +458,7 @@ export class KeyValueEditor extends PureComponent<Props, State> {
           <Row
             key={i}
             index={i}
+            sortable={true}
             displayDescription={this.state.displayDescription}
             descriptionPlaceholder={descriptionPlaceholder}
             readOnly

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -407,7 +407,7 @@ export class KeyValueEditor extends PureComponent<Props, State> {
 
   _setFocusedPair(pair: Pair) {
     if (pair) {
-      this._focusedPairId = pair.id;
+      this._focusedPairId = pair.id || 'n/a';
     } else {
       this._focusedPairId = null;
     }
@@ -446,17 +446,17 @@ export class KeyValueEditor extends PureComponent<Props, State> {
     const hasMaxPairsAndNotExceeded = !maxPairs || pairs.length < maxPairs;
     const showNewHeaderInput = !isDisabled && hasMaxPairsAndNotExceeded;
     const readOnlyPairs = [
-      { id: '1', name: 'Connection', value: 'Upgrade', description:'' },
-      { id: '2', name: 'Upgrade', value: 'websocket', description:'' },
-      { id: '3', name: 'Sec-WebSocket-Key', value: '<calculated at runtime>', description:'' },
-      { id: '4', name: 'Sec-WebSocket-Version', value: '13', description:'' },
-      { id: '5', name: 'Sec-WebSocket-Extensions', value: 'permessage-deflate; client_max_window_bits', description:'' },
+      { name: 'Connection', value: 'Upgrade' },
+      { name: 'Upgrade', value: 'websocket' },
+      { name: 'Sec-WebSocket-Key', value: '<calculated at runtime>' },
+      { name: 'Sec-WebSocket-Version', value: '13' },
+      { name: 'Sec-WebSocket-Extensions', value: 'permessage-deflate; client_max_window_bits' },
     ];
     return (
       <ul className={classes}>
         {isWebSocketRequest ? readOnlyPairs.map((pair, i) => (
           <Row
-            key={pair.name}
+            key={i}
             index={i}
             displayDescription={this.state.displayDescription}
             descriptionPlaceholder={descriptionPlaceholder}
@@ -531,11 +531,9 @@ export class KeyValueEditor extends PureComponent<Props, State> {
             onFocusDescription={this._handleAddFromDescription}
             allowMultiline={allowMultiline}
             allowFile={allowFile}
-            // @ts-expect-error -- TSCONVERSION missing defaults
             pair={{
               name: '',
               value: '',
-              description: '',
             }}
           />
         ) : null}

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -41,6 +41,7 @@ interface Props {
   onDelete?: Function;
   onCreate?: Function;
   className?: string;
+  isDisabled?: boolean;
 }
 
 interface State {
@@ -435,9 +436,13 @@ export class KeyValueEditor extends PureComponent<Props, State> {
       allowMultiline,
       sortable,
       disableDelete,
+      isDisabled,
     } = this.props;
     const { pairs } = this.state;
+
     const classes = classnames('key-value-editor', 'wide', className);
+    const hasMaxPairsAndNotExceeded = !maxPairs || pairs.length < maxPairs;
+    const showNewHeaderInput = !isDisabled && hasMaxPairsAndNotExceeded;
     return (
       <ul className={classes}>
         {pairs.map((pair, i) => (
@@ -466,13 +471,13 @@ export class KeyValueEditor extends PureComponent<Props, State> {
             handleGetAutocompleteValueConstants={handleGetAutocompleteValueConstants}
             allowMultiline={allowMultiline}
             allowFile={allowFile}
-            readOnly={pair.readOnly}
-            hideButtons={pair.readOnly}
+            readOnly={isDisabled || pair.readOnly}
+            hideButtons={isDisabled || pair.readOnly}
             pair={pair}
           />
         ))}
 
-        {!maxPairs || pairs.length < maxPairs ? (
+        {showNewHeaderInput ? (
           <Row
             key="empty-row"
             hideButtons

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -42,6 +42,7 @@ interface Props {
   onCreate?: Function;
   className?: string;
   isDisabled?: boolean;
+  forceInput?: boolean;
 }
 
 interface State {
@@ -437,6 +438,7 @@ export class KeyValueEditor extends PureComponent<Props, State> {
       sortable,
       disableDelete,
       isDisabled,
+      forceInput,
     } = this.props;
     const { pairs } = this.state;
 
@@ -473,6 +475,7 @@ export class KeyValueEditor extends PureComponent<Props, State> {
             allowFile={allowFile}
             readOnly={isDisabled || pair.readOnly}
             hideButtons={isDisabled || pair.readOnly}
+            forceInput={forceInput}
             pair={pair}
           />
         ))}

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -42,7 +42,7 @@ interface Props {
   onCreate?: Function;
   className?: string;
   isDisabled?: boolean;
-  forceInput?: boolean;
+  isWebSocketRequest?: boolean;
 }
 
 interface State {
@@ -438,15 +438,34 @@ export class KeyValueEditor extends PureComponent<Props, State> {
       sortable,
       disableDelete,
       isDisabled,
-      forceInput,
+      isWebSocketRequest,
     } = this.props;
     const { pairs } = this.state;
 
     const classes = classnames('key-value-editor', 'wide', className);
     const hasMaxPairsAndNotExceeded = !maxPairs || pairs.length < maxPairs;
     const showNewHeaderInput = !isDisabled && hasMaxPairsAndNotExceeded;
+    const readOnlyPairs = [
+      { id: '1', name: 'Connection', value: 'Upgrade', description:'' },
+      { id: '2', name: 'Upgrade', value: 'websocket', description:'' },
+      { id: '3', name: 'Sec-WebSocket-Key', value: '<calculated at runtime>', description:'' },
+      { id: '4', name: 'Sec-WebSocket-Version', value: '13', description:'' },
+      { id: '5', name: 'Sec-WebSocket-Extensions', value: 'permessage-deflate; client_max_window_bits', description:'' },
+    ];
     return (
       <ul className={classes}>
+        {isWebSocketRequest ? readOnlyPairs.map((pair, i) => (
+          <Row
+            key={pair.name}
+            index={i}
+            displayDescription={this.state.displayDescription}
+            descriptionPlaceholder={descriptionPlaceholder}
+            readOnly
+            hideButtons
+            forceInput
+            pair={pair}
+          />
+        )) : null}
         {pairs.map((pair, i) => (
           <Row
             noDelete={disableDelete}
@@ -473,9 +492,10 @@ export class KeyValueEditor extends PureComponent<Props, State> {
             handleGetAutocompleteValueConstants={handleGetAutocompleteValueConstants}
             allowMultiline={allowMultiline}
             allowFile={allowFile}
-            readOnly={isDisabled || pair.readOnly}
-            hideButtons={isDisabled || pair.readOnly}
-            forceInput={forceInput}
+            readOnly={isDisabled}
+            hideButtons={isDisabled}
+            // @TODO disabled nunjucks: remove this when nunjucks support is added
+            forceInput={isWebSocketRequest}
             pair={pair}
           />
         ))}

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -466,6 +466,8 @@ export class KeyValueEditor extends PureComponent<Props, State> {
             handleGetAutocompleteValueConstants={handleGetAutocompleteValueConstants}
             allowMultiline={allowMultiline}
             allowFile={allowFile}
+            readOnly={pair.readOnly}
+            hideButtons={pair.readOnly}
             pair={pair}
           />
         ))}
@@ -476,7 +478,6 @@ export class KeyValueEditor extends PureComponent<Props, State> {
             hideButtons
             sortable
             noDropZone
-            readOnly
             forceInput
             index={-1}
             onChange={noop}

--- a/packages/insomnia/src/ui/components/key-value-editor/row.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/row.tsx
@@ -34,11 +34,11 @@ export type AutocompleteHandler = (pair: Pair) => string[] | PromiseLike<string[
 type DragDirection = 0 | 1 | -1;
 
 interface Props {
-  onChange: (pair: Pair) => void;
-  onDelete: (pair: Pair) => void;
-  onFocusName: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
-  onFocusValue: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
-  onFocusDescription: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
+  onChange?: (pair: Pair) => void;
+  onDelete?: (pair: Pair) => void;
+  onFocusName?: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
+  onFocusValue?: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
+  onFocusDescription?: (pair: Pair, event: FocusEvent | React.FocusEvent<Element, Element>) => void;
   displayDescription: boolean;
   index: number;
   pair: Pair;
@@ -195,15 +195,15 @@ class KeyValueEditorRowInternal extends PureComponent<Props, State> {
   }
 
   _handleFocusName(event: FocusEvent | React.FocusEvent<Element, Element>) {
-    this.props.onFocusName(this.props.pair, event);
+    this.props.onFocusName?.(this.props.pair, event);
   }
 
   _handleFocusValue(event: FocusEvent | React.FocusEvent<Element, Element>) {
-    this.props.onFocusValue(this.props.pair, event);
+    this.props.onFocusValue?.(this.props.pair, event);
   }
 
   _handleFocusDescription(event: FocusEvent | React.FocusEvent<Element, Element>) {
-    this.props.onFocusDescription(this.props.pair, event);
+    this.props.onFocusDescription?.(this.props.pair, event);
   }
 
   _handleBlurName(event: FocusEvent | React.FocusEvent<Element, Element>) {

--- a/packages/insomnia/src/ui/components/key-value-editor/row.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/row.tsx
@@ -19,10 +19,10 @@ import { CodePromptModal } from '../modals/code-prompt-modal';
 import { showModal } from '../modals/index';
 
 export interface Pair {
-  id: string;
+  id?: string;
   name: string;
   value: string;
-  description: string;
+  description?: string;
   fileName?: string;
   type?: string;
   disabled?: boolean;

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -37,6 +37,7 @@ interface Props {
   headerEditorKey: string;
   request?: Request | null;
   settings: Settings;
+  toggleBulkHeaderEditor: () => void;
   updateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   workspace: Workspace;
 }
@@ -50,6 +51,7 @@ export const RequestPane: FC<Props> = ({
   headerEditorKey,
   request,
   settings,
+  toggleBulkHeaderEditor,
   updateRequestMimeType,
   workspace,
 }) => {
@@ -72,10 +74,6 @@ export const RequestPane: FC<Props> = ({
   const autocompleteUrls = useCallback(() => {
     return queryAllWorkspaceUrls(workspace, models.request.type, request?._id);
   }, [workspace, request]);
-
-  const handleUpdateSettingsUseBulkHeaderEditor = useCallback(() => {
-    models.settings.update(settings, { useBulkHeaderEditor:!settings.useBulkHeaderEditor });
-  }, [settings]);
 
   const handleUpdateSettingsUseBulkParametersEditor = useCallback(() => {
     models.settings.update(settings, { useBulkParametersEditor:!settings.useBulkParametersEditor });
@@ -249,7 +247,7 @@ export const RequestPane: FC<Props> = ({
           <div className="pad-right text-right">
             <button
               className="margin-top-sm btn btn--clicky"
-              onClick={handleUpdateSettingsUseBulkHeaderEditor}
+              onClick={toggleBulkHeaderEditor}
             >
               {settings.useBulkHeaderEditor ? 'Regular Edit' : 'Bulk Edit'}
             </button>

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -37,7 +37,6 @@ interface Props {
   headerEditorKey: string;
   request?: Request | null;
   settings: Settings;
-  toggleBulkHeaderEditor: () => void;
   updateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
   workspace: Workspace;
 }
@@ -51,7 +50,6 @@ export const RequestPane: FC<Props> = ({
   headerEditorKey,
   request,
   settings,
-  toggleBulkHeaderEditor,
   updateRequestMimeType,
   workspace,
 }) => {
@@ -74,6 +72,10 @@ export const RequestPane: FC<Props> = ({
   const autocompleteUrls = useCallback(() => {
     return queryAllWorkspaceUrls(workspace, models.request.type, request?._id);
   }, [workspace, request]);
+
+  const handleUpdateSettingsUseBulkHeaderEditor = useCallback(() => {
+    models.settings.update(settings, { useBulkHeaderEditor:!settings.useBulkHeaderEditor });
+  }, [settings]);
 
   const handleUpdateSettingsUseBulkParametersEditor = useCallback(() => {
     models.settings.update(settings, { useBulkParametersEditor:!settings.useBulkParametersEditor });
@@ -247,7 +249,7 @@ export const RequestPane: FC<Props> = ({
           <div className="pad-right text-right">
             <button
               className="margin-top-sm btn btn--clicky"
-              onClick={toggleBulkHeaderEditor}
+              onClick={handleUpdateSettingsUseBulkHeaderEditor}
             >
               {settings.useBulkHeaderEditor ? 'Regular Edit' : 'Bulk Edit'}
             </button>

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import * as models from '../../../models';
 import { WebSocketRequest } from '../../../models/websocket-request';
-import { ReadyState, useWSReadyState } from '../../context/websocket-client/use-ws-ready-state';
+import { ReadyState } from '../../context/websocket-client/use-ws-ready-state';
 import { useWebSocketClient } from '../../context/websocket-client/websocket-client-context';
 import { selectActiveRequest } from '../../redux/selectors';
 

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -48,7 +48,7 @@ const ActionButton: FC<ActionButtonProps> = ({ requestId, readyState }) => {
 
 interface ActionBarProps {
   requestId: string;
-  requestUrl: string;
+  defaultValue: string;
   readyState: ReadyState;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
 }
@@ -74,7 +74,7 @@ const WebSocketIcon = styled.span({
   paddingLeft: 'var(--padding-md)',
 });
 
-export const WebSocketActionBar: FC<ActionBarProps> = ({ requestId, requestUrl, onChange, readyState }) => {
+export const WebSocketActionBar: FC<ActionBarProps> = ({ requestId, defaultValue, onChange, readyState }) => {
   const { create, close } = useWebSocketClient();
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -97,7 +97,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ requestId, requestUrl, 
           disabled={readyState === ReadyState.OPEN}
           required
           placeholder="wss://ws-feed.exchange.coinbase.com"
-          defaultValue={requestUrl}
+          defaultValue={defaultValue}
           onChange={onChange}
         />
       </Form>

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -52,6 +52,7 @@ const ActionButton: FC<ActionButtonProps> = ({ requestId, readyState }) => {
 
 interface ActionBarProps {
   requestId: string;
+  readyState: ReadyState;
 }
 
 const Form = styled.form({
@@ -75,11 +76,10 @@ const WebSocketIcon = styled.span({
   paddingLeft: 'var(--padding-md)',
 });
 
-export const WebsocketActionBar: FC<ActionBarProps> = ({ requestId }) => {
+export const WebsocketActionBar: FC<ActionBarProps> = ({ requestId, readyState }) => {
   const request = useSelector(selectActiveRequest);
 
   const { create, close } = useWebSocketClient();
-  const readyState = useWSReadyState(requestId);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -1,12 +1,8 @@
-import React, { FC, FormEvent, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import React, { ChangeEvent, FC, FormEvent, useEffect } from 'react';
 import styled from 'styled-components';
 
-import * as models from '../../../models';
-import { WebSocketRequest } from '../../../models/websocket-request';
 import { ReadyState } from '../../context/websocket-client/use-ws-ready-state';
 import { useWebSocketClient } from '../../context/websocket-client/websocket-client-context';
-import { selectActiveRequest } from '../../redux/selectors';
 
 const Button = styled.button({
   paddingRight: 'var(--padding-md)',
@@ -52,7 +48,9 @@ const ActionButton: FC<ActionButtonProps> = ({ requestId, readyState }) => {
 
 interface ActionBarProps {
   requestId: string;
+  requestUrl: string;
   readyState: ReadyState;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
 }
 
 const Form = styled.form({
@@ -76,24 +74,11 @@ const WebSocketIcon = styled.span({
   paddingLeft: 'var(--padding-md)',
 });
 
-export const WebsocketActionBar: FC<ActionBarProps> = ({ requestId, readyState }) => {
-  const request = useSelector(selectActiveRequest);
-
+export const WebSocketActionBar: FC<ActionBarProps> = ({ requestId, requestUrl, onChange, readyState }) => {
   const { create, close } = useWebSocketClient();
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-    const url = (formData.get('websocketUrlInput') as string) || '';
-
-    if (!request) {
-      return;
-    }
-
-    if (request.url !== url) {
-      await models.websocketRequest.update(request as WebSocketRequest, { url });
-    }
-
     create({ requestId });
   };
 
@@ -112,7 +97,8 @@ export const WebsocketActionBar: FC<ActionBarProps> = ({ requestId, readyState }
           disabled={readyState === ReadyState.OPEN}
           required
           placeholder="wss://ws-feed.exchange.coinbase.com"
-          defaultValue={request?.url}
+          defaultValue={requestUrl}
+          onChange={onChange}
         />
       </Form>
       <ActionButton requestId={requestId} readyState={readyState} />

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -96,7 +96,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ requestId, defaultValue
           name="websocketUrlInput"
           disabled={readyState === ReadyState.OPEN}
           required
-          placeholder="wss://ws-feed.exchange.coinbase.com"
+          placeholder="wss://example.com/chat"
           defaultValue={defaultValue}
           onChange={onChange}
         />

--- a/packages/insomnia/src/ui/components/websockets/event-log-table.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-table.tsx
@@ -251,7 +251,6 @@ interface Props {
 }
 export const EventLogTable: FC<Props> = ({ events, onSelect, selectionId }) => {
   return (
-    // <TableWrapper>
     <Table data-testid="EventLogTabe__Table" className="table--fancy table--compact">
       <thead>
         <tr>
@@ -271,6 +270,5 @@ export const EventLogTable: FC<Props> = ({ events, onSelect, selectionId }) => {
         ))}
       </tbody>
     </Table>
-    // </TableWrapper>
   );
 };

--- a/packages/insomnia/src/ui/components/websockets/event-log-table.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-table.tsx
@@ -9,7 +9,6 @@ import {
   WebsocketEvent,
   WebsocketMessageEvent,
   WebsocketOpenEvent,
-  WebsocketUpgradeEvent,
 } from '../../../main/network/websocket';
 
 const Table = styled.table({
@@ -129,34 +128,6 @@ export const OpenEventTableRow = memo(
 );
 OpenEventTableRow.displayName = 'OpenEventTableRow';
 
-export const UpgradeEventTableRow = memo(
-  (props: {
-      event: WebsocketUpgradeEvent;
-      isActive: boolean;
-      onClick: () => void;
-    }) => {
-    const { isActive, onClick } = props;
-    return (
-      <TableRow data-testid="EventLogTable__EventTableRow" isActive={isActive} onClick={onClick}>
-        <TableCell>
-          <TableCellIconWrapper>
-            <SvgIcon icon="ellipsis-circle2" />
-          </TableCellIconWrapper>
-        </TableCell>
-        <TableCell>
-          <TableCellTextWrapper>
-            Connection upgraded to WebSocket
-          </TableCellTextWrapper>
-        </TableCell>
-        <TableCell>
-          <Timestamp time={props.event.timestamp} />
-        </TableCell>
-      </TableRow>
-    );
-  }
-);
-UpgradeEventTableRow.displayName = 'UpgradeEventTableRow';
-
 export const ErrorEventTableRow = memo(
   (props: {
       event: WebsocketErrorEvent;
@@ -209,15 +180,7 @@ export const EventTableRow = memo(
           />
         );
       }
-      case 'upgrade': {
-        return (
-          <UpgradeEventTableRow
-            event={event}
-            isActive={isActive}
-            onClick={_onClick}
-          />
-        );
-      }
+
       case 'close': {
         return (
           <CloseEventTableRow

--- a/packages/insomnia/src/ui/components/websockets/event-log-table.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-table.tsx
@@ -9,6 +9,7 @@ import {
   WebsocketEvent,
   WebsocketMessageEvent,
   WebsocketOpenEvent,
+  WebsocketUpgradeEvent,
 } from '../../../main/network/websocket';
 
 const Table = styled.table({
@@ -128,6 +129,34 @@ export const OpenEventTableRow = memo(
 );
 OpenEventTableRow.displayName = 'OpenEventTableRow';
 
+export const UpgradeEventTableRow = memo(
+  (props: {
+      event: WebsocketUpgradeEvent;
+      isActive: boolean;
+      onClick: () => void;
+    }) => {
+    const { isActive, onClick } = props;
+    return (
+      <TableRow data-testid="EventLogTable__EventTableRow" isActive={isActive} onClick={onClick}>
+        <TableCell>
+          <TableCellIconWrapper>
+            <SvgIcon icon="ellipsis-circle2" />
+          </TableCellIconWrapper>
+        </TableCell>
+        <TableCell>
+          <TableCellTextWrapper>
+            HTTP connection upgraded successfully
+          </TableCellTextWrapper>
+        </TableCell>
+        <TableCell>
+          <Timestamp time={props.event.timestamp} />
+        </TableCell>
+      </TableRow>
+    );
+  }
+);
+UpgradeEventTableRow.displayName = 'UpgradeEventTableRow';
+
 export const ErrorEventTableRow = memo(
   (props: {
       event: WebsocketErrorEvent;
@@ -174,6 +203,15 @@ export const EventTableRow = memo(
       case 'open': {
         return (
           <OpenEventTableRow
+            event={event}
+            isActive={isActive}
+            onClick={_onClick}
+          />
+        );
+      }
+      case 'upgrade': {
+        return (
+          <UpgradeEventTableRow
             event={event}
             isActive={isActive}
             onClick={_onClick}

--- a/packages/insomnia/src/ui/components/websockets/event-log-table.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-table.tsx
@@ -145,7 +145,7 @@ export const UpgradeEventTableRow = memo(
         </TableCell>
         <TableCell>
           <TableCellTextWrapper>
-            HTTP connection upgraded successfully
+            Connection upgraded to WebSocket
           </TableCellTextWrapper>
         </TableCell>
         <TableCell>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -88,7 +88,7 @@ const RequestPane: FC<Props> = ({ request }) => {
         <WebSocketActionBar
           key={request._id}
           requestId={request._id}
-          requestUrl={request.url}
+          defaultValue={request.url}
           readyState={readyState}
           onChange={handleOnChange}
         />

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -74,6 +74,10 @@ interface Props {
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
 const RequestPane: FC<Props> = ({ request }) => {
   const readyState = useWSReadyState(request._id);
+  const readOnlyRequest = {
+    ...request,
+    headers: request.headers.map(header => ({ ...header, readOnly: true })),
+  };
   return (
     <Pane type="request">
       <PaneHeader>
@@ -102,7 +106,8 @@ const RequestPane: FC<Props> = ({ request }) => {
         </TabPanel>
         <TabPanel className="react-tabs__tab-panel header-editor">
           <RequestHeadersEditor
-            request={request}
+            key={`${request._id}-${readyState}-header-editor`}
+            request={readyState === ReadyState.CLOSED ? request : readOnlyRequest}
             bulk={false}
           />
         </TabPanel>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -1,7 +1,8 @@
-import React, { FC, FormEvent, useRef } from 'react';
+import React, { ChangeEvent, FC, FormEvent, useRef } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import styled from 'styled-components';
 
+import * as models from '../../../models';
 import { WebSocketRequest } from '../../../models/websocket-request';
 import { createWebSocketClient } from '../../context/websocket-client/create-websocket-client';
 import { ReadyState, useWSReadyState } from '../../context/websocket-client/use-ws-ready-state';
@@ -9,7 +10,7 @@ import { useWebSocketClient, WebSocketClientProvider } from '../../context/webso
 import { CodeEditor, UnconnectedCodeEditor } from '../codemirror/code-editor';
 import { RequestHeadersEditor } from '../editors/request-headers-editor';
 import { Pane, PaneHeader as OriginalPaneHeader } from '../panes/pane';
-import { WebsocketActionBar } from './action-bar';
+import { WebSocketActionBar } from './action-bar';
 
 const EditorWrapper = styled.div({
   height: '100%',
@@ -74,10 +75,23 @@ interface Props {
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
 const RequestPane: FC<Props> = ({ request }) => {
   const readyState = useWSReadyState(request._id);
+  const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const url = event.currentTarget.value || '';
+    if (url !== request.url) {
+      models.websocketRequest.update(request, { url });
+    }
+  };
+
   return (
     <Pane type="request">
       <PaneHeader>
-        <WebsocketActionBar requestId={request._id} readyState={readyState} />
+        <WebSocketActionBar
+          key={request._id}
+          requestId={request._id}
+          requestUrl={request.url}
+          readyState={readyState}
+          onChange={handleOnChange}
+        />
       </PaneHeader>
       <Tabs className="pane__body theme--pane__body react-tabs">
         <TabList>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -107,7 +107,7 @@ const RequestPane: FC<Props> = ({ request }) => {
         <TabPanel className="react-tabs__tab-panel header-editor">
           <RequestHeadersEditor
             key={`${request._id}-${readyState}-header-editor`}
-            request={readyState === ReadyState.CLOSED ? request : readOnlyRequest}
+            request={readyState !== ReadyState.OPEN ? request : readOnlyRequest}
             bulk={false}
           />
         </TabPanel>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -74,10 +74,6 @@ interface Props {
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
 const RequestPane: FC<Props> = ({ request }) => {
   const readyState = useWSReadyState(request._id);
-  const readOnlyRequest = {
-    ...request,
-    headers: request.headers.map(header => ({ ...header, readOnly: true })),
-  };
   return (
     <Pane type="request">
       <PaneHeader>
@@ -107,8 +103,9 @@ const RequestPane: FC<Props> = ({ request }) => {
         <TabPanel className="react-tabs__tab-panel header-editor">
           <RequestHeadersEditor
             key={`${request._id}-${readyState}-header-editor`}
-            request={readyState !== ReadyState.OPEN ? request : readOnlyRequest}
+            request={request}
             bulk={false}
+            isDisabled={readyState === ReadyState.OPEN}
           />
         </TabPanel>
       </Tabs>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -9,9 +9,7 @@ import { CodeEditor, UnconnectedCodeEditor } from '../codemirror/code-editor';
 import { RequestHeadersEditor } from '../editors/request-headers-editor';
 import { Pane, PaneHeader as OriginalPaneHeader } from '../panes/pane';
 import { WebsocketActionBar } from './action-bar';
-interface Props {
-  request: WebSocketRequest;
-}
+
 const PaneBody = styled.div({
   display: 'flex',
   flexDirection: 'column',
@@ -61,7 +59,7 @@ const PaneHeader = styled(OriginalPaneHeader)({
   '&&': { alignItems: 'stretch' },
 });
 
-const WebSocketRequestForm: FC<{requestId: string}> = ({ requestId }) => {
+const WebSocketRequestForm: FC<{ requestId: string }> = ({ requestId }) => {
   const { send } = useWebSocketClient();
   const editorRef = useRef<UnconnectedCodeEditor>(null);
 
@@ -83,11 +81,21 @@ const WebSocketRequestForm: FC<{requestId: string}> = ({ requestId }) => {
   );
 };
 
+interface Props {
+  request: WebSocketRequest;
+  useBulkHeaderEditor: boolean;
+  toggleBulkHeaderEditor: () => void;
+}
+
 // requestId is something we can read from the router params in the future.
 // essentially we can lift up the states and merge request pane and response pane into a single page and divide the UI there.
 // currently this is blocked by the way page layout divide the panes with dragging functionality
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
-export const WebSocketRequestPane: FC<Props> = ({ request }) => {
+export const WebSocketRequestPane: FC<Props> = ({
+  request,
+  useBulkHeaderEditor,
+  toggleBulkHeaderEditor,
+}) => {
   const wsClient = createWebSocketClient();
   return (
     <WebSocketClientProvider client={wsClient}>
@@ -124,14 +132,14 @@ export const WebSocketRequestPane: FC<Props> = ({ request }) => {
               <TabPanel className="react-tabs__tab-panel header-editor">
                 <RequestHeadersEditor
                   request={request}
-                  bulk={false}
+                  bulk={useBulkHeaderEditor}
                 />
                 <div className="pad-right text-right">
                   <button
                     className="margin-top-sm btn btn--clicky"
-                    onClick={() => {}}
+                    onClick={toggleBulkHeaderEditor}
                   >
-                    {false ? 'Regular Edit' : 'Bulk Edit'}
+                    {useBulkHeaderEditor ? 'Regular Edit' : 'Bulk Edit'}
                   </button>
                 </div>
               </TabPanel>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -66,15 +66,13 @@ const WebSocketRequestForm: FC<{ requestId: string }> = ({ requestId }) => {
 
 interface Props {
   request: WebSocketRequest;
-  useBulkHeaderEditor: boolean;
-  toggleBulkHeaderEditor: () => void;
 }
 
 // requestId is something we can read from the router params in the future.
 // essentially we can lift up the states and merge request pane and response pane into a single page and divide the UI there.
 // currently this is blocked by the way page layout divide the panes with dragging functionality
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
-const RequestPane: FC<Props> = ({ request, useBulkHeaderEditor, toggleBulkHeaderEditor }) => {
+const RequestPane: FC<Props> = ({ request }) => {
   const readyState = useWSReadyState(request._id);
   return (
     <Pane type="request">
@@ -105,16 +103,8 @@ const RequestPane: FC<Props> = ({ request, useBulkHeaderEditor, toggleBulkHeader
         <TabPanel className="react-tabs__tab-panel header-editor">
           <RequestHeadersEditor
             request={request}
-            bulk={useBulkHeaderEditor}
+            bulk={false}
           />
-          <div className="pad-right text-right">
-            <button
-              className="margin-top-sm btn btn--clicky"
-              onClick={toggleBulkHeaderEditor}
-            >
-              {useBulkHeaderEditor ? 'Regular Edit' : 'Bulk Edit'}
-            </button>
-          </div>
         </TabPanel>
       </Tabs>
     </Pane>
@@ -122,16 +112,12 @@ const RequestPane: FC<Props> = ({ request, useBulkHeaderEditor, toggleBulkHeader
 };
 export const WebSocketRequestPane: FC<Props> = ({
   request,
-  useBulkHeaderEditor,
-  toggleBulkHeaderEditor,
 }) => {
   const wsClient = createWebSocketClient();
   return (
     <WebSocketClientProvider client={wsClient}>
       <RequestPane
         request={request}
-        useBulkHeaderEditor={useBulkHeaderEditor}
-        toggleBulkHeaderEditor={toggleBulkHeaderEditor}
       />
     </WebSocketClientProvider>
   );

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -4,25 +4,15 @@ import styled from 'styled-components';
 
 import { WebSocketRequest } from '../../../models/websocket-request';
 import { createWebSocketClient } from '../../context/websocket-client/create-websocket-client';
+import { ReadyState, useWSReadyState } from '../../context/websocket-client/use-ws-ready-state';
 import { useWebSocketClient, WebSocketClientProvider } from '../../context/websocket-client/websocket-client-context';
 import { CodeEditor, UnconnectedCodeEditor } from '../codemirror/code-editor';
 import { RequestHeadersEditor } from '../editors/request-headers-editor';
 import { Pane, PaneHeader as OriginalPaneHeader } from '../panes/pane';
 import { WebsocketActionBar } from './action-bar';
 
-const PaneBody = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-});
-const PaneBodyContent = styled.div({
-  flex: 1,
-});
 const EditorWrapper = styled.div({
   height: '100%',
-});
-const ButtonWrapper = styled.div({
-  paddingTop: 3,
-  paddingBottom: 3,
 });
 const SendMessageForm = styled.form({
   width: '100%',
@@ -39,21 +29,14 @@ const SendButton = styled.button({
     backgroundColor: 'var(--hl-xs)',
   },
 });
-const PaneBodyTitle = styled.div({
-  position: 'relative',
+const PaneSendButton = styled.div({
   display: 'flex',
   flexDirection: 'row',
-  justifyContent: 'space-between',
-  background: 'var(--color-bg)',
-  color: 'var(--color-font)',
+  justifyContent: 'flex-end',
   boxSizing: 'border-box',
   height: 'var(--line-height-sm)',
-  alignItems: 'stretch',
-});
-const Title = styled.div({
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
+  borderBottom: '1px solid var(--hl-lg)',
+  padding: 3,
 });
 const PaneHeader = styled(OriginalPaneHeader)({
   '&&': { alignItems: 'stretch' },
@@ -91,6 +74,52 @@ interface Props {
 // essentially we can lift up the states and merge request pane and response pane into a single page and divide the UI there.
 // currently this is blocked by the way page layout divide the panes with dragging functionality
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
+const RequestPane: FC<Props> = ({ request, useBulkHeaderEditor, toggleBulkHeaderEditor }) => {
+  const readyState = useWSReadyState(request._id);
+  return (
+    <Pane type="request">
+      <PaneHeader>
+        <WebsocketActionBar requestId={request._id} readyState={readyState} />
+      </PaneHeader>
+      <Tabs className="pane__body theme--pane__body react-tabs">
+        <TabList>
+          <Tab tabIndex="-1" >
+            <button>Message</button>
+          </Tab>
+          <Tab tabIndex="-1" >
+            <button>Headers</button>
+          </Tab>
+        </TabList>
+        <TabPanel className="react-tabs__tab-panel">
+          <PaneSendButton>
+            <SendButton
+              type="submit"
+              form="websocketMessageForm"
+              disabled={readyState !== ReadyState.OPEN}
+            >
+              Send
+            </SendButton>
+          </PaneSendButton>
+          <WebSocketRequestForm requestId={request._id} />
+        </TabPanel>
+        <TabPanel className="react-tabs__tab-panel header-editor">
+          <RequestHeadersEditor
+            request={request}
+            bulk={useBulkHeaderEditor}
+          />
+          <div className="pad-right text-right">
+            <button
+              className="margin-top-sm btn btn--clicky"
+              onClick={toggleBulkHeaderEditor}
+            >
+              {useBulkHeaderEditor ? 'Regular Edit' : 'Bulk Edit'}
+            </button>
+          </div>
+        </TabPanel>
+      </Tabs>
+    </Pane>
+  );
+};
 export const WebSocketRequestPane: FC<Props> = ({
   request,
   useBulkHeaderEditor,
@@ -99,54 +128,11 @@ export const WebSocketRequestPane: FC<Props> = ({
   const wsClient = createWebSocketClient();
   return (
     <WebSocketClientProvider client={wsClient}>
-      <Pane type="request">
-        <PaneHeader>
-          <WebsocketActionBar requestId={request._id} />
-        </PaneHeader>
-        <PaneBody>
-          <Tabs className="pane__body theme--pane__body react-tabs">
-            <TabList>
-              <PaneBodyTitle>
-                <Title>
-                  <Tab tabIndex="-1" >
-                    <button>Message</button>
-                  </Tab>
-                  <Tab tabIndex="-1" >
-                    <button>Headers</button>
-                  </Tab>
-                </Title>
-                <ButtonWrapper>
-                  <SendButton
-                    type="submit"
-                    form="websocketMessageForm"
-                  >
-                    Send
-                  </SendButton>
-                </ButtonWrapper>
-              </PaneBodyTitle>
-            </TabList>
-            <PaneBodyContent>
-              <TabPanel className="react-tabs__tab-panel">
-                <WebSocketRequestForm requestId={request._id} />
-              </TabPanel>
-              <TabPanel className="react-tabs__tab-panel header-editor">
-                <RequestHeadersEditor
-                  request={request}
-                  bulk={useBulkHeaderEditor}
-                />
-                <div className="pad-right text-right">
-                  <button
-                    className="margin-top-sm btn btn--clicky"
-                    onClick={toggleBulkHeaderEditor}
-                  >
-                    {useBulkHeaderEditor ? 'Regular Edit' : 'Bulk Edit'}
-                  </button>
-                </div>
-              </TabPanel>
-            </PaneBodyContent>
-          </Tabs>
-        </PaneBody>
-      </Pane>
+      <RequestPane
+        request={request}
+        useBulkHeaderEditor={useBulkHeaderEditor}
+        toggleBulkHeaderEditor={toggleBulkHeaderEditor}
+      />
     </WebSocketClientProvider>
   );
 };

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -128,7 +128,7 @@ export const WrapperDebug: FC<Props> = ({
               />
             ) : (
               isWebSocketRequest(activeRequest) ? (
-                <WebSocketRequestPane requestId={activeRequest._id} />
+                <WebSocketRequestPane request={activeRequest} />
               ) : (
                 <RequestPane
                   environmentId={activeEnvironment ? activeEnvironment._id : ''}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -1,6 +1,7 @@
-import React, { FC, Fragment, ReactNode } from 'react';
+import React, { FC, Fragment, ReactNode, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
+import * as models from '../../models';
 import { isGrpcRequest } from '../../models/grpc-request';
 import { isRemoteProject } from '../../models/project';
 import { Request, RequestHeader } from '../../models/request';
@@ -77,6 +78,10 @@ export const WrapperDebug: FC<Props> = ({
 
   const isTeamSync = isLoggedIn && activeWorkspace && isCollection(activeWorkspace) && isRemoteProject(activeProject) && vcs;
 
+  const toggleBulkHeaderEditor = useCallback(() => {
+    models.settings.update(settings, { useBulkHeaderEditor: !settings.useBulkHeaderEditor });
+  }, [settings]);
+
   return (
     <PageLayout
       renderPageHeader={activeWorkspace ?
@@ -128,7 +133,11 @@ export const WrapperDebug: FC<Props> = ({
               />
             ) : (
               isWebSocketRequest(activeRequest) ? (
-                <WebSocketRequestPane request={activeRequest} />
+                <WebSocketRequestPane
+                  request={activeRequest}
+                  useBulkHeaderEditor={settings.useBulkHeaderEditor}
+                  toggleBulkHeaderEditor={toggleBulkHeaderEditor}
+                />
               ) : (
                 <RequestPane
                   environmentId={activeEnvironment ? activeEnvironment._id : ''}
@@ -139,6 +148,7 @@ export const WrapperDebug: FC<Props> = ({
                   headerEditorKey={headerEditorKey}
                   request={activeRequest}
                   settings={settings}
+                  toggleBulkHeaderEditor={toggleBulkHeaderEditor}
                   updateRequestMimeType={handleUpdateRequestMimeType}
                   workspace={activeWorkspace}
                 />

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -1,7 +1,6 @@
-import React, { FC, Fragment, ReactNode, useCallback } from 'react';
+import React, { FC, Fragment, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
-import * as models from '../../models';
 import { isGrpcRequest } from '../../models/grpc-request';
 import { isRemoteProject } from '../../models/project';
 import { Request, RequestHeader } from '../../models/request';
@@ -78,10 +77,6 @@ export const WrapperDebug: FC<Props> = ({
 
   const isTeamSync = isLoggedIn && activeWorkspace && isCollection(activeWorkspace) && isRemoteProject(activeProject) && vcs;
 
-  const toggleBulkHeaderEditor = useCallback(() => {
-    models.settings.update(settings, { useBulkHeaderEditor: !settings.useBulkHeaderEditor });
-  }, [settings]);
-
   return (
     <PageLayout
       renderPageHeader={activeWorkspace ?
@@ -135,8 +130,6 @@ export const WrapperDebug: FC<Props> = ({
               isWebSocketRequest(activeRequest) ? (
                 <WebSocketRequestPane
                   request={activeRequest}
-                  useBulkHeaderEditor={settings.useBulkHeaderEditor}
-                  toggleBulkHeaderEditor={toggleBulkHeaderEditor}
                 />
               ) : (
                 <RequestPane
@@ -148,7 +141,6 @@ export const WrapperDebug: FC<Props> = ({
                   headerEditorKey={headerEditorKey}
                   request={activeRequest}
                   settings={settings}
-                  toggleBulkHeaderEditor={toggleBulkHeaderEditor}
                   updateRequestMimeType={handleUpdateRequestMimeType}
                   workspace={activeWorkspace}
                 />


### PR DESCRIPTION
Motivation: Send custom headers

## Highlights
- adds header tab to request pane
- extends RequestHeaderEditor component to support WebSocketRequest and readOnly headers
- adds outgoing header logging to ws smoke test server

## Todo
- [x] add headers tab
- [x] init model with some defaults
- [x] get everything rendering consistently
- [x] wire up bulk editor toggle
- [x] fix tab/button/bar css alignment
- [x] make default header values accurate
- [x] disable editing while connected


## Possible future work
- nunjucks rendering, not done in message tab yet, better tackled at the same time
- prettify event log view / payload
- add upgrade event, response status code/message, headers and handle set-cookies
- add outgoing headers to request object?


## Notes: 
Since the websocket client doesn't expose the request headers which are actually sent to the server. 
We can either construct it or perhaps redirect it through a local server to capture, but for now we show the headers as read only in the headers tab.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
