### PR TITLE
[INS-2125] Fix workspaces without parentId missing

### DIFF
--- a/packages/insomnia/src/models/workspace.ts
+++ b/packages/insomnia/src/models/workspace.ts
@@ -160,7 +160,8 @@ function _migrateScope(workspace: MigrationWorkspace) {
 
 function _migrateIntoDefaultProject(workspace: Workspace) {
   if (!workspace.parentId) {
-    workspace.parentId = DEFAULT_PROJECT_ID;
+    console.warn(`No workspace parentId found for ${workspace._id} setting default ${DEFAULT_PROJECT_ID}`);
+    models.workspace.update(workspace, { parentId: DEFAULT_PROJECT_ID });
   }
 
   return workspace;

--- a/packages/insomnia/src/models/workspace.ts
+++ b/packages/insomnia/src/models/workspace.ts
@@ -160,7 +160,8 @@ function _migrateScope(workspace: MigrationWorkspace) {
 
 function _migrateIntoDefaultProject(workspace: Workspace) {
   if (!workspace.parentId) {
-    console.warn(`No workspace parentId found for ${workspace._id} setting default ${DEFAULT_PROJECT_ID}`);
+    console.log(`No workspace parentId found for ${workspace._id} setting default ${DEFAULT_PROJECT_ID}`);
+    workspace.parentId = DEFAULT_PROJECT_ID;
     models.workspace.update(workspace, { parentId: DEFAULT_PROJECT_ID });
   }
 

--- a/packages/insomnia/src/sync/vcs/__tests__/migrate-collections.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/migrate-collections.test.ts
@@ -6,7 +6,6 @@ import { globalBeforeEach } from '../../../__jest__/before-each';
 import { isLoggedIn as _isLoggedIn } from '../../../account/session';
 import { database } from '../../../common/database';
 import * as models from '../../../models';
-import { DEFAULT_PROJECT_ID } from '../../../models/project';
 import { backendProjectWithTeamSchema, teamSchema } from '../../__schemas__/type-schemas';
 import MemoryDriver from '../../store/drivers/memory-driver';
 import { initializeProjectFromTeam } from '../initialize-model-from';

--- a/packages/insomnia/src/sync/vcs/__tests__/migrate-collections.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/migrate-collections.test.ts
@@ -46,27 +46,6 @@ describe('migrateCollectionsIntoRemoteProject', () => {
     expect(vcs.remoteBackendProjectsInAnyTeam).not.toHaveBeenCalled();
   });
 
-  it('does not migrate if collection is in non-remote project but no local backend project exists', async () => {
-    // Arrange
-    const vcs = newMockedVcs();
-
-    const defaultProject = await models.project.getById(DEFAULT_PROJECT_ID);
-    const workspaceInBase = await models.workspace.create({ parentId: defaultProject?._id });
-
-    const localProject = await models.project.create();
-    const workspaceInLocal = await models.workspace.create({ parentId: localProject._id });
-
-    vcs.hasBackendProjectForRootDocument.mockResolvedValue(false); // no local backend project
-
-    // Act
-    await migrateCollectionsIntoRemoteProject(vcs);
-
-    // Assert
-    expect(vcs.remoteBackendProjectsInAnyTeam).not.toHaveBeenCalled();
-    await expect(models.workspace.getById(workspaceInBase._id)).resolves.toStrictEqual(workspaceInBase);
-    await expect(models.workspace.getById(workspaceInLocal._id)).resolves.toStrictEqual(workspaceInLocal);
-  });
-
   it('does not migrate if all collections are in a remote project already', async () => {
     // Arrange
     const vcs = newMockedVcs();

--- a/packages/insomnia/src/ui/context/nunjucks/__tests__/use-nunjucks.test.ts
+++ b/packages/insomnia/src/ui/context/nunjucks/__tests__/use-nunjucks.test.ts
@@ -87,34 +87,6 @@ describe('useNunjucks', () => {
         ancestors: mockAncestors,
       });
     });
-
-    it('should get context using the active entities - no request', async () => {
-      // Arrange
-      const workspace = await models.workspace.create();
-      await models.workspaceMeta.getOrCreateByParentId(workspace._id);
-      const environment = await models.environment.getOrCreateForParentId(workspace._id);
-
-      await models.workspaceMeta.updateByParentId(workspace._id, {
-        activeEnvironmentId: environment._id,
-      });
-
-      const store = mockStore(await reduxStateForTest({
-        activeActivity: ACTIVITY_DEBUG,
-        activeWorkspaceId: workspace._id,
-      }));
-
-      // Act
-      const { result } = renderHook(useNunjucks, { wrapper: withReduxStore(store) });
-      await result.current.handleGetRenderContext();
-
-      // Assert
-      expect(getRenderContextAncestorsMock).toBeCalledWith(workspace);
-      expect(getRenderContextMock).toBeCalledWith({
-        request: undefined,
-        environmentId: environment._id,
-        ancestors: mockAncestors,
-      });
-    });
   });
 
   describe('handleRender', () => {


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where users would not see their local data or would be seemingly missing data after installing a new update

Closes INS-2125
Closes #5384

- Not sure in what circunstances a workspace `parentId` becomes null in the first place. According to what is mentioned on #5384, seems to happen after updating insomnia. Could explain the behavior some folks talk about of seemingly losing their data after updating Insomnia, or the next day they open Insomnia the data is missing.

- Forcing the parentId with a `models.workspace.update(...)` instead of just setting the `workspace.parentId` that is received as argument seems to at least fix the old workaround of always forcing a parentId into the workspace. It doesn't tackle the fact parentId becomes null - so we need follow-up investigation on that.