### PR TITLE
INS-1785: Add Inso NPM package test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,9 @@ jobs:
           echo ::set-output name=pkg-name::$PKG_NAME
           echo ::set-output name=inso-version::$INSO_VERSION
 
+      - name: Run Inso NPM package tests
+        run: npm run inso-test
+
       - name: Package Inso CLI binary
         run: npm run inso-package
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
           echo ::set-output name=inso-version::$INSO_VERSION
 
       - name: Run Inso NPM package tests
-        run: npm run inso-test
+        run: npm run test:bundled-inso
 
       - name: Package Inso CLI binary
         run: npm run inso-package

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "inso-start": "npm start --prefix packages/insomnia-inso",
     "inso-package": "npm run build:sr --prefix packages/insomnia && npm run package --prefix packages/insomnia-inso",
     "inso-package:artifacts": "npm run artifacts --prefix packages/insomnia-inso",
+    "inso-test": "npm run bootstrap && npm run test:npm --prefix packages/insomnia-inso",
     "watch:app": "npm run build:main.min.js --prefix packages/insomnia && npm run start:dev-server --prefix packages/insomnia",
     "app-start": "npm start --prefix packages/insomnia",
     "app-build": "npm run build --prefix packages/insomnia",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "inso-start": "npm start --prefix packages/insomnia-inso",
     "inso-package": "npm run build:sr --prefix packages/insomnia && npm run package --prefix packages/insomnia-inso",
     "inso-package:artifacts": "npm run artifacts --prefix packages/insomnia-inso",
-    "inso-test": "npm run bootstrap && npm run test:npm --prefix packages/insomnia-inso",
+    "test:bundled-inso": "npm run bootstrap && npm run test:npm --prefix packages/insomnia-inso",
     "watch:app": "npm run build:main.min.js --prefix packages/insomnia && npm run start:dev-server --prefix packages/insomnia",
     "app-start": "npm start --prefix packages/insomnia",
     "app-build": "npm run build --prefix packages/insomnia",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "inso-start": "npm start --prefix packages/insomnia-inso",
     "inso-package": "npm run build:sr --prefix packages/insomnia && npm run package --prefix packages/insomnia-inso",
     "inso-package:artifacts": "npm run artifacts --prefix packages/insomnia-inso",
-    "test:bundled-inso": "npm run bootstrap && npm run test:npm --prefix packages/insomnia-inso",
+    "test:bundled-inso": "npm run bootstrap && npm run test:bundled-inso --prefix packages/insomnia-inso",
     "watch:app": "npm run build:main.min.js --prefix packages/insomnia && npm run start:dev-server --prefix packages/insomnia",
     "app-start": "npm start --prefix packages/insomnia",
     "app-build": "npm run build --prefix packages/insomnia",

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -27,7 +27,7 @@
     "test": "jest --runInBand",
     "test:watch": "npm run test -- --watch",
     "test:snapshots": "npm run build && npm run test -- -u",
-    "test:npm": "./src/scripts/test-inso.sh",
+    "test:npm": "./bin/inso run test \"Another suite\" -e \"OpenAPI env\" --src src/db/fixtures/nedb",
     "build": "concurrently --names source,types \"npm run build:source\" \"npm run build:types\"",
     "build:source": "esr esbuild.ts",
     "build:types": "tsc --build tsconfig.build.json",

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -27,7 +27,7 @@
     "test": "jest --runInBand",
     "test:watch": "npm run test -- --watch",
     "test:snapshots": "npm run build && npm run test -- -u",
-    "test:npm": "./bin/inso run test \"Another suite\" -e \"OpenAPI env\" --src src/db/fixtures/nedb",
+    "test:bundled-inso": "./bin/inso run test \"Another suite\" -e \"OpenAPI env\" --src src/db/fixtures/nedb",
     "build": "concurrently --names source,types \"npm run build:source\" \"npm run build:types\"",
     "build:source": "esr esbuild.ts",
     "build:types": "tsc --build tsconfig.build.json",

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -27,6 +27,7 @@
     "test": "jest --runInBand",
     "test:watch": "npm run test -- --watch",
     "test:snapshots": "npm run build && npm run test -- -u",
+    "test:npm": "./src/scripts/test-inso.sh",
     "build": "concurrently --names source,types \"npm run build:source\" \"npm run build:types\"",
     "build:source": "esr esbuild.ts",
     "build:types": "tsc --build tsconfig.build.json",

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -27,7 +27,7 @@
     "test": "jest --runInBand",
     "test:watch": "npm run test -- --watch",
     "test:snapshots": "npm run build && npm run test -- -u",
-    "test:bundled-inso": "./bin/inso run test \"Another suite\" -e \"OpenAPI env\" --src src/db/fixtures/nedb",
+    "test:bundled-inso": "cross-env ./bin/inso run test \"Another suite\" -e \"OpenAPI env\" --src src/db/fixtures/nedb",
     "build": "concurrently --names source,types \"npm run build:source\" \"npm run build:types\"",
     "build:source": "esr esbuild.ts",
     "build:types": "tsc --build tsconfig.build.json",

--- a/packages/insomnia-inso/src/scripts/test-inso.sh
+++ b/packages/insomnia-inso/src/scripts/test-inso.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./bin/inso run test "Sample Specification" -e "OpenAPI env" --src src/db/fixtures/git-repo

--- a/packages/insomnia-inso/src/scripts/test-inso.sh
+++ b/packages/insomnia-inso/src/scripts/test-inso.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-./bin/inso run test "Sample Specification" -e "OpenAPI env" --src src/db/fixtures/git-repo


### PR DESCRIPTION
This changeset adds a test to catch a previous regression involving the built version of the Inso package. I've confirmed that it fails for the previous behavior, and succeeds for the current fixed behavior.

Closes INS-1785
