### PR TITLE
Add API Key auth

### DIFF
--- a/packages/insomnia-importers/src/importers/fixtures/postman/api-key-default-v2_1-input.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/api-key-default-v2_1-input.json
@@ -1,0 +1,44 @@
+{
+	"info": {
+		"_postman_id": "test",
+		"name": "New Collection",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "test"
+	},
+	"item": [
+		{
+			"name": "New Request",
+			"request": {
+				"auth": {
+					"type": "apikey",
+					"apikey": [
+						{
+							"key": "value",
+							"value": "test",
+							"type": "string"
+						},
+						{
+							"key": "key",
+							"value": "test",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "mockbin.org/request/any",
+					"host": [
+						"mockbin",
+						"org"
+					],
+					"path": [
+						"request",
+						"any"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/packages/insomnia-importers/src/importers/fixtures/postman/api-key-default-v2_1-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/api-key-default-v2_1-output.json
@@ -1,0 +1,35 @@
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2022-11-09T17:15:02.632Z",
+  "__export_source": "insomnia.importers:v0.1.0",
+  "resources": [
+    {
+      "_id": "__GRP_1__",
+      "_type": "request_group",
+      "description": "",
+      "environment": {},
+      "name": "New Collection",
+      "parentId": "__WORKSPACE_ID__"
+    },
+    {
+      "_id": "__REQ_1__",
+      "parentId": "__GRP_1__",
+      "url": "mockbin.org/request/any",
+      "name": "New Request",
+      "description": "",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [],
+      "authentication": {
+        "type": "apikey",
+        "key": "test",
+        "value": "test",
+        "addTo": "header",
+        "disabled": false
+      },
+      "_type": "request"
+    }
+  ]
+}

--- a/packages/insomnia-importers/src/importers/fixtures/postman/api-key-header-v2_1-input.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/api-key-header-v2_1-input.json
@@ -1,0 +1,49 @@
+{
+	"info": {
+		"_postman_id": "test",
+		"name": "New Collection",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "test"
+	},
+	"item": [
+		{
+			"name": "New Request",
+			"request": {
+				"auth": {
+					"type": "apikey",
+					"apikey": [
+						{
+							"key": "in",
+							"value": "header",
+							"type": "string"
+						},
+						{
+							"key": "value",
+							"value": "test",
+							"type": "string"
+						},
+						{
+							"key": "key",
+							"value": "test",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "mockbin.org/request/any",
+					"host": [
+						"mockbin",
+						"org"
+					],
+					"path": [
+						"request",
+						"any"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/packages/insomnia-importers/src/importers/fixtures/postman/api-key-header-v2_1-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/api-key-header-v2_1-output.json
@@ -1,0 +1,35 @@
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2022-11-09T17:15:02.632Z",
+  "__export_source": "insomnia.importers:v0.1.0",
+  "resources": [
+    {
+      "_id": "__GRP_1__",
+      "_type": "request_group",
+      "description": "",
+      "environment": {},
+      "name": "New Collection",
+      "parentId": "__WORKSPACE_ID__"
+    },
+    {
+      "_id": "__REQ_1__",
+      "parentId": "__GRP_1__",
+      "url": "mockbin.org/request/any",
+      "name": "New Request",
+      "description": "",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [],
+      "authentication": {
+        "type": "apikey",
+        "key": "test",
+        "value": "test",
+        "addTo": "header",
+        "disabled": false
+      },
+      "_type": "request"
+    }
+  ]
+}

--- a/packages/insomnia-importers/src/importers/fixtures/postman/api-key-queryParams-v2_1-input.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/api-key-queryParams-v2_1-input.json
@@ -1,0 +1,49 @@
+{
+	"info": {
+		"_postman_id": "test",
+		"name": "New Collection",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "test"
+	},
+	"item": [
+		{
+			"name": "New Request",
+			"request": {
+				"auth": {
+					"type": "apikey",
+					"apikey": [
+						{
+							"key": "in",
+							"value": "query",
+							"type": "string"
+						},
+						{
+							"key": "value",
+							"value": "test",
+							"type": "string"
+						},
+						{
+							"key": "key",
+							"value": "test",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "mockbin.org/request/any",
+					"host": [
+						"mockbin",
+						"org"
+					],
+					"path": [
+						"request",
+						"any"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/packages/insomnia-importers/src/importers/fixtures/postman/api-key-queryParams-v2_1-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/postman/api-key-queryParams-v2_1-output.json
@@ -1,0 +1,35 @@
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2022-11-09T17:15:02.632Z",
+  "__export_source": "insomnia.importers:v0.1.0",
+  "resources": [
+    {
+      "_id": "__GRP_1__",
+      "_type": "request_group",
+      "description": "",
+      "environment": {},
+      "name": "New Collection",
+      "parentId": "__WORKSPACE_ID__"
+    },
+    {
+      "_id": "__REQ_1__",
+      "parentId": "__GRP_1__",
+      "url": "mockbin.org/request/any",
+      "name": "New Request",
+      "description": "",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [],
+      "authentication": {
+        "type": "apikey",
+        "key": "test",
+        "value": "test",
+        "addTo": "queryParams",
+        "disabled": false
+      },
+      "_type": "request"
+    }
+  ]
+}

--- a/packages/insomnia-importers/src/importers/postman.ts
+++ b/packages/insomnia-importers/src/importers/postman.ts
@@ -405,6 +405,12 @@ export class ImportPostman {
           headers,
         };
 
+      case 'apikey':
+        return {
+          authentication: this.importApiKeyAuthentication(authentication),
+          headers,
+        };
+
       default:
         return {
           authentication: {},
@@ -684,6 +690,19 @@ export class ImportPostman {
 
   };
 
+  importApiKeyAuthentication = (auth: Authetication) => {
+    if (!auth.apikey) {
+      return {};
+    }
+    const apikey = auth.apikey as V210Auth['apikey'];
+    return {
+      type: 'apikey',
+      key: this.findValueByKey(apikey, 'key'),
+      value: this.findValueByKey(apikey, 'value'),
+      addTo: this.findValueByKey(apikey, 'in')  === 'query' ? 'queryParams' : 'header',
+      disabled: false,
+    };
+  };
   importOauth2Authentication = (auth: Authetication) => {
     if (!auth.oauth2) {
       return {};

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -27,6 +27,7 @@ export const getSentryDsn = () => appConfig.sentryDsn;
 export const getAppBuildDate = () => new Date(process.env.BUILD_DATE ?? '').toLocaleDateString();
 export type AuthType =
   | 'none'
+  | 'apikey'
   | 'oauth2'
   | 'oauth1'
   | 'basic'
@@ -278,6 +279,7 @@ const contentTypesMap: Record<string, string[]> = {
 
 // Auth Types
 export const AUTH_NONE = 'none';
+export const AUTH_API_KEY = 'apikey';
 export const AUTH_OAUTH_2 = 'oauth2';
 export const AUTH_OAUTH_1 = 'oauth1';
 export const AUTH_BASIC = 'basic';
@@ -296,6 +298,7 @@ export const JSON_ORDER_PREFIX = '&';
 export const JSON_ORDER_SEPARATOR = '~|';
 
 const authTypesMap: Record<string, string[]> = {
+  [AUTH_API_KEY]: ['API Key', 'API Key Auth'],
   [AUTH_BASIC]: ['Basic', 'Basic Auth'],
   [AUTH_DIGEST]: ['Digest', 'Digest Auth'],
   [AUTH_NTLM]: ['NTLM', 'Microsoft NTLM'],

--- a/packages/insomnia/src/network/__tests__/authentication.test.ts
+++ b/packages/insomnia/src/network/__tests__/authentication.test.ts
@@ -169,12 +169,12 @@ describe('API Key', () => {
       });
     });
 
-    it('Does nothing, when addTo is "queryParams"', async () => {
+    it('Creates cookie with key as name and value as value, when addTo is "cookie"', async () => {
       const authentication = {
         type: AUTH_API_KEY,
         key: 'x-api-key',
         value: 'test',
-        addTo: 'queryParams',
+        addTo: 'cookie',
       };
       const request = {
         url: 'https://insomnia.rest/',
@@ -182,12 +182,14 @@ describe('API Key', () => {
         authentication,
       };
       const header = await getAuthHeader(request, 'https://insomnia.rest/');
-      expect(header).toBeUndefined();
+      expect(header).toEqual({
+        'name': 'Cookie',
+        'value': 'x-api-key=test',
+      });
     });
-
   });
-  describe('getAuthQueryParams', () => {
 
+  describe('getAuthQueryParams', () => {
     it('Creates a query param with key as parameter name and value as parameter value, when addTo is "queryParams"', async () => {
       const authentication = {
         type: AUTH_API_KEY,
@@ -205,22 +207,6 @@ describe('API Key', () => {
         'name': 'x-api-key',
         'value': 'test',
       });
-    });
-
-    it('Does nothing, when addTo is "header"', async () => {
-      const authentication = {
-        type: AUTH_API_KEY,
-        key: 'x-api-key',
-        value: 'test',
-        addTo: 'header',
-      };
-      const request = {
-        url: 'https://insomnia.rest/',
-        method: 'GET',
-        authentication,
-      };
-      const header = await getAuthQueryParams(request, 'https://insomnia.rest/');
-      expect(header).toBeUndefined();
     });
   });
 });

--- a/packages/insomnia/src/network/__tests__/authentication.test.ts
+++ b/packages/insomnia/src/network/__tests__/authentication.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { AUTH_OAUTH_1 } from '../../common/constants';
-import { _buildBearerHeader, getAuthHeader } from '../authentication';
+import { AUTH_API_KEY, AUTH_OAUTH_1 } from '../../common/constants';
+import {
+  _buildBearerHeader,
+  getAuthHeader,
+  getAuthQueryParams,
+} from '../authentication';
 
 describe('OAuth 1.0', () => {
   it('Does OAuth 1.0', async () => {
@@ -140,6 +144,83 @@ describe('_buildBearerHeader()', () => {
     expect(result).toEqual({
       name: 'Authorization',
       value: 'token',
+    });
+  });
+});
+
+describe('API Key', () => {
+  describe('getAuthHeader', () => {
+    it('Creates header with key as header name and value as header value, when addTo is "header"', async () => {
+      const authentication = {
+        type: AUTH_API_KEY,
+        key: 'x-api-key',
+        value: 'test',
+        addTo: 'header',
+      };
+      const request = {
+        url: 'https://insomnia.rest/',
+        method: 'GET',
+        authentication,
+      };
+      const header = await getAuthHeader(request, 'https://insomnia.rest/');
+      expect(header).toEqual({
+        'name': 'x-api-key',
+        'value': 'test',
+      });
+    });
+
+    it('Does nothing, when addTo is "queryParams"', async () => {
+      const authentication = {
+        type: AUTH_API_KEY,
+        key: 'x-api-key',
+        value: 'test',
+        addTo: 'queryParams',
+      };
+      const request = {
+        url: 'https://insomnia.rest/',
+        method: 'GET',
+        authentication,
+      };
+      const header = await getAuthHeader(request, 'https://insomnia.rest/');
+      expect(header).toBeUndefined();
+    });
+
+  });
+  describe('getAuthQueryParams', () => {
+
+    it('Creates a query param with key as parameter name and value as parameter value, when addTo is "queryParams"', async () => {
+      const authentication = {
+        type: AUTH_API_KEY,
+        key: 'x-api-key',
+        value: 'test',
+        addTo: 'queryParams',
+      };
+      const request = {
+        url: 'https://insomnia.rest/',
+        method: 'GET',
+        authentication,
+      };
+      const header = await getAuthQueryParams(request, 'https://insomnia.rest/');
+      expect(header).toEqual({
+        'name': 'x-api-key',
+        'value': 'test',
+      });
+    });
+
+    it('Does nothing, when addTo is "header"', async () => {
+      const authentication = {
+        type: AUTH_API_KEY,
+        key: 'x-api-key',
+        value: 'test',
+        addTo: 'header',
+      };
+      const request = {
+        url: 'https://insomnia.rest/',
+        method: 'GET',
+        authentication,
+      };
+      const header = await getAuthQueryParams(request, 'https://insomnia.rest/');
+      expect(header).toBeUndefined();
     });
   });
 });

--- a/packages/insomnia/src/network/api-key/constants.ts
+++ b/packages/insomnia/src/network/api-key/constants.ts
@@ -1,0 +1,4 @@
+export type ApiKeyAuthType = 'header' | 'queryParams' | 'cookie';
+export const HEADER: ApiKeyAuthType = 'header';
+export const QUERY_PARAMS: ApiKeyAuthType = 'queryParams';
+export const COOKIE: ApiKeyAuthType = 'cookie';

--- a/packages/insomnia/src/network/authentication.ts
+++ b/packages/insomnia/src/network/authentication.ts
@@ -2,6 +2,7 @@ import * as Hawk from 'hawk';
 import jwtAuthentication from 'jwt-authentication';
 
 import {
+  AUTH_API_KEY,
   AUTH_ASAP,
   AUTH_BASIC,
   AUTH_BEARER,
@@ -10,6 +11,7 @@ import {
   AUTH_OAUTH_2,
 } from '../common/constants';
 import type { RenderedRequest } from '../common/render';
+import { RequestParameter } from '../models/request';
 import { getBasicAuthHeader } from './basic-auth/get-header';
 import { getBearerAuthHeader } from './bearer-auth/get-header';
 import getOAuth1Token from './o-auth-1/get-token';
@@ -26,6 +28,14 @@ export async function getAuthHeader(renderedRequest: RenderedRequest, url: strin
 
   if (authentication.disabled) {
     return;
+  }
+
+  if (authentication.type === AUTH_API_KEY && authentication.addTo === 'header') {
+    const { key, value } = authentication;
+    return {
+      name: key,
+      value: value,
+    } as Header;
   }
 
   if (authentication.type === AUTH_BASIC) {
@@ -136,6 +146,24 @@ export async function getAuthHeader(renderedRequest: RenderedRequest, url: strin
         }
       });
     });
+  }
+
+  return;
+}
+
+export async function getAuthQueryParams(renderedRequest: RenderedRequest) {
+  const { authentication } = renderedRequest;
+
+  if (authentication.disabled) {
+    return;
+  }
+
+  if (authentication.type === AUTH_API_KEY && authentication.addTo === 'queryParams') {
+    const { key, value } = authentication;
+    return {
+      name: key,
+      value: value,
+    } as RequestParameter;
   }
 
   return;

--- a/packages/insomnia/src/network/authentication.ts
+++ b/packages/insomnia/src/network/authentication.ts
@@ -12,6 +12,7 @@ import {
 } from '../common/constants';
 import type { RenderedRequest } from '../common/render';
 import { RequestParameter } from '../models/request';
+import { COOKIE, HEADER, QUERY_PARAMS } from './api-key/constants';
 import { getBasicAuthHeader } from './basic-auth/get-header';
 import { getBearerAuthHeader } from './bearer-auth/get-header';
 import getOAuth1Token from './o-auth-1/get-token';
@@ -30,11 +31,19 @@ export async function getAuthHeader(renderedRequest: RenderedRequest, url: strin
     return;
   }
 
-  if (authentication.type === AUTH_API_KEY && authentication.addTo === 'header') {
+  if (authentication.type === AUTH_API_KEY && authentication.addTo === HEADER) {
     const { key, value } = authentication;
     return {
       name: key,
       value: value,
+    } as Header;
+  }
+
+  if (authentication.type === AUTH_API_KEY && authentication.addTo === COOKIE) {
+    const { key, value } = authentication;
+    return {
+      name: 'Cookie',
+      value: `${key}=${value}`,
     } as Header;
   }
 
@@ -158,7 +167,7 @@ export async function getAuthQueryParams(renderedRequest: RenderedRequest) {
     return;
   }
 
-  if (authentication.type === AUTH_API_KEY && authentication.addTo === 'queryParams') {
+  if (authentication.type === AUTH_API_KEY && authentication.addTo === QUERY_PARAMS) {
     const { key, value } = authentication;
     return {
       name: key,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -37,7 +37,7 @@ import type { Settings } from '../models/settings';
 import { isWorkspace } from '../models/workspace';
 import * as pluginContexts from '../plugins/context/index';
 import * as plugins from '../plugins/index';
-import { getAuthHeader } from './authentication';
+import { getAuthHeader, getAuthQueryParams } from './authentication';
 import { urlMatchesCertHost } from './url-matches-cert-host';
 
 // Time since user's last keypress to wait before making the request
@@ -86,8 +86,13 @@ export async function _actuallySend(
           timelinePath,
         });
       };
+      const authQueryParam = await getAuthQueryParams(renderedRequest);
       // Set the URL, including the query parameters
-      const qs = buildQueryStringFromParams(renderedRequest.parameters);
+      const qs = buildQueryStringFromParams(
+        authQueryParam
+          ? renderedRequest.parameters.concat([authQueryParam])
+          : renderedRequest.parameters
+      );
       const url = joinUrlAndQueryString(renderedRequest.url, qs);
       const isUnixSocket = url.match(/https?:\/\/unix:\//);
       let finalUrl, socketPath;

--- a/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
@@ -19,6 +19,7 @@ import { showModal } from '../modals';
 import { AlertModal } from '../modals/alert-modal';
 
 const defaultTypes: AuthType[] = [
+  'apikey',
   'basic',
   'digest',
   'oauth1',
@@ -36,6 +37,16 @@ function makeNewAuth(type: string, oldAuth: RequestAuthentication = {}): Request
     // No Auth
     case 'none':
       return {};
+
+    // API Key Authentication
+    case 'apikey':
+      return {
+        type,
+        disabled: oldAuth.disabled || false,
+        key: oldAuth.key || '',
+        value: oldAuth.value || '',
+        addTo: oldAuth.addTo || 'header',
+      };
 
     // HTTP Basic Authentication
     case 'basic':

--- a/packages/insomnia/src/ui/components/editors/auth/api-key-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/api-key-auth.tsx
@@ -1,0 +1,15 @@
+import React, { FC } from 'react';
+
+import { AuthInputRow } from './components/auth-input-row';
+import { AuthSelectRow } from './components/auth-select-row';
+import { AuthTableBody } from './components/auth-table-body';
+import { AuthToggleRow } from './components/auth-toggle-row';
+
+export const ApiKeyAuth: FC<{ disabled?: boolean }> = ({ disabled = false }) => (
+  <AuthTableBody>
+    <AuthToggleRow label="Enabled" property="disabled" invert disabled={disabled} />
+    <AuthInputRow label='Key' property='key' disabled={disabled} />
+    <AuthInputRow label='Value' property='value' disabled={disabled} />
+    <AuthSelectRow label='Add to' property='addTo' options={[{ name: 'Header', value: 'header' }, { name: 'Query params', value: 'queryParams' }]} disabled={disabled} />
+  </AuthTableBody>
+);

--- a/packages/insomnia/src/ui/components/editors/auth/api-key-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/api-key-auth.tsx
@@ -1,15 +1,22 @@
 import React, { FC } from 'react';
 
+import { COOKIE, HEADER, QUERY_PARAMS } from '../../../../network/api-key/constants';
 import { AuthInputRow } from './components/auth-input-row';
 import { AuthSelectRow } from './components/auth-select-row';
 import { AuthTableBody } from './components/auth-table-body';
 import { AuthToggleRow } from './components/auth-toggle-row';
 
+export const options = [
+  { name: 'Header', value: HEADER },
+  { name: 'Query params', value: QUERY_PARAMS },
+  { name: 'Cookie', value: COOKIE },
+];
+
 export const ApiKeyAuth: FC<{ disabled?: boolean }> = ({ disabled = false }) => (
   <AuthTableBody>
     <AuthToggleRow label="Enabled" property="disabled" invert disabled={disabled} />
     <AuthInputRow label='Key' property='key' disabled={disabled} />
-    <AuthInputRow label='Value' property='value' disabled={disabled} />
-    <AuthSelectRow label='Add to' property='addTo' options={[{ name: 'Header', value: 'header' }, { name: 'Query params', value: 'queryParams' }]} disabled={disabled} />
+    <AuthInputRow label='Value' property='value' mask disabled={disabled} />
+    <AuthSelectRow label='Add to' property='addTo' options={options} disabled={disabled} />
   </AuthTableBody>
 );

--- a/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
@@ -2,6 +2,7 @@ import React, { FC, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
 import {
+  AUTH_API_KEY,
   AUTH_ASAP,
   AUTH_AWS_IAM,
   AUTH_BASIC,
@@ -14,6 +15,7 @@ import {
   AUTH_OAUTH_2,
 } from '../../../../common/constants';
 import { selectActiveRequest } from '../../../redux/selectors';
+import { ApiKeyAuth } from './api-key-auth';
 import { AsapAuth } from './asap-auth';
 import { AWSAuth } from './aws-auth';
 import { BasicAuth } from './basic-auth';
@@ -38,6 +40,8 @@ export const AuthWrapper: FC<{ disabled?: boolean }> = ({ disabled = false }) =>
 
   if (type === AUTH_BASIC) {
     authBody = <BasicAuth disabled={disabled} />;
+  } else if (type === AUTH_API_KEY) {
+    authBody = <ApiKeyAuth disabled={disabled} />;
   } else if (type === AUTH_OAUTH_2) {
     authBody = <OAuth2Auth />;
   } else if (type === AUTH_HAWK) {

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -27,7 +27,7 @@ import { Pane, PaneHeader as OriginalPaneHeader } from '../panes/pane';
 import { RenderedQueryString } from '../rendered-query-string';
 import { WebSocketActionBar } from './action-bar';
 
-const supportedAuthTypes: AuthType[] = ['basic', 'bearer'];
+const supportedAuthTypes: AuthType[] = ['apikey', 'basic', 'bearer'];
 
 const SendMessageForm = styled.form({
   width: '100%',


### PR DESCRIPTION
Supports header / query parameter in both webrequest and websocket

changelog(Improvements): Added API Key Authentication method for HTTP and WebSocket requests