### PR TITLE
 [INS-2119] Inso CLI logging parity 

### DIFF
--- a/packages/insomnia-inso/package-lock.json
+++ b/packages/insomnia-inso/package-lock.json
@@ -12,6 +12,7 @@
 				"@stoplight/spectral-core": "^1.12.2",
 				"@stoplight/spectral-formats": "^1.2.0",
 				"@stoplight/spectral-rulesets": "^1.9.0",
+				"@stoplight/types": "^13.8.0",
 				"axios": "^0.21.2",
 				"commander": "^5.1.0",
 				"consola": "^2.15.0",
@@ -1193,18 +1194,6 @@
 				"node": ">=8.3.0"
 			}
 		},
-		"node_modules/@stoplight/spectral-formats/node_modules/@stoplight/types": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.2.0.tgz",
-			"integrity": "sha512-V3BRfzWEAcCpICGQh/WW2LX4rcB2KagQ7/msf0BDTCF5qpFMSwOxcjv25k1NUMVQSh3qwGfGoka/gYGA5m+NQA==",
-			"dependencies": {
-				"@types/json-schema": "^7.0.4",
-				"utility-types": "^3.10.0"
-			},
-			"engines": {
-				"node": "^12.20 || >=14.13"
-			}
-		},
 		"node_modules/@stoplight/spectral-formats/node_modules/tslib": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -1659,6 +1648,18 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
+		"node_modules/@stoplight/types": {
+			"version": "13.8.0",
+			"resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.8.0.tgz",
+			"integrity": "sha512-5glKswz7y9aACh+a+JegID+4xX//4TsIdv7iPl29hWnOoWrnlPbg3Gjc4nYUXXgMSaSlSsA15JU/0+rE89fR4A==",
+			"dependencies": {
+				"@types/json-schema": "^7.0.4",
+				"utility-types": "^3.10.0"
+			},
+			"engines": {
+				"node": "^12.20 || >=14.13"
+			}
 		},
 		"node_modules/@stoplight/yaml-ast-parser": {
 			"version": "0.0.48",
@@ -7741,15 +7742,6 @@
 						"safe-stable-stringify": "^1.1"
 					}
 				},
-				"@stoplight/types": {
-					"version": "13.2.0",
-					"resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.2.0.tgz",
-					"integrity": "sha512-V3BRfzWEAcCpICGQh/WW2LX4rcB2KagQ7/msf0BDTCF5qpFMSwOxcjv25k1NUMVQSh3qwGfGoka/gYGA5m+NQA==",
-					"requires": {
-						"@types/json-schema": "^7.0.4",
-						"utility-types": "^3.10.0"
-					}
-				},
 				"tslib": {
 					"version": "2.4.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -8114,6 +8106,15 @@
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 				}
+			}
+		},
+		"@stoplight/types": {
+			"version": "13.8.0",
+			"resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.8.0.tgz",
+			"integrity": "sha512-5glKswz7y9aACh+a+JegID+4xX//4TsIdv7iPl29hWnOoWrnlPbg3Gjc4nYUXXgMSaSlSsA15JU/0+rE89fR4A==",
+			"requires": {
+				"@types/json-schema": "^7.0.4",
+				"utility-types": "^3.10.0"
 			}
 		},
 		"@stoplight/yaml-ast-parser": {

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -64,6 +64,7 @@
     "@stoplight/spectral-core": "^1.12.2",
     "@stoplight/spectral-formats": "^1.2.0",
     "@stoplight/spectral-rulesets": "^1.9.0",
+    "@stoplight/types": "^13.8.0",
     "axios": "^0.21.2",
     "commander": "^5.1.0",
     "consola": "^2.15.0",


### PR DESCRIPTION
changelog(Inso CLI): Improved the log output of `inso lint spec` command to print warning logs

Closes INS-2119

Workaround changes so the log output matches the default of spectral cli:

- Keep failing on on errors, but print out any results found
- Warn if errors or warnings are present in results
- Add a small info note on the ruleset being used (since we get that question a lot of which ruleset is used)

After change, on Inso CLI
![image](https://user-images.githubusercontent.com/11976836/201656474-67ae978a-46cc-4dc0-b96f-d5af7baa92cd.png)

On spectral:
![image](https://user-images.githubusercontent.com/11976836/201656677-3de8acc4-40ed-455c-8aaf-d0556f156661.png)




