### PR TITLE
[INS-2151] Fix plugins installation for npm run dev

### DIFF
--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -1,10 +1,9 @@
 import { KeyCombination } from 'insomnia-common';
-import path from 'path';
 import { unreachableCase } from 'ts-assert-unreachable';
 
 import appConfig from '../../config/config.json';
 import { version } from '../../package.json';
-import { getDataDirectory, getPortableExecutableDir } from './electron-helpers';
+import { getPortableExecutableDir } from './electron-helpers';
 
 const env = process['env'];
 

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -83,7 +83,6 @@ export const LARGE_RESPONSE_MB = 5;
 export const HUGE_RESPONSE_MB = 100;
 export const FLEXIBLE_URL_REGEX = /^(http|https):\/\/[\wàâäèéêëîïôóœùûüÿçÀÂÄÈÉÊËÎÏÔŒÙÛÜŸÇ\-_.]+[/\wàâäèéêëîïôóœùûüÿçÀÂÄÈÉÊËÎÏÔŒÙÛÜŸÇ.\-+=:\][@%^*&!#?;$~'(),]*/;
 export const CHECK_FOR_UPDATES_INTERVAL = 1000 * 60 * 60 * 3; // 3 hours
-export const PLUGIN_PATH = path.join(getDataDirectory(), 'plugins');
 
 // Available editor key map
 export enum EditorKeyMap {

--- a/packages/insomnia/src/main/install-plugin.ts
+++ b/packages/insomnia/src/main/install-plugin.ts
@@ -6,8 +6,8 @@ import fsx from 'fs-extra';
 import mkdirp from 'mkdirp';
 import path from 'path';
 
-import { isDevelopment, isWindows, PLUGIN_PATH } from '../common/constants';
-import { getTempDir } from '../common/electron-helpers';
+import { isDevelopment, isWindows } from '../common/constants';
+import { getDataDirectory, getTempDir } from '../common/electron-helpers';
 
 const YARN_DEPRECATED_WARN = /(?<keyword>warning)(?<dependencies>[^>:].+[>:])(?<issue>.+)/;
 
@@ -51,7 +51,7 @@ export default async function(lookupName: string) {
       info = await _isInsomniaPlugin(lookupName);
       // Get actual module name without version suffixes and things
       const moduleName = info.name;
-      const pluginDir = path.join(PLUGIN_PATH, moduleName);
+      const pluginDir = path.join(getDataDirectory(), 'plugins', moduleName);
 
       // Make plugin directory
       mkdirp.sync(pluginDir);

--- a/packages/insomnia/src/plugins/create.ts
+++ b/packages/insomnia/src/plugins/create.ts
@@ -3,14 +3,14 @@ import mkdirp from 'mkdirp';
 import path from 'path';
 import rimraf from 'rimraf';
 
-import { PLUGIN_PATH } from '../common/constants';
+import { getDataDirectory } from '../common/electron-helpers';
 
 export async function createPlugin(
   moduleName: string,
   version: string,
   mainJs: string,
 ) {
-  const pluginDir = path.join(PLUGIN_PATH, moduleName);
+  const pluginDir = path.join(getDataDirectory(), 'plugins', moduleName);
 
   if (fs.existsSync(pluginDir)) {
     throw new Error(`Plugin already exists at "${pluginDir}"`);

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import appConfig from '../../config/config.json';
 import { ParsedApiSpec } from '../common/api-specs';
-import { PLUGIN_PATH } from '../common/constants';
+import { getDataDirectory } from '../common/electron-helpers';
 import { resolveHomePath } from '../common/misc';
 import * as models from '../models';
 import { GrpcRequest } from '../models/grpc-request';
@@ -209,9 +209,10 @@ export async function getPlugins(force = false): Promise<Plugin[]> {
       .filter(p => p)
       .map(resolveHomePath);
     // Make sure the default directories exist
-    mkdirp.sync(PLUGIN_PATH);
+    const pluginPath = path.join(getDataDirectory(), 'plugins');
+    mkdirp.sync(pluginPath);
     // Also look in node_modules folder in each directory
-    const basePaths = [PLUGIN_PATH, ...extraPaths];
+    const basePaths = [pluginPath, ...extraPaths];
     const extendedPaths = basePaths.map(p => path.join(p, 'node_modules'));
     const allPaths = [...basePaths, ...extendedPaths];
     // Store plugins in a map so that plugins with the same

--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -4,10 +4,9 @@ import React, { FC, useEffect, useState } from 'react';
 import {
   NPM_PACKAGE_BASE,
   PLUGIN_HUB_BASE,
-  PLUGIN_PATH,
 } from '../../../common/constants';
 import { docsPlugins } from '../../../common/documentation';
-import { clickLink } from '../../../common/electron-helpers';
+import { clickLink, getDataDirectory } from '../../../common/electron-helpers';
 import * as models from '../../../models';
 import type { Settings } from '../../../models/settings';
 import { createPlugin } from '../../../plugins/create';
@@ -254,7 +253,7 @@ export const Plugins: FC<Props> = ({ settings }) => {
           style={{
             marginLeft: '0.3em',
           }}
-          onClick={() => window.shell.showItemInFolder(PLUGIN_PATH)}
+          onClick={() => window.shell.showItemInFolder(path.join(getDataDirectory(), 'plugins'))}
         >
           Reveal Plugins Folder
         </Button>


### PR DESCRIPTION
When running `npm run dev` we hit an edge-case:
- when app boots up, the `process.type` assumes value of `browser` initially.
- this would make the `PLUGIN_PATH` variable default to `Insomnia` instead of `insomnia-app` and stay like that forever.

So anything that touched plugins when running `npm run dev` was never visible on the app, because it was installing on the Production plugins folder which was set during boot time.

Fix is to just calculate the plugin path when it is needed, not while app is booting up.

Closes INS-2151