### PR TITLE
use active env id in response

### DIFF
--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -84,7 +84,7 @@ export async function getSendRequestCallbackMemDb(environmentId: string, memDB: 
         caCert,
         settings,
       );
-      const res = await responseTransform(response, renderedRequest, renderResult.context);
+      const res = await responseTransform(response, environmentId, renderedRequest, renderResult.context);
       const { statusCode: status, statusMessage, headers: headerArray, elapsedTime: responseTime } = res;
       const headers = headerArray?.reduce((acc, { name, value }) => ({ ...acc, [name.toLowerCase() || '']: value || '' }), []);
       const bodyBuffer = await getBodyBuffer(res) as Buffer;


### PR DESCRIPTION
changelog(Fixes): Fixed an issue (#5664) where filter responses by environment setting being enabled prevented users from seeing responses


fixes filter by env

Closes #5664
Closes INS-2267
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
