### PR TITLE
Fix #5531 bump snapcraft base to core22

### DIFF
--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -126,6 +126,10 @@ const config = {
       },
     ],
   },
+  snap: {
+    base: 'core22',
+  },
+  npmRebuild: false,
 };
 
 const { env: { BUILD_TARGETS }, platform } = process;

--- a/packages/insomnia/package-lock.json
+++ b/packages/insomnia/package-lock.json
@@ -114,8 +114,8 @@
 				"date-fns": "^2.28.0",
 				"deep-equal": "^1.0.1",
 				"electron": "22.0.0",
-				"electron-builder": "23.0.7",
-				"electron-builder-squirrel-windows": "23.0.7",
+				"electron-builder": "23.6.0",
+				"electron-builder-squirrel-windows": "23.6.0",
 				"electron-devtools-installer": "^3.2.0",
 				"electron-notarize": "^1.1.1",
 				"esbuild": "^0.15.13",
@@ -1020,6 +1020,36 @@
 			"integrity": "sha512-Dh6N0yhDHfkOoGwKH5TpuOY5kaMDWPB7rmtXfa40OVsgfF+MMv+rOky71UQTecJDVqe4qqS7VBBIDD3qbuiDPg==",
 			"dev": true
 		},
+		"node_modules/@electron/asar": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.2.tgz",
+			"integrity": "sha512-32fMU68x8a6zvxtC1IC/BhPDKTh8rQjdmwEplj3CDpnkcwBzZVN9v/8cK0LJqQ0FOQQVZW8BWZ1S6UU53TYR4w==",
+			"dev": true,
+			"dependencies": {
+				"chromium-pickle-js": "^0.2.0",
+				"commander": "^5.0.0",
+				"glob": "^7.1.6",
+				"minimatch": "^3.0.4"
+			},
+			"bin": {
+				"asar": "bin/asar.js"
+			},
+			"engines": {
+				"node": ">=10.12.0"
+			},
+			"optionalDependencies": {
+				"@types/glob": "^7.1.1"
+			}
+		},
+		"node_modules/@electron/asar/node_modules/commander": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/@electron/get": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.2.tgz",
@@ -1041,57 +1071,6 @@
 				"global-agent": "^3.0.0"
 			}
 		},
-		"node_modules/@electron/get/node_modules/@sindresorhus/is": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/is?sponsor=1"
-			}
-		},
-		"node_modules/@electron/get/node_modules/@szmarczak/http-timer": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-			"dev": true,
-			"dependencies": {
-				"defer-to-connect": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@electron/get/node_modules/cacheable-request": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
-			"dev": true,
-			"dependencies": {
-				"clone-response": "^1.0.2",
-				"get-stream": "^5.1.0",
-				"http-cache-semantics": "^4.0.0",
-				"keyv": "^4.0.0",
-				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^6.0.1",
-				"responselike": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@electron/get/node_modules/defer-to-connect": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@electron/get/node_modules/fs-extra": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -1104,21 +1083,6 @@
 			},
 			"engines": {
 				"node": ">=6 <7 || >=8"
-			}
-		},
-		"node_modules/@electron/get/node_modules/get-stream": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-			"dev": true,
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@electron/get/node_modules/got": {
@@ -1146,12 +1110,6 @@
 				"url": "https://github.com/sindresorhus/got?sponsor=1"
 			}
 		},
-		"node_modules/@electron/get/node_modules/json-buffer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"dev": true
-		},
 		"node_modules/@electron/get/node_modules/jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -1159,45 +1117,6 @@
 			"dev": true,
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/@electron/get/node_modules/keyv": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-			"integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
-			"dev": true,
-			"dependencies": {
-				"json-buffer": "3.0.1"
-			}
-		},
-		"node_modules/@electron/get/node_modules/lowercase-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@electron/get/node_modules/p-cancelable": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@electron/get/node_modules/responselike": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-			"dev": true,
-			"dependencies": {
-				"lowercase-keys": "^2.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@electron/get/node_modules/semver": {
@@ -1218,22 +1137,671 @@
 				"node": ">= 4.0.0"
 			}
 		},
-		"node_modules/@electron/universal": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.1.tgz",
-			"integrity": "sha512-7323HyMh7KBAl/nPDppdLsC87G6RwRU02dy5FPeGB1eS7rUePh55+WNWiDPLhFQqqVPHzh77M69uhmoT8XnwMQ==",
+		"node_modules/@electron/notarize": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-1.2.3.tgz",
+			"integrity": "sha512-9oRzT56rKh5bspk3KpAVF8lPKHYQrBnRwcgiOeR0hdilVEQmszDaAu0IPCPrwwzJN0ugNs0rRboTreHMt/6mBQ==",
 			"dev": true,
 			"dependencies": {
+				"debug": "^4.1.1",
+				"fs-extra": "^9.0.1"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@electron/notarize/node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@electron/notarize/node_modules/universalify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@electron/osx-sign": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.0.4.tgz",
+			"integrity": "sha512-xfhdEcIOfAZg7scZ9RQPya1G1lWo8/zMCwUXAulq0SfY7ONIW+b9qGyKdMyuMctNYwllrIS+vmxfijSfjeh97g==",
+			"dev": true,
+			"dependencies": {
+				"compare-version": "^0.1.2",
+				"debug": "^4.3.4",
+				"fs-extra": "^10.0.0",
+				"isbinaryfile": "^4.0.8",
+				"minimist": "^1.2.6",
+				"plist": "^3.0.5"
+			},
+			"bin": {
+				"electron-osx-flat": "bin/electron-osx-flat.js",
+				"electron-osx-sign": "bin/electron-osx-sign.js"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@electron/osx-sign/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+			"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/gjtorikian/"
+			}
+		},
+		"node_modules/@electron/osx-sign/node_modules/universalify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild": {
+			"version": "3.2.10",
+			"resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.2.10.tgz",
+			"integrity": "sha512-SUBM6Mwi3yZaDFQjZzfGKpYTtOp9m60glounwX6tfGeVc/ZOl4jbquktUcyy7gYSLDWFLtKkftkY2xgMJZLQgg==",
+			"dev": true,
+			"dependencies": {
+				"@malept/cross-spawn-promise": "^2.0.0",
+				"chalk": "^4.0.0",
+				"debug": "^4.1.1",
+				"detect-libc": "^2.0.1",
+				"fs-extra": "^10.0.0",
+				"got": "^11.7.0",
+				"lzma-native": "^8.0.5",
+				"node-abi": "^3.0.0",
+				"node-api-version": "^0.1.4",
+				"node-gyp": "^9.0.0",
+				"ora": "^5.1.0",
+				"semver": "^7.3.5",
+				"tar": "^6.0.5",
+				"yargs": "^17.0.1"
+			},
+			"bin": {
+				"electron-rebuild": "lib/src/cli.js"
+			},
+			"engines": {
+				"node": ">=12.13.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/@npmcli/fs": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+			"integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+			"dev": true,
+			"dependencies": {
+				"@gar/promisify": "^1.1.3",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/@npmcli/move-file": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+			"integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+			"deprecated": "This functionality has been moved to @npmcli/fs",
+			"dev": true,
+			"dependencies": {
+				"mkdirp": "^1.0.4",
+				"rimraf": "^3.0.2"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/@tootallnate/once": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/are-we-there-yet": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+			"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+			"dev": true,
+			"dependencies": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/cacache": {
+			"version": "16.1.3",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+			"integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+			"dev": true,
+			"dependencies": {
+				"@npmcli/fs": "^2.1.0",
+				"@npmcli/move-file": "^2.0.0",
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.1.0",
+				"glob": "^8.0.1",
+				"infer-owner": "^1.0.4",
+				"lru-cache": "^7.7.1",
+				"minipass": "^3.1.6",
+				"minipass-collect": "^1.0.2",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"mkdirp": "^1.0.4",
+				"p-map": "^4.0.0",
+				"promise-inflight": "^1.0.1",
+				"rimraf": "^3.0.2",
+				"ssri": "^9.0.0",
+				"tar": "^6.1.11",
+				"unique-filename": "^2.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/cacache/node_modules/glob": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+			"integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/@electron/rebuild/node_modules/detect-libc": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/gauge": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+			"dev": true,
+			"dependencies": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.3",
+				"console-control-strings": "^1.1.0",
+				"has-unicode": "^2.0.1",
+				"signal-exit": "^3.0.7",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.5"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/http-proxy-agent": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+			"dev": true,
+			"dependencies": {
+				"@tootallnate/once": "2",
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/lru-cache": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+			"integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/make-fetch-happen": {
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+			"integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+			"dev": true,
+			"dependencies": {
+				"agentkeepalive": "^4.2.1",
+				"cacache": "^16.1.0",
+				"http-cache-semantics": "^4.1.0",
+				"http-proxy-agent": "^5.0.0",
+				"https-proxy-agent": "^5.0.0",
+				"is-lambda": "^1.0.1",
+				"lru-cache": "^7.7.1",
+				"minipass": "^3.1.6",
+				"minipass-collect": "^1.0.2",
+				"minipass-fetch": "^2.0.3",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"negotiator": "^0.6.3",
+				"promise-retry": "^2.0.1",
+				"socks-proxy-agent": "^7.0.0",
+				"ssri": "^9.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/minimatch": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+			"integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/minipass-fetch": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+			"integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+			"dev": true,
+			"dependencies": {
+				"minipass": "^3.1.6",
+				"minipass-sized": "^1.0.3",
+				"minizlib": "^2.1.2"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			},
+			"optionalDependencies": {
+				"encoding": "^0.1.13"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"dev": true,
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/node-gyp": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.3.0.tgz",
+			"integrity": "sha512-A6rJWfXFz7TQNjpldJ915WFb1LnhO4lIve3ANPbWreuEoLoKlFT3sxIepPBkLhM27crW8YmN+pjlgbasH6cH/Q==",
+			"dev": true,
+			"dependencies": {
+				"env-paths": "^2.2.0",
+				"glob": "^7.1.4",
+				"graceful-fs": "^4.2.6",
+				"make-fetch-happen": "^10.0.3",
+				"nopt": "^6.0.0",
+				"npmlog": "^6.0.0",
+				"rimraf": "^3.0.2",
+				"semver": "^7.3.5",
+				"tar": "^6.1.2",
+				"which": "^2.0.2"
+			},
+			"bin": {
+				"node-gyp": "bin/node-gyp.js"
+			},
+			"engines": {
+				"node": "^12.22 || ^14.13 || >=16"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/nopt": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+			"integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+			"dev": true,
+			"dependencies": {
+				"abbrev": "^1.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/npmlog": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+			"dev": true,
+			"dependencies": {
+				"are-we-there-yet": "^3.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^4.0.3",
+				"set-blocking": "^2.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/@electron/rebuild/node_modules/socks-proxy-agent": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+			"integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^6.0.2",
+				"debug": "^4.3.3",
+				"socks": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/ssri": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+			"integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+			"dev": true,
+			"dependencies": {
+				"minipass": "^3.1.1"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/unique-filename": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+			"integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+			"dev": true,
+			"dependencies": {
+				"unique-slug": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/unique-slug": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+			"integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+			"dev": true,
+			"dependencies": {
+				"imurmurhash": "^0.1.4"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/universalify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/yargs": {
+			"version": "17.6.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+			"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@electron/rebuild/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@electron/universal": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.3.4.tgz",
+			"integrity": "sha512-BdhBgm2ZBnYyYRLRgOjM5VHkyFItsbggJ0MHycOjKWdFGYwK97ZFXH54dTvUWEfha81vfvwr5On6XBjt99uDcg==",
+			"dev": true,
+			"dependencies": {
+				"@electron/asar": "^3.2.1",
 				"@malept/cross-spawn-promise": "^1.1.0",
-				"asar": "^3.1.0",
 				"debug": "^4.3.1",
-				"dir-compare": "^2.4.0",
+				"dir-compare": "^3.0.0",
 				"fs-extra": "^9.0.1",
 				"minimatch": "^3.0.4",
 				"plist": "^3.0.4"
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/@electron/universal/node_modules/@malept/cross-spawn-promise": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+			"integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/malept"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+				}
+			],
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"engines": {
+				"node": ">= 10"
 			}
 		},
 		"node_modules/@electron/universal/node_modules/fs-extra": {
@@ -3175,9 +3743,9 @@
 			}
 		},
 		"node_modules/@malept/cross-spawn-promise": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-			"integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
 			"dev": true,
 			"funding": [
 				{
@@ -3193,7 +3761,7 @@
 				"cross-spawn": "^7.0.1"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 12.13.0"
 			}
 		},
 		"node_modules/@malept/flatpak-bundler": {
@@ -5138,12 +5706,15 @@
 			"integrity": "sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg=="
 		},
 		"node_modules/@sindresorhus/is": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
 			"dev": true,
 			"engines": {
-				"node": ">=6"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
 			}
 		},
 		"node_modules/@sinonjs/commons": {
@@ -5769,15 +6340,15 @@
 			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
 		},
 		"node_modules/@szmarczak/http-timer": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
 			"dev": true,
 			"dependencies": {
-				"defer-to-connect": "^1.0.1"
+				"defer-to-connect": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=10"
 			}
 		},
 		"node_modules/@tanstack/react-virtual": {
@@ -6664,9 +7235,9 @@
 			"dev": true
 		},
 		"node_modules/@types/verror": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.5.tgz",
-			"integrity": "sha512-9UjMCHK5GPgQRoNbqdLIAvAy0EInuiqbW0PBMtVP6B5B2HQJlvoJHM+KodPZMEjOa5VkSc+5LH7xy+cUzQdmHw==",
+			"version": "1.10.6",
+			"resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.6.tgz",
+			"integrity": "sha512-NNm+gdePAX1VGvPcGZCDKQZKYSiAWigKhKaz5KF94hG6f2s8de9Ow5+7AbXoeKxL8gavZfk4UquSAygOF2duEQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -6953,15 +7524,6 @@
 				}
 			}
 		},
-		"node_modules/ansi-align": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-			"integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.1.0"
-			}
-		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -7072,40 +7634,75 @@
 			"dev": true
 		},
 		"node_modules/app-builder-lib": {
-			"version": "23.0.7",
-			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.0.7.tgz",
-			"integrity": "sha512-pEsbRqyVURBo/mqGXkcEojOjZ2urP4NxfArBZt6xvzDCeiZ2cwP8N0ZpXzM/886WSPplcrsJvb/xdVSde8uvjA==",
+			"version": "24.0.0-alpha.8",
+			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.0.0-alpha.8.tgz",
+			"integrity": "sha512-/F/QFLgfX8rcobWFctu5myDsorwZ8Yr0QieOsm7QA1DI+bcPl9J0k9UpVjj7e0X4wvTIozS7ndZuqpnJAkTI9g==",
 			"dev": true,
 			"dependencies": {
 				"@develar/schema-utils": "~2.6.5",
-				"@electron/universal": "1.2.1",
+				"@electron/notarize": "^1.2.3",
+				"@electron/osx-sign": "^1.0.4",
+				"@electron/rebuild": "^3.2.10",
+				"@electron/universal": "1.3.4",
 				"@malept/flatpak-bundler": "^0.4.0",
 				"7zip-bin": "~5.1.1",
 				"async-exit-hook": "^2.0.1",
 				"bluebird-lst": "^1.0.9",
-				"builder-util": "23.0.6",
-				"builder-util-runtime": "9.0.1",
+				"builder-util": "24.0.0-alpha.8",
+				"builder-util-runtime": "9.2.0-alpha.2",
 				"chromium-pickle-js": "^0.2.0",
-				"debug": "^4.3.2",
-				"ejs": "^3.1.6",
-				"electron-osx-sign": "^0.6.0",
-				"electron-publish": "23.0.6",
+				"debug": "^4.3.4",
+				"ejs": "^3.1.8",
+				"electron-publish": "24.0.0-alpha.8",
 				"form-data": "^4.0.0",
-				"fs-extra": "^10.0.0",
-				"hosted-git-info": "^4.0.2",
+				"fs-extra": "^10.1.0",
+				"hosted-git-info": "^4.1.0",
 				"is-ci": "^3.0.0",
-				"isbinaryfile": "^4.0.8",
+				"isbinaryfile": "^5.0.0",
 				"js-yaml": "^4.1.0",
 				"lazy-val": "^1.0.5",
-				"minimatch": "^3.0.4",
-				"read-config-file": "6.2.0",
+				"minimatch": "^5.1.1",
+				"read-config-file": "6.3.2",
 				"sanitize-filename": "^1.6.3",
-				"semver": "^7.3.5",
-				"tar": "^6.1.11",
+				"semver": "^7.3.8",
+				"tar": "^6.1.12",
 				"temp-file": "^3.4.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@tootallnate/once": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@types/fs-extra": {
+			"version": "9.0.13",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+			"integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/app-builder-lib/node_modules/argparse": {
@@ -7114,10 +7711,85 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"node_modules/app-builder-lib/node_modules/ci-info": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-			"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+		"node_modules/app-builder-lib/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/builder-util": {
+			"version": "24.0.0-alpha.8",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-24.0.0-alpha.8.tgz",
+			"integrity": "sha512-18NtwmgSweocvAV1hp3UMhG67n5NzFcZ1UBb7L38oWchfPfgus4N+aIkVuOYwWG8FvUFcbkm6KT59NVLC2lFqg==",
+			"dev": true,
+			"dependencies": {
+				"@types/debug": "^4.1.6",
+				"@types/fs-extra": "^9.0.11",
+				"7zip-bin": "~5.1.1",
+				"app-builder-bin": "4.0.0",
+				"bluebird-lst": "^1.0.9",
+				"builder-util-runtime": "9.2.0-alpha.2",
+				"chalk": "^4.1.2",
+				"cross-spawn": "^7.0.3",
+				"debug": "^4.3.4",
+				"fs-extra": "^10.1.0",
+				"http-proxy-agent": "^5.0.0",
+				"https-proxy-agent": "^5.0.1",
+				"is-ci": "^3.0.0",
+				"js-yaml": "^4.1.0",
+				"source-map-support": "^0.5.19",
+				"stat-mode": "^1.0.0",
+				"temp-file": "^3.4.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/builder-util-runtime": {
+			"version": "9.2.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.0-alpha.2.tgz",
+			"integrity": "sha512-MFuU0OSYQ4TIa5uMmVis3aJd7i5buaC9qrb0GjGNPD/GVwQ2LqydquqlKSBlptCib6bjSnL15dHsTbD2xWlVqQ==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4",
+				"sax": "^1.2.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
 		"node_modules/app-builder-lib/node_modules/form-data": {
@@ -7148,6 +7820,15 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/app-builder-lib/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/app-builder-lib/node_modules/hosted-git-info": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -7160,16 +7841,18 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/app-builder-lib/node_modules/is-ci": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+		"node_modules/app-builder-lib/node_modules/http-proxy-agent": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
 			"dev": true,
 			"dependencies": {
-				"ci-info": "^3.2.0"
+				"@tootallnate/once": "2",
+				"agent-base": "6",
+				"debug": "4"
 			},
-			"bin": {
-				"is-ci": "bin.js"
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/app-builder-lib/node_modules/js-yaml": {
@@ -7182,6 +7865,62 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/minimatch": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+			"integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/read-config-file": {
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.3.2.tgz",
+			"integrity": "sha512-M80lpCjnE6Wt6zb98DoW8WHR09nzMSpu8XHtPkiTHrJ5Az9CybfeQhTJ8D7saeBHpGhLPIVyA8lcL6ZmdKwY6Q==",
+			"dev": true,
+			"dependencies": {
+				"config-file-ts": "^0.2.4",
+				"dotenv": "^9.0.2",
+				"dotenv-expand": "^5.1.0",
+				"js-yaml": "^4.1.0",
+				"json5": "^2.2.0",
+				"lazy-val": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/app-builder-lib/node_modules/universalify": {
@@ -7341,40 +8080,10 @@
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
-		"node_modules/asar": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/asar/-/asar-3.1.0.tgz",
-			"integrity": "sha512-vyxPxP5arcAqN4F/ebHd/HhwnAiZtwhglvdmc7BR2f0ywbVNTOpSeyhLDbGXtE/y58hv1oC75TaNIXutnsOZsQ==",
-			"dev": true,
-			"dependencies": {
-				"chromium-pickle-js": "^0.2.0",
-				"commander": "^5.0.0",
-				"glob": "^7.1.6",
-				"minimatch": "^3.0.4"
-			},
-			"bin": {
-				"asar": "bin/asar.js"
-			},
-			"engines": {
-				"node": ">=10.12.0"
-			},
-			"optionalDependencies": {
-				"@types/glob": "^7.1.1"
-			}
-		},
-		"node_modules/asar/node_modules/commander": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
 			"dev": true,
 			"optional": true,
 			"engines": {
@@ -7836,122 +8545,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"node_modules/boxen": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
-			"integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-align": "^3.0.0",
-				"camelcase": "^6.2.0",
-				"chalk": "^4.1.0",
-				"cli-boxes": "^2.2.1",
-				"string-width": "^4.2.2",
-				"type-fest": "^0.20.2",
-				"widest-line": "^3.1.0",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/boxen/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/boxen/node_modules/camelcase": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
-			"integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/boxen/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/boxen/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/boxen/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
-		"node_modules/boxen/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/boxen/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/boxen/node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -8037,22 +8630,6 @@
 				"ieee754": "^1.2.1"
 			}
 		},
-		"node_modules/buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"dev": true,
-			"dependencies": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"node_modules/buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"dev": true
-		},
 		"node_modules/buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -8062,24 +8639,21 @@
 			}
 		},
 		"node_modules/buffer-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-			"integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
+			"integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
 			"dev": true,
 			"engines": {
-				"node": ">=0.4.0"
+				"node": ">=0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
-		},
-		"node_modules/buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-			"dev": true
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.1",
@@ -8088,9 +8662,9 @@
 			"dev": true
 		},
 		"node_modules/builder-util": {
-			"version": "23.0.6",
-			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.6.tgz",
-			"integrity": "sha512-xV6JmZmHvpeUtsJNKDoKTefFLo9LRPnm4ii3ckRQe39BNu0nDyfpRLhici7KqnRxBdMSpIVIfayJX9syN+7zDw==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.6.0.tgz",
+			"integrity": "sha512-QiQHweYsh8o+U/KNCZFSvISRnvRctb8m/2rB2I1JdByzvNKxPeFLlHFRPQRXab6aYeXc18j9LpsDLJ3sGQmWTQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/debug": "^4.1.6",
@@ -8098,10 +8672,10 @@
 				"7zip-bin": "~5.1.1",
 				"app-builder-bin": "4.0.0",
 				"bluebird-lst": "^1.0.9",
-				"builder-util-runtime": "9.0.1",
+				"builder-util-runtime": "9.1.1",
 				"chalk": "^4.1.1",
 				"cross-spawn": "^7.0.3",
-				"debug": "^4.3.2",
+				"debug": "^4.3.4",
 				"fs-extra": "^10.0.0",
 				"http-proxy-agent": "^5.0.0",
 				"https-proxy-agent": "^5.0.0",
@@ -8113,12 +8687,12 @@
 			}
 		},
 		"node_modules/builder-util-runtime": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.1.tgz",
-			"integrity": "sha512-f9pjsGKjGaLWqYwIn11Lxc2YL0g8UnnxWECOS9GubCRNYWnqMz1ZjwwCedOUKk2UlD2J7zyVKJcCMt9v/pP/uQ==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+			"integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
 			"dev": true,
 			"dependencies": {
-				"debug": "^4.3.2",
+				"debug": "^4.3.4",
 				"sax": "^1.2.4"
 			},
 			"engines": {
@@ -8180,12 +8754,6 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/builder-util/node_modules/ci-info": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-			"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
-			"dev": true
-		},
 		"node_modules/builder-util/node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -8239,18 +8807,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/builder-util/node_modules/is-ci": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-			"dev": true,
-			"dependencies": {
-				"ci-info": "^3.2.0"
-			},
-			"bin": {
-				"is-ci": "bin.js"
 			}
 		},
 		"node_modules/builder-util/node_modules/js-yaml": {
@@ -8340,49 +8896,19 @@
 			}
 		},
 		"node_modules/cacheable-request": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
 			"dev": true,
 			"dependencies": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
 				"http-cache-semantics": "^4.0.0",
-				"keyv": "^3.0.0",
+				"keyv": "^4.0.0",
 				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^4.1.0",
-				"responselike": "^1.0.2"
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
 			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cacheable-request/node_modules/get-stream": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-			"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-			"dev": true,
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cacheable-request/node_modules/lowercase-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cacheable-request/node_modules/normalize-url": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -8556,14 +9082,17 @@
 		"node_modules/chromium-pickle-js": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
-			"integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
+			"integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
 			"dev": true
 		},
 		"node_modules/ci-info": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-			"dev": true
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+			"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/cjs-module-lexer": {
 			"version": "1.2.2",
@@ -8602,18 +9131,6 @@
 				"node": ">=0.2.5"
 			}
 		},
-		"node_modules/cli-boxes": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-			"integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/cli-color": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.2.tgz",
@@ -8628,6 +9145,30 @@
 			},
 			"engines": {
 				"node": ">=0.10"
+			}
+		},
+		"node_modules/cli-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"dev": true,
+			"dependencies": {
+				"restore-cursor": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-spinners": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+			"integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cli-truncate": {
@@ -8781,13 +9322,13 @@
 				"simple-swizzle": "^0.2.2"
 			}
 		},
-		"node_modules/colors": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+		"node_modules/color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
 			"dev": true,
-			"engines": {
-				"node": ">=0.1.90"
+			"bin": {
+				"color-support": "bin.js"
 			}
 		},
 		"node_modules/combined-stream": {
@@ -8814,7 +9355,7 @@
 		"node_modules/compare-version": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
-			"integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=",
+			"integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -8995,45 +9536,14 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/configstore": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-			"integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+		"node_modules/config-file-ts": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.4.tgz",
+			"integrity": "sha512-cKSW0BfrSaAUnxpgvpXPLaaW/umg4bqg4k3GO1JqlRfpx+d5W0GDXznCMkWotJQek5Mmz1MJVChQnz3IVaeMZQ==",
 			"dev": true,
 			"dependencies": {
-				"dot-prop": "^5.2.0",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^3.0.0",
-				"unique-string": "^2.0.0",
-				"write-file-atomic": "^3.0.0",
-				"xdg-basedir": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/configstore/node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/configstore/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
+				"glob": "^7.1.6",
+				"typescript": "^4.0.2"
 			}
 		},
 		"node_modules/console-browserify": {
@@ -9294,15 +9804,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/crypto-random-string": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/css": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
@@ -9542,15 +10043,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
 		"node_modules/deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -9565,11 +10057,35 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/defaults": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+			"integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+			"dev": true,
+			"dependencies": {
+				"clone": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/defaults/node_modules/clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/defer-to-connect": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
-			"dev": true
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/define-properties": {
 			"version": "1.1.3",
@@ -9665,30 +10181,13 @@
 			"integrity": "sha1-1OXDpM305f4SEatC5pP8tDIVgPw="
 		},
 		"node_modules/dir-compare": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-2.4.0.tgz",
-			"integrity": "sha512-l9hmu8x/rjVC9Z2zmGzkhOEowZvW7pmYws5CWHutg8u1JgvsKWMx7Q/UODeu4djLZ4FgW5besw5yvMQnBHzuCA==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-3.3.0.tgz",
+			"integrity": "sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==",
 			"dev": true,
 			"dependencies": {
-				"buffer-equal": "1.0.0",
-				"colors": "1.0.3",
-				"commander": "2.9.0",
-				"minimatch": "3.0.4"
-			},
-			"bin": {
-				"dircompare": "src/cli/dircompare.js"
-			}
-		},
-		"node_modules/dir-compare/node_modules/commander": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-			"dev": true,
-			"dependencies": {
-				"graceful-readlink": ">= 1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6.x"
+				"buffer-equal": "^1.0.0",
+				"minimatch": "^3.0.4"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -9704,20 +10203,20 @@
 			}
 		},
 		"node_modules/dmg-builder": {
-			"version": "23.0.7",
-			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.0.7.tgz",
-			"integrity": "sha512-t9vwdFOI9YlDjjOxP8Y9y2L+eSASLR3tcDSSGbzlxLkK7U2z6PnShiTH6YYcnfFLln508YIVvu4Od9XhprMGag==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.6.0.tgz",
+			"integrity": "sha512-jFZvY1JohyHarIAlTbfQOk+HnceGjjAdFjVn3n8xlDWKsYNqbO4muca6qXEZTfGXeQMG7TYim6CeS5XKSfSsGA==",
 			"dev": true,
 			"dependencies": {
-				"app-builder-lib": "23.0.7",
-				"builder-util": "23.0.6",
-				"builder-util-runtime": "9.0.1",
+				"app-builder-lib": "23.6.0",
+				"builder-util": "23.6.0",
+				"builder-util-runtime": "9.1.1",
 				"fs-extra": "^10.0.0",
 				"iconv-lite": "^0.6.2",
 				"js-yaml": "^4.1.0"
 			},
 			"optionalDependencies": {
-				"dmg-license": "^1.0.9"
+				"dmg-license": "^1.0.11"
 			}
 		},
 		"node_modules/dmg-builder/node_modules/argparse": {
@@ -9765,7 +10264,6 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
 			"integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
-			"deprecated": "Disk image license agreements are deprecated by Apple and will probably be removed in a future macOS release. Discussion at: https://github.com/argv-minus-one/dmg-license/issues/11",
 			"dev": true,
 			"optional": true,
 			"os": [
@@ -9901,27 +10399,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
 			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
 		},
-		"node_modules/dot-prop": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-			"dev": true,
-			"dependencies": {
-				"is-obj": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/dot-prop/node_modules/is-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/dotenv": {
 			"version": "9.0.2",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
@@ -9959,12 +10436,6 @@
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
-		"node_modules/duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
-		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -9974,9 +10445,9 @@
 			}
 		},
 		"node_modules/ejs": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
-			"integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+			"integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
 			"dev": true,
 			"dependencies": {
 				"jake": "^10.8.5"
@@ -10007,23 +10478,23 @@
 			}
 		},
 		"node_modules/electron-builder": {
-			"version": "23.0.7",
-			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.0.7.tgz",
-			"integrity": "sha512-4JdWmTkF2bciiZ2jnxvH/0gg7wh9btY07z+dLEi4Z/ROLMROrkDJXGD1Wtp4Qak+3DgWvNbWb7nPu63HtIoqmQ==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.6.0.tgz",
+			"integrity": "sha512-y8D4zO+HXGCNxFBV/JlyhFnoQ0Y0K7/sFH+XwIbj47pqaW8S6PGYQbjoObolKBR1ddQFPt4rwp4CnwMJrW3HAw==",
 			"dev": true,
 			"dependencies": {
 				"@types/yargs": "^17.0.1",
-				"app-builder-lib": "23.0.7",
-				"builder-util": "23.0.6",
-				"builder-util-runtime": "9.0.1",
+				"app-builder-lib": "23.6.0",
+				"builder-util": "23.6.0",
+				"builder-util-runtime": "9.1.1",
 				"chalk": "^4.1.1",
-				"dmg-builder": "23.0.7",
+				"dmg-builder": "23.6.0",
 				"fs-extra": "^10.0.0",
 				"is-ci": "^3.0.0",
 				"lazy-val": "^1.0.5",
 				"read-config-file": "6.2.0",
-				"update-notifier": "^5.1.0",
-				"yargs": "^17.0.1"
+				"simple-update-notifier": "^1.0.7",
+				"yargs": "^17.5.1"
 			},
 			"bin": {
 				"electron-builder": "cli.js",
@@ -10034,14 +10505,14 @@
 			}
 		},
 		"node_modules/electron-builder-squirrel-windows": {
-			"version": "23.0.7",
-			"resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-23.0.7.tgz",
-			"integrity": "sha512-HNx1W4vK4i5JAXZGLN6GSLVo57che2LMy9L4JvKLkbSu9ZLpjhbMX2/r9IA6OprErUF/Nhs/eyPz967iDSfdVA==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-23.6.0.tgz",
+			"integrity": "sha512-udKnP0GfbGtB1assAPgQ5EGpVpmZd/6RrcYh9r8Cy96FwGkKwhMOKB+aZBxOILHkX7skG5XPWqc6eu6i9I1lAw==",
 			"dev": true,
 			"dependencies": {
-				"app-builder-lib": "23.0.7",
-				"archiver": "^5.3.0",
-				"builder-util": "23.0.6",
+				"app-builder-lib": "23.6.0",
+				"archiver": "^5.3.1",
+				"builder-util": "23.6.0",
 				"fs-extra": "^10.0.0"
 			},
 			"optionalDependencies": {
@@ -10111,11 +10582,19 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/electron-builder/node_modules/ci-info": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-			"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
-			"dev": true
+		"node_modules/electron-builder/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/electron-builder/node_modules/color-convert": {
 			"version": "2.0.1",
@@ -10158,18 +10637,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/electron-builder/node_modules/is-ci": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-			"dev": true,
-			"dependencies": {
-				"ci-info": "^3.2.0"
-			},
-			"bin": {
-				"is-ci": "bin.js"
-			}
-		},
 		"node_modules/electron-builder/node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10191,37 +10658,28 @@
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/electron-builder/node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/electron-builder/node_modules/yargs": {
-			"version": "17.3.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-			"integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+			"version": "17.6.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+			"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
 			"dev": true,
 			"dependencies": {
-				"cliui": "^7.0.2",
+				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
 				"get-caller-file": "^2.0.5",
 				"require-directory": "^2.1.1",
 				"string-width": "^4.2.3",
 				"y18n": "^5.0.5",
-				"yargs-parser": "^21.0.0"
+				"yargs-parser": "^21.1.1"
 			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
 		"node_modules/electron-builder/node_modules/yargs-parser": {
-			"version": "21.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-			"integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -10321,67 +10779,28 @@
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/electron-osx-sign": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz",
-			"integrity": "sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==",
-			"dev": true,
-			"dependencies": {
-				"bluebird": "^3.5.0",
-				"compare-version": "^0.1.2",
-				"debug": "^2.6.8",
-				"isbinaryfile": "^3.0.2",
-				"minimist": "^1.2.0",
-				"plist": "^3.0.1"
-			},
-			"bin": {
-				"electron-osx-flat": "bin/electron-osx-flat.js",
-				"electron-osx-sign": "bin/electron-osx-sign.js"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/electron-osx-sign/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/electron-osx-sign/node_modules/isbinaryfile": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
-			"integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
-			"dev": true,
-			"dependencies": {
-				"buffer-alloc": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=0.6.0"
-			}
-		},
-		"node_modules/electron-osx-sign/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
-		},
 		"node_modules/electron-publish": {
-			"version": "23.0.6",
-			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.6.tgz",
-			"integrity": "sha512-ikjgf93uHKyjfTIxVBs3jrDY3x2C06c7Vbq7QDMIQnvMWUqZd1mNTqWUBAr1IQfwX5xvapsWxAJ5TF/Ops5KLg==",
+			"version": "24.0.0-alpha.8",
+			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.0.0-alpha.8.tgz",
+			"integrity": "sha512-DTu/Waa8UVTbuFXWzSn+Wp7IKJC21sx64eM0mY4b7FESa/6BXQnIiFgaC6DU4b8TLofhFQ1uVgp6g1sFWi9fAQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/fs-extra": "^9.0.11",
-				"builder-util": "23.0.6",
-				"builder-util-runtime": "9.0.1",
-				"chalk": "^4.1.1",
-				"fs-extra": "^10.0.0",
+				"builder-util": "24.0.0-alpha.8",
+				"builder-util-runtime": "9.2.0-alpha.2",
+				"chalk": "^4.1.2",
+				"fs-extra": "^10.1.0",
 				"lazy-val": "^1.0.5",
 				"mime": "^2.5.2"
+			}
+		},
+		"node_modules/electron-publish/node_modules/@tootallnate/once": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10"
 			}
 		},
 		"node_modules/electron-publish/node_modules/@types/fs-extra": {
@@ -10406,6 +10825,50 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/electron-publish/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"node_modules/electron-publish/node_modules/builder-util": {
+			"version": "24.0.0-alpha.8",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-24.0.0-alpha.8.tgz",
+			"integrity": "sha512-18NtwmgSweocvAV1hp3UMhG67n5NzFcZ1UBb7L38oWchfPfgus4N+aIkVuOYwWG8FvUFcbkm6KT59NVLC2lFqg==",
+			"dev": true,
+			"dependencies": {
+				"@types/debug": "^4.1.6",
+				"@types/fs-extra": "^9.0.11",
+				"7zip-bin": "~5.1.1",
+				"app-builder-bin": "4.0.0",
+				"bluebird-lst": "^1.0.9",
+				"builder-util-runtime": "9.2.0-alpha.2",
+				"chalk": "^4.1.2",
+				"cross-spawn": "^7.0.3",
+				"debug": "^4.3.4",
+				"fs-extra": "^10.1.0",
+				"http-proxy-agent": "^5.0.0",
+				"https-proxy-agent": "^5.0.1",
+				"is-ci": "^3.0.0",
+				"js-yaml": "^4.1.0",
+				"source-map-support": "^0.5.19",
+				"stat-mode": "^1.0.0",
+				"temp-file": "^3.4.0"
+			}
+		},
+		"node_modules/electron-publish/node_modules/builder-util-runtime": {
+			"version": "9.2.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.0-alpha.2.tgz",
+			"integrity": "sha512-MFuU0OSYQ4TIa5uMmVis3aJd7i5buaC9qrb0GjGNPD/GVwQ2LqydquqlKSBlptCib6bjSnL15dHsTbD2xWlVqQ==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4",
+				"sax": "^1.2.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/electron-publish/node_modules/chalk": {
@@ -10463,6 +10926,32 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/electron-publish/node_modules/http-proxy-agent": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+			"dev": true,
+			"dependencies": {
+				"@tootallnate/once": "2",
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/electron-publish/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/electron-publish/node_modules/mime": {
@@ -11302,25 +11791,10 @@
 				"@types/yauzl": "^2.9.1"
 			}
 		},
-		"node_modules/extract-zip/node_modules/get-stream": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-			"dev": true,
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+			"integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
 			"dev": true,
 			"engines": [
 				"node >=0.6.0"
@@ -11402,9 +11876,9 @@
 			}
 		},
 		"node_modules/filelist": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.3.tgz",
-			"integrity": "sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+			"integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
 			"dev": true,
 			"dependencies": {
 				"minimatch": "^5.0.1"
@@ -11420,9 +11894,9 @@
 			}
 		},
 		"node_modules/filelist/node_modules/minimatch": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-			"integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+			"integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -11704,15 +12178,18 @@
 			}
 		},
 		"node_modules/get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 			"dev": true,
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/glob": {
@@ -11779,30 +12256,6 @@
 				"node": ">=10.0"
 			}
 		},
-		"node_modules/global-dirs": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-			"integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
-			"dev": true,
-			"dependencies": {
-				"ini": "2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/global-dirs/node_modules/ini": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-			"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -11853,58 +12306,34 @@
 			"integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
 		},
 		"node_modules/got": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+			"version": "11.8.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
 			"dev": true,
 			"dependencies": {
-				"@sindresorhus/is": "^0.14.0",
-				"@szmarczak/http-timer": "^1.1.2",
-				"cacheable-request": "^6.0.0",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^4.1.0",
-				"lowercase-keys": "^1.0.1",
-				"mimic-response": "^1.0.1",
-				"p-cancelable": "^1.0.0",
-				"to-readable-stream": "^1.0.0",
-				"url-parse-lax": "^3.0.0"
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=8.6"
-			}
-		},
-		"node_modules/got/node_modules/decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"dev": true,
-			"dependencies": {
-				"mimic-response": "^1.0.0"
+				"node": ">=10.19.0"
 			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/got/node_modules/mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
 			}
 		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
-		},
-		"node_modules/graceful-readlink": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-			"dev": true
 		},
 		"node_modules/graphql": {
 			"version": "16.3.0",
@@ -12160,15 +12589,6 @@
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
-		"node_modules/has-yarn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
-			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/hawk": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-9.0.1.tgz",
@@ -12304,9 +12724,9 @@
 			}
 		},
 		"node_modules/https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
@@ -12522,15 +12942,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/import-lazy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/import-local": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -12584,12 +12995,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"node_modules/ini": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true
 		},
 		"node_modules/inline-style-prefixer": {
 			"version": "6.0.1",
@@ -12676,12 +13081,12 @@
 			}
 		},
 		"node_modules/is-ci": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
 			"dev": true,
 			"dependencies": {
-				"ci-info": "^2.0.0"
+				"ci-info": "^3.2.0"
 			},
 			"bin": {
 				"is-ci": "bin.js"
@@ -12748,38 +13153,19 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-installed-globally": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
-			"integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+		"node_modules/is-interactive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
 			"dev": true,
-			"dependencies": {
-				"global-dirs": "^3.0.0",
-				"is-path-inside": "^3.0.2"
-			},
 			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-lambda": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
 			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="
-		},
-		"node_modules/is-npm": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
-			"integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
@@ -12795,15 +13181,6 @@
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-path-inside": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/is-plain-obj": {
@@ -12892,17 +13269,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
-		},
-		"node_modules/is-yarn-global": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
-			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
-			"dev": true
+		"node_modules/is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/isarray": {
 			"version": "0.0.1",
@@ -12910,12 +13287,12 @@
 			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 		},
 		"node_modules/isbinaryfile": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-			"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.0.tgz",
+			"integrity": "sha512-UDdnyGvMajJUWCkib7Cei/dvyJrrvo4FIrsvSFWdPpXSUorzXrDJ0S+X5Q4ZlasfPjca4yqCNNsjbCeiy8FFeg==",
 			"dev": true,
 			"engines": {
-				"node": ">= 8.0.0"
+				"node": ">= 14.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/gjtorikian/"
@@ -13159,9 +13536,9 @@
 			}
 		},
 		"node_modules/jake/node_modules/async": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
 			"dev": true
 		},
 		"node_modules/jake/node_modules/chalk": {
@@ -13544,15 +13921,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/jest-cli/node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/jest-cli/node_modules/yargs": {
@@ -16122,9 +16490,9 @@
 			}
 		},
 		"node_modules/json-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
 			"dev": true
 		},
 		"node_modules/json-order": {
@@ -16415,12 +16783,12 @@
 			}
 		},
 		"node_modules/keyv": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+			"integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
 			"dev": true,
 			"dependencies": {
-				"json-buffer": "3.0.0"
+				"json-buffer": "3.0.1"
 			}
 		},
 		"node_modules/klaw": {
@@ -16438,18 +16806,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/latest-version": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
-			"integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-			"dev": true,
-			"dependencies": {
-				"package-json": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/lazy-val": {
@@ -16667,6 +17023,92 @@
 			"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
 			"dev": true
 		},
+		"node_modules/log-symbols": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.0",
+				"is-unicode-supported": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-symbols/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/log-symbols/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/log-symbols/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/log-symbols/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/log-symbols/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/log-symbols/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/long": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -16698,12 +17140,12 @@
 			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
 		},
 		"node_modules/lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
 			"dev": true,
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
 			}
 		},
 		"node_modules/lru_map": {
@@ -16738,6 +17180,73 @@
 			"dev": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
+			}
+		},
+		"node_modules/lzma-native": {
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-8.0.6.tgz",
+			"integrity": "sha512-09xfg67mkL2Lz20PrrDeNYZxzeW7ADtpYFbwSQh9U8+76RIzx5QsJBMy8qikv3hbUPfpy6hqwxt6FcGK81g9AA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"node-addon-api": "^3.1.0",
+				"node-gyp-build": "^4.2.1",
+				"readable-stream": "^3.6.0"
+			},
+			"bin": {
+				"lzmajs": "bin/lzmajs"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/lzma-native/node_modules/node-addon-api": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+			"integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+			"dev": true
+		},
+		"node_modules/lzma-native/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/lzma-native/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/lzma-native/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/magic-string": {
@@ -17039,9 +17548,12 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/minimisted": {
 			"version": "2.0.1",
@@ -17344,12 +17856,33 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
 			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
 		},
+		"node_modules/node-abi": {
+			"version": "3.30.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.30.0.tgz",
+			"integrity": "sha512-qWO5l3SCqbwQavymOmtTVuCWZE23++S+rxyoHjXqUmPyzRcaoI4lA2gO55/drddGnedAyjA7sk76SfQ5lfUMnw==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/node-addon-api": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
 			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
 			"dev": true,
 			"optional": true
+		},
+		"node_modules/node-api-version": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.1.4.tgz",
+			"integrity": "sha512-KGXihXdUChwJAOHO53bv9/vXcLmdUsZ6jIptbvYvkpKfth+r7jw44JkVxQFA3kX5nQjzjmGu1uAu/xNNLNlI5g==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.3.5"
+			}
 		},
 		"node_modules/node-cache": {
 			"version": "3.2.1",
@@ -17457,6 +17990,17 @@
 			},
 			"engines": {
 				"node": ">= 10.12.0"
+			}
+		},
+		"node_modules/node-gyp-build": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+			"integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+			"dev": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/node-gyp/node_modules/nopt": {
@@ -17739,6 +18283,99 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/ora": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+			"dev": true,
+			"dependencies": {
+				"bl": "^4.1.0",
+				"chalk": "^4.1.0",
+				"cli-cursor": "^3.1.0",
+				"cli-spinners": "^2.5.0",
+				"is-interactive": "^1.0.0",
+				"is-unicode-supported": "^0.1.0",
+				"log-symbols": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"wcwidth": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/ora/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/ora/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/ora/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/ora/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ora/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -17768,12 +18405,12 @@
 			}
 		},
 		"node_modules/p-cancelable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
 			"dev": true,
 			"engines": {
-				"node": ">=6"
+				"node": ">=8"
 			}
 		},
 		"node_modules/p-limit": {
@@ -17821,30 +18458,6 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/package-json": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
-			"integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
-			"dev": true,
-			"dependencies": {
-				"got": "^9.6.0",
-				"registry-auth-token": "^4.0.0",
-				"registry-url": "^5.0.0",
-				"semver": "^6.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/package-json/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/pako": {
@@ -18040,25 +18653,16 @@
 			}
 		},
 		"node_modules/plist": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.5.tgz",
-			"integrity": "sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
+			"integrity": "sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==",
 			"dev": true,
 			"dependencies": {
 				"base64-js": "^1.5.1",
-				"xmlbuilder": "^9.0.7"
+				"xmlbuilder": "^15.1.1"
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/plist/node_modules/xmlbuilder": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
 			}
 		},
 		"node_modules/pony-cause": {
@@ -18335,30 +18939,6 @@
 			"integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dev": true,
-			"dependencies": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"bin": {
-				"rc": "cli.js"
-			}
-		},
-		"node_modules/rc/node_modules/strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react": {
@@ -18801,30 +19381,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/registry-auth-token": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-			"integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
-			"dev": true,
-			"dependencies": {
-				"rc": "^1.2.8"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/registry-url": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
-			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
-			"dev": true,
-			"dependencies": {
-				"rc": "^1.2.8"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -18932,12 +19488,28 @@
 			}
 		},
 		"node_modules/responselike": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
 			"dev": true,
 			"dependencies": {
-				"lowercase-keys": "^1.0.0"
+				"lowercase-keys": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/restore-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"dev": true,
+			"dependencies": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/retry": {
@@ -19133,27 +19705,6 @@
 			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
 			"dev": true,
 			"optional": true
-		},
-		"node_modules/semver-diff": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-			"integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/semver-diff/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
 		},
 		"node_modules/sentence-case": {
 			"version": "3.0.4",
@@ -19352,6 +19903,27 @@
 			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
 			"dependencies": {
 				"is-arrayish": "^0.3.1"
+			}
+		},
+		"node_modules/simple-update-notifier": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
+			"integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+			"dev": true,
+			"dependencies": {
+				"semver": "~7.0.0"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/simple-update-notifier/node_modules/semver": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+			"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/sisteransi": {
@@ -20076,19 +20648,19 @@
 			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
 		},
 		"node_modules/tar": {
-			"version": "6.1.11",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-			"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+			"version": "6.1.13",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+			"integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
 			"dependencies": {
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.0.0",
-				"minipass": "^3.0.0",
+				"minipass": "^4.0.0",
 				"minizlib": "^2.1.1",
 				"mkdirp": "^1.0.3",
 				"yallist": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": ">=10"
 			}
 		},
 		"node_modules/tar-stream": {
@@ -20148,6 +20720,17 @@
 			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/tar/node_modules/minipass": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+			"integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/tar/node_modules/mkdirp": {
@@ -20280,16 +20863,7 @@
 			"integrity": "sha512-ysnVd2E4nWbNXIbHaUidcKGLTmNimqP0hdpsD0Ph5hPJ84ntCF6PHj+Jg3im9nZt9/hNsBg/E6m1psHc2KaPnQ==",
 			"dev": true
 		},
-		"node_modules/tmp-promise": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
-			"integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
-			"dev": true,
-			"dependencies": {
-				"tmp": "^0.2.0"
-			}
-		},
-		"node_modules/tmp-promise/node_modules/tmp": {
+		"node_modules/tmp": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
 			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
@@ -20299,6 +20873,15 @@
 			},
 			"engines": {
 				"node": ">=8.17.0"
+			}
+		},
+		"node_modules/tmp-promise": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+			"integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+			"dev": true,
+			"dependencies": {
+				"tmp": "^0.2.0"
 			}
 		},
 		"node_modules/tmpl": {
@@ -20312,15 +20895,6 @@
 			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/to-readable-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -20385,7 +20959,7 @@
 		"node_modules/truncate-utf8-bytes": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-			"integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+			"integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
 			"dev": true,
 			"dependencies": {
 				"utf8-byte-length": "^1.0.1"
@@ -20477,15 +21051,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"dev": true,
-			"dependencies": {
-				"is-typedarray": "^1.0.0"
 			}
 		},
 		"node_modules/typescript": {
@@ -20584,18 +21149,6 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
-		"node_modules/unique-string": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-			"dev": true,
-			"dependencies": {
-				"crypto-random-string": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/universalify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
@@ -20677,104 +21230,6 @@
 				"browserslist": ">= 4.21.0"
 			}
 		},
-		"node_modules/update-notifier": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
-			"integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
-			"dev": true,
-			"dependencies": {
-				"boxen": "^5.0.0",
-				"chalk": "^4.1.0",
-				"configstore": "^5.0.1",
-				"has-yarn": "^2.1.0",
-				"import-lazy": "^2.1.0",
-				"is-ci": "^2.0.0",
-				"is-installed-globally": "^0.4.0",
-				"is-npm": "^5.0.0",
-				"is-yarn-global": "^0.3.0",
-				"latest-version": "^5.1.0",
-				"pupa": "^2.1.1",
-				"semver": "^7.3.4",
-				"semver-diff": "^3.1.1",
-				"xdg-basedir": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/yeoman/update-notifier?sponsor=1"
-			}
-		},
-		"node_modules/update-notifier/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/update-notifier/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/update-notifier/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/update-notifier/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
-		"node_modules/update-notifier/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/update-notifier/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/upper-case": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
@@ -20814,31 +21269,10 @@
 			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
 			"integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
 		},
-		"node_modules/url-parse-lax": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"dev": true,
-			"dependencies": {
-				"prepend-http": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/url-parse-lax/node_modules/prepend-http": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/utf8-byte-length": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-			"integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
+			"integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
 			"dev": true
 		},
 		"node_modules/util-deprecate": {
@@ -20918,18 +21352,18 @@
 			}
 		},
 		"node_modules/verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+			"integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
 			"dev": true,
-			"engines": [
-				"node >=0.6.0"
-			],
 			"optional": true,
 			"dependencies": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=0.6.0"
 			}
 		},
 		"node_modules/vite": {
@@ -21042,6 +21476,15 @@
 				"makeerror": "1.0.12"
 			}
 		},
+		"node_modules/wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+			"dev": true,
+			"dependencies": {
+				"defaults": "^1.0.3"
+			}
+		},
 		"node_modules/web-streams-polyfill": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
@@ -21116,18 +21559,6 @@
 				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
-		"node_modules/widest-line": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/wolfy87-eventemitter": {
 			"version": "5.2.9",
 			"resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.9.tgz",
@@ -21193,18 +21624,6 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
-		"node_modules/write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-			"dev": true,
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
-			}
-		},
 		"node_modules/ws": {
 			"version": "8.8.1",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
@@ -21224,15 +21643,6 @@
 				"utf-8-validate": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/xdg-basedir": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/xml-name-validator": {
@@ -21269,7 +21679,6 @@
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
 			"integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
 			"dev": true,
-			"optional": true,
 			"engines": {
 				"node": ">=8.0"
 			}
@@ -21309,6 +21718,14 @@
 			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
 			"engines": {
 				"node": ">=0.4"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/yaku": {
@@ -21359,14 +21776,6 @@
 			"version": "20.2.9",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/yargs/node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 			"engines": {
 				"node": ">=10"
 			}
@@ -22134,6 +22543,27 @@
 			"integrity": "sha512-Dh6N0yhDHfkOoGwKH5TpuOY5kaMDWPB7rmtXfa40OVsgfF+MMv+rOky71UQTecJDVqe4qqS7VBBIDD3qbuiDPg==",
 			"dev": true
 		},
+		"@electron/asar": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.2.tgz",
+			"integrity": "sha512-32fMU68x8a6zvxtC1IC/BhPDKTh8rQjdmwEplj3CDpnkcwBzZVN9v/8cK0LJqQ0FOQQVZW8BWZ1S6UU53TYR4w==",
+			"dev": true,
+			"requires": {
+				"@types/glob": "^7.1.1",
+				"chromium-pickle-js": "^0.2.0",
+				"commander": "^5.0.0",
+				"glob": "^7.1.6",
+				"minimatch": "^3.0.4"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+					"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+					"dev": true
+				}
+			}
+		},
 		"@electron/get": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.2.tgz",
@@ -22150,42 +22580,6 @@
 				"sumchecker": "^3.0.1"
 			},
 			"dependencies": {
-				"@sindresorhus/is": {
-					"version": "4.6.0",
-					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-					"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-					"dev": true
-				},
-				"@szmarczak/http-timer": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-					"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-					"dev": true,
-					"requires": {
-						"defer-to-connect": "^2.0.0"
-					}
-				},
-				"cacheable-request": {
-					"version": "7.0.2",
-					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-					"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
-					"dev": true,
-					"requires": {
-						"clone-response": "^1.0.2",
-						"get-stream": "^5.1.0",
-						"http-cache-semantics": "^4.0.0",
-						"keyv": "^4.0.0",
-						"lowercase-keys": "^2.0.0",
-						"normalize-url": "^6.0.1",
-						"responselike": "^2.0.0"
-					}
-				},
-				"defer-to-connect": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-					"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-					"dev": true
-				},
 				"fs-extra": {
 					"version": "8.1.0",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -22195,15 +22589,6 @@
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^4.0.0",
 						"universalify": "^0.1.0"
-					}
-				},
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
 					}
 				},
 				"got": {
@@ -22225,12 +22610,6 @@
 						"responselike": "^2.0.0"
 					}
 				},
-				"json-buffer": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-					"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-					"dev": true
-				},
 				"jsonfile": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -22238,36 +22617,6 @@
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.6"
-					}
-				},
-				"keyv": {
-					"version": "4.5.2",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-					"integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
-					"dev": true,
-					"requires": {
-						"json-buffer": "3.0.1"
-					}
-				},
-				"lowercase-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-					"dev": true
-				},
-				"p-cancelable": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-					"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-					"dev": true
-				},
-				"responselike": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-					"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-					"dev": true,
-					"requires": {
-						"lowercase-keys": "^2.0.0"
 					}
 				},
 				"semver": {
@@ -22284,21 +22633,500 @@
 				}
 			}
 		},
-		"@electron/universal": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.1.tgz",
-			"integrity": "sha512-7323HyMh7KBAl/nPDppdLsC87G6RwRU02dy5FPeGB1eS7rUePh55+WNWiDPLhFQqqVPHzh77M69uhmoT8XnwMQ==",
+		"@electron/notarize": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-1.2.3.tgz",
+			"integrity": "sha512-9oRzT56rKh5bspk3KpAVF8lPKHYQrBnRwcgiOeR0hdilVEQmszDaAu0IPCPrwwzJN0ugNs0rRboTreHMt/6mBQ==",
 			"dev": true,
 			"requires": {
+				"debug": "^4.1.1",
+				"fs-extra": "^9.0.1"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+					"dev": true,
+					"requires": {
+						"at-least-node": "^1.0.0",
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				},
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+					"dev": true
+				}
+			}
+		},
+		"@electron/osx-sign": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.0.4.tgz",
+			"integrity": "sha512-xfhdEcIOfAZg7scZ9RQPya1G1lWo8/zMCwUXAulq0SfY7ONIW+b9qGyKdMyuMctNYwllrIS+vmxfijSfjeh97g==",
+			"dev": true,
+			"requires": {
+				"compare-version": "^0.1.2",
+				"debug": "^4.3.4",
+				"fs-extra": "^10.0.0",
+				"isbinaryfile": "^4.0.8",
+				"minimist": "^1.2.6",
+				"plist": "^3.0.5"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+					"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				},
+				"isbinaryfile": {
+					"version": "4.0.10",
+					"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+					"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+					"dev": true
+				},
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+					"dev": true
+				}
+			}
+		},
+		"@electron/rebuild": {
+			"version": "3.2.10",
+			"resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.2.10.tgz",
+			"integrity": "sha512-SUBM6Mwi3yZaDFQjZzfGKpYTtOp9m60glounwX6tfGeVc/ZOl4jbquktUcyy7gYSLDWFLtKkftkY2xgMJZLQgg==",
+			"dev": true,
+			"requires": {
+				"@malept/cross-spawn-promise": "^2.0.0",
+				"chalk": "^4.0.0",
+				"debug": "^4.1.1",
+				"detect-libc": "^2.0.1",
+				"fs-extra": "^10.0.0",
+				"got": "^11.7.0",
+				"lzma-native": "^8.0.5",
+				"node-abi": "^3.0.0",
+				"node-api-version": "^0.1.4",
+				"node-gyp": "^9.0.0",
+				"ora": "^5.1.0",
+				"semver": "^7.3.5",
+				"tar": "^6.0.5",
+				"yargs": "^17.0.1"
+			},
+			"dependencies": {
+				"@npmcli/fs": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+					"integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+					"dev": true,
+					"requires": {
+						"@gar/promisify": "^1.1.3",
+						"semver": "^7.3.5"
+					}
+				},
+				"@npmcli/move-file": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+					"integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+					"dev": true,
+					"requires": {
+						"mkdirp": "^1.0.4",
+						"rimraf": "^3.0.2"
+					}
+				},
+				"@tootallnate/once": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+					"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"are-we-there-yet": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+					"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+					"dev": true,
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^3.6.0"
+					}
+				},
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"cacache": {
+					"version": "16.1.3",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+					"integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+					"dev": true,
+					"requires": {
+						"@npmcli/fs": "^2.1.0",
+						"@npmcli/move-file": "^2.0.0",
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.1.0",
+						"glob": "^8.0.1",
+						"infer-owner": "^1.0.4",
+						"lru-cache": "^7.7.1",
+						"minipass": "^3.1.6",
+						"minipass-collect": "^1.0.2",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.4",
+						"mkdirp": "^1.0.4",
+						"p-map": "^4.0.0",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^3.0.2",
+						"ssri": "^9.0.0",
+						"tar": "^6.1.11",
+						"unique-filename": "^2.0.0"
+					},
+					"dependencies": {
+						"glob": {
+							"version": "8.0.3",
+							"resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+							"integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+							"dev": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^5.0.1",
+								"once": "^1.3.0"
+							}
+						}
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"cliui": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+					"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.1",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"detect-libc": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+					"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+					"dev": true
+				},
+				"fs-extra": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+					"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				},
+				"gauge": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+					"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+					"dev": true,
+					"requires": {
+						"aproba": "^1.0.3 || ^2.0.0",
+						"color-support": "^1.1.3",
+						"console-control-strings": "^1.1.0",
+						"has-unicode": "^2.0.1",
+						"signal-exit": "^3.0.7",
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1",
+						"wide-align": "^1.1.5"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"http-proxy-agent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+					"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+					"dev": true,
+					"requires": {
+						"@tootallnate/once": "2",
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"lru-cache": {
+					"version": "7.14.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+					"integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+					"dev": true
+				},
+				"make-fetch-happen": {
+					"version": "10.2.1",
+					"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+					"integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+					"dev": true,
+					"requires": {
+						"agentkeepalive": "^4.2.1",
+						"cacache": "^16.1.0",
+						"http-cache-semantics": "^4.1.0",
+						"http-proxy-agent": "^5.0.0",
+						"https-proxy-agent": "^5.0.0",
+						"is-lambda": "^1.0.1",
+						"lru-cache": "^7.7.1",
+						"minipass": "^3.1.6",
+						"minipass-collect": "^1.0.2",
+						"minipass-fetch": "^2.0.3",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.4",
+						"negotiator": "^0.6.3",
+						"promise-retry": "^2.0.1",
+						"socks-proxy-agent": "^7.0.0",
+						"ssri": "^9.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+					"integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				},
+				"minipass-fetch": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+					"integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+					"dev": true,
+					"requires": {
+						"encoding": "^0.1.13",
+						"minipass": "^3.1.6",
+						"minipass-sized": "^1.0.3",
+						"minizlib": "^2.1.2"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				},
+				"node-gyp": {
+					"version": "9.3.0",
+					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.3.0.tgz",
+					"integrity": "sha512-A6rJWfXFz7TQNjpldJ915WFb1LnhO4lIve3ANPbWreuEoLoKlFT3sxIepPBkLhM27crW8YmN+pjlgbasH6cH/Q==",
+					"dev": true,
+					"requires": {
+						"env-paths": "^2.2.0",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.2.6",
+						"make-fetch-happen": "^10.0.3",
+						"nopt": "^6.0.0",
+						"npmlog": "^6.0.0",
+						"rimraf": "^3.0.2",
+						"semver": "^7.3.5",
+						"tar": "^6.1.2",
+						"which": "^2.0.2"
+					}
+				},
+				"nopt": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+					"integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+					"dev": true,
+					"requires": {
+						"abbrev": "^1.0.0"
+					}
+				},
+				"npmlog": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+					"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+					"dev": true,
+					"requires": {
+						"are-we-there-yet": "^3.0.0",
+						"console-control-strings": "^1.1.0",
+						"gauge": "^4.0.3",
+						"set-blocking": "^2.0.0"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+					"dev": true
+				},
+				"socks-proxy-agent": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+					"integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^6.0.2",
+						"debug": "^4.3.3",
+						"socks": "^2.6.2"
+					}
+				},
+				"ssri": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+					"integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+					"dev": true,
+					"requires": {
+						"minipass": "^3.1.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.2.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"unique-filename": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+					"integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+					"dev": true,
+					"requires": {
+						"unique-slug": "^3.0.0"
+					}
+				},
+				"unique-slug": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+					"integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4"
+					}
+				},
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "17.6.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+					"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^8.0.1",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.3",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^21.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "21.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+					"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+					"dev": true
+				}
+			}
+		},
+		"@electron/universal": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.3.4.tgz",
+			"integrity": "sha512-BdhBgm2ZBnYyYRLRgOjM5VHkyFItsbggJ0MHycOjKWdFGYwK97ZFXH54dTvUWEfha81vfvwr5On6XBjt99uDcg==",
+			"dev": true,
+			"requires": {
+				"@electron/asar": "^3.2.1",
 				"@malept/cross-spawn-promise": "^1.1.0",
-				"asar": "^3.1.0",
 				"debug": "^4.3.1",
-				"dir-compare": "^2.4.0",
+				"dir-compare": "^3.0.0",
 				"fs-extra": "^9.0.1",
 				"minimatch": "^3.0.4",
 				"plist": "^3.0.4"
 			},
 			"dependencies": {
+				"@malept/cross-spawn-promise": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+					"integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.1"
+					}
+				},
 				"fs-extra": {
 					"version": "9.1.0",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -23896,9 +24724,9 @@
 			}
 		},
 		"@malept/cross-spawn-promise": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-			"integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+			"integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.1"
@@ -25486,9 +26314,9 @@
 			"integrity": "sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg=="
 		},
 		"@sindresorhus/is": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
 			"dev": true
 		},
 		"@sinonjs/commons": {
@@ -26008,12 +26836,12 @@
 			"integrity": "sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg=="
 		},
 		"@szmarczak/http-timer": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
 			"dev": true,
 			"requires": {
-				"defer-to-connect": "^1.0.1"
+				"defer-to-connect": "^2.0.0"
 			}
 		},
 		"@tanstack/react-virtual": {
@@ -26813,9 +27641,9 @@
 			"dev": true
 		},
 		"@types/verror": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.5.tgz",
-			"integrity": "sha512-9UjMCHK5GPgQRoNbqdLIAvAy0EInuiqbW0PBMtVP6B5B2HQJlvoJHM+KodPZMEjOa5VkSc+5LH7xy+cUzQdmHw==",
+			"version": "1.10.6",
+			"resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.6.tgz",
+			"integrity": "sha512-NNm+gdePAX1VGvPcGZCDKQZKYSiAWigKhKaz5KF94hG6f2s8de9Ow5+7AbXoeKxL8gavZfk4UquSAygOF2duEQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -27036,15 +27864,6 @@
 				}
 			}
 		},
-		"ansi-align": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-			"integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-			"dev": true,
-			"requires": {
-				"string-width": "^4.1.0"
-			}
-		},
 		"ansi-escapes": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -27128,49 +27947,138 @@
 			"dev": true
 		},
 		"app-builder-lib": {
-			"version": "23.0.7",
-			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.0.7.tgz",
-			"integrity": "sha512-pEsbRqyVURBo/mqGXkcEojOjZ2urP4NxfArBZt6xvzDCeiZ2cwP8N0ZpXzM/886WSPplcrsJvb/xdVSde8uvjA==",
+			"version": "24.0.0-alpha.8",
+			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.0.0-alpha.8.tgz",
+			"integrity": "sha512-/F/QFLgfX8rcobWFctu5myDsorwZ8Yr0QieOsm7QA1DI+bcPl9J0k9UpVjj7e0X4wvTIozS7ndZuqpnJAkTI9g==",
 			"dev": true,
 			"requires": {
 				"@develar/schema-utils": "~2.6.5",
-				"@electron/universal": "1.2.1",
+				"@electron/notarize": "^1.2.3",
+				"@electron/osx-sign": "^1.0.4",
+				"@electron/rebuild": "^3.2.10",
+				"@electron/universal": "1.3.4",
 				"@malept/flatpak-bundler": "^0.4.0",
 				"7zip-bin": "~5.1.1",
 				"async-exit-hook": "^2.0.1",
 				"bluebird-lst": "^1.0.9",
-				"builder-util": "23.0.6",
-				"builder-util-runtime": "9.0.1",
+				"builder-util": "24.0.0-alpha.8",
+				"builder-util-runtime": "9.2.0-alpha.2",
 				"chromium-pickle-js": "^0.2.0",
-				"debug": "^4.3.2",
-				"ejs": "^3.1.6",
-				"electron-osx-sign": "^0.6.0",
-				"electron-publish": "23.0.6",
+				"debug": "^4.3.4",
+				"ejs": "^3.1.8",
+				"electron-publish": "24.0.0-alpha.8",
 				"form-data": "^4.0.0",
-				"fs-extra": "^10.0.0",
-				"hosted-git-info": "^4.0.2",
+				"fs-extra": "^10.1.0",
+				"hosted-git-info": "^4.1.0",
 				"is-ci": "^3.0.0",
-				"isbinaryfile": "^4.0.8",
+				"isbinaryfile": "^5.0.0",
 				"js-yaml": "^4.1.0",
 				"lazy-val": "^1.0.5",
-				"minimatch": "^3.0.4",
-				"read-config-file": "6.2.0",
+				"minimatch": "^5.1.1",
+				"read-config-file": "6.3.2",
 				"sanitize-filename": "^1.6.3",
-				"semver": "^7.3.5",
-				"tar": "^6.1.11",
+				"semver": "^7.3.8",
+				"tar": "^6.1.12",
 				"temp-file": "^3.4.0"
 			},
 			"dependencies": {
+				"@tootallnate/once": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+					"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+					"dev": true
+				},
+				"@types/fs-extra": {
+					"version": "9.0.13",
+					"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+					"integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
 				"argparse": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 					"dev": true
 				},
-				"ci-info": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-					"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"builder-util": {
+					"version": "24.0.0-alpha.8",
+					"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-24.0.0-alpha.8.tgz",
+					"integrity": "sha512-18NtwmgSweocvAV1hp3UMhG67n5NzFcZ1UBb7L38oWchfPfgus4N+aIkVuOYwWG8FvUFcbkm6KT59NVLC2lFqg==",
+					"dev": true,
+					"requires": {
+						"@types/debug": "^4.1.6",
+						"@types/fs-extra": "^9.0.11",
+						"7zip-bin": "~5.1.1",
+						"app-builder-bin": "4.0.0",
+						"bluebird-lst": "^1.0.9",
+						"builder-util-runtime": "9.2.0-alpha.2",
+						"chalk": "^4.1.2",
+						"cross-spawn": "^7.0.3",
+						"debug": "^4.3.4",
+						"fs-extra": "^10.1.0",
+						"http-proxy-agent": "^5.0.0",
+						"https-proxy-agent": "^5.0.1",
+						"is-ci": "^3.0.0",
+						"js-yaml": "^4.1.0",
+						"source-map-support": "^0.5.19",
+						"stat-mode": "^1.0.0",
+						"temp-file": "^3.4.0"
+					}
+				},
+				"builder-util-runtime": {
+					"version": "9.2.0-alpha.2",
+					"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.0-alpha.2.tgz",
+					"integrity": "sha512-MFuU0OSYQ4TIa5uMmVis3aJd7i5buaC9qrb0GjGNPD/GVwQ2LqydquqlKSBlptCib6bjSnL15dHsTbD2xWlVqQ==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.3.4",
+						"sax": "^1.2.4"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
 				"form-data": {
@@ -27195,6 +28103,12 @@
 						"universalify": "^2.0.0"
 					}
 				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
 				"hosted-git-info": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -27204,13 +28118,15 @@
 						"lru-cache": "^6.0.0"
 					}
 				},
-				"is-ci": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-					"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+				"http-proxy-agent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+					"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
 					"dev": true,
 					"requires": {
-						"ci-info": "^3.2.0"
+						"@tootallnate/once": "2",
+						"agent-base": "6",
+						"debug": "4"
 					}
 				},
 				"js-yaml": {
@@ -27220,6 +28136,47 @@
 					"dev": true,
 					"requires": {
 						"argparse": "^2.0.1"
+					}
+				},
+				"minimatch": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+					"integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				},
+				"read-config-file": {
+					"version": "6.3.2",
+					"resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.3.2.tgz",
+					"integrity": "sha512-M80lpCjnE6Wt6zb98DoW8WHR09nzMSpu8XHtPkiTHrJ5Az9CybfeQhTJ8D7saeBHpGhLPIVyA8lcL6ZmdKwY6Q==",
+					"dev": true,
+					"requires": {
+						"config-file-ts": "^0.2.4",
+						"dotenv": "^9.0.2",
+						"dotenv-expand": "^5.1.0",
+						"js-yaml": "^4.1.0",
+						"json5": "^2.2.0",
+						"lazy-val": "^1.0.4"
+					}
+				},
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				},
 				"universalify": {
@@ -27348,31 +28305,10 @@
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
-		"asar": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/asar/-/asar-3.1.0.tgz",
-			"integrity": "sha512-vyxPxP5arcAqN4F/ebHd/HhwnAiZtwhglvdmc7BR2f0ywbVNTOpSeyhLDbGXtE/y58hv1oC75TaNIXutnsOZsQ==",
-			"dev": true,
-			"requires": {
-				"@types/glob": "^7.1.1",
-				"chromium-pickle-js": "^0.2.0",
-				"commander": "^5.0.0",
-				"glob": "^7.1.6",
-				"minimatch": "^3.0.4"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-					"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-					"dev": true
-				}
-			}
-		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
 			"dev": true,
 			"optional": true
 		},
@@ -27713,85 +28649,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"boxen": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
-			"integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
-			"dev": true,
-			"requires": {
-				"ansi-align": "^3.0.0",
-				"camelcase": "^6.2.0",
-				"chalk": "^4.1.0",
-				"cli-boxes": "^2.2.1",
-				"string-width": "^4.2.2",
-				"type-fest": "^0.20.2",
-				"widest-line": "^3.1.0",
-				"wrap-ansi": "^7.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"camelcase": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
-					"integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
-					"dev": true
-				},
-				"chalk": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
-			}
-		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -27844,43 +28701,21 @@
 				"ieee754": "^1.2.1"
 			}
 		},
-		"buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"dev": true,
-			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"dev": true
-		},
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
 		},
 		"buffer-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-			"integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
+			"integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
 			"dev": true
 		},
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
-		},
-		"buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-			"dev": true
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -27889,9 +28724,9 @@
 			"dev": true
 		},
 		"builder-util": {
-			"version": "23.0.6",
-			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.6.tgz",
-			"integrity": "sha512-xV6JmZmHvpeUtsJNKDoKTefFLo9LRPnm4ii3ckRQe39BNu0nDyfpRLhici7KqnRxBdMSpIVIfayJX9syN+7zDw==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.6.0.tgz",
+			"integrity": "sha512-QiQHweYsh8o+U/KNCZFSvISRnvRctb8m/2rB2I1JdByzvNKxPeFLlHFRPQRXab6aYeXc18j9LpsDLJ3sGQmWTQ==",
 			"dev": true,
 			"requires": {
 				"@types/debug": "^4.1.6",
@@ -27899,10 +28734,10 @@
 				"7zip-bin": "~5.1.1",
 				"app-builder-bin": "4.0.0",
 				"bluebird-lst": "^1.0.9",
-				"builder-util-runtime": "9.0.1",
+				"builder-util-runtime": "9.1.1",
 				"chalk": "^4.1.1",
 				"cross-spawn": "^7.0.3",
-				"debug": "^4.3.2",
+				"debug": "^4.3.4",
 				"fs-extra": "^10.0.0",
 				"http-proxy-agent": "^5.0.0",
 				"https-proxy-agent": "^5.0.0",
@@ -27953,12 +28788,6 @@
 						"supports-color": "^7.1.0"
 					}
 				},
-				"ci-info": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-					"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
-					"dev": true
-				},
 				"color-convert": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -28002,15 +28831,6 @@
 						"debug": "4"
 					}
 				},
-				"is-ci": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-					"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-					"dev": true,
-					"requires": {
-						"ci-info": "^3.2.0"
-					}
-				},
 				"js-yaml": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -28038,12 +28858,12 @@
 			}
 		},
 		"builder-util-runtime": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.1.tgz",
-			"integrity": "sha512-f9pjsGKjGaLWqYwIn11Lxc2YL0g8UnnxWECOS9GubCRNYWnqMz1ZjwwCedOUKk2UlD2J7zyVKJcCMt9v/pP/uQ==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+			"integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
 			"dev": true,
 			"requires": {
-				"debug": "^4.3.2",
+				"debug": "^4.3.4",
 				"sax": "^1.2.4"
 			}
 		},
@@ -28091,41 +28911,18 @@
 			"dev": true
 		},
 		"cacheable-request": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
 			"dev": true,
 			"requires": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
 				"http-cache-semantics": "^4.0.0",
-				"keyv": "^3.0.0",
+				"keyv": "^4.0.0",
 				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^4.1.0",
-				"responselike": "^1.0.2"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"lowercase-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-					"dev": true
-				},
-				"normalize-url": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-					"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-					"dev": true
-				}
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
 			}
 		},
 		"call-me-maybe": {
@@ -28267,13 +29064,13 @@
 		"chromium-pickle-js": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
-			"integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
+			"integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
 			"dev": true
 		},
 		"ci-info": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+			"integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
 			"dev": true
 		},
 		"cjs-module-lexer": {
@@ -28307,12 +29104,6 @@
 				"glob": "^7.1.1"
 			}
 		},
-		"cli-boxes": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-			"integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
-			"dev": true
-		},
 		"cli-color": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.2.tgz",
@@ -28325,6 +29116,21 @@
 				"memoizee": "^0.4.15",
 				"timers-ext": "^0.1.7"
 			}
+		},
+		"cli-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "^3.1.0"
+			}
+		},
+		"cli-spinners": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+			"integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+			"dev": true
 		},
 		"cli-truncate": {
 			"version": "2.1.0",
@@ -28449,10 +29255,10 @@
 				"simple-swizzle": "^0.2.2"
 			}
 		},
-		"colors": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
 			"dev": true
 		},
 		"combined-stream": {
@@ -28476,7 +29282,7 @@
 		"compare-version": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
-			"integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=",
+			"integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
 			"dev": true
 		},
 		"component-type": {
@@ -28607,35 +29413,14 @@
 				}
 			}
 		},
-		"configstore": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-			"integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+		"config-file-ts": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.4.tgz",
+			"integrity": "sha512-cKSW0BfrSaAUnxpgvpXPLaaW/umg4bqg4k3GO1JqlRfpx+d5W0GDXznCMkWotJQek5Mmz1MJVChQnz3IVaeMZQ==",
 			"dev": true,
 			"requires": {
-				"dot-prop": "^5.2.0",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^3.0.0",
-				"unique-string": "^2.0.0",
-				"write-file-atomic": "^3.0.0",
-				"xdg-basedir": "^4.0.0"
-			},
-			"dependencies": {
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
+				"glob": "^7.1.6",
+				"typescript": "^4.0.2"
 			}
 		},
 		"console-browserify": {
@@ -28837,12 +29622,6 @@
 			"resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
 			"integrity": "sha1-RwqBuGvkxe4XrMggeh9TFa4g27A="
 		},
-		"crypto-random-string": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-			"dev": true
-		},
 		"css": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
@@ -29042,12 +29821,6 @@
 				"regexp.prototype.flags": "^1.2.0"
 			}
 		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true
-		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -29059,10 +29832,27 @@
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
 			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
 		},
+		"defaults": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+			"integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+			"dev": true,
+			"requires": {
+				"clone": "^1.0.2"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+					"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+					"dev": true
+				}
+			}
+		},
 		"defer-to-connect": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
 			"dev": true
 		},
 		"define-properties": {
@@ -29135,26 +29925,13 @@
 			"integrity": "sha1-1OXDpM305f4SEatC5pP8tDIVgPw="
 		},
 		"dir-compare": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-2.4.0.tgz",
-			"integrity": "sha512-l9hmu8x/rjVC9Z2zmGzkhOEowZvW7pmYws5CWHutg8u1JgvsKWMx7Q/UODeu4djLZ4FgW5besw5yvMQnBHzuCA==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-3.3.0.tgz",
+			"integrity": "sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==",
 			"dev": true,
 			"requires": {
-				"buffer-equal": "1.0.0",
-				"colors": "1.0.3",
-				"commander": "2.9.0",
-				"minimatch": "3.0.4"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-					"dev": true,
-					"requires": {
-						"graceful-readlink": ">= 1.0.0"
-					}
-				}
+				"buffer-equal": "^1.0.0",
+				"minimatch": "^3.0.4"
 			}
 		},
 		"dir-glob": {
@@ -29167,15 +29944,15 @@
 			}
 		},
 		"dmg-builder": {
-			"version": "23.0.7",
-			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.0.7.tgz",
-			"integrity": "sha512-t9vwdFOI9YlDjjOxP8Y9y2L+eSASLR3tcDSSGbzlxLkK7U2z6PnShiTH6YYcnfFLln508YIVvu4Od9XhprMGag==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.6.0.tgz",
+			"integrity": "sha512-jFZvY1JohyHarIAlTbfQOk+HnceGjjAdFjVn3n8xlDWKsYNqbO4muca6qXEZTfGXeQMG7TYim6CeS5XKSfSsGA==",
 			"dev": true,
 			"requires": {
-				"app-builder-lib": "23.0.7",
-				"builder-util": "23.0.6",
-				"builder-util-runtime": "9.0.1",
-				"dmg-license": "^1.0.9",
+				"app-builder-lib": "24.0.0-alpha.8",
+				"builder-util": "23.6.0",
+				"builder-util-runtime": "9.1.1",
+				"dmg-license": "^1.0.11",
 				"fs-extra": "^10.0.0",
 				"iconv-lite": "^0.6.2",
 				"js-yaml": "^4.1.0"
@@ -29344,23 +30121,6 @@
 				}
 			}
 		},
-		"dot-prop": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-			"dev": true,
-			"requires": {
-				"is-obj": "^2.0.0"
-			},
-			"dependencies": {
-				"is-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-					"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-					"dev": true
-				}
-			}
-		},
 		"dotenv": {
 			"version": "9.0.2",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
@@ -29389,12 +30149,6 @@
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
-		"duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
-		},
 		"ecdsa-sig-formatter": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -29404,9 +30158,9 @@
 			}
 		},
 		"ejs": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
-			"integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+			"integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
 			"dev": true,
 			"requires": {
 				"jake": "^10.8.5"
@@ -29424,23 +30178,23 @@
 			}
 		},
 		"electron-builder": {
-			"version": "23.0.7",
-			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.0.7.tgz",
-			"integrity": "sha512-4JdWmTkF2bciiZ2jnxvH/0gg7wh9btY07z+dLEi4Z/ROLMROrkDJXGD1Wtp4Qak+3DgWvNbWb7nPu63HtIoqmQ==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.6.0.tgz",
+			"integrity": "sha512-y8D4zO+HXGCNxFBV/JlyhFnoQ0Y0K7/sFH+XwIbj47pqaW8S6PGYQbjoObolKBR1ddQFPt4rwp4CnwMJrW3HAw==",
 			"dev": true,
 			"requires": {
 				"@types/yargs": "^17.0.1",
-				"app-builder-lib": "23.0.7",
-				"builder-util": "23.0.6",
-				"builder-util-runtime": "9.0.1",
+				"app-builder-lib": "24.0.0-alpha.8",
+				"builder-util": "23.6.0",
+				"builder-util-runtime": "9.1.1",
 				"chalk": "^4.1.1",
-				"dmg-builder": "23.0.7",
+				"dmg-builder": "23.6.0",
 				"fs-extra": "^10.0.0",
 				"is-ci": "^3.0.0",
 				"lazy-val": "^1.0.5",
 				"read-config-file": "6.2.0",
-				"update-notifier": "^5.1.0",
-				"yargs": "^17.0.1"
+				"simple-update-notifier": "^1.0.7",
+				"yargs": "^17.5.1"
 			},
 			"dependencies": {
 				"@types/yargs": {
@@ -29471,11 +30225,16 @@
 						"supports-color": "^7.1.0"
 					}
 				},
-				"ci-info": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-					"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
-					"dev": true
+				"cliui": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+					"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.1",
+						"wrap-ansi": "^7.0.0"
+					}
 				},
 				"color-convert": {
 					"version": "2.0.1",
@@ -29509,15 +30268,6 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"is-ci": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-					"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-					"dev": true,
-					"requires": {
-						"ci-info": "^3.2.0"
-					}
-				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -29533,45 +30283,39 @@
 					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				},
-				"y18n": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-					"dev": true
-				},
 				"yargs": {
-					"version": "17.3.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-					"integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+					"version": "17.6.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+					"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
 					"dev": true,
 					"requires": {
-						"cliui": "^7.0.2",
+						"cliui": "^8.0.1",
 						"escalade": "^3.1.1",
 						"get-caller-file": "^2.0.5",
 						"require-directory": "^2.1.1",
 						"string-width": "^4.2.3",
 						"y18n": "^5.0.5",
-						"yargs-parser": "^21.0.0"
+						"yargs-parser": "^21.1.1"
 					}
 				},
 				"yargs-parser": {
-					"version": "21.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-					"integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+					"version": "21.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+					"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 					"dev": true
 				}
 			}
 		},
 		"electron-builder-squirrel-windows": {
-			"version": "23.0.7",
-			"resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-23.0.7.tgz",
-			"integrity": "sha512-HNx1W4vK4i5JAXZGLN6GSLVo57che2LMy9L4JvKLkbSu9ZLpjhbMX2/r9IA6OprErUF/Nhs/eyPz967iDSfdVA==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-23.6.0.tgz",
+			"integrity": "sha512-udKnP0GfbGtB1assAPgQ5EGpVpmZd/6RrcYh9r8Cy96FwGkKwhMOKB+aZBxOILHkX7skG5XPWqc6eu6i9I1lAw==",
 			"dev": true,
 			"requires": {
 				"7zip-bin": "~5.1.1",
-				"app-builder-lib": "23.0.7",
-				"archiver": "^5.3.0",
-				"builder-util": "23.0.6",
+				"app-builder-lib": "24.0.0-alpha.8",
+				"archiver": "^5.3.1",
+				"builder-util": "23.6.0",
 				"fs-extra": "^10.0.0"
 			},
 			"dependencies": {
@@ -29674,61 +30418,27 @@
 				}
 			}
 		},
-		"electron-osx-sign": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz",
-			"integrity": "sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==",
-			"dev": true,
-			"requires": {
-				"bluebird": "^3.5.0",
-				"compare-version": "^0.1.2",
-				"debug": "^2.6.8",
-				"isbinaryfile": "^3.0.2",
-				"minimist": "^1.2.0",
-				"plist": "^3.0.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"isbinaryfile": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
-					"integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
-					"dev": true,
-					"requires": {
-						"buffer-alloc": "^1.2.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
 		"electron-publish": {
-			"version": "23.0.6",
-			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.6.tgz",
-			"integrity": "sha512-ikjgf93uHKyjfTIxVBs3jrDY3x2C06c7Vbq7QDMIQnvMWUqZd1mNTqWUBAr1IQfwX5xvapsWxAJ5TF/Ops5KLg==",
+			"version": "24.0.0-alpha.8",
+			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.0.0-alpha.8.tgz",
+			"integrity": "sha512-DTu/Waa8UVTbuFXWzSn+Wp7IKJC21sx64eM0mY4b7FESa/6BXQnIiFgaC6DU4b8TLofhFQ1uVgp6g1sFWi9fAQ==",
 			"dev": true,
 			"requires": {
 				"@types/fs-extra": "^9.0.11",
-				"builder-util": "23.0.6",
-				"builder-util-runtime": "9.0.1",
-				"chalk": "^4.1.1",
-				"fs-extra": "^10.0.0",
+				"builder-util": "24.0.0-alpha.8",
+				"builder-util-runtime": "9.2.0-alpha.2",
+				"chalk": "^4.1.2",
+				"fs-extra": "^10.1.0",
 				"lazy-val": "^1.0.5",
 				"mime": "^2.5.2"
 			},
 			"dependencies": {
+				"@tootallnate/once": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+					"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+					"dev": true
+				},
 				"@types/fs-extra": {
 					"version": "9.0.13",
 					"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
@@ -29745,6 +30455,47 @@
 					"dev": true,
 					"requires": {
 						"color-convert": "^2.0.1"
+					}
+				},
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
+				"builder-util": {
+					"version": "24.0.0-alpha.8",
+					"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-24.0.0-alpha.8.tgz",
+					"integrity": "sha512-18NtwmgSweocvAV1hp3UMhG67n5NzFcZ1UBb7L38oWchfPfgus4N+aIkVuOYwWG8FvUFcbkm6KT59NVLC2lFqg==",
+					"dev": true,
+					"requires": {
+						"@types/debug": "^4.1.6",
+						"@types/fs-extra": "^9.0.11",
+						"7zip-bin": "~5.1.1",
+						"app-builder-bin": "4.0.0",
+						"bluebird-lst": "^1.0.9",
+						"builder-util-runtime": "9.2.0-alpha.2",
+						"chalk": "^4.1.2",
+						"cross-spawn": "^7.0.3",
+						"debug": "^4.3.4",
+						"fs-extra": "^10.1.0",
+						"http-proxy-agent": "^5.0.0",
+						"https-proxy-agent": "^5.0.1",
+						"is-ci": "^3.0.0",
+						"js-yaml": "^4.1.0",
+						"source-map-support": "^0.5.19",
+						"stat-mode": "^1.0.0",
+						"temp-file": "^3.4.0"
+					}
+				},
+				"builder-util-runtime": {
+					"version": "9.2.0-alpha.2",
+					"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.0-alpha.2.tgz",
+					"integrity": "sha512-MFuU0OSYQ4TIa5uMmVis3aJd7i5buaC9qrb0GjGNPD/GVwQ2LqydquqlKSBlptCib6bjSnL15dHsTbD2xWlVqQ==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.3.4",
+						"sax": "^1.2.4"
 					}
 				},
 				"chalk": {
@@ -29788,6 +30539,26 @@
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
+				},
+				"http-proxy-agent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+					"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+					"dev": true,
+					"requires": {
+						"@tootallnate/once": "2",
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"js-yaml": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"dev": true,
+					"requires": {
+						"argparse": "^2.0.1"
+					}
 				},
 				"mime": {
 					"version": "2.6.0",
@@ -30337,23 +31108,12 @@
 				"debug": "^4.1.1",
 				"get-stream": "^5.1.0",
 				"yauzl": "^2.10.0"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				}
 			}
 		},
 		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+			"integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
 			"dev": true,
 			"optional": true
 		},
@@ -30429,9 +31189,9 @@
 			}
 		},
 		"filelist": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.3.tgz",
-			"integrity": "sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+			"integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
 			"dev": true,
 			"requires": {
 				"minimatch": "^5.0.1"
@@ -30447,9 +31207,9 @@
 					}
 				},
 				"minimatch": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-					"integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+					"integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
 					"dev": true,
 					"requires": {
 						"brace-expansion": "^2.0.1"
@@ -30676,9 +31436,9 @@
 			"dev": true
 		},
 		"get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 			"dev": true,
 			"requires": {
 				"pump": "^3.0.0"
@@ -30730,23 +31490,6 @@
 				"serialize-error": "^7.0.1"
 			}
 		},
-		"global-dirs": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-			"integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
-			"dev": true,
-			"requires": {
-				"ini": "2.0.0"
-			},
-			"dependencies": {
-				"ini": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-					"dev": true
-				}
-			}
-		},
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -30782,51 +31525,28 @@
 			"integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
 		},
 		"got": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+			"version": "11.8.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
 			"dev": true,
 			"requires": {
-				"@sindresorhus/is": "^0.14.0",
-				"@szmarczak/http-timer": "^1.1.2",
-				"cacheable-request": "^6.0.0",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^4.1.0",
-				"lowercase-keys": "^1.0.1",
-				"mimic-response": "^1.0.1",
-				"p-cancelable": "^1.0.0",
-				"to-readable-stream": "^1.0.0",
-				"url-parse-lax": "^3.0.0"
-			},
-			"dependencies": {
-				"decompress-response": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-					"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-					"dev": true,
-					"requires": {
-						"mimic-response": "^1.0.0"
-					}
-				},
-				"mimic-response": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-					"dev": true
-				}
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
 			}
 		},
 		"graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
-		},
-		"graceful-readlink": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-			"dev": true
 		},
 		"graphql": {
 			"version": "16.3.0",
@@ -31015,12 +31735,6 @@
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
-		"has-yarn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
-			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
-			"dev": true
-		},
 		"hawk": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-9.0.1.tgz",
@@ -31145,9 +31859,9 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"requires": {
 				"agent-base": "6",
 				"debug": "4"
@@ -31299,12 +32013,6 @@
 				}
 			}
 		},
-		"import-lazy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-			"dev": true
-		},
 		"import-local": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -31343,12 +32051,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"ini": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true
 		},
 		"inline-style-prefixer": {
 			"version": "6.0.1",
@@ -31425,12 +32127,12 @@
 			"dev": true
 		},
 		"is-ci": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^2.0.0"
+				"ci-info": "^3.2.0"
 			}
 		},
 		"is-core-module": {
@@ -31473,26 +32175,16 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
-		"is-installed-globally": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
-			"integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
-			"dev": true,
-			"requires": {
-				"global-dirs": "^3.0.0",
-				"is-path-inside": "^3.0.2"
-			}
+		"is-interactive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+			"dev": true
 		},
 		"is-lambda": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
 			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="
-		},
-		"is-npm": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
-			"integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
-			"dev": true
 		},
 		"is-number": {
 			"version": "7.0.0",
@@ -31503,12 +32195,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-		},
-		"is-path-inside": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-			"dev": true
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
@@ -31569,16 +32255,10 @@
 				"has-symbols": "^1.0.1"
 			}
 		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
-		},
-		"is-yarn-global": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
-			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+		"is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
 			"dev": true
 		},
 		"isarray": {
@@ -31587,9 +32267,9 @@
 			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 		},
 		"isbinaryfile": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-			"integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.0.tgz",
+			"integrity": "sha512-UDdnyGvMajJUWCkib7Cei/dvyJrrvo4FIrsvSFWdPpXSUorzXrDJ0S+X5Q4ZlasfPjca4yqCNNsjbCeiy8FFeg==",
 			"dev": true
 		},
 		"isexe": {
@@ -31763,9 +32443,9 @@
 					}
 				},
 				"async": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-					"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+					"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
 					"dev": true
 				},
 				"chalk": {
@@ -32049,12 +32729,6 @@
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
-				},
-				"y18n": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-					"dev": true
 				},
 				"yargs": {
 					"version": "17.5.0",
@@ -34003,9 +34677,9 @@
 			}
 		},
 		"json-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
 			"dev": true
 		},
 		"json-order": {
@@ -34255,12 +34929,12 @@
 			}
 		},
 		"keyv": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+			"integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
 			"dev": true,
 			"requires": {
-				"json-buffer": "3.0.0"
+				"json-buffer": "3.0.1"
 			}
 		},
 		"klaw": {
@@ -34276,15 +34950,6 @@
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
-		},
-		"latest-version": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
-			"integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-			"dev": true,
-			"requires": {
-				"package-json": "^6.3.0"
-			}
 		},
 		"lazy-val": {
 			"version": "1.0.5",
@@ -34476,6 +35141,67 @@
 			"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
 			"dev": true
 		},
+		"log-symbols": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.0",
+				"is-unicode-supported": "^0.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"long": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -34506,9 +35232,9 @@
 			}
 		},
 		"lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
 			"dev": true
 		},
 		"lru_map": {
@@ -34538,6 +35264,51 @@
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
 			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
 			"dev": true
+		},
+		"lzma-native": {
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-8.0.6.tgz",
+			"integrity": "sha512-09xfg67mkL2Lz20PrrDeNYZxzeW7ADtpYFbwSQh9U8+76RIzx5QsJBMy8qikv3hbUPfpy6hqwxt6FcGK81g9AA==",
+			"dev": true,
+			"requires": {
+				"node-addon-api": "^3.1.0",
+				"node-gyp-build": "^4.2.1",
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"node-addon-api": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+					"integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+					"dev": true
+				},
+				"string_decoder": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.2.0"
+					}
+				}
+			}
 		},
 		"magic-string": {
 			"version": "0.26.7",
@@ -34769,9 +35540,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
 		},
 		"minimisted": {
 			"version": "2.0.1",
@@ -35006,12 +35777,30 @@
 				}
 			}
 		},
+		"node-abi": {
+			"version": "3.30.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.30.0.tgz",
+			"integrity": "sha512-qWO5l3SCqbwQavymOmtTVuCWZE23++S+rxyoHjXqUmPyzRcaoI4lA2gO55/drddGnedAyjA7sk76SfQ5lfUMnw==",
+			"dev": true,
+			"requires": {
+				"semver": "^7.3.5"
+			}
+		},
 		"node-addon-api": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
 			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
 			"dev": true,
 			"optional": true
+		},
+		"node-api-version": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.1.4.tgz",
+			"integrity": "sha512-KGXihXdUChwJAOHO53bv9/vXcLmdUsZ6jIptbvYvkpKfth+r7jw44JkVxQFA3kX5nQjzjmGu1uAu/xNNLNlI5g==",
+			"dev": true,
+			"requires": {
+				"semver": "^7.3.5"
+			}
 		},
 		"node-cache": {
 			"version": "3.2.1",
@@ -35095,6 +35884,12 @@
 					}
 				}
 			}
+		},
+		"node-gyp-build": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+			"integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+			"dev": true
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -35304,6 +36099,74 @@
 				"word-wrap": "~1.2.3"
 			}
 		},
+		"ora": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+			"dev": true,
+			"requires": {
+				"bl": "^4.1.0",
+				"chalk": "^4.1.0",
+				"cli-cursor": "^3.1.0",
+				"cli-spinners": "^2.5.0",
+				"is-interactive": "^1.0.0",
+				"is-unicode-supported": "^0.1.0",
+				"log-symbols": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"wcwidth": "^1.0.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -35327,9 +36190,9 @@
 			}
 		},
 		"p-cancelable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
 			"dev": true
 		},
 		"p-limit": {
@@ -35360,26 +36223,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-		},
-		"package-json": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
-			"integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
-			"dev": true,
-			"requires": {
-				"got": "^9.6.0",
-				"registry-auth-token": "^4.0.0",
-				"registry-url": "^5.0.0",
-				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
 		},
 		"pako": {
 			"version": "1.0.11",
@@ -35541,21 +36384,13 @@
 			}
 		},
 		"plist": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.5.tgz",
-			"integrity": "sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
+			"integrity": "sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==",
 			"dev": true,
 			"requires": {
 				"base64-js": "^1.5.1",
-				"xmlbuilder": "^9.0.7"
-			},
-			"dependencies": {
-				"xmlbuilder": {
-					"version": "9.0.7",
-					"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-					"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-					"dev": true
-				}
+				"xmlbuilder": "^15.1.1"
 			}
 		},
 		"pony-cause": {
@@ -35761,26 +36596,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
 			"integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
-		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dev": true,
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"dev": true
-				}
-			}
 		},
 		"react": {
 			"version": "18.2.0",
@@ -36154,24 +36969,6 @@
 				"es-abstract": "^1.17.0-next.1"
 			}
 		},
-		"registry-auth-token": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-			"integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
-			"dev": true,
-			"requires": {
-				"rc": "^1.2.8"
-			}
-		},
-		"registry-url": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
-			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
-			"dev": true,
-			"requires": {
-				"rc": "^1.2.8"
-			}
-		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -36255,12 +37052,22 @@
 			"dev": true
 		},
 		"responselike": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "^1.0.0"
+				"lowercase-keys": "^2.0.0"
+			}
+		},
+		"restore-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"dev": true,
+			"requires": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"retry": {
@@ -36414,23 +37221,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"semver-diff": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-			"integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
-			"dev": true,
-			"requires": {
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
-		},
 		"sentence-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
@@ -36564,6 +37354,23 @@
 			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
 			"requires": {
 				"is-arrayish": "^0.3.1"
+			}
+		},
+		"simple-update-notifier": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
+			"integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+			"dev": true,
+			"requires": {
+				"semver": "~7.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+					"dev": true
+				}
 			}
 		},
 		"sisteransi": {
@@ -37148,18 +37955,26 @@
 			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
 		},
 		"tar": {
-			"version": "6.1.11",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-			"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+			"version": "6.1.13",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+			"integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
 			"requires": {
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.0.0",
-				"minipass": "^3.0.0",
+				"minipass": "^4.0.0",
 				"minizlib": "^2.1.1",
 				"mkdirp": "^1.0.3",
 				"yallist": "^4.0.0"
 			},
 			"dependencies": {
+				"minipass": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+					"integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
 				"mkdirp": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -37308,6 +38123,15 @@
 			"integrity": "sha512-ysnVd2E4nWbNXIbHaUidcKGLTmNimqP0hdpsD0Ph5hPJ84ntCF6PHj+Jg3im9nZt9/hNsBg/E6m1psHc2KaPnQ==",
 			"dev": true
 		},
+		"tmp": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+			"dev": true,
+			"requires": {
+				"rimraf": "^3.0.0"
+			}
+		},
 		"tmp-promise": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
@@ -37315,17 +38139,6 @@
 			"dev": true,
 			"requires": {
 				"tmp": "^0.2.0"
-			},
-			"dependencies": {
-				"tmp": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-					"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-					"dev": true,
-					"requires": {
-						"rimraf": "^3.0.0"
-					}
-				}
 			}
 		},
 		"tmpl": {
@@ -37337,12 +38150,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-		},
-		"to-readable-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-			"dev": true
 		},
 		"to-regex-range": {
 			"version": "5.0.1",
@@ -37391,7 +38198,7 @@
 		"truncate-utf8-bytes": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-			"integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+			"integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
 			"dev": true,
 			"requires": {
 				"utf8-byte-length": "^1.0.1"
@@ -37460,15 +38267,6 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.12.0.tgz",
 			"integrity": "sha512-Qe5GRT+n/4GoqCNGGVp5Snapg1Omq3V7irBJB3EaKsp7HWDo5Gv2d/67gfNyV+d5EXD+x/RF5l1h4yJ7qNkcGA==",
 			"dev": true
-		},
-		"typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"dev": true,
-			"requires": {
-				"is-typedarray": "^1.0.0"
-			}
 		},
 		"typescript": {
 			"version": "4.5.5",
@@ -37545,15 +38343,6 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
-		"unique-string": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-			"dev": true,
-			"requires": {
-				"crypto-random-string": "^2.0.0"
-			}
-		},
 		"universalify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
@@ -37609,79 +38398,6 @@
 				"picocolors": "^1.0.0"
 			}
 		},
-		"update-notifier": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
-			"integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
-			"dev": true,
-			"requires": {
-				"boxen": "^5.0.0",
-				"chalk": "^4.1.0",
-				"configstore": "^5.0.1",
-				"has-yarn": "^2.1.0",
-				"import-lazy": "^2.1.0",
-				"is-ci": "^2.0.0",
-				"is-installed-globally": "^0.4.0",
-				"is-npm": "^5.0.0",
-				"is-yarn-global": "^0.3.0",
-				"latest-version": "^5.1.0",
-				"pupa": "^2.1.1",
-				"semver": "^7.3.4",
-				"semver-diff": "^3.1.1",
-				"xdg-basedir": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"upper-case": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
@@ -37725,27 +38441,10 @@
 			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
 			"integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
 		},
-		"url-parse-lax": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"dev": true,
-			"requires": {
-				"prepend-http": "^2.0.0"
-			},
-			"dependencies": {
-				"prepend-http": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-					"dev": true
-				}
-			}
-		},
 		"utf8-byte-length": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-			"integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
+			"integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
 			"dev": true
 		},
 		"util-deprecate": {
@@ -37810,9 +38509,9 @@
 			"dev": true
 		},
 		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+			"integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -37887,6 +38586,15 @@
 				"makeerror": "1.0.12"
 			}
 		},
+		"wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+			"dev": true,
+			"requires": {
+				"defaults": "^1.0.3"
+			}
+		},
 		"web-streams-polyfill": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
@@ -37940,15 +38648,6 @@
 				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
-		"widest-line": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-			"dev": true,
-			"requires": {
-				"string-width": "^4.0.0"
-			}
-		},
 		"wolfy87-eventemitter": {
 			"version": "5.2.9",
 			"resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.9.tgz",
@@ -37998,30 +38697,12 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
-		"write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-			"dev": true,
-			"requires": {
-				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
-			}
-		},
 		"ws": {
 			"version": "8.8.1",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
 			"integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
 			"dev": true,
 			"requires": {}
-		},
-		"xdg-basedir": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "4.0.0",
@@ -38049,8 +38730,7 @@
 			"version": "15.1.1",
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
 			"integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"xmlchars": {
 			"version": "2.2.0",
@@ -38079,6 +38759,11 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
 			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+		},
+		"y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
 		},
 		"yaku": {
 			"version": "0.16.7",
@@ -38114,13 +38799,6 @@
 				"string-width": "^4.2.0",
 				"y18n": "^5.0.5",
 				"yargs-parser": "^20.2.2"
-			},
-			"dependencies": {
-				"y18n": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-				}
 			}
 		},
 		"yargs-parser": {

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -216,6 +216,6 @@
   },
   "overrides": {
     "protobufjs": "github:Kong/protobuf.js#eca9f0f",
-	"app-builder-lib": "24.0.0-alpha.8"
+    "app-builder-lib": "24.0.0-alpha.8"
   }
 }

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -166,8 +166,8 @@
     "date-fns": "^2.28.0",
     "deep-equal": "^1.0.1",
     "electron": "22.0.0",
-    "electron-builder": "23.0.7",
-    "electron-builder-squirrel-windows": "23.0.7",
+    "electron-builder": "23.6.0",
+    "electron-builder-squirrel-windows": "23.6.0",
     "electron-devtools-installer": "^3.2.0",
     "electron-notarize": "^1.1.1",
     "esbuild": "^0.15.13",
@@ -215,6 +215,7 @@
     "dev-server-port": 3334
   },
   "overrides": {
-    "protobufjs": "github:Kong/protobuf.js#eca9f0f"
+    "protobufjs": "github:Kong/protobuf.js#eca9f0f",
+	"app-builder-lib": "24.0.0-alpha.8"
   }
 }


### PR DESCRIPTION
changelog(Fixes): Fixed an issue that prevented running Insomnia when installed via Snapcraft / `.snap` package

Closes #5531 

See [this comment](https://github.com/Kong/insomnia/issues/5531#issuecomment-1355900285)

For `.snap` builds we rely on [this template](https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/templates/snap/snapcraft.yaml), which uses Ubuntu 18 base image that is too old for latest Electron & node-libcurl - causing folks the issue in #5531 

The solution was:
1) Add ability on electron-builder to override the base to recent Ubuntu version (e.g. `core22`) - done in https://github.com/electron-userland/electron-builder/pull/7320
2) Use the updated `electron-builder` dependency (`app-builder-lib`) that allows the override to `base`


Seems to work OK in Ubuntu 22
![image](https://user-images.githubusercontent.com/11976836/208513859-0661c71e-a91b-4b0c-ae79-c809de774d35.png)

