### PR TITLE
Fix how path variables are escaped for Swagger

### DIFF
--- a/packages/openapi-2-kong/src/common.test.ts
+++ b/packages/openapi-2-kong/src/common.test.ts
@@ -235,7 +235,7 @@ describe('common', () => {
   describe('pathVariablesToRegex()', () => {
     it('converts variables to regex path', () => {
       expect(pathVariablesToRegex('/foo/{bar}/{baz}')).toBe(
-        '/foo/(?<bar>[^\\/]+)/(?<baz>[^\\/]+)$',
+        '/foo/(?<bar>[^/]+)/(?<baz>[^/]+)$',
       );
     });
 

--- a/packages/openapi-2-kong/src/common.test.ts
+++ b/packages/openapi-2-kong/src/common.test.ts
@@ -244,7 +244,7 @@ describe('common', () => {
     });
 
     it('escape special characters not present in curly braces', () => {
-      expect(pathVariablesToRegex('/*foo$bar?baz')).toBe('/\*foo\$bar\?baz$');
+      expect(pathVariablesToRegex('/*foo$bar?baz')).toBe('/\\*foo\\$bar\\?baz$');
     });
   });
 

--- a/packages/openapi-2-kong/src/common.test.ts
+++ b/packages/openapi-2-kong/src/common.test.ts
@@ -242,6 +242,10 @@ describe('common', () => {
     it('does not convert to regex if no variables present', () => {
       expect(pathVariablesToRegex('/foo/bar/baz')).toBe('/foo/bar/baz$');
     });
+
+    it('escape special characters not present in curly braces', () => {
+      expect(pathVariablesToRegex('/*foo$bar?baz')).toBe('/\*foo\$bar\?baz$');
+    });
   });
 
   describe('getPluginNameFromKey()', () => {

--- a/packages/openapi-2-kong/src/common.test.ts
+++ b/packages/openapi-2-kong/src/common.test.ts
@@ -244,7 +244,7 @@ describe('common', () => {
     });
 
     it('escape special characters not present in curly braces', () => {
-      expect(pathVariablesToRegex('/*foo$bar?baz')).toBe('/\\*foo\\$bar\\?baz$');
+      expect(pathVariablesToRegex('/foo/bar/$baz')).toBe('/foo/bar/\$baz$');
     });
   });
 

--- a/packages/openapi-2-kong/src/common.test.ts
+++ b/packages/openapi-2-kong/src/common.test.ts
@@ -244,7 +244,7 @@ describe('common', () => {
     });
 
     it('escape special characters not present in curly braces', () => {
-      expect(pathVariablesToRegex('/foo/bar/$baz')).toBe('/foo/bar/\$baz$');
+      expect(pathVariablesToRegex('/foo/bar/$baz')).toBe('/foo/bar/\\$baz$');
     });
   });
 

--- a/packages/openapi-2-kong/src/common.ts
+++ b/packages/openapi-2-kong/src/common.ts
@@ -69,7 +69,7 @@ export function pathVariablesToRegex(p: string) {
   // escape URL special characters except the curly braces
   p = p.replace(/[$()]/g, '\\$&');
   // match anything except whitespace and '/'
-  const result = p.replace(pathVariableSearchValue, '(?<$1>[^\\/]+)');
+  const result = p.replace(pathVariableSearchValue, '(?<$1>[^/]+)');
   // add a line ending because it is a regex
   return result + '$';
 }

--- a/packages/openapi-2-kong/src/common.ts
+++ b/packages/openapi-2-kong/src/common.ts
@@ -66,6 +66,8 @@ export function generateSlug(str: string, options: SlugifyOptions = {}) {
 const pathVariableSearchValue = /{([^}]+)}(?!:\/\/)/g;
 
 export function pathVariablesToRegex(p: string) {
+  // escape URL special characters except the curly braces
+  p = p.replace(/[.*+?^$()|[\]\\]/g, '\\$&'); 
   // match anything except whitespace and '/'
   const result = p.replace(pathVariableSearchValue, '(?<$1>[^\\/]+)');
   // add a line ending because it is a regex

--- a/packages/openapi-2-kong/src/common.ts
+++ b/packages/openapi-2-kong/src/common.ts
@@ -67,7 +67,7 @@ const pathVariableSearchValue = /{([^}]+)}(?!:\/\/)/g;
 
 export function pathVariablesToRegex(p: string) {
   // escape URL special characters except the curly braces
-  p = p.replace(/[!*+?^<>$';:@&=,/%#[]()|[\]\\]/g, '\\$&');
+  p = p.replace(/[$()]/g, '\\$&');
   // match anything except whitespace and '/'
   const result = p.replace(pathVariableSearchValue, '(?<$1>[^\\/]+)');
   // add a line ending because it is a regex

--- a/packages/openapi-2-kong/src/common.ts
+++ b/packages/openapi-2-kong/src/common.ts
@@ -67,7 +67,7 @@ const pathVariableSearchValue = /{([^}]+)}(?!:\/\/)/g;
 
 export function pathVariablesToRegex(p: string) {
   // escape URL special characters except the curly braces
-  p = p.replace(/[.*+?^$()|[\]\\]/g, '\\$&'); 
+  p = p.replace(/[!*+?^<>$';:@&=,/%#[]()|[\]\\]/g, '\\$&');
   // match anything except whitespace and '/'
   const result = p.replace(pathVariableSearchValue, '(?<$1>[^\\/]+)');
   // add a line ending because it is a regex

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/httpbin.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/httpbin.expected.json
@@ -27,21 +27,21 @@
               "tags": ["OAS3_import", "OAS3file_httpbin.yaml"]
             }
           ],
-          "paths": ["/basic-auth/(?<user>[^\\/]+)/(?<password>[^\\/]+)$"]
+          "paths": ["/basic-auth/(?<user>[^/]+)/(?<password>[^/]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-image-format-get",
-          "paths": ["/image/(?<format>[^\\/]+)$"]
+          "paths": ["/image/(?<format>[^/]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-delay-n-get",
-          "paths": ["/delay/(?<n>[^\\/]+)$"]
+          "paths": ["/delay/(?<n>[^/]+)$"]
         },
         {
           "methods": ["GET"],
@@ -55,35 +55,35 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-status-statusCode-delete",
-          "paths": ["/status/(?<statusCode>[^\\/]+)$"]
+          "paths": ["/status/(?<statusCode>[^/]+)$"]
         },
         {
           "methods": ["PUT"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-status-statusCode-put",
-          "paths": ["/status/(?<statusCode>[^\\/]+)$"]
+          "paths": ["/status/(?<statusCode>[^/]+)$"]
         },
         {
           "methods": ["PATCH"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-status-statusCode-patch",
-          "paths": ["/status/(?<statusCode>[^\\/]+)$"]
+          "paths": ["/status/(?<statusCode>[^/]+)$"]
         },
         {
           "methods": ["POST"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-status-statusCode-post",
-          "paths": ["/status/(?<statusCode>[^\\/]+)$"]
+          "paths": ["/status/(?<statusCode>[^/]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-status-statusCode-get",
-          "paths": ["/status/(?<statusCode>[^\\/]+)$"]
+          "paths": ["/status/(?<statusCode>[^/]+)$"]
         },
         {
           "methods": ["GET"],
@@ -105,7 +105,7 @@
             }
           ],
           "paths": [
-            "/hidden-basic-auth/(?<user>[^\\/]+)/(?<password>[^\\/]+)$"
+            "/hidden-basic-auth/(?<user>[^/]+)/(?<password>[^/]+)$"
           ]
         },
         {
@@ -161,7 +161,7 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_httpbin.yaml"],
           "name": "httpbin-parse-machine_timestamp-get",
-          "paths": ["/parse/(?<machine_timestamp>[^\\/]+)$"]
+          "paths": ["/parse/(?<machine_timestamp>[^/]+)$"]
         },
         {
           "methods": ["POST"],
@@ -209,7 +209,7 @@
               "enabled": true
             }
           ],
-          "paths": ["/when/(?<human_timestamp>[^\\/]+)$"]
+          "paths": ["/when/(?<human_timestamp>[^/]+)$"]
         },
         {
           "methods": ["GET"],

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/link-example.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/link-example.expected.json
@@ -13,14 +13,14 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "Link_Example-getUserByName",
-          "paths": ["/2.0/users/(?<username>[^\\/]+)$"]
+          "paths": ["/2.0/users/(?<username>[^/]+)$"]
         },
         {
           "methods": ["GET"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "Link_Example-getRepositoriesByOwner",
-          "paths": ["/2.0/repositories/(?<username>[^\\/]+)$"]
+          "paths": ["/2.0/repositories/(?<username>[^/]+)$"]
         },
         {
           "methods": ["GET"],
@@ -28,7 +28,7 @@
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "Link_Example-getRepository",
           "paths": [
-            "/2.0/repositories/(?<username>[^\\/]+)/(?<slug>[^\\/]+)$"
+            "/2.0/repositories/(?<username>[^/]+)/(?<slug>[^/]+)$"
           ]
         },
         {
@@ -37,7 +37,7 @@
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "Link_Example-getPullRequestsByRepository",
           "paths": [
-            "/2.0/repositories/(?<username>[^\\/]+)/(?<slug>[^\\/]+)/pullrequests$"
+            "/2.0/repositories/(?<username>[^/]+)/(?<slug>[^/]+)/pullrequests$"
           ]
         },
         {
@@ -46,7 +46,7 @@
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "Link_Example-getPullRequestsById",
           "paths": [
-            "/2.0/repositories/(?<username>[^\\/]+)/(?<slug>[^\\/]+)/pullrequests/(?<pid>[^\\/]+)$"
+            "/2.0/repositories/(?<username>[^/]+)/(?<slug>[^/]+)/pullrequests/(?<pid>[^/]+)$"
           ]
         },
         {
@@ -55,7 +55,7 @@
           "tags": ["OAS3_import", "OAS3file_link-example.yaml"],
           "name": "Link_Example-mergePullRequest",
           "paths": [
-            "/2.0/repositories/(?<username>[^\\/]+)/(?<slug>[^\\/]+)/pullrequests/(?<pid>[^\\/]+)/merge$"
+            "/2.0/repositories/(?<username>[^/]+)/(?<slug>[^/]+)/pullrequests/(?<pid>[^/]+)/merge$"
           ]
         }
       ],

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/petstore-expanded.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/petstore-expanded.expected.json
@@ -27,14 +27,14 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore-expanded.yaml"],
           "name": "Swagger_Petstore-find_pet_by_id",
-          "paths": ["/pets/(?<id>[^\\/]+)$"]
+          "paths": ["/pets/(?<id>[^/]+)$"]
         },
         {
           "methods": ["DELETE"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore-expanded.yaml"],
           "name": "Swagger_Petstore-deletePet",
-          "paths": ["/pets/(?<id>[^\\/]+)$"]
+          "paths": ["/pets/(?<id>[^/]+)$"]
         }
       ],
       "tags": ["OAS3_import", "OAS3file_petstore-expanded.yaml"]

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/petstore.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/petstore.expected.json
@@ -27,7 +27,7 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_petstore.yaml"],
           "name": "Swagger_Petstore-showPetById",
-          "paths": ["/pets/(?<petId>[^\\/]+)$"]
+          "paths": ["/pets/(?<petId>[^/]+)$"]
         }
       ],
       "tags": ["OAS3_import", "OAS3file_petstore.yaml"]

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/request-validator-plugin.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/request-validator-plugin.expected.json
@@ -60,7 +60,7 @@
         {
           "methods": ["GET"],
           "name": "Example-params-pathid-get",
-          "paths": ["/params/(?<pathid>[^\\/]+)/$"],
+          "paths": ["/params/(?<pathid>[^/]+)/$"],
           "plugins": [
             {
               "config": {

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/uspto.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/uspto.expected.json
@@ -20,14 +20,14 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_uspto.yaml"],
           "name": "USPTO_Data_Set_API-list-searchable-fields",
-          "paths": ["/(?<dataset>[^\\/]+)/(?<version>[^\\/]+)/fields$"]
+          "paths": ["/(?<dataset>[^/]+)/(?<version>[^/]+)/fields$"]
         },
         {
           "methods": ["POST"],
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_uspto.yaml"],
           "name": "USPTO_Data_Set_API-perform-search",
-          "paths": ["/(?<dataset>[^\\/]+)/(?<version>[^\\/]+)/records$"]
+          "paths": ["/(?<dataset>[^/]+)/(?<version>[^/]+)/records$"]
         }
       ],
       "tags": ["OAS3_import", "OAS3file_uspto.yaml"]

--- a/packages/openapi-2-kong/src/declarative-config/services.test.ts
+++ b/packages/openapi-2-kong/src/declarative-config/services.test.ts
@@ -43,7 +43,7 @@ const getSpecResult = (): DCService =>
           name: 'My_API-birds-id-get',
           strip_path: false,
           methods: ['GET'],
-          paths: ['/birds/(?<id>[^\\/]+)$'],
+          paths: ['/birds/(?<id>[^/]+)$'],
           tags,
         },
       ],
@@ -255,7 +255,7 @@ describe('services', () => {
           tags,
           name: 'My_API-birds-id-get',
           methods: ['GET'],
-          paths: ['/birds/(?<id>[^\\/]+)$'],
+          paths: ['/birds/(?<id>[^/]+)$'],
           strip_path: false,
           plugins: [
             {

--- a/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
@@ -18,7 +18,7 @@ module.exports = {
       // We know for certain the result.documents has only one entry for declarative config: packages/openapi-2-kong/src/declarative-config/generate.ts#L20
       const declarativeConfig = result.documents?.[0]
       return {
-        document: JSON.stringify(declarativeConfig, null, '\t'),
+        document: JSON.stringify(declarativeConfig, null, '\t').replaceAll("\\\\","\\"),
         error: null,
       };
     } catch (err) {

--- a/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
+++ b/plugins/insomnia-plugin-kong-declarative-config/src/generate.js
@@ -18,7 +18,7 @@ module.exports = {
       // We know for certain the result.documents has only one entry for declarative config: packages/openapi-2-kong/src/declarative-config/generate.ts#L20
       const declarativeConfig = result.documents?.[0]
       return {
-        document: JSON.stringify(declarativeConfig, null, '\t').replaceAll("\\\\","\\"),
+        document: JSON.stringify(declarativeConfig, null, '\t'),
         error: null,
       };
     } catch (err) {


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where Path variables weren't properly escaped for Swagger specs

paths in swagger are not correctly escaped and won't be correct. You can try with following swagger:
```yaml
openapi: 3.0.0
info:
 title: SampleAPI
 version: "1.0"
tags:
  - description: Sample API
    name: Sample Echo API
paths:
  /healthcheck/$echo:
    get:
      parameters:
        - in: query
          name: message
          required: true
          schema:
            type: string
          description: The echo message
      responses:
        "200":
          description: An echo message.
      summary: Return a echo message.
      operationId: getEcho
      tags:
        - Generate echo message
  /batchs(Material='{Material}',Batch='{Batch}'):
    get:
      parameters:
        - in: path
          name: Material
          required: true
          schema:
            type: string
          description: The echo message
        - in: path
          name: Batch
          required: true
          schema:
            type: string
          description: The echo message
      responses:
        "200":
          description: An echo message.
      summary: Return a echo message.
      operationId: getBatch
      tags:
        - Generate echo message
servers:
  - url: https://httpbin.org/anything`
```