### PR TITLE
[INS-1805] Add Auth Header Tab

### DIFF
--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -25,7 +25,20 @@ export const isDevelopment = () => getAppEnvironment() === 'development';
 export const getSegmentWriteKey = () => appConfig.segmentWriteKeys[(isDevelopment() || env.PLAYWRIGHT) ? 'development' : 'production'];
 export const getSentryDsn = () => appConfig.sentryDsn;
 export const getAppBuildDate = () => new Date(process.env.BUILD_DATE ?? '').toLocaleDateString();
-
+export type AuthType =
+  | 'none'
+  | 'oauth2'
+  | 'oauth1'
+  | 'basic'
+  | 'digest'
+  | 'bearer'
+  | 'ntlm'
+  | 'hawk'
+  | 'iam'
+  | 'netrc'
+  | 'asap'
+  | 'sha256'
+  | 'sha1';
 export const getBrowserUserAgent = () => encodeURIComponent(
   String(window.navigator.userAgent)
     .replace(new RegExp(`${getAppId()}\\/\\d+\\.\\d+\\.\\d+ `), '')

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -1,6 +1,6 @@
 import { database } from '../common/database';
 import type { BaseModel } from '.';
-import { RequestHeader } from './request';
+import { RequestAuthentication, RequestHeader } from './request';
 
 export const name = 'WebSocket Request';
 
@@ -18,6 +18,7 @@ export interface BaseWebSocketRequest {
   url: string;
   metaSortKey: number;
   headers: RequestHeader[];
+  authentication: RequestAuthentication;
 }
 
 export type WebSocketRequest = BaseModel & BaseWebSocketRequest & { type: typeof type };
@@ -35,9 +36,8 @@ export const init = (): BaseWebSocketRequest => ({
   url: '',
   metaSortKey: -1 * Date.now(),
   headers: [],
+  authentication: {},
 });
-
-export const migrate = (doc: WebSocketRequest) => doc;
 
 export const create = (patch: Partial<WebSocketRequest> = {}) => {
   if (!patch.parentId) {

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -39,6 +39,8 @@ export const init = (): BaseWebSocketRequest => ({
   authentication: {},
 });
 
+export const migrate = (doc: WebSocketRequest) => doc;
+
 export const create = (patch: Partial<WebSocketRequest> = {}) => {
   if (!patch.parentId) {
     throw new Error(`New WebSocketRequest missing \`parentId\`: ${JSON.stringify(patch)}`);

--- a/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
@@ -29,7 +29,6 @@ const defaultTypes: AuthType[] = [
   'hawk',
   'asap',
   'netrc',
-  'none',
 ];
 
 function makeNewAuth(type: string, oldAuth: RequestAuthentication = {}): RequestAuthentication {
@@ -172,7 +171,7 @@ export const AuthDropdown: FC<Props> = ({ authTypes = defaultTypes, disabled = f
         break;
       }
     }
-    update(activeRequest, { authentication:newAuthentication });
+    update(activeRequest, { authentication: newAuthentication });
   }, [activeRequest]);
   const isCurrent = useCallback((type: AuthType) => {
     if (!activeRequest || !('authentication' in activeRequest)) {
@@ -194,29 +193,21 @@ export const AuthDropdown: FC<Props> = ({ authTypes = defaultTypes, disabled = f
         {'authentication' in activeRequest ? getAuthTypeName(activeRequest.authentication.type) || 'Auth' : 'Auth'}
         <i className="fa fa-caret-down space-left" />
       </DropdownButton>
-      {authTypes.reduce<ReactElement[]>((acc: ReactElement[], authType: AuthType) => {
-        if (authType === 'none') {
-          return acc.concat([
-            <DropdownDivider key="divider-other">
-              Other
-            </DropdownDivider>,
-            <AuthItem
-              key={authType}
-              type={authType}
-              nameOverride="No Authentication"
-              {...itemProps}
-            />,
-          ]);
-        }
-
-        return acc.concat(
-          <AuthItem
-            key={authType}
-            type={authType}
-            {...itemProps}
-          />
-        );
-      }, [])}
+      {authTypes.map(authType =>
+        <AuthItem
+          key={authType}
+          type={authType}
+          {...itemProps}
+        />)}
+      <DropdownDivider key="divider-other">
+        Other
+      </DropdownDivider>
+      <AuthItem
+        key="none"
+        type="none"
+        nameOverride="No Authentication"
+        {...itemProps}
+      />
     </Dropdown>
   );
 };

--- a/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import {

--- a/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
@@ -133,8 +133,9 @@ AuthItem.displayName = DropdownItem.name;
 
 interface Props {
   authTypes?: AuthType[];
+  disabled?: boolean;
 }
-export const AuthDropdown: FC<Props> = ({ authTypes = defaultTypes }) => {
+export const AuthDropdown: FC<Props> = ({ authTypes = defaultTypes, disabled = false }) => {
   const activeRequest = useSelector(selectActiveRequest);
 
   const onClick = useCallback(async (type: AuthType) => {
@@ -189,7 +190,7 @@ export const AuthDropdown: FC<Props> = ({ authTypes = defaultTypes }) => {
   return (
     <Dropdown beside>
       <DropdownDivider>Auth Types</DropdownDivider>
-      <DropdownButton className="tall">
+      <DropdownButton className="tall" disabled={disabled}>
         {'authentication' in activeRequest ? getAuthTypeName(activeRequest.authentication.type) || 'Auth' : 'Auth'}
         <i className="fa fa-caret-down space-left" />
       </DropdownButton>

--- a/packages/insomnia/src/ui/components/editors/auth/asap-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/asap-auth.tsx
@@ -3,9 +3,11 @@ import React, { FC } from 'react';
 import { AuthInputRow } from './components/auth-input-row';
 import { AuthPrivateKeyRow } from './components/auth-private-key-row';
 import { AuthTableBody } from './components/auth-table-body';
+import { AuthToggleRow } from './components/auth-toggle-row';
 
 export const AsapAuth: FC = () => (
   <AuthTableBody>
+    <AuthToggleRow label="Enabled" property="disabled" invert />
     <AuthInputRow label='Issuer (iss)' property='issuer' />
     <AuthInputRow label='Subject (sub)' property='subject' />
     <AuthInputRow label='Audience (aud)' property='audience' />

--- a/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
@@ -25,7 +25,7 @@ import { NTLMAuth } from './ntlm-auth';
 import { OAuth1Auth } from './o-auth-1-auth';
 import { OAuth2Auth } from './o-auth-2-auth';
 
-export const AuthWrapper: FC = () => {
+export const AuthWrapper: FC<{ disabled?: boolean }> = ({ disabled = false }) => {
   const request = useSelector(selectActiveRequest);
 
   if (!request || !('authentication' in request)) {
@@ -37,7 +37,7 @@ export const AuthWrapper: FC = () => {
   let authBody: ReactNode = null;
 
   if (type === AUTH_BASIC) {
-    authBody = <BasicAuth />;
+    authBody = <BasicAuth disabled={disabled} />;
   } else if (type === AUTH_OAUTH_2) {
     authBody = <OAuth2Auth />;
   } else if (type === AUTH_HAWK) {
@@ -45,11 +45,11 @@ export const AuthWrapper: FC = () => {
   } else if (type === AUTH_OAUTH_1) {
     authBody = <OAuth1Auth />;
   } else if (type === AUTH_DIGEST) {
-    authBody = <DigestAuth />;
+    authBody = <DigestAuth disabled={disabled} />;
   } else if (type === AUTH_NTLM) {
     authBody = <NTLMAuth />;
   } else if (type === AUTH_BEARER) {
-    authBody = <BearerAuth />;
+    authBody = <BearerAuth disabled={disabled} />;
   } else if (type === AUTH_AWS_IAM) {
     authBody = <AWSAuth />;
   } else if (type === AUTH_NETRC) {

--- a/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
@@ -13,7 +13,6 @@ import {
   AUTH_OAUTH_1,
   AUTH_OAUTH_2,
 } from '../../../../common/constants';
-import { isRequest } from '../../../../models/request';
 import { selectActiveRequest } from '../../../redux/selectors';
 import { AsapAuth } from './asap-auth';
 import { AWSAuth } from './aws-auth';
@@ -29,7 +28,7 @@ import { OAuth2Auth } from './o-auth-2-auth';
 export const AuthWrapper: FC = () => {
   const request = useSelector(selectActiveRequest);
 
-  if (!request || !isRequest(request)) {
+  if (!request || !('authentication' in request)) {
     return null;
   }
 

--- a/packages/insomnia/src/ui/components/editors/auth/aws-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/aws-auth.tsx
@@ -2,9 +2,11 @@ import React, { FC } from 'react';
 
 import { AuthInputRow } from './components/auth-input-row';
 import { AuthTableBody } from './components/auth-table-body';
+import { AuthToggleRow } from './components/auth-toggle-row';
 
 export const AWSAuth: FC = () => (
   <AuthTableBody>
+    <AuthToggleRow label="Enabled" property="disabled" invert />
     <AuthInputRow
       label="Access Key ID"
       property="accessKeyId"

--- a/packages/insomnia/src/ui/components/editors/auth/basic-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/basic-auth.tsx
@@ -4,14 +4,16 @@ import { AuthInputRow } from './components/auth-input-row';
 import { AuthTableBody } from './components/auth-table-body';
 import { AuthToggleRow } from './components/auth-toggle-row';
 
-export const BasicAuth: FC = () => (
+export const BasicAuth: FC<{ disabled?: boolean }> = ({ disabled = false }) => (
   <AuthTableBody>
-    <AuthInputRow label="Username" property="username" />
-    <AuthInputRow label="Password" property="password" mask />
+    <AuthToggleRow label="Enabled" property="disabled" invert disabled={disabled} />
+    <AuthInputRow label="Username" property="username" disabled={disabled} />
+    <AuthInputRow label="Password" property="password" mask disabled={disabled} />
     <AuthToggleRow
       label="Use ISO 8859-1"
       help="Check this to use ISO-8859-1 encoding instead of default UTF-8"
       property='useISO88591'
+      disabled={disabled}
     />
   </AuthTableBody>
 );

--- a/packages/insomnia/src/ui/components/editors/auth/bearer-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/bearer-auth.tsx
@@ -2,10 +2,12 @@ import React, { FC } from 'react';
 
 import { AuthInputRow } from './components/auth-input-row';
 import { AuthTableBody } from './components/auth-table-body';
+import { AuthToggleRow } from './components/auth-toggle-row';
 
-export const BearerAuth: FC = () => (
+export const BearerAuth: FC<{ disabled?: boolean }> = ({ disabled = false }) => (
   <AuthTableBody>
-    <AuthInputRow label='Token' property='token' />
-    <AuthInputRow label='Prefix' property='prefix' />
+    <AuthToggleRow label="Enabled" property="disabled" invert disabled={disabled} />
+    <AuthInputRow label='Token' property='token' disabled={disabled} />
+    <AuthInputRow label='Prefix' property='prefix' disabled={disabled} />
   </AuthTableBody>
 );

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-input-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-input-row.tsx
@@ -14,9 +14,10 @@ interface Props extends Pick<ComponentProps<typeof OneLineEditor>, 'getAutocompl
   property: string;
   help?: ReactNode;
   mask?: boolean;
+  disabled?: boolean;
 }
 
-export const AuthInputRow: FC<Props> = ({ label, getAutocompleteConstants, property, mask, mode, help }) => {
+export const AuthInputRow: FC<Props> = ({ label, getAutocompleteConstants, property, mask, mode, help, disabled = false }) => {
   const { showPasswords } = useSelector(selectSettings);
   const { activeRequest: { authentication }, patchAuth } = useActiveRequest();
 
@@ -32,13 +33,14 @@ export const AuthInputRow: FC<Props> = ({ label, getAutocompleteConstants, prope
   const id = toKebabCase(label);
 
   return (
-    <AuthRow labelFor={id} label={label} help={help}>
+    <AuthRow labelFor={id} label={label} help={help} disabled={disabled}>
       <OneLineEditor
         id={id}
         type={isMasked ? 'password' : 'text'}
         mode={mode}
         onChange={onChange}
         disabled={authentication.disabled}
+        readOnly={disabled}
         defaultValue={authentication[property] || ''}
         getAutocompleteConstants={getAutocompleteConstants}
       />
@@ -47,6 +49,7 @@ export const AuthInputRow: FC<Props> = ({ label, getAutocompleteConstants, prope
           className="btn btn--super-duper-compact pointer"
           onClick={onClick}
           value={isMasked}
+          disabled={disabled}
         >
           {isMasked ? <i className="fa fa-eye" data-testid="reveal-password-icon" /> : <i className="fa fa-eye-slash" data-testid="mask-password-icon" />}
         </Button>

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-table-body.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-table-body.tsx
@@ -1,12 +1,9 @@
 import React, { FC, ReactNode } from 'react';
 
-import { AuthEnabledRow } from './auth-enabled-row';
-
 export const AuthTableBody: FC<{children: ReactNode}> = ({ children }) => (
   <div className="pad">
     <table>
       <tbody>
-        <AuthEnabledRow />
         {children}
       </tbody>
     </table>

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-toggle-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-toggle-row.tsx
@@ -12,6 +12,7 @@ interface Props {
   help?: ReactNode;
   onTitle?: string;
   offTitle?: string;
+  disabled?: boolean;
 }
 
 const ToggleIcon: FC<{isOn: boolean}> = ({ isOn }) => isOn ? <i data-testid="toggle-is-on" className="fa fa-check-square-o" /> : <i data-testid="toggle-is-off" className="fa fa-square-o" />;
@@ -23,6 +24,7 @@ export const AuthToggleRow: FC<Props> = ({
   invert,
   onTitle = 'Disable item',
   offTitle = 'Enable item',
+  disabled = false,
 }) => {
   const { activeRequest: { authentication }, patchAuth } = useActiveRequest();
 
@@ -38,13 +40,14 @@ export const AuthToggleRow: FC<Props> = ({
   const title = isActuallyOn ? onTitle : offTitle;
 
   return (
-    <AuthRow labelFor={id} label={label} help={help}>
+    <AuthRow labelFor={id} label={label} help={help} disabled={disabled}>
       <Button
         className="btn btn--super-duper-compact"
         id={id}
         onClick={toggle}
         value={!databaseValue}
         title={title}
+        disabled={disabled}
       >
         <ToggleIcon isOn={isActuallyOn} />
       </Button>

--- a/packages/insomnia/src/ui/components/editors/auth/digest-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/digest-auth.tsx
@@ -2,10 +2,12 @@ import React, { FC } from 'react';
 
 import { AuthInputRow } from './components/auth-input-row';
 import { AuthTableBody } from './components/auth-table-body';
+import { AuthToggleRow } from './components/auth-toggle-row';
 
-export const DigestAuth: FC = () => (
+export const DigestAuth: FC<{ disabled?: boolean }> = ({ disabled = false }) => (
   <AuthTableBody>
-    <AuthInputRow label='Username' property='username' />
-    <AuthInputRow label='Password' property='password' mask />
+    <AuthToggleRow label="Enabled" property="disabled" invert disabled={disabled} />
+    <AuthInputRow label='Username' property='username' disabled={disabled} />
+    <AuthInputRow label='Password' property='password' mask disabled={disabled} />
   </AuthTableBody>
 );

--- a/packages/insomnia/src/ui/components/editors/auth/hawk-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/hawk-auth.tsx
@@ -11,6 +11,7 @@ import { AuthToggleRow } from './components/auth-toggle-row';
 
 export const HawkAuth: FC = () => (
   <AuthTableBody>
+    <AuthToggleRow label="Enabled" property="disabled" invert />
     <AuthInputRow label='Auth Id' property='id' />
     <AuthInputRow label='Auth Key' property='key' />
     <AuthSelectRow

--- a/packages/insomnia/src/ui/components/editors/auth/ntlm-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/ntlm-auth.tsx
@@ -2,9 +2,11 @@ import React, { FC } from 'react';
 
 import { AuthInputRow } from './components/auth-input-row';
 import { AuthTableBody } from './components/auth-table-body';
+import { AuthToggleRow } from './components/auth-toggle-row';
 
 export const NTLMAuth: FC = () => (
   <AuthTableBody>
+    <AuthToggleRow label="Enabled" property="disabled" invert />
     <AuthInputRow label="Username" property="username" />
     <AuthInputRow label="Password" property="password" mask />
   </AuthTableBody>

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-1-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-1-auth.tsx
@@ -37,6 +37,7 @@ export const OAuth1Auth: FC = () => {
 
   return (
     <AuthTableBody>
+      <AuthToggleRow label="Enabled" property="disabled" invert />
       <AuthInputRow label='Consumer Key' property='consumerKey' />
       <AuthInputRow label='Consumer Secret' property='consumerSecret' />
       <AuthInputRow label='Token Key' property='tokenKey' />

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -255,6 +255,7 @@ export const OAuth2Auth: FC = () => {
   return (
     <>
       <AuthTableBody>
+        <AuthToggleRow label="Enabled" property="disabled" invert />
         <AuthSelectRow
           label='Grant Type'
           property='grantType'

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -2,6 +2,7 @@ import React, { ChangeEvent, FC, FormEvent, useRef } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import styled from 'styled-components';
 
+import { AuthType } from '../../../common/constants';
 import * as models from '../../../models';
 import { WebSocketRequest } from '../../../models/websocket-request';
 import { ReadyState, useWSReadyState } from '../../context/websocket-client/use-ws-ready-state';
@@ -11,6 +12,8 @@ import { AuthWrapper } from '../editors/auth/auth-wrapper';
 import { RequestHeadersEditor } from '../editors/request-headers-editor';
 import { Pane, PaneHeader as OriginalPaneHeader } from '../panes/pane';
 import { WebSocketActionBar } from './action-bar';
+
+const supportedAuthTypes: AuthType[] = ['basic', 'digest', 'bearer'];
 
 const EditorWrapper = styled.div({
   height: '100%',
@@ -103,7 +106,7 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId }) => {
             <button>Headers</button>
           </Tab>
           <Tab tabIndex="-1" >
-            <AuthDropdown />
+            <AuthDropdown authTypes={supportedAuthTypes} />
           </Tab>
         </TabList>
         <TabPanel className="react-tabs__tab-panel">
@@ -127,7 +130,10 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId }) => {
           />
         </TabPanel>
         <TabPanel className="react-tabs__tab-panel">
-          <AuthWrapper />
+          <AuthWrapper
+            key={`${request._id}-${readyState}-auth-header`}
+            disabled={readyState === ReadyState.OPEN || readyState === ReadyState.CLOSING}
+          />
         </TabPanel>
       </Tabs>
     </Pane>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -78,6 +78,7 @@ interface Props {
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
 export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId }) => {
   const readyState = useWSReadyState(request._id);
+  const disabled = readyState === ReadyState.OPEN || readyState === ReadyState.CLOSING;
   const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
     const url = event.currentTarget.value || '';
     if (url !== request.url) {
@@ -106,7 +107,10 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId }) => {
             <button>Headers</button>
           </Tab>
           <Tab tabIndex="-1" >
-            <AuthDropdown authTypes={supportedAuthTypes} />
+            <AuthDropdown
+              authTypes={supportedAuthTypes}
+              disabled={disabled}
+            />
           </Tab>
         </TabList>
         <TabPanel className="react-tabs__tab-panel">
@@ -131,7 +135,7 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId }) => {
         </TabPanel>
         <TabPanel className="react-tabs__tab-panel">
           <AuthWrapper
-            key={`${request._id}-${readyState}-auth-header`}
+            key={`${request._id}-${request.authentication.type}-auth-header`}
             disabled={readyState === ReadyState.OPEN || readyState === ReadyState.CLOSING}
           />
         </TabPanel>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -6,6 +6,8 @@ import * as models from '../../../models';
 import { WebSocketRequest } from '../../../models/websocket-request';
 import { ReadyState, useWSReadyState } from '../../context/websocket-client/use-ws-ready-state';
 import { CodeEditor, UnconnectedCodeEditor } from '../codemirror/code-editor';
+import { AuthDropdown } from '../dropdowns/auth-dropdown';
+import { AuthWrapper } from '../editors/auth/auth-wrapper';
 import { RequestHeadersEditor } from '../editors/request-headers-editor';
 import { Pane, PaneHeader as OriginalPaneHeader } from '../panes/pane';
 import { WebSocketActionBar } from './action-bar';
@@ -100,6 +102,9 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId }) => {
           <Tab tabIndex="-1" >
             <button>Headers</button>
           </Tab>
+          <Tab tabIndex="-1" >
+            <AuthDropdown />
+          </Tab>
         </TabList>
         <TabPanel className="react-tabs__tab-panel">
           <PaneSendButton>
@@ -120,6 +125,9 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId }) => {
             bulk={false}
             isDisabled={readyState === ReadyState.OPEN}
           />
+        </TabPanel>
+        <TabPanel className="react-tabs__tab-panel">
+          <AuthWrapper />
         </TabPanel>
       </Tabs>
     </Pane>

--- a/packages/insomnia/src/ui/hooks/use-active-request.ts
+++ b/packages/insomnia/src/ui/hooks/use-active-request.ts
@@ -1,29 +1,24 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import * as models from '../../models';
-import { isRequest, Request } from '../../models/request';
+import * as requestOperations from '../../models/helpers/request-operations';
+import { Request, RequestAuthentication } from '../../models/request';
+import { WebSocketRequest } from '../../models/websocket-request';
 import { selectActiveRequest } from '../redux/selectors';
 
 export const useActiveRequest = () => {
   const activeRequest = useSelector(selectActiveRequest);
 
-  if (!activeRequest) {
-    throw new Error('Tried to load null request');
+  if (!activeRequest || !('authentication' in activeRequest)) {
+    throw new Error('Tried to load invalid request type');
   }
 
-  if (!isRequest(activeRequest)) {
-    throw new Error('Expected to load Request');
-  }
-
-  const patchRequest = useCallback(async (patch: Partial<Request>) => {
-    await models.request.update(activeRequest, patch);
+  const updateAuth = useCallback((authentication: RequestAuthentication) => {
+    requestOperations.update(activeRequest, { authentication });
   }, [activeRequest]);
 
-  const updateAuth = useCallback((authentication: Request['authentication']) => patchRequest({ authentication }), [patchRequest]);
-
   const { authentication } = activeRequest;
-  const patchAuth = useCallback((patch: Partial<Request['authentication']>) => updateAuth({ ...authentication, ...patch }), [authentication, updateAuth]);
+  const patchAuth = useCallback((patch: Partial<Request['authentication'] | WebSocketRequest['authentication']>) => updateAuth({ ...authentication, ...patch }), [authentication, updateAuth]);
 
   return {
     activeRequest,


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

This PR adds the following additions;
- checking 'authentication' prop instead of checking a request type
- adding 'disabled' prop to disable components when the websocket connection is open, closing.

| Screenshot | Description |
| --- | ----------- |
| <img width="712" alt="image" src="https://user-images.githubusercontent.com/103070941/186481054-23114b63-3140-4e17-8de0-2b68f4842709.png"> | AuthDropdown |
| <img width="716" alt="image" src="https://user-images.githubusercontent.com/103070941/186481191-56eb47d2-c8bc-4e0d-b38e-9bd3d2037c5c.png"> | Basic Auth |
| <img width="713" alt="image" src="https://user-images.githubusercontent.com/103070941/186481311-7d9208c0-9838-4f3d-9153-72c833d81f64.png"> | Digest Auth |
| <img width="719" alt="image" src="https://user-images.githubusercontent.com/103070941/186481416-174cf166-8fc2-408f-9cc7-f597bc3a9e5e.png"> | Bearer Auth |
| <img width="937" alt="image" src="https://user-images.githubusercontent.com/103070941/186481268-8de690fc-5994-47f7-90d5-5e5ff5711d9e.png"> | Switching from one auth to another |
| <img width="717" alt="image" src="https://user-images.githubusercontent.com/103070941/186989246-b136eab1-a748-44af-9909-ba93274bc4df.png"> <img width="715" alt="image" src="https://user-images.githubusercontent.com/103070941/186989347-37a69fed-6dd4-46f5-ad87-eb1a48426e8b.png"> <img width="716" alt="image" src="https://user-images.githubusercontent.com/103070941/186989482-50c3e08e-0af4-46a2-b2a1-aa0a398ac397.png"> | Disabled states |
