### PR TITLE
fix: allow toggle between basic auth and request body for oauth2.0 cr…

### DIFF
--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-select-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-select-row.tsx
@@ -20,7 +20,14 @@ export const AuthSelectRow: FC<Props> = ({ label, property, help, options, disab
 
   const selectedValue = authentication.hasOwnProperty(property) ? authentication[property] : options[0].value;
 
-  const onChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => patchAuth({ [property]: event.currentTarget.value }), [patchAuth, property]);
+  const onChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
+    let updatedValue = event.currentTarget.value;
+    // Convert boolean strings to boolean values for further processing.
+    if (updatedValue === 'true' || updatedValue === 'false') {
+      updatedValue = JSON.parse(updatedValue);
+    }
+    patchAuth({ [property]: updatedValue });
+  }, [patchAuth, property]);
 
   const id = toKebabCase(label);
 


### PR DESCRIPTION
Closes #4715

`Boolean('false')` being true causes this.

changelog(Fixes): Fixed an issue that prevented users from switching Client Credentials between Basic Auth and Request Body in OAuth2 requests