### PR TITLE
Proposal/conventional-websocket-naming

### DIFF
--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -563,7 +563,7 @@ export async function getRenderContextAncestors(base?: Request | GrpcRequest | W
   return await db.withAncestors<RenderContextAncestor>(base || null, [
     models.request.type,
     models.grpcRequest.type,
-    models.webSocketRequest.type,
+    models.websocketRequest.type,
     models.requestGroup.type,
     models.workspace.type,
     models.project.type,

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -15,7 +15,7 @@ export interface MainBridgeAPI {
   cancelCurlRequest: typeof cancelCurlRequest;
   curlRequest: typeof curlRequest;
   on: (channel: string, listener: (event: IpcRendererEvent, ...args: any[]) => void) => () => void;
-  webSocket: WebSocketBridgeAPI;
+  websocket: WebSocketBridgeAPI;
 }
 export function registerMainHandlers() {
   ipcMain.handle('authorizeUserInWindow', (_, options: Parameters<typeof authorizeUserInWindow>[0]) => {

--- a/packages/insomnia/src/models/helpers/request-operations.ts
+++ b/packages/insomnia/src/models/helpers/request-operations.ts
@@ -8,7 +8,7 @@ export function getById(requestId: string): Promise<Request | GrpcRequest | WebS
     return models.grpcRequest.getById(requestId);
   }
   if (isWebSocketRequestId(requestId)) {
-    return models.webSocketRequest.getById(requestId);
+    return models.websocketRequest.getById(requestId);
   }
   return models.request.getById(requestId);
 }
@@ -18,7 +18,7 @@ export function remove(request: Request | GrpcRequest | WebSocketRequest) {
     return models.grpcRequest.remove(request);
   }
   if (isWebSocketRequest(request)) {
-    return models.webSocketRequest.remove(request);
+    return models.websocketRequest.remove(request);
   }
   return models.request.remove(request);
 }
@@ -32,7 +32,7 @@ export function update<T extends object>(request: T, patch: Partial<T> = {}): Pr
   // @ts-expect-error -- TSCONVERSION
   if (isWebSocketRequest(request)) {
     // @ts-expect-error -- TSCONVERSION
-    return models.webSocketRequest.update(request, patch);
+    return models.websocketRequest.update(request, patch);
   }
   // @ts-expect-error -- TSCONVERSION
   return models.request.update(request, patch);
@@ -47,7 +47,7 @@ export function duplicate<T extends object>(request: T, patch: Partial<T> = {}):
   // @ts-expect-error -- TSCONVERSION
   if (isWebSocketRequest(request)) {
     // @ts-expect-error -- TSCONVERSION
-    return models.webSocketRequest.duplicate(request, patch);
+    return models.websocketRequest.duplicate(request, patch);
   }
   // @ts-expect-error -- TSCONVERSION
   return models.request.duplicate(request, patch);

--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -37,9 +37,9 @@ import * as _stats from './stats';
 import * as _unitTest from './unit-test';
 import * as _unitTestResult from './unit-test-result';
 import * as _unitTestSuite from './unit-test-suite';
-import * as _webSocketPayload from './websocket-payload';
-import * as _webSocketRequest from './websocket-request';
-import * as _webSocketResponse from './websocket-response';
+import * as _websocketPayload from './websocket-payload';
+import * as _websocketRequest from './websocket-request';
+import * as _websocketResponse from './websocket-response';
 import * as _workspace from './workspace';
 import * as _workspaceMeta from './workspace-meta';
 
@@ -80,9 +80,9 @@ export const protoFile = _protoFile;
 export const protoDirectory = _protoDirectory;
 export const grpcRequest = _grpcRequest;
 export const grpcRequestMeta = _grpcRequestMeta;
-export const webSocketPayload = _webSocketPayload;
-export const webSocketRequest = _webSocketRequest;
-export const webSocketResponse = _webSocketResponse;
+export const websocketPayload = _websocketPayload;
+export const websocketRequest = _websocketRequest;
+export const websocketResponse = _websocketResponse;
 export const workspace = _workspace;
 export const workspaceMeta = _workspaceMeta;
 
@@ -116,9 +116,9 @@ export function all() {
     protoDirectory,
     grpcRequest,
     grpcRequestMeta,
-    webSocketPayload,
-    webSocketRequest,
-    webSocketResponse,
+    websocketPayload,
+    websocketRequest,
+    websocketResponse,
   ] as const;
 }
 
@@ -218,8 +218,8 @@ export async function initModel<T extends BaseModel>(type: string, ...sources: R
 
 export const MODELS_BY_EXPORT_TYPE: Record<string, any> = {
   [EXPORT_TYPE_REQUEST]: request,
-  [EXPORT_TYPE_WEBSOCKET_PAYLOAD]: webSocketPayload,
-  [EXPORT_TYPE_WEBSOCKET_REQUEST]: webSocketRequest,
+  [EXPORT_TYPE_WEBSOCKET_PAYLOAD]: websocketPayload,
+  [EXPORT_TYPE_WEBSOCKET_REQUEST]: websocketRequest,
   [EXPORT_TYPE_GRPC_REQUEST]: grpcRequest,
   [EXPORT_TYPE_REQUEST_GROUP]: requestGroup,
   [EXPORT_TYPE_UNIT_TEST_SUITE]: unitTestSuite,

--- a/packages/insomnia/src/models/websocket-payload.ts
+++ b/packages/insomnia/src/models/websocket-payload.ts
@@ -3,7 +3,7 @@ import type { BaseModel } from '.';
 
 export const name = 'WebSocket Payload';
 
-export const type = 'WebSocketPayload';
+export const type = 'WebsocketPayload';
 
 export const prefix = 'ws-payload';
 

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -4,7 +4,7 @@ import { RequestAuthentication, RequestHeader } from './request';
 
 export const name = 'WebSocket Request';
 
-export const type = 'WebSocketRequest';
+export const type = 'WebsocketRequest';
 
 export const prefix = 'ws-req';
 

--- a/packages/insomnia/src/models/websocket-response.ts
+++ b/packages/insomnia/src/models/websocket-response.ts
@@ -8,7 +8,7 @@ import { ResponseHeader } from './response';
 
 export const name = 'WebSocket Response';
 
-export const type = 'WebSocketResponse';
+export const type = 'WebsocketResponse';
 
 export const prefix = 'ws-res';
 

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -2,16 +2,16 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 import type { WebSocketBridgeAPI } from './main/network/websocket';
 
-const webSocket: WebSocketBridgeAPI = {
-  create: options => ipcRenderer.invoke('webSocket.create', options),
-  close: options => ipcRenderer.invoke('webSocket.close', options),
-  closeAll: () => ipcRenderer.invoke('webSocket.closeAll'),
+const websocket: WebSocketBridgeAPI = {
+  create: options => ipcRenderer.invoke('websocket.create', options),
+  close: options => ipcRenderer.invoke('websocket.close', options),
+  closeAll: () => ipcRenderer.invoke('websocket.closeAll'),
   readyState: {
-    getCurrent: options => ipcRenderer.invoke('webSocket.readyState', options),
+    getCurrent: options => ipcRenderer.invoke('websocket.readyState', options),
   },
   event: {
-    findMany: options => ipcRenderer.invoke('webSocket.event.findMany', options),
-    send: options => ipcRenderer.invoke('webSocket.event.send', options),
+    findMany: options => ipcRenderer.invoke('websocket.event.findMany', options),
+    send: options => ipcRenderer.invoke('websocket.event.send', options),
   },
 };
 
@@ -27,7 +27,7 @@ const main: Window['main'] = {
     ipcRenderer.on(channel, listener);
     return () => ipcRenderer.removeListener(channel, listener);
   },
-  webSocket,
+  websocket,
 };
 const dialog: Window['dialog'] = {
   showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -51,7 +51,7 @@ export const ResponseHistoryDropdown = <GenericResponse extends Response | WebSo
   const handleDeleteResponses = useCallback(async () => {
     const environmentId = activeEnvironment ? activeEnvironment._id : null;
     if (isWebSocketResponse(activeResponse)) {
-      await models.webSocketResponse.removeForRequest(requestId, environmentId);
+      await models.websocketResponse.removeForRequest(requestId, environmentId);
     } else {
       await models.response.removeForRequest(requestId, environmentId);
     }
@@ -64,7 +64,7 @@ export const ResponseHistoryDropdown = <GenericResponse extends Response | WebSo
   const handleDeleteResponse = useCallback(async () => {
     if (activeResponse) {
       if (isWebSocketResponse(activeResponse)) {
-        await models.webSocketResponse.remove(activeResponse);
+        await models.websocketResponse.remove(activeResponse);
       } else {
         await models.response.remove(activeResponse);
       }

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -43,7 +43,7 @@ const ActionButton: FC<ActionButtonProps> = ({ requestId, readyState }) => {
       type="button"
       warning
       onClick={() => {
-        window.main.webSocket.close({ requestId });
+        window.main.websocket.close({ requestId });
       }}
     >
       Disconnect
@@ -111,7 +111,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, workspaceId, e
         authentication,
       }, renderContext);
 
-      window.main.webSocket.create({
+      window.main.websocket.create({
         requestId: request._id,
         workspaceId,
         url: rendered.url,

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -86,7 +86,7 @@ const WebSocketRequestForm: FC<FormProps> = ({
       const renderContext = await getRenderContext({ request, environmentId, purpose: RENDER_PURPOSE_SEND });
       const renderedMessage = await render(message, renderContext);
 
-      window.main.webSocket.event.send({ requestId: request._id, message: renderedMessage });
+      window.main.websocket.event.send({ requestId: request._id, message: renderedMessage });
     } catch (err) {
       if (err.type === 'render') {
         showModal(RequestRenderErrorModal, {
@@ -135,17 +135,13 @@ interface Props {
   forceRefreshKey: number;
 }
 
-// requestId is something we can read from the router params in the future.
-// essentially we can lift up the states and merge request pane and response pane into a single page and divide the UI there.
-// currently this is blocked by the way page layout divide the panes with dragging functionality
-// TODO: @gatzjames discuss above assertion in light of request and settings drills
 export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environmentId, forceRefreshKey }) => {
   const readyState = useWSReadyState(request._id);
 
   const disabled = readyState === ReadyState.OPEN || readyState === ReadyState.CLOSING;
   const handleOnChange = (url: string) => {
     if (url !== request.url) {
-      models.webSocketRequest.update(request, { url });
+      models.websocketRequest.update(request, { url });
     }
   };
   const [previewMode, setPreviewMode] = useState(CONTENT_TYPE_JSON);
@@ -154,7 +150,7 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
   useEffect(() => {
     let isMounted = true;
     const fn = async () => {
-      const payload = await models.webSocketPayload.getByParentId(request._id);
+      const payload = await models.websocketPayload.getByParentId(request._id);
       if (isMounted && payload) {
         setInitialValue(payload.value);
         setPreviewMode(payload.mode);
@@ -173,12 +169,12 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
 
   const createOrUpdatePayload = async (value: string, mode: string) => {
     // @TODO: multiple payloads
-    const payload = await models.webSocketPayload.getByParentId(request._id);
+    const payload = await models.websocketPayload.getByParentId(request._id);
     if (payload) {
-      await models.webSocketPayload.update(payload, { value, mode });
+      await models.websocketPayload.update(payload, { value, mode });
       return;
     }
-    await models.webSocketPayload.create({
+    await models.websocketPayload.create({
       parentId: request._id,
       value,
       mode,

--- a/packages/insomnia/src/ui/components/websockets/websocket-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-response-pane.tsx
@@ -90,7 +90,7 @@ const WebSocketActiveResponsePane: FC<{ requestId: string; response: WebSocketRe
 
   const setActiveResponseAndDisconnect = (requestId: string, response: WebSocketResponse | null) => {
     handleSetActiveResponse(requestId, response);
-    window.main.webSocket.close({ requestId });
+    window.main.websocket.close({ requestId });
   };
 
   useEffect(() => {

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -78,7 +78,7 @@ export const WrapperDebug: FC<Props> = ({
   // Close all websocket connections when the active environment changes
   useEffect(() => {
     return () => {
-      window.main.webSocket.closeAll();
+      window.main.websocket.closeAll();
     };
   }, [activeEnvironment?._id]);
 

--- a/packages/insomnia/src/ui/context/websocket-client/use-ws-connection-events.ts
+++ b/packages/insomnia/src/ui/context/websocket-client/use-ws-connection-events.ts
@@ -9,7 +9,7 @@ export function useWebSocketConnectionEvents({ responseId }: { responseId: strin
     () => {
       let isMounted = true;
       const fn = async () => {
-        const allEvents = await window.main.webSocket.event.findMany({ responseId });
+        const allEvents = await window.main.websocket.event.findMany({ responseId });
         if (isMounted) {
           setEvents(allEvents);
         }

--- a/packages/insomnia/src/ui/context/websocket-client/use-ws-ready-state.ts
+++ b/packages/insomnia/src/ui/context/websocket-client/use-ws-ready-state.ts
@@ -10,14 +10,14 @@ export function useWSReadyState(requestId: string): ReadyState {
   const [readyState, setReadyState] = useState<ReadyState>(ReadyState.CLOSED);
 
   useEffect(() => {
-    window.main.webSocket.readyState.getCurrent({ requestId })
+    window.main.websocket.readyState.getCurrent({ requestId })
       .then((currentReadyState: ReadyState) => {
         setReadyState(currentReadyState);
       });
   }, [requestId]);
 
   useEffect(() => {
-    const unsubscribe = window.main.on(`webSocket.${requestId}.readyState`,
+    const unsubscribe = window.main.on(`websocket.${requestId}.readyState`,
       (_, incomingReadyState: ReadyState) => {
         setReadyState(incomingReadyState);
       });

--- a/packages/insomnia/src/ui/hooks/create-request.ts
+++ b/packages/insomnia/src/ui/hooks/create-request.ts
@@ -111,10 +111,11 @@ export const createRequest: RequestCreator = async ({
     }
 
     case 'WebSocket': {
-      const request = await models.webSocketRequest.create({
+      const request = await models.websocketRequest.create({
         parentId,
         name: 'New WebSocket Request',
       });
+      console.log(request._id);
       models.stats.incrementCreatedRequests();
       setActiveRequest(request._id, workspaceId);
       break;

--- a/packages/insomnia/src/ui/redux/__tests__/sidebar-selectors.test.ts
+++ b/packages/insomnia/src/ui/redux/__tests__/sidebar-selectors.test.ts
@@ -17,7 +17,7 @@ const grpcRequestModelBuilder = createBuilder(grpcRequestModelSchema);
 
 describe('shouldShowInSidebar', () => {
   const allTypes = models.types();
-  const supported = [models.request.type, models.requestGroup.type, models.grpcRequest.type, models.webSocketRequest.type];
+  const supported = [models.request.type, models.requestGroup.type, models.grpcRequest.type, models.websocketRequest.type];
   const unsupported = difference(allTypes, supported);
 
   it.each(supported)('should show %s in sidebar', type => {

--- a/packages/insomnia/src/ui/redux/modules/entities.ts
+++ b/packages/insomnia/src/ui/redux/modules/entities.ts
@@ -73,9 +73,9 @@ export interface EntitiesState {
   protoDirectories: EntityRecord<ProtoDirectory>;
   grpcRequests: EntityRecord<GrpcRequest>;
   grpcRequestMetas: EntityRecord<GrpcRequestMeta>;
-  webSocketPayloads: EntityRecord<WebSocketPayload>;
-  webSocketRequests: EntityRecord<WebSocketRequest>;
-  webSocketResponses: EntityRecord<WebSocketResponse>;
+  websocketPayloads: EntityRecord<WebSocketPayload>;
+  websocketRequests: EntityRecord<WebSocketRequest>;
+  websocketResponses: EntityRecord<WebSocketResponse>;
 }
 
 export const initialEntitiesState: EntitiesState = {
@@ -104,9 +104,9 @@ export const initialEntitiesState: EntitiesState = {
   protoDirectories: {},
   grpcRequests: {},
   grpcRequestMetas: {},
-  webSocketPayloads: {},
-  webSocketRequests: {},
-  webSocketResponses: {},
+  websocketPayloads: {},
+  websocketRequests: {},
+  websocketResponses: {},
 };
 
 export function reducer(state = initialEntitiesState, action: any) {
@@ -206,8 +206,8 @@ export async function allDocs() {
     ...(await models.protoDirectory.all()),
     ...(await models.grpcRequest.all()),
     ...(await models.grpcRequestMeta.all()),
-    ...(await models.webSocketPayload.all()),
-    ...(await models.webSocketRequest.all()),
-    ...(await models.webSocketResponse.all()),
+    ...(await models.websocketPayload.all()),
+    ...(await models.websocketRequest.all()),
+    ...(await models.websocketResponse.all()),
   ];
 }

--- a/packages/insomnia/src/ui/redux/selectors.ts
+++ b/packages/insomnia/src/ui/redux/selectors.ts
@@ -314,7 +314,7 @@ export const selectActiveWorkspaceEntities = createSelector(
 
 export const selectPinnedRequests = createSelector(selectEntitiesLists, entities => {
   const pinned: Record<string, boolean> = {};
-  const requests = [...entities.requests, ...entities.grpcRequests, ...entities.webSocketRequests];
+  const requests = [...entities.requests, ...entities.grpcRequests, ...entities.websocketRequests];
   const requestMetas = [...entities.requestMetas, ...entities.grpcRequestMetas];
 
   // Default all to unpinned
@@ -353,8 +353,8 @@ export const selectActiveRequest = createSelector(
       return entities.grpcRequests[id];
     }
 
-    if (id in entities.webSocketRequests) {
-      return entities.webSocketRequests[id];
+    if (id in entities.websocketRequests) {
+      return entities.websocketRequests[id];
     }
 
     return null;
@@ -442,7 +442,7 @@ export const selectActiveRequestResponses = createSelector(
   (activeRequest, entities, activeEnvironment, settings) => {
     const requestId = activeRequest ? activeRequest._id : 'n/a';
 
-    const responses: (Response | WebSocketResponse)[] = (activeRequest && isWebSocketRequest(activeRequest)) ?  entities.webSocketResponses : entities.responses;
+    const responses: (Response | WebSocketResponse)[] = (activeRequest && isWebSocketRequest(activeRequest)) ?  entities.websocketResponses : entities.responses;
 
     // Filter responses down if the setting is enabled
     return responses.filter(response => {


### PR DESCRIPTION
allow only websocket and WebSocket capitalisation with one exception in the filename/type of the database model.
The explanation for this exception includes two conflicting points.
- the redux hack in entities.ts which lowercases the model types in `getReducerName` meaning if we use the WebSocket capitalisation it will lowercase the W forcing the redux stored datamodels to be addressed as webSocket and breaking or convention.
- there are no other database types with lowercase initials.

Either we use this proposal or we use webSocket two word styling in code as we are currently.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
