### PR TITLE
[INS-1575] Remove mousemove handleActivity on Team Sync

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -167,14 +167,12 @@ class UnconnectedSyncDropdown extends PureComponent<Props, State> {
         await this.refreshMainAttributes();
       }
     }, REFRESH_PERIOD);
-    document.addEventListener('mousemove', this._handleUserActivity);
   }
 
   componentWillUnmount() {
     if (this.checkInterval !== null) {
       clearInterval(this.checkInterval);
     }
-    document.removeEventListener('mousemove', this._handleUserActivity);
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -195,10 +193,6 @@ class UnconnectedSyncDropdown extends PureComponent<Props, State> {
         this.refreshOnNextSyncItems = false;
       }
     }
-  }
-
-  _handleUserActivity() {
-    this.lastUserActivity = Date.now();
   }
 
   _handleShowBranchesModal() {


### PR DESCRIPTION
Paired with @kreosus on this one. We are not sure the `this._handleUserActivity` call when folks move their mouse is no longer needed.

We did some testing, and Team Sync seemed to work fine without it.