### PR TITLE
fix response pane flash

### DIFF
--- a/packages/insomnia/src/common/har.ts
+++ b/packages/insomnia/src/common/har.ts
@@ -485,9 +485,8 @@ function getResponseContent(response: Response) {
   if (body === null) {
     body = Buffer.alloc(0);
   }
-
   const harContent: HarContent = {
-    size: body.byteLength,
+    size: Buffer.byteLength(body),
     mimeType: response.contentType,
     text: body.toString('utf8'),
   };

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -229,7 +229,6 @@ export const getBodyBuffer = (
   }
   try {
     const rawBuffer = fs.readFileSync(response?.bodyPath);
-    console.log(`[response] Read body ${rawBuffer}`);
     if (response?.bodyCompression === 'zip') {
       return zlib.gunzipSync(rawBuffer);
     } else {

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -199,26 +199,51 @@ export function getLatestByParentId(parentId: string) {
   });
 }
 
-export function getBodyStream<T extends Response, TFail extends Readable>(
-  response: T,
-  readFailureValue?: TFail | null,
-) {
-  return getBodyStreamFromPath(response.bodyPath || '', response.bodyCompression, readFailureValue);
-}
-
-export const getBodyBuffer = <TFail = null>(
+export const getBodyStream = (
   response?: { bodyPath?: string; bodyCompression?: Compression },
-  readFailureValue?: TFail | null,
-) => getBodyBufferFromPath(
-    response?.bodyPath || '',
-    response?.bodyCompression || null,
-    readFailureValue,
-  );
+  readFailureValue?: string,
+): Readable | string | null => {
+  if (!response?.bodyPath) {
+    return null;
+  }
+  try {
+    fs.statSync(response?.bodyPath);
+  } catch (err) {
+    console.warn('Failed to read response body', err.message);
+    return readFailureValue === undefined ? null : readFailureValue;
+  }
+  if (response?.bodyCompression === 'zip') {
+    return fs.createReadStream(response?.bodyPath).pipe(zlib.createGunzip());
+  } else {
+    return fs.createReadStream(response?.bodyPath);
+  }
+};
+
+export const getBodyBuffer = (
+  response?: { bodyPath?: string; bodyCompression?: Compression },
+  readFailureValue?: string,
+): Buffer | string | null => {
+  if (!response?.bodyPath) {
+    // No body, so return empty Buffer
+    return Buffer.alloc(0);
+  }
+  try {
+    const rawBuffer = fs.readFileSync(response?.bodyPath);
+    console.log(`[response] Read body ${rawBuffer}`);
+    if (response?.bodyCompression === 'zip') {
+      return zlib.gunzipSync(rawBuffer);
+    } else {
+      return rawBuffer;
+    }
+  } catch (err) {
+    console.warn('Failed to read response body', err.message);
+    return readFailureValue === undefined ? null : readFailureValue;
+  }
+};
 
 export function getTimeline(response: Response, showBody?: boolean) {
   const { timelinePath, bodyPath } = response;
 
-  // No body, so return empty Buffer
   if (!timelinePath) {
     return [];
   }
@@ -239,56 +264,6 @@ export function getTimeline(response: Response, showBody?: boolean) {
   } catch (err) {
     console.warn('Failed to read response body', err.message);
     return [];
-  }
-}
-
-function getBodyStreamFromPath<TFail extends Readable>(
-  bodyPath: string,
-  compression: Compression,
-  readFailureValue?: TFail | null,
-): Readable | null | TFail {
-  // No body, so return empty Buffer
-  if (!bodyPath) {
-    return null;
-  }
-
-  try {
-    fs.statSync(bodyPath);
-  } catch (err) {
-    console.warn('Failed to read response body', err.message);
-    return readFailureValue === undefined ? null : readFailureValue;
-  }
-
-  const readStream = fs.createReadStream(bodyPath);
-
-  if (compression === 'zip') {
-    return readStream.pipe(zlib.createGunzip());
-  } else {
-    return readStream;
-  }
-}
-
-function getBodyBufferFromPath<T>(
-  bodyPath: string,
-  compression: Compression,
-  readFailureValue?: T | null,
-) {
-  // No body, so return empty Buffer
-  if (!bodyPath) {
-    return Buffer.alloc(0);
-  }
-
-  try {
-    const rawBuffer = fs.readFileSync(bodyPath);
-
-    if (compression === 'zip') {
-      return zlib.gunzipSync(rawBuffer);
-    } else {
-      return rawBuffer;
-    }
-  } catch (err) {
-    console.warn('Failed to read response body', err.message);
-    return readFailureValue === undefined ? null : readFailureValue;
   }
 }
 

--- a/packages/insomnia/src/plugins/context/response.ts
+++ b/packages/insomnia/src/plugins/context/response.ts
@@ -52,7 +52,6 @@ export function init(response?: MaybeResponse) {
       },
 
       getBodyStream() {
-        // @ts-expect-error -- TSCONVERSION
         return models.response.getBodyStream(response);
       },
 

--- a/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
@@ -84,7 +84,7 @@ export const PreviewModeDropdown: FC<Props> = ({
     }
     const readStream = models.response.getBodyStream(response);
 
-    if (readStream && filePath) {
+    if (readStream && filePath && typeof readStream !== 'string') {
       const to = fs.createWriteStream(filePath);
       to.write(headers);
       readStream.pipe(to);

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -94,7 +94,7 @@ export const ResponsePane: FC<Props> = ({
     const readStream = models.response.getBodyStream(response);
     const dataBuffers: any[] = [];
 
-    if (readStream && outputPath) {
+    if (readStream && outputPath && typeof readStream !== 'string') {
       readStream.on('data', data => {
         dataBuffers.push(data);
       });

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -136,10 +136,9 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
         }
 
         const to = fs.createWriteStream(filename);
-        // @ts-expect-error -- TSCONVERSION
         const readStream = models.response.getBodyStream(responsePatch);
 
-        if (!readStream) {
+        if (!readStream || typeof readStream === 'string') {
           return;
         }
 

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -54,7 +54,7 @@ export const Debug: FC = () => {
     invariant(activeRequest, 'No active request');
     setRunningRequests({
       ...runningRequests,
-      [activeRequest._id]: isLoading ? Date.now() : 0,
+      [activeRequest._id]: isLoading ? true : false,
     });
   };
 


### PR DESCRIPTION
changelog(Fixes): Fixed an issue that caused the response pane to sometimes flash for a brief moment

removes some indirection caused by generics and function chaining, ensured error cases and typed and handled by callers.
I chose to infer stream type using typeof body === 'string'
open to suggestions to a better approach, or removal of the optional error argument.
also simplify response viewer
closes INS-2165

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
