### PR TITLE
Make screen readers read the HTTP status when the request finishes

### DIFF
--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -140,7 +140,7 @@ export const ResponsePane: FC<Props> = ({
     <Pane type="response">
       {!response ? null : (
         <PaneHeader className="row-spaced">
-          <div className="no-wrap scrollable scrollable--no-bars pad-left">
+          <div aria-atomic="true" aria-live="polite" className="no-wrap scrollable scrollable--no-bars pad-left">
             <StatusTag statusCode={response.statusCode} statusMessage={response.statusMessage} />
             <TimeTag milliseconds={response.elapsedTime} />
             <SizeTag bytesRead={response.bytesRead} bytesContent={response.bytesContent} />


### PR DESCRIPTION
changelog(Improvements): Added an improvement that allows screen readers to read the HTTP status when the request finishes

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Closes #5369 .

Implementation explanation:
1. The aria-live attribute was added with the "polite" flag. This attributes informs the screen reader that if the div is updated, the screen reader needs to speak its content.

2. The aria-atomic attribute was added. This attribute makes the screen reader to read all the content instead of reading only a character if only part of the string changes (for example, two 200 requests but only the time changes between them), it reads everything instead of only the time.