### PR TITLE
[INS-1979] Add disconnect dropdown

### DIFF
--- a/packages/insomnia-smoke-test/tests/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/websocket.test.ts
@@ -48,86 +48,14 @@ test('can make websocket connection', async ({ app, page }) => {
   await expect(statusTag).toContainText('101 Switching Protocols');
   await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
   await expect(responseBody).toContainText('WebSocket connection established');
-});
 
-test('can close a websocket connection', async ({ app, page }) => {
-  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
-  const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
-  const responseBody = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
-    has: page.locator('.CodeMirror-activeline'),
-  });
+  const webSocketActiveConnections = page.locator('[data-testid="WebSocketSpinner__Connected"]');
 
-  await page.click('[data-testid="project"]');
-  await page.click('text=Create');
+  // Basic auth, Bearer auth, and Redirect connections are displayed as open
+  await expect(webSocketActiveConnections).toHaveCount(3);
 
-  const text = await loadFixture('websockets.yaml');
-  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
-
-  await page.click('button:has-text("Clipboard")');
-  await page.click('text=CollectionWebSocketsjust now');
-
-  await page.click('button:has-text("localhost:4010")');
-  await page.click('text=Connect');
-  await expect(statusTag).toContainText('101 Switching Protocols');
-
-  await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
-  await expect(responseBody).toContainText('WebSocket connection established');
-
-  const dropdownTrigger = await page.locator('button[name="DisconnectDropdown__DropdownButton"]');
-  await expect(dropdownTrigger).toBeDefined();
-  await dropdownTrigger.click();
-
-  const disconnectThisRequest = page.locator('text=Disconnect this request');
-  const disconnectAllRequest = page.locator('text=Disconnect all requests');
-  await expect(disconnectThisRequest).toBeDefined();
-  await expect(disconnectAllRequest).toBeDefined();
-
-  await disconnectThisRequest.click();
-  await expect(responseBody).toContainText('Closing connection with code 1005');
-});
-
-test('can close all websocket connection', async ({ app, page }) => {
-  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
-  const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
-  const responseBody = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
-    has: page.locator('.CodeMirror-activeline'),
-  });
-
-  await page.click('[data-testid="project"]');
-  await page.click('text=Create');
-
-  const text = await loadFixture('websockets.yaml');
-  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
-
-  await page.click('button:has-text("Clipboard")');
-  await page.click('text=CollectionWebSocketsjust now');
-
-  await page.click('button:has-text("localhost:4010")');
-  await page.click('text=Connect');
-  await expect(statusTag).toContainText('101 Switching Protocols');
-
-  await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
-  await expect(responseBody).toContainText('WebSocket connection established');
-
-  await page.click('button:has-text("basic-auth")');
-  await page.click('text=Connect');
-  await expect(statusTag).toContainText('101 Switching Protocols');
-  await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
-  await expect(responseBody).toContainText('> authorization: Basic dXNlcjpwYXNzd29yZA==');
-
-  await expect(await page.locator('[data-testid="WebSocketSpinner__Connected"]').count()).toBe(2);
-
-  const dropdownTrigger = await page.locator('button[name="DisconnectDropdown__DropdownButton"]');
-  await expect(dropdownTrigger).toBeDefined();
-  await dropdownTrigger.click();
-
-  const disconnectThisRequest = page.locator('text=Disconnect this request');
-  const disconnectAllRequest = page.locator('text=Disconnect all requests');
-  await expect(disconnectThisRequest).toBeDefined();
-  await expect(disconnectAllRequest).toBeDefined();
-
-  await disconnectAllRequest.click();
-  await expect(responseBody).toContainText('Closing connection with code 1005');
-
-  await expect(await page.locator('[data-testid="WebSocketSpinner__Connected"]').count()).toBe(0);
+  // Can disconnect from all connections
+  await page.locator('button[name="DisconnectDropdown__DropdownButton"]').click();
+  await page.locator('text=Disconnect all requests').click();
+  await expect(webSocketActiveConnections).toHaveCount(0);
 });

--- a/packages/insomnia-smoke-test/tests/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/websocket.test.ts
@@ -48,5 +48,86 @@ test('can make websocket connection', async ({ app, page }) => {
   await expect(statusTag).toContainText('101 Switching Protocols');
   await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
   await expect(responseBody).toContainText('WebSocket connection established');
+});
 
+test('can close a websocket connection', async ({ app, page }) => {
+  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+  const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+  const responseBody = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
+    has: page.locator('.CodeMirror-activeline'),
+  });
+
+  await page.click('[data-testid="project"]');
+  await page.click('text=Create');
+
+  const text = await loadFixture('websockets.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+  await page.click('button:has-text("Clipboard")');
+  await page.click('text=CollectionWebSocketsjust now');
+
+  await page.click('button:has-text("localhost:4010")');
+  await page.click('text=Connect');
+  await expect(statusTag).toContainText('101 Switching Protocols');
+
+  await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
+  await expect(responseBody).toContainText('WebSocket connection established');
+
+  const dropdownTrigger = await page.locator('button[name="DisconnectDropdown__DropdownButton"]');
+  await expect(dropdownTrigger).toBeDefined();
+  await dropdownTrigger.click();
+
+  const disconnectThisRequest = page.locator('text=Disconnect this request');
+  const disconnectAllRequest = page.locator('text=Disconnect all requests');
+  await expect(disconnectThisRequest).toBeDefined();
+  await expect(disconnectAllRequest).toBeDefined();
+
+  await disconnectThisRequest.click();
+  await expect(responseBody).toContainText('Closing connection with code 1005');
+});
+
+test('can close all websocket connection', async ({ app, page }) => {
+  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+  const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+  const responseBody = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
+    has: page.locator('.CodeMirror-activeline'),
+  });
+
+  await page.click('[data-testid="project"]');
+  await page.click('text=Create');
+
+  const text = await loadFixture('websockets.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+  await page.click('button:has-text("Clipboard")');
+  await page.click('text=CollectionWebSocketsjust now');
+
+  await page.click('button:has-text("localhost:4010")');
+  await page.click('text=Connect');
+  await expect(statusTag).toContainText('101 Switching Protocols');
+
+  await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
+  await expect(responseBody).toContainText('WebSocket connection established');
+
+  await page.click('button:has-text("basic-auth")');
+  await page.click('text=Connect');
+  await expect(statusTag).toContainText('101 Switching Protocols');
+  await page.click('[data-testid="response-pane"] >> [role="tab"]:has-text("Timeline")');
+  await expect(responseBody).toContainText('> authorization: Basic dXNlcjpwYXNzd29yZA==');
+
+  await expect(await page.locator('[data-testid="WebSocketSpinner__Connected"]').count()).toBe(2);
+
+  const dropdownTrigger = await page.locator('button[name="DisconnectDropdown__DropdownButton"]');
+  await expect(dropdownTrigger).toBeDefined();
+  await dropdownTrigger.click();
+
+  const disconnectThisRequest = page.locator('text=Disconnect this request');
+  const disconnectAllRequest = page.locator('text=Disconnect all requests');
+  await expect(disconnectThisRequest).toBeDefined();
+  await expect(disconnectAllRequest).toBeDefined();
+
+  await disconnectAllRequest.click();
+  await expect(responseBody).toContainText('Closing connection with code 1005');
+
+  await expect(await page.locator('[data-testid="WebSocketSpinner__Connected"]').count()).toBe(0);
 });

--- a/packages/insomnia/src/ui/components/base/dropdown/dropdown-item.tsx
+++ b/packages/insomnia/src/ui/components/base/dropdown/dropdown-item.tsx
@@ -1,6 +1,6 @@
 import { autoBindMethodsForReact } from 'class-autobind-decorator';
 import classnames from 'classnames';
-import React, { createElement, PureComponent, ReactNode } from 'react';
+import React, { ButtonHTMLAttributes, createElement, PureComponent, ReactNode } from 'react';
 
 import { AUTOBIND_CFG } from '../../../../common/constants';
 
@@ -15,6 +15,7 @@ interface Props {
   children: ReactNode;
   className?: string;
   color?: string;
+  widthUnset?: boolean;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -44,6 +45,7 @@ export class DropdownItem extends PureComponent<Props> {
       className,
       color,
       onClick,
+      widthUnset,
       // eslint-disable-line @typescript-eslint/no-unused-vars
       stayOpenAfterClick,
       // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -61,11 +63,16 @@ export class DropdownItem extends PureComponent<Props> {
         </div>
       </div>
     );
-    const buttonProps = {
+    const buttonProps: ButtonHTMLAttributes<HTMLButtonElement> = {
       type: 'button',
       onClick: this._handleClick,
       ...props,
     };
+
+    if (widthUnset) {
+      buttonProps.className = 'dropdown__item-button-unset';
+    }
+
     return createElement(buttonClass || 'button', buttonProps, inner);
   }
 }

--- a/packages/insomnia/src/ui/components/base/dropdown/dropdown-item.tsx
+++ b/packages/insomnia/src/ui/components/base/dropdown/dropdown-item.tsx
@@ -15,7 +15,7 @@ interface Props {
   children: ReactNode;
   className?: string;
   color?: string;
-  widthUnset?: boolean;
+  unsetStyles?: boolean;
 }
 
 @autoBindMethodsForReact(AUTOBIND_CFG)
@@ -45,7 +45,7 @@ export class DropdownItem extends PureComponent<Props> {
       className,
       color,
       onClick,
-      widthUnset,
+      unsetStyles,
       // eslint-disable-line @typescript-eslint/no-unused-vars
       stayOpenAfterClick,
       // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -69,7 +69,7 @@ export class DropdownItem extends PureComponent<Props> {
       ...props,
     };
 
-    if (widthUnset) {
+    if (unsetStyles) {
       buttonProps.className = 'dropdown__item-button-unset';
     }
 

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -337,5 +337,5 @@ export const SidebarRequestRow = DropTarget('SIDEBAR_REQUEST_ROW', dragTarget, t
 
 const WebSocketSpinner = ({ requestId }: { requestId: string }) => {
   const readyState = useWSReadyState(requestId);
-  return readyState === ReadyState.OPEN ? <ConnectionCircle /> : null;
+  return readyState === ReadyState.OPEN ? <ConnectionCircle data-testid="WebSocketSpinner__Connected" /> : null;
 };

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -10,7 +10,7 @@ import { OneLineEditor } from '../codemirror/one-line-editor';
 import { useDocBodyKeyboardShortcuts } from '../keydown-binder';
 import { showAlert, showModal } from '../modals';
 import { RequestRenderErrorModal } from '../modals/request-render-error-modal';
-import { DisconnectDropdown } from './disconnect-dropdown';
+import { DisconnectButton } from './disconnect-button';
 
 const Button = styled.button<{ warning?: boolean }>(({ warning }) => ({
   paddingRight: 'var(--padding-md)',
@@ -162,7 +162,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, workspaceId, e
         </StyledUrlBar>
         {isConnectingOrClosed
           ? <Button type="submit">Connect</Button>
-          : <DisconnectDropdown requestId={request._id} />}
+          : <DisconnectButton requestId={request._id} />}
       </Form>
     </>
   );

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -10,6 +10,7 @@ import { OneLineEditor } from '../codemirror/one-line-editor';
 import { useDocBodyKeyboardShortcuts } from '../keydown-binder';
 import { showAlert, showModal } from '../modals';
 import { RequestRenderErrorModal } from '../modals/request-render-error-modal';
+import { DisconnectDropdown } from './disconnect-dropdown';
 
 const Button = styled.button<{ warning?: boolean }>(({ warning }) => ({
   paddingRight: 'var(--padding-md)',
@@ -161,7 +162,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, workspaceId, e
         </StyledUrlBar>
         {isConnectingOrClosed
           ? <Button type="submit">Connect</Button>
-          : <Button type="submit" warning>Disconnect</Button>}
+          : <DisconnectDropdown requestId={request._id} />}
       </Form>
     </>
   );

--- a/packages/insomnia/src/ui/components/websockets/disconnect-button.tsx
+++ b/packages/insomnia/src/ui/components/websockets/disconnect-button.tsx
@@ -48,7 +48,7 @@ const TextWrapper = styled.div({
   paddingLeft: 'var(--padding-xs)',
 });
 
-export const DisconnectDropdown: FC<{ requestId: string }> = ({ requestId }) => {
+export const DisconnectButton: FC<{ requestId: string }> = ({ requestId }) => {
   const dropdownRef = useRef<DropdownHandle>();
   const handleCloseThisRequest = () => {
     window.main.webSocket.close({ requestId });

--- a/packages/insomnia/src/ui/components/websockets/disconnect-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/websockets/disconnect-dropdown.tsx
@@ -17,16 +17,14 @@ const Button = styled(DropdownButton)({
     filter: 'brightness(0.8)',
   },
 });
-
 Button.displayName = DROPDOWN_BUTTON_DISPLAY_NAME;
+
 export const DisconnectDropdown: FC<{ requestId: string }> = ({ requestId }) => {
   const dropdownRef = useRef<DropdownHandle>();
   const handleCloseThisRequest = () => {
-    console.log('close');
     window.main.webSocket.close({ requestId });
   };
   const handleCloseAllRequests = () => {
-    console.log('close all');
     window.main.webSocket.closeAll();
   };
   return (

--- a/packages/insomnia/src/ui/components/websockets/disconnect-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/websockets/disconnect-dropdown.tsx
@@ -1,23 +1,49 @@
 import React, { FC, useRef } from 'react';
 import styled from 'styled-components';
 
-import { Dropdown, DropdownHandle } from '../base/dropdown/dropdown';
-import { DROPDOWN_BUTTON_DISPLAY_NAME, DropdownButton } from '../base/dropdown/dropdown-button';
+import { Dropdown as OriginalDropdown, DropdownHandle } from '../base/dropdown/dropdown';
+import { DropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownItem } from '../base/dropdown/dropdown-item';
 
-const Button = styled(DropdownButton)({
-  paddingRight: 'var(--padding-md)',
-  paddingLeft: 'var(--padding-md)',
-  textAlign: 'center',
-  background: 'var(--color-danger)',
+const SplitButton = styled.div({
+  display: 'flex',
   color: 'var(--color-font-surprise)',
-  height: '100%',
-  flex: '0 0 100px',
+});
+const Dropdown = styled(OriginalDropdown)({
+  display: 'flex',
+  paddingRight: 'var(--padding-xs)',
+  paddingLeft: 'var(--padding-xs)',
+  textAlign: 'center',
+  borderLeft: '1px solid var(--hl-md)',
+  background: 'var(--color-danger)',
   ':hover': {
-    filter: 'brightness(0.8)',
+    opacity: 0.9,
   },
 });
-Button.displayName = DROPDOWN_BUTTON_DISPLAY_NAME;
+const ActionButton = styled.button({
+  paddingRight: 'var(--padding-md)',
+  paddingLeft: 'var(--padding-md)',
+  background: 'var(--color-danger)',
+  ':hover': {
+    opacity: 0.9,
+  },
+});
+const Connections = styled.div({
+  display: 'flex',
+  justifyContent: 'space-evenly',
+  width: 25,
+});
+const Connection = styled.div<{ size?: number }>(({ size = 10 }) => ({
+  borderRadius: '50%',
+  width: size,
+  height: size,
+  background: 'var(--color-success)',
+}));
+const TextWrapper = styled.div({
+  textAlign: 'left',
+  width: '100%',
+  paddingLeft: 'var(--padding-xs)',
+});
 
 export const DisconnectDropdown: FC<{ requestId: string }> = ({ requestId }) => {
   const dropdownRef = useRef<DropdownHandle>();
@@ -28,21 +54,40 @@ export const DisconnectDropdown: FC<{ requestId: string }> = ({ requestId }) => 
     window.main.webSocket.closeAll();
   };
   return (
-    <Dropdown
-      key="dropdown"
-      className="tall"
-      right
-    >
-      <Button onClick={() => dropdownRef.current?.show()}>
+    <SplitButton>
+      <ActionButton
+        type="button"
+        onClick={handleCloseThisRequest}
+      >
         Disconnect
-        <i className="fa fa-caret-down space-left" />
-      </Button>
-      <DropdownItem onClick={handleCloseThisRequest}>
-        Disconnect this request
-      </DropdownItem>
-      <DropdownItem onClick={handleCloseAllRequests}>
-        Disconnect all requests
-      </DropdownItem>
-    </Dropdown>
+      </ActionButton>
+      <Dropdown
+        key="dropdown"
+        className="tall"
+        right
+      >
+        <DropdownButton onClick={() => dropdownRef.current?.show()}>
+          <i className="fa fa-caret-down" />
+        </DropdownButton>
+        <DropdownItem widthUnset onClick={handleCloseThisRequest}>
+          <Connections>
+            <Connection />
+          </Connections>
+          <TextWrapper>
+            Disconnect this request
+          </TextWrapper>
+        </DropdownItem>
+        <DropdownItem widthUnset onClick={handleCloseAllRequests}>
+          <Connections>
+            <Connection size={5} />
+            <Connection size={5} />
+            <Connection size={5} />
+          </Connections>
+          <TextWrapper>
+            Disconnect all requests
+          </TextWrapper>
+        </DropdownItem>
+      </Dropdown>
+    </SplitButton>
   );
 };

--- a/packages/insomnia/src/ui/components/websockets/disconnect-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/websockets/disconnect-dropdown.tsx
@@ -1,0 +1,50 @@
+import React, { FC, useRef } from 'react';
+import styled from 'styled-components';
+
+import { Dropdown, DropdownHandle } from '../base/dropdown/dropdown';
+import { DROPDOWN_BUTTON_DISPLAY_NAME, DropdownButton } from '../base/dropdown/dropdown-button';
+import { DropdownItem } from '../base/dropdown/dropdown-item';
+
+const Button = styled(DropdownButton)({
+  paddingRight: 'var(--padding-md)',
+  paddingLeft: 'var(--padding-md)',
+  textAlign: 'center',
+  background: 'var(--color-danger)',
+  color: 'var(--color-font-surprise)',
+  height: '100%',
+  flex: '0 0 100px',
+  ':hover': {
+    filter: 'brightness(0.8)',
+  },
+});
+
+Button.displayName = DROPDOWN_BUTTON_DISPLAY_NAME;
+export const DisconnectDropdown: FC<{ requestId: string }> = ({ requestId }) => {
+  const dropdownRef = useRef<DropdownHandle>();
+  const handleCloseThisRequest = () => {
+    console.log('close');
+    window.main.webSocket.close({ requestId });
+  };
+  const handleCloseAllRequests = () => {
+    console.log('close all');
+    window.main.webSocket.closeAll();
+  };
+  return (
+    <Dropdown
+      key="dropdown"
+      className="tall"
+      right
+    >
+      <Button onClick={() => dropdownRef.current?.show()}>
+        Disconnect
+        <i className="fa fa-caret-down space-left" />
+      </Button>
+      <DropdownItem onClick={handleCloseThisRequest}>
+        Disconnect this request
+      </DropdownItem>
+      <DropdownItem onClick={handleCloseAllRequests}>
+        Disconnect all requests
+      </DropdownItem>
+    </Dropdown>
+  );
+};

--- a/packages/insomnia/src/ui/components/websockets/disconnect-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/websockets/disconnect-dropdown.tsx
@@ -2,7 +2,7 @@ import React, { FC, useRef } from 'react';
 import styled from 'styled-components';
 
 import { Dropdown as OriginalDropdown, DropdownHandle } from '../base/dropdown/dropdown';
-import { DropdownButton } from '../base/dropdown/dropdown-button';
+import { DROPDOWN_BUTTON_DISPLAY_NAME, DropdownButton as OriginalDropdownButton } from '../base/dropdown/dropdown-button';
 import { DropdownItem } from '../base/dropdown/dropdown-item';
 
 const SplitButton = styled.div({
@@ -11,8 +11,6 @@ const SplitButton = styled.div({
 });
 const Dropdown = styled(OriginalDropdown)({
   display: 'flex',
-  paddingRight: 'var(--padding-xs)',
-  paddingLeft: 'var(--padding-xs)',
   textAlign: 'center',
   borderLeft: '1px solid var(--hl-md)',
   background: 'var(--color-danger)',
@@ -20,6 +18,11 @@ const Dropdown = styled(OriginalDropdown)({
     opacity: 0.9,
   },
 });
+const DropdownButton = styled(OriginalDropdownButton)({
+  paddingRight: 'var(--padding-xs)',
+  paddingLeft: 'var(--padding-xs)',
+});
+DropdownButton.displayName = DROPDOWN_BUTTON_DISPLAY_NAME;
 const ActionButton = styled.button({
   paddingRight: 'var(--padding-md)',
   paddingLeft: 'var(--padding-md)',
@@ -65,11 +68,15 @@ export const DisconnectDropdown: FC<{ requestId: string }> = ({ requestId }) => 
         key="dropdown"
         className="tall"
         right
+        data-testid="DisconnectDropdown__Dropdown"
       >
-        <DropdownButton onClick={() => dropdownRef.current?.show()}>
+        <DropdownButton
+          name="DisconnectDropdown__DropdownButton"
+          onClick={() => dropdownRef.current?.show()}
+        >
           <i className="fa fa-caret-down" />
         </DropdownButton>
-        <DropdownItem widthUnset onClick={handleCloseThisRequest}>
+        <DropdownItem unsetStyles onClick={handleCloseThisRequest}>
           <Connections>
             <Connection />
           </Connections>
@@ -77,7 +84,7 @@ export const DisconnectDropdown: FC<{ requestId: string }> = ({ requestId }) => 
             Disconnect this request
           </TextWrapper>
         </DropdownItem>
-        <DropdownItem widthUnset onClick={handleCloseAllRequests}>
+        <DropdownItem unsetStyles onClick={handleCloseAllRequests}>
           <Connections>
             <Connection size={5} />
             <Connection size={5} />

--- a/packages/insomnia/src/ui/css/components/dropdown.less
+++ b/packages/insomnia/src/ui/css/components/dropdown.less
@@ -126,7 +126,12 @@
         text-align: center;
       }
     }
-
+    li > .dropdown__item-button-unset {
+      min-width: unset;
+      .dropdown__text > * {
+        margin-left: unset;
+      }
+    }
     li > button:hover:not(:disabled),
     li.active > button:not(:disabled) {
       background: var(--hl-sm);


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Reflecting on the most recent discussion; we want to have it like the split button we have for the Send button
- added split border between the button and dropdown
- modified the base dropdown styles to remove some extra styles
- added e2e tests

Working state demo:
https://www.loom.com/share/7c02e4325df24533ac1830bfc36b47e8

Hover state 1
![image](https://user-images.githubusercontent.com/103070941/193661084-b9fab761-2cb3-45d6-bb0c-7b103f71e52c.png)

Hover state 2
![image](https://user-images.githubusercontent.com/103070941/193661166-2a3ddb11-0843-4185-af69-d4096b4529a3.png)

Dropdown Open state
![image](https://user-images.githubusercontent.com/103070941/193661031-33f04b1b-1ee0-4669-ae0c-4eb5bc784273.png)

changelog(Improvements): Adding WebSocket Disconnect dropdown to support Disconnect All
