### PR TITLE
chore, Switch fork for tag-and-release in release-publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -46,7 +46,7 @@ jobs:
           echo "INSO_VERSION=$(jq .version packages/insomnia-inso/package.json -rj)" >> $GITHUB_ENV
 
       - name: Create Release for Inso CLI
-        uses: avakar/tag-and-release@v1
+        uses: filfreire/tag-and-release@v1
         id: release_inso_cli
         with:
           tag_name: lib@${{ env.INSO_VERSION }}
@@ -70,7 +70,7 @@ jobs:
           draft: false
 
       - name: Create Tag and Release
-        uses: avakar/tag-and-release@v1
+        uses: filfreire/tag-and-release@v1
         id: core_tag_and_release
         with:
           tag_name: ${{ env.RELEASE_CORE_TAG }}


### PR DESCRIPTION
Clears deprecation warnings
![image](https://user-images.githubusercontent.com/11976836/198570250-a5944e60-3a89-4cce-9f65-f8ba354c8d77.png)
