### PR TITLE
[INS-1789] Fix issue preventing selection of custom HTTP methods

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
@@ -46,7 +46,7 @@ export const MethodDropdown = forwardRef<DropdownHandle, Props>(({
         // It solves the case where you try to delete more than one method at a time, because recent is updated only once
         const localStorageHttpMethods = window.localStorage.getItem(LOCALSTORAGE_KEY);
         const currentRecent = localStorageHttpMethods ? JSON.parse(localStorageHttpMethods) as string[] : [];
-        const newRecent = currentRecent.filter((m: any) => m !== methodToDelete);
+        const newRecent = currentRecent.filter(m => m !== methodToDelete);
         setRecent(newRecent);
         window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(newRecent));
       },

--- a/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
@@ -44,7 +44,8 @@ export const MethodDropdown = forwardRef<DropdownHandle, Props>(({
       onDeleteHint: methodToDelete => {
         // Note: We need to read and remove the method from localStorage and not rely on react state
         // It solves the case where you try to delete more than one method at a time, because recent is updated only once
-        const currentRecent = JSON.parse(window.localStorage.getItem(LOCALSTORAGE_KEY) as string);
+        const localStorageHttpMethods = window.localStorage.getItem(LOCALSTORAGE_KEY);
+        const currentRecent = localStorageHttpMethods ? JSON.parse(localStorageHttpMethods) as string[] : [];
         const newRecent = currentRecent.filter((m: any) => m !== methodToDelete);
         setRecent(newRecent);
         window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(newRecent));
@@ -61,7 +62,8 @@ export const MethodDropdown = forwardRef<DropdownHandle, Props>(({
 
         // Note: We need to read and remove the method from localStorage and not rely on react state
         // It solves the case where you try to add a new method after you deleted some others
-        const currentRecent = JSON.parse(window.localStorage.getItem(LOCALSTORAGE_KEY) as string);
+        const localStorageHttpMethods = window.localStorage.getItem(LOCALSTORAGE_KEY);
+        const currentRecent = localStorageHttpMethods ? JSON.parse(localStorageHttpMethods) as string[] : [];
         // Save method as recent
         if (!currentRecent.includes(methodToAdd)) {
           const newRecent = [...currentRecent, methodToAdd];

--- a/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-dropdown.tsx
@@ -42,8 +42,12 @@ export const MethodDropdown = forwardRef<DropdownHandle, Props>(({
       placeholder: 'CUSTOM',
       hints: recent,
       onDeleteHint: methodToDelete => {
-        setRecent(recent.filter(m => m !== methodToDelete));
-        window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(recent.filter(m => m !== methodToDelete)));
+        // Note: We need to read and remove the method from localStorage and not rely on react state
+        // It solves the case where you try to delete more than one method at a time, because recent is updated only once
+        const currentRecent = JSON.parse(window.localStorage.getItem(LOCALSTORAGE_KEY) as string);
+        const newRecent = currentRecent.filter((m: any) => m !== methodToDelete);
+        setRecent(newRecent);
+        window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(newRecent));
       },
       onComplete: methodToAdd => {
         // Don't add empty methods
@@ -54,12 +58,16 @@ export const MethodDropdown = forwardRef<DropdownHandle, Props>(({
         if (constants.HTTP_METHODS.includes(methodToAdd)) {
           return;
         }
+
+        // Note: We need to read and remove the method from localStorage and not rely on react state
+        // It solves the case where you try to add a new method after you deleted some others
+        const currentRecent = JSON.parse(window.localStorage.getItem(LOCALSTORAGE_KEY) as string);
         // Save method as recent
-        if (recent.includes(methodToAdd)) {
-          return;
+        if (!currentRecent.includes(methodToAdd)) {
+          const newRecent = [...currentRecent, methodToAdd];
+          setRecent(newRecent);
+          window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(newRecent));
         }
-        setRecent([...recent, methodToAdd]);
-        window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(recent));
         onChange(methodToAdd);
       },
     });


### PR DESCRIPTION
changelog(Fixes): Fixed an issue that prevented choosing and deleting user-created custom HTTP methods

Closes INS-1789
Closes #5083 

This PR fixes two regressions:
- A user couldn't select an existing Custom HTTP method;
- A user couldn't delete more than one HTTP method at a time, needing to close and reopen the custom-methods dialogue.

These issues seem to have spawned from two problems:
- We returned early when trying to pick a custom method that already existed
- Relying on `recent` and `setRecent` doesn't seem to do what we think it does, and is only "valid for one change", hence why I edited the addition and deletion to rely on localStorage instead. I'm open to suggestions on how to improve this, it felt like a hacky workaround, but I couldn't find another way to make it work due to `setRecent` not working "a second time in a row" for the same time the modal is open.

⚠️ this PR doesn't solve a problem that we had before in earlier versions of Insomnia - where if we press `Enter` on the Custom Method modal, it is not seemingly picked up like pressing the `Done` button.