### PR TITLE
Refactor/decouple-db-and-request

### DIFF
--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -450,6 +450,10 @@ export async function getRenderedGrpcRequestMessage(
 }
 
 type RenderRequestOptions = BaseRenderContextOptions & RenderRequest<Request>;
+export interface RequestAndContext {
+  request: RenderedRequest;
+  context: Record<string, any>;
+}
 export async function getRenderedRequestAndContext(
   {
     request,
@@ -457,7 +461,7 @@ export async function getRenderedRequestAndContext(
     extraInfo,
     purpose,
   }: RenderRequestOptions,
-) {
+): Promise<RequestAndContext> {
   const ancestors = await getRenderContextAncestors(request);
   const workspace = ancestors.find(isWorkspace);
   const parentId = workspace ? workspace._id : 'n/a';

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -2,9 +2,17 @@ import { BaseModel, types as modelTypes } from '../models';
 import * as models from '../models';
 import { getBodyBuffer } from '../models/response';
 import { Settings } from '../models/settings';
-import { send } from '../network/network';
+import { isWorkspace } from '../models/workspace';
+import {
+  responseTransform,
+  sendCurlAndWriteTimeline,
+  tryToInterpolateRequest,
+  tryToTransformRequestWithPlugins,
+} from '../network/network';
 import * as plugins from '../plugins';
+import { invariant } from '../utils/invariant';
 import { database } from './database';
+import { RENDER_PURPOSE_SEND } from './render';
 
 // The network layer uses settings from the settings model
 // We want to give consumers the ability to override certain settings
@@ -35,14 +43,50 @@ export async function getSendRequestCallbackMemDb(environmentId: string, memDB: 
     upsert: docs,
     remove: [],
   });
+  const fetchInsoRequestData = async (requestId: string, environmentId: string) => {
+    const request = await models.request.getById(requestId);
+    invariant(request, 'failed to find request');
+    const ancestors = await database.withAncestors(request, [
+      models.request.type,
+      models.requestGroup.type,
+      models.workspace.type,
+    ]);
+    const workspaceDoc = ancestors.find(isWorkspace);
+    const workspaceId = workspaceDoc ? workspaceDoc._id : 'n/a';
+    const workspace = await models.workspace.getById(workspaceId);
+    invariant(workspace, 'failed to find workspace');
 
+    const settings = await models.settings.getOrCreate();
+    invariant(settings, 'failed to create settings');
+    const clientCertificates = await models.clientCertificate.findByParentId(workspaceId);
+    const caCert = await models.caCertificate.findByParentId(workspaceId);
+    // NOTE: inso must name environment
+    const environment = await models.environment.getById(environmentId);
+
+    return { request, environment: environment || {}, settings, clientCertificates, caCert };
+  };
   // Return callback helper to send requests
   return async function sendRequest(requestId: string) {
     try {
       plugins.ignorePlugin('insomnia-plugin-kong-declarative-config');
       plugins.ignorePlugin('insomnia-plugin-kong-kubernetes-config');
       plugins.ignorePlugin('insomnia-plugin-kong-portal');
-      const res = await send(requestId, environmentId);
+      const {
+        request,
+        environment,
+        settings,
+        clientCertificates,
+        caCert,
+      } = await fetchInsoRequestData(requestId, environmentId);
+      const renderResult = await tryToInterpolateRequest(request, environment._id, RENDER_PURPOSE_SEND);
+      const renderedRequest = await tryToTransformRequestWithPlugins(renderResult);
+      const response = await sendCurlAndWriteTimeline(
+        renderedRequest,
+        clientCertificates,
+        caCert,
+        settings,
+      );
+      const res = await responseTransform(response, renderedRequest, renderResult.context);
       const { statusCode: status, statusMessage, headers: headerArray, elapsedTime: responseTime } = res;
       const headers = headerArray?.reduce((acc, { name, value }) => ({ ...acc, [name.toLowerCase() || '']: value || '' }), []);
       const bodyBuffer = await getBodyBuffer(res) as Buffer;

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -1,6 +1,6 @@
 // NOTE: this file should not be imported by electron renderer because node-libcurl is not-context-aware
 // Related issue https://github.com/JCMais/node-libcurl/issues/155
-
+import { invariant } from '../../utils/invariant';
 invariant(process.type !== 'renderer', 'Native abstractions for Nodejs module unavailable in renderer');
 
 import { Curl, CurlAuth, CurlCode, CurlFeature, CurlHttpVersion, CurlInfoDebug, CurlNetrc } from '@getinsomnia/node-libcurl';
@@ -18,7 +18,6 @@ import { AUTH_AWS_IAM, AUTH_DIGEST, AUTH_NETRC, AUTH_NTLM, CONTENT_TYPE_FORM_DAT
 import { describeByteSize, hasAuthHeader, hasUserAgentHeader } from '../../common/misc';
 import { ClientCertificate } from '../../models/client-certificate';
 import { ResponseHeader } from '../../models/response';
-import { invariant } from '../../utils/invariant';
 import { buildMultipart } from './multipart';
 import { parseHeaderStrings } from './parse-header-strings';
 

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -22,7 +22,7 @@ import { ResponseHeader } from '../../models/response';
 import { buildMultipart } from './multipart';
 import { parseHeaderStrings } from './parse-header-strings';
 
-interface CurlRequestOptions {
+export interface CurlRequestOptions {
   requestId: string; // for cancellation
   req: RequestUsedHere;
   finalUrl: string;
@@ -63,7 +63,7 @@ export interface ResponseTimelineEntry {
   value: string;
 }
 
-interface CurlRequestOutput {
+export interface CurlRequestOutput {
   patch: ResponsePatch;
   debugTimeline: ResponseTimelineEntry[];
   headerResults: HeaderResult[];

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -338,7 +338,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
     });
     // NOTE: legacy write end callback
     curl.on('error', () => responseBodyWriteStream.end());
-    curl.on('error', async function(err, code) {
+    curl.on('error', async (err, code) => {
       const elapsedTime = curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000;
       curl.close();
       await waitForStreamToFinish(responseBodyWriteStream);
@@ -380,7 +380,7 @@ const closeReadFunction = (fd: number, isMultipart: boolean, path?: string) => {
   }
 };
 
-interface HeaderResult {
+export interface HeaderResult {
   headers: ResponseHeader[];
   version: string;
   code: number;

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -1,8 +1,7 @@
 // NOTE: this file should not be imported by electron renderer because node-libcurl is not-context-aware
 // Related issue https://github.com/JCMais/node-libcurl/issues/155
-if (process.type === 'renderer') {
-  throw new Error('node-libcurl unavailable in renderer');
-}
+
+invariant(process.type !== 'renderer', 'Native abstractions for Nodejs module unavailable in renderer');
 
 import { Curl, CurlAuth, CurlCode, CurlFeature, CurlHttpVersion, CurlInfoDebug, CurlNetrc } from '@getinsomnia/node-libcurl';
 import electron from 'electron';
@@ -19,6 +18,7 @@ import { AUTH_AWS_IAM, AUTH_DIGEST, AUTH_NETRC, AUTH_NTLM, CONTENT_TYPE_FORM_DAT
 import { describeByteSize, hasAuthHeader, hasUserAgentHeader } from '../../common/misc';
 import { ClientCertificate } from '../../models/client-certificate';
 import { ResponseHeader } from '../../models/response';
+import { invariant } from '../../utils/invariant';
 import { buildMultipart } from './multipart';
 import { parseHeaderStrings } from './parse-header-strings';
 
@@ -234,9 +234,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
     const { authentication } = req;
     if (requestBodyPath) {
       // AWS IAM file upload not supported
-      if (authentication.type === AUTH_AWS_IAM) {
-        throw new Error('AWS authentication not supported for provided body type');
-      }
+      invariant(authentication.type !== AUTH_AWS_IAM, 'AWS authentication not supported for provided body type');
       const { size: contentLength } = fs.statSync(requestBodyPath);
       curl.setOpt(Curl.option.INFILESIZE_LARGE, contentLength);
       curl.setOpt(Curl.option.UPLOAD, 1);

--- a/packages/insomnia/src/network/__tests__/authentication.test.ts
+++ b/packages/insomnia/src/network/__tests__/authentication.test.ts
@@ -197,12 +197,8 @@ describe('API Key', () => {
         value: 'test',
         addTo: 'queryParams',
       };
-      const request = {
-        url: 'https://insomnia.rest/',
-        method: 'GET',
-        authentication,
-      };
-      const header = await getAuthQueryParams(request, 'https://insomnia.rest/');
+
+      const header = getAuthQueryParams(authentication, 'https://insomnia.rest/');
       expect(header).toEqual({
         'name': 'x-api-key',
         'value': 'test',

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -28,7 +28,7 @@ window.app = electron.app;
 
 const getRenderedRequest = async (args: Parameters<typeof getRenderedRequestAndContext>[0]) => (await getRenderedRequestAndContext(args)).request;
 
-describe('actuallySend()', () => {
+describe('sendCurlAndWriteTimeline()', () => {
   beforeEach(async () => {
     await globalBeforeEach();
     await models.project.all();
@@ -101,9 +101,10 @@ describe('actuallySend()', () => {
       },
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const response = await networkUtils._actuallySend(
+    const response = await networkUtils.sendCurlAndWriteTimeline(
       renderedRequest,
-      '',
+      [],
+      null,
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -176,9 +177,10 @@ describe('actuallySend()', () => {
       url: 'http://localhost',
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const response = await networkUtils._actuallySend(
+    const response = await networkUtils.sendCurlAndWriteTimeline(
       renderedRequest,
-      '',
+      [],
+      null,
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -276,9 +278,10 @@ describe('actuallySend()', () => {
       settingSendCookies: false,
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const response = await networkUtils._actuallySend(
+    const response = await networkUtils.sendCurlAndWriteTimeline(
       renderedRequest,
-      '',
+      [],
+      null,
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -336,9 +339,10 @@ describe('actuallySend()', () => {
       },
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const response = await networkUtils._actuallySend(
+    const response = await networkUtils.sendCurlAndWriteTimeline(
       renderedRequest,
-      '',
+      [],
+      null,
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -416,9 +420,10 @@ describe('actuallySend()', () => {
       },
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const response = await networkUtils._actuallySend(
+    const response = await networkUtils.sendCurlAndWriteTimeline(
       renderedRequest,
-      '',
+      [],
+      null,
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -477,9 +482,10 @@ describe('actuallySend()', () => {
       method: 'GET',
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const response = await networkUtils._actuallySend(
+    const response = await networkUtils.sendCurlAndWriteTimeline(
       renderedRequest,
-      '',
+      [],
+      null,
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -517,9 +523,10 @@ describe('actuallySend()', () => {
       method: 'HEAD',
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const response = await networkUtils._actuallySend(
+    const response = await networkUtils.sendCurlAndWriteTimeline(
       renderedRequest,
-      '',
+      [],
+      null,
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -556,9 +563,10 @@ describe('actuallySend()', () => {
       method: 'GET',
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const response = await networkUtils._actuallySend(
+    const response = await networkUtils.sendCurlAndWriteTimeline(
       renderedRequest,
-      '',
+      [],
+      null,
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -596,9 +604,10 @@ describe('actuallySend()', () => {
       },
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const response = await networkUtils._actuallySend(
+    const response = await networkUtils.sendCurlAndWriteTimeline(
       renderedRequest,
-      '',
+      [],
+      null,
       settings,
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -693,9 +702,10 @@ describe('actuallySend()', () => {
       },
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const response = await networkUtils._actuallySend(
+    const response = await networkUtils.sendCurlAndWriteTimeline(
       renderedRequest,
-      '',
+      [],
+      null,
       { ...settings, validateSSL: false },
     );
     const bodyBuffer = models.response.getBodyBuffer(response);
@@ -745,7 +755,7 @@ describe('actuallySend()', () => {
       parentId: workspace._id,
     });
     const renderedRequest = await getRenderedRequest({ request });
-    const responseV1 = await networkUtils._actuallySend(renderedRequest, '', {
+    const responseV1 = await networkUtils.sendCurlAndWriteTimeline(renderedRequest, [], null, {
       ...settings,
       preferredHttpVersion: HttpVersions.V1_0,
     });

--- a/packages/insomnia/src/network/authentication.ts
+++ b/packages/insomnia/src/network/authentication.ts
@@ -11,7 +11,7 @@ import {
   AUTH_OAUTH_2,
 } from '../common/constants';
 import type { RenderedRequest } from '../common/render';
-import { RequestParameter } from '../models/request';
+import { RequestAuthentication, RequestParameter } from '../models/request';
 import { COOKIE, HEADER, QUERY_PARAMS } from './api-key/constants';
 import { getBasicAuthHeader } from './basic-auth/get-header';
 import { getBearerAuthHeader } from './bearer-auth/get-header';
@@ -160,9 +160,7 @@ export async function getAuthHeader(renderedRequest: RenderedRequest, url: strin
   return;
 }
 
-export async function getAuthQueryParams(renderedRequest: RenderedRequest) {
-  const { authentication } = renderedRequest;
-
+export function getAuthQueryParams(authentication: RequestAuthentication) {
   if (authentication.disabled) {
     return;
   }

--- a/packages/insomnia/src/network/cancellation.ts
+++ b/packages/insomnia/src/network/cancellation.ts
@@ -1,4 +1,4 @@
-import { CurlRequestOptions, CurlRequestOutput } from '../main/network/libcurl-promise';
+import type { CurlRequestOptions, CurlRequestOutput } from '../main/network/libcurl-promise';
 const cancelRequestFunctionMap = new Map<string, () => void>();
 export async function cancelRequestById(requestId: string) {
   const cancel = cancelRequestFunctionMap.get(requestId);

--- a/packages/insomnia/src/network/cancellations.ts
+++ b/packages/insomnia/src/network/cancellations.ts
@@ -7,26 +7,38 @@ export async function cancelRequestById(requestId: string) {
   }
   console.log(`[network] Failed to cancel req=${requestId} because cancel function not found`);
 }
-export const cancellableCurlRequest = (requestOptions: CurlRequestOptions) => {
+export const cancellableCurlRequest = async (requestOptions: CurlRequestOptions) => {
   const requestId = requestOptions.requestId;
-  return new Promise<CurlRequestOutput | { statusMessage: string; error: string }>(async resolve => {
-    try {
-      cancelRequestFunctionMap.set(requestId, async () => {
-        cancelRequestFunctionMap.delete(requestId);
-        window.main.cancelCurlRequest(requestId);
-        return resolve({ statusMessage: 'Cancelled', error: 'Request was cancelled' });
-      });
-
-      // NOTE: conditionally use ipc bridge, renderer cannot import native modules directly
-      const nodejsCurlRequest = process.type === 'renderer'
-        ? window.main.curlRequest
-        : (await import('../main/network/libcurl-promise')).curlRequest;
-      return resolve(nodejsCurlRequest(requestOptions));
-
-    } catch (err) {
-      console.log('[network] Error', err);
-      cancelRequestFunctionMap.delete(requestId);
-      return resolve({ statusMessage: 'Error', error: err.message || 'Something went wrong' });
+  const controller = new AbortController();
+  const cancelRequest = () => {
+    window.main.cancelCurlRequest(requestId);
+    controller.abort();
+  };
+  cancelRequestFunctionMap.set(requestId, cancelRequest);
+  try {
+    const result = await cancellablePromise({ signal: controller.signal, fn: window.main.curlRequest(requestOptions) });
+    return result as CurlRequestOutput;
+  } catch (err) {
+    cancelRequestFunctionMap.delete(requestId);
+    if (err.name === 'AbortError') {
+      return { statusMessage: 'Cancelled', error: 'Request was cancelled' };
     }
+    console.log('[network] Error', err);
+    return { statusMessage: 'Error', error: err.message || 'Something went wrong' };
+  }
+};
+const cancellablePromise = ({ signal, fn }: { signal: AbortSignal; fn: Promise<any> }) => {
+  if (signal?.aborted) {
+    return Promise.reject(new DOMException('Aborted', 'AbortError'));
+  }
+  return new Promise((resolve, reject) => {
+    const abortHandler = () => {
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    fn.then(res => {
+      resolve(res);
+      signal?.removeEventListener('abort', abortHandler);
+    }, reject);
+    signal?.addEventListener('abort', abortHandler);
   });
 };

--- a/packages/insomnia/src/network/cancellations.ts
+++ b/packages/insomnia/src/network/cancellations.ts
@@ -1,0 +1,32 @@
+import { CurlRequestOptions, CurlRequestOutput } from '../main/network/libcurl-promise';
+const cancelRequestFunctionMap = new Map<string, () => void>();
+export async function cancelRequestById(requestId: string) {
+  const cancel = cancelRequestFunctionMap.get(requestId);
+  if (cancel) {
+    return cancel();
+  }
+  console.log(`[network] Failed to cancel req=${requestId} because cancel function not found`);
+}
+export const cancellableCurlRequest = (requestOptions: CurlRequestOptions) => {
+  const requestId = requestOptions.requestId;
+  return new Promise<CurlRequestOutput | { statusMessage: string; error: string }>(async resolve => {
+    try {
+      cancelRequestFunctionMap.set(requestId, async () => {
+        cancelRequestFunctionMap.delete(requestId);
+        window.main.cancelCurlRequest(requestId);
+        return resolve({ statusMessage: 'Cancelled', error: 'Request was cancelled' });
+      });
+
+      // NOTE: conditionally use ipc bridge, renderer cannot import native modules directly
+      const nodejsCurlRequest = process.type === 'renderer'
+        ? window.main.curlRequest
+        : (await import('../main/network/libcurl-promise')).curlRequest;
+      return resolve(nodejsCurlRequest(requestOptions));
+
+    } catch (err) {
+      console.log('[network] Error', err);
+      cancelRequestFunctionMap.delete(requestId);
+      return resolve({ statusMessage: 'Error', error: err.message || 'Something went wrong' });
+    }
+  });
+};

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -74,7 +74,6 @@ export async function send(
 ) {
   console.log(`[network] Sending req=${requestId} env=${environmentId || 'null'}`);
 
-  // Fetch some things
   const { request,
     environment,
     settings,
@@ -115,7 +114,8 @@ const fetchRequestData = async (requestId: string) => {
 
   return { request, environment, settings, clientCertificates, caCert };
 };
-const tryToInterpolateRequest = async (request: Request, environmentId: string, purpose?: RenderPurpose, extraInfo?: ExtraRenderInfo) => {
+
+export const tryToInterpolateRequest = async (request: Request, environmentId: string, purpose?: RenderPurpose, extraInfo?: ExtraRenderInfo) => {
   try {
     return await getRenderedRequestAndContext({
       request: request,
@@ -127,7 +127,7 @@ const tryToInterpolateRequest = async (request: Request, environmentId: string, 
     throw new Error(`Failed to render request: ${request._id}`);
   }
 };
-const tryToTransformRequestWithPlugins = async (renderResult: RequestAndContext) => {
+export const tryToTransformRequestWithPlugins = async (renderResult: RequestAndContext) => {
   const { request, context } = renderResult;
   try {
     return await _applyRequestPluginHooks(request, context);
@@ -208,7 +208,7 @@ export async function sendCurlAndWriteTimeline(
     ...patch,
   };
 }
-const responseTransform = (patch: ResponsePatch, renderedRequest: RenderedRequest, context: Record<string, any>) => {
+export const responseTransform = (patch: ResponsePatch, renderedRequest: RenderedRequest, context: Record<string, any>) => {
   const response = {
     ...patch,
     environmentId: patch.environmentId,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -39,6 +39,12 @@ import { getAuthHeader, getAuthQueryParams } from './authentication';
 import { cancellableCurlRequest } from './cancellations';
 import { urlMatchesCertHost } from './url-matches-cert-host';
 
+// used for oauth grant types
+// creates a new request with the patch args
+// and uses env and settings from workspace
+// not cancellable but currently is
+// used indirectly by send and getAuthHeader to fetch tokens
+// @TODO unpack oauth into regular timeline and remove oauth timeine dialog
 export async function sendWithSettings(
   requestId: string,
   requestPatch: Record<string, any>,
@@ -67,6 +73,8 @@ export async function sendWithSettings(
   return responseTransform(response, renderedRequest, renderResult.context);
 }
 
+// used by test feature, inso, and plugin api
+// not all need to be cancellable or to use curl
 export async function send(
   requestId: string,
   environmentId?: string,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -312,20 +312,6 @@ export async function send(
   extraInfo?: ExtraRenderInfo,
 ) {
   console.log(`[network] Sending req=${requestId} env=${environmentId || 'null'}`);
-  // HACK: wait for all debounces to finish
-
-  /*
-   * TODO: Do this in a more robust way
-   * The following block adds a "long" delay to let potential debounces and
-   * database updates finish before making the request. This is done by tracking
-   * the time of the user's last keypress and making sure the request is sent a
-   * significant time after the last press.
-   */
-  const timeSinceLastInteraction = Date.now() - lastUserInteraction;
-  const delayMillis = Math.max(0, MAX_DELAY_TIME - timeSinceLastInteraction);
-  if (delayMillis > 0) {
-    await delay(delayMillis);
-  }
 
   // Fetch some things
   const { request,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -136,6 +136,7 @@ export async function _actuallySend(
       url: requestOptions.finalUrl,
       error: output.error,
       elapsedTime: 0, // 0 because this path is hit during plugin calls
+      bytesRead: 0,
       statusMessage: output.statusMessage,
       timelinePath,
     };

--- a/packages/insomnia/src/network/unit-test-feature.ts
+++ b/packages/insomnia/src/network/unit-test-feature.ts
@@ -10,6 +10,7 @@ export function getSendRequestCallback(environmentId?: string) {
       plugins.ignorePlugin('insomnia-plugin-kong-declarative-config');
       plugins.ignorePlugin('insomnia-plugin-kong-kubernetes-config');
       plugins.ignorePlugin('insomnia-plugin-kong-portal');
+      // NOTE: unit tests will use the UI selected environment
       const res = await send(requestId, environmentId);
       const { statusCode: status, statusMessage, headers: headerArray, elapsedTime: responseTime } = res;
       const headers = headerArray?.reduce((acc, { name, value }) => ({ ...acc, [name.toLowerCase() || '']: value || '' }), []);

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -9,7 +9,7 @@ import { getSetCookieHeaders } from '../../../common/misc';
 import * as models from '../../../models';
 import type { Request } from '../../../models/request';
 import type { Response } from '../../../models/response';
-import { cancelRequestById } from '../../../network/network';
+import { cancelRequestById } from '../../../network/cancellations';
 import { jsonPrettify } from '../../../utils/prettify/json';
 import { updateRequestMetaByParentId } from '../../hooks/create-request';
 import { selectActiveResponse, selectResponseFilter, selectResponseFilterHistory, selectResponsePreviewMode, selectSettings } from '../../redux/selectors';

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -9,7 +9,7 @@ import { getSetCookieHeaders } from '../../../common/misc';
 import * as models from '../../../models';
 import type { Request } from '../../../models/request';
 import type { Response } from '../../../models/response';
-import { cancelRequestById } from '../../../network/cancellations';
+import { cancelRequestById } from '../../../network/cancellation';
 import { jsonPrettify } from '../../../utils/prettify/json';
 import { updateRequestMetaByParentId } from '../../hooks/create-request';
 import { selectActiveResponse, selectResponseFilter, selectResponseFilterHistory, selectResponsePreviewMode, selectSettings } from '../../redux/selectors';


### PR DESCRIPTION
motivation: insomnia network stack is a tangled mess of concerns, this PR splits db, fs, cancellation, transforming request properties, in order to make code easier to read and maintain.


todo
- [x] extract cancellation and try catch
- [x] extract model fetcher
- [x] extract cookies 

assertions:
1. only allow cancellation in the ui code paths
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
