### PR TITLE
Enable automated security plugins at the service (root spec) level

### DIFF
--- a/packages/openapi-2-kong/src/declarative-config/services.test.ts
+++ b/packages/openapi-2-kong/src/declarative-config/services.test.ts
@@ -353,18 +353,18 @@ describe('services', () => {
       } as OpenAPIV3.OpenIdSecurityScheme;
 
       if (!spec.components) {
-        spec.components = {}
+        spec.components = {};
       }
 
       spec.components.securitySchemes = {
-        "common-aad-scheme": securityScheme
+        'common-aad-scheme': securityScheme,
       };
 
       spec.security = [
         {
-          "common-aad-scheme": ["Api.Security.All"],
+          'common-aad-scheme': ['Api.Security.All'],
         },
-      ]
+      ];
 
       spec.paths = {
         '/dogs': {
@@ -373,9 +373,9 @@ describe('services', () => {
           post: {
             security: [
               {
-                "common-aad-scheme": ["Api.Security.Write"],
+                'common-aad-scheme': ['Api.Security.Write'],
               },
-            ]
+            ],
           },
         },
       };
@@ -383,7 +383,7 @@ describe('services', () => {
       const specResult = getSpecResult();
       specResult.plugins = [
         {
-          name: "openid-connect",
+          name: 'openid-connect',
           config: {
             'issuer': 'https://idp-endpoint.example.com/.well-kown',
             'auth_methods': ['bearer'],
@@ -409,7 +409,7 @@ describe('services', () => {
           tags,
           plugins: [
             {
-              name: "openid-connect",
+              name: 'openid-connect',
               config: {
                 'issuer': 'https://idp-endpoint.example.com/.well-kown',
                 'auth_methods': ['bearer'],
@@ -420,7 +420,6 @@ describe('services', () => {
           ],
         },
       ];
-      
 
       expect(await generateServices(spec, tags)).toEqual([specResult]);
     });
@@ -441,23 +440,23 @@ describe('services', () => {
       } as OpenAPIV3.OpenIdSecurityScheme;
 
       if (!spec.components) {
-        spec.components = {}
+        spec.components = {};
       }
 
       spec.components.securitySchemes = {
-        "common-aad-scheme": securityScheme
+        'common-aad-scheme': securityScheme,
       };
-      
+
       spec.security = [
         {
-          "common-aad-scheme": ["Api.Security.All"],
+          'common-aad-scheme': ['Api.Security.All'],
         },
-      ]
+      ];
 
       const specResult = getSpecResult();
       specResult.plugins = [
         {
-          name: "openid-connect",
+          name: 'openid-connect',
           config: {
             'issuer': 'https://idp-endpoint.example.com/.well-kown',
             'auth_methods': ['bearer'],
@@ -465,7 +464,7 @@ describe('services', () => {
           },
           tags: tags,
         },
-      ]
+      ];
 
       expect(await generateServices(spec, tags)).toEqual([specResult]);
     });

--- a/packages/openapi-2-kong/src/declarative-config/services.test.ts
+++ b/packages/openapi-2-kong/src/declarative-config/services.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
+import { OpenAPIV3 } from 'openapi-types';
 
 import { OA3Operation } from '../types';
 import { DCRoute, DCService } from '../types/declarative-config';
@@ -43,7 +44,7 @@ const getSpecResult = (): DCService =>
           name: 'My_API-birds-id-get',
           strip_path: false,
           methods: ['GET'],
-          paths: ['/birds/(?<id>[^/]+)$'],
+          paths: ['/birds/(?<id>[^\\/]+)$'],
           tags,
         },
       ],
@@ -255,7 +256,7 @@ describe('services', () => {
           tags,
           name: 'My_API-birds-id-get',
           methods: ['GET'],
-          paths: ['/birds/(?<id>[^/]+)$'],
+          paths: ['/birds/(?<id>[^\\/]+)$'],
           strip_path: false,
           plugins: [
             {
@@ -333,6 +334,139 @@ describe('services', () => {
           ],
         },
       ];
+      expect(await generateServices(spec, tags)).toEqual([specResult]);
+    });
+
+    it('generates service with securityDefinition-based openid-connect plugin', async () => {
+      const spec = getSpec();
+
+      const securityScheme = {
+        type: 'openIdConnect',
+        openIdConnectUrl: 'https://idp-endpoint.example.com/.well-kown',
+        'x-kong-security-openid-connect': {
+          config: {
+            'auth_methods': ['bearer'],
+          },
+          enabled: true,
+          protocols: ['http', 'https'],
+        },
+      } as OpenAPIV3.OpenIdSecurityScheme;
+
+      if (!spec.components) {
+        spec.components = {}
+      }
+
+      spec.components.securitySchemes = {
+        "common-aad-scheme": securityScheme
+      };
+
+      spec.security = [
+        {
+          "common-aad-scheme": ["Api.Security.All"],
+        },
+      ]
+
+      spec.paths = {
+        '/dogs': {
+          summary: 'Dog stuff',
+          get: {},
+          post: {
+            security: [
+              {
+                "common-aad-scheme": ["Api.Security.Write"],
+              },
+            ]
+          },
+        },
+      };
+
+      const specResult = getSpecResult();
+      specResult.plugins = [
+        {
+          name: "openid-connect",
+          config: {
+            'issuer': 'https://idp-endpoint.example.com/.well-kown',
+            'auth_methods': ['bearer'],
+            'scopes_required': ['Api.Security.All'],
+          },
+          tags: tags,
+        },
+      ];
+
+      specResult.routes = [
+        {
+          name: 'My_API-dogs-get',
+          strip_path: false,
+          methods: ['GET'],
+          paths: ['/dogs$'],
+          tags,
+        },
+        {
+          name: 'My_API-dogs-post',
+          strip_path: false,
+          methods: ['POST'],
+          paths: ['/dogs$'],
+          tags,
+          plugins: [
+            {
+              name: "openid-connect",
+              config: {
+                'issuer': 'https://idp-endpoint.example.com/.well-kown',
+                'auth_methods': ['bearer'],
+                'scopes_required': ['Api.Security.Write'],
+              },
+              tags: tags,
+            },
+          ],
+        },
+      ];
+      
+
+      expect(await generateServices(spec, tags)).toEqual([specResult]);
+    });
+
+    it('generates service and route (override) with securityDefinition-based openid-connect plugin', async () => {
+      const spec = getSpec();
+
+      const securityScheme = {
+        type: 'openIdConnect',
+        openIdConnectUrl: 'https://idp-endpoint.example.com/.well-kown',
+        'x-kong-security-openid-connect': {
+          config: {
+            'auth_methods': ['bearer'],
+          },
+          enabled: true,
+          protocols: ['http', 'https'],
+        },
+      } as OpenAPIV3.OpenIdSecurityScheme;
+
+      if (!spec.components) {
+        spec.components = {}
+      }
+
+      spec.components.securitySchemes = {
+        "common-aad-scheme": securityScheme
+      };
+      
+      spec.security = [
+        {
+          "common-aad-scheme": ["Api.Security.All"],
+        },
+      ]
+
+      const specResult = getSpecResult();
+      specResult.plugins = [
+        {
+          name: "openid-connect",
+          config: {
+            'issuer': 'https://idp-endpoint.example.com/.well-kown',
+            'auth_methods': ['bearer'],
+            'scopes_required': ['Api.Security.All'],
+          },
+          tags: tags,
+        },
+      ]
+
       expect(await generateServices(spec, tags)).toEqual([specResult]);
     });
 

--- a/packages/openapi-2-kong/src/declarative-config/services.test.ts
+++ b/packages/openapi-2-kong/src/declarative-config/services.test.ts
@@ -44,7 +44,7 @@ const getSpecResult = (): DCService =>
           name: 'My_API-birds-id-get',
           strip_path: false,
           methods: ['GET'],
-          paths: ['/birds/(?<id>[^\\/]+)$'],
+          paths: ['/birds/(?<id>[^/]+)$'],
           tags,
         },
       ],
@@ -256,7 +256,7 @@ describe('services', () => {
           tags,
           name: 'My_API-birds-id-get',
           methods: ['GET'],
-          paths: ['/birds/(?<id>[^\\/]+)$'],
+          paths: ['/birds/(?<id>[^/]+)$'],
           strip_path: false,
           plugins: [
             {

--- a/packages/openapi-2-kong/src/declarative-config/services.ts
+++ b/packages/openapi-2-kong/src/declarative-config/services.ts
@@ -49,6 +49,9 @@ export async function generateService(server: OA3Server, api: OpenApi3Spec, tags
     throw new Error(`expected '${xKongServiceDefaults}' to be an object`);
   }
 
+  // Generate generic and security-related service-level plugin objects
+  const serviceSecurityPlugins = generateSecurityPlugins(null, api, tags);
+
   const service: DCService = {
     ...serviceDefaults,
     name,
@@ -58,7 +61,7 @@ export async function generateService(server: OA3Server, api: OpenApi3Spec, tags
     // not a hostname, but the Upstream name
     port: Number(parsedUrl.port || '80'),
     path: parsedUrl.pathname,
-    plugins: globalPlugins.plugins,
+    plugins: [...globalPlugins.plugins, ...serviceSecurityPlugins],
     routes: [],
     tags,
   };


### PR DESCRIPTION
changelog(Improvements): Added ability to enable automated security plugins at service-level (root of spec) when generating Kong (or Kubernetes) declarative configs


<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

# FIXES https://github.com/Kong/insomnia/issues/3389

This enhancement adds the ability to use **openapi-2-kong** to create service-level (root of spec) security plugins, specifically OpenID-Connect, whilst generating Kong (or Kubernetes) declarative config.

It works with other security definition types also.

You will see in the tests what this is doing:

1. If `security:` definition is present at the root of the document, it now creates a service-level Kong plugin to go with this declaration
2. If a user specifies finer-grained `security:` on a route/method level, then a plugin will additionally be created at that level
3. In Kong, the route-level plugin will override the service-level one, which gives the user a transparent approach for adding API specification native security to their API, without needing to use `x-kong-plugin-` declarations.
