### PR TITLE
fix: leave focus on send button instead of autochanging to url bar

### DIFF
--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -228,7 +228,6 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     } else {
       handleSend();
     }
-    inputRef.current?.focus(true);
   }, [downloadPath, handleSend, sendThenSetFilePath]);
 
   useInterval(send, currentInterval ? currentInterval : null);


### PR DESCRIPTION
Closes #5274

changelog(Fixes): Fixed an issue where URL bar would always get auto-focused when sending a request