### PR TITLE
update git.listfiles to list files in .insomnia directory

### DIFF
--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -147,7 +147,7 @@ export class GitVCS {
   async listFiles() {
     console.log('[git] List files');
     const repositoryFiles = await git.listFiles({ ...this._baseOpts });
-    const insomniaFiles = files.filter(file => file.startsWith(GIT_INSOMNIA_DIR_NAME)).map(convertToOsSep);
+    const insomniaFiles = repositoryFiles.filter(file => file.startsWith(GIT_INSOMNIA_DIR_NAME)).map(convertToOsSep);
     return insomniaFiles;
   }
 

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -146,7 +146,8 @@ export class GitVCS {
 
   async listFiles() {
     console.log('[git] List files');
-    const files = await git.listFiles({ ...this._baseOpts, dir: GIT_INSOMNIA_DIR, gitdir: GIT_INSOMNIA_DIR });
+    let files = await git.listFiles({ ...this._baseOpts });
+    files = files.filter(file => file.startsWith(GIT_INSOMNIA_DIR_NAME));
     return files.map(convertToOsSep);
   }
 

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -146,7 +146,7 @@ export class GitVCS {
 
   async listFiles() {
     console.log('[git] List files');
-    const files = await git.listFiles({ ...this._baseOpts });
+    const files = await git.listFiles({ ...this._baseOpts, dir: GIT_INSOMNIA_DIR, gitdir: GIT_INSOMNIA_DIR });
     return files.map(convertToOsSep);
   }
 

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -146,9 +146,9 @@ export class GitVCS {
 
   async listFiles() {
     console.log('[git] List files');
-    let files = await git.listFiles({ ...this._baseOpts });
-    files = files.filter(file => file.startsWith(GIT_INSOMNIA_DIR_NAME));
-    return files.map(convertToOsSep);
+    const repositoryFiles = await git.listFiles({ ...this._baseOpts });
+    const insomniaFiles = files.filter(file => file.startsWith(GIT_INSOMNIA_DIR_NAME)).map(convertToOsSep);
+    return insomniaFiles;
   }
 
   async getBranch() {


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where insomnia would take longer to calculate file changes on Git Sync depending on the size of the Git repository

I noticed in my own working with Insomnia git sync that the git.listfiles method seems to pull all the files in the entire git repository. and runs them through a for loop in the getGitChanges function. This makes the repository I am trying to use insomnia with take 3 minutes to calculate what files were changed and can be committed. Limiting the git.listfiles to the .insomnia directory seems to speed up the load time of this part of the program dramatically. This should address the following open issues #5551 #3269

Closes #5551
Closes #3269
