### PR TITLE
Additional option "skipAnnotations" for the export of spec

### DIFF
--- a/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
+++ b/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
@@ -71,8 +71,9 @@ exports[`Snapshot for "inso export spec -h" 1`] = `
 Export an API Specification to a file
 
 Options:
-  -o, --output <path>  save the generated config to a file
-  -h, --help           display help for command"
+  -o, --output <path>    save the generated config to a file
+  -s, --skipAnnotations  remove all \\"x-kong-\\" annotations  (default: false)
+  -h, --help             display help for command"
 `;
 
 exports[`Snapshot for "inso generate -h" 1`] = `

--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -205,7 +205,7 @@ describe('cli', () => {
   describe('export spec', () => {
     it('should call exportSpec with no arg', () => {
       inso('export spec');
-      expect(exportSpecification).toHaveBeenCalledWith(undefined, 
+      expect(exportSpecification).toHaveBeenCalledWith(undefined,
         { skipAnnotations: false });
     });
 

--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -205,13 +205,14 @@ describe('cli', () => {
   describe('export spec', () => {
     it('should call exportSpec with no arg', () => {
       inso('export spec');
-      expect(exportSpecification).toHaveBeenCalledWith(undefined, {});
+      expect(exportSpecification).toHaveBeenCalledWith(undefined, 
+        { skipAnnotations: false });
     });
 
     it('should call exportSpec with all expected arguments', () => {
-      inso('export spec spc_123 -o output.yaml');
+      inso('export spec spc_123 -o output.yaml -s');
       expect(exportSpecification).toHaveBeenCalledWith('spc_123', {
-        output: 'output.yaml',
+        output: 'output.yaml', skipAnnotations: true,
       });
     });
 

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -112,6 +112,7 @@ const makeExportCommand = (commandCreator: CreateCommand) => {
     .command('spec [identifier]')
     .description('Export an API Specification to a file')
     .option('-o, --output <path>', 'save the generated config to a file')
+    .option('-s, --skipAnnotations', 'remove all "x-kong-" annotations ', false)
     .action((identifier, cmd) => {
       let options = getOptions<ExportSpecificationOptions>(cmd);
       options = prepareCommand(options);

--- a/packages/insomnia-inso/src/commands/export-specification.test.ts
+++ b/packages/insomnia-inso/src/commands/export-specification.test.ts
@@ -32,14 +32,22 @@ describe('exportSpecification()', () => {
     expect(logger.__getLogs().log).toEqual([expect.stringContaining("openapi: '3.0.2")]);
   });
 
-  it('should remove all x-kong annotations from spec', async () => {
+  it('should not remove all x-kong annotations from spec if skipAnnotations false', async () => {
+    const result = await exportSpecification('spc_46c5a4a40e83445a9bd9d9758b86c16c', {
+      workingDir: 'src/db/fixtures/git-repo', skipAnnotations: false,
+    });
+    expect(result).toBe(true);
+    expect(writeFileWithCliOptions).not.toHaveBeenCalled();
+    expect(logger.__getLogs().log?.toString()).toContain('x-kong-');
+  });
+
+  it('should remove all x-kong annotations from spec if skipAnnotations true', async () => {
     const result = await exportSpecification('spc_46c5a4a40e83445a9bd9d9758b86c16c', {
       workingDir: 'src/db/fixtures/git-repo', skipAnnotations: true,
     });
     expect(result).toBe(true);
     expect(writeFileWithCliOptions).not.toHaveBeenCalled();
-    expect.not.stringContaining('x-kong-'),
-    expect(logger.__getLogs().log).toEqual([expect.stringContaining("openapi: '3.0.2")]);
+    expect(logger.__getLogs().log?.toString()).not.toContain('x-kong-');
   });
 
   it('should output document to a file', async () => {

--- a/packages/insomnia-inso/src/commands/export-specification.test.ts
+++ b/packages/insomnia-inso/src/commands/export-specification.test.ts
@@ -32,6 +32,16 @@ describe('exportSpecification()', () => {
     expect(logger.__getLogs().log).toEqual([expect.stringContaining("openapi: '3.0.2")]);
   });
 
+  it('should remove all x-kong annotations from spec', async () => {
+    const result = await exportSpecification('spc_46c5a4a40e83445a9bd9d9758b86c16c', {
+      workingDir: 'src/db/fixtures/git-repo', skipAnnotations: true,
+    });
+    expect(result).toBe(true);
+    expect(writeFileWithCliOptions).not.toHaveBeenCalled();
+    expect.not.stringContaining('x-kong-'),
+    expect(logger.__getLogs().log).toEqual([expect.stringContaining("openapi: '3.0.2")]);
+  });
+
   it('should output document to a file', async () => {
     const outputPath = 'this-is-the-output-path';
     writeFileWithCliOptions.mockResolvedValue(outputPath);

--- a/packages/insomnia-inso/src/commands/export-specification.ts
+++ b/packages/insomnia-inso/src/commands/export-specification.ts
@@ -39,7 +39,7 @@ export async function exportSpecification(
   }
 
   let contents = specFromDb.contents;
-  if (Boolean(skipAnnotations)) {
+  if (skipAnnotations) {
     const yamlObj = YAML.parse(contents);
     deleteField(yamlObj, 'x-kong-');
     contents = YAML.stringify(yamlObj);

--- a/packages/insomnia-inso/src/commands/export-specification.ts
+++ b/packages/insomnia-inso/src/commands/export-specification.ts
@@ -39,18 +39,17 @@ export async function exportSpecification(
   }
 
   let contents = specFromDb.contents;
-  if (skipAnnotations) {
+  if (Boolean(skipAnnotations)) {
     const yamlObj = YAML.parse(contents);
     deleteField(yamlObj, 'x-kong-');
     contents = YAML.stringify(yamlObj);
-    // logger.log('All x-kong-* annotations removed');
   }
 
   if (output) {
     const outputPath = await writeFileWithCliOptions(output, contents, workingDir);
     logger.log(`Specification exported to "${outputPath}".`);
   } else {
-    logger.log(specFromDb.contents);
+    logger.log(contents);
   }
 
   return true;

--- a/packages/insomnia-inso/src/commands/export-specification.ts
+++ b/packages/insomnia-inso/src/commands/export-specification.ts
@@ -1,3 +1,5 @@
+import YAML from 'yaml';
+
 import { loadDb } from '../db';
 import { loadApiSpec, promptApiSpec } from '../db/models/api-spec';
 import type { GlobalOptions } from '../get-options';
@@ -6,11 +8,22 @@ import { writeFileWithCliOptions } from '../write-file';
 
 export type ExportSpecificationOptions = GlobalOptions & {
   output?: string;
+  skipAnnotations?: boolean;
 };
+
+function  deleteField(obj: any, field: any): void {
+  Object.keys(obj).forEach(key => {
+    if (key.startsWith(field)) {
+      delete obj[key];
+    } else if (typeof obj[key] === 'object') {
+      deleteField(obj[key], field);
+    }
+  });
+}
 
 export async function exportSpecification(
   identifier: string | null | undefined,
-  { output, workingDir, appDataDir, ci, src }: ExportSpecificationOptions,
+  { output, skipAnnotations, workingDir, appDataDir, ci, src }: ExportSpecificationOptions,
 ) {
   const db = await loadDb({
     workingDir,
@@ -25,8 +38,16 @@ export async function exportSpecification(
     return false;
   }
 
+  let contents = specFromDb.contents;
+  if (skipAnnotations) {
+    const yamlObj = YAML.parse(contents);
+    deleteField(yamlObj, 'x-kong-');
+    contents = YAML.stringify(yamlObj);
+    // logger.log('All x-kong-* annotations removed');
+  }
+
   if (output) {
-    const outputPath = await writeFileWithCliOptions(output, specFromDb.contents, workingDir);
+    const outputPath = await writeFileWithCliOptions(output, contents, workingDir);
     logger.log(`Specification exported to "${outputPath}".`);
   } else {
     logger.log(specFromDb.contents);

--- a/packages/insomnia-inso/src/commands/generate-config.ts
+++ b/packages/insomnia-inso/src/commands/generate-config.ts
@@ -32,6 +32,7 @@ export type GenerateConfigOptions = GlobalOptions & {
   type: ConversionOption;
   output?: string;
   format?: FormatOption;
+  skipAnnotations?: boolean;
 
   /** a comma-separated list of tags */
   tags?: string;

--- a/packages/insomnia-inso/src/db/fixtures/git-repo/.insomnia/ApiSpec/spc_46c5a4a40e83445a9bd9d9758b86c16c.yml
+++ b/packages/insomnia-inso/src/db/fixtures/git-repo/.insomnia/ApiSpec/spc_46c5a4a40e83445a9bd9d9758b86c16c.yml
@@ -14,6 +14,7 @@ contents: |
     - name: Folder
   paths:
     /global:
+      x-kong-name: global
       get:
         description: Global
         operationId: get_global


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

changelog(Inso CLI): Added a new `--skipAnnotations` option to `inso export spec` command. If the flag is set all `x-kong-*` annotations are removed.
