### PR TITLE
Fixes 944 | Remove the check for returning more than one JSON result in Response Plugin

### DIFF
--- a/plugins/insomnia-plugin-response/__tests__/index.test.js
+++ b/plugins/insomnia-plugin-response/__tests__/index.test.js
@@ -150,7 +150,7 @@ describe('Response tag', () => {
       }
     });
 
-    it('fails on more than 1 result', async () => {
+    it('allows more than 1 result', async () => {
       const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
 
       const responses = [
@@ -165,12 +165,9 @@ describe('Response tag', () => {
 
       const context = _genTestContext(requests, responses);
 
-      try {
-        await tag.run(context, 'body', 'req_1', '$.array.*');
-        fail('JSON should have failed to parse');
-      } catch (err) {
-        expect(err.message).toContain('Returned more than one result: $.array.*');
-      }
+
+      const result = await tag.run(context, 'body', 'req_1', '$.array');
+      expect(result).toBe('["bar","baz"]');
     });
 
     it('works with utf-16 encoding', async () => {

--- a/plugins/insomnia-plugin-response/__tests__/index.test.js
+++ b/plugins/insomnia-plugin-response/__tests__/index.test.js
@@ -150,7 +150,7 @@ describe('Response tag', () => {
       }
     });
 
-    it('allows more than 1 result', async () => {
+    it('allows more than 1 result if array of strings', async () => {
       const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
 
       const responses = [
@@ -168,6 +168,26 @@ describe('Response tag', () => {
 
       const result = await tag.run(context, 'body', 'req_1', '$.array');
       expect(result).toBe('["bar","baz"]');
+    });
+
+    it('allows more than 1 result if array of integers', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+
+      const responses = [
+        {
+          _id: 'res_1',
+          parentId: 'req_1',
+          statusCode: 200,
+          contentType: 'application/json',
+          _body: '{"array": [1, 2]}',
+        },
+      ];
+
+      const context = _genTestContext(requests, responses);
+
+
+      const result = await tag.run(context, 'body', 'req_1', '$.array');
+      expect(result).toBe('[1,2]');
     });
 
     it('works with utf-16 encoding', async () => {

--- a/plugins/insomnia-plugin-response/index.js
+++ b/plugins/insomnia-plugin-response/index.js
@@ -134,7 +134,7 @@ module.exports.templateTags = [
             shouldResend = ageSeconds > maxAgeSeconds;
           }
           break;
-        
+
         case 'always':
           shouldResend = true;
           break;
@@ -209,7 +209,7 @@ module.exports.templateTags = [
             console.warn('[response] Failed to decode body', err);
             body = bodyBuffer.toString();
           }
-    
+
           if (sanitizedFilter.indexOf('$') === 0) {
             return matchJSONPath(body, sanitizedFilter);
           } else {
@@ -241,8 +241,6 @@ function matchJSONPath(bodyStr, query) {
 
   if (results.length === 0) {
     throw new Error(`Returned no results: ${query}`);
-  } else if (results.length > 1) {
-    throw new Error(`Returned more than one result: ${query}`);
   }
 
   if (typeof results[0] !== 'string') {

--- a/plugins/insomnia-plugin-response/index.js
+++ b/plugins/insomnia-plugin-response/index.js
@@ -243,6 +243,10 @@ function matchJSONPath(bodyStr, query) {
     throw new Error(`Returned no results: ${query}`);
   }
 
+  if (results.length > 1 ) {
+    return JSON.stringify(results);
+  }
+
   if (typeof results[0] !== 'string') {
     return JSON.stringify(results[0]);
   } else {


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where the Response template wouldn't return more than one result when parsing a JSON response by path


Fixes https://github.com/Kong/insomnia/issues/944

Removes the check for returning more than one JSON result in the Response Plugin. If the result is an array of objects, the code following the removed check will just stringify the result. This allows the response to be more easily chained and parsed by the JSONPath plugin.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
