### PR TITLE
o2k: removed partial support for oauth2

### DIFF
--- a/packages/openapi-2-kong/README.md
+++ b/packages/openapi-2-kong/README.md
@@ -564,9 +564,6 @@ Supported types are:
 
 - `oauth2`
   - NOT YET IMPLEMENTED!
-  - except for the implicit flow
-  - implemented using the Kong plugin `openid-connect`
-  - extended by: `x-kong-security-openid-connect`
 - `openIdConnect`
   - implemented using the Kong plugin `openid-connect`
   - extended by: `x-kong-security-openid-connect`
@@ -635,7 +632,7 @@ The `request-validator` plugin has three [parameters](https://docs.konghq.com/hu
 - `config.parameter_schema`
 - `config.allowed_content_types`
 
-If any of these are *not* specified in the `x-kong-plugin-request-validator.config` object in the OpenAPI spec, they will be generated if possible, otherwise will be configured to allow all body/parameter/content types.
+If any of these are _not_ specified in the `x-kong-plugin-request-validator.config` object in the OpenAPI spec, they will be generated if possible, otherwise will be configured to allow all body/parameter/content types.
 
 ```yaml
 paths:

--- a/packages/openapi-2-kong/src/declarative-config/fixtures/security.expected.json
+++ b/packages/openapi-2-kong/src/declarative-config/fixtures/security.expected.json
@@ -13,13 +13,6 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_security.yaml"],
           "name": "Security_Example-only-oath2-get",
-          "plugins": [
-            {
-              "config": { "auth_methods": ["client_credentials"] },
-              "name": "openid-connect",
-              "tags": ["OAS3_import", "OAS3file_security.yaml"]
-            }
-          ],
           "paths": ["/only/oath2$"]
         },
         {
@@ -41,13 +34,6 @@
           "strip_path": false,
           "tags": ["OAS3_import", "OAS3file_security.yaml"],
           "name": "Security_Example-and-based-auth-get",
-          "plugins": [
-            {
-              "config": { "auth_methods": ["client_credentials"] },
-              "name": "openid-connect",
-              "tags": ["OAS3_import", "OAS3file_security.yaml"]
-            }
-          ],
           "paths": ["/and/based/auth$"]
         },
         {

--- a/packages/openapi-2-kong/src/declarative-config/security-plugins.ts
+++ b/packages/openapi-2-kong/src/declarative-config/security-plugins.ts
@@ -71,13 +71,6 @@ export const generateOpenIdConnectSecurityPlugin = (scheme: OpenAPIV3.OpenIdSecu
   return openIdConnectPlugin;
 };
 
-export const generateOAuth2SecurityPlugin = (): OpenIDConnectPlugin => ({
-  config: {
-    auth_methods: ['client_credentials'],
-  },
-  name: 'openid-connect',
-});
-
 export function generateSecurityPlugin(
   scheme: OA3SecurityScheme | null,
   args: string[],
@@ -97,10 +90,6 @@ export function generateSecurityPlugin(
 
     case 'openidconnect':
       plugin = generateOpenIdConnectSecurityPlugin(scheme as OpenAPIV3.OpenIdSecurityScheme, args);
-      break;
-
-    case 'oauth2':
-      plugin = generateOAuth2SecurityPlugin();
       break;
 
     default:


### PR DESCRIPTION
oidc workaround was causing conflicts when inferring security schema -> kong plugin config
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Closes INS-2027

changelog(OpenAPI-2-Kong): Removed an implicit workaround that was causing plugin conflicts when inferring security schema

