### PR TITLE
catch error emitted by setting lintOptions

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -445,7 +445,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
         try {
           const newValue = shouldLint ? lintOption : false;
           if (!deepEqual(codeMirror.current?.getOption('lint'), newValue)) {
-            codeMirror.current?.setOption('lint', newValue);
+            tryToSetOption('lint', newValue);
           }
         } catch (err) {
           console.log('Failed to set CodeMirror option', err.message);
@@ -464,11 +464,19 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
     return () => codeMirror.current?.on('blur', handleOnBlur);
   }, [onBlur]);
 
-  useEffect(() => codeMirror.current?.setOption('hintOptions', hintOptions), [hintOptions]);
-  useEffect(() => codeMirror.current?.setOption('info', infoOptions), [infoOptions]);
-  useEffect(() => codeMirror.current?.setOption('jump', jumpOptions), [jumpOptions]);
-  useEffect(() => codeMirror.current?.setOption('lint', lintOptions), [lintOptions]);
-  useEffect(() => codeMirror.current?.setOption('mode', !handleRender ? normalizeMimeType(mode) : { name: 'nunjucks', baseMode: normalizeMimeType(mode) }), [handleRender, mode]);
+  const tryToSetOption = (key: keyof EditorConfiguration, value: any) => {
+    try {
+      codeMirror.current?.setOption(key, value);
+    } catch (err) {
+      console.log('Failed to set CodeMirror option', err.message, { key, value });
+    }
+  };
+
+  useEffect(() => tryToSetOption('hintOptions', hintOptions), [hintOptions]);
+  useEffect(() => tryToSetOption('info', infoOptions), [infoOptions]);
+  useEffect(() => tryToSetOption('jump', jumpOptions), [jumpOptions]);
+  useEffect(() => tryToSetOption('lint', lintOptions), [lintOptions]);
+  useEffect(() => tryToSetOption('mode', !handleRender ? normalizeMimeType(mode) : { name: 'nunjucks', baseMode: normalizeMimeType(mode) }), [handleRender, mode]);
 
   useImperativeHandle(ref, () => ({
     setValue: value => codeMirror.current?.setValue(value),


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where users would get a Render Failure on GraphQL requests, for example, when trying to enter enum values in variables for a GraphQL query 

Fixes #5625 and #5553
- reverts try catch around setOption
- shows lint error in console.log but would be better if it was shown in the red variable error field
- error is thrown by enum definitions https://github.com/graphql/graphql-js/blob/505d096cf6586dc9af0eee50217683d9dd619b53/src/type/definition.ts#L1357
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
