### PR TITLE
[INS-1843] Add more checks to WS smoke test

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/websockets.yaml
+++ b/packages/insomnia-smoke-test/fixtures/websockets.yaml
@@ -21,6 +21,72 @@ resources:
     description: ""
     scope: collection
     _type: workspace
+  - _id: ws-req_c522379d686b44179e9626fc6c8ed88a
+    parentId: wrk_db59cf2b74764e6a80c0dcbcf3d67130
+    modified: 1662451274029
+    created: 1662451239058
+    name: basic-auth
+    url: ws://localhost:4010/basic-auth
+    metaSortKey: -1661942202823
+    headers: []
+    authentication:
+      type: basic
+      useISO88591: false
+      disabled: false
+      username: user
+      password: password
+    _type: websocket_request
+  - _id: ws-req_adcce29c84ed497fbe69abac3df48867
+    parentId: wrk_db59cf2b74764e6a80c0dcbcf3d67130
+    modified: 1662451303201
+    created: 1662451298316
+    name: basic-auth (fail)
+    url: ws://localhost:4010/basic-auth
+    metaSortKey: -1661942202773
+    headers: []
+    authentication:
+      type: basic
+      useISO88591: false
+      disabled: false
+      username: user
+      password: fail
+    _type: websocket_request
+  - _id: ws-req_2157c597bcbb4614b64c7c99c6f7a982
+    parentId: wrk_db59cf2b74764e6a80c0dcbcf3d67130
+    modified: 1662451369688
+    created: 1662451318293
+    name: bearer
+    url: ws://localhost:4010/bearer
+    metaSortKey: -1661942202723
+    headers: []
+    authentication:
+      type: bearer
+      token: insomnia-cool-token-!!!1112113243111
+      disabled: false
+    _type: websocket_request
+  - _id: ws-req_7a98a4adb9f44c0a84d989d69180c839
+    parentId: wrk_db59cf2b74764e6a80c0dcbcf3d67130
+    modified: 1662451400034
+    created: 1662451393778
+    name: bearer (fail)
+    url: ws://localhost:4010/bearer
+    metaSortKey: -1661942202673
+    headers: []
+    authentication:
+      type: bearer
+      token: ""
+      disabled: false
+    _type: websocket_request
+  - _id: ws-req_6b9c944a7f034fcb8b0a92e5442538d7
+    parentId: wrk_db59cf2b74764e6a80c0dcbcf3d67130
+    modified: 1662451456879
+    created: 1662451430343
+    name: redirect
+    url: ws://localhost:4010/redirect
+    metaSortKey: -1661942202623
+    headers: []
+    authentication: {}
+    _type: websocket_request
   - _id: env_78d7375877d288dfb527a256e6d7e92dce4ff968
     parentId: wrk_db59cf2b74764e6a80c0dcbcf3d67130
     modified: 1661942194375

--- a/packages/insomnia-smoke-test/fixtures/websockets.yaml
+++ b/packages/insomnia-smoke-test/fixtures/websockets.yaml
@@ -36,21 +36,6 @@ resources:
       username: user
       password: password
     _type: websocket_request
-  - _id: ws-req_adcce29c84ed497fbe69abac3df48867
-    parentId: wrk_db59cf2b74764e6a80c0dcbcf3d67130
-    modified: 1662451303201
-    created: 1662451298316
-    name: basic-auth (fail)
-    url: ws://localhost:4010/basic-auth
-    metaSortKey: -1661942202773
-    headers: []
-    authentication:
-      type: basic
-      useISO88591: false
-      disabled: false
-      username: user
-      password: fail
-    _type: websocket_request
   - _id: ws-req_2157c597bcbb4614b64c7c99c6f7a982
     parentId: wrk_db59cf2b74764e6a80c0dcbcf3d67130
     modified: 1662451369688
@@ -62,19 +47,6 @@ resources:
     authentication:
       type: bearer
       token: insomnia-cool-token-!!!1112113243111
-      disabled: false
-    _type: websocket_request
-  - _id: ws-req_7a98a4adb9f44c0a84d989d69180c839
-    parentId: wrk_db59cf2b74764e6a80c0dcbcf3d67130
-    modified: 1662451400034
-    created: 1662451393778
-    name: bearer (fail)
-    url: ws://localhost:4010/bearer
-    metaSortKey: -1661942202673
-    headers: []
-    authentication:
-      type: bearer
-      token: ""
       disabled: false
     _type: websocket_request
   - _id: ws-req_6b9c944a7f034fcb8b0a92e5442538d7

--- a/packages/insomnia-smoke-test/tests/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/websocket.test.ts
@@ -26,4 +26,28 @@ test('can make websocket connection', async ({ app, page }) => {
   await expect(responseBody).toContainText('WebSocket connection established');
 
   await page.click('text=Disconnect');
+  await expect(responseBody).toContainText('Closing connection with code 1005');
+
+  // Can connect with Basic Auth
+  await page.click('button:has-text("basic-auth")');
+  await page.click('text=Connect');
+  await expect(statusTag).toContainText('101 Switching Protocols');
+  await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
+  await expect(responseBody).toContainText('> authorization: Basic dXNlcjpwYXNzd29yZA==');
+
+  // Can connect with Bearer Auth
+  await page.click('button:has-text("bearer")');
+  await page.click('text=Connect');
+  await expect(statusTag).toContainText('101 Switching Protocols');
+  await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
+  await expect(responseBody).toContainText('WebSocket connection established');
+  await expect(responseBody).toContainText('> authorization: Bearer insomnia-cool-token-!!!1112113243111');
+
+  // Can handle redirects
+  await page.click('button:has-text("redirect")');
+  await page.click('text=Connect');
+  await expect(statusTag).toContainText('101 Switching Protocols');
+  await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
+  await expect(responseBody).toContainText('WebSocket connection established');
+
 });

--- a/packages/insomnia-smoke-test/tests/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/websocket.test.ts
@@ -40,7 +40,6 @@ test('can make websocket connection', async ({ app, page }) => {
   await page.click('text=Connect');
   await expect(statusTag).toContainText('101 Switching Protocols');
   await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
-  await expect(responseBody).toContainText('WebSocket connection established');
   await expect(responseBody).toContainText('> authorization: Bearer insomnia-cool-token-!!!1112113243111');
 
   // Can handle redirects

--- a/packages/insomnia-smoke-test/tests/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/websocket.test.ts
@@ -25,5 +25,5 @@ test('can make websocket connection', async ({ app, page }) => {
   await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
   await expect(responseBody).toContainText('WebSocket connection established');
 
-  await page.click('text=Close');
+  await page.click('text=Disconnect');
 });


### PR DESCRIPTION
Closes INS-1843

In this PR we add simple coverage for supported auth methods of WS connections as well as for handling redirects. 

Not done in this PR: handling "negative"/401 http status scenarios or different scenarios, e.g. Trying to close WS connection in different ways. That will need to be added once we finalize UX for how connections should be closed.