### PR TITLE
[INS-2174] fixes create new plugin issue

### DIFF
--- a/packages/insomnia/src/plugins/create.ts
+++ b/packages/insomnia/src/plugins/create.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
-import rimraf from 'rimraf';
 
 import { getDataDirectory } from '../common/electron-helpers';
 
@@ -16,7 +15,6 @@ export async function createPlugin(
     throw new Error(`Plugin already exists at "${pluginDir}"`);
   }
 
-  rimraf.sync(pluginDir);
   mkdirp.sync(pluginDir);
   // Write package.json
   fs.writeFileSync(

--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -240,6 +240,7 @@ export const Plugins: FC<Props> = ({ settings }) => {
                   ].join('\n'),
                 );
               } catch (err) {
+                console.error(err);
                 showAlert({
                   title: 'Failed to Create Plugin',
                   message: err.message,


### PR DESCRIPTION
changelog(Fixes): Fixed an error that showed up when attempting to create a new plugin from the plugin preferences menu
Closes INS-2174

Solves a case where folks will get an error when trying to create a new plugin:
![Screenshot 2022-11-30 at 17 23 57](https://user-images.githubusercontent.com/11976836/204870397-8b9bca39-2600-4039-82ad-20c90388226a.jpg)
