### PR TITLE
Fix release-start attempt, revert lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,19 @@
 {
   "version": "3.6.1-beta.2",
+  "includeMergedTags": true,
   "packages": [
     "packages/*",
     "plugins/*"
-  ]
+  ],
+  "command": {
+    "version": {
+      "exact": true,
+      "forcePublish": true,
+      "gitTagVersion": false,
+      "push": false
+    },
+    "publish": {
+      "verifyAccess": false
+    }
+  }
 }


### PR DESCRIPTION
Not sure if this works, but trying to fix the current `release-start` failure:

https://github.com/Kong/insomnia/actions/runs/3344948434/jobs/5539894533#step:8:52
```
lerna ERR! Error: Command failed with exit code 128: git push --follow-tags --no-verify --atomic origin release/2022.7.0-beta.4
lerna ERR! fatal: could not read Username for 'https://github.com/': No such device or address
lerna ERR!     at makeError (/home/runner/work/insomnia/insomnia/node_modules/execa/lib/error.js:60:11)
lerna ERR!     at handlePromise (/home/runner/work/insomnia/insomnia/node_modules/execa/index.js:118:26)
lerna ERR! lerna Command failed with exit code 128: git push --follow-tags --no-verify --atomic origin release/2022.7.0-beta.4
lerna ERR! lerna fatal: could not read Username for 'https://github.com/': No such device or address
```

I suspect it was [this change](https://github.com/Kong/insomnia/commit/2bdd84ad22d670d857acc153b67ba1fa876979e2#diff-2d72bdead8afa0798d18995311992d684348a694c2d5e214e8e4d2b6153e4821L9-L14) that might be causing the lerna weirdness 