### PR TITLE
Feat/modal

### DIFF
--- a/packages/insomnia/src/ui/components/global-modal/global-modal.tsx
+++ b/packages/insomnia/src/ui/components/global-modal/global-modal.tsx
@@ -1,0 +1,72 @@
+import EventEmitter from 'events';
+import React from 'react';
+import { ComponentType, useEffect, useState } from 'react';
+import { OverlayContainer, OverlayProvider } from 'react-aria';
+import { useOverlayTriggerState } from 'react-stately';
+
+export interface ModalComposition<T> {
+  component: ComponentType<T>;
+  props?: T;
+}
+
+const MODAL_TRIGGER = 'modal';
+const $onModal = new EventEmitter();
+
+interface UseGlobalModal<T> {
+  showModal: (instance: ModalComposition<T>) => void;
+  hideModal: () => void;
+}
+export function useGlobalModal<T>(): UseGlobalModal<T> {
+  const showModal = (instance: ModalComposition<T>) => {
+    $onModal.emit('modal', instance);
+  };
+  const hideModal = () => {
+    $onModal.emit('modal', null);
+  };
+
+  return { showModal, hideModal };
+}
+export const GlobalMoal = () => {
+  const state = useOverlayTriggerState({});
+  const [composition, setComposition] = useState<ModalComposition<any> | null>();
+
+  useEffect(() => {
+    const handler = (instance: ModalComposition<any> | null) => {
+      const composed = instance ? {
+        component: instance.component,
+        props: { ...instance.props, onClose: state.close },
+      } : null;
+      setComposition(composed);
+    };
+
+    $onModal.on(MODAL_TRIGGER, handler);
+
+    return () => {
+      $onModal.off(MODAL_TRIGGER, handler);
+    };
+  }, [state.close]);
+
+  useEffect(() => {
+    composition ? state.open() : state.close();
+  }, [composition, state]);
+
+  useEffect(() => {
+    if (!state.isOpen) {
+      setComposition(null);
+    }
+  }, [state.isOpen]);
+
+  if (!state.isOpen || !composition?.component) {
+    return null;
+  }
+
+  const { component: Modal, props } = composition;
+  console.log(props);
+  return (
+    <OverlayProvider>
+      <OverlayContainer>
+        <Modal {...props} />
+      </OverlayContainer>
+    </OverlayProvider>
+  );
+};

--- a/packages/insomnia/src/ui/components/modals/create-collection-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/create-collection-modal.tsx
@@ -1,0 +1,123 @@
+import React, { FC, useRef } from 'react';
+import { AriaDialogProps, AriaOverlayProps, FocusScope, useDialog, useModal, useOverlay, usePreventScroll } from 'react-aria';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { SegmentEvent, trackSegmentEvent } from '../../../common/analytics';
+import { isDesign, Workspace, WorkspaceScope } from '../../../models/workspace';
+import { activateWorkspace, createWorkspaceAndChildren } from '../../redux/modules/workspace';
+import { selectActiveProject } from '../../redux/selectors';
+
+export const ModalDialog: FC<{ title: string } & AriaOverlayProps & AriaDialogProps> = props => {
+  const { title, children } = props;
+
+  // Handle interacting outside the dialog and pressing
+  // the Escape key to close the modal.
+  const ref = React.useRef<HTMLDivElement>(null);
+  const { overlayProps, underlayProps } = useOverlay(props, ref);
+
+  // Prevent scrolling while the modal is open, and hide content
+  // outside the modal from screen readers.
+  usePreventScroll();
+  const { modalProps } = useModal();
+
+  // Get props for the dialog and its title
+  const { dialogProps, titleProps } = useDialog(props, ref);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        zIndex: 100,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        background: 'rgba(0, 0, 0, 0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      {...underlayProps}
+    >
+      <FocusScope contain restoreFocus autoFocus>
+        <div
+          {...overlayProps}
+          {...dialogProps}
+          {...modalProps}
+          ref={ref}
+          style={{
+            background: 'white',
+            color: 'black',
+            padding: 30,
+          }}
+        >
+          <h3
+            {...titleProps}
+            style={{ marginTop: 0 }}
+          >
+            {title}
+          </h3>
+          {children}
+        </div>
+      </FocusScope>
+    </div>
+  );
+};
+
+type OnWorkspaceCreateCallback = (arg0: Workspace) => Promise<void> | void;
+export const CreateCollectionModal: FC<{
+  scope: WorkspaceScope;
+  onCreate: OnWorkspaceCreateCallback;
+  onClose?: () => void;
+}> = ({ scope, onClose, onCreate }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const activeProject = useSelector(selectActiveProject);
+  const dispatch = useDispatch();
+
+  const design = isDesign({
+    scope,
+  });
+  const title = design ? 'Design Document' : 'Request Collection';
+  const defaultValue = design ? 'my-spec.yaml' : 'My Collection';
+  const segmentEvent = design ? SegmentEvent.documentCreate : SegmentEvent.collectionCreate;
+
+  const handleCreate = async () => {
+    const workspace = await createWorkspaceAndChildren({
+      name: inputRef.current?.value,
+      scope,
+      parentId: activeProject._id,
+    });
+
+    if (onCreate) {
+      await onCreate(workspace);
+    }
+    trackSegmentEvent(segmentEvent);
+    onClose?.();
+    await dispatch(activateWorkspace({ workspace }));
+  };
+  return (
+    <ModalDialog
+      title={`Create New ${title}`}
+      isOpen
+      onClose={onClose}
+      isDismissable
+    >
+      <form style={{ display: 'flex', flexDirection: 'column' }}>
+        <label htmlFor="collection-name">Name</label>
+        <input
+          id="collection-name"
+          ref={inputRef}
+          defaultValue={defaultValue}
+          placeholder={defaultValue}
+        />
+        <button
+          type="button"
+          onClick={handleCreate}
+          style={{ marginTop: 10 }}
+        >
+          Create
+        </button>
+      </form>
+    </ModalDialog>
+  );
+};

--- a/packages/insomnia/src/ui/components/wrapper-home.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-home.tsx
@@ -36,8 +36,10 @@ import { AppHeader } from './app-header';
 import { DashboardSortDropdown } from './dropdowns/dashboard-sort-dropdown';
 import { ProjectDropdown } from './dropdowns/project-dropdown';
 import { RemoteWorkspacesDropdown } from './dropdowns/remote-workspaces-dropdown';
+import { useGlobalModal } from './global-modal/global-modal';
 import { useDocBodyKeyboardShortcuts } from './keydown-binder';
 import { showPrompt } from './modals';
+import { CreateCollectionModal } from './modals/create-collection-modal';
 import { PageLayout } from './page-layout';
 import { WrapperHomeEmptyStatePane } from './panes/wrapper-home-empty-state-pane';
 import { WorkspaceCard, WorkspaceCardProps } from './workspace-card';
@@ -145,6 +147,7 @@ const mapWorkspaceToWorkspaceCard = ({
 };
 
 const WrapperHome: FC<Props> = (({ vcs }) => {
+  const { showModal } = useGlobalModal();
   const sortOrder = useSelector(selectDashboardSortOrder);
   const activeProject = useSelector(selectActiveProject);
   const isLoggedIn = useSelector(selectIsLoggedIn);
@@ -201,17 +204,20 @@ const WrapperHome: FC<Props> = (({ vcs }) => {
       />
     ));
 
-  const createRequestCollection = useCallback(() => {
-    handleCreateWorkspace({
-      scope: WorkspaceScopeKeys.collection,
-      onCreate: async (workspace: Workspace) => {
-        // Don't mark for sync if not logged in at the time of creation
-        if (isLoggedIn && vcs && isRemoteProject(activeProject)) {
-          await initializeLocalBackendProjectAndMarkForSync({ vcs: vcs.newInstance(), workspace });
-        }
-      },
+  const createRequestCollection = () => {
+    const scope = WorkspaceScopeKeys.collection;
+    const onCreate = async (workspace: Workspace) => {
+      // Don't mark for sync if not logged in at the time of creation
+      if (isLoggedIn && vcs && isRemoteProject(activeProject)) {
+        await initializeLocalBackendProjectAndMarkForSync({ vcs: vcs.newInstance(), workspace });
+      }
+    };
+
+    showModal({
+      component: CreateCollectionModal,
+      props: { scope, onCreate },
     });
-  }, [activeProject, handleCreateWorkspace, isLoggedIn, vcs]);
+  };
 
   const createDesignDocument = useCallback(() => {
     handleCreateWorkspace({ scope: WorkspaceScopeKeys.design });

--- a/packages/insomnia/src/ui/containers/app.tsx
+++ b/packages/insomnia/src/ui/containers/app.tsx
@@ -11,6 +11,7 @@ import {
 import { database as db } from '../../common/database';
 import * as models from '../../models';
 import { ErrorBoundary } from '../components/error-boundary';
+import { GlobalMoal } from '../components/global-modal/global-modal';
 import { AddKeyCombinationModal } from '../components/modals/add-key-combination-modal';
 import { AlertModal } from '../components/modals/alert-modal';
 import { AnalyticsModal } from '../components/modals/analytics-modal';
@@ -207,6 +208,7 @@ const App = () => {
     <GrpcProvider>
       <NunjucksEnabledProvider>
         <AppHooks />
+        <GlobalMoal />
         <div className="app" key={uniquenessKey}>
           <ErrorBoundary showAlert>
             <div key="modals" className="modals">

--- a/packages/insomnia/src/ui/redux/modules/workspace.ts
+++ b/packages/insomnia/src/ui/redux/modules/workspace.ts
@@ -13,7 +13,7 @@ import { setActiveActivity, setActiveProject, setActiveWorkspace } from './globa
 
 type OnWorkspaceCreateCallback = (arg0: Workspace) => Promise<void> | void;
 
-const createWorkspaceAndChildren = async (patch: Partial<Workspace>) => {
+export const createWorkspaceAndChildren = async (patch: Partial<Workspace>) => {
   const flushId = await database.bufferChanges();
 
   const workspace = await models.workspace.create(patch);


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
This is on top of @gatzjames's PR branch, so commits are a little messed up. I just took example code and stitched them together to see if we can do something like global modal but handle on and off by react state instead. It seems doable. This approach prevents re-rendering of the below dom tree but just itself only.