### PR TITLE
Remove support email

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,6 @@ Please take a moment to review this document in order to make the contribution p
 
 Please respect the following restrictions:
 
-- Please **do not** use the issue tracker for personal support requests (email [support@insomnia.rest](mailto:support@insomnia.rest)).
-
 - Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others.
 
 ## Bug Reports

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ from the website.
 Have a bug or a feature request? First, read the
 [issue guidelines](CONTRIBUTING.md#using-the-issue-tracker) and search for existing and closed issues. If your problem or idea is not addressed yet, [please open a new issue](https://github.com/Kong/insomnia/issues).
 
-For more generic product questions and feedback, join the [Slack Team](https://chat.insomnia.rest) or email [support@insomnia.rest](mailto:support@insomnia.rest)
-
+For more generic product questions and feedback, join the [Slack Team](https://chat.insomnia.rest).
 ## Contributing
 
 Please read through our [contributing guidelines](CONTRIBUTING.md) and [code of conduct](CODE_OF_CONDUCT.md). Included are directions for opening issues, coding standards, and notes on development.


### PR DESCRIPTION
This PR clarifies to users in documentation and in error modals to report issues to Github Issues.  

Questions: Remove mailto FC?  A quick search in codebase doesn't show the Mailto FC is used anywhere else.

Also, not tested.