### PR TITLE
remove check for password in git sync

### DIFF
--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -434,15 +434,13 @@ export const updateGitRepoAction: ActionFunction = async ({
       oauth2format,
     };
   } else {
-    const password = formData.get('password');
-    invariant(typeof password === 'string', 'Password is required');
     const token = formData.get('token');
     invariant(typeof token === 'string', 'Token is required');
     const username = formData.get('username');
     invariant(typeof username === 'string', 'Username is required');
 
     repoSettingsPatch.credentials = {
-      password,
+      password: token,
       username,
     };
   }


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where git sync would in some cases fail with a password check error message

Closes #5654 
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
