### PR TITLE
remove environment-highlight color setting

### DIFF
--- a/packages/insomnia-common/src/entities/settings.ts
+++ b/packages/insomnia-common/src/entities/settings.ts
@@ -1,11 +1,6 @@
 import { HttpVersion } from '../constants';
 import { HotKeyRegistry } from './hotkeys';
 
-type Sides = 'top' | 'bottom' | 'left' | 'right';
-type WindowSides = `window-${Sides}`;
-type SidebarSides = `sidebar-${'edge' | 'indicator'}`;
-export type EnvironmentHighlightColorStyle = WindowSides | SidebarSides;
-
 export enum UpdateChannel {
   stable = 'stable',
   beta = 'beta',
@@ -47,7 +42,6 @@ export interface Settings {
 
   /** If true, Insomnia will send anonymous data about features and plugins used. */
   enableAnalytics: boolean;
-  environmentHighlightColorStyle: EnvironmentHighlightColorStyle;
   filterResponsesByEnv: boolean;
   followRedirects: boolean;
   fontInterface: string | null;

--- a/packages/insomnia/src/models/settings.ts
+++ b/packages/insomnia/src/models/settings.ts
@@ -42,7 +42,6 @@ export function init(): BaseSettings {
     editorKeyMap: 'default',
     editorLineWrapping: true,
     enableAnalytics: false,
-    environmentHighlightColorStyle: 'sidebar-indicator',
     showVariableSourceAndValue: false,
     filterResponsesByEnv: false,
     followRedirects: true,

--- a/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
@@ -1,4 +1,3 @@
-import { EnvironmentHighlightColorStyle } from 'insomnia-common';
 import React, { FC, useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -18,13 +17,11 @@ import { Tooltip } from '../tooltip';
 
 interface Props {
   activeEnvironment?: Environment | null;
-  environmentHighlightColorStyle: EnvironmentHighlightColorStyle;
   workspace: Workspace;
 }
 
 export const EnvironmentsDropdown: FC<Props> = ({
   activeEnvironment,
-  environmentHighlightColorStyle,
   workspace,
 }) => {
   const environments = useSelector(selectEnvironments);
@@ -61,14 +58,14 @@ export const EnvironmentsDropdown: FC<Props> = ({
             </Tooltip>
           )}
           <div className="sidebar__menu__thing__text">
-            {activeEnvironment?.color && environmentHighlightColorStyle === 'sidebar-indicator' ? (
+            {activeEnvironment?.color && (
               <i
                 className="fa fa-circle space-right"
                 style={{
                   color: activeEnvironment.color,
                 }}
               />
-            ) : null}
+            )}
             {description}
           </div>
           <i className="space-left fa fa-caret-down" />

--- a/packages/insomnia/src/ui/components/page-layout.tsx
+++ b/packages/insomnia/src/ui/components/page-layout.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import { COLLAPSE_SIDEBAR_REMS, DEFAULT_PANE_HEIGHT, DEFAULT_PANE_WIDTH, DEFAULT_SIDEBAR_WIDTH, MAX_PANE_HEIGHT, MAX_PANE_WIDTH, MAX_SIDEBAR_REMS, MIN_PANE_HEIGHT, MIN_PANE_WIDTH, MIN_SIDEBAR_REMS } from '../../common/constants';
 import { debounce } from '../../common/misc';
 import * as models from '../../models';
-import { selectActiveEnvironment, selectActiveWorkspaceMeta, selectSettings } from '../redux/selectors';
+import { selectActiveWorkspaceMeta, selectSettings } from '../redux/selectors';
 import { selectPaneHeight, selectPaneWidth, selectSidebarWidth } from '../redux/sidebar-selectors';
 import { ErrorBoundary } from './error-boundary';
 import { Sidebar } from './sidebar/sidebar';
@@ -35,7 +35,6 @@ export const PageLayout: FC<Props> = ({
   renderPageHeader,
   renderPageSidebar,
 }) => {
-  const activeEnvironment = useSelector(selectActiveEnvironment);
   const settings = useSelector(selectSettings);
   const activeWorkspaceMeta = useSelector(selectActiveWorkspaceMeta);
   const reduxPaneHeight = useSelector(selectPaneHeight);
@@ -209,30 +208,6 @@ export const PageLayout: FC<Props> = ({
         gridTemplateColumns: gridColumns,
         gridTemplateRows: gridRows,
         boxSizing: 'border-box',
-        borderTop:
-          activeEnvironment &&
-            activeEnvironment.color &&
-            settings.environmentHighlightColorStyle === 'window-top'
-            ? '5px solid ' + activeEnvironment.color
-            : undefined,
-        borderBottom:
-          activeEnvironment &&
-            activeEnvironment.color &&
-            settings.environmentHighlightColorStyle === 'window-bottom'
-            ? '5px solid ' + activeEnvironment.color
-            : undefined,
-        borderLeft:
-          activeEnvironment &&
-            activeEnvironment.color &&
-            settings.environmentHighlightColorStyle === 'window-left'
-            ? '5px solid ' + activeEnvironment.color
-            : undefined,
-        borderRight:
-          activeEnvironment &&
-            activeEnvironment.color &&
-            settings.environmentHighlightColorStyle === 'window-right'
-            ? '5px solid ' + activeEnvironment.color
-            : undefined,
       }}
     >
       {renderPageHeader && <ErrorBoundary showAlert>{renderPageHeader}</ErrorBoundary>}
@@ -241,8 +216,6 @@ export const PageLayout: FC<Props> = ({
         <ErrorBoundary showAlert>
           <Sidebar
             ref={sidebarRef}
-            activeEnvironment={activeEnvironment}
-            environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
             hidden={activeWorkspaceMeta?.sidebarHidden || false}
             width={sidebarWidth}
           >

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -1,4 +1,4 @@
-import { EnvironmentHighlightColorStyle, HttpVersion, HttpVersions, UpdateChannel } from 'insomnia-common';
+import { HttpVersion, HttpVersions, UpdateChannel } from 'insomnia-common';
 import React, { FC, Fragment } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -121,20 +121,6 @@ export const General: FC = () => {
       </div>
 
       <div className="row-fill row-fill--top pad-top-sm">
-        <EnumSetting<EnvironmentHighlightColorStyle>
-          label="Environment highlight style"
-          help="Select the sub-environment highlight area. Configure the highlight color itself in your environment settings."
-          setting="environmentHighlightColorStyle"
-          values={[
-            { value:'sidebar-indicator', name: 'Sidebar indicator' },
-            { value:'sidebar-edge', name: 'Sidebar edge' },
-            { value:'window-top', name: 'Window top' },
-            { value:'window-bottom', name: 'Window bottom' },
-            { value:'window-left', name: 'Window left' },
-            { value:'window-right', name: 'Window right' },
-          ]}
-        />
-
         <NumberSetting
           label="Autocomplete popup delay (ms)"
           setting="autocompleteDelay"

--- a/packages/insomnia/src/ui/components/sidebar/sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar.tsx
@@ -1,26 +1,20 @@
 import classnames from 'classnames';
-import { EnvironmentHighlightColorStyle } from 'insomnia-common';
 import React, { forwardRef, memo, ReactNode } from 'react';
 
 import {
   COLLAPSE_SIDEBAR_REMS,
   SIDEBAR_SKINNY_REMS,
 } from '../../../common/constants';
-import type { Environment } from '../../../models/environment';
 
 interface Props {
-  activeEnvironment: Environment | null;
   children: ReactNode;
-  environmentHighlightColorStyle: EnvironmentHighlightColorStyle;
   hidden: boolean;
   width: number;
 }
 
 export const Sidebar = memo(
   forwardRef<HTMLElement, Props>(({
-    activeEnvironment,
     children,
-    environmentHighlightColorStyle,
     hidden,
     width,
   }, ref) => {
@@ -32,14 +26,6 @@ export const Sidebar = memo(
           'sidebar--skinny': width < SIDEBAR_SKINNY_REMS,
           'sidebar--collapsed': width < COLLAPSE_SIDEBAR_REMS,
         })}
-        style={{
-          borderRight:
-            activeEnvironment &&
-            activeEnvironment.color &&
-            environmentHighlightColorStyle === 'sidebar-edge'
-              ? '5px solid ' + activeEnvironment.color
-              : undefined,
-        }}
       >
         {children}
       </aside>

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -162,7 +162,6 @@ export const WrapperDebug: FC = () => {
         <div className="sidebar__menu">
           <EnvironmentsDropdown
             activeEnvironment={activeEnvironment}
-            environmentHighlightColorStyle={settings.environmentHighlightColorStyle}
             workspace={activeWorkspace}
           />
           <button className="btn btn--super-compact" onClick={showCookiesModal}>


### PR DESCRIPTION
This setting allows users to chose where to display a color (left/top border etc.) based on the selected environment but this won't exist in the new designs.
This PR simplifies the design for selected/linked environments by removing it.