### PR TITLE
fix graphql query variable parsing

### DIFF
--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -509,12 +509,9 @@ export const GraphQLEditor: FC<Props> = ({
   } catch (err) {
     body = { query: '' };
   }
-  let maybeVariables;
-  if (typeof body.variables === 'string') {
-    maybeVariables = jsonParseOr(body.variables, '');
-  }
+
   const query = body.query || '';
-  const variables = jsonPrettify(JSON.stringify(maybeVariables));
+  const variables = jsonPrettify(JSON.stringify(body.variables));
   const variableTypes = buildVariableTypes(schema);
 
   // Create portal for GraphQL Explorer


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where GraphQL query variables disappeared from the variables editor

Fixes an issue where graphql query variables are not parsed and shown in the variables editor.

Closes INS-2064
Closes #5265 