### PR TITLE
[ UX ] Fixes misleading tooltip info :: Organization creation

### DIFF
--- a/packages/insomnia/src/ui/components/organizations-navbar.tsx
+++ b/packages/insomnia/src/ui/components/organizations-navbar.tsx
@@ -160,7 +160,7 @@ export const OrganizationsNav: FC = () => {
             );
           })}
           <li>
-            <Tooltip position='right' message="Create new project">
+            <Tooltip position='right' message="Create new organization">
               <CreateButton
                 type="button"
                 onClick={() => {


### PR DESCRIPTION
This PR attempts to fix a misleading information provided to user via tooltip at left top on UI with + ( plus ) button, for creating a new organization. 

**Before**:

![bug_ui](https://user-images.githubusercontent.com/17321286/209650671-88aa6769-ec8d-4f0f-852d-513314cd16a3.jpeg)


**After**:

![bug_ui_fix](https://user-images.githubusercontent.com/17321286/209650086-be3ef6fc-e7bb-4791-a60e-4d134fd6eb8a.jpeg)



