### PR TITLE
Fix INS-2232 default theme darker

### DIFF
--- a/plugins/insomnia-plugin-core-themes/index.js
+++ b/plugins/insomnia-plugin-core-themes/index.js
@@ -1,5 +1,6 @@
 module.exports.themes = [
   require('./themes/default'),
+  require('./themes/legacy'),
   require('./themes/studio-light'),
   require('./themes/studio-dark'),
   require('./themes/material'),

--- a/plugins/insomnia-plugin-core-themes/themes/legacy.js
+++ b/plugins/insomnia-plugin-core-themes/themes/legacy.js
@@ -9,12 +9,12 @@ const sidebarBackground = {
 };
 
 module.exports = {
-  name: 'default',
-  displayName: 'Default',
+  name: 'legacy',
+  displayName: 'Legacy',
   theme: {
     background: sidebarBackground,
     foreground: {
-      default: '#ddd',
+      default: '#eee',
     },
     styles: {
       transparentOverlay: {
@@ -27,7 +27,10 @@ module.exports = {
       },
       dialog: {
         background: {
-          default: '#2a2a2a',
+          default: '#fff',
+        },
+        foreground: {
+          default: '#333',
         },
       },
       appHeader: {


### PR DESCRIPTION
changelog(Improvements): Edited the default theme so previously bright modals are now darker. The previous default theme is still available as the Legacy theme 

Closes INS-2232

- Makes default theme darker, while preserving `default` to not break theming after people upgrade
- Created `legacy` theme in case folks want to go back to previous one

Before:
![Screenshot 2023-01-13 at 12 47 09](https://user-images.githubusercontent.com/11976836/212323983-8d1f1cb1-71b7-43cc-9217-106881879f75.jpg)

After:

![Screenshot 2023-01-13 at 12 51 05](https://user-images.githubusercontent.com/11976836/212324286-a1ce5312-3e6b-45a1-a6aa-dc124e75c978.jpg)

Pros: 
- removes CS 1.6 flashbang effect when opening a modal like cookie editor or preferences. Also sparks joy