### PR TITLE
Fixes #5218, where nested environment variables on a sub environment don't always work

### DIFF
--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -149,7 +149,7 @@ export async function buildRenderContext(
         }
       } else if (Object.prototype.toString.call(subContext[key]) === '[object Object]') {
         // Context is of Type object, Call this function recursively to handle nested objects.
-        subContext[key] = renderSubContext(subObject[key], subContext[key]);
+        subContext[key] = await renderSubContext(subObject[key], subContext[key]);
       } else {
         // For all other Types, add the Object to the Context.
         subContext[key] = subObject[key];


### PR DESCRIPTION
Closes #5218

I opened #5218 today, and decided to dig into this with the debugger. I discovered that we weren't properly `await`ing the `async` function `renderSubContext()`. Adding the `await` fixes this issue and deeply nested environment variables work properly.

changelog(Fixes): Fixed an issue where deeply nested environments variables didn't work for sub environments