### PR TITLE
Support custom CA cert in WebSockets (mTLS)

### DIFF
--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -111,7 +111,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
     curl.setOpt(Curl.option.NOPROGRESS, true); // True so debug function works
     curl.setOpt(Curl.option.ACCEPT_ENCODING, ''); // True so curl doesn't print progress
     // attempt to read CA Certificate PEM from disk, fallback to root certificates
-    const caCert = caCertficatePath && (await fs.promises.readFile(caCertficatePath)).toString() || tls.rootCertificates.join('\n');
+    const caCert = (caCertficatePath && (await fs.promises.readFile(caCertficatePath)).toString()) || tls.rootCertificates.join('\n');
     curl.setOpt(Curl.option.CAINFO_BLOB, caCert);
 
     certificates.forEach(validCert => {


### PR DESCRIPTION
wires up custom ca certs to the websocket client the same way as libcurl
Closes INS-2266
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
