### PR TITLE
remove bad CSS child combinator in markdown lists preview (#5526)

### DIFF
--- a/packages/insomnia/src/ui/css/components/markdown-preview.less
+++ b/packages/insomnia/src/ui/css/components/markdown-preview.less
@@ -105,7 +105,7 @@
     padding-left: var(--padding-xs);
   }
 
-  & > ul {
+  ul {
     list-style: disc;
 
     ul {
@@ -113,7 +113,7 @@
     }
   }
 
-  & > ol {
+  ol {
     list-style: decimal;
 
     ol {


### PR DESCRIPTION
changelog(Fixes): Fixed an issue with how lists are displayed in markdown previews

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.
-->
Closes #5526 

As described in [my comment](https://github.com/Kong/insomnia/issues/5526#issuecomment-1374367658), the [child combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Child_combinator) `>` only match the direct descendants, so in nested lists the rule will not apply.

The solution was to remove these child combinators, as there is no point in styling only the direct descendants of the markdown preview container. That's why this bug also appear in these situations:

![image](https://user-images.githubusercontent.com/98111143/211131073-d616410e-d298-4244-96f2-96e76f28f203.png)

Also fixed.

![image|w](https://user-images.githubusercontent.com/98111143/211131147-376b3040-cae2-4c4d-bc1c-8358ca644244.png)

