### PR TITLE
Implement nunjucks rendering for websocket urls, authentication, headers and urls

### DIFF
--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -9,6 +9,7 @@ import type { GrpcRequest, GrpcRequestBody } from '../models/grpc-request';
 import { isProject, Project } from '../models/project';
 import type { Request } from '../models/request';
 import { isRequestGroup, RequestGroup } from '../models/request-group';
+import { WebSocketRequest } from '../models/websocket-request';
 import { isWorkspace, Workspace } from '../models/workspace';
 import * as templating from '../templating';
 import * as templatingUtils from '../templating/utils';
@@ -289,7 +290,7 @@ export async function render<T>(
   return next<T>(newObj, name, true);
 }
 
-interface RenderRequest<T extends Request | GrpcRequest> {
+interface RenderRequest<T extends Request | GrpcRequest | WebSocketRequest> {
   request: T;
 }
 
@@ -299,7 +300,7 @@ interface BaseRenderContextOptions {
   extraInfo?: ExtraRenderInfo;
 }
 
-interface RenderContextOptions extends BaseRenderContextOptions, Partial<RenderRequest<Request | GrpcRequest>> {
+interface RenderContextOptions extends BaseRenderContextOptions, Partial<RenderRequest<Request | GrpcRequest | WebSocketRequest>> {
   ancestors?: RenderContextAncestor[];
 }
 export async function getRenderContext(
@@ -557,8 +558,8 @@ function _getOrderedEnvironmentKeys(finalRenderContext: Record<string, any>): st
   });
 }
 
-type RenderContextAncestor = Request | GrpcRequest | RequestGroup | Workspace | Project;
-export async function getRenderContextAncestors(base?: Request | GrpcRequest | Workspace): Promise<RenderContextAncestor[]> {
+type RenderContextAncestor = Request | GrpcRequest | WebSocketRequest | RequestGroup | Workspace | Project;
+export async function getRenderContextAncestors(base?: Request | GrpcRequest | WebSocketRequest | Workspace): Promise<RenderContextAncestor[]> {
   return await db.withAncestors<RenderContextAncestor>(base || null, [
     models.request.type,
     models.grpcRequest.type,

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -420,6 +420,10 @@ const closeWebSocketConnection = async (
   ws.close();
 };
 
+const closeAllWebSocketConnections = (): void => {
+  WebSocketConnections.forEach(ws => ws.close());
+};
+
 const findMany = async (
   options: { responseId: string }
 ): Promise<WebSocketEvent[]> => {
@@ -463,6 +467,7 @@ export interface WebSocketBridgeAPI {
     authentication: RequestAuthentication;
   }) => void;
   close: typeof closeWebSocketConnection;
+  closeAll: typeof closeAllWebSocketConnections;
   readyState: {
     getCurrent: typeof getWebSocketReadyState;
   };
@@ -477,6 +482,7 @@ export const registerWebSocketHandlers = () => {
   ipcMain.handle('webSocket.event.send', sendWebSocketEvent);
   ipcMain.handle('webSocket.clearToSend', signalClearToSend);
   ipcMain.handle('webSocket.close', (_, options: Parameters<typeof closeWebSocketConnection>[0]) => closeWebSocketConnection(options));
+  ipcMain.handle('webSocket.closeAll', closeAllWebSocketConnections);
   ipcMain.handle('webSocket.readyState', (_, options: Parameters<typeof getWebSocketReadyState>[0]) => getWebSocketReadyState(options));
   ipcMain.handle('webSocket.event.findMany', (_, options: Parameters<typeof findMany>[0]) => findMany(options));
 };

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -5,6 +5,7 @@ import type { WebSocketBridgeAPI } from './main/network/websocket';
 const webSocket: WebSocketBridgeAPI = {
   create: options => ipcRenderer.invoke('webSocket.create', options),
   close: options => ipcRenderer.invoke('webSocket.close', options),
+  closeAll: () => ipcRenderer.invoke('webSocket.closeAll'),
   readyState: {
     getCurrent: options => ipcRenderer.invoke('webSocket.readyState', options),
   },

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -495,9 +495,8 @@ export class KeyValueEditor extends PureComponent<Props, State> {
             allowFile={allowFile}
             readOnly={isDisabled}
             hideButtons={isDisabled}
-            // @TODO disabled nunjucks: remove this when nunjucks support is added
-            forceInput={isWebSocketRequest}
             pair={pair}
+            // TODO: Look if there's an easy way to disable the "Edit variable" modal or something here..
           />
         ))}
 

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -496,7 +496,6 @@ export class KeyValueEditor extends PureComponent<Props, State> {
             readOnly={isDisabled}
             hideButtons={isDisabled}
             pair={pair}
-            // TODO: Look if there's an easy way to disable the "Edit variable" modal or something here..
           />
         ))}
 

--- a/packages/insomnia/src/ui/components/modals/request-render-error-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-render-error-modal.tsx
@@ -4,6 +4,7 @@ import React, { PureComponent } from 'react';
 
 import { AUTOBIND_CFG } from '../../../common/constants';
 import { docsTemplateTags } from '../../../common/documentation';
+import { isRequest } from '../../../models/request';
 import { Link } from '../base/link';
 import { Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
@@ -58,7 +59,7 @@ export class RequestRenderErrorModal extends PureComponent<{}, State> {
             Failed to render <strong>{fullPath}</strong> prior to sending
           </p>
           <div className="pad-top-sm">
-            {error.path.match(/^body/) && (
+            {error.path.match(/^body/) && isRequest(request) && (
               <button
                 className="btn btn--clicky margin-right-sm"
                 onClick={this._handleShowRequestSettings}

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -142,11 +142,6 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, workspaceId, e
     }
   };
 
-  const uniquenessKey = `${environmentId}::${request._id}`;
-
-  // TODO: How do we handle if you switch to an environment where the variable no longer resolves, and the connection is active?
-  // Close the websockets on environment change always, since it also messes with history?
-
   return (
     <>
       {!isOpen && <WebSocketIcon>WS</WebSocketIcon>}
@@ -163,7 +158,6 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, workspaceId, e
             placeholder="wss://example.com/chat"
             defaultValue={defaultValue}
             onChange={onChange}
-            key={uniquenessKey}
             type="text"
             forceEditor
           />

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -1,7 +1,10 @@
-import React, { ChangeEvent, FC, FormEvent } from 'react';
+import React, { FC, FormEvent } from 'react';
 import styled from 'styled-components';
 
+import { getRenderContext, render, RENDER_PURPOSE_SEND } from '../../../common/render';
+import { WebSocketRequest } from '../../../models/websocket-request';
 import { ReadyState } from '../../context/websocket-client/use-ws-ready-state';
+import { OneLineEditor } from '../codemirror/one-line-editor';
 
 const Button = styled.button<{ warning?: boolean }>(({ warning }) => ({
   paddingRight: 'var(--padding-md)',
@@ -49,11 +52,12 @@ const ActionButton: FC<ActionButtonProps> = ({ requestId, readyState }) => {
 };
 
 interface ActionBarProps {
-  requestId: string;
+  request: WebSocketRequest;
   workspaceId: string;
+  environmentId: string;
   defaultValue: string;
   readyState: ReadyState;
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChange: (value: string) => void;
 }
 
 const Form = styled.form({
@@ -61,7 +65,7 @@ const Form = styled.form({
   display: 'flex',
 });
 
-const Input = styled.input({
+const StyledUrlBar = styled.div({
   boxSizing: 'border-box',
   width: '100%',
   height: '100%',
@@ -90,12 +94,41 @@ const ConnectionCircle = styled.span({
   borderRadius: '50%',
 });
 
-export const WebSocketActionBar: FC<ActionBarProps> = ({ requestId, workspaceId, defaultValue, onChange, readyState }) => {
+export const WebSocketActionBar: FC<ActionBarProps> = ({ request, workspaceId, environmentId, defaultValue, onChange, readyState }) => {
   const isOpen = readyState === ReadyState.OPEN;
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    window.main.webSocket.create({ requestId, workspaceId });
+
+    // Render any nunjucks tag in the message
+    const renderContext = await getRenderContext({ request, environmentId, purpose: RENDER_PURPOSE_SEND });
+
+    // TODO: Should we filter out disabled headers/authentication here, as we do in getRenderedRequestAndContext?
+
+    const { url, headers, authentication } = request;
+
+    const rendered = await render({
+      url,
+      headers,
+      authentication,
+    }, renderContext);
+
+    // TODO: Handle error in rendering
+
+    window.main.webSocket.create({
+      requestId: request._id,
+      workspaceId,
+      url: rendered.url,
+      headers: rendered.headers,
+      authentication: rendered.authentication,
+    });
   };
+
+  const uniquenessKey = `${environmentId}::${request._id}`;
+
+  // TODO: Use getAutocompleteConstants to get existing websocket URLs?
+
+  // TODO: How do we handle if you switch to an environment where the variable no longer resolves, and the connection is active?
+  // Close the websockets on environment change always, since it also messes with history?
 
   return (
     <>
@@ -107,15 +140,19 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ requestId, workspaceId,
         </ConnectionStatus>
       )}
       <Form aria-disabled={isOpen} id="websocketUrlForm" onSubmit={handleSubmit}>
-        <Input
-          name="websocketUrlInput"
-          disabled={readyState === ReadyState.OPEN}
-          placeholder="wss://example.com/chat"
-          defaultValue={defaultValue}
-          onChange={onChange}
-        />
+        <StyledUrlBar>
+          <OneLineEditor
+            disabled={readyState === ReadyState.OPEN}
+            placeholder="wss://example.com/chat"
+            defaultValue={defaultValue}
+            onChange={onChange}
+            key={uniquenessKey}
+            type="text"
+            forceEditor
+          />
+        </StyledUrlBar>
       </Form>
-      <ActionButton requestId={requestId} readyState={readyState} />
+      <ActionButton requestId={request._id} readyState={readyState} />
     </>
   );
 };

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -103,21 +103,24 @@ interface Props {
 export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environmentId }) => {
   const readyState = useWSReadyState(request._id);
   const disabled = readyState === ReadyState.OPEN || readyState === ReadyState.CLOSING;
-  const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const url = event.currentTarget.value || '';
+  const handleOnChange = (url: string) => {
     if (url !== request.url) {
       models.websocketRequest.update(request, { url });
     }
   };
   const [payloadType, setPayloadType] = useState(CONTENT_TYPE_JSON);
 
+  // TODO: Check if we need any keys/force refresh here to correctly update rendering of nunjucks tags
+  // Definitely needed for headers
+
   return (
     <Pane type="request">
       <PaneHeader>
         <WebSocketActionBar
           key={request._id}
-          requestId={request._id}
+          request={request}
           workspaceId={workspaceId}
+          environmentId={environmentId}
           defaultValue={request.url}
           readyState={readyState}
           onChange={handleOnChange}

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -115,13 +115,14 @@ interface Props {
   request: WebSocketRequest;
   workspaceId: string;
   environmentId: string;
+  forceRefreshKey: number;
 }
 
 // requestId is something we can read from the router params in the future.
 // essentially we can lift up the states and merge request pane and response pane into a single page and divide the UI there.
 // currently this is blocked by the way page layout divide the panes with dragging functionality
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
-export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environmentId }) => {
+export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environmentId, forceRefreshKey }) => {
   const readyState = useWSReadyState(request._id);
   const disabled = readyState === ReadyState.OPEN || readyState === ReadyState.CLOSING;
   const handleOnChange = (url: string) => {
@@ -131,14 +132,13 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
   };
   const [payloadType, setPayloadType] = useState(CONTENT_TYPE_JSON);
 
-  // TODO: Check if we need any keys/force refresh here to correctly update rendering of nunjucks tags
-  // Definitely needed for headers
+  const uniqueKey = `${forceRefreshKey}::${request._id}`;
 
   return (
     <Pane type="request">
       <PaneHeader>
         <WebSocketActionBar
-          key={request._id}
+          key={uniqueKey}
           request={request}
           workspaceId={workspaceId}
           environmentId={environmentId}
@@ -173,7 +173,7 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
             </SendButton>
           </PaneSendButton>
           <WebSocketRequestForm
-            key={`${environmentId}::${request._id}`} // Needed to ensure nunjucks rendering updates on environment change
+            key={uniqueKey}
             request={request}
             payloadType={payloadType}
             environmentId={environmentId}
@@ -181,13 +181,13 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
         </TabPanel>
         <TabPanel className="react-tabs__tab-panel">
           <AuthWrapper
-            key={`${request._id}-${request.authentication.type}-auth-header`}
+            key={`${uniqueKey}-${request.authentication.type}-auth-header`}
             disabled={readyState === ReadyState.OPEN || readyState === ReadyState.CLOSING}
           />
         </TabPanel>
         <TabPanel className="react-tabs__tab-panel header-editor">
           <RequestHeadersEditor
-            key={`${request._id}-${readyState}-header-editor`}
+            key={`${uniqueKey}-${readyState}-header-editor`}
             request={request}
             bulk={false}
             isDisabled={readyState === ReadyState.OPEN}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -131,6 +131,7 @@ export const WrapperDebug: FC<Props> = ({
                 <WebSocketRequestPane
                   request={activeRequest}
                   workspaceId={activeWorkspace._id}
+                  environmentId={activeEnvironment ? activeEnvironment._id : ''}
                 />
               ) : (
                 <RequestPane

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -132,6 +132,7 @@ export const WrapperDebug: FC<Props> = ({
                   request={activeRequest}
                   workspaceId={activeWorkspace._id}
                   environmentId={activeEnvironment ? activeEnvironment._id : ''}
+                  forceRefreshKey={forceRefreshKey}
                 />
               ) : (
                 <RequestPane

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment, ReactNode } from 'react';
+import React, { FC, Fragment, ReactNode, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import { isGrpcRequest } from '../../models/grpc-request';
@@ -76,6 +76,13 @@ export const WrapperDebug: FC<Props> = ({
   const sidebarFilter = useSelector(selectSidebarFilter);
 
   const isTeamSync = isLoggedIn && activeWorkspace && isCollection(activeWorkspace) && isRemoteProject(activeProject) && vcs;
+
+  // Close all websocket connections when the active environment changes
+  useEffect(() => {
+    return () => {
+      window.main.webSocket.closeAll();
+    };
+  }, [activeEnvironment?._id]);
 
   return (
     <PageLayout

--- a/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
+++ b/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import { getRenderContext, getRenderContextAncestors, HandleGetRenderContext, HandleRender, render } from '../../../common/render';
-import { isWebSocketRequest } from '../../../models/websocket-request';
 import { NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME } from '../../../templating';
 import { getKeys } from '../../../templating/utils';
 import { selectActiveEnvironment, selectActiveRequest, selectActiveWorkspace } from '../../redux/selectors';
@@ -20,8 +19,7 @@ initializeNunjucksRenderPromiseCache();
  */
 export const useNunjucks = () => {
   const environmentId = useSelector(selectActiveEnvironment)?._id;
-  const activeRequest = useSelector(selectActiveRequest);
-  const request = activeRequest && isWebSocketRequest(activeRequest) ? null : activeRequest;
+  const request = useSelector(selectActiveRequest);
   const workspace = useSelector(selectActiveWorkspace);
 
   const fetchRenderContext = useCallback(async () => {


### PR DESCRIPTION
![2022-09-06 14 01 37](https://user-images.githubusercontent.com/174626/188630489-b6963363-58ee-4d22-a838-04890c3a8ad8.gif)

To avoid issues with the history/response pane et-al when switching environments, we now close all connections on environment changes.

Closes INS-1823
Closes INS-1849