### PR TITLE
GQL third pass

### DIFF
--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -269,6 +269,7 @@ export const GraphQLEditor: FC<Props> = ({
 
       setState(state => ({
         ...state,
+        documentAST,
         body: { ...state.body, query, operationName },
         operations,
       }));
@@ -409,6 +410,9 @@ export const GraphQLEditor: FC<Props> = ({
       },
     };
   }
+
+  console.log({ variableTypes, operationDefinitions: state.documentAST?.definitions.filter(isOperationDefinition) });
+
   const canShowSchema = schema && !schemaIsFetching && !schemaFetchError && schemaLastFetchTime > 0;
   return (
     <div className="graphql-editor">

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -274,7 +274,12 @@ export const GraphQLEditor: FC<Props> = ({
       }));
     } catch (error) {
       console.warn('failed to parse', error);
-      setState(state => ({ ...state, documentAST: null, body: { ...state.body, query } }));
+      setState(state => ({
+        ...state,
+        documentAST: null,
+        body: { ...state.body, query },
+        operations: query ? state.operations : [],
+      }));
     }
   };
 

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -222,9 +222,7 @@ export const GraphQLEditor: FC<Props> = ({
       useTabs: editorIndentWithTabs,
       tabWidth: editorIndentSize,
     });
-    const prettyVariables = body.variables && JSON.parse(jsonPrettify(JSON.stringify(body.variables)));
     changeQuery(prettyQuery);
-    changeVariables(prettyVariables);
     // Update editor contents
     if (editorRef.current) {
       editorRef.current?.setValue(prettyQuery);
@@ -240,7 +238,7 @@ export const GraphQLEditor: FC<Props> = ({
   };
   const changeVariables = (variablesInput: string) => {
     try {
-      const variables = JSON.parse(variablesInput || 'null');
+      const variables = JSON.parse(variablesInput || '{}');
       onChange(JSON.stringify({ ...state.body, variables }));
       setState(state => ({
         ...state,

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -277,7 +277,7 @@ export const GraphQLEditor: FC<Props> = ({
       setState(state => ({
         ...state,
         documentAST: null,
-        body: { ...state.body, query },
+        body: { ...state.body, query, operationName: query ? state.body.operationName : 'Operations' },
         operations: query ? state.operations : [],
       }));
     }

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -411,8 +411,6 @@ export const GraphQLEditor: FC<Props> = ({
     };
   }
 
-  console.log({ variableTypes, operationDefinitions: state.documentAST?.definitions.filter(isOperationDefinition) });
-
   const canShowSchema = schema && !schemaIsFetching && !schemaFetchError && schemaLastFetchTime > 0;
   return (
     <div className="graphql-editor">

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -251,23 +251,25 @@ export const GraphQLEditor: FC<Props> = ({
     }
   };
   const changeQuery = (query: string) => {
-    onChange(JSON.stringify({ ...state.body, query }));
     try {
       const documentAST = parse(query);
       const operations = documentAST.definitions.filter(isOperationDefinition)?.map(def => def.name?.value || '');
-      const operationsChanged = state.operations.join() !== operations.join();
-      if (operationsChanged && state.body.operationName) {
-        const oldPostion = state.operations.indexOf(state.body.operationName);
+      // default to first operation when none selected
+      let operationName = state.body.operationName || operations[0] || '';
+      if (operations.length && state.body.operationName) {
+        const operationsChanged = state.operations.join() !== operations.join();
         const operationNameWasChanged = !operations.includes(state.body.operationName);
-        if (operationNameWasChanged) {
+        if (operationsChanged && operationNameWasChanged) {
           // preserve selection during name change or fallback to first operation
-          changeOperationName(operations[oldPostion] || operations[0] || '');
+          const oldPostion = state.operations.indexOf(state.body.operationName);
+          operationName = operations[oldPostion] || operations[0] || '';
         }
       }
+      onChange(JSON.stringify({ ...state.body, query, operationName }));
 
       setState(state => ({
         ...state,
-        body: { ...state.body, query },
+        body: { ...state.body, query, operationName },
         operations,
       }));
     } catch (error) {


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where renaming a GraphQL operation would not preserve the selected one


- disable prettify action for variables
- fallback to {} instead of null
- fallback to first operation if none selected
- preserve operation selection if name changes

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
