### PR TITLE
[INS-2118] Fix missing insomnia-plugin-default-headers for inso CLI

### DIFF
--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -73,6 +73,7 @@
     "insomnia-plugin-base64": "^3.6.1-beta.3",
     "insomnia-plugin-cookie-jar": "^3.6.1-beta.3",
     "insomnia-plugin-core-themes": "^3.6.1-beta.3",
+    "insomnia-plugin-default-headers": "^3.6.1-beta.3",
     "insomnia-plugin-file": "^3.6.1-beta.3",
     "insomnia-plugin-hash": "^3.6.1-beta.3",
     "insomnia-plugin-jsonpath": "^3.6.1-beta.3",


### PR DESCRIPTION
Closes INS-2118

Fixes a warning thrown by packaged inso cli, example:

```
[plugin] Failed to load plugin: insomnia-plugin-default-headers Error: Cannot find module 'insomnia-plugin-default-headers/package.json'
Require stack:
- /snapshot/insomnia/packages/insomnia-inso/bin/inso
1) If you want to compile the package/file into executable, please pay attention to compilation warnings and specify a literal in 'require' call. 2) If you don't want to compile the package/file into executable and want to 'require' it from filesystem (likely plugin), specify an absolute path in 'require' call using process.cwd() or process.execPath.
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function._resolveFilename (pkg/prelude/bootstrap.js:1776:46)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at Module.require (pkg/prelude/bootstrap.js:1676:31)
    at require (node:internal/modules/cjs/helpers:94:18)
    at getPlugins (/snapshot/insomnia/packages/insomnia-send-request/dist/index.js)
    at async getActivePlugins (/snapshot/insomnia/packages/insomnia-send-request/dist/index.js)
    at async getTemplateTags (/snapshot/insomnia/packages/insomnia-send-request/dist/index.js)
    at async getNunjucks (/snapshot/insomnia/packages/insomnia-send-request/dist/index.js) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/snapshot/insomnia/packages/insomnia-inso/bin/inso' ],
  pkg: true
}
```