### PR TITLE
[INS-2014] Add Move/Copy to option in gRPC request settings

### DIFF
--- a/packages/insomnia/src/models/proto-directory.ts
+++ b/packages/insomnia/src/models/proto-directory.ts
@@ -44,6 +44,17 @@ export function create(patch: Partial<ProtoDirectory> = {}) {
   return db.docCreate<ProtoDirectory>(type, patch);
 }
 
+export async function duplicate(protoDirectory: ProtoDirectory, patch: Partial<ProtoDirectory> = {}) {
+  if (!patch.name) {
+    patch.name = `${protoDirectory.name} (Copy)`;
+  }
+
+  return db.duplicate<ProtoDirectory>(protoDirectory, {
+    name,
+    ...patch,
+  });
+}
+
 export function getById(_id: string) {
   return db.getWhere<ProtoDirectory>(type, { _id });
 }

--- a/packages/insomnia/src/models/proto-file.ts
+++ b/packages/insomnia/src/models/proto-file.ts
@@ -57,6 +57,17 @@ export async function batchRemoveIds(ids: string[]) {
   });
 }
 
+export async function duplicate(protoFile: ProtoFile, patch: Partial<ProtoFile> = {}) {
+  if (!patch.name) {
+    patch.name = `${protoFile.name} (Copy)`;
+  }
+
+  return db.duplicate<ProtoFile>(protoFile, {
+    name,
+    ...patch,
+  });
+}
+
 export function update(protoFile: ProtoFile, patch: Partial<ProtoFile> = {}) {
   return db.docUpdate<ProtoFile>(protoFile, patch);
 }

--- a/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
@@ -107,9 +107,6 @@ export class UnconnectedRequestGroupSettingsModal extends React.PureComponent<Pr
       return;
     }
 
-    // TODO: if there are gRPC requests in a request group
-    //  we should also copy the protofiles to the destination workspace - INS-267
-
     await models.requestGroup.duplicate(requestGroup, {
       metaSortKey: -1e9,
       parentId: activeWorkspaceIdToCopyTo,

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -87,7 +87,7 @@ export const RequestSettingsModal = forwardRef<RequestSettingsModalHandle, Modal
       // Move to top of sort order
       parentId: activeWorkspaceIdToCopyTo,
     };
-    // TODO: if gRPC, we should also copy the protofile to the destination workspace - INS-267
+
     await requestOperations.update(request, patch);
     setState({
       ...state,
@@ -117,7 +117,7 @@ export const RequestSettingsModal = forwardRef<RequestSettingsModalHandle, Modal
       // Because duplicate will add (Copy) suffix if name is not provided in patch
       parentId: activeWorkspaceIdToCopyTo,
     };
-    // TODO: if gRPC, we should also copy the protofile to the destination workspace - INS-267
+
     await requestOperations.duplicate(request, patch);
     setState({
       ...state,

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -135,7 +135,7 @@ export const RequestSettingsModal = forwardRef<RequestSettingsModalHandle, Modal
   if (!request) {
     return null;
   }
-  const toggleCheckBox = async (event:any) => {
+  const toggleCheckBox = async (event: any) => {
     const updated = await requestOperations.update(request, {
       [event.currentTarget.name]: event.currentTarget.checked,
     });
@@ -300,10 +300,63 @@ export const RequestSettingsModal = forwardRef<RequestSettingsModalHandle, Modal
               </div>
             </>)}
           {isGrpcRequest(request) && (
-            <p className="faint italic">
-              Are there any gRPC settings you expect to see? Create a{' '}
-              <a href={'https://github.com/Kong/insomnia/issues/new/choose'}>feature request</a>!
-            </p>
+            <>
+              <p className="faint italic">
+                Are there any gRPC settings you expect to see? Create a{' '}
+                <a href={'https://github.com/Kong/insomnia/issues/new/choose'}>feature request</a>!
+              </p>
+              <hr />
+              <div className="form-row">
+                <div className="form-control form-control--outlined">
+                  <label>
+                    Move/Copy to Workspace
+                    <HelpTooltip position="top" className="space-left">
+                      Copy or move the current request to a new workspace. It will be placed at the root of
+                      the new workspace's folder structure.
+                    </HelpTooltip>
+                    <select
+                      value={activeWorkspaceIdToCopyTo || '__NULL__'}
+                      onChange={event => {
+                        const { value } = event.currentTarget;
+                        const workspaceId = value === '__NULL__' ? null : value;
+                        setState({ ...state, activeWorkspaceIdToCopyTo: workspaceId });
+                      }}
+                    >
+                      <option value="__NULL__">-- Select Workspace --</option>
+                      {workspacesForActiveProject.map(w => {
+                        if (workspace && workspace._id === w._id) {
+                          return null;
+                        }
+
+                        return (
+                          <option key={w._id} value={w._id}>
+                            {w.name}
+                          </option>
+                        );
+                      })}
+                    </select>
+                  </label>
+                </div>
+                <div className="form-control form-control--no-label width-auto">
+                  <button
+                    disabled={justCopied || !activeWorkspaceIdToCopyTo}
+                    className="btn btn--clicky"
+                    onClick={_handleCopyToWorkspace}
+                  >
+                    {justCopied ? 'Copied!' : 'Copy'}
+                  </button>
+                </div>
+                <div className="form-control form-control--no-label width-auto">
+                  <button
+                    disabled={justMoved || !activeWorkspaceIdToCopyTo}
+                    className="btn btn--clicky"
+                    onClick={_handleMoveToWorkspace}
+                  >
+                    {justMoved ? 'Moved!' : 'Move'}
+                  </button>
+                </div>
+              </div>
+            </>
           )}
           {isRequest(request) && (
             <>


### PR DESCRIPTION
Closes INS-2014
Closes INS-267

![image](https://user-images.githubusercontent.com/11976836/192530667-d7984290-9379-4b28-8224-f3b9c20d73d4.png)

This PR adds move/copy to option to gRPC request settings.

It also handles duplicating the related proto files of the gRPC requests being moved/copied and assigning those duplicates as the related protofiles in the new workspace. 

## Tested
- Users can copy and move a single gRPC request to another collection/doc
- A user can update the new proto file associated with the new moved/copied request independently of the original gRPC request

## Side-effects
- Copying and moving a requestGroup doesn't work properly yet, the duplicate gRPC requests still point to the original protoFileId ⚠️ 
- This adds a new side-effect - if we duplicate a grpc request within the same collection, this will be duplicating proto files instead of referencing the existing one in the collection ⚠️ 
