### PR TITLE
fix: parameter order for date-fns#differenceInMinutes

### DIFF
--- a/packages/insomnia/src/ui/components/time-from-now.tsx
+++ b/packages/insomnia/src/ui/components/time-from-now.tsx
@@ -14,7 +14,7 @@ interface Props {
 function getTimeFromNow(timestamp: string | number | Date, titleCase: boolean): string {
   const date = new Date(timestamp);
   let text = formatDistanceToNowStrict(date, { addSuffix: true });
-  const lessThanOneMinuteAgo = differenceInMinutes(Date.now(), date) < 1;
+  const lessThanOneMinuteAgo = differenceInMinutes(date, Date.now()) < 1;
   if (lessThanOneMinuteAgo) {
     text = 'just now';
   }


### PR DESCRIPTION
Closes #5084

Earlier date should be on the right https://date-fns.org/v2.29.3/docs/differenceInMinutes#arguments