### PR TITLE
Add plugin hub link

### DIFF
--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -11,6 +11,7 @@ import {
   PLUGIN_PATH,
 } from '../../../common/constants';
 import { docsPlugins } from '../../../common/documentation';
+import { clickLink } from '../../../common/electron-helpers';
 import { delay } from '../../../common/misc';
 import * as models from '../../../models';
 import type { Settings } from '../../../models/settings';
@@ -330,7 +331,19 @@ export class Plugins extends PureComponent<Props, State> {
         <hr />
 
         <div className="text-right">
-          <Button onClick={this._handleCreatePlugin}>Generate New Plugin</Button>
+          <Button
+            onClick={() => {
+              clickLink('https://insomnia.rest/plugins');
+            }}
+          >
+            Browse Plugin Hub
+          </Button>
+          <Button
+            style={{
+              marginLeft: '0.3em',
+            }}
+            onClick={this._handleCreatePlugin}
+          >Generate New Plugin</Button>
           <Button
             style={{
               marginLeft: '0.3em',


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

![image](https://user-images.githubusercontent.com/11976836/189321055-4f8700e3-8913-4b71-a023-c4c62e5b7a85.png)


Closes [INS-1678](https://linear.app/insomnia/issue/INS-1678/as-a-user-i-should-easily-see-plugin-catelog-from-plugin-view-in)

Changelog(Improvements): Added a shortcut to open Insomnia's [Plugin Hub](https://insomnia.rest/plugins) from within the App's Plugin view