### PR TITLE
Remove document focus global shortcut

### DIFF
--- a/packages/insomnia-common/src/entities/hotkeys.ts
+++ b/packages/insomnia-common/src/entities/hotkeys.ts
@@ -55,8 +55,7 @@ export type KeyboardShortcut =
   | 'request_togglePin'
   | 'environment_showVariableSourceAndValue'
   | 'beautifyRequestBody'
-  | 'graphql_explorer_focus_filter'
-  | 'documents_filter';
+  | 'graphql_explorer_focus_filter';
 
 /**
  * The collection of defined hotkeys.

--- a/packages/insomnia/src/common/hotkeys.ts
+++ b/packages/insomnia/src/common/hotkeys.ts
@@ -39,7 +39,6 @@ export const keyboardShortcutDescriptions: Record<KeyboardShortcut, string> = {
   'environment_showVariableSourceAndValue': 'Show variable source and value',
   'beautifyRequestBody': 'Beautify Active Code Editors',
   'graphql_explorer_focus_filter': 'Focus GraphQL Explorer Filter',
-  'documents_filter': 'Focus Documents Filter',
 };
 
 /**
@@ -175,10 +174,6 @@ const defaultRegistry: HotKeyRegistry = {
   graphql_explorer_focus_filter: {
     macKeys: [{ shift: true, meta: true, keyCode: keyboardKeys.i.keyCode }],
     winLinuxKeys: [{ ctrl: true, shift: true, keyCode: keyboardKeys.i.keyCode }],
-  },
-  documents_filter: {
-    macKeys: [{ meta: true, keyCode: keyboardKeys.f.keyCode }],
-    winLinuxKeys: [{ ctrl: true, keyCode: keyboardKeys.f.keyCode }],
   },
 };
 

--- a/packages/insomnia/src/ui/components/wrapper-home.tsx
+++ b/packages/insomnia/src/ui/components/wrapper-home.tsx
@@ -1,6 +1,6 @@
 import 'swagger-ui-react/swagger-ui.css';
 
-import React, { FC, useCallback, useRef, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { unreachableCase } from 'ts-assert-unreachable';
@@ -32,7 +32,6 @@ import { DropdownItem } from './base/dropdown/dropdown-item';
 import { DashboardSortDropdown } from './dropdowns/dashboard-sort-dropdown';
 import { ProjectDropdown } from './dropdowns/project-dropdown';
 import { RemoteWorkspacesDropdown } from './dropdowns/remote-workspaces-dropdown';
-import { useDocBodyKeyboardShortcuts } from './keydown-binder';
 import { showPrompt } from './modals';
 import { PageLayout } from './page-layout';
 import { WrapperHomeEmptyStatePane } from './panes/wrapper-home-empty-state-pane';
@@ -190,7 +189,6 @@ const WrapperHome: FC<Props> = (({ vcs }) => {
     dispatch(activateWorkspace({ workspace }));
   }, [dispatch]);
 
-  const inputRef = useRef<HTMLInputElement>(null);
   const [filter, setFilter] = useState('');
 
   // Render each card, removing all the ones that don't match the filter
@@ -252,10 +250,6 @@ const WrapperHome: FC<Props> = (({ vcs }) => {
     setFilter(event.currentTarget.value);
   }, []);
 
-  useDocBodyKeyboardShortcuts({
-    documents_filter: () => inputRef.current?.focus(),
-  });
-
   return (
     <PageLayout
       renderPageHeader={
@@ -284,7 +278,7 @@ const WrapperHome: FC<Props> = (({ vcs }) => {
                   }}
                 >
                   <input
-                    ref={inputRef}
+                    autoFocus
                     type="text"
                     placeholder="Filter..."
                     onChange={onChangeFilter}


### PR DESCRIPTION
changelog(Fixes): Fixed an issue that prevented users from using CTRL/CMD+F keyboard shortcut

Reasoning:
Removing as it creates trouble with other places in the app and does not appear useful atm. (Similar to allowing changing Esc in modals/dropdowns)

Moving forward:
Lists or components with a search functionality should implement a default `Ctrl/Cmd+F` to focus the search input.


Closes INS-2060
