### PR TITLE
Fixes #2241 by adding a JSON Linting CodeMirror helper that renders the contents before linting

### DIFF
--- a/packages/insomnia/src/global.d.ts
+++ b/packages/insomnia/src/global.d.ts
@@ -15,8 +15,6 @@ declare const __DEV__: boolean;
 declare namespace NodeJS {
   interface Global {
     __DEV__: boolean;
-    /** this is required by codemirror/addon/lint/json-lint */
-    jsonlint: any;
     /** this is required by codemirror/addon/lint/yaml-lint */
     jsyaml: any;
   }

--- a/packages/insomnia/src/jsonlint.d.ts
+++ b/packages/insomnia/src/jsonlint.d.ts
@@ -1,2 +1,22 @@
 declare module 'jsonlint-mod-fixed' {
+
+    interface ParseErrorHash {
+        expected?: string[];
+        line?: number;
+        loc?: {
+            first_column: number;
+            first_line: number;
+            last_column: number;
+            last_line: number;
+        };
+        message?: string;
+        text?: string;
+        token?: string | null;
+    }
+
+    export function parse(input: string): string;
+    export namespace parser {
+        export function parseError(str: string, hash: ParseErrorHash): void;
+    }
+
 }

--- a/packages/insomnia/src/templating/utils.ts
+++ b/packages/insomnia/src/templating/utils.ts
@@ -87,7 +87,7 @@ export function normalizeToDotAndBracketNotation(prefix: string) {
 }
 
 /**
- * Parse a Nunjucks tag string into a usable abject
+ * Parse a Nunjucks tag string into a usable object
  * @param {string} tagStr - the template string for the tag
  */
 export function tokenizeTag(tagStr: string) {

--- a/packages/insomnia/src/ui/components/codemirror/base-imports.ts
+++ b/packages/insomnia/src/ui/components/codemirror/base-imports.ts
@@ -38,22 +38,6 @@ import 'codemirror/addon/selection/selection-pointer';
 import 'codemirror/addon/display/placeholder';
 import 'codemirror/addon/lint/lint';
 
-declare global {
-  // eslint-disable-next-line no-var -- necessary, let will not work here
-  var jsonlint: unknown;
-}
-
-/**/
-/**
- * Unfortunately, the CodeMirror addon for linting makes use of a pattern whereby linting dependencies are required to be attached to `window` (i.e. `global`) at runtime.
- * For that reason, if you search our codebase, you will not find anywhere where these imports are used.
- */
-/**/
-// for the code that uses this json parser, see https://github.com/codemirror/CodeMirror/blob/master/addon/lint/json-lint.js
-import * as jsonlint from 'jsonlint-mod-fixed';
-global.jsonlint = jsonlint;
-import 'codemirror/addon/lint/json-lint';
-
 // for the code that uses this yaml parser, see https://github.com/codemirror/CodeMirror/blob/master/addon/lint/yaml-lint.js
 import * as jsyaml from 'js-yaml';
 global.jsyaml = jsyaml;
@@ -75,6 +59,7 @@ import './modes/curl';
 import './modes/openapi';
 import './lint/openapi';
 import './lint/javascript-async-lint';
+import './lint/json-lint';
 import './extensions/autocomplete';
 import './extensions/clickable';
 import './extensions/nunjucks-tags';

--- a/packages/insomnia/src/ui/components/codemirror/lint/json-lint.ts
+++ b/packages/insomnia/src/ui/components/codemirror/lint/json-lint.ts
@@ -1,0 +1,50 @@
+// This linter override allows Nunjuck templates to be rendered before attempting
+// the linting process to ensure accurate parsing of values is completed.
+// It still uses under the hood the jsonlint-mod-fixed library found at
+// https://github.com/circlecell/jsonlint-mod/blob/master/lib/jsonlint.js
+
+import 'codemirror/addon/lint/json-lint';
+
+import CodeMirror from 'codemirror';
+import * as jsonlint from 'jsonlint-mod-fixed';
+
+import { render } from '../../../../../../insomnia/src/templating/index';
+CodeMirror.registerHelper('lint', 'json', validator);
+
+interface ValidationError {
+  message: string;
+  from: CodeMirror.Position;
+  to: CodeMirror.Position;
+}
+
+async function validator(text: string): Promise<ValidationError[]> {
+  const found: ValidationError[] = [];
+
+  // Override jsonlint's parseError function so we pull the errors into our collection of ValidationErrors
+  jsonlint.parser.parseError = (str: string, hash: jsonlint.ParseErrorHash) => {
+    if (hash.line && !(hash.loc)) {
+      found.push({
+        from: CodeMirror.Pos(hash.line),
+        to: CodeMirror.Pos(hash.line),
+        message: str,
+      });
+    } else if (hash.loc) {
+      const loc = hash.loc;
+      found.push({
+        from: CodeMirror.Pos(loc.first_line - 1, loc.first_column),
+        to: CodeMirror.Pos(loc.last_line - 1, loc.last_column),
+        message: str,
+      });
+    }
+  };
+
+  // Render any Nunjucks templates before attempting to parse
+  const renderedText: string | null = await render(text, {});
+  if (renderedText) {
+    try {
+      jsonlint.parse(renderedText);
+    } catch (e) {}
+  }
+
+  return found;
+}


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where certain template tags would result in JSON Parse error when used as number

Closes #2241 by adding a JSON linting helper to CodeMirror that renders the contents before linting. 

Previously, we could not use the Unix timestamp template as an unquoted value, or Faker Date or Faker JSON template due to the JSON linter expecting the values to be quoted.

![image](https://user-images.githubusercontent.com/30680/188335623-38abc899-6311-4189-8fcd-c1b872f1d695.png)

With this PR, we are attempting to render the nunjuck template values before linting JSON objects. This enables us to validly use the template objects ...

![image](https://user-images.githubusercontent.com/30680/188335662-b5e48265-60bc-4ec4-af11-1d1c7ec6a80a.png)

... but still errors appropriately:

![image](https://user-images.githubusercontent.com/30680/188335689-27180d5a-5048-47e8-98b6-1d69e133328b.png)

---

~Note, this still broken in the Environment editor, primarily due to the handling of ordering the JSON keys. Will have to address in a future PR.~
Should not be an issue in the Environment editor when used in conjunction with the `JSONPath` filter.
