### PR TITLE
Fix setting auth header for fetchGraphQLSchemaForRequest

### DIFF
--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -20,6 +20,7 @@ import { getRenderedRequestAndContext, render, RENDER_PURPOSE_SEND } from '../..
 import type { ResponsePatch } from '../../../../main/network/libcurl-promise';
 import * as models from '../../../../models';
 import type { Request } from '../../../../models/request';
+import { getAuthHeader } from '../../../../network/authentication';
 import { axiosRequest } from '../../../../network/axios-request';
 import { jsonPrettify } from '../../../../utils/prettify/json';
 import { setDefaultProtocol } from '../../../../utils/url/protocol';
@@ -36,7 +37,6 @@ import { HelpTooltip } from '../../help-tooltip';
 import { Toolbar } from '../../key-value-editor/key-value-editor';
 import { useDocBodyKeyboardShortcuts } from '../../keydown-binder';
 import { TimeFromNow } from '../../time-from-now';
-import { getAuthHeader } from '../../../../network/authentication';
 const explorerContainer = document.querySelector('#graphql-explorer-container');
 
 if (!explorerContainer) {


### PR DESCRIPTION
Closes #5542 

Now appends missing auth header. I've been only able to verify that fixes the issue when using Bearer token.

I'm not familiar with TS or Electron development so any feedback on the implementation would be appreciated. 