### PR TITLE
Add flex gap to app header center

### DIFF
--- a/packages/insomnia/src/ui/components/app-header.tsx
+++ b/packages/insomnia/src/ui/components/app-header.tsx
@@ -45,6 +45,7 @@ const StyledHeader = styled.div({
     textAlign: 'center',
     display: 'flex',
     alignItems: 'center',
+    gap: 'var(--padding-sm)',
   },
   '.header_right': {
     gridArea: 'header_right',


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Add gap to app header center elements.

Before:

![image](https://user-images.githubusercontent.com/68000455/201381007-2aa73260-8420-4fb1-b036-e9d268112987.png)

![image](https://user-images.githubusercontent.com/68000455/201380916-d2a281fd-36bb-48d4-88c7-b9e5c82ca7a4.png)

After:

![image](https://user-images.githubusercontent.com/68000455/201381076-6fcfa5da-bd4e-4741-a9b9-267acee4e8c1.png)

![image](https://user-images.githubusercontent.com/68000455/201380829-7a32305a-41e1-4e1f-8ee5-768f2d5616d9.png)