### PR TITLE
fix duplicate error response after upgrade

### DIFF
--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -332,7 +332,6 @@ const openWebSocketConnection = async (
 
       deleteRequestMaps(request._id, message, errorEvent);
       event.sender.send(readyStateChannel, ws.readyState);
-      createErrorResponse(responseId, request._id, responseEnvironmentId, timelinePath, message || 'Something went wrong');
     });
   } catch (e) {
     console.error('unhandled error:', e);

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -332,6 +332,9 @@ const openWebSocketConnection = async (
 
       deleteRequestMaps(request._id, message, errorEvent);
       event.sender.send(readyStateChannel, ws.readyState);
+      if (error.code === 'ENOTFOUND') {
+        createErrorResponse(responseId, request._id, responseEnvironmentId, timelinePath, message || 'Something went wrong');
+      }
     });
   } catch (e) {
     console.error('unhandled error:', e);


### PR DESCRIPTION
errors like ENOTFOUND are triggered before the upgrade event
and those like `Server sent a subprotocol but none was requested` occur after the upgrade event. This means we our error event may or may not need to create an error response object.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

changelog(Fixes): Fixed duplicate error response after upgrade