### PR TITLE
ux: all modals can be dismissed

### DIFF
--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -399,7 +399,6 @@ export function askToImportIntoWorkspace({ workspaceId, forceToWorkspace, active
                   message: `Select a ${strings.workspace.singular.toLowerCase()} to import into`,
                   options,
                   value: options[0]?.value,
-                  noEscape: true,
                   onDone: workspaceId => {
                     resolve(workspaceId);
                   },
@@ -476,7 +475,6 @@ export function askToImportIntoProject({ projects, activeProject }: { projects?:
         message: `Select a ${strings.project.singular.toLowerCase()} to import into`,
         options,
         value: defaultValue,
-        noEscape: true,
         onDone: selectedProjectId => {
           // @ts-expect-error onDone can send null as an argument; why/how?
           resolve(selectedProjectId);

--- a/packages/insomnia/src/plugins/context/app.tsx
+++ b/packages/insomnia/src/plugins/context/app.tsx
@@ -48,7 +48,7 @@ export interface AppContext {
     message?: string
   ) => ReturnType<typeof showAlert>;
   dialog: (title: string, body: HTMLElement, options?: DialogOptions) => void;
-  prompt: (title: string, options?: Pick<PromptModalOptions, 'label' | 'defaultValue' | 'submitName' | 'cancelable'>) => Promise<string>;
+  prompt: (title: string, options?: Pick<PromptModalOptions, 'label' | 'defaultValue' | 'submitName'>) => Promise<string>;
   getPath: (name: string) => string;
   getInfo: () => AppInfo;
   showSaveDialog: (options?: ShowDialogOptions) => Promise<string | null>;

--- a/packages/insomnia/src/ui/components/base/modal.tsx
+++ b/packages/insomnia/src/ui/components/base/modal.tsx
@@ -11,7 +11,6 @@ export interface ModalProps {
   tall?: boolean;
   wide?: boolean;
   skinny?: boolean;
-  noEscape?: boolean;
   onShow?: Function;
   onHide?: Function;
   children?: ReactNode;
@@ -28,7 +27,6 @@ export const Modal = forwardRef<ModalHandle, ModalProps>(({
   centered,
   children,
   className,
-  noEscape,
   onHide: onHideProp,
   onShow,
   skinny,
@@ -69,29 +67,21 @@ export const Modal = forwardRef<ModalHandle, ModalProps>(({
     'theme--dialog',
     className,
     { 'modal--fixed-height': tall },
-    { 'modal--noescape': noEscape },
     { 'modal--wide': wide },
     { 'modal--skinny': skinny },
   );
 
   useEffect(() => {
-    // Don't check for close keys if we don't want them
-    if (noEscape) {
-      return;
-    }
-
     const closeElements = containerRef.current?.querySelectorAll('[data-close-modal]');
 
     for (const element of closeElements || []) {
       element.addEventListener('click', hide);
     }
-  }, [hide, open, noEscape]);
+  }, [hide, open]);
 
   const handleKeydown = createKeybindingsHandler({
     'Escape': () => {
-      if (!noEscape) {
-        hide();
-      }
+      hide();
     },
   });
   useEffect(() => {

--- a/packages/insomnia/src/ui/components/modals/analytics-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/analytics-modal.tsx
@@ -99,7 +99,7 @@ export const AnalyticsModal: FC = () => {
   }
 
   return (
-    <Modal centered noEscape skinny ref={ref}>
+    <Modal centered skinny ref={ref}>
       <Wrapper>
         <Header>
           <InsomniaLogo>

--- a/packages/insomnia/src/ui/components/modals/ask-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/ask-modal.tsx
@@ -49,7 +49,7 @@ export const AskModal = forwardRef<AskModalHandle, ModalProps>((_, ref) => {
   }), []);
   const { message, title, yesText, noText, onDone } = state;
   return (
-    <Modal ref={modalRef} noEscape>
+    <Modal ref={modalRef}>
       <ModalHeader>{title || 'Confirm?'}</ModalHeader>
       <ModalBody className="wide pad">{message}</ModalBody>
       <ModalFooter>

--- a/packages/insomnia/src/ui/components/modals/prompt-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/prompt-modal.tsx
@@ -18,7 +18,6 @@ interface State {
   label?: string | null;
   placeholder?: string | null;
   inputType?: string | null;
-  cancelable?: boolean | null;
   onComplete?: (arg0: string) => Promise<void> | void;
   onHide?: () => void;
   onDeleteHint?: ((arg0?: string) => void) | null;
@@ -31,7 +30,6 @@ export interface PromptModalOptions {
   selectText?: boolean;
   upperCase?: boolean;
   hint?: string;
-  cancelable?: boolean;
   inputType?: string;
   placeholder?: string;
   validate?: (arg0: string) => string;
@@ -61,7 +59,6 @@ export const PromptModal = forwardRef<PromptModalHandle, ModalProps>((_, ref) =>
     label: '',
     placeholder: '',
     inputType: '',
-    cancelable: true,
     onComplete: undefined,
     onDeleteHint: undefined,
     onHide: undefined,
@@ -100,7 +97,6 @@ export const PromptModal = forwardRef<PromptModalHandle, ModalProps>((_, ref) =>
     label,
     upperCase,
     hints,
-    cancelable,
   } = state;
   const input = (
     <input
@@ -175,7 +171,6 @@ export const PromptModal = forwardRef<PromptModalHandle, ModalProps>((_, ref) =>
   return (
     <Modal
       ref={modalRef}
-      noEscape={!cancelable}
       onHide={state.onHide}
     >
       <ModalHeader>{title}</ModalHeader>

--- a/packages/insomnia/src/ui/components/modals/select-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/select-modal.tsx
@@ -15,7 +15,6 @@ export interface SelectModalOptions {
   }[];
   title: string | null;
   value: string | null;
-  noEscape?: boolean;
 }
 export interface SelectModalHandle {
   show: (options: SelectModalOptions) => void;
@@ -40,10 +39,10 @@ export const SelectModal = forwardRef<SelectModalHandle, ModalProps>((_, ref) =>
       modalRef.current?.show();
     },
   }), []);
-  const { message, title, options, value, noEscape, onDone } = state;
+  const { message, title, options, value, onDone } = state;
 
   return (
-    <Modal ref={modalRef} noEscape={noEscape}>
+    <Modal ref={modalRef}>
       <ModalHeader>{title || 'Confirm?'}</ModalHeader>
       <ModalBody className="wide pad">
         <p>{message}</p>

--- a/packages/insomnia/src/ui/css/components/modal.less
+++ b/packages/insomnia/src/ui/css/components/modal.less
@@ -100,10 +100,6 @@
     }
   }
 
-  &.modal--noescape .modal__close-btn {
-    display: none;
-  }
-
   .modal__body {
     overflow: auto;
     min-height: 2rem;

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -273,7 +273,6 @@ const OrganizationProjectsSidebar: FC<{
               showPrompt({
                 title: `Create New ${strings.project.singular}`,
                 submitName: 'Create',
-                cancelable: true,
                 placeholder: defaultValue,
                 defaultValue,
                 selectText: true,
@@ -572,7 +571,6 @@ const ProjectRoute: FC = () => {
     showPrompt({
       title: 'Create New Request Collection',
       submitName: 'Create',
-      cancelable: true,
       placeholder: 'My Collection',
       defaultValue: 'My Collection',
       selectText: true,
@@ -595,7 +593,6 @@ const ProjectRoute: FC = () => {
     showPrompt({
       title: 'Create New Design Document',
       submitName: 'Create',
-      cancelable: true,
       placeholder: 'my-spec.yaml',
       defaultValue: 'my-spec.yaml',
       selectText: true,
@@ -619,7 +616,6 @@ const ProjectRoute: FC = () => {
       title: 'Import document from URL',
       submitName: 'Fetch and Import',
       label: 'URL',
-      cancelable: true,
       placeholder: 'https://website.com/insomnia-import.json',
       onComplete: uri => {
         importUri(uri, {


### PR DESCRIPTION
changelog(Fixes): Fixed an issue that prevented users from closing modals when importing collections leaving the user unable to undo an import by mistake other than continuing with the import

Closes INS-2153


Closes #5411
Closes #5333 
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
