### PR TITLE
add url shim for swagger-client issue

### DIFF
--- a/packages/insomnia/src/ui/routes/design.tsx
+++ b/packages/insomnia/src/ui/routes/design.tsx
@@ -1,3 +1,5 @@
+import 'swagger-ui-react/swagger-ui.css';
+
 import { IRuleResult } from '@stoplight/spectral-core';
 import React, { createRef, FC, RefObject, useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';

--- a/packages/insomnia/src/url.shim.js
+++ b/packages/insomnia/src/url.shim.js
@@ -1,0 +1,5 @@
+// @TODO - Remove this shim once we fix the issue with the URL polyfill for swagger-client
+// https://github.com/swagger-api/swagger-ui/issues/7762
+import url from 'url';
+
+export default url;

--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -35,6 +35,11 @@ export default defineConfig(({ mode }) => {
       'process.env.NODE_ENV': JSON.stringify(mode),
       'process.env.INSOMNIA_ENV': JSON.stringify(mode),
     },
+    resolve: {
+      alias: {
+        'url': path.join(__dirname, 'src', 'url.shim.js'),
+      },
+    },
     optimizeDeps: {
       exclude: commonjsPackages,
     },


### PR DESCRIPTION
Fixes swagger-client not rendering due to import of url module