### PR TITLE
Remove negative space from event log view

### DIFF
--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -67,7 +67,7 @@ const EventLog = styled('div')({
   width: '100%',
   height: '100%',
   overflow: 'hidden',
-  border: '1px solid var(--hl-md)',
+  borderTop: '1px solid var(--hl-md)',
 });
 
 const EventIconCell = styled('div')({

--- a/packages/insomnia/src/ui/components/websockets/websocket-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-response-pane.tsx
@@ -32,7 +32,6 @@ const EventLogTableWrapper = styled.div({
   width: '100%',
   flex: 1,
   overflow: 'hidden',
-  padding: 'var(--padding-sm)',
   boxSizing: 'border-box',
 });
 


### PR DESCRIPTION
Removes negative space from event log view making it more compact.
Closes INS-1965

**Before:**
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/12115431/189881175-401a8cef-0e65-4e1f-b85f-f2cbacb8c1db.png">

**After:**
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/12115431/189881028-80450d97-c97c-48c9-8bd0-634dac666250.png">