### PR TITLE
Reverse the order of WebSocket events

### DIFF
--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -96,6 +96,7 @@ const dispatchWebSocketEvent = (target: Electron.WebContents, eventChannel: stri
   // Otherwise, append to send queue for this event channel.
   const sendQueue = sendQueueMap.get(eventChannel);
   if (sendQueue) {
+    // Add the event to the top of queue so that the latest message is first.
     sendQueue.unshift(wsEvent);
   } else {
     sendQueueMap.set(eventChannel, [wsEvent]);
@@ -433,7 +434,10 @@ const findMany = async (
   }
   const body = await fs.promises.readFile(response.bodyPath);
   return body.toString().split('\n').filter(e => e?.trim())
-    .map(e => JSON.parse(e)).reverse() || [];
+    // Parse the message
+    .map(e => JSON.parse(e))
+    // Reverse the list of messages so that we get the latest message first
+    .reverse() || [];
 };
 
 /**

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -96,7 +96,7 @@ const dispatchWebSocketEvent = (target: Electron.WebContents, eventChannel: stri
   // Otherwise, append to send queue for this event channel.
   const sendQueue = sendQueueMap.get(eventChannel);
   if (sendQueue) {
-    sendQueue.push(wsEvent);
+    sendQueue.unshift(wsEvent);
   } else {
     sendQueueMap.set(eventChannel, [wsEvent]);
   }
@@ -433,7 +433,7 @@ const findMany = async (
   }
   const body = await fs.promises.readFile(response.bodyPath);
   return body.toString().split('\n').filter(e => e?.trim())
-    .map(e => JSON.parse(e)) || [];
+    .map(e => JSON.parse(e)).reverse() || [];
 };
 
 /**

--- a/packages/insomnia/src/ui/context/websocket-client/use-ws-connection-events.ts
+++ b/packages/insomnia/src/ui/context/websocket-client/use-ws-connection-events.ts
@@ -23,12 +23,17 @@ export function useWebSocketConnectionEvents({ responseId }: { responseId: strin
       if (isMounted) {
         setEvents(allEvents);
       }
+
+      const afterLatestEvent = (event: WebSocketEvent) => {
+        return event.timestamp > allEvents[0].timestamp;
+      };
+
       // Subscribe to new events and update the state.
       unsubscribe = window.main.on(`webSocket.${responseId}.event`,
         (_, events: WebSocketEvent[]) => {
           console.log('received events', events);
           if (isMounted) {
-            setEvents(allEvents => allEvents.concat(events));
+            setEvents(allEvents => events.filter(afterLatestEvent).concat(allEvents));
           }
 
           // Wait to give the CTS signal until we've rendered a frame.

--- a/packages/insomnia/src/ui/context/websocket-client/use-ws-connection-events.ts
+++ b/packages/insomnia/src/ui/context/websocket-client/use-ws-connection-events.ts
@@ -24,8 +24,12 @@ export function useWebSocketConnectionEvents({ responseId }: { responseId: strin
         setEvents(allEvents);
       }
 
-      const afterLatestEvent = (event: WebSocketEvent) => {
-        return event.timestamp > allEvents[0].timestamp;
+      const afterLatestEvent = (event: WebSocketEvent, prevEvents: WebSocketEvent[]) => {
+        if (prevEvents.length === 0) {
+          return true;
+        }
+
+        return event.timestamp > prevEvents[0]?.timestamp;
       };
 
       // Subscribe to new events and update the state.
@@ -33,7 +37,7 @@ export function useWebSocketConnectionEvents({ responseId }: { responseId: strin
         (_, events: WebSocketEvent[]) => {
           console.log('received events', events);
           if (isMounted) {
-            setEvents(allEvents => events.filter(afterLatestEvent).concat(allEvents));
+            setEvents(prevEvents => events.filter(event => afterLatestEvent(event, prevEvents)).concat(prevEvents));
           }
 
           // Wait to give the CTS signal until we've rendered a frame.


### PR DESCRIPTION
Reverse the order of WebSocket events so that the latest is on top.
Also filters by the last message timestamp so there's no duplicate events in the view.

![Screen Recording 2022-09-07 at 17 32 34](https://user-images.githubusercontent.com/12115431/188919444-fe7772a8-8b10-4016-aa01-9bd00c8cf856.gif)

Closes INS-1949