### PR TITLE
websocket team sync

### DIFF
--- a/packages/insomnia/src/models/websocket-payload.ts
+++ b/packages/insomnia/src/models/websocket-payload.ts
@@ -9,8 +9,7 @@ export const prefix = 'ws-payload';
 
 export const canDuplicate = true;
 
-// @TODO: enable this at some point
-export const canSync = false;
+export const canSync = true;
 
 export interface BaseWebSocketPayload {
   value: string;

--- a/packages/insomnia/src/models/websocket-payload.ts
+++ b/packages/insomnia/src/models/websocket-payload.ts
@@ -12,6 +12,7 @@ export const canDuplicate = true;
 export const canSync = true;
 
 export interface BaseWebSocketPayload {
+  name: string;
   value: string;
   mode: string;
 }
@@ -27,6 +28,7 @@ export const isWebSocketPayloadId = (id: string | null) => (
 );
 
 export const init = (): BaseWebSocketPayload => ({
+  name: 'New Payload',
   value: '',
   mode: 'application/json',
 });

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -10,8 +10,7 @@ export const prefix = 'ws-req';
 
 export const canDuplicate = true;
 
-// @TODO: enable this at some point
-export const canSync = false;
+export const canSync = true;
 
 export interface BaseWebSocketRequest {
   name: string;

--- a/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
@@ -57,8 +57,8 @@ describe('NeDBClient', () => {
         models.requestGroup.type,
         models.unitTest.type,
         models.unitTestSuite.type,
-        models.webSocketRequest.type,
         models.webSocketPayload.type,
+        models.webSocketRequest.type,
         models.workspace.type,
       ]);
       expect(await neDbClient.readdir(reqDir)).toEqual(['req_1.yml', 'req_2.yml']);

--- a/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
@@ -58,6 +58,8 @@ describe('NeDBClient', () => {
         models.unitTest.type,
         models.unitTestSuite.type,
         models.workspace.type,
+        models.webSocketRequest.type,
+        models.webSocketPayload.type,
       ]);
       expect(await neDbClient.readdir(reqDir)).toEqual(['req_1.yml', 'req_2.yml']);
       expect(await neDbClient.readdir(wrkDir)).toEqual(['wrk_1.yml']);

--- a/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
@@ -57,9 +57,9 @@ describe('NeDBClient', () => {
         models.requestGroup.type,
         models.unitTest.type,
         models.unitTestSuite.type,
-        models.workspace.type,
         models.webSocketRequest.type,
         models.webSocketPayload.type,
+        models.workspace.type,
       ]);
       expect(await neDbClient.readdir(reqDir)).toEqual(['req_1.yml', 'req_2.yml']);
       expect(await neDbClient.readdir(wrkDir)).toEqual(['wrk_1.yml']);

--- a/packages/insomnia/src/sync/git/ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/ne-db-client.ts
@@ -148,6 +148,8 @@ export class NeDBClient {
         models.grpcRequest.type,
         models.protoFile.type,
         models.protoDirectory.type,
+        models.webSocketRequest.type,
+        models.webSocketPayload.type,
       ];
     } else if (type !== null && id === null) {
       const workspace = await db.get(models.workspace.type, this._workspaceId);


### PR DESCRIPTION
highlights:
- can sync ws request
- can sync ws payload
- adds a default payload name of "New Payload" in order to prepare for multiple payloads and have something to show in the staging table.

note
- responses are not synced in any request types
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
