### PR TITLE
Fix GH actions changelog warnings

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -114,7 +114,7 @@ jobs:
           body-includes: Auto-generated changelog
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v2
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ steps.find-pull-request.outputs.number }}


### PR DESCRIPTION
Fixes warnings thrown in Changelog github actions

![Screenshot 2023-01-11 at 16 16 31](https://user-images.githubusercontent.com/11976836/211859203-abeed301-50f6-471e-831e-f62dfbc4e73e.jpg)
