### PR TITLE
add keywords to desktop entry

### DIFF
--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -106,6 +106,7 @@ const config = {
       Name: 'Insomnia',
       Comment: 'Insomnia is a cross-platform REST client, built on top of Electron.',
       Categories: 'Development',
+      Keywords: 'GraphQL;REST;gRPC;SOAP;openAPI;GitOps;'
     },
     target: [
       {

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -106,7 +106,7 @@ const config = {
       Name: 'Insomnia',
       Comment: 'Insomnia is a cross-platform REST client, built on top of Electron.',
       Categories: 'Development',
-      Keywords: 'GraphQL;REST;gRPC;SOAP;openAPI;GitOps;'
+      Keywords: 'GraphQL;REST;gRPC;SOAP;openAPI;GitOps;',
     },
     target: [
       {


### PR DESCRIPTION
Closes https://github.com/Kong/insomnia/discussions/5452

changelog(Fixes): Added missing keywords to `.desktop` entry for Linux builds of Insomnia