### PR TITLE
Fix #5207 - Query parameters ignored when importing Postman collection

### DIFF
--- a/packages/insomnia-importers/src/importers/fixtures/postman/complex-url-v2_0-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/complex-url-v2_0-output.json
@@ -16,10 +16,16 @@
       "_id": "__REQ_1__",
       "_type": "request",
       "parentId": "__GRP_1__",
-      "url": "https://insomnia.rest?foo=bar",
+      "url": "https://insomnia.rest",
       "name": "Test Request",
       "description": "",
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "foo",
+          "value": "bar",
+          "disabled": false
+        }
+      ],
       "method": "GET",
       "body": {},
       "headers": [],

--- a/packages/insomnia-importers/src/importers/fixtures/postman/complex-url-v2_1-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/complex-url-v2_1-output.json
@@ -16,9 +16,15 @@
       "_id": "__REQ_1__",
       "_type": "request",
       "parentId": "__GRP_1__",
-      "url": "https://insomnia.rest?foo=bar",
+      "url": "https://insomnia.rest",
       "name": "Test Request",
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "foo",
+          "value": "bar",
+          "disabled": false
+        }
+      ],
       "description": "",
       "method": "GET",
       "body": {},

--- a/packages/insomnia-importers/src/importers/fixtures/postman/complex-v2_0_fromHeaders-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/complex-v2_0_fromHeaders-output.json
@@ -46,7 +46,13 @@
       ],
       "method": "GET",
       "name": "Return the complete project hierarchy.",
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "team_id",
+          "value": "",
+          "disabled": true
+        }
+      ],
       "parentId": "__GRP_2__",
       "url": ""
     },
@@ -78,7 +84,23 @@
       ],
       "method": "GET",
       "name": "Return a list containing all projects.",
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "title",
+          "value": "root",
+          "disabled": false
+        },
+        {
+          "name": "hide_archived",
+          "value": "true",
+          "disabled": false
+        },
+        {
+          "name": "team_id",
+          "value": "",
+          "disabled": true
+        }
+      ],
       "parentId": "__GRP_2__",
       "url": ""
     },

--- a/packages/insomnia-importers/src/importers/fixtures/postman/oauth2_0-auth-v2_1-input.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/oauth2_0-auth-v2_1-input.json
@@ -95,13 +95,7 @@
 						"request",
 						"any"
 					],
-					"query": [
-						{
-							"key": "foo",
-							"value": "bar",
-							"disabled": true
-						}
-					]
+					"query": []
 				}
 			},
 			"response": []
@@ -200,13 +194,7 @@
 						"request",
 						"any"
 					],
-					"query": [
-						{
-							"key": "foo",
-							"value": "bar",
-							"disabled": true
-						}
-					]
+					"query": []
 				}
 			},
 			"response": []
@@ -298,13 +286,7 @@
 						"request",
 						"any"
 					],
-					"query": [
-						{
-							"key": "foo",
-							"value": "bar",
-							"disabled": true
-						}
-					]
+					"query": []
 				}
 			},
 			"response": []
@@ -406,13 +388,7 @@
 						"request",
 						"any"
 					],
-					"query": [
-						{
-							"key": "foo",
-							"value": "bar",
-							"disabled": true
-						}
-					]
+					"query": []
 				}
 			},
 			"response": []
@@ -511,13 +487,7 @@
 						"request",
 						"any"
 					],
-					"query": [
-						{
-							"key": "foo",
-							"value": "bar",
-							"disabled": true
-						}
-					]
+					"query": []
 				}
 			},
 			"response": []

--- a/packages/insomnia-importers/src/importers/postman.ts
+++ b/packages/insomnia-importers/src/importers/postman.ts
@@ -197,7 +197,7 @@ export class ImportPostman {
     }
 
     // remove ? and everything after it if there are QueryParams strictly defined
-    if (typeof url === 'object' && url.query) {
+    if (typeof url === 'object' && url.query && url.raw?.includes('?')) {
       return url.raw?.slice(0, url.raw.indexOf('?')) || '';
     }
 

--- a/packages/insomnia-importers/src/importers/postman.ts
+++ b/packages/insomnia-importers/src/importers/postman.ts
@@ -21,6 +21,7 @@ import {
   Header as V210Header,
   HttpsSchemaGetpostmanComJsonCollectionV210 as V210Schema,
   Item as V210Item,
+  QueryParam,
   Request1 as V210Request1,
   UrlEncodedParameter as V210UrlEncodedParameter,
   Variable2 as V210Variable2,
@@ -123,6 +124,9 @@ export class ImportPostman {
 
     const { authentication, headers } = this.importAuthentication(request.auth, request.header as Header[]);
 
+    // @ts-expect-error - property query does not exist?
+    const parameters = this.importParameters(request.url.query as QueryParam[]);
+
     return {
       parentId,
       _id: `__REQ_${requestCount++}__`,
@@ -130,6 +134,7 @@ export class ImportPostman {
       name,
       description: (request.description as string) || '',
       url: this.importUrl(request.url),
+      parameters: parameters,
       method: request.method || 'GET',
       headers: headers.map(({ key, value }) => ({
         name: key,
@@ -138,6 +143,17 @@ export class ImportPostman {
       body: this.importBody(request.body, headers.find(({ key }) => key === 'Content-Type')?.value),
       authentication,
     };
+  };
+
+  importParameters = (parameters: QueryParam[]): Parameter[] => {
+    if (parameters?.length === 0) {
+      return [];
+    }
+    return parameters.map(({ key, value, disabled }) => ({
+      name: key,
+      value,
+      disabled: disabled || false,
+    }) as Parameter);
   };
 
   importFolderItem = ({ name, description }: Folder, parentId: string) => {
@@ -176,6 +192,11 @@ export class ImportPostman {
   importUrl = (url?: Url | string) => {
     if (!url) {
       return '';
+    }
+
+    // remove ? and everything after it if there are QueryParams strictly defined
+    if (typeof url === 'object' && url.query) {
+      return url.raw?.slice(0, url.raw.indexOf('?')) || '';
     }
 
     if (typeof url === 'object' && url.raw) {

--- a/packages/insomnia-importers/src/importers/postman.ts
+++ b/packages/insomnia-importers/src/importers/postman.ts
@@ -124,9 +124,12 @@ export class ImportPostman {
 
     const { authentication, headers } = this.importAuthentication(request.auth, request.header as Header[]);
 
-    // @ts-expect-error - property query does not exist?
-    const parameters = this.importParameters(request.url.query as QueryParam[]);
+    let parameters = [] as Parameter[];
 
+    if (typeof request.url !== 'string') {
+      // @ts-expect-error  -- Url can be both string and Url type.
+      parameters = this.importParameters(request.url?.query);
+    }
     return {
       parentId,
       _id: `__REQ_${requestCount++}__`,
@@ -146,7 +149,7 @@ export class ImportPostman {
   };
 
   importParameters = (parameters: QueryParam[]): Parameter[] => {
-    if (parameters?.length === 0) {
+    if (!parameters || parameters?.length === 0) {
       return [];
     }
     return parameters.map(({ key, value, disabled }) => ({

--- a/packages/insomnia-importers/src/importers/postman.ts
+++ b/packages/insomnia-importers/src/importers/postman.ts
@@ -126,8 +126,7 @@ export class ImportPostman {
 
     let parameters = [] as Parameter[];
 
-    if (typeof request.url !== 'string') {
-      // @ts-expect-error  -- Url can be both string and Url type.
+    if (typeof request.url === 'object' && request.url.query) {
       parameters = this.importParameters(request.url?.query);
     }
     return {


### PR DESCRIPTION
changelog(Fixes): Fixed an issue that prevented query parameters from being properly imported from Postman V2.1 collections

Fixes #5207 

<details>
  <summary>Example collection</summary>

  ```json
  {
      "info": {
          "_postman_id": "5F653FA6-D8E8-4A92-B243-4F5D7F8D7A4B",
          "name": "Query Parameters",
          "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
          "_exporter_id": "18121341"
      },
      "item": [
          {
              "name": "mockbin",
              "request": {
                  "method": "GET",
                  "header": [],
                  "url": {
                      "raw": "mockbin.org/request/any?foo=bar",
                      "host": [
                          "mockbin",
                          "org"
                      ],
                      "path": [
                          "request",
                          "any"
                      ],
                      "query": [
                          {
                              "key": "foo",
                              "value": "bar"
                          }
                      ]
                  }
              },
              "response": []
          }
      ]
  }
  ```

</details>

Before:
![image](https://user-images.githubusercontent.com/11976836/195589575-8f953fba-25ec-4567-bcee-c49c5188c22b.png)


After:
![image](https://user-images.githubusercontent.com/11976836/195589341-1fde9643-afe0-4d5e-922f-a9062f54b341.png)

