### PR TITLE
OpenAPI 3 Import: Add support for importing API Key Authentication as authentication

### DIFF
--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/dereferenced-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/dereferenced-output.json
@@ -131,15 +131,14 @@
     {
       "_id": "req___WORKSPACE_ID__3d1a51d3",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "addTo": "header",
+        "key": "api_key",
+        "type": "apikey",
+        "value": "{{ apiKey }}"
+      },
       "body": {},
-      "headers": [
-        {
-          "disabled": false,
-          "name": "api_key",
-          "value": "{{ apiKey }}"
-        }
-      ],
+      "headers": [],
       "method": "GET",
       "name": "Find pet by ID",
       "parameters": [],
@@ -216,15 +215,14 @@
     {
       "_id": "req___WORKSPACE_ID__443ac9e7",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "addTo": "header",
+        "key": "api_key",
+        "type": "apikey",
+        "value": "{{ apiKey }}"
+      },
       "body": {},
-      "headers": [
-        {
-          "disabled": false,
-          "name": "api_key",
-          "value": "{{ apiKey }}"
-        }
-      ],
+      "headers": [],
       "method": "GET",
       "name": "Returns pet inventories by status",
       "parameters": [],

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/dereferenced-with-tags-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/dereferenced-with-tags-output.json
@@ -155,15 +155,14 @@
     {
       "_id": "req___WORKSPACE_ID__3d1a51d3",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "addTo": "header",
+        "key": "api_key",
+        "type": "apikey",
+        "value": "{{ apiKey }}"
+      },
       "body": {},
-      "headers": [
-        {
-          "disabled": false,
-          "name": "api_key",
-          "value": "{{ apiKey }}"
-        }
-      ],
+      "headers": [],
       "method": "GET",
       "name": "Find pet by ID",
       "parameters": [],
@@ -240,15 +239,14 @@
     {
       "_id": "req___WORKSPACE_ID__443ac9e7",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "addTo": "header",
+        "key": "api_key",
+        "type": "apikey",
+        "value": "{{ apiKey }}"
+      },
       "body": {},
-      "headers": [
-        {
-          "disabled": false,
-          "name": "api_key",
-          "value": "{{ apiKey }}"
-        }
-      ],
+      "headers": [],
       "method": "GET",
       "name": "Returns pet inventories by status",
       "parameters": [],

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/global-security-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/global-security-output.json
@@ -65,15 +65,14 @@
       "url": "{{ base_url }}/override",
       "body": {},
       "method": "GET",
-      "parameters": [
-        {
-          "name": "apiKeyHere",
-          "disabled": false,
-          "value": "{{ apiKeyHere }}"
-        }
-      ],
+      "parameters": [],
       "headers": [],
-      "authentication": {},
+      "authentication": {
+        "addTo": "query",
+        "key": "apiKeyHere",
+        "type": "apikey",
+        "value": "{{ apiKeyHere }}"
+      },
       "_type": "request",
       "_id": "req___WORKSPACE_ID__b410454b"
     }

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/petstore-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/petstore-output.json
@@ -131,15 +131,14 @@
     {
       "_id": "req___WORKSPACE_ID__3d1a51d3",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "addTo": "header",
+        "key": "api_key",
+        "type": "apikey",
+        "value": "{{ apiKey }}"
+      },
       "body": {},
-      "headers": [
-        {
-          "disabled": false,
-          "name": "api_key",
-          "value": "{{ apiKey }}"
-        }
-      ],
+      "headers": [],
       "method": "GET",
       "name": "Find pet by ID",
       "parameters": [],
@@ -216,15 +215,14 @@
     {
       "_id": "req___WORKSPACE_ID__443ac9e7",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "addTo": "header",
+        "key": "api_key",
+        "type": "apikey",
+        "value": "{{ apiKey }}"
+      },
       "body": {},
-      "headers": [
-        {
-          "disabled": false,
-          "name": "api_key",
-          "value": "{{ apiKey }}"
-        }
-      ],
+      "headers": [],
       "method": "GET",
       "name": "Returns pet inventories by status",
       "parameters": [],

--- a/packages/insomnia-importers/src/importers/fixtures/openapi3/petstore-with-tags-output.json
+++ b/packages/insomnia-importers/src/importers/fixtures/openapi3/petstore-with-tags-output.json
@@ -155,15 +155,14 @@
     {
       "_id": "req___WORKSPACE_ID__3d1a51d3",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "addTo": "header",
+        "key": "api_key",
+        "type": "apikey",
+        "value": "{{ apiKey }}"
+      },
       "body": {},
-      "headers": [
-        {
-          "disabled": false,
-          "name": "api_key",
-          "value": "{{ apiKey }}"
-        }
-      ],
+      "headers": [],
       "method": "GET",
       "name": "Find pet by ID",
       "parameters": [],
@@ -240,15 +239,14 @@
     {
       "_id": "req___WORKSPACE_ID__443ac9e7",
       "_type": "request",
-      "authentication": {},
+      "authentication": {
+        "addTo": "header",
+        "key": "api_key",
+        "type": "apikey",
+        "value": "{{ apiKey }}"
+      },
       "body": {},
-      "headers": [
-        {
-          "disabled": false,
-          "name": "api_key",
-          "value": "{{ apiKey }}"
-        }
-      ],
+      "headers": [],
       "method": "GET",
       "name": "Returns pet inventories by status",
       "parameters": [],


### PR DESCRIPTION
Now imports API Key as the authentication scheme, if there is only one API Key security schema.
Otherwise it will preserve the existing behavior and use query parameters, or headers.