### PR TITLE
make all packages private

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -136,13 +136,6 @@ jobs:
           snap: artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.snap
           release: stable
 
-      - name: Publish npm packages
-        run: |
-          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          npm run publish -- --pre-dist-tag ${{ contains(github.event.inputs.version, 'alpha') && 'alpha' || 'beta' }} --yes
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Upload .deb to pulp (stable only)
         if: ${{ env.IS_PRERELEASE == 'false' }}
         uses: docker://kong/release-script:latest

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -18,11 +18,6 @@ on:
         required: false
         description: iteration of the release, used for non-stable releases (version-channel.iteration) (e.g. 0, 1, 2, 3 ...)
         default: '0'
-      major-npm:
-        required: false
-        type: boolean
-        description: increment the major version of the NPM packages
-        default: false
 
 env:
   RELEASE_VERSION: ${{ github.event.inputs.version }}${{ github.event.inputs.channel != 'stable' && format('-{0}.{1}', github.event.inputs.channel, github.event.inputs.iteration) || '' }}
@@ -61,11 +56,11 @@ jobs:
 
       - name: Lerna version (stable)
         if: github.event.inputs.channel == 'stable'
-        run: npm run version -- --yes "${{ github.event.inputs.major-npm != 'true' && 'minor' || 'major' }}"
+        run: npm run version -- --yes 'minor'
 
       - name: Lerna version (alpha/beta)
         if: github.event.inputs.channel != 'stable'
-        run: npm run version -- --yes --preid "${{ github.event.inputs.channel }}" "${{ github.event.inputs.iteration == '0' && (github.event.inputs.major-npm != 'true' && 'preminor' || 'premajor') || 'prerelease' }}"
+        run: npm run version -- --yes --preid "${{ github.event.inputs.channel }}" "${{ github.event.inputs.iteration == '0' && 'preminor' || 'prerelease' }}"
 
       - name: Config version
         run: APP_VERSION="${{ env.RELEASE_VERSION }}" npm run app-bump-version

--- a/lerna.json
+++ b/lerna.json
@@ -1,19 +1,7 @@
 {
   "version": "3.6.1-beta.2",
-  "includeMergedTags": true,
   "packages": [
     "packages/*",
     "plugins/*"
-  ],
-  "command": {
-    "version": {
-      "exact": true,
-      "forcePublish": true,
-      "gitTagVersion": false,
-      "push": false
-    },
-    "publish": {
-      "verifyAccess": false
-    }
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "lint:fix": "lerna run lint:fix --stream --no-bail",
     "bootstrap": "npm install && lerna bootstrap && lerna run --stream bootstrap",
     "version": "lerna version",
-    "publish": "lerna publish from-package",
     "clean": "lerna run clean --parallel --stream && lerna clean --yes && rimraf node_modules **/*.tsbuildinfo",
     "test": "lerna run --stream --parallel test",
     "inso-start": "npm start --prefix packages/insomnia-inso",

--- a/packages/insomnia-common/package.json
+++ b/packages/insomnia-common/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-common",
   "version": "3.6.1-beta.2",
   "homepage": "https://insomnia.rest",

--- a/packages/insomnia-config/package.json
+++ b/packages/insomnia-config/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-config",
   "version": "3.6.1-beta.2",
   "homepage": "https://insomnia.rest",

--- a/packages/insomnia-cookies/package.json
+++ b/packages/insomnia-cookies/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-cookies",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/packages/insomnia-importers/package.json
+++ b/packages/insomnia-importers/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "insomnia-importers",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/packages/insomnia-inso/.npmignore
+++ b/packages/insomnia-inso/.npmignore
@@ -1,7 +1,0 @@
-# Ignore everything by default
-# NOTE: NPM publish will never ignore package.json, package-lock.json, README, LICENSE, CHANGELOG
-# https://npm.github.io/publishing-pkgs-docs/publishing/the-npmignore-file.html
-*
-
-# Don't ignore dist folder
-!dist/**

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "insomnia-inso",
   "version": "3.6.1-beta.2",
   "homepage": "https://insomnia.rest",

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -39,8 +39,7 @@
     "package": "esr src/scripts/pkg.ts",
     "pkg": "pkg .",
     "postpackage": "esr src/scripts/verify-pkg.ts",
-    "artifacts": "esr src/scripts/artifacts.ts",
-    "prepublishOnly": "npm run build:production"
+    "artifacts": "esr src/scripts/artifacts.ts"
   },
   "devDependencies": {
     "@jest/globals": "^28.1.0",

--- a/packages/insomnia-prettify/package.json
+++ b/packages/insomnia-prettify/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-prettify",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-send-request",
   "license": "Apache-2.0",
   "version": "3.6.1-beta.2",

--- a/packages/insomnia-testing/.npmignore
+++ b/packages/insomnia-testing/.npmignore
@@ -1,7 +1,0 @@
-# Ignore everything by default
-# NOTE: NPM publish will never ignore package.json, package-lock.json, README, LICENSE, CHANGELOG
-# https://npm.github.io/publishing-pkgs-docs/publishing/the-npmignore-file.html
-*
-
-# Don't ignore dist folder
-!dist/**

--- a/packages/insomnia-testing/package.json
+++ b/packages/insomnia-testing/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-testing",
   "license": "Apache-2.0",
   "version": "3.6.1-beta.2",

--- a/packages/insomnia-testing/package.json
+++ b/packages/insomnia-testing/package.json
@@ -22,8 +22,7 @@
     "postclean": "rimraf dist",
     "test": "jest",
     "build": "tsc --build tsconfig.build.json",
-    "watch": "npm run build -- --watch",
-    "prepublish": "npm run build"
+    "watch": "npm run build -- --watch"
   },
   "devDependencies": {
     "@jest/globals": "^28.1.0",

--- a/packages/insomnia-url/package.json
+++ b/packages/insomnia-url/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-url",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/packages/insomnia-xpath/package.json
+++ b/packages/insomnia-xpath/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-xpath",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/packages/openapi-2-kong/.npmignore
+++ b/packages/openapi-2-kong/.npmignore
@@ -1,7 +1,0 @@
-# Ignore everything by default
-# NOTE: NPM publish will never ignore package.json, package-lock.json, README, LICENSE, CHANGELOG
-# https://npm.github.io/publishing-pkgs-docs/publishing/the-npmignore-file.html
-*
-
-# Don't ignore dist folder
-!dist/**

--- a/packages/openapi-2-kong/package.json
+++ b/packages/openapi-2-kong/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "openapi-2-kong",
   "license": "Apache-2.0",
   "version": "3.6.1-beta.2",

--- a/packages/openapi-2-kong/package.json
+++ b/packages/openapi-2-kong/package.json
@@ -13,8 +13,7 @@
     "clean": "tsc --build tsconfig.build.json --clean",
     "postclean": "rimraf dist",
     "build": "tsc --build tsconfig.build.json",
-    "test": "jest",
-    "prepublish": "npm run build"
+    "test": "jest"
   },
   "dependencies": {
     "openapi-types": "^8.0.0",

--- a/plugins/insomnia-plugin-base64/package.json
+++ b/plugins/insomnia-plugin-base64/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-plugin-base64",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-cookie-jar/package.json
+++ b/plugins/insomnia-plugin-cookie-jar/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-plugin-cookie-jar",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-core-themes/package.json
+++ b/plugins/insomnia-plugin-core-themes/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-plugin-core-themes",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-default-headers/package.json
+++ b/plugins/insomnia-plugin-default-headers/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "insomnia-plugin-default-headers",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-file/package.json
+++ b/plugins/insomnia-plugin-file/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-plugin-file",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-hash/package.json
+++ b/plugins/insomnia-plugin-hash/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-plugin-hash",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-jsonpath/package.json
+++ b/plugins/insomnia-plugin-jsonpath/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-plugin-jsonpath",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-kong-portal/.npmignore
+++ b/plugins/insomnia-plugin-kong-portal/.npmignore
@@ -1,7 +1,0 @@
-# Ignore everything by default
-# NOTE: NPM publish will never ignore package.json, package-lock.json, README, LICENSE, CHANGELOG
-# https://npm.github.io/publishing-pkgs-docs/publishing/the-npmignore-file.html
-*
-
-# Don't ignore dist folder
-!dist/**

--- a/plugins/insomnia-plugin-now/package.json
+++ b/plugins/insomnia-plugin-now/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-plugin-now",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-os/package.json
+++ b/plugins/insomnia-plugin-os/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "insomnia-plugin-os",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-prompt/package.json
+++ b/plugins/insomnia-plugin-prompt/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-plugin-prompt",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-request/package.json
+++ b/plugins/insomnia-plugin-request/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-plugin-request",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-response/package.json
+++ b/plugins/insomnia-plugin-response/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-plugin-response",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",

--- a/plugins/insomnia-plugin-uuid/package.json
+++ b/plugins/insomnia-plugin-uuid/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "insomnia-plugin-uuid",
   "version": "3.6.1-beta.2",
   "author": "Kong <office@konghq.com>",


### PR DESCRIPTION
changelog(Breaking changes): Different insomnia packages and default plugins are no longer published on npmjs.com. This includes `insomnia-inso`. If you previously installed Inso CLI through npm, please refer to the builds available in [Insomnia Releases](https://github.com/Kong/insomnia/releases) instead for future use

We are deprecating all insomnia npm packges. 

insomnia-inso will still be available in github releases.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
