### PR TITLE
Force refresh cleanup

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -64,6 +64,7 @@ export const ResponseHistoryDropdown = <GenericResponse extends Response | WebSo
     if (!response || !response.requestVersionId) {
       return;
     }
+    models.requestVersion.restore(response.requestVersionId);
   }, [activeEnvironment]);
 
   const handleDeleteResponses = useCallback(async () => {

--- a/packages/insomnia/src/ui/components/editors/body/body-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/body-editor.tsx
@@ -12,11 +12,10 @@ import {
 } from '../../../../common/constants';
 import { documentationLinks } from '../../../../common/documentation';
 import { getContentTypeHeader } from '../../../../common/misc';
-import { update } from '../../../../models/helpers/request-operations';
+import * as models from '../../../../models';
 import type {
   Request,
   RequestBodyParameter,
-  RequestHeader,
 } from '../../../../models/request';
 import {
   newBodyFile,
@@ -37,7 +36,6 @@ import { RawEditor } from './raw-editor';
 import { UrlEncodedEditor } from './url-encoded-editor';
 
 interface Props {
-  onChangeHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   request: Request;
   workspace: Workspace;
   settings: Settings;
@@ -45,7 +43,6 @@ interface Props {
 }
 
 export const BodyEditor: FC<Props> = ({
-  onChangeHeaders,
   request,
   workspace,
   settings,
@@ -54,28 +51,28 @@ export const BodyEditor: FC<Props> = ({
   const handleRawChange = useCallback((rawValue: string) => {
     const oldContentType = request.body.mimeType || '';
     const body = newBodyRaw(rawValue, oldContentType);
-    update(request, { body });
+    models.request.update(request, { body });
   }, [request]);
 
   const handleGraphQLChange = useCallback((content: string) => {
     const body = newBodyRaw(content, CONTENT_TYPE_GRAPHQL);
-    update(request, { body });
+    models.request.update(request, { body });
   }, [request]);
 
   const handleFormUrlEncodedChange = useCallback((parameters: RequestBodyParameter[]) => {
     const body = newBodyFormUrlEncoded(parameters);
-    update(request, { body });
+    models.request.update(request, { body });
   }, [request]);
 
   const handleFormChange = useCallback((parameters: RequestBodyParameter[]) => {
     const body = newBodyForm(parameters);
-    update(request, { body });
+    models.request.update(request, { body });
   }, [request]);
 
   const handleFileChange = async (path: string) => {
     const headers = clone(request.headers);
     const body = newBodyFile(path);
-    const newRequest = await update(request, { body });
+    const newRequest = await models.request.update(request, { body });
     let contentTypeHeader = getContentTypeHeader(headers);
 
     if (!contentTypeHeader) {
@@ -100,7 +97,7 @@ export const BodyEditor: FC<Props> = ({
         </p>,
         onDone: (saidYes: boolean) => {
           if (saidYes) {
-            onChangeHeaders(newRequest, headers);
+            models.request.update(newRequest, { headers });
           }
         },
       });

--- a/packages/insomnia/src/ui/components/modals/nunjucks-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/nunjucks-modal.tsx
@@ -11,7 +11,6 @@ import { TagEditor } from '../templating/tag-editor';
 import { VariableEditor } from '../templating/variable-editor';
 
 interface Props {
-  uniqueKey: string;
   workspace: Workspace;
 }
 
@@ -66,7 +65,7 @@ export class NunjucksModal extends PureComponent<Props, State> {
   }
 
   render() {
-    const { uniqueKey, workspace } = this.props;
+    const { workspace } = this.props;
     const { defaultTemplate } = this.state;
     let editor: JSX.Element | null = null;
     let title = '';
@@ -80,7 +79,7 @@ export class NunjucksModal extends PureComponent<Props, State> {
     }
 
     return (
-      <Modal ref={this._setModalRef} onHide={this._handleModalHide} key={uniqueKey}>
+      <Modal ref={this._setModalRef} onHide={this._handleModalHide}>
         <ModalHeader>Edit {title}</ModalHeader>
         <ModalBody className="pad" key={defaultTemplate}>
           <form onSubmit={this._handleSubmit}>{editor}</form>

--- a/packages/insomnia/src/ui/components/panes/grpc-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-response-pane.tsx
@@ -1,21 +1,26 @@
 import React, { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
 
 import type { GrpcRequest } from '../../../models/grpc-request';
 import { useGrpcRequestState } from '../../context/grpc';
+import { useActiveRequestSyncVCSVersion, useGitVCSVersion } from '../../hooks/use-vcs-version';
+import { selectActiveEnvironment } from '../../redux/selectors';
 import { GrpcSpinner } from '../grpc-spinner';
 import { GrpcStatusTag } from '../tags/grpc-status-tag';
 import { GrpcTabbedMessages } from '../viewers/grpc-tabbed-messages';
 import { Pane, PaneBody, PaneHeader } from './pane';
 
 interface Props {
-  forceRefreshKey: number;
   activeRequest: GrpcRequest;
 }
 
-export const GrpcResponsePane: FunctionComponent<Props> = ({ activeRequest, forceRefreshKey }) => {
-  // Used to refresh input fields to their default value when switching between requests.
-  // This is a common pattern in this codebase.
-  const uniquenessKey = `${forceRefreshKey}::${activeRequest._id}`;
+export const GrpcResponsePane: FunctionComponent<Props> = ({ activeRequest }) => {
+  const gitVersion = useGitVCSVersion();
+  const activeRequestSyncVersion = useActiveRequestSyncVCSVersion();
+  const activeEnvironment = useSelector(selectActiveEnvironment);
+  // Force re-render when we switch requests, the environment gets modified, or the (Git|Sync)VCS version changes
+  const uniquenessKey = `${activeEnvironment?.modified}::${activeRequest?._id}::${gitVersion}::${activeRequestSyncVersion}`;
+
   const { responseMessages, status, error } = useGrpcRequestState(activeRequest._id);
   return (
     <Pane type="response">

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -9,10 +9,7 @@ import { getContentTypeFromHeaders } from '../../../common/constants';
 import * as models from '../../../models';
 import { queryAllWorkspaceUrls } from '../../../models/helpers/query-all-workspace-urls';
 import { update } from '../../../models/helpers/request-operations';
-import type {
-  Request,
-  RequestHeader,
-} from '../../../models/request';
+import type { Request } from '../../../models/request';
 import type { Settings } from '../../../models/settings';
 import type { Workspace } from '../../../models/workspace';
 import { useActiveRequestSyncVCSVersion, useGitVCSVersion } from '../../hooks/use-vcs-version';
@@ -34,8 +31,6 @@ import { PlaceholderRequestPane } from './placeholder-request-pane';
 
 interface Props {
   environmentId: string;
-  forceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
-  forceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleImport: Function;
   request?: Request | null;
   settings: Settings;
@@ -44,8 +39,6 @@ interface Props {
 
 export const RequestPane: FC<Props> = ({
   environmentId,
-  forceUpdateRequest,
-  forceUpdateRequestHeaders,
   handleImport,
   request,
   settings,
@@ -100,12 +93,12 @@ export const RequestPane: FC<Props> = ({
 
     // Only update if url changed
     if (url !== request.url) {
-      forceUpdateRequest(request, {
+      models.request.update(request, {
         url,
         parameters,
       });
     }
-  }, [request, forceUpdateRequest]);
+  }, [request]);
 
   const requestUrlBarRef = useRef<RequestUrlBarHandle>(null);
   useMount(() => {
@@ -200,7 +193,6 @@ export const RequestPane: FC<Props> = ({
             workspace={workspace}
             environmentId={environmentId}
             settings={settings}
-            onChangeHeaders={forceUpdateRequestHeaders}
           />
         </TabPanel>
         <TabPanel className="react-tabs__tab-panel scrollable-container">

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -13,7 +13,7 @@ import type { Request } from '../../../models/request';
 import type { Settings } from '../../../models/settings';
 import type { Workspace } from '../../../models/workspace';
 import { useActiveRequestSyncVCSVersion, useGitVCSVersion } from '../../hooks/use-vcs-version';
-import { selectActiveEnvironment } from '../../redux/selectors';
+import { selectActiveEnvironment, selectActiveRequestMeta } from '../../redux/selectors';
 import { AuthDropdown } from '../dropdowns/auth-dropdown';
 import { ContentTypeDropdown } from '../dropdowns/content-type-dropdown';
 import { AuthWrapper } from '../editors/auth/auth-wrapper';
@@ -113,8 +113,10 @@ export const RequestPane: FC<Props> = ({
   const gitVersion = useGitVCSVersion();
   const activeRequestSyncVersion = useActiveRequestSyncVCSVersion();
   const activeEnvironment = useSelector(selectActiveEnvironment);
+  // const activeResponse = useSelector(selectActiveResponse);
+  const activeRequestMeta = useSelector(selectActiveRequestMeta);
   // Force re-render when we switch requests, the environment gets modified, or the (Git|Sync)VCS version changes
-  const uniqueKey = `${activeEnvironment?.modified}::${request?._id}::${gitVersion}::${activeRequestSyncVersion}`;
+  const uniqueKey = `${activeEnvironment?.modified}::${request?._id}::${gitVersion}::${activeRequestSyncVersion}::${activeRequestMeta?.activeResponseId}`;
 
   if (!request) {
     return (

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -33,12 +33,10 @@ import { PlaceholderResponsePane } from './placeholder-response-pane';
 
 interface Props {
   handleSetFilter: (filter: string) => void;
-  handleSetActiveResponse: (requestId: string, activeResponse: Response | null) => void;
   request?: Request | null;
 }
 export const ResponsePane: FC<Props> = ({
   handleSetFilter,
-  handleSetActiveResponse,
   request,
 }) => {
   const response = useSelector(selectActiveResponse) as Response | null;
@@ -135,7 +133,6 @@ export const ResponsePane: FC<Props> = ({
           </div>
           <ResponseHistoryDropdown
             activeResponse={response}
-            handleSetActiveResponse={handleSetActiveResponse}
             requestId={request._id}
             className="tall pane__header__right"
           />

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -6,9 +6,11 @@ import styled from 'styled-components';
 import { AuthType, CONTENT_TYPE_JSON } from '../../../common/constants';
 import { getRenderContext, render, RENDER_PURPOSE_SEND } from '../../../common/render';
 import * as models from '../../../models';
+import { Environment } from '../../../models/environment';
 import { WebSocketRequest } from '../../../models/websocket-request';
 import { ReadyState, useWSReadyState } from '../../context/websocket-client/use-ws-ready-state';
-import { selectSettings } from '../../redux/selectors';
+import { useActiveRequestSyncVCSVersion, useGitVCSVersion } from '../../hooks/use-vcs-version';
+import {  selectSettings } from '../../redux/selectors';
 import { CodeEditor, UnconnectedCodeEditor } from '../codemirror/code-editor';
 import { AuthDropdown } from '../dropdowns/auth-dropdown';
 import { WebSocketPreviewModeDropdown } from '../dropdowns/websocket-preview-mode';
@@ -152,15 +154,14 @@ const WebSocketRequestForm: FC<FormProps> = ({
 interface Props {
   request: WebSocketRequest;
   workspaceId: string;
-  environmentId: string;
-  forceRefreshKey: number;
+  environment: Environment | null;
 }
 
 // requestId is something we can read from the router params in the future.
 // essentially we can lift up the states and merge request pane and response pane into a single page and divide the UI there.
 // currently this is blocked by the way page layout divide the panes with dragging functionality
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
-export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environmentId, forceRefreshKey }) => {
+export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environment }) => {
   const readyState = useWSReadyState(request._id);
   const { useBulkParametersEditor } = useSelector(selectSettings);
 
@@ -205,7 +206,11 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
     }
   };
 
-  const uniqueKey = `${forceRefreshKey}::${request._id}`;
+  const gitVersion = useGitVCSVersion();
+  const activeRequestSyncVersion = useActiveRequestSyncVCSVersion();
+
+  // Reset the response pane state when we switch requests, the environment gets modified, or the (Git|Sync)VCS version changes
+  const uniqueKey = `${environment?.modified}::${request?._id}::${gitVersion}::${activeRequestSyncVersion}`;
 
   return (
     <Pane type="request">
@@ -214,7 +219,7 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
           key={uniqueKey}
           request={request}
           workspaceId={workspaceId}
-          environmentId={environmentId}
+          environmentId={environment?._id || ''}
           defaultValue={request.url}
           readyState={readyState}
           onChange={handleOnChange}
@@ -249,12 +254,12 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
             key={uniqueKey}
             request={request}
             previewMode={previewMode}
-            environmentId={environmentId}
+            environmentId={environment?._id || ''}
           />
         </PayloadTabPanel>
         <TabPanel className="react-tabs__tab-panel">
           <AuthWrapper
-            key={`${uniqueKey}-${request.authentication.type}-auth-header`}
+            key={uniqueKey}
             disabled={disabled}
           />
         </TabPanel>
@@ -285,7 +290,7 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
         </TabPanel>
         <TabPanel className="react-tabs__tab-panel header-editor">
           <RequestHeadersEditor
-            key={`${uniqueKey}-${readyState}-header-editor`}
+            key={uniqueKey}
             request={request}
             bulk={false}
             isDisabled={readyState === ReadyState.OPEN}

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -10,7 +10,7 @@ import { Environment } from '../../../models/environment';
 import { WebSocketRequest } from '../../../models/websocket-request';
 import { ReadyState, useWSReadyState } from '../../context/websocket-client/use-ws-ready-state';
 import { useActiveRequestSyncVCSVersion, useGitVCSVersion } from '../../hooks/use-vcs-version';
-import {  selectSettings } from '../../redux/selectors';
+import {  selectActiveRequestMeta, selectSettings } from '../../redux/selectors';
 import { CodeEditor, UnconnectedCodeEditor } from '../codemirror/code-editor';
 import { AuthDropdown } from '../dropdowns/auth-dropdown';
 import { WebSocketPreviewModeDropdown } from '../dropdowns/websocket-preview-mode';
@@ -208,9 +208,10 @@ export const WebSocketRequestPane: FC<Props> = ({ request, workspaceId, environm
 
   const gitVersion = useGitVCSVersion();
   const activeRequestSyncVersion = useActiveRequestSyncVCSVersion();
+  const activeRequestMeta = useSelector(selectActiveRequestMeta);
 
   // Reset the response pane state when we switch requests, the environment gets modified, or the (Git|Sync)VCS version changes
-  const uniqueKey = `${environment?.modified}::${request?._id}::${gitVersion}::${activeRequestSyncVersion}`;
+  const uniqueKey = `${environment?.modified}::${request?._id}::${gitVersion}::${activeRequestSyncVersion}::${activeRequestMeta?.activeResponseId}`;
 
   return (
     <Pane type="request">

--- a/packages/insomnia/src/ui/components/websockets/websocket-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-response-pane.tsx
@@ -48,10 +48,9 @@ const PaneBodyContent = styled.div({
   gridTemplateRows: 'repeat(auto-fit, minmax(0, 1fr))',
 });
 
-export const WebSocketResponsePane: FC<{ requestId: string; handleSetActiveResponse: (requestId: string, activeResponse: WebSocketResponse | null) => void }> =
+export const WebSocketResponsePane: FC<{ requestId: string }> =
   ({
     requestId,
-    handleSetActiveResponse,
   }) => {
     const response = useSelector(selectActiveResponse) as WebSocketResponse | null;
     if (!response) {
@@ -72,24 +71,18 @@ export const WebSocketResponsePane: FC<{ requestId: string; handleSetActiveRespo
         </Pane>
       );
     }
-    return <WebSocketActiveResponsePane requestId={requestId} response={response} handleSetActiveResponse={handleSetActiveResponse} />;
+    return <WebSocketActiveResponsePane requestId={requestId} response={response} />;
   };
 
-const WebSocketActiveResponsePane: FC<{ requestId: string; response: WebSocketResponse; handleSetActiveResponse: (requestId: string, activeResponse: WebSocketResponse | null) => void }> = ({
+const WebSocketActiveResponsePane: FC<{ requestId: string; response: WebSocketResponse }> = ({
   requestId,
   response,
-  handleSetActiveResponse,
 }) => {
   const [selectedEvent, setSelectedEvent] = useState<WebSocketEvent | null>(null);
   const [timeline, setTimeline] = useState<ResponseTimelineEntry[]>([]);
   const events = useWebSocketConnectionEvents({ responseId: response._id });
   const handleSelection = (event: WebSocketEvent) => {
     setSelectedEvent((selected: WebSocketEvent | null) => selected?._id === event._id ? null : event);
-  };
-
-  const setActiveResponseAndDisconnect = (requestId: string, response: WebSocketResponse | null) => {
-    handleSetActiveResponse(requestId, response);
-    window.main.webSocket.close({ requestId });
   };
 
   useEffect(() => {
@@ -123,7 +116,6 @@ const WebSocketActiveResponsePane: FC<{ requestId: string; response: WebSocketRe
         </div>
         <ResponseHistoryDropdown
           activeResponse={response}
-          handleSetActiveResponse={setActiveResponseAndDisconnect}
           requestId={requestId}
           className="tall pane__header__right"
         />

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -127,11 +127,9 @@ export const WrapperDebug: FC<Props> = ({
             ) : (
               isWebSocketRequest(activeRequest) ? (
                 <WebSocketRequestPane
-                  key={activeRequest._id}
                   request={activeRequest}
                   workspaceId={activeWorkspace._id}
-                  environmentId={activeEnvironment ? activeEnvironment._id : ''}
-                  forceRefreshKey={forceRefreshKey}
+                  environment={activeEnvironment}
                 />
               ) : (
                 <RequestPane

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -35,7 +35,6 @@ import { WorkspacePageHeader } from './workspace-page-header';
 import type { HandleActivityChange } from './wrapper';
 
 interface Props {
-  forceRefreshKey: number;
   gitSyncDropdown: ReactNode;
   handleActivityChange: HandleActivityChange;
   handleSetActiveEnvironment: (id: string | null) => void;
@@ -47,7 +46,6 @@ interface Props {
   vcs: VCS | null;
 }
 export const WrapperDebug: FC<Props> = ({
-  forceRefreshKey,
   gitSyncDropdown,
   handleActivityChange,
   handleSetActiveEnvironment,
@@ -121,7 +119,6 @@ export const WrapperDebug: FC<Props> = ({
                 activeRequest={activeRequest}
                 environmentId={activeEnvironment ? activeEnvironment._id : ''}
                 workspaceId={activeWorkspace._id}
-                forceRefreshKey={forceRefreshKey}
                 settings={settings}
               />
             ) : (
@@ -134,7 +131,6 @@ export const WrapperDebug: FC<Props> = ({
               ) : (
                 <RequestPane
                   environmentId={activeEnvironment ? activeEnvironment._id : ''}
-                  forceRefreshCounter={forceRefreshKey}
                   forceUpdateRequest={handleForceUpdateRequest}
                   forceUpdateRequestHeaders={handleForceUpdateRequestHeaders}
                   handleImport={handleImport}
@@ -153,7 +149,6 @@ export const WrapperDebug: FC<Props> = ({
             isGrpcRequest(activeRequest) ? (
               <GrpcResponsePane
                 activeRequest={activeRequest}
-                forceRefreshKey={forceRefreshKey}
               />
             ) : (
               isWebSocketRequest(activeRequest) ? (

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 
 import { isGrpcRequest } from '../../models/grpc-request';
 import { isRemoteProject } from '../../models/project';
-import { Request, RequestHeader } from '../../models/request';
 import type { Response } from '../../models/response';
 import { isWebSocketRequest } from '../../models/websocket-request';
 import { WebSocketResponse } from '../../models/websocket-response';
@@ -39,8 +38,6 @@ interface Props {
   handleActivityChange: HandleActivityChange;
   handleSetActiveEnvironment: (id: string | null) => void;
   handleSetActiveResponse: (requestId: string, activeResponse: Response | WebSocketResponse | null) => void;
-  handleForceUpdateRequest: (r: Request, patch: Partial<Request>) => Promise<Request>;
-  handleForceUpdateRequestHeaders: (r: Request, headers: RequestHeader[]) => Promise<Request>;
   handleImport: Function;
   handleSetResponseFilter: (filter: string) => void;
   vcs: VCS | null;
@@ -50,8 +47,6 @@ export const WrapperDebug: FC<Props> = ({
   handleActivityChange,
   handleSetActiveEnvironment,
   handleSetActiveResponse,
-  handleForceUpdateRequest,
-  handleForceUpdateRequestHeaders,
   handleImport,
   handleSetResponseFilter,
   vcs,
@@ -131,8 +126,6 @@ export const WrapperDebug: FC<Props> = ({
               ) : (
                 <RequestPane
                   environmentId={activeEnvironment ? activeEnvironment._id : ''}
-                  forceUpdateRequest={handleForceUpdateRequest}
-                  forceUpdateRequestHeaders={handleForceUpdateRequestHeaders}
                   handleImport={handleImport}
                   request={activeRequest}
                   settings={settings}

--- a/packages/insomnia/src/ui/components/wrapper-debug.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-debug.tsx
@@ -3,9 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { isGrpcRequest } from '../../models/grpc-request';
 import { isRemoteProject } from '../../models/project';
-import type { Response } from '../../models/response';
 import { isWebSocketRequest } from '../../models/websocket-request';
-import { WebSocketResponse } from '../../models/websocket-response';
 import { isCollection, isDesign } from '../../models/workspace';
 import { VCS } from '../../sync/vcs/vcs';
 import {
@@ -37,7 +35,6 @@ interface Props {
   gitSyncDropdown: ReactNode;
   handleActivityChange: HandleActivityChange;
   handleSetActiveEnvironment: (id: string | null) => void;
-  handleSetActiveResponse: (requestId: string, activeResponse: Response | WebSocketResponse | null) => void;
   handleImport: Function;
   handleSetResponseFilter: (filter: string) => void;
   vcs: VCS | null;
@@ -46,7 +43,6 @@ export const WrapperDebug: FC<Props> = ({
   gitSyncDropdown,
   handleActivityChange,
   handleSetActiveEnvironment,
-  handleSetActiveResponse,
   handleImport,
   handleSetResponseFilter,
   vcs,
@@ -147,13 +143,11 @@ export const WrapperDebug: FC<Props> = ({
               isWebSocketRequest(activeRequest) ? (
                 <WebSocketResponsePane
                   requestId={activeRequest._id}
-                  handleSetActiveResponse={handleSetActiveResponse}
                 />
               ) : (
                 <ResponsePane
                   handleSetFilter={handleSetResponseFilter}
                   request={activeRequest}
-                  handleSetActiveResponse={handleSetActiveResponse}
                 />
               )
             )

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -480,7 +480,6 @@ export class WrapperClass extends PureComponent<Props, State> {
             element={
               <Suspense fallback={<div />}>
                 <WrapperDebug
-                  forceRefreshKey={this.state.forceRefreshKey}
                   gitSyncDropdown={gitSyncDropdown}
                   handleActivityChange={this._handleWorkspaceActivityChange}
                   handleSetActiveEnvironment={this._handleSetActiveEnvironment}

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -20,13 +20,10 @@ import * as models from '../../models/index';
 import {
   isRequest,
 } from '../../models/request';
-import { Response } from '../../models/response';
-import { WebSocketResponse } from '../../models/websocket-response';
 import { GitVCS } from '../../sync/git/git-vcs';
 import { VCS } from '../../sync/vcs/vcs';
 import { CookieModifyModal } from '../components/modals/cookie-modify-modal';
 import { GrpcDispatchModalWrapper } from '../context/grpc';
-import { updateRequestMetaByParentId } from '../hooks/create-request';
 import { RootState } from '../redux/modules';
 import { setActiveActivity } from '../redux/modules/global';
 import { selectActiveActivity, selectActiveApiSpec, selectActiveCookieJar, selectActiveEnvironment, selectActiveGitRepository, selectActiveRequest, selectActiveResponse, selectActiveWorkspace, selectActiveWorkspaceMeta, selectSettings } from '../redux/selectors';
@@ -168,28 +165,6 @@ export class WrapperClass extends PureComponent<Props, State> {
     return null;
   }
 
-  async handleSetActiveResponse(requestId: string, activeResponse: Response | WebSocketResponse | null = null) {
-    const { activeEnvironment } = this.props;
-    const activeResponseId = activeResponse ? activeResponse._id : null;
-    await updateRequestMetaByParentId(requestId, {
-      activeResponseId,
-    });
-
-    let response: Response | null;
-    if (activeResponseId) {
-      response = await models.response.getById(activeResponseId);
-    } else {
-      const environmentId = activeEnvironment ? activeEnvironment._id : null;
-      response = await models.response.getLatestForRequest(requestId, environmentId);
-    }
-    if (!response || !response.requestVersionId) {
-      return;
-    }
-    const request = await models.requestVersion.restore(response.requestVersionId);
-    if (!request) {
-      return;
-    }
-  }
   async _handleWorkspaceActivityChange({ workspaceId, nextActivity }: Parameters<HandleActivityChange>[0]): ReturnType<HandleActivityChange> {
     const { activeActivity, activeApiSpec, handleSetActiveActivity } = this.props;
 
@@ -448,7 +423,6 @@ export class WrapperClass extends PureComponent<Props, State> {
                   handleSetActiveEnvironment={this._handleSetActiveEnvironment}
                   handleImport={this._handleImport}
                   handleSetResponseFilter={this._handleSetResponseFilter}
-                  handleSetActiveResponse={this.handleSetActiveResponse}
                   vcs={vcs}
                 />
               </Suspense>

--- a/packages/insomnia/src/ui/components/wrapper.tsx
+++ b/packages/insomnia/src/ui/components/wrapper.tsx
@@ -366,7 +366,6 @@ export class WrapperClass extends PureComponent<Props, State> {
               </> : null}
 
               <NunjucksModal
-                uniqueKey={`key::${this.state.forceRefreshKey}`}
                 ref={registerModal}
                 workspace={activeWorkspace}
               />

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -89,7 +89,6 @@ export type AppProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof ma
 interface State {
   vcs: VCS | null;
   gitVCS: GitVCS | null;
-  forceRefreshCounter: number;
   isMigratingChildren: boolean;
 }
 
@@ -106,7 +105,6 @@ class App extends PureComponent<AppProps, State> {
     this.state = {
       vcs: null,
       gitVCS: null,
-      forceRefreshCounter: 0,
       isMigratingChildren: false,
     };
 
@@ -405,13 +403,6 @@ class App extends PureComponent<AppProps, State> {
     this._updateDocumentTitle();
 
     this._ensureWorkspaceChildren();
-
-    // Force app refresh if login state changes
-    if (prevProps.isLoggedIn !== this.props.isLoggedIn) {
-      this.setState(state => ({
-        forceRefreshCounter: state.forceRefreshCounter + 1,
-      }));
-    }
 
     // Check on VCS things
     const { activeWorkspace, activeProject, activeGitRepository } = this.props;
@@ -768,13 +759,12 @@ class App extends PureComponent<AppProps, State> {
       return null;
     }
 
-    const { activeWorkspace } = this.props;
+    const { activeWorkspace, isLoggedIn } = this.props;
     const {
       gitVCS,
       vcs,
-      forceRefreshCounter,
     } = this.state;
-    const uniquenessKey = `${forceRefreshCounter}::${activeWorkspace?._id || 'n/a'}`;
+    const uniquenessKey = `${isLoggedIn}::${activeWorkspace?._id || 'n/a'}`;
     return (
       <KeydownBinder onKeydown={this._handleKeyDown}>
         <GrpcProvider>

--- a/packages/insomnia/src/ui/hooks/use-vcs-version.ts
+++ b/packages/insomnia/src/ui/hooks/use-vcs-version.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { database } from '../../common/database';
+import { selectActiveRequest, selectActiveWorkspaceMeta } from '../redux/selectors';
+
+// We use this hook to determine if the active request has been updated from the VCS
+// For example, by pulling a new version from the remote, switching branches, etc.
+export function useActiveRequestSyncVCSVersion() {
+  const [version, setVersion] = useState(0);
+  const activeRequest = useSelector(selectActiveRequest);
+
+  useEffect(() => {
+    database.onChange(changes => {
+      for (const change of changes) {
+        const [, doc, fromSync] = change;
+
+        // Force refresh if sync changes the active request
+        if (activeRequest?._id === doc._id && fromSync) {
+          setVersion(v => v + 1);
+        }
+      }
+    });
+  }, [activeRequest?._id]);
+
+  return version;
+}
+
+// We use this hook to determine if the active workspace has been updated from the Git VCS
+// For example, by pulling a new version from the remote, switching branches, etc.
+export function useGitVCSVersion() {
+  const activeWorkspaceMeta = useSelector(selectActiveWorkspaceMeta);
+
+  return ((activeWorkspaceMeta?.cachedGitLastCommitTime + '') + activeWorkspaceMeta?.cachedGitRepositoryBranch) + '';
+}


### PR DESCRIPTION
The forceRefreshKey is updated by many dependencies:
- Modifying/Switching Environments
- Getting new data from Git/Sync VCS
- Switching Requests

This PR aims to simplify the logic and remove the need for a refreshKey where possible to deal with issues where the environment is updating and the request is having previous data.

Closes INS-1984