### PR TITLE
Fix for set-ouput deprecation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Save release version as output
         id: version
-        run: echo "::set-output name=version::$RELEASE_VERSION"
+        run: echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
         env:
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
 
@@ -104,7 +104,7 @@ jobs:
 
       - name: Set timestamp
         id: timestamp
-        run: echo "::set-output name=timestamp::$(date --iso-8601=seconds)"
+        run: echo "timestamp=$(date --iso-8601=seconds)" >> $GITHUB_OUTPUT
 
       - name: Find Comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -136,7 +136,7 @@ jobs:
         id: release_version
         shell: bash
         run: |
-           echo ::set-output name=version::${BRANCH/release\//}
+           echo "version=${BRANCH/release\//}"  >> $GITHUB_OUTPUT
         env:
           BRANCH: ${{ github.ref_name }}
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -136,7 +136,7 @@ jobs:
         id: release_version
         shell: bash
         run: |
-           echo "version=${BRANCH/release\//}"  >> $GITHUB_OUTPUT
+           echo "version=${BRANCH/release\//}" >> $GITHUB_OUTPUT
         env:
           BRANCH: ${{ github.ref_name }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,8 @@ jobs:
           INSO_VERSION="$(jq .version packages/insomnia-inso/package.json -rj)-run.${{ github.run_number }}"
           PKG_NAME="inso-${{ matrix.os }}-$INSO_VERSION"
 
-          echo ::set-output name=pkg-name::$PKG_NAME
-          echo ::set-output name=inso-version::$INSO_VERSION
+          echo "pkg-name=$PKG_NAME" >> $GITHUB_OUTPUT
+          echo "inso-version=$INSO_VERSION" >> $GITHUB_OUTPUT
 
       - name: Run Inso NPM package tests
         run: npm run test:bundled-inso


### PR DESCRIPTION
Related to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
