### PR TITLE
Add support for OpenAPI v3.1

### DIFF
--- a/packages/insomnia/package-lock.json
+++ b/packages/insomnia/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@apideck/better-ajv-errors": "^0.2.6",
-				"@apidevtools/swagger-parser": "10.0.2",
+				"@apidevtools/swagger-parser": "10.1.0",
 				"@getinsomnia/node-libcurl": "2.3.5-6",
 				"@grpc/grpc-js": "^1.1.8",
 				"@grpc/proto-loader": "^0.5.5",
@@ -189,6 +189,7 @@
 			"version": "9.0.9",
 			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
 			"integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+			"dev": true,
 			"dependencies": {
 				"@jsdevtools/ono": "^7.1.3",
 				"@types/json-schema": "^7.0.6",
@@ -199,12 +200,14 @@
 		"node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
 		},
 		"node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -226,19 +229,30 @@
 			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
 		},
 		"node_modules/@apidevtools/swagger-parser": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
-			"integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.0.tgz",
+			"integrity": "sha512-9Kt7EuS/7WbMAUv2gSziqjvxwDbFSg3Xeyfuj5laUODX8o/k/CpsAKiQ8W7/R88eXFTMbJYg6+7uAmOWNKmwnw==",
 			"dependencies": {
-				"@apidevtools/json-schema-ref-parser": "^9.0.6",
-				"@apidevtools/openapi-schemas": "^2.0.4",
+				"@apidevtools/json-schema-ref-parser": "9.0.6",
+				"@apidevtools/openapi-schemas": "^2.1.0",
 				"@apidevtools/swagger-methods": "^3.0.2",
 				"@jsdevtools/ono": "^7.1.3",
-				"call-me-maybe": "^1.0.1",
-				"z-schema": "^4.2.3"
+				"ajv": "^8.6.3",
+				"ajv-draft-04": "^1.0.0",
+				"call-me-maybe": "^1.0.1"
 			},
 			"peerDependencies": {
 				"openapi-types": ">=7"
+			}
+		},
+		"node_modules/@apidevtools/swagger-parser/node_modules/@apidevtools/json-schema-ref-parser": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+			"integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
+			"dependencies": {
+				"@jsdevtools/ono": "^7.1.3",
+				"call-me-maybe": "^1.0.1",
+				"js-yaml": "^3.13.1"
 			}
 		},
 		"node_modules/@asyncapi/specs": {
@@ -5358,19 +5372,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@stoplight/spectral-functions/node_modules/ajv-draft-04": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-			"peerDependencies": {
-				"ajv": "^8.5.0"
-			},
-			"peerDependenciesMeta": {
-				"ajv": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@stoplight/spectral-functions/node_modules/ajv-errors": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
@@ -6752,6 +6753,19 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-draft-04": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+			"peerDependencies": {
+				"ajv": "^8.5.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/ajv-formats": {
@@ -21580,6 +21594,7 @@
 			"version": "9.0.9",
 			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
 			"integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+			"dev": true,
 			"requires": {
 				"@jsdevtools/ono": "^7.1.3",
 				"@types/json-schema": "^7.0.6",
@@ -21590,12 +21605,14 @@
 				"argparse": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
 				},
 				"js-yaml": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"dev": true,
 					"requires": {
 						"argparse": "^2.0.1"
 					}
@@ -21613,16 +21630,29 @@
 			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
 		},
 		"@apidevtools/swagger-parser": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
-			"integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.0.tgz",
+			"integrity": "sha512-9Kt7EuS/7WbMAUv2gSziqjvxwDbFSg3Xeyfuj5laUODX8o/k/CpsAKiQ8W7/R88eXFTMbJYg6+7uAmOWNKmwnw==",
 			"requires": {
-				"@apidevtools/json-schema-ref-parser": "^9.0.6",
-				"@apidevtools/openapi-schemas": "^2.0.4",
+				"@apidevtools/json-schema-ref-parser": "9.0.6",
+				"@apidevtools/openapi-schemas": "^2.1.0",
 				"@apidevtools/swagger-methods": "^3.0.2",
 				"@jsdevtools/ono": "^7.1.3",
-				"call-me-maybe": "^1.0.1",
-				"z-schema": "^4.2.3"
+				"ajv": "^8.6.3",
+				"ajv-draft-04": "^1.0.0",
+				"call-me-maybe": "^1.0.1"
+			},
+			"dependencies": {
+				"@apidevtools/json-schema-ref-parser": {
+					"version": "9.0.6",
+					"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+					"integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
+					"requires": {
+						"@jsdevtools/ono": "^7.1.3",
+						"call-me-maybe": "^1.0.1",
+						"js-yaml": "^3.13.1"
+					}
+				}
 			}
 		},
 		"@asyncapi/specs": {
@@ -25739,12 +25769,6 @@
 						"utility-types": "^3.10.0"
 					}
 				},
-				"ajv-draft-04": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-					"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-					"requires": {}
-				},
 				"ajv-errors": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
@@ -26951,6 +26975,12 @@
 				"require-from-string": "^2.0.2",
 				"uri-js": "^4.2.2"
 			}
+		},
+		"ajv-draft-04": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+			"requires": {}
 		},
 		"ajv-formats": {
 			"version": "2.1.1",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -52,7 +52,7 @@
     "@stoplight/spectral-formats": "^1.2.0",
     "@stoplight/spectral-rulesets": "^1.9.0",
     "@apideck/better-ajv-errors": "^0.2.6",
-    "@apidevtools/swagger-parser": "10.0.2",
+    "@apidevtools/swagger-parser": "10.1.0",
     "apiconnect-wsdl": "^1.8.31",
     "change-case": "^4.1.1",
     "ajv": "^8.6.2",

--- a/packages/openapi-2-kong/package-lock.json
+++ b/packages/openapi-2-kong/package-lock.json
@@ -9,9 +9,9 @@
 			"version": "3.6.1-beta.4",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@apidevtools/swagger-parser": "10.1.0",
 				"openapi-types": "^8.0.0",
 				"slugify": "1.6.5",
-				"swagger-parser": "^10.0.3",
 				"url-join": "^4.0.1",
 				"yaml": "2.0.0-5"
 			},
@@ -37,30 +37,13 @@
 			}
 		},
 		"node_modules/@apidevtools/json-schema-ref-parser": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-			"integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+			"integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
 			"dependencies": {
 				"@jsdevtools/ono": "^7.1.3",
-				"@types/json-schema": "^7.0.6",
 				"call-me-maybe": "^1.0.1",
-				"js-yaml": "^4.1.0"
-			}
-		},
-		"node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-		},
-		"node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
+				"js-yaml": "^3.13.1"
 			}
 		},
 		"node_modules/@apidevtools/openapi-schemas": {
@@ -77,16 +60,17 @@
 			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
 		},
 		"node_modules/@apidevtools/swagger-parser": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-			"integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.0.tgz",
+			"integrity": "sha512-9Kt7EuS/7WbMAUv2gSziqjvxwDbFSg3Xeyfuj5laUODX8o/k/CpsAKiQ8W7/R88eXFTMbJYg6+7uAmOWNKmwnw==",
 			"dependencies": {
-				"@apidevtools/json-schema-ref-parser": "^9.0.6",
-				"@apidevtools/openapi-schemas": "^2.0.4",
+				"@apidevtools/json-schema-ref-parser": "9.0.6",
+				"@apidevtools/openapi-schemas": "^2.1.0",
 				"@apidevtools/swagger-methods": "^3.0.2",
 				"@jsdevtools/ono": "^7.1.3",
-				"call-me-maybe": "^1.0.1",
-				"z-schema": "^5.0.1"
+				"ajv": "^8.6.3",
+				"ajv-draft-04": "^1.0.0",
+				"call-me-maybe": "^1.0.1"
 			},
 			"peerDependencies": {
 				"openapi-types": ">=7"
@@ -1086,11 +1070,6 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
-		"node_modules/@types/json-schema": {
-			"version": "7.0.11",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
-		},
 		"node_modules/@types/node": {
 			"version": "18.0.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
@@ -1139,6 +1118,34 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
 			"integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
 			"dev": true
+		},
+		"node_modules/ajv": {
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+			"integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-draft-04": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+			"peerDependencies": {
+				"ajv": "^8.5.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
@@ -1208,7 +1215,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -1376,9 +1382,9 @@
 			"dev": true
 		},
 		"node_modules/call-me-maybe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha512-wCyFsDQkKPwwF8BDwOiWNx/9K45L/hvggQiDbve+viMNMQnWhrlYIuBk09offfwCRtCO9P6XwUttufzU11WCVw=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
 		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
@@ -1495,12 +1501,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
-		},
-		"node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"optional": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -1636,7 +1636,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true,
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -1692,6 +1691,11 @@
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
 			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -2622,7 +2626,6 @@
 			"version": "3.14.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
 			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"dev": true,
 			"dependencies": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -2648,6 +2651,11 @@
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"node_modules/json5": {
 			"version": "2.2.1",
@@ -2696,16 +2704,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-		},
-		"node_modules/lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
@@ -3023,6 +3021,14 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/react-is": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -3034,6 +3040,14 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
 			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3187,8 +3201,7 @@
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-			"dev": true
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
 		},
 		"node_modules/stack-utils": {
 			"version": "2.0.5",
@@ -3308,17 +3321,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/swagger-parser": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-			"integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
-			"dependencies": {
-				"@apidevtools/swagger-parser": "10.0.3"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/terminal-link": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -3429,6 +3431,14 @@
 				"browserslist": ">= 4.21.0"
 			}
 		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
 		"node_modules/url-join": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -3446,14 +3456,6 @@
 			},
 			"engines": {
 				"node": ">=10.12.0"
-			}
-		},
-		"node_modules/validator": {
-			"version": "13.7.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-			"integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
-			"engines": {
-				"node": ">= 0.10"
 			}
 		},
 		"node_modules/walker": {
@@ -3565,25 +3567,6 @@
 			"engines": {
 				"node": ">=12"
 			}
-		},
-		"node_modules/z-schema": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.3.tgz",
-			"integrity": "sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==",
-			"dependencies": {
-				"lodash.get": "^4.4.2",
-				"lodash.isequal": "^4.5.0",
-				"validator": "^13.7.0"
-			},
-			"bin": {
-				"z-schema": "bin/z-schema"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"optionalDependencies": {
-				"commander": "^2.20.3"
-			}
 		}
 	},
 	"dependencies": {
@@ -3598,29 +3581,13 @@
 			}
 		},
 		"@apidevtools/json-schema-ref-parser": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-			"integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+			"integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
 			"requires": {
 				"@jsdevtools/ono": "^7.1.3",
-				"@types/json-schema": "^7.0.6",
 				"call-me-maybe": "^1.0.1",
-				"js-yaml": "^4.1.0"
-			},
-			"dependencies": {
-				"argparse": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-				},
-				"js-yaml": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-					"requires": {
-						"argparse": "^2.0.1"
-					}
-				}
+				"js-yaml": "^3.13.1"
 			}
 		},
 		"@apidevtools/openapi-schemas": {
@@ -3634,16 +3601,17 @@
 			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
 		},
 		"@apidevtools/swagger-parser": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-			"integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.0.tgz",
+			"integrity": "sha512-9Kt7EuS/7WbMAUv2gSziqjvxwDbFSg3Xeyfuj5laUODX8o/k/CpsAKiQ8W7/R88eXFTMbJYg6+7uAmOWNKmwnw==",
 			"requires": {
-				"@apidevtools/json-schema-ref-parser": "^9.0.6",
-				"@apidevtools/openapi-schemas": "^2.0.4",
+				"@apidevtools/json-schema-ref-parser": "9.0.6",
+				"@apidevtools/openapi-schemas": "^2.1.0",
 				"@apidevtools/swagger-methods": "^3.0.2",
 				"@jsdevtools/ono": "^7.1.3",
-				"call-me-maybe": "^1.0.1",
-				"z-schema": "^5.0.1"
+				"ajv": "^8.6.3",
+				"ajv-draft-04": "^1.0.0",
+				"call-me-maybe": "^1.0.1"
 			}
 		},
 		"@babel/code-frame": {
@@ -4435,11 +4403,6 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
-		"@types/json-schema": {
-			"version": "7.0.11",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
-		},
 		"@types/node": {
 			"version": "18.0.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
@@ -4488,6 +4451,23 @@
 			"integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
 			"dev": true
 		},
+		"ajv": {
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+			"integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+			"requires": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ajv-draft-04": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+			"integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+			"requires": {}
+		},
 		"ansi-escapes": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -4534,7 +4514,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -4662,9 +4641,9 @@
 			"dev": true
 		},
 		"call-me-maybe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha512-wCyFsDQkKPwwF8BDwOiWNx/9K45L/hvggQiDbve+viMNMQnWhrlYIuBk09offfwCRtCO9P6XwUttufzU11WCVw=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
 		},
 		"callsites": {
 			"version": "3.1.0",
@@ -4749,12 +4728,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
-		},
-		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"optional": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -4857,8 +4830,7 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"execa": {
 			"version": "5.1.1",
@@ -4895,6 +4867,11 @@
 				"jest-message-util": "^28.1.1",
 				"jest-util": "^28.1.1"
 			}
+		},
+		"fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -5601,7 +5578,6 @@
 			"version": "3.14.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
 			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -5618,6 +5594,11 @@
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"json5": {
 			"version": "2.2.1",
@@ -5651,16 +5632,6 @@
 			"requires": {
 				"p-locate": "^4.1.0"
 			}
-		},
-		"lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
 		},
 		"lru-cache": {
 			"version": "6.0.0",
@@ -5899,6 +5870,11 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+		},
 		"react-is": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -5910,6 +5886,11 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
 			"dev": true
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"resolve": {
 			"version": "1.22.1",
@@ -6021,8 +6002,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-			"dev": true
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
 		},
 		"stack-utils": {
 			"version": "2.0.5",
@@ -6106,14 +6086,6 @@
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
 			"dev": true
 		},
-		"swagger-parser": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-			"integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
-			"requires": {
-				"@apidevtools/swagger-parser": "10.0.3"
-			}
-		},
 		"terminal-link": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -6184,6 +6156,14 @@
 				"picocolors": "^1.0.0"
 			}
 		},
+		"uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
 		"url-join": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -6199,11 +6179,6 @@
 				"@types/istanbul-lib-coverage": "^2.0.1",
 				"convert-source-map": "^1.6.0"
 			}
-		},
-		"validator": {
-			"version": "13.7.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-			"integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
 		},
 		"walker": {
 			"version": "1.0.8",
@@ -6287,17 +6262,6 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
 			"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
 			"dev": true
-		},
-		"z-schema": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.3.tgz",
-			"integrity": "sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==",
-			"requires": {
-				"commander": "^2.20.3",
-				"lodash.get": "^4.4.2",
-				"lodash.isequal": "^4.5.0",
-				"validator": "^13.7.0"
-			}
 		}
 	}
 }

--- a/packages/openapi-2-kong/package.json
+++ b/packages/openapi-2-kong/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "openapi-types": "^8.0.0",
     "slugify": "1.6.5",
-    "swagger-parser": "^10.0.3",
+    "@apidevtools/swagger-parser": "10.1.0",
     "url-join": "^4.0.1",
     "yaml": "2.0.0-5"
   },


### PR DESCRIPTION
changelog(Improvements): Added support for OpenAPI v3.1 specifications

Adds support for OpenAPI v3.1 specs. Closes #4732

Note: previews won't work - that's one argument in favour of #5457 - as they are dependant on swagger-ui which hasn't added support for it yet.

Basic stuff seems to work (e.g. importing a spec, generating requests from it, ...)

Can be merged after #5457 and #5458


<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
