### PR TITLE
Refactor/remove-react-hack-mime-type

### DIFF
--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -1,9 +1,10 @@
 import classnames from 'classnames';
 import { deconstructQueryStringToParams, extractQueryStringFromUrl } from 'insomnia-url';
-import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
+import React, { FC, useCallback, useEffect, useRef } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import { useMount } from 'react-use';
 
+import { getContentTypeFromHeaders } from '../../../common/constants';
 import * as models from '../../../models';
 import { queryAllWorkspaceUrls } from '../../../models/helpers/query-all-workspace-urls';
 import { update } from '../../../models/helpers/request-operations';
@@ -12,7 +13,6 @@ import type {
   RequestHeader,
 } from '../../../models/request';
 import type { Settings } from '../../../models/settings';
-import { isWebSocketRequest } from '../../../models/websocket-request';
 import type { Workspace } from '../../../models/workspace';
 import { AuthDropdown } from '../dropdowns/auth-dropdown';
 import { ContentTypeDropdown } from '../dropdowns/content-type-dropdown';
@@ -116,7 +116,6 @@ export const RequestPane: FC<Props> = ({
     request?._id, // happens when the user switches requests
     settings.hasPromptedAnalytics, // happens when the user dismisses the analytics modal
   ]);
-  const [forceRefreshHeaderCounter, setForceRefreshHeaderCounter] = useState(0);
 
   if (!request) {
     return (
@@ -125,43 +124,23 @@ export const RequestPane: FC<Props> = ({
   }
 
   async function updateRequestMimeType(mimeType: string | null): Promise<Request | null> {
-    console.log(request);
     if (!request) {
       console.warn('Tried to update request mime-type when no active request');
       return null;
     }
-
-    if (isWebSocketRequest(request)) {
-      console.warn('Tried to update request mime-type on WebSocket request');
-      return null;
-    }
-
-    const requestMeta = await models.requestMeta.getOrCreateByParentId(
-      request._id,
-    );
-    const savedBody = requestMeta.savedRequestBody;
-    const saveValue =
-      typeof mimeType !== 'string' // Switched to No body
-        ? request.body
-        : {};
+    const requestMeta = await models.requestMeta.getOrCreateByParentId(request._id,);
+    // Switched to No body
+    const savedRequestBody = typeof mimeType !== 'string' ? request.body : {};
     // Clear saved value in requestMeta
-    await models.requestMeta.update(requestMeta, {
-      savedRequestBody: saveValue,
-    });
-    // @ts-expect-error -- TSCONVERSION should skip this if active request is grpc request
-    const newRequest = await models.request.updateMimeType(request, mimeType, false, savedBody);
-    // Force it to update, because other editor components (header editor)
-    // needs to change. Need to wait a delay so the next render can finish
-    setTimeout(() => {
-      setForceRefreshHeaderCounter(forceRefreshHeaderCounter + 1);
-    }, 500);
-    return newRequest;
+    await models.requestMeta.update(requestMeta, { savedRequestBody });
+    // @ts-expect-error -- TSCONVERSION mimeType can be null when no body is selected but the updateMimeType logic needs to be reexamined
+    return models.request.updateMimeType(request, mimeType, false, requestMeta.savedRequestBody);
   }
   const numParameters = request.parameters.filter(p => !p.disabled).length;
   const numHeaders = request.headers.filter(h => !h.disabled).length;
   const urlHasQueryParameters = request.url.indexOf('?') >= 0;
   const uniqueKey = `${forceRefreshCounter}::${request._id}`;
-
+  const contentType = getContentTypeFromHeaders(request.headers) || request.body.mimeType;
   return (
     <Pane type="request">
       <PaneHeader>
@@ -244,7 +223,7 @@ export const RequestPane: FC<Props> = ({
               errorClassName="tall wide vertically-align font-error pad text-center"
             >
               <RequestParametersEditor
-                key={forceRefreshHeaderCounter + ''}
+                key={contentType}
                 request={request}
                 bulk={settings.useBulkParametersEditor}
               />
@@ -269,7 +248,7 @@ export const RequestPane: FC<Props> = ({
         <TabPanel className="react-tabs__tab-panel header-editor">
           <ErrorBoundary key={uniqueKey} errorClassName="font-error pad text-center">
             <RequestHeadersEditor
-              key={forceRefreshHeaderCounter + ''}
+              key={contentType}
               request={request}
               bulk={settings.useBulkHeaderEditor}
             />

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -154,14 +154,13 @@ interface Props {
   workspaceId: string;
   environmentId: string;
   forceRefreshKey: number;
-  headerEditorKey: string;
 }
 
 // requestId is something we can read from the router params in the future.
 // essentially we can lift up the states and merge request pane and response pane into a single page and divide the UI there.
 // currently this is blocked by the way page layout divide the panes with dragging functionality
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
-export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environmentId, forceRefreshKey, headerEditorKey }) => {
+export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environmentId, forceRefreshKey }) => {
   const readyState = useWSReadyState(request._id);
   const { useBulkParametersEditor } = useSelector(selectSettings);
 
@@ -277,7 +276,6 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
               errorClassName="tall wide vertically-align font-error pad text-center"
             >
               <RequestParametersEditor
-                key={headerEditorKey}
                 request={request}
                 bulk={useBulkParametersEditor}
                 disabled={disabled}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -44,8 +44,6 @@ interface Props {
   handleForceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleImport: Function;
   handleSetResponseFilter: (filter: string) => void;
-  handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
-  headerEditorKey: string;
   vcs: VCS | null;
 }
 export const WrapperDebug: FC<Props> = ({
@@ -58,8 +56,6 @@ export const WrapperDebug: FC<Props> = ({
   handleForceUpdateRequestHeaders,
   handleImport,
   handleSetResponseFilter,
-  handleUpdateRequestMimeType,
-  headerEditorKey,
   vcs,
 }) => {
   const activeProject = useSelector(selectActiveProject);
@@ -136,7 +132,6 @@ export const WrapperDebug: FC<Props> = ({
                   workspaceId={activeWorkspace._id}
                   environmentId={activeEnvironment ? activeEnvironment._id : ''}
                   forceRefreshKey={forceRefreshKey}
-                  headerEditorKey={headerEditorKey}
                 />
               ) : (
                 <RequestPane
@@ -145,10 +140,8 @@ export const WrapperDebug: FC<Props> = ({
                   forceUpdateRequest={handleForceUpdateRequest}
                   forceUpdateRequestHeaders={handleForceUpdateRequestHeaders}
                   handleImport={handleImport}
-                  headerEditorKey={headerEditorKey}
                   request={activeRequest}
                   settings={settings}
-                  updateRequestMimeType={handleUpdateRequestMimeType}
                   workspace={activeWorkspace}
                 />
               )

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -121,8 +121,6 @@ const spectral = initializeSpectral();
 
 export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps> & {
   handleSetResponseFilter: Function;
-  handleUpdateRequestMimeType: (mimeType: string | null) => Promise<Request | null>;
-  headerEditorKey: string;
   vcs: VCS | null;
   gitVCS: GitVCS | null;
 };
@@ -313,10 +311,8 @@ export class WrapperClass extends PureComponent<Props, State> {
       activeGitRepository,
       activeWorkspace,
       activeApiSpec,
-      handleUpdateRequestMimeType,
       gitVCS,
       vcs,
-      headerEditorKey,
     } = this.props;
 
     // Setup git sync dropdown for use in Design/Debug pages
@@ -492,10 +488,8 @@ export class WrapperClass extends PureComponent<Props, State> {
                   handleForceUpdateRequestHeaders={this._handleForceUpdateRequestHeaders}
                   handleImport={this._handleImport}
                   handleSetResponseFilter={this._handleSetResponseFilter}
-                  handleUpdateRequestMimeType={handleUpdateRequestMimeType}
                   handleSetActiveResponse={this.handleSetActiveResponse}
                   vcs={vcs}
-                  headerEditorKey={headerEditorKey}
                 />
               </Suspense>
             }


### PR DESCRIPTION
https://user-images.githubusercontent.com/3679927/190354438-eb285f3f-914b-4b7d-b1c4-81e23c87caf1.mov

eliminated the forceRefreshHeaderCounter
Set by: ContentTypeDropdown onChange
Key on: RequestParametersEditor + RequestHeadersEditor
 story: when I change content type I want body, header and query tabs to rerender
 
I accomplish this by keying the two other tabs on content type.

**future work:**
 This PR is cut from work to simplify the app.tsx god component in order to make reasoning about state easier. There are several other render hacks to solve to simplify app.tsx and unblock react-router and eliminate underlying state consistency bugs.

- forceRefreshCounter
- forceRefreshKey
- _forceRequestPaneRefresh
- _forceRequestPaneRefreshAfterDelay
- _updateGitVCS

 

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
