### PR TITLE
[INS-1800] Remove value validity check in the WebSocket headers

### DIFF
--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -142,7 +142,7 @@ const createWebSocketConnection = async (
     }
 
     const lowerCasedEnabledHeaders = headers
-      .filter(({ value, disabled }) => !!value && !disabled)
+      .filter(({ disabled }) => !disabled)
       .reduce(reduceArrayToLowerCaseKeyedDictionary, {});
 
     const settings = await models.settings.getOrCreate();

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -142,9 +142,8 @@ const createWebSocketConnection = async (
     }
 
     const lowerCasedEnabledHeaders = headers
-      .filter(({ disabled }) => !disabled)
+      .filter(({ name, disabled }) => Boolean(name) && !disabled)
       .reduce(reduceArrayToLowerCaseKeyedDictionary, {});
-
     const settings = await models.settings.getOrCreate();
     const start = performance.now();
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

- Removed the validity check on the value when parsing headers for WebSocket

Closes [INS-1800](https://linear.app/insomnia/issue/INS-1800/support-headers-with-empty-value-for-websockets)
