### PR TITLE
Fix Mac M1 bootstrap build

### DIFF
--- a/packages/insomnia/package-lock.json
+++ b/packages/insomnia/package-lock.json
@@ -32,7 +32,7 @@
 				"electron-context-menu": "^3.1.1",
 				"electron-log": "^4.4.3",
 				"fs-extra": "^5.0.0",
-				"grpc-reflection-js": "github:Kong/grpc-reflection-js#6658e40",
+				"grpc-reflection-js": "github:Kong/grpc-reflection-js#355c24c",
 				"hawk": "9.0.1",
 				"hkdf": "^0.0.2",
 				"html-entities": "^1.2.0",
@@ -12050,15 +12050,15 @@
 			}
 		},
 		"node_modules/grpc-reflection-js": {
-			"version": "0.1.2",
-			"resolved": "git+ssh://git@github.com/Kong/grpc-reflection-js.git#70308fe318b25b11cab080d90915aa0a20a83bfe",
+			"version": "0.1.2-kongfix",
+			"resolved": "git+ssh://git@github.com/Kong/grpc-reflection-js.git#355c24cd062dcc9531f8dd702f04df4ac9a7180c",
 			"license": "MIT",
 			"dependencies": {
 				"@types/google-protobuf": "^3.7.2",
 				"@types/lodash.set": "^4.3.6",
 				"google-protobuf": "^3.12.2",
 				"lodash.set": "^4.3.2",
-				"protobufjs": "github:Kong/protobuf.js#master"
+				"protobufjs": "github:Kong/protobuf.js#eca9f0f"
 			},
 			"peerDependencies": {
 				"@grpc/grpc-js": "^1.0.0"
@@ -30934,8 +30934,8 @@
 			"requires": {}
 		},
 		"grpc-reflection-js": {
-			"version": "git+ssh://git@github.com/Kong/grpc-reflection-js.git#70308fe318b25b11cab080d90915aa0a20a83bfe",
-			"from": "grpc-reflection-js@github:Kong/grpc-reflection-js#6658e40",
+			"version": "git+ssh://git@github.com/Kong/grpc-reflection-js.git#355c24cd062dcc9531f8dd702f04df4ac9a7180c",
+			"from": "grpc-reflection-js@github:Kong/grpc-reflection-js#355c24c",
 			"requires": {
 				"@types/google-protobuf": "^3.7.2",
 				"@types/lodash.set": "^4.3.6",

--- a/packages/insomnia/package-lock.json
+++ b/packages/insomnia/package-lock.json
@@ -32,7 +32,7 @@
 				"electron-context-menu": "^3.1.1",
 				"electron-log": "^4.4.3",
 				"fs-extra": "^5.0.0",
-				"grpc-reflection-js": "0.1.2",
+				"grpc-reflection-js": "github:Kong/grpc-reflection-js#6658e40",
 				"hawk": "9.0.1",
 				"hkdf": "^0.0.2",
 				"html-entities": "^1.2.0",
@@ -12051,14 +12051,14 @@
 		},
 		"node_modules/grpc-reflection-js": {
 			"version": "0.1.2",
-			"resolved": "git+ssh://git@github.com/jackkav/grpc-reflection-js.git#b2b2cd8094de7451e773a2848a333c9d7c083161",
+			"resolved": "git+ssh://git@github.com/Kong/grpc-reflection-js.git#70308fe318b25b11cab080d90915aa0a20a83bfe",
 			"license": "MIT",
 			"dependencies": {
 				"@types/google-protobuf": "^3.7.2",
 				"@types/lodash.set": "^4.3.6",
 				"google-protobuf": "^3.12.2",
 				"lodash.set": "^4.3.2",
-				"protobufjs": "7.1.2"
+				"protobufjs": "github:Kong/protobuf.js#master"
 			},
 			"peerDependencies": {
 				"@grpc/grpc-js": "^1.0.0"
@@ -22877,7 +22877,7 @@
 				"@types/long": "^4.0.1",
 				"lodash.camelcase": "^4.3.0",
 				"long": "^4.0.0",
-				"protobufjs": "github:Kong/protobuf.js#master",
+				"protobufjs": "github:Kong/protobuf.js#eca9f0f",
 				"yargs": "^16.2.0"
 			}
 		},
@@ -30934,14 +30934,14 @@
 			"requires": {}
 		},
 		"grpc-reflection-js": {
-			"version": "git+ssh://git@github.com/jackkav/grpc-reflection-js.git#b2b2cd8094de7451e773a2848a333c9d7c083161",
-			"from": "grpc-reflection-js@0.1.2",
+			"version": "git+ssh://git@github.com/Kong/grpc-reflection-js.git#70308fe318b25b11cab080d90915aa0a20a83bfe",
+			"from": "grpc-reflection-js@github:Kong/grpc-reflection-js#6658e40",
 			"requires": {
 				"@types/google-protobuf": "^3.7.2",
 				"@types/lodash.set": "^4.3.6",
 				"google-protobuf": "^3.12.2",
 				"lodash.set": "^4.3.2",
-				"protobufjs": "github:Kong/protobuf.js#master"
+				"protobufjs": "github:Kong/protobuf.js#eca9f0f"
 			}
 		},
 		"har-schema": {
@@ -35688,7 +35688,7 @@
 		},
 		"protobufjs": {
 			"version": "git+ssh://git@github.com/Kong/protobuf.js.git#eca9f0fcfc816460d5fe899c160e1462c2edf49b",
-			"from": "protobufjs@github:Kong/protobuf.js#master",
+			"from": "protobufjs@github:Kong/protobuf.js#eca9f0f",
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -66,7 +66,7 @@
     "electron-context-menu": "^3.1.1",
     "electron-log": "^4.4.3",
     "fs-extra": "^5.0.0",
-    "grpc-reflection-js": "github:Kong/grpc-reflection-js#6658e40",
+    "grpc-reflection-js": "github:Kong/grpc-reflection-js#355c24c",
     "hawk": "9.0.1",
     "hkdf": "^0.0.2",
     "html-entities": "^1.2.0",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -66,7 +66,7 @@
     "electron-context-menu": "^3.1.1",
     "electron-log": "^4.4.3",
     "fs-extra": "^5.0.0",
-    "grpc-reflection-js": "0.1.2",
+    "grpc-reflection-js": "github:Kong/grpc-reflection-js#6658e40",
     "hawk": "9.0.1",
     "hkdf": "^0.0.2",
     "html-entities": "^1.2.0",
@@ -215,6 +215,6 @@
     "dev-server-port": 3334
   },
   "overrides": {
-    "protobufjs": "github:Kong/protobuf.js#master"
+    "protobufjs": "github:Kong/protobuf.js#eca9f0f"
   }
 }


### PR DESCRIPTION
changelog(Fixes): Fixed an issue that prevented local developer compilation of Insomnia on Mac Apple Silicon and on Alpine Linux

This pr fixes bootstrap build for Mac M1/M2 - using [updated grpc-reflection-js](https://github.com/kong/grpc-reflection-js)