### PR TITLE
[INS-1833] Include Auth Header in Headers mapping for WebSocket Connection

### DIFF
--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -425,9 +425,7 @@ export async function getAuthHeader(authentication: RequestAuthentication) {
     case 'basic': {
       const { username, password, useISO88591 } = authentication;
       const encoding = useISO88591 ? 'latin1' : 'utf8';
-      console.log('?????????/');
       const header = getBasicAuthHeader(username, password, encoding);
-      console.log('header', header);
       return header;
     }
 

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -16,7 +16,7 @@ import {
 import { generateId } from '../../common/misc';
 import { websocketRequest } from '../../models';
 import * as models from '../../models';
-import { RequestAuthentication } from '../../models/request';
+import { RequestAuthentication, RequestHeader } from '../../models/request';
 import type { Response } from '../../models/response';
 import { BaseWebSocketRequest } from '../../models/websocket-request';
 import { getBasicAuthHeader } from '../../network/basic-auth/get-header';
@@ -125,7 +125,7 @@ async function createWebSocketConnection(
   try {
     const eventChannel = `webSocketRequest.connection.${responseId}.event`;
     const readyStateChannel = `webSocketRequest.connection.${request._id}.readyState`;
-    const authHeader = await getAuthHeader(request.authentication);
+    const authHeader = getAuthHeader(request.authentication);
     // @TODO: Render nunjucks tags in these headers
     const reduceArrayToLowerCaseKeyedDictionary = (acc: { [key: string]: string }, { name, value }: BaseWebSocketRequest['headers'][0]) =>
       ({ ...acc, [name.toLowerCase() || '']: value || '' });
@@ -416,7 +416,7 @@ electron.app.on('window-all-closed', () => {
   });
 });
 
-export async function getAuthHeader(authentication: RequestAuthentication) {
+export function getAuthHeader(authentication: RequestAuthentication): RequestHeader | undefined {
   if (!authentication || authentication.disabled) {
     return;
   }


### PR DESCRIPTION
Highlights
- adds smoke test endpoints 
  - ws://localhost:4010/redirect
  - ws://localhost:4010/basic-auth
  - ws://localhost:4010/bearer
- shows http status error codes in status tag
- sends basic and bearer auth types as headers 


https://user-images.githubusercontent.com/3679927/187934205-da648818-ea7e-46d2-a05a-7ca6aec8b0ce.mov


<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
