### PR TITLE
chore, Bump version of release-build dependency

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -141,7 +141,7 @@ jobs:
           BRANCH: ${{ github.ref_name }}
 
       - name: update-pull-request
-        uses: kt3k/update-pr-description@v1.0.1
+        uses: kt3k/update-pr-description@v2.0.0
         with:
           pr_body: |
             Download release artifacts [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
Clears the node12 deprecation warning on release-build
![Screenshot 2022-10-28 at 11 19 22](https://user-images.githubusercontent.com/11976836/198564652-ac73c6ea-6629-4a72-9ea9-d287d4d76c64.jpg)
