### PR TITLE
INS-1844: Implement basic event view functionality.

### DIFF
--- a/packages/insomnia/src/ui/components/websockets/event-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-view.tsx
@@ -29,7 +29,7 @@ const PreviewPaneButtons = styled.div({
   boxSizing: 'border-box',
   height: 'var(--line-height-sm)',
   borderBottom: '1px solid var(--hl-lg)',
-  padding: 'var(--padding-sm)',
+  padding: 'var(--padding-sm) var(--padding-md)',
 });
 
 const PreviewPaneContents = styled.div({

--- a/packages/insomnia/src/ui/components/websockets/event-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-view.tsx
@@ -1,18 +1,136 @@
-import React, { FC } from 'react';
+import { clipboard } from 'electron';
+import fs from 'fs';
+import React, { FC, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
 
-import { WebSocketEvent } from '../../../main/network/websocket';
+import { PREVIEW_MODE_FRIENDLY, PREVIEW_MODE_RAW, PREVIEW_MODE_SOURCE, PreviewMode } from '../../../common/constants';
+import { WebSocketEvent, WebSocketMessageEvent } from '../../../main/network/websocket';
+import { requestMeta } from '../../../models';
+import { selectResponsePreviewMode } from '../../redux/selectors';
 import { CodeEditor } from '../codemirror/code-editor';
-interface Props {
-  event: WebSocketEvent;
+import { showError } from '../modals';
+import { WebSocketPreviewModeDropdown } from './websocket-preview-dropdown';
+
+interface Props<T extends WebSocketEvent> {
+  event: T;
+  requestId: string;
 }
-export const EventView: FC<Props> = ({ event }) => {
+
+const PreviewPane = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+});
+
+const PreviewPaneButtons = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  boxSizing: 'border-box',
+  height: 'var(--line-height-sm)',
+  borderBottom: '1px solid var(--hl-lg)',
+  padding: 'var(--padding-sm)',
+});
+
+const PreviewPaneContents = styled.div({
+  padding: 'var(--padding-sm)',
+  flexGrow: 1,
+});
+
+export const MessageEventView: FC<Props<WebSocketMessageEvent>> = ({ event, requestId }) => {
+  // TODO: Handle non-string data.
+  const raw = event.data.toString('utf-8');
+
+  const handleDownloadResponseBody = useCallback(async () => {
+    const { canceled, filePath: outputPath } = await window.dialog.showSaveDialog({
+      title: 'Save Response Body',
+      buttonLabel: 'Save',
+    });
+
+    if (canceled || !outputPath) {
+      return;
+    }
+
+    const to = fs.createWriteStream(outputPath);
+
+    to.on('error', err => {
+      showError({
+        title: 'Save Failed',
+        message: 'Failed to save response body',
+        error: err,
+      });
+    });
+
+    to.write(raw);
+
+    to.end();
+  }, [raw]);
+
+  const handleCopyResponseToClipboard = useCallback(() => {
+    clipboard.writeText(raw);
+  }, [raw]);
+
+  const previewMode = useSelector(selectResponsePreviewMode);
+
+  const setPreviewMode = async (previewMode: PreviewMode) => {
+    return requestMeta.updateOrCreateByParentId(requestId, { previewMode });
+  };
+
+  // TODO(johnwchadwick): Maybe shouldn't try if it's too large.
+  // TODO(johnwchadwick): Should allow selecting a type instead of assuming JSON.
+  let pretty = raw;
+  try {
+    const parsed = JSON.parse(raw);
+    pretty = JSON.stringify(parsed, null, '\t');
+  } catch {
+    // Can't parse as JSON.
+  }
+
   return (
-    <CodeEditor
-      hideLineNumbers
-      mode={'text/plain'}
-      defaultValue={JSON.stringify(event)}
-      uniquenessKey={event._id}
-      readOnly
-    />
+    <PreviewPane>
+      <PreviewPaneButtons>
+        <WebSocketPreviewModeDropdown
+          download={handleDownloadResponseBody}
+          copyToClipboard={handleCopyResponseToClipboard}
+          previewMode={previewMode}
+          setPreviewMode={setPreviewMode}
+        />
+      </PreviewPaneButtons>
+      <PreviewPaneContents>
+        {previewMode === PREVIEW_MODE_FRIENDLY &&
+        <CodeEditor
+          hideLineNumbers
+          mode={'text/json'}
+          defaultValue={pretty}
+          uniquenessKey={event._id}
+          readOnly
+        />}
+        {previewMode === PREVIEW_MODE_SOURCE &&
+        <CodeEditor
+          hideLineNumbers
+          mode={'text/json'}
+          defaultValue={raw}
+          uniquenessKey={event._id}
+          readOnly
+        />}
+        {previewMode === PREVIEW_MODE_RAW &&
+        <CodeEditor
+          hideLineNumbers
+          mode={'text/plain'}
+          defaultValue={raw}
+          uniquenessKey={event._id}
+          readOnly
+        />}
+      </PreviewPaneContents>
+    </PreviewPane>
   );
+};
+
+export const EventView: FC<Props<WebSocketEvent>> = ({ event, ...props }) => {
+  switch (event.type) {
+    case 'message':
+      return <MessageEventView event={event} {...props}/>;
+    default:
+      return null;
+  }
 };

--- a/packages/insomnia/src/ui/components/websockets/websocket-preview-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-preview-dropdown.tsx
@@ -1,0 +1,42 @@
+import React, { FC } from 'react';
+
+import { getPreviewModeName, PREVIEW_MODES, PreviewMode } from '../../../common/constants';
+import { Dropdown } from '../base/dropdown/dropdown';
+import { DropdownButton } from '../base/dropdown/dropdown-button';
+import { DropdownDivider } from '../base/dropdown/dropdown-divider';
+import { DropdownItem } from '../base/dropdown/dropdown-item';
+
+interface Props {
+  download: () => void;
+  copyToClipboard: () => void;
+  previewMode: PreviewMode;
+  setPreviewMode: (mode: PreviewMode) => void;
+}
+
+export const WebSocketPreviewModeDropdown: FC<Props> = ({
+  download,
+  copyToClipboard,
+  previewMode,
+  setPreviewMode,
+}) => {
+  return <Dropdown beside>
+    <DropdownButton className="tall">
+      {getPreviewModeName(previewMode)}
+      <i className="fa fa-caret-down space-left" />
+    </DropdownButton>
+    <DropdownDivider>Preview Mode</DropdownDivider>
+    {PREVIEW_MODES.map(mode => <DropdownItem key={mode} onClick={setPreviewMode} value={mode}>
+      {previewMode === mode ? <i className="fa fa-check" /> : <i className="fa fa-empty" />}
+      {getPreviewModeName(mode, true)}
+    </DropdownItem>)}
+    <DropdownDivider>Actions</DropdownDivider>
+    <DropdownItem onClick={copyToClipboard}>
+      <i className="fa fa-copy" />
+      Copy raw response
+    </DropdownItem>
+    <DropdownItem onClick={download}>
+      <i className="fa fa-save" />
+      Export raw response
+    </DropdownItem>
+  </Dropdown>;
+};

--- a/packages/insomnia/src/ui/components/websockets/websocket-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-response-pane.tsx
@@ -37,7 +37,6 @@ const EventViewWrapper = styled.div({
   flex: 1,
   borderTop: '1px solid var(--hl-md)',
   height: '100%',
-  padding: 'var(--padding-sm)',
 });
 
 const PaneBodyContent = styled.div({
@@ -156,7 +155,10 @@ const WebSocketActiveResponsePane: FC<{ requestId: string; response: Response; h
                 )}
                 {selectedEvent && (
                   <EventViewWrapper>
-                    <EventView event={selectedEvent} />
+                    <EventView
+                      requestId={requestId}
+                      event={selectedEvent}
+                    />
                   </EventViewWrapper>
                 )}
               </>}


### PR DESCRIPTION
First pass at a useful event view. This handles only message events, does not treat binary data specially, and only handles pretty printing/highlighting for JSON-formatted messages. Still, it's a start.

There's some things I had difficulty in untangling, so I cut it short and did things a bit simpler. For example, I would've liked to reuse the existing PreviewMode dropdown, but it proved too difficult, so this one contains a Websocket-specific dropdown instead.

I left TODOs for the issues that should be addressed.