### PR TITLE
axios upgrade 1.1.3

### DIFF
--- a/packages/insomnia-inso/package-lock.json
+++ b/packages/insomnia-inso/package-lock.json
@@ -12,7 +12,7 @@
 				"@stoplight/spectral-core": "^1.12.2",
 				"@stoplight/spectral-formats": "^1.2.0",
 				"@stoplight/spectral-rulesets": "^1.9.0",
-				"axios": "^0.21.2",
+				"axios": "1.1.3",
 				"commander": "^5.1.0",
 				"consola": "^2.15.0",
 				"cosmiconfig": "^6.0.0",
@@ -2041,6 +2041,11 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
 			"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
 		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
 		"node_modules/at-least-node": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -2051,11 +2056,13 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+			"integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
 			"dependencies": {
-				"follow-redirects": "^1.14.0"
+				"follow-redirects": "^1.15.0",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/babel-jest": {
@@ -2474,6 +2481,17 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/commander": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -2712,6 +2730,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/delegates": {
@@ -3474,6 +3500,19 @@
 				"debug": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/from2": {
@@ -4961,6 +5000,25 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -5686,6 +5744,11 @@
 			"engines": {
 				"node": ">= 6"
 			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
@@ -8487,6 +8550,11 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
 			"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
 		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
 		"at-least-node": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -8494,11 +8562,13 @@
 			"dev": true
 		},
 		"axios": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+			"integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
 			"requires": {
-				"follow-redirects": "^1.14.0"
+				"follow-redirects": "^1.15.0",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"babel-jest": {
@@ -8809,6 +8879,14 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
 		"commander": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -8987,6 +9065,11 @@
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
 			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 			"dev": true
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
 		},
 		"delegates": {
 			"version": "1.0.0",
@@ -9452,6 +9535,16 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
 			"integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+		},
+		"form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
 		},
 		"from2": {
 			"version": "2.3.0",
@@ -10600,6 +10693,19 @@
 				"picomatch": "^2.3.1"
 			}
 		},
+		"mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+		},
+		"mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"requires": {
+				"mime-db": "1.52.0"
+			}
+		},
 		"mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -11144,6 +11250,11 @@
 				"kleur": "^3.0.3",
 				"sisteransi": "^1.0.5"
 			}
+		},
+		"proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
 		"pump": {
 			"version": "3.0.0",

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -65,7 +65,7 @@
     "@stoplight/spectral-core": "^1.12.2",
     "@stoplight/spectral-formats": "^1.2.0",
     "@stoplight/spectral-rulesets": "^1.9.0",
-    "axios": "^0.21.2",
+    "axios": "1.1.3",
     "commander": "^5.1.0",
     "consola": "^2.15.0",
     "cosmiconfig": "^6.0.0",

--- a/packages/insomnia-send-request/package-lock.json
+++ b/packages/insomnia-send-request/package-lock.json
@@ -15,7 +15,7 @@
 				"@stoplight/spectral-rulesets": "^1.9.0",
 				"analytics-node": "^6.0.0",
 				"aws4": "^1.10.0",
-				"axios": "^0.21.2",
+				"axios": "1.1.3",
 				"clone": "^2.1.2",
 				"color": "^3.1.2",
 				"fs-extra": "^9.0.1",
@@ -1146,11 +1146,13 @@
 			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
 		},
 		"node_modules/axios": {
-			"version": "0.21.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-			"integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+			"integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
 			"dependencies": {
-				"follow-redirects": "^1.14.0"
+				"follow-redirects": "^1.15.0",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/axios-retry": {
@@ -1159,6 +1161,19 @@
 			"integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
 			"dependencies": {
 				"is-retry-allowed": "^1.1.0"
+			}
+		},
+		"node_modules/axios/node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -1639,9 +1654,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.14.8",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-			"integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -3064,6 +3079,11 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
 		"node_modules/psl": {
 			"version": "1.8.0",
@@ -4531,11 +4551,25 @@
 			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
 		},
 		"axios": {
-			"version": "0.21.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-			"integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+			"integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
 			"requires": {
-				"follow-redirects": "^1.14.0"
+				"follow-redirects": "^1.15.0",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
+			},
+			"dependencies": {
+				"form-data": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+					"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.8",
+						"mime-types": "^2.1.12"
+					}
+				}
 			}
 		},
 		"axios-retry": {
@@ -4943,9 +4977,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.14.8",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-			"integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
 		},
 		"form-data": {
 			"version": "3.0.0",
@@ -6027,6 +6061,11 @@
 				"err-code": "^2.0.2",
 				"retry": "^0.12.0"
 			}
+		},
+		"proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
 		"psl": {
 			"version": "1.8.0",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -13,7 +13,7 @@
     "@stoplight/spectral-rulesets": "^1.9.0",
     "analytics-node": "^6.0.0",
     "aws4": "^1.10.0",
-    "axios": "^0.21.2",
+    "axios": "1.1.3",
     "clone": "^2.1.2",
     "color": "^3.1.2",
     "fs-extra": "^9.0.1",

--- a/packages/insomnia/package-lock.json
+++ b/packages/insomnia/package-lock.json
@@ -19,7 +19,7 @@
 				"@stoplight/spectral-rulesets": "^1.9.0",
 				"analytics-node": "^6.0.0",
 				"aws4": "^1.11.0",
-				"axios": "^0.21.2",
+				"axios": "1.1.3",
 				"clone": "^2.1.0",
 				"color": "^3.1.2",
 				"crypto-browserify": "^3.12.0",
@@ -6844,25 +6844,6 @@
 				"follow-redirects": "^1.14.0"
 			}
 		},
-		"node_modules/analytics-node/node_modules/follow-redirects": {
-			"version": "1.14.7",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-			"integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/RubenVerborgh"
-				}
-			],
-			"engines": {
-				"node": ">=4.0"
-			},
-			"peerDependenciesMeta": {
-				"debug": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/ansi-align": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -7343,11 +7324,13 @@
 			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
 		},
 		"node_modules/axios": {
-			"version": "0.21.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-			"integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+			"integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
 			"dependencies": {
-				"follow-redirects": "^1.14.0"
+				"follow-redirects": "^1.15.0",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/axios-retry": {
@@ -7358,23 +7341,17 @@
 				"is-retry-allowed": "^1.1.0"
 			}
 		},
-		"node_modules/axios/node_modules/follow-redirects": {
-			"version": "1.14.7",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-			"integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/RubenVerborgh"
-				}
-			],
-			"engines": {
-				"node": ">=4.0"
+		"node_modules/axios/node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
 			},
-			"peerDependenciesMeta": {
-				"debug": {
-					"optional": true
-				}
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/babel-jest": {
@@ -11643,6 +11620,25 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/form-data": {
@@ -18871,6 +18867,11 @@
 			"version": "13.13.30",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.30.tgz",
 			"integrity": "sha512-HmqFpNzp3TSELxU/bUuRK+xzarVOAsR00hzcvM0TXrMlt/+wcSLa5q6YhTb6/cA6wqDCZLDcfd8fSL95x5h7AA=="
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
 		"node_modules/prr": {
 			"version": "1.0.1",
@@ -27822,11 +27823,6 @@
 					"requires": {
 						"follow-redirects": "^1.14.0"
 					}
-				},
-				"follow-redirects": {
-					"version": "1.14.7",
-					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-					"integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
 				}
 			}
 		},
@@ -28214,17 +28210,24 @@
 			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
 		},
 		"axios": {
-			"version": "0.21.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-			"integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+			"integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
 			"requires": {
-				"follow-redirects": "^1.14.0"
+				"follow-redirects": "^1.15.0",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			},
 			"dependencies": {
-				"follow-redirects": {
-					"version": "1.14.7",
-					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-					"integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+				"form-data": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+					"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.8",
+						"mime-types": "^2.1.12"
+					}
 				}
 			}
 		},
@@ -31495,6 +31498,11 @@
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
 			}
+		},
+		"follow-redirects": {
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
 		},
 		"form-data": {
 			"version": "3.0.0",
@@ -37054,6 +37062,11 @@
 					"integrity": "sha512-HmqFpNzp3TSELxU/bUuRK+xzarVOAsR00hzcvM0TXrMlt/+wcSLa5q6YhTb6/cA6wqDCZLDcfd8fSL95x5h7AA=="
 				}
 			}
+		},
+		"proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
 		"prr": {
 			"version": "1.0.1",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -51,7 +51,7 @@
     "@stoplight/spectral-rulesets": "^1.9.0",
     "analytics-node": "^6.0.0",
     "aws4": "^1.11.0",
-    "axios": "^0.21.2",
+    "axios": "1.1.3",
     "clone": "^2.1.0",
     "color": "^3.1.2",
     "crypto-browserify": "^3.12.0",

--- a/packages/insomnia/src/common/analytics.ts
+++ b/packages/insomnia/src/common/analytics.ts
@@ -1,5 +1,4 @@
 import Analytics from 'analytics-node';
-import { AxiosRequestConfig } from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getAccountId } from '../account/session';
@@ -13,19 +12,7 @@ import {
   getSegmentWriteKey,
 } from './constants';
 
-const axiosConfig: AxiosRequestConfig = {
-  // This is needed to ensure that we use the NodeJS adapter in the render process
-  ...(global?.require ? {
-    adapter: global.require('axios/lib/adapters/http'),
-  } : {}),
-};
-
-const segmentClient = new Analytics(getSegmentWriteKey(), {
-  // @ts-expect-error this is missing from the analytics-node types (and docs) but is present in the source code
-  // https://github.com/segmentio/analytics-node/blob/0a6aa0d9d865b56f799f9d014b4d7b98ae5d2f2e/index.js#L28
-  // as for the types: since (as of @types/analytics-node v3.1.7) this is hardcoded into a class constructor, it makes it hard to fix with module augmentation
-  axiosConfig,
-});
+const segmentClient = new Analytics(getSegmentWriteKey());
 
 const getDeviceId = async () => {
   const settings = await models.settings.getOrCreate();

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -1,6 +1,7 @@
 import { app, ipcMain, IpcRendererEvent } from 'electron';
 import { writeFile } from 'fs/promises';
 
+import { axiosRequest } from '../../network/axios-request';
 import { authorizeUserInWindow } from '../../network/o-auth-2/misc';
 import installPlugin from '../install-plugin';
 import { cancelCurlRequest, curlRequest } from '../network/libcurl-promise';
@@ -16,6 +17,7 @@ export interface MainBridgeAPI {
   curlRequest: typeof curlRequest;
   on: (channel: string, listener: (event: IpcRendererEvent, ...args: any[]) => void) => () => void;
   webSocket: WebSocketBridgeAPI;
+  axiosRequest: typeof axiosRequest;
 }
 export function registerMainHandlers() {
   ipcMain.handle('authorizeUserInWindow', (_, options: Parameters<typeof authorizeUserInWindow>[0]) => {
@@ -43,8 +45,13 @@ export function registerMainHandlers() {
   ipcMain.handle('installPlugin', (_, lookupName: string) => {
     return installPlugin(lookupName);
   });
+
   ipcMain.on('restart', () => {
     app.relaunch();
     app.exit();
+  });
+
+  ipcMain.handle('axiosRequest', (_, options: Parameters<typeof axiosRequest>[0]) => {
+    return axiosRequest(options);
   });
 }

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -1,9 +1,9 @@
 import { app, ipcMain, IpcRendererEvent } from 'electron';
 import { writeFile } from 'fs/promises';
 
-import { axiosRequest } from '../../network/axios-request';
 import { authorizeUserInWindow } from '../../network/o-auth-2/misc';
 import installPlugin from '../install-plugin';
+import { axiosRequest } from '../network/axios-request';
 import { cancelCurlRequest, curlRequest } from '../network/libcurl-promise';
 import { WebSocketBridgeAPI } from '../network/websocket';
 

--- a/packages/insomnia/src/main/network/__tests__/axios-request.test.ts
+++ b/packages/insomnia/src/main/network/__tests__/axios-request.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import axios from 'axios';
 
-import { globalBeforeEach } from '../../__jest__/before-each';
-import * as models from '../../models';
+import { globalBeforeEach } from '../../../__jest__/before-each';
+import * as models from '../../../models';
 import { axiosRequest } from '../axios-request';
 
 interface AxiosRequestMockUserSettings {

--- a/packages/insomnia/src/main/network/axios-request.ts
+++ b/packages/insomnia/src/main/network/axios-request.ts
@@ -3,9 +3,9 @@ import * as https from 'https';
 import { setDefaultProtocol } from 'insomnia-url';
 import { parse as urlParse } from 'url';
 
-import { isDevelopment } from '../common/constants';
-import * as models from '../models';
-import { isUrlMatchedInNoProxyRule } from './is-url-matched-in-no-proxy-rule';
+import { isDevelopment } from '../../common/constants';
+import * as models from '../../models';
+import { isUrlMatchedInNoProxyRule } from '../../network/is-url-matched-in-no-proxy-rule';
 
 export async function axiosRequest(config: AxiosRequestConfig) {
   const settings = await models.settings.getOrCreate();
@@ -54,6 +54,9 @@ export async function axiosRequest(config: AxiosRequestConfig) {
       res: {
         responseUrl: response?.request?.res?.responseUrl,
       },
+    },
+    config: {
+      proxy: response.config.proxy,
     },
   };
 }

--- a/packages/insomnia/src/main/network/axios-request.ts
+++ b/packages/insomnia/src/main/network/axios-request.ts
@@ -50,6 +50,8 @@ export async function axiosRequest(config: AxiosRequestConfig) {
   return {
     data: response?.data,
     status: response?.status,
+    statusText: response?.statusText,
+    headers: response?.headers,
     request: {
       res: {
         responseUrl: response?.request?.res?.responseUrl,

--- a/packages/insomnia/src/network/axios-request.ts
+++ b/packages/insomnia/src/network/axios-request.ts
@@ -20,7 +20,6 @@ export async function axiosRequest(config: AxiosRequestConfig) {
 
   const finalConfig: AxiosRequestConfig = {
     ...config,
-    adapter: global.require('axios/lib/adapters/http'),
     httpsAgent: new https.Agent({
       rejectUnauthorized: settings.validateSSL,
     }),
@@ -48,5 +47,13 @@ export async function axiosRequest(config: AxiosRequestConfig) {
     });
   }
 
-  return response;
+  return {
+    data: response?.data,
+    status: response?.status,
+    request: {
+      res: {
+        responseUrl: response?.request?.res?.responseUrl,
+      },
+    },
+  };
 }

--- a/packages/insomnia/src/plugins/context/app.tsx
+++ b/packages/insomnia/src/plugins/context/app.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import type ReactDOM from 'react-dom';
 
 import * as analytics from '../../../src/common/analytics';
-import { axiosRequest as axios } from '../../../src/network/axios-request';
 import { getAppPlatform, getAppVersion } from '../../common/constants';
 import type { RenderPurpose } from '../../common/render';
 import {
@@ -63,7 +62,7 @@ export interface AppContext {
 }
 
 export interface PrivateProperties {
-  axios: typeof axios;
+  axios: typeof window.main.axiosRequest;
   analytics: typeof analytics;
   loadRendererModules: () => Promise<{
     ReactDOM: typeof ReactDOM;
@@ -215,7 +214,7 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): {
       },
     },
     __private: {
-      axios,
+      axios: window.main.axiosRequest,
       analytics,
       // Provide modules that can be used in the renderer process
       async loadRendererModules() {

--- a/packages/insomnia/src/plugins/context/app.tsx
+++ b/packages/insomnia/src/plugins/context/app.tsx
@@ -214,7 +214,7 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): {
       },
     },
     __private: {
-      axios: window.main.axiosRequest,
+      axios: window.main?.axiosRequest,
       analytics,
       // Provide modules that can be used in the renderer process
       async loadRendererModules() {

--- a/packages/insomnia/src/plugins/context/app.tsx
+++ b/packages/insomnia/src/plugins/context/app.tsx
@@ -10,6 +10,7 @@ import {
   RENDER_PURPOSE_NO_RENDER,
   RENDER_PURPOSE_SEND,
 } from '../../common/render';
+import { axiosRequest } from '../../main/network/axios-request';
 import { HtmlElementWrapper } from '../../ui/components/html-element-wrapper';
 import { showAlert, showModal, showPrompt } from '../../ui/components/modals';
 import { PromptModalOptions } from '../../ui/components/modals/prompt-modal';
@@ -214,7 +215,7 @@ export function init(renderPurpose: RenderPurpose = RENDER_PURPOSE_GENERAL): {
       },
     },
     __private: {
-      axios: window.main?.axiosRequest,
+      axios: process.type === 'renderer' ? window.main?.axiosRequest : axiosRequest,
       analytics,
       // Provide modules that can be used in the renderer process
       async loadRendererModules() {

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -28,6 +28,7 @@ const main: Window['main'] = {
     return () => ipcRenderer.removeListener(channel, listener);
   },
   webSocket,
+  axiosRequest: options => ipcRenderer.invoke('axiosRequest', options),
 };
 const dialog: Window['dialog'] = {
   showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),

--- a/packages/insomnia/src/sync/git/github-oauth-provider.ts
+++ b/packages/insomnia/src/sync/git/github-oauth-provider.ts
@@ -1,7 +1,6 @@
 import { v4 } from 'uuid';
 
 import { getApiBaseURL, getAppWebsiteBaseURL, getGitHubGraphQLApiURL } from '../../common/constants';
-import { axiosRequest } from '../../network/axios-request';
 
 export const GITHUB_TOKEN_STORAGE_KEY = 'github-oauth-token';
 export const GITHUB_GRAPHQL_API_URL = getGitHubGraphQLApiURL();
@@ -44,7 +43,7 @@ export async function exchangeCodeForToken({
     );
   }
 
-  return axiosRequest({
+  return window.main.axiosRequest({
     url: getApiBaseURL() + '/v1/oauth/github',
     method: 'POST',
     headers: {

--- a/packages/insomnia/src/sync/git/gitlab-oauth-provider.ts
+++ b/packages/insomnia/src/sync/git/gitlab-oauth-provider.ts
@@ -2,7 +2,6 @@ import { createHash, randomBytes } from 'crypto';
 import { v4 as uuid } from 'uuid';
 
 import { getApiBaseURL } from '../../common/constants';
-import { axiosRequest } from '../../network/axios-request';
 
 const env = process['env'];
 
@@ -27,7 +26,7 @@ const getGitLabConfig = async () => {
   }
 
   // Otherwise fetch the config for the GitLab API
-  return axiosRequest({
+  return window.main.axiosRequest({
     url: getApiBaseURL() + '/v1/oauth/gitlab/config',
     method: 'GET',
   }).then(({ data }) => {
@@ -117,7 +116,7 @@ export async function exchangeCodeForGitLabToken(input: {
     code_verifier: verifier,
   }).toString();
 
-  return axiosRequest({
+  return window.main.axiosRequest({
     url: url.toString(),
     method: 'POST',
     headers: {
@@ -145,7 +144,7 @@ export async function refreshToken() {
     client_id: clientId,
   }).toString();
 
-  return axiosRequest({
+  return window.main.axiosRequest({
     url: url.toString(),
     method: 'POST',
     headers: {

--- a/packages/insomnia/src/sync/git/http-client.ts
+++ b/packages/insomnia/src/sync/git/http-client.ts
@@ -1,4 +1,3 @@
-import { axiosRequest } from '../../network/axios-request';
 
 /** This is a client for isomorphic-git {@link https://isomorphic-git.org/docs/en/http} */
 export const httpClient = {
@@ -15,7 +14,7 @@ export const httpClient = {
     }
 
     try {
-      response = await axiosRequest({
+      response = await window.main.axiosRequest({
         url: config.url,
         method: config.method,
         headers: config.headers,

--- a/packages/insomnia/src/sync/git/http-client.ts
+++ b/packages/insomnia/src/sync/git/http-client.ts
@@ -1,42 +1,43 @@
+import { HttpClient } from 'isomorphic-git';
 
 /** This is a client for isomorphic-git {@link https://isomorphic-git.org/docs/en/http} */
-export const httpClient = {
-  request: async (config: any) => {
-    let response;
-    let body: Buffer | null = null;
-
-    if (config.headers && !config.headers.Accept) {
-      config.headers.Accept = '*/*';
-    }
-
-    if (Array.isArray(config.body)) {
-      body = Buffer.concat(config.body);
-    }
+export const httpClient: HttpClient = {
+  request: async config => {
+    console.log('httpClient', config);
 
     try {
-      response = await window.main.axiosRequest({
+      const response = await window.main.axiosRequest({
         url: config.url,
         method: config.method,
         headers: config.headers,
-        data: body,
+        data: Array.isArray(config.body) && Buffer.concat(config.body),
         responseType: 'arraybuffer',
         maxRedirects: 10,
       });
+      console.log('httpClient response', response);
+      return {
+        url: response.request.res.responseUrl,
+        method: response.request.method,
+        headers: response.headers,
+        body: [response.data],
+        statusCode: response.status,
+        statusMessage: response.statusText,
+      };
     } catch (err) {
+      console.log('httpClient error', err);
       if (!err.response) {
         // NOTE: config.url is unreachable
         throw err;
       }
-      response = err.response;
+      const response = err.response || { request:{}, config:{}, headers:{}, data:{} };
+      return {
+        url: response.request.res.responseUrl,
+        method: response.request.method,
+        headers: response.headers,
+        body: [response.data],
+        statusCode: response.status,
+        statusMessage: response.statusText,
+      };
     }
-
-    return {
-      url: response.request.res.responseUrl,
-      method: response.request.method,
-      headers: response.headers,
-      body: [response.data],
-      statusCode: response.status,
-      statusMessage: response.statusText,
-    };
   },
 };

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -21,7 +21,6 @@ import type { ResponsePatch } from '../../../../main/network/libcurl-promise';
 import * as models from '../../../../models';
 import type { Request } from '../../../../models/request';
 import type { Settings } from '../../../../models/settings';
-import { axiosRequest } from '../../../../network/axios-request';
 import { Dropdown } from '../../base/dropdown/dropdown';
 import { DropdownButton } from '../../base/dropdown/dropdown-button';
 import { DropdownDivider } from '../../base/dropdown/dropdown-divider';
@@ -102,7 +101,7 @@ const fetchGraphQLSchemaForRequest = async ({
         enabledHeaders['cookie'] = cookieHeader;
       }
     }
-    const response = await axiosRequest({
+    const response = await window.main.axiosRequest({
       url: setDefaultProtocol(joinUrlAndQueryString(rendered.url, queryString)),
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...enabledHeaders },

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -104,7 +104,7 @@ const fetchGraphQLSchemaForRequest = async ({
     const response = await window.main.axiosRequest({
       url: setDefaultProtocol(joinUrlAndQueryString(rendered.url, queryString)),
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...enabledHeaders },
+      headers: enabledHeaders,
       data: {
         query: getIntrospectionQuery(),
       },

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/gitlab-repository-settings-form-group.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/gitlab-repository-settings-form-group.tsx
@@ -5,7 +5,6 @@ import { useInterval, useLocalStorage } from 'react-use';
 import styled from 'styled-components';
 
 import { GitRepository } from '../../../../models/git-repository';
-import { axiosRequest } from '../../../../network/axios-request';
 import {
   generateAuthorizationUrl,
   getGitLabOauthApiURL,
@@ -163,7 +162,7 @@ const GitLabRepositoryForm = ({
 
   useEffect(() => {
     if (token && !user) {
-      axiosRequest({
+      window.main.axiosRequest({
         method: 'GET',
         url: `${getGitLabOauthApiURL()}/api/v4/user`,
         headers: {

--- a/plugins/insomnia-plugin-kong-portal/package-lock.json
+++ b/plugins/insomnia-plugin-kong-portal/package-lock.json
@@ -16,7 +16,7 @@
 				"@types/react-dom": "^16.9.12",
 				"@types/styled-components": "^5.1.23",
 				"@types/url-join": "^4.0.1",
-				"axios": "^0.21.2",
+				"axios": "1.1.3",
 				"concurrently": "^7.0.0",
 				"cross-env": "^7.0.3",
 				"esbuild": "^0.14.29",
@@ -282,13 +282,21 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true
+		},
 		"node_modules/axios": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+			"integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
 			"dev": true,
 			"dependencies": {
-				"follow-redirects": "^1.14.0"
+				"follow-redirects": "^1.15.0",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/babel-plugin-syntax-jsx": {
@@ -364,6 +372,18 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -557,6 +577,15 @@
 			"dev": true,
 			"dependencies": {
 				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/emoji-regex": {
@@ -955,9 +984,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.14.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
 			"dev": true,
 			"funding": [
 				{
@@ -972,6 +1001,20 @@
 				"debug": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dev": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -1109,6 +1152,27 @@
 				"loose-envify": "cli.js"
 			}
 		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1179,6 +1243,12 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"dev": true
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
 		"node_modules/react": {
@@ -1794,13 +1864,21 @@
 				"color-convert": "^1.9.0"
 			}
 		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true
+		},
 		"axios": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+			"integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
 			"dev": true,
 			"requires": {
-				"follow-redirects": "^1.14.0"
+				"follow-redirects": "^1.15.0",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"babel-plugin-syntax-jsx": {
@@ -1873,6 +1951,15 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
+		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -2015,6 +2102,12 @@
 			"requires": {
 				"ms": "^2.1.1"
 			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -2213,10 +2306,21 @@
 			"dev": true
 		},
 		"follow-redirects": {
-			"version": "1.14.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
 			"dev": true
+		},
+		"form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -2328,6 +2432,21 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
+		"mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"requires": {
+				"mime-db": "1.52.0"
+			}
+		},
 		"minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2380,6 +2499,12 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"dev": true
+		},
+		"proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
 		"react": {

--- a/plugins/insomnia-plugin-kong-portal/package.json
+++ b/plugins/insomnia-plugin-kong-portal/package.json
@@ -35,7 +35,7 @@
     "@types/react-dom": "^16.9.12",
     "@types/styled-components": "^5.1.23",
     "@types/url-join": "^4.0.1",
-    "axios": "^0.21.2",
+    "axios": "1.1.3",
     "concurrently": "^7.0.0",
     "cross-env": "^7.0.3",
     "esbuild": "^0.14.29",

--- a/plugins/insomnia-plugin-kong-portal/src/deploy-to-portal.tsx
+++ b/plugins/insomnia-plugin-kong-portal/src/deploy-to-portal.tsx
@@ -293,7 +293,7 @@ export function getDeployToPortalComponent(options: {
           if (isAxiosError(connectionError) && connectionError.response) {
             const response = connectionError.response;
             messageToShow = `${response.status} ${response.statusText}`;
-            const responseMessage = response.data?.message;
+            const responseMessage = connectionError.message;
             if (responseMessage) {
               messageToShow += `: ${responseMessage}`;
             }


### PR DESCRIPTION
also moves axios calls over the ipc bridge

appears to be blocked by an aborted stream when cloning with isometric git

ref: upstream issues `AxiosError: maxContentLength size of -1 exceeded` which is an inappropriate error, https://github.com/axios/axios/pull/4917


options: 
- use alternative or default fetch mechanic supplied with isometric-git
- remove proxy and ssl toggle support from git-sync
- don't upgrade axios
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
