### PR TITLE
[INS-1804] Add Query Tab for WebSocket

### DIFF
--- a/packages/insomnia-smoke-test/server/index.ts
+++ b/packages/insomnia-smoke-test/server/index.ts
@@ -78,5 +78,6 @@ startGRPCServer(grpcPort).then(() => {
     console.log(`Listening at wss://localhost:${httpsPort}`);
   });
 
-  startWebSocketServer(server, httpsServer);
+  startWebSocketServer(server);
+  startWebSocketServer(httpsServer);
 });

--- a/packages/insomnia-smoke-test/server/websocket.ts
+++ b/packages/insomnia-smoke-test/server/websocket.ts
@@ -5,18 +5,14 @@ import { WebSocket, WebSocketServer } from 'ws';
 /**
  * Starts an echo WebSocket server that receives messages from a client and echoes them back.
  */
-export function startWebSocketServer(server: Server, httpsServer: Server) {
+export function startWebSocketServer(server: Server) {
   const wsServer = new WebSocketServer({ noServer: true });
-  const wssServer = new WebSocketServer({ noServer: true });
 
   server.on('upgrade', (request, socket, head) => {
     upgrade(wsServer, request, socket, head);
   });
-  httpsServer.on('upgrade', (request, socket, head) => {
-    upgrade(wssServer, request, socket, head);
-  });
+
   wsServer.on('connection', handleConnection);
-  wssServer.on('connection', handleConnection);
 }
 
 const handleConnection = (ws: WebSocket, req: IncomingMessage) => {

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -1,6 +1,6 @@
 import { database } from '../common/database';
 import type { BaseModel } from '.';
-import { RequestAuthentication, RequestHeader } from './request';
+import { RequestAuthentication, RequestHeader, RequestParameter } from './request';
 
 export const name = 'WebSocket Request';
 
@@ -19,6 +19,8 @@ export interface BaseWebSocketRequest {
   metaSortKey: number;
   headers: RequestHeader[];
   authentication: RequestAuthentication;
+  parameters: RequestParameter[];
+  settingEncodeUrl: boolean;
 }
 
 export type WebSocketRequest = BaseModel & BaseWebSocketRequest & { type: typeof type };
@@ -37,6 +39,8 @@ export const init = (): BaseWebSocketRequest => ({
   metaSortKey: -1 * Date.now(),
   headers: [],
   authentication: {},
+  parameters: [],
+  settingEncodeUrl: true,
 });
 
 export const migrate = (doc: WebSocketRequest) => doc;

--- a/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
@@ -9,11 +9,13 @@ import { KeyValueEditor } from '../key-value-editor/key-value-editor';
 interface Props {
   bulk: boolean;
   request: Request | WebSocketRequest;
+  disabled?: boolean;
 }
 
 export const RequestParametersEditor: FC<Props> = ({
   request,
   bulk,
+  disabled = false,
 }) => {
   const handleBulkUpdate = useCallback((paramsString: string) => {
     const parameters: {
@@ -63,6 +65,7 @@ export const RequestParametersEditor: FC<Props> = ({
         onChange={handleBulkUpdate}
         defaultValue={paramsString}
         enableNunjucks
+        readOnly={disabled}
       />
     );
   }
@@ -76,6 +79,7 @@ export const RequestParametersEditor: FC<Props> = ({
       descriptionPlaceholder="description"
       pairs={request.parameters}
       onChange={onChangeParameter}
+      isDisabled={disabled}
     />
   );
 };

--- a/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
@@ -2,12 +2,13 @@ import React, { FC, useCallback } from 'react';
 
 import { update } from '../../../models/helpers/request-operations';
 import type { Request, RequestParameter } from '../../../models/request';
+import { WebSocketRequest } from '../../../models/websocket-request';
 import { CodeEditor } from '../codemirror/code-editor';
 import { KeyValueEditor } from '../key-value-editor/key-value-editor';
 
 interface Props {
   bulk: boolean;
-  request: Request;
+  request: Request | WebSocketRequest;
 }
 
 export const RequestParametersEditor: FC<Props> = ({

--- a/packages/insomnia/src/ui/components/rendered-query-string.tsx
+++ b/packages/insomnia/src/ui/components/rendered-query-string.tsx
@@ -4,6 +4,7 @@ import { useAsync } from 'react-use';
 import styled from 'styled-components';
 
 import { Request } from '../../models/request';
+import { WebSocketRequest } from '../../models/websocket-request';
 import { useNunjucks } from '../context/nunjucks/use-nunjucks';
 import { CopyButton as _CopyButton } from './base/copy-button';
 
@@ -27,7 +28,7 @@ const CopyButton = styled(_CopyButton)({
 });
 
 interface Props {
-  request: Request;
+  request: Request | WebSocketRequest;
 }
 
 const defaultPreview = '...';
@@ -43,6 +44,8 @@ export const RenderedQueryString: FC<Props> = ({ request }) => {
         url: request.url,
         parameters: enabledParameters,
       });
+
+      console.log(result);
       if (!result) {
         return;
       }

--- a/packages/insomnia/src/ui/components/rendered-query-string.tsx
+++ b/packages/insomnia/src/ui/components/rendered-query-string.tsx
@@ -45,7 +45,6 @@ export const RenderedQueryString: FC<Props> = ({ request }) => {
         parameters: enabledParameters,
       });
 
-      console.log(result);
       if (!result) {
         return;
       }

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -80,10 +80,10 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, workspaceId, e
     }
     try {
       const renderContext = await getRenderContext({ request, environmentId, purpose: RENDER_PURPOSE_SEND });
-      const { url, headers, authentication, parameters } = request;
+      const { url: rawUrl, headers, authentication, parameters } = request;
       // Render any nunjucks tags in the url/headers/authentication settings
       const rendered = await render({
-        url,
+        url: rawUrl,
         headers,
         authentication,
         parameters,

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -89,7 +89,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, workspaceId, e
         parameters,
       }, renderContext);
       const queryString = buildQueryStringFromParams(rendered.parameters);
-      const urlWithQueries = joinUrlAndQueryString(rendered.url, qs);
+      const url = joinUrlAndQueryString(rendered.url, queryString);
       window.main.webSocket.create({
         requestId: request._id,
         workspaceId,

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -93,7 +93,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, workspaceId, e
       window.main.webSocket.create({
         requestId: request._id,
         workspaceId,
-        url: urlWithQueries,
+        url,
         headers: rendered.headers,
         authentication: rendered.authentication,
       });

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -1,3 +1,4 @@
+import { buildQueryStringFromParams, joinUrlAndQueryString } from 'insomnia-url';
 import React, { FC, useCallback, useLayoutEffect, useRef } from 'react';
 import styled from 'styled-components';
 
@@ -79,17 +80,20 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, workspaceId, e
     }
     try {
       const renderContext = await getRenderContext({ request, environmentId, purpose: RENDER_PURPOSE_SEND });
-      const { url, headers, authentication } = request;
+      const { url, headers, authentication, parameters } = request;
       // Render any nunjucks tags in the url/headers/authentication settings
       const rendered = await render({
         url,
         headers,
         authentication,
+        parameters,
       }, renderContext);
+      const qs = buildQueryStringFromParams(rendered.parameters);
+      const urlWithQueries = joinUrlAndQueryString(rendered.url, qs);
       window.main.webSocket.create({
         requestId: request._id,
         workspaceId,
-        url: rendered.url,
+        url: urlWithQueries,
         headers: rendered.headers,
         authentication: rendered.authentication,
       });

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -88,7 +88,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, workspaceId, e
         authentication,
         parameters,
       }, renderContext);
-      const qs = buildQueryStringFromParams(rendered.parameters);
+      const queryString = buildQueryStringFromParams(rendered.parameters);
       const urlWithQueries = joinUrlAndQueryString(rendered.url, qs);
       window.main.webSocket.create({
         requestId: request._id,

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -256,10 +256,7 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
         <TabPanel className="react-tabs__tab-panel">
           <AuthWrapper
             key={`${uniqueKey}-${request.authentication.type}-auth-header`}
-            disabled={
-              readyState === ReadyState.OPEN ||
-              readyState === ReadyState.CLOSING
-            }
+            disabled={disabled}
           />
         </TabPanel>
         <TabPanel className="react-tabs__tab-panel">
@@ -283,6 +280,7 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
                 key={headerEditorKey}
                 request={request}
                 bulk={useBulkParametersEditor}
+                disabled={disabled}
               />
             </ErrorBoundary>
           </div>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -1,4 +1,5 @@
 import React, { FC, FormEvent, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import styled from 'styled-components';
 
@@ -7,14 +8,18 @@ import { getRenderContext, render, RENDER_PURPOSE_SEND } from '../../../common/r
 import * as models from '../../../models';
 import { WebSocketRequest } from '../../../models/websocket-request';
 import { ReadyState, useWSReadyState } from '../../context/websocket-client/use-ws-ready-state';
+import { selectSettings } from '../../redux/selectors';
 import { CodeEditor, UnconnectedCodeEditor } from '../codemirror/code-editor';
 import { AuthDropdown } from '../dropdowns/auth-dropdown';
 import { WebSocketPreviewModeDropdown } from '../dropdowns/websocket-preview-mode';
 import { AuthWrapper } from '../editors/auth/auth-wrapper';
 import { RequestHeadersEditor } from '../editors/request-headers-editor';
+import { RequestParametersEditor } from '../editors/request-parameters-editor';
+import { ErrorBoundary } from '../error-boundary';
 import { showAlert, showModal } from '../modals';
 import { RequestRenderErrorModal } from '../modals/request-render-error-modal';
 import { Pane, PaneHeader as OriginalPaneHeader } from '../panes/pane';
+import { RenderedQueryString } from '../rendered-query-string';
 import { WebSocketActionBar } from './action-bar';
 
 const supportedAuthTypes: AuthType[] = ['basic', 'bearer'];
@@ -149,14 +154,16 @@ interface Props {
   workspaceId: string;
   environmentId: string;
   forceRefreshKey: number;
+  headerEditorKey: string;
 }
 
 // requestId is something we can read from the router params in the future.
 // essentially we can lift up the states and merge request pane and response pane into a single page and divide the UI there.
 // currently this is blocked by the way page layout divide the panes with dragging functionality
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
-export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environmentId, forceRefreshKey }) => {
+export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environmentId, forceRefreshKey, headerEditorKey }) => {
   const readyState = useWSReadyState(request._id);
+  const { useBulkParametersEditor } = useSelector(selectSettings);
 
   const disabled = readyState === ReadyState.OPEN || readyState === ReadyState.CLOSING;
   const handleOnChange = (url: string) => {
@@ -222,6 +229,9 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
           <Tab tabIndex="-1">
             <AuthDropdown authTypes={supportedAuthTypes} disabled={disabled} />
           </Tab>
+          <Tab tabIndex='-1'>
+            <button>Query</button>
+          </Tab>
           <Tab tabIndex="-1">
             <button>Headers</button>
           </Tab>
@@ -251,6 +261,31 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
               readyState === ReadyState.CLOSING
             }
           />
+        </TabPanel>
+        <TabPanel className="react-tabs__tab-panel">
+          <div className="pad pad-bottom-sm query-editor__preview">
+            <label className="label--small no-pad-top">Url Preview</label>
+            <code className="txt-sm block faint">
+              <ErrorBoundary
+                key={uniqueKey}
+                errorClassName="tall wide vertically-align font-error pad text-center"
+              >
+                <RenderedQueryString request={request} />
+              </ErrorBoundary>
+            </code>
+          </div>
+          <div className="query-editor__editor">
+            <ErrorBoundary
+              key={uniqueKey}
+              errorClassName="tall wide vertically-align font-error pad text-center"
+            >
+              <RequestParametersEditor
+                key={headerEditorKey}
+                request={request}
+                bulk={useBulkParametersEditor}
+              />
+            </ErrorBoundary>
+          </div>
         </TabPanel>
         <TabPanel className="react-tabs__tab-panel header-editor">
           <RequestHeadersEditor

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -136,6 +136,7 @@ export const WrapperDebug: FC<Props> = ({
                   workspaceId={activeWorkspace._id}
                   environmentId={activeEnvironment ? activeEnvironment._id : ''}
                   forceRefreshKey={forceRefreshKey}
+                  headerEditorKey={headerEditorKey}
                 />
               ) : (
                 <RequestPane


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
- Adding Query tab reusing the existing component used from RequestPane component
- Adding a new property in the websocket model
- Importing query building functions from 'insomnia-url' package
- (Bonus) tidying up smoke ws server creation function into two

Closes [INS-1804](https://linear.app/insomnia/issue/INS-1804/add-query-tab-to-request-pane)

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/103070941/189986283-88ef0d32-d161-4727-a907-648095dbd007.png">

Disabled when connected
<img width="603" alt="image" src="https://user-images.githubusercontent.com/103070941/189987362-feadbc5c-800d-4c60-812b-66b6cad5482d.png">

