### PR TITLE
use responseId for timeline name

### DIFF
--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -116,7 +116,7 @@ async function createWebSocketConnection(
   mkdirp.sync(responsesDir);
   const responseBodyPath = path.join(responsesDir, uuidV4() + '.response');
   eventLogFileStreams.set(options.requestId, fs.createWriteStream(responseBodyPath));
-  const timelinePath = path.join(responsesDir, uuidV4() + '.timeline');
+  const timelinePath = path.join(responsesDir, responseId + '.timeline');
   timelineFileStreams.set(options.requestId, fs.createWriteStream(timelinePath));
 
   try {


### PR DESCRIPTION
In order to signify the newline delimitation change in timeline format and its relationship to response, this bakes it into the file name rather than a UUID.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
