### PR TITLE
[INS-1839] Rename tab header everywhere

### DIFF
--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -165,7 +165,7 @@ export const RequestPane: FC<Props> = ({
           </Tab>
           <Tab tabIndex="-1">
             <button>
-              Header
+              Headers
               {numHeaders > 0 && <span className="bubble space-left">{numHeaders}</span>}
             </button>
           </Tab>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -104,13 +104,13 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId }) => {
             <button>Message</button>
           </Tab>
           <Tab tabIndex="-1" >
-            <button>Headers</button>
-          </Tab>
-          <Tab tabIndex="-1" >
             <AuthDropdown
               authTypes={supportedAuthTypes}
               disabled={disabled}
             />
+          </Tab>
+          <Tab tabIndex="-1" >
+            <button>Headers</button>
           </Tab>
         </TabList>
         <TabPanel className="react-tabs__tab-panel">
@@ -125,18 +125,18 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId }) => {
           </PaneSendButton>
           <WebSocketRequestForm requestId={request._id} />
         </TabPanel>
+        <TabPanel className="react-tabs__tab-panel">
+          <AuthWrapper
+            key={`${request._id}-${request.authentication.type}-auth-header`}
+            disabled={readyState === ReadyState.OPEN || readyState === ReadyState.CLOSING}
+          />
+        </TabPanel>
         <TabPanel className="react-tabs__tab-panel header-editor">
           <RequestHeadersEditor
             key={`${request._id}-${readyState}-header-editor`}
             request={request}
             bulk={false}
             isDisabled={readyState === ReadyState.OPEN}
-          />
-        </TabPanel>
-        <TabPanel className="react-tabs__tab-panel">
-          <AuthWrapper
-            key={`${request._id}-${request.authentication.type}-auth-header`}
-            disabled={readyState === ReadyState.OPEN || readyState === ReadyState.CLOSING}
           />
         </TabPanel>
       </Tabs>


### PR DESCRIPTION
Closes INS-1839

Renames and orders Headers tab to keep consistency between HTTP, WebSockets, gRPC and GraphQL.
