### PR TITLE
[ISSUE-5106] converts path variables with invalid characters to regex with underscores

### DIFF
--- a/packages/openapi-2-kong/src/common.test.ts
+++ b/packages/openapi-2-kong/src/common.test.ts
@@ -242,6 +242,18 @@ describe('common', () => {
     it('does not convert to regex if no variables present', () => {
       expect(pathVariablesToRegex('/foo/bar/baz')).toBe('/foo/bar/baz$');
     });
+
+    it('converts variables with invalid characters to regex with underscores', () => {
+      expect(pathVariablesToRegex('/foo/{bar@var}/{baz-var}')).toBe('/foo/(?<bar_var>[^\\/]+)/(?<baz_var>[^\\/]+)$');
+    });
+
+    it('does not convert invalid characters not in a variable name', () => {
+      expect(pathVariablesToRegex('/foo-bar/baz')).not.toBe('/foo_bar/baz$');
+    });
+
+    it('does not convert numbers in a variable name', () => {
+      expect(pathVariablesToRegex('/foo/{bar9}/{baz6}')).toBe('/foo/(?<bar9>[^\\/]+)/(?<baz6>[^\\/]+)$');
+    });
   });
 
   describe('getPluginNameFromKey()', () => {

--- a/packages/openapi-2-kong/src/common.ts
+++ b/packages/openapi-2-kong/src/common.ts
@@ -71,9 +71,9 @@ const invalidPathVariableCharacters = /[^\w]/g;
 export function pathVariablesToRegex(p: string) {
   const result = p
     // match anything except whitespace and '/'
-    .replace(pathVariableSearchValue, (_match, b) => {
+    .replace(pathVariableSearchValue, (_match, pathVariableString) => {
       // replace all invalid with an underscore, so that the regex remains valid
-      const validCapturingGroupName = b.replace(invalidPathVariableCharacters, '_');
+      const validCapturingGroupName = pathVariableString.replace(invalidPathVariableCharacters, '_');
       return `(?<${validCapturingGroupName}>[^\\/]+)`;
     });
   // add a line ending because it is a regex

--- a/packages/openapi-2-kong/src/common.ts
+++ b/packages/openapi-2-kong/src/common.ts
@@ -65,9 +65,17 @@ export function generateSlug(str: string, options: SlugifyOptions = {}) {
 /** characters in curly braces not immediately followed by `://`, e.g. `{foo}` will match but `{foo}://` will not. */
 const pathVariableSearchValue = /{([^}]+)}(?!:\/\/)/g;
 
+// Any character that isn't allowed in a regex capturing group
+const invalidPathVariableCharacters = /[^\w]/g;
+
 export function pathVariablesToRegex(p: string) {
-  // match anything except whitespace and '/'
-  const result = p.replace(pathVariableSearchValue, '(?<$1>[^\\/]+)');
+  const result = p
+    // match anything except whitespace and '/'
+    .replace(pathVariableSearchValue, (_match, b) => {
+      // replace all invalid with an underscore, so that the regex remains valid
+      const validCapturingGroupName = b.replace(invalidPathVariableCharacters, '_');
+      return `(?<${validCapturingGroupName}>[^\\/]+)`;
+    });
   // add a line ending because it is a regex
   return result + '$';
 }


### PR DESCRIPTION
changelog(OpenAPI-2-Kong): Fixed an issue where path variables with special characters in OpenAPI spec would get converted to invalid regex expressions

Fixes a bug where variable regexes generated by kong-2-openapi contained characters that are invalid (and thus not accepted by kong).

Closes [ISSUE-5106](https://github.com/Kong/insomnia/issues/5106)