### PR TITLE
fix: Type safe modals

### DIFF
--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -1,10 +1,5 @@
-import { decodeBase64, encodeBase64 } from '@getinsomnia/api-client/base64';
-import { keyPair, open } from '@getinsomnia/api-client/sealedbox';
-import { invariant } from '@remix-run/router';
-import * as Sentry from '@sentry/electron';
 import * as srp from 'srp-js';
 
-import { getAppWebsiteBaseURL } from '../common/constants';
 import * as crypt from './crypt';
 import * as fetch from './fetch';
 
@@ -283,35 +278,4 @@ function _getSrpParams() {
 
 function _sanitizePassphrase(passphrase: string) {
   return passphrase.trim().normalize('NFKD');
-}
-
-interface AuthBox {
-  token: string;
-  key: string;
-}
-
-/**
- * Keypair used for the login handshake.
- * This keypair can be re-used for the entire session.
- */
-const sessionKeyPair = keyPair();
-
-export async function submitAuthCode(code: string) {
-  try {
-    const rawBox = await decodeBase64(code.trim());
-    const boxData = open(rawBox, sessionKeyPair.publicKey, sessionKeyPair.secretKey);
-    invariant(boxData, 'Invalid authentication code.');
-
-    const decoder = new TextDecoder();
-    const box: AuthBox = JSON.parse(decoder.decode(boxData));
-    await absorbKey(box.token, box.key);
-  } catch (error) {
-    Sentry.captureException(error);
-    throw error;
-  }
-}
-
-export async function getLoginUrl() {
-  const loginKey = await encodeBase64(sessionKeyPair.publicKey);
-  return `${getAppWebsiteBaseURL()}/app/auth-app/?loginKey=${encodeURIComponent(loginKey)}`;
 }

--- a/packages/insomnia/src/plugins/context/app.tsx
+++ b/packages/insomnia/src/plugins/context/app.tsx
@@ -46,7 +46,7 @@ export interface AppContext {
   alert: (
     title: string,
     message?: string
-  ) => Promise<undefined> | ReturnType<typeof showAlert>;
+  ) => ReturnType<typeof showAlert>;
   dialog: (title: string, body: HTMLElement, options?: DialogOptions) => void;
   prompt: (title: string, options?: Pick<PromptModalOptions, 'label' | 'defaultValue' | 'submitName' | 'cancelable'>) => Promise<string>;
   getPath: (name: string) => string;

--- a/packages/insomnia/src/ui/auth-session-provider.ts
+++ b/packages/insomnia/src/ui/auth-session-provider.ts
@@ -1,0 +1,38 @@
+import { decodeBase64, encodeBase64 } from '@getinsomnia/api-client/base64';
+import { keyPair, open } from '@getinsomnia/api-client/sealedbox';
+import { invariant } from '@remix-run/router';
+import * as Sentry from '@sentry/electron';
+
+import * as session from '../account/session';
+import { getAppWebsiteBaseURL } from '../common/constants';
+
+interface AuthBox {
+  token: string;
+  key: string;
+}
+
+/**
+ * Keypair used for the login handshake.
+ * This keypair can be re-used for the entire session.
+ */
+const sessionKeyPair = keyPair();
+
+export async function submitAuthCode(code: string) {
+  try {
+    const rawBox = await decodeBase64(code.trim());
+    const boxData = open(rawBox, sessionKeyPair.publicKey, sessionKeyPair.secretKey);
+    invariant(boxData, 'Invalid authentication code.');
+
+    const decoder = new TextDecoder();
+    const box: AuthBox = JSON.parse(decoder.decode(boxData));
+    await session.absorbKey(box.token, box.key);
+  } catch (error) {
+    Sentry.captureException(error);
+    throw error;
+  }
+}
+
+export async function getLoginUrl() {
+  const loginKey = await encodeBase64(sessionKeyPair.publicKey);
+  return `${getAppWebsiteBaseURL()}/app/auth-app/?loginKey=${encodeURIComponent(loginKey)}`;
+}

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -570,7 +570,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
                 </Dropdown>
               )) : null}
             {showFilter ?
-              (<button key="help" className="btn btn--compact" onClick={() => showModal(FilterHelpModal, { isJSON: mode?.includes('json') })}>
+              (<button key="help" className="btn btn--compact" onClick={() => showModal(FilterHelpModal, { isJSON: Boolean(mode?.includes('json')) })}>
                 <i className="fa fa-question-circle" />
               </button>) : null}
             {showPrettify ?

--- a/packages/insomnia/src/ui/components/dropdowns/account-dropdown/account-dropdown.test.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/account-dropdown/account-dropdown.test.tsx
@@ -74,7 +74,7 @@ describe('<AccountDropdownButton />', () => {
     render(
       <Provider store={store}>
         <AccountDropdownButton />
-        <LoginModal ref={registerModal} />
+        <LoginModal ref={instance => registerModal(instance, 'LoginModal')} />
       </Provider>, { container }
     );
     const loginBtn = screen.getByText('Log In');

--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -233,7 +233,6 @@ export const GitSyncDropdown: FC<Props> = ({ workspace, vcs, className }) => {
             <DropdownItem
               onClick={() => showModal(GitStagingModal, {
                 onCommit: refreshState,
-                gitRepository,
               })}
             >
               <i className="fa fa-check" /> Commit

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -90,7 +90,9 @@ export const RequestActionsDropdown = forwardRef<DropdownHandle, Props>(({
   }, [handleDuplicateRequest, request]);
 
   const generateCode = useCallback(() => {
-    showModal(GenerateCodeModal, { request });
+    if (isRequest(request)) {
+      showModal(GenerateCodeModal, { request });
+    }
   }, [request]);
 
   const copyAsCurl = useCallback(async () => {

--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -28,7 +28,7 @@ import { Link } from '../base/link';
 import { PromptButton } from '../base/prompt-button';
 import { HelpTooltip } from '../help-tooltip';
 import { showError, showModal } from '../modals';
-import { LoginModalHandle } from '../modals/login-modal';
+import { LoginModal } from '../modals/login-modal';
 import { SyncBranchesModal } from '../modals/sync-branches-modal';
 import { SyncDeleteModal } from '../modals/sync-delete-modal';
 import { SyncHistoryModal } from '../modals/sync-history-modal';
@@ -425,7 +425,7 @@ export const SyncDropdown: FC<Props> = ({ vcs, workspace, project }) => {
         {syncMenuHeader}
 
         {!session.isLoggedIn() && (
-          <DropdownItem onClick={() => showModal(LoginModalHandle)}>
+          <DropdownItem onClick={() => showModal(LoginModal)}>
             <i className="fa fa-sign-in" /> Log In
           </DropdownItem>
         )}

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-private-key-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-private-key-row.tsx
@@ -39,7 +39,7 @@ export const AuthPrivateKeyRow: FC<Props> = ({ label, property, help }) => {
       title: 'Edit Private Key',
       defaultValue: privateKey,
       onChange,
-      enableRender: handleRender || handleGetRenderContext,
+      enableRender: Boolean(handleRender || handleGetRenderContext),
       placeholder: PRIVATE_KEY_PLACEHOLDER,
       mode: 'text/plain',
       hideMode: true,

--- a/packages/insomnia/src/ui/components/editors/body/body-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/body-editor.tsx
@@ -95,7 +95,7 @@ export const BodyEditor: FC<Props> = ({
           Do you want set the <span className="monospace">Content-Type</span> header to{' '}
           <span className="monospace">{newContentType}</span>?
         </p>,
-        onDone: (saidYes: boolean) => {
+        onDone: async (saidYes: boolean) => {
           if (saidYes) {
             models.request.update(newRequest, { headers });
           }

--- a/packages/insomnia/src/ui/components/key-value-editor/row.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/row.tsx
@@ -117,7 +117,7 @@ export const Row: FC<Props> = ({
                 defaultValue: pair.value,
                 onChange: (value: string) => onChange({ ...pair, value }),
                 enableRender: enabled,
-                mode: pair.multiline || 'text/plain',
+                mode: pair.multiline && typeof pair.multiline === 'string' ? pair.multiline : 'text/plain',
                 onModeChange: (mode: string) => onChange({ ...pair, multiline: mode }),
               })}
             >

--- a/packages/insomnia/src/ui/components/modals/add-key-combination-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/add-key-combination-modal.tsx
@@ -13,7 +13,7 @@ export interface AddKeyCombinationModalOptions {
   keyboardShortcut: KeyboardShortcut | null;
   checkKeyCombinationDuplicate: (pressedKeyComb: KeyCombination) => boolean;
   addKeyCombination: (keyboardShortcut: KeyboardShortcut, keyComb: KeyCombination) => void;
-  pressedKeyCombination: KeyCombination | null;
+  pressedKeyCombination?: KeyCombination | null;
 }
 export interface AddKeyCombinationModalHandle {
   show: (options: AddKeyCombinationModalOptions) => void;

--- a/packages/insomnia/src/ui/components/modals/ask-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/ask-modal.tsx
@@ -6,14 +6,14 @@ import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
 interface State {
   title: string;
-  message: string;
+  message: React.ReactNode;
   yesText: string;
   noText: string;
   onDone?: (success: boolean) => Promise<void>;
 }
 export interface AskModalOptions {
   title?: string;
-  message?: string;
+  message: React.ReactNode;
   onDone?: (success: boolean) => Promise<void>;
   yesText?: string;
   noText?: string;

--- a/packages/insomnia/src/ui/components/modals/code-prompt-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/code-prompt-modal.tsx
@@ -26,12 +26,12 @@ interface CodePromptModalOptions {
   title: string;
   defaultValue: string;
   submitName: string;
-  placeholder: string;
-  hint: string;
+  placeholder?: string;
+  hint?: string;
   mode: string;
-  hideMode: boolean;
+  hideMode?: boolean;
   enableRender: boolean;
-  showCopyButton: boolean;
+  showCopyButton?: boolean;
   onChange: (value: string) => void;
   onModeChange?: (value: string) => void;
 }

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
@@ -17,7 +17,7 @@ import { GitLabRepositorySetupFormGroup } from './gitlab-repository-settings-for
 
 interface GitRepositorySettingsModalOptions {
   gitRepository: GitRepository | null;
-  onSubmitEdits: (gitRepoPatch: GitRepository) => Promise<void> | void;
+  onSubmitEdits: (gitRepoPatch: Partial<GitRepository>) => Promise<void> | void;
 }
 export interface GitRepositorySettingsModalHandle {
   show: (options: GitRepositorySettingsModalOptions) => void;
@@ -45,7 +45,7 @@ export const GitRepositorySettingsModal = forwardRef<GitRepositorySettingsModalH
     <Modal ref={modalRef}>
       <ModalForm
         onSubmit={patch => {
-          gitRepository?._id && onSubmitEdits({ ...gitRepository, ...patch });
+          onSubmitEdits({ ...gitRepository, ...patch });
           modalRef.current?.hide();
         }}
         onReset={() => {

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
@@ -17,7 +17,7 @@ import { GitLabRepositorySetupFormGroup } from './gitlab-repository-settings-for
 
 interface GitRepositorySettingsModalOptions {
   gitRepository: GitRepository | null;
-  onSubmitEdits: (gitRepoPatch: Partial<GitRepository>) => void;
+  onSubmitEdits: (gitRepoPatch: GitRepository) => Promise<void> | void;
 }
 export interface GitRepositorySettingsModalHandle {
   show: (options: GitRepositorySettingsModalOptions) => void;
@@ -45,7 +45,7 @@ export const GitRepositorySettingsModal = forwardRef<GitRepositorySettingsModalH
     <Modal ref={modalRef}>
       <ModalForm
         onSubmit={patch => {
-          onSubmitEdits({ ...gitRepository, ...patch });
+          gitRepository?._id && onSubmitEdits({ ...gitRepository, ...patch });
           modalRef.current?.hide();
         }}
         onReset={() => {

--- a/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
@@ -37,7 +37,7 @@ type Props = ModalProps & {
   gitRepository: GitRepository | null;
 };
 
-export interface GitStagingModalOptions {
+interface State {
   loading: boolean;
   branch: string;
   message: string;
@@ -45,13 +45,17 @@ export interface GitStagingModalOptions {
   onCommit: () => Promise<void>;
   statusNames: Record<string, string>;
 }
+
+export interface GitStagingModalOptions {
+  onCommit: () => Promise<void>;
+}
 export interface GitStagingModalHandle {
   show: (options: GitStagingModalOptions) => void;
   hide: () => void;
 }
 export const GitStagingModal = forwardRef<GitStagingModalHandle, Props>(({ vcs, workspace, gitRepository }, ref) => {
   const modalRef = useRef<ModalHandle>(null);
-  const [state, setState] = useState<GitStagingModalOptions>({
+  const [state, setState] = useState<State>({
     loading: false,
     branch: '',
     message: '',

--- a/packages/insomnia/src/ui/components/modals/index.ts
+++ b/packages/insomnia/src/ui/components/modals/index.ts
@@ -1,9 +1,17 @@
+import { invariant } from '@remix-run/router';
+
 import { trackPageView } from '../../../common/analytics';
+import { ModalProps } from '../base/modal';
 import { AlertModal, AlertModalOptions } from './alert-modal';
 import { ErrorModal, ErrorModalOptions } from './error-modal';
 import { PromptModal, PromptModalOptions } from './prompt-modal';
 
-const modals: Record<string, any> = {};
+interface ModalHandle {
+  show:(options: any) => void;
+  hide:() => void;
+}
+
+const modals: Record<string, ModalHandle> = {};
 
 export function registerModal(instance: any, modalName?: string) {
   if (instance === null) {
@@ -14,14 +22,27 @@ export function registerModal(instance: any, modalName?: string) {
   modals[modalName ?? instance.constructor.name] = instance;
 }
 
-export function showModal(modalCls: any, ...args: any[]) {
-  const name = modalCls.name || modalCls.WrappedComponent?.name || modalCls.displayName;
+type GetRefHandleFromProps<Props> = Props extends React.RefAttributes<infer TModalHandle> ? TModalHandle : never;
+
+type ModalComponent<TModalProps> = React.ForwardRefExoticComponent<TModalProps & React.RefAttributes<GetRefHandleFromProps<TModalProps>>>;
+
+type ModalHandleShowOptions<TModalHandle> = TModalHandle extends {
+  show: (options: infer TOptions) => void;
+} ? TOptions : any;
+
+export function showModal<TModalProps extends ModalProps & React.RefAttributes<{
+  show:(options: any) => void;
+}>>(
+  modalComponent: ModalComponent<TModalProps>, config?: ModalHandleShowOptions<GetRefHandleFromProps<TModalProps>>,
+) {
+  const name = modalComponent.name || modalComponent.displayName;
+  invariant(name, 'Modal must have a name or displayName');
   trackPageView(name);
-  return _getModal(name).show(...args);
+  return getModalComponentHandle<GetRefHandleFromProps<TModalProps>>(name).show(config);
 }
 
-export function showPrompt(config: PromptModalOptions) {
-  return showModal(PromptModal, config);
+export function showPrompt(options: PromptModalOptions) {
+  return showModal(PromptModal, options);
 }
 
 export function showAlert(config: AlertModalOptions) {
@@ -43,11 +64,9 @@ export function hideAllModals() {
   }
 }
 
-function _getModal(name: string) {
-  const m = modals[name];
-  if (!m) {
-    throw new Error('Modal was not registered with the app');
-  }
+function getModalComponentHandle<TModalHandle>(name: string) {
+  const modalComponentRef = modals[name] as TModalHandle;
+  invariant(modalComponentRef, `Modal ${name} not found`);
 
-  return m;
+  return modalComponentRef;
 }

--- a/packages/insomnia/src/ui/components/modals/index.ts
+++ b/packages/insomnia/src/ui/components/modals/index.ts
@@ -38,7 +38,10 @@ export function showModal<TModalProps extends ModalProps & React.RefAttributes<{
   const name = modalComponent.name || modalComponent.displayName;
   invariant(name, 'Modal must have a name or displayName');
   trackPageView(name);
-  return getModalComponentHandle<GetRefHandleFromProps<TModalProps>>(name).show(config);
+
+  const modalHandle = getModalComponentHandle(name) as unknown as GetRefHandleFromProps<TModalProps>;
+
+  return modalHandle.show(config);
 }
 
 export function showPrompt(options: PromptModalOptions) {
@@ -64,8 +67,8 @@ export function hideAllModals() {
   }
 }
 
-function getModalComponentHandle<TModalHandle>(name: string) {
-  const modalComponentRef = modals[name] as TModalHandle;
+function getModalComponentHandle(name: string) {
+  const modalComponentRef = modals[name];
   invariant(modalComponentRef, `Modal ${name} not found`);
 
   return modalComponentRef;

--- a/packages/insomnia/src/ui/components/modals/login-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/login-modal.tsx
@@ -2,8 +2,8 @@ import { clipboard } from 'electron';
 import React, { FormEvent, forwardRef, memo, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 import * as session from '../../../account/session';
-import { getLoginUrl, submitAuthCode } from '../../../account/session';
 import { clickLink } from '../../../common/electron-helpers';
+import { getLoginUrl, submitAuthCode } from '../../auth-session-provider';
 import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';

--- a/packages/insomnia/src/ui/components/modals/login-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/login-modal.tsx
@@ -1,32 +1,14 @@
-import { decodeBase64, encodeBase64 } from '@getinsomnia/api-client/base64';
-import { keyPair, open } from '@getinsomnia/api-client/sealedbox';
-import * as Sentry from '@sentry/electron';
 import { clipboard } from 'electron';
-import React, { Dispatch, FormEvent, forwardRef, memo, RefObject, SetStateAction, useCallback, useImperativeHandle, useRef, useState } from 'react';
+import React, { FormEvent, forwardRef, memo, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 import * as session from '../../../account/session';
-import { getAppWebsiteBaseURL } from '../../../common/constants';
+import { getLoginUrl, submitAuthCode } from '../../../account/session';
 import { clickLink } from '../../../common/electron-helpers';
 import { type ModalHandle, Modal } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
 import { showModal } from './index';
-
-/**
- * Keypair used for the login handshake.
- * This keypair can be re-used for the entire session.
- */
-const sessionKeyPair = keyPair();
-
-/**
- * Global of latest modal instance, or null if none exist.
- */
-export let currentLoginModalHandle: LoginModalHandle | null = null;
-
-session.onLoginLogout(() => {
-  currentLoginModalHandle?.hide();
-});
 
 interface State {
   state: 'ready' | 'error' | 'token-entry' | 'loading-session';
@@ -35,67 +17,14 @@ interface State {
 }
 
 interface Options {
-  title: string;
-  message: string;
-  reauth: boolean;
+  title?: string;
+  message?: string;
+  reauth?: boolean;
+  onHide?: () => void;
 }
 
-interface AuthBox {
-  token: string;
-  key: string;
-}
-
-export class LoginModalHandle {
-  constructor(
-    private readonly modalRef: RefObject<ModalHandle>,
-    private readonly setState: Dispatch<SetStateAction<State & Options>>,
-  ) {}
-
-  private async getLoginUrl() {
-    const loginKey = await encodeBase64(sessionKeyPair.publicKey);
-    return `${getAppWebsiteBaseURL()}/app/auth-app/?loginKey=${encodeURIComponent(loginKey)}`;
-  }
-
-  async submitAuthCode(code: string) {
-    this.setState(state => ({ ...state, state: 'loading-session' }));
-    try {
-      const rawBox = await decodeBase64(code.trim());
-      const boxData = open(rawBox, sessionKeyPair.publicKey, sessionKeyPair.secretKey);
-      if (!boxData) {
-        this.setState(state => ({ ...state, state: 'error', error: 'Invalid authentication code.' }));
-        return;
-      }
-      const decoder = new TextDecoder();
-      const box: AuthBox = JSON.parse(decoder.decode(boxData));
-      await session.absorbKey(box.token, box.key);
-    } catch (e) {
-      Sentry.captureException(e);
-      this.setState(state => ({ ...state, state: 'error', error: `Error loading credentials: ${String(e)}` }));
-    }
-  }
-
-  async show(options: Partial<Options> = {}) {
-    const { title, message, reauth } = options;
-    const url = await this.getLoginUrl();
-    this.setState({
-      error: '',
-      state: 'ready',
-      title: title ?? '',
-      message: message ?? '',
-      reauth: reauth ?? false,
-      url,
-    });
-
-    this.modalRef.current?.show();
-
-    if (!reauth) {
-      clickLink(url);
-    }
-  }
-
-  hide() {
-    this.modalRef.current?.hide();
-  }
+export interface LoginModalHandle extends ModalHandle {
+  show: (options?: Options) => void;
 }
 
 export const LoginModal = memo(forwardRef<LoginModalHandle, {}>(function LoginModal({ ...props }, ref) {
@@ -111,10 +40,37 @@ export const LoginModal = memo(forwardRef<LoginModalHandle, {}>(function LoginMo
     url: '',
   });
 
-  useImperativeHandle(ref, () => {
-    currentLoginModalHandle = new LoginModalHandle(modalRef, setState);
-    return currentLoginModalHandle;
-  }, []);
+  useEffect(() => {
+    session.onLoginLogout(() => {
+      modalRef.current?.hide();
+    });
+  });
+
+  useImperativeHandle(ref, () => ({
+    hide: () => {
+      modalRef.current?.hide;
+    },
+    toggle: () => modalRef.current?.toggle(),
+    isOpen: () => Boolean(modalRef.current?.isOpen()),
+    show: async (options: Partial<Options> = {}) => {
+      const { title, message, reauth } = options;
+      const url = await getLoginUrl();
+      setState({
+        error: '',
+        state: 'ready',
+        title: title ?? '',
+        message: message ?? '',
+        reauth: reauth ?? false,
+        url,
+      });
+
+      modalRef.current?.show();
+
+      if (!reauth) {
+        clickLink(url);
+      }
+    },
+  }), []);
 
   const reset = useCallback(() => {
     setState(state => ({ ...state, state: 'ready', error: '' }));
@@ -124,9 +80,13 @@ export const LoginModal = memo(forwardRef<LoginModalHandle, {}>(function LoginMo
     setState(state => ({ ...state, state: 'token-entry' }));
   }, []);
 
-  const submitToken = useCallback((event: FormEvent) => {
+  const submitToken = useCallback(async (event: FormEvent) => {
     event.preventDefault();
-    currentLoginModalHandle?.submitAuthCode(tokenInputRef.current?.value ?? '');
+    try {
+      await submitAuthCode(tokenInputRef.current?.value ?? '');
+    } catch (e) {
+      setState(state => ({ ...state, state: 'error', error: e.message }));
+    }
   }, []);
 
   const copyUrl = useCallback(() => {
@@ -231,4 +191,4 @@ export const LoginModal = memo(forwardRef<LoginModalHandle, {}>(function LoginMo
 
 LoginModal.displayName = 'LoginModal';
 
-export const showLoginModal = () => showModal(LoginModalHandle);
+export const showLoginModal = () => showModal(LoginModal);

--- a/packages/insomnia/src/ui/components/modals/nunjucks-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/nunjucks-modal.tsx
@@ -12,6 +12,12 @@ interface Props {
   workspace: Workspace;
 }
 
+interface State {
+  isTag: boolean;
+  template: string;
+  onDone: Function;
+}
+
 interface NunjucksModalOptions {
   template: string;
   onDone: Function;
@@ -23,7 +29,8 @@ export interface NunjucksModalHandle {
 }
 export const NunjucksModal = forwardRef<NunjucksModalHandle, ModalProps & Props>((props, ref) => {
   const modalRef = useRef<ModalHandle>(null);
-  const [state, setState] = useState<NunjucksModalOptions>({
+  const [state, setState] = useState<State>({
+    isTag: false,
     template: '',
     onDone: () => { },
   });
@@ -34,6 +41,7 @@ export const NunjucksModal = forwardRef<NunjucksModalHandle, ModalProps & Props>
     },
     show: ({ onDone, template }) => {
       setState({
+        isTag: template.indexOf('{%') === 0,
         template,
         onDone,
       });
@@ -43,31 +51,29 @@ export const NunjucksModal = forwardRef<NunjucksModalHandle, ModalProps & Props>
 
   const handleTemplateChange = (template: string) => {
     setState(state => ({
+      ...state,
       template,
-      onDone: state.onDone,
     }));
   };
 
   const { workspace } = props;
-  const { template } = state;
+  const { template, isTag } = state;
+  const title = isTag ? 'Tag' : 'Variable';
   let editor: JSX.Element | null = null;
-  let title = '';
-
-  if (template.indexOf('{{') === 0) {
-    title = 'Variable';
-    editor = <VariableEditor onChange={handleTemplateChange} defaultValue={template} />;
-  } else if (template.indexOf('{%') === 0) {
-    title = 'Tag';
+  if (isTag) {
     editor = <TagEditor onChange={handleTemplateChange} defaultValue={template} workspace={workspace} />;
+  } else {
+    editor = <VariableEditor onChange={handleTemplateChange} defaultValue={template} />;
   }
+
   return (
     <Modal
       ref={modalRef}
       onHide={() => {
         state.onDone(state.template);
         setState(state => ({
+          ...state,
           template: '',
-          onDone: state.onDone,
         }));
       }}
     >

--- a/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
@@ -16,7 +16,7 @@ import { MarkdownEditor } from '../markdown-editor';
 
 export interface RequestGroupSettingsModalOptions {
   requestGroup: RequestGroup;
-  forceEditMode: boolean;
+  forceEditMode?: boolean;
 }
 interface State {
   requestGroup: RequestGroup | null;

--- a/packages/insomnia/src/ui/components/modals/request-render-error-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-render-error-modal.tsx
@@ -4,6 +4,7 @@ import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { docsTemplateTags } from '../../../common/documentation';
 import { Request } from '../../../models/request';
 import { isRequest } from '../../../models/request';
+import { WebSocketRequest } from '../../../models/websocket-request';
 import { RenderError } from '../../../templating';
 import { Link } from '../base/link';
 import { type ModalHandle, Modal, ModalProps } from '../base/modal';
@@ -13,7 +14,7 @@ import { RequestSettingsModal } from '../modals/request-settings-modal';
 import { showModal } from './index';
 export interface RequestRenderErrorModalOptions {
   error: RenderError | null;
-  request: Request | null;
+  request: Request | WebSocketRequest | null;
 }
 export interface RequestRenderErrorModalHandle {
   show: (options: RequestRenderErrorModalOptions) => void;
@@ -26,6 +27,7 @@ export const RequestRenderErrorModal = forwardRef<RequestRenderErrorModalHandle,
     error: null,
     request: null,
   });
+  const { request, error } = state;
 
   useImperativeHandle(ref, () => ({
     hide: () => {
@@ -37,15 +39,15 @@ export const RequestRenderErrorModal = forwardRef<RequestRenderErrorModalHandle,
     },
   }), []);
 
-  const { request, error } = state;
   const fullPath = `Request.${error?.path}`;
   const result = JSONPath({ json: request, path: `$.${error?.path}` });
   const template = result && result.length ? result[0] : null;
   const locationLabel = template?.includes('\n') ? `line ${error?.location.line} of` : null;
+
   return (
     <Modal ref={modalRef}>
       <ModalHeader>Failed to Render Request</ModalHeader>
-      <ModalBody>{request && error && error ? (
+      <ModalBody>{request && error ? (
         <div className="pad">
           <div className="notice warning">
             <p>
@@ -57,7 +59,7 @@ export const RequestRenderErrorModal = forwardRef<RequestRenderErrorModalHandle,
                   className="btn btn--clicky margin-right-sm"
                   onClick={() => {
                     modalRef.current?.hide();
-                    showModal(RequestSettingsModal, { request: state.request });
+                    showModal(RequestSettingsModal, { request });
                   }}
                 >
                   Adjust Render Settings
@@ -85,4 +87,5 @@ export const RequestRenderErrorModal = forwardRef<RequestRenderErrorModalHandle,
     </Modal>
   );
 });
+
 RequestRenderErrorModal.displayName = 'RequestRenderErrorModal';

--- a/packages/insomnia/src/ui/components/modals/sync-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-branches-modal.tsx
@@ -14,12 +14,15 @@ import { SyncPullButton } from '../sync-pull-button';
 type Props = ModalProps & {
   vcs: VCS;
 };
-export interface SyncBranchesModalOptions {
-  error: string;
+
+interface State {
+  error?: string;
   newBranchName: string;
   currentBranch: string;
   branches: string[];
   remoteBranches: string[];
+}
+export interface SyncBranchesModalOptions {
   onHide?: () => void;
 }
 export interface SyncBranchesModalHandle {
@@ -28,7 +31,7 @@ export interface SyncBranchesModalHandle {
 }
 export const SyncBranchesModal = forwardRef<SyncBranchesModalHandle, Props>(({ vcs }, ref) => {
   const modalRef = useRef<ModalHandle>(null);
-  const [state, setState] = useState<SyncBranchesModalOptions>({
+  const [state, setState] = useState<State>({
     error: '',
     newBranchName: '',
     branches: [],

--- a/packages/insomnia/src/ui/components/modals/sync-delete-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-delete-modal.tsx
@@ -12,9 +12,13 @@ import { ModalHeader } from '../base/modal-header';
 type Props = ModalProps & {
   vcs: VCS;
 };
-export interface SyncDeleteModalOptions {
-  error: string;
+
+interface State {
+  error?: string;
   workspaceName: string;
+  onHide?: () => void;
+}
+export interface SyncDeleteModalOptions {
   onHide?: () => void;
 }
 export interface SyncDeleteModalHandle {
@@ -23,7 +27,7 @@ export interface SyncDeleteModalHandle {
 }
 export const SyncDeleteModal = forwardRef<SyncDeleteModalHandle, Props>(({ vcs }, ref) => {
   const modalRef = useRef<ModalHandle>(null);
-  const [state, setState] = useState<SyncDeleteModalOptions>({
+  const [state, setState] = useState<State>({
     error: '',
     workspaceName: '',
   });

--- a/packages/insomnia/src/ui/components/modals/sync-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-staging-modal.tsx
@@ -19,6 +19,16 @@ type Props = ModalProps & {
   vcs: VCS;
 };
 
+interface State {
+  status: Status;
+  message: string;
+  error: string;
+  branch: string;
+  lookupMap: LookupMap;
+  onSnapshot: () => Promise<void>;
+  handlePush: () => Promise<void>;
+}
+
 type LookupMap = Record<string, {
   entry: StageEntry;
   changes: null | string[];
@@ -27,11 +37,6 @@ type LookupMap = Record<string, {
 }>;
 
 export interface SyncStagingModalOptions {
-  status: Status;
-  message: string;
-  error: string;
-  branch: string;
-  lookupMap: LookupMap;
   onSnapshot: () => Promise<void>;
   handlePush: () => Promise<void>;
 }
@@ -44,7 +49,7 @@ export interface SyncStagingModalHandle {
 export const SyncStagingModal = forwardRef<SyncStagingModalHandle, Props>(({ vcs }, ref) => {
   const modalRef = useRef<ModalHandle>(null);
   const syncItems = useSelector(selectSyncItems);
-  const [state, setState] = useState<SyncStagingModalOptions>({
+  const [state, setState] = useState<State>({
     status: {
       stage: {},
       unstaged: {},

--- a/packages/insomnia/src/ui/components/modals/wrapper-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/wrapper-modal.tsx
@@ -5,7 +5,7 @@ import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 
 interface WrapperModalOptions {
-  title: string;
+  title: ReactNode;
   body: ReactNode;
   tall?: boolean;
   skinny?: boolean;

--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane/use-change-handlers.ts
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane/use-change-handlers.ts
@@ -45,7 +45,7 @@ const useChangeHandlers = (request: GrpcRequest, dispatch: GrpcDispatch): Change
 
     const protoFile = async () => {
       showModal(ProtoFilesModal, {
-        selected: request.protoFileId,
+        selectedId: request.protoFileId,
         onSave: async (protoFileId: string) => {
           if (request.protoFileId !== protoFileId) {
             const initial = models.grpcRequest.init();

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -79,7 +79,7 @@ export const RequestPane: FC<Props> = ({
   };
 
   const handleEditDescription = useCallback((forceEditMode: boolean) => {
-    showModal(RequestSettingsModal, { request, forceEditMode });
+    request && showModal(RequestSettingsModal, { request, forceEditMode });
   }, [request]);
 
   const handleEditDescriptionAdd = useCallback(() => {

--- a/packages/insomnia/src/ui/components/settings/account.tsx
+++ b/packages/insomnia/src/ui/components/settings/account.tsx
@@ -7,7 +7,7 @@ import { Link } from '../base/link';
 import { PromptButton } from '../base/prompt-button';
 import { HelpTooltip } from '../help-tooltip';
 import { hideAllModals, showModal } from '../modals/index';
-import { LoginModalHandle } from '../modals/login-modal';
+import { LoginModal } from '../modals/login-modal';
 
 export const Account: FC = () => {
   const { disablePaidFeatureAds } = useSelector(selectSettings);
@@ -19,7 +19,7 @@ export const Account: FC = () => {
   const handleLogin = useCallback((event: React.SyntheticEvent<HTMLAnchorElement>) => {
     event.preventDefault();
     hideAllModals();
-    showModal(LoginModalHandle);
+    showModal(LoginModal);
   }, []);
 
   const handleSubmitPasswordChange = useCallback(async (event: React.SyntheticEvent<HTMLFormElement>) => {

--- a/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx
@@ -161,7 +161,7 @@ export const _SidebarRequestRow: FC<Props> = forwardRef(({
   }, [requestGroup?._id, activeWorkspaceId]);
 
   const handleShowRequestSettings = useCallback(() => {
-    showModal(RequestSettingsModal, { request });
+    request && showModal(RequestSettingsModal, { request });
   }, [request]);
 
   const [methodOverrideValue, setMethodOverrideValue] = useState<string | null>(null);

--- a/packages/insomnia/src/ui/hooks/use-global-keyboard-shortcuts.ts
+++ b/packages/insomnia/src/ui/hooks/use-global-keyboard-shortcuts.ts
@@ -15,7 +15,7 @@ export const useGlobalKeyboardShortcuts = () => {
 
   useDocBodyKeyboardShortcuts({
     workspace_showSettings:
-      () => showModal(WorkspaceSettingsModal, { workspace: activeWorkspace }),
+      () => activeWorkspace && showModal(WorkspaceSettingsModal),
     plugin_reload:
       () => plugins.reloadPlugins(),
     environment_showVariableSourceAndValue:

--- a/packages/insomnia/src/ui/hooks/use-vcs.ts
+++ b/packages/insomnia/src/ui/hooks/use-vcs.ts
@@ -33,7 +33,7 @@ export function useVCS({
           return new Promise(resolve => {
             showModal(SyncMergeModal, {
               conflicts,
-              handleDone: (conflicts: MergeConflict[]) => resolve(conflicts),
+              handleDone: (conflicts?: MergeConflict[]) => resolve(conflicts || []),
             });
           });
         });

--- a/packages/insomnia/src/ui/redux/modules/git.tsx
+++ b/packages/insomnia/src/ui/redux/modules/git.tsx
@@ -53,7 +53,7 @@ export const setupGitRepository: SetupGitRepositoryCallback = ({ createFsClient,
     trackSegmentEvent(SegmentEvent.vcsSyncStart, vcsSegmentEventProperties('git', 'setup'));
     showModal(GitRepositorySettingsModal, {
       gitRepository: null,
-      onSubmitEdits: async (gitRepoPatch: GitRepository) => {
+      onSubmitEdits: async (gitRepoPatch: Partial<GitRepository>) => {
         const providerName  = getOauth2FormatName(gitRepoPatch.credentials);
 
         dispatch(loadStart());
@@ -65,7 +65,7 @@ export const setupGitRepository: SetupGitRepositoryCallback = ({ createFsClient,
           try {
             await shallowClone({
               fsClient,
-              gitRepository: gitRepoPatch,
+              gitRepository: gitRepoPatch as GitRepository,
             });
           } catch (err) {
             showError({

--- a/packages/insomnia/src/ui/redux/modules/global.tsx
+++ b/packages/insomnia/src/ui/redux/modules/global.tsx
@@ -5,6 +5,7 @@ import React, { Fragment } from 'react';
 import { combineReducers, Dispatch } from 'redux';
 import { unreachableCase } from 'ts-assert-unreachable';
 
+import { submitAuthCode } from '../../../account/session';
 import { trackPageView } from '../../../common/analytics';
 import type { DashboardSortOrder, GlobalActivity } from '../../../common/constants';
 import {
@@ -36,7 +37,7 @@ import { exchangeCodeForGitLabToken } from '../../../sync/git/gitlab-oauth-provi
 import { AskModal } from '../../../ui/components/modals/ask-modal';
 import { AlertModal } from '../../components/modals/alert-modal';
 import { showAlert, showError, showModal } from '../../components/modals/index';
-import { currentLoginModalHandle, LoginModalHandle } from '../../components/modals/login-modal';
+import { LoginModal } from '../../components/modals/login-modal';
 import { SelectModal } from '../../components/modals/select-modal';
 import {
   SettingsModal,
@@ -203,7 +204,7 @@ export const newCommand = (command: string, args: any) => async (dispatch: Dispa
       break;
 
     case COMMAND_LOGIN:
-      showModal(LoginModalHandle, {
+      showModal(LoginModal, {
         title: args.title,
         message: args.message,
         reauth: true,
@@ -308,11 +309,7 @@ export const newCommand = (command: string, args: any) => async (dispatch: Dispa
     }
 
     case COMMAND_FINISH_AUTHENTICATION: {
-      if (currentLoginModalHandle) {
-        currentLoginModalHandle?.submitAuthCode(args.box);
-      } else {
-        console.log(`Received auth box, but no login modal... ${command}`);
-      }
+      submitAuthCode(args.box);
       break;
     }
 
@@ -427,17 +424,30 @@ const showSelectExportTypeModal = ({ onDone }: {
     value: defaultValue,
     options,
     message: 'Which format would you like to export as?',
-    onDone: async (selectedFormat: SelectedFormat) => {
-      window.localStorage.setItem('insomnia.lastExportFormat', selectedFormat);
-      await onDone(selectedFormat);
+    onDone: async selectedFormat => {
+      if (selectedFormat) {
+        window.localStorage.setItem('insomnia.lastExportFormat', selectedFormat);
+        await onDone(selectedFormat as SelectedFormat);
+      }
     },
   });
 };
 
-const showExportPrivateEnvironmentsModal = (privateEnvNames: string) => showModal(AskModal, {
-  title: 'Export Private Environments?',
-  message: `Do you want to include private environments (${privateEnvNames}) in your export?`,
-});
+const showExportPrivateEnvironmentsModal = async (privateEnvNames: string) => {
+  return new Promise<boolean>(resolve => {
+    showModal(AskModal, {
+      title: 'Export Private Environments?',
+      message: `Do you want to include private environments (${privateEnvNames}) in your export?`,
+      onDone: async (isYes: boolean) => {
+        if (isYes) {
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      },
+    });
+  });
+};
 
 const showSaveExportedFileDialog = async ({
   exportedFileNamePrefix,

--- a/packages/insomnia/src/ui/redux/modules/global.tsx
+++ b/packages/insomnia/src/ui/redux/modules/global.tsx
@@ -5,7 +5,6 @@ import React, { Fragment } from 'react';
 import { combineReducers, Dispatch } from 'redux';
 import { unreachableCase } from 'ts-assert-unreachable';
 
-import { submitAuthCode } from '../../../account/session';
 import { trackPageView } from '../../../common/analytics';
 import type { DashboardSortOrder, GlobalActivity } from '../../../common/constants';
 import {
@@ -35,6 +34,7 @@ import { setTheme } from '../../../plugins/misc';
 import { exchangeCodeForToken } from '../../../sync/git/github-oauth-provider';
 import { exchangeCodeForGitLabToken } from '../../../sync/git/gitlab-oauth-provider';
 import { AskModal } from '../../../ui/components/modals/ask-modal';
+import { submitAuthCode } from '../../auth-session-provider';
 import { AlertModal } from '../../components/modals/alert-modal';
 import { showAlert, showError, showModal } from '../../components/modals/index';
 import { LoginModal } from '../../components/modals/login-modal';

--- a/packages/insomnia/src/ui/redux/modules/helpers.ts
+++ b/packages/insomnia/src/ui/redux/modules/helpers.ts
@@ -36,7 +36,7 @@ async function askToImportIntoNewWorkspace(): Promise<boolean> {
       message: `Do you want to import into an existing ${strings.workspace.singular.toLowerCase()} or a new one?`,
       yesText: 'Existing',
       noText: 'New',
-      onDone: (yes: boolean) => {
+      onDone: async (yes: boolean) => {
         resolve(yes);
       },
     });
@@ -88,7 +88,7 @@ export function askToImportIntoWorkspace({ workspaceId, forceToWorkspace, active
             message: 'Do you want to import into the current workspace or a new one?',
             yesText: 'Current',
             noText: 'New Workspace',
-            onDone: (yes: boolean) => {
+            onDone: async (yes: boolean) => {
               resolve(yes ? workspaceId : null);
             },
           });
@@ -117,7 +117,7 @@ export function askToSetWorkspaceScope(scope?: WorkspaceScope): SetWorkspaceScop
             message,
             noText: 'Request Collection',
             yesText: 'Design Document',
-            onDone: (yes: boolean) => {
+            onDone: async (yes: boolean) => {
               resolve(yes ? WorkspaceScopeKeys.design : WorkspaceScopeKeys.collection);
             },
           });

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -6,6 +6,7 @@ import * as models from '../../models';
 import { isGrpcRequest } from '../../models/grpc-request';
 import { getByParentId as getGrpcRequestMetaByParentId } from '../../models/grpc-request-meta';
 import * as requestOperations from '../../models/helpers/request-operations';
+import { isRequest } from '../../models/request';
 import { getByParentId as getRequestMetaByParentId } from '../../models/request-meta';
 import { isWebSocketRequest } from '../../models/websocket-request';
 import { EnvironmentsDropdown } from '../components/dropdowns/environments-dropdown';
@@ -59,7 +60,7 @@ export const WrapperDebug: FC = () => {
       },
     request_showSettings:
       () => {
-        if (activeRequest) {
+        if (activeRequest && isRequest(activeRequest)) {
           showModal(RequestSettingsModal, { request: activeRequest });
         }
       },
@@ -144,7 +145,11 @@ export const WrapperDebug: FC = () => {
     showCookiesEditor:
       () => showModal(CookiesModal),
     request_showGenerateCodeEditor:
-      () => showModal(GenerateCodeModal, { request: activeRequest }),
+      () => {
+        if (activeRequest && isRequest(activeRequest)) {
+          showModal(GenerateCodeModal, { request: activeRequest });
+        }
+      },
   });
   // Close all websocket connections when the active environment changes
   useEffect(() => {

--- a/packages/insomnia/src/ui/routes/modals.tsx
+++ b/packages/insomnia/src/ui/routes/modals.tsx
@@ -81,7 +81,7 @@ const Modals: FC = () => {
         <WrapperModal
           ref={instance => registerModal(instance, 'WrapperModal')}
         />
-        <LoginModal ref={registerModal} />
+        <LoginModal ref={instance => registerModal(instance, 'LoginModal')} />
         <AskModal ref={instance => registerModal(instance, 'AskModal')} />
         <SelectModal
           ref={instance => registerModal(instance, 'SelectModal')}


### PR DESCRIPTION
Makes the showModal function typed and fixes the issues found:
- [x] Brings back WebSocket Request Settings
- [x] Fixes exporting private environments
- [x] Moves login modal to function component and updates the handle
- [x] Fixes: We now correctly display the selected protofile when users try to change it in gRPC requests
- [x] Removes unused types from the conversion