### PR TITLE
INS-1788: Add control flow to improve responsiveness.

### DIFF
--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -43,12 +43,12 @@ const webSocketConnection = {
     },
     subscribe: (
       options: { responseId: string },
-      listener: (webSocketEvent: WebsocketEvent[]) => any
+      listener: (webSocketEvents: WebsocketEvent[]) => any
     ) => {
       const channel = `webSocketRequest.connection.${options.responseId}.event`;
 
-      function onNewEvent(_event: IpcRendererEvent, webSocketEvent: WebsocketEvent[]) {
-        listener(webSocketEvent);
+      function onNewEvent(_event: IpcRendererEvent, webSocketEvents: WebsocketEvent[]) {
+        listener(webSocketEvents);
       }
 
       ipcRenderer.on(channel, onNewEvent);

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -43,11 +43,11 @@ const webSocketConnection = {
     },
     subscribe: (
       options: { responseId: string },
-      listener: (webSocketEvent: WebsocketEvent) => any
+      listener: (webSocketEvent: WebsocketEvent[]) => any
     ) => {
       const channel = `webSocketRequest.connection.${options.responseId}.event`;
 
-      function onNewEvent(_event: IpcRendererEvent, webSocketEvent: WebsocketEvent) {
+      function onNewEvent(_event: IpcRendererEvent, webSocketEvent: WebsocketEvent[]) {
         listener(webSocketEvent);
       }
 
@@ -64,6 +64,9 @@ const webSocketConnection = {
         'webSocketRequest.connection.event.send',
         options
       );
+    },
+    clearToSend: () => {
+      return ipcRenderer.invoke('webSocketRequest.connection.clearToSend');
     },
   },
 };

--- a/packages/insomnia/src/ui/context/websocket-client/test-utils.ts
+++ b/packages/insomnia/src/ui/context/websocket-client/test-utils.ts
@@ -14,6 +14,7 @@ export const getMockWsClient = (onChangeEvent: EventEmitter) => {
         onChangeEvent.on(channel, listener);
         return () => onChangeEvent.removeListener(channel, listener);
       },
+      clearToSend: jest.fn(),
     },
     create: jest.fn(),
     close: jest.fn(),

--- a/packages/insomnia/src/ui/context/websocket-client/use-ws-connection-events.ts
+++ b/packages/insomnia/src/ui/context/websocket-client/use-ws-connection-events.ts
@@ -34,6 +34,10 @@ export function useWebSocketConnectionEvents({ responseId }: { responseId: strin
           if (isMounted) {
             setEvents(allEvents => allEvents.concat(events));
           }
+
+          // Wait to give the CTS signal until we've rendered a frame.
+          // This gives the UI a chance to render and respond to user interactions between receiving events.
+          // Note that we do this even if the component isn't mounted, to ensure that CTS gets set even if a race occurs.
           window.requestAnimationFrame(clearToSend);
         }
       );


### PR DESCRIPTION
This prevents events from flooding the UI thread; currently, when a lot of events are coming in, they come in one-by-one but completely block the UI. This causes events to come in at a much faster rate, although for now the UI gets very sluggish quickly. (When the viewport is virtualized, it should allow for events to come in at a very fast rate; right now, if you limit the rendering to a fixed number of events, there is no noticeable slowdown. So we're bottlenecked on rendering, now.)