### PR TITLE
[INS-2017] add ws subprotocol support

### DIFF
--- a/packages/insomnia-smoke-test/server/websocket.ts
+++ b/packages/insomnia-smoke-test/server/websocket.ts
@@ -6,7 +6,7 @@ import { WebSocket, WebSocketServer } from 'ws';
  * Starts an echo WebSocket server that receives messages from a client and echoes them back.
  */
 export function startWebSocketServer(server: Server) {
-  const wsServer = new WebSocketServer({ noServer: true });
+  const wsServer = new WebSocketServer({ noServer: true, handleProtocols: () => 'chat' });
 
   server.on('upgrade', (request, socket, head) => {
     upgrade(wsServer, request, socket, head);

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -190,8 +190,8 @@ const openWebSocketConnection = async (
       'on': true,
       'global': settings.followRedirects,
     }[request.settingFollowRedirects] ?? true;
-
-    const ws = new WebSocket(options.url, {
+    const protocols = lowerCasedEnabledHeaders['sec-websocket-protocol'];
+    const ws = new WebSocket(options.url, protocols, {
       headers: lowerCasedEnabledHeaders,
       cert: pemCertificates,
       key: pemCertificateKeys,


### PR DESCRIPTION
the value of this header: `sec-websocket-protocol` will now be passed to the websocket library as a protocol rather than just as the header.
- [x] add subprotocol to ws smoke test server


Closes INS-2017

changelog(Improvements): Adding ws subprotocol support