### PR TITLE
bump playwright to 1.30 canary

### DIFF
--- a/packages/insomnia-smoke-test/package-lock.json
+++ b/packages/insomnia-smoke-test/package-lock.json
@@ -12,7 +12,7 @@
 				"@grpc/grpc-js": "^1.6.7",
 				"@grpc/proto-loader": "^0.6.11",
 				"@jest/globals": "^28.1.0",
-				"@playwright/test": "^1.29.2",
+				"@playwright/test": "^1.30.0-alpha-jan-17-2023",
 				"@ravanallc/grpc-server-reflection": "^0.1.6",
 				"@types/concurrently": "^6.0.1",
 				"@types/express": "^4.17.11",
@@ -1006,13 +1006,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.2.tgz",
-			"integrity": "sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==",
+			"version": "1.30.0-alpha-jan-9-2023",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0-alpha-jan-9-2023.tgz",
+			"integrity": "sha512-YwZujgX8/kBKAtF1EpUFmt66yPhc07wIJVV+8NWPgenM+jnxCnVtYozfu65VPl8jnm/uwY0thrpFdi7OKq3UPg==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
-				"playwright-core": "1.29.2"
+				"playwright-core": "1.30.0-alpha-jan-9-2023"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -5176,9 +5176,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
-			"integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
+			"version": "1.30.0-alpha-jan-9-2023",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0-alpha-jan-9-2023.tgz",
+			"integrity": "sha512-Mqwbq1HV5iYS00aFj84tO2PsjuyK1TDkClAKf/9KRA6CMcoHFOfsFZwWAipGuCyjeqj50w69xT+LD6+l8pDm3A==",
 			"dev": true,
 			"bin": {
 				"playwright": "cli.js"
@@ -6978,13 +6978,13 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.2.tgz",
-			"integrity": "sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==",
+			"version": "1.30.0-alpha-jan-9-2023",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0-alpha-jan-9-2023.tgz",
+			"integrity": "sha512-YwZujgX8/kBKAtF1EpUFmt66yPhc07wIJVV+8NWPgenM+jnxCnVtYozfu65VPl8jnm/uwY0thrpFdi7OKq3UPg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
-				"playwright-core": "1.29.2"
+				"playwright-core": "1.30.0-alpha-jan-9-2023"
 			}
 		},
 		"@protobufjs/aspromise": {
@@ -10199,9 +10199,9 @@
 			}
 		},
 		"playwright-core": {
-			"version": "1.29.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
-			"integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
+			"version": "1.30.0-alpha-jan-9-2023",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0-alpha-jan-9-2023.tgz",
+			"integrity": "sha512-Mqwbq1HV5iYS00aFj84tO2PsjuyK1TDkClAKf/9KRA6CMcoHFOfsFZwWAipGuCyjeqj50w69xT+LD6+l8pDm3A==",
 			"dev": true
 		},
 		"pretty-format": {

--- a/packages/insomnia-smoke-test/package-lock.json
+++ b/packages/insomnia-smoke-test/package-lock.json
@@ -12,7 +12,7 @@
 				"@grpc/grpc-js": "^1.6.7",
 				"@grpc/proto-loader": "^0.6.11",
 				"@jest/globals": "^28.1.0",
-				"@playwright/test": "^1.26.1",
+				"@playwright/test": "^1.29.2",
 				"@ravanallc/grpc-server-reflection": "^0.1.6",
 				"@types/concurrently": "^6.0.1",
 				"@types/express": "^4.17.11",
@@ -1006,13 +1006,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.26.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
-			"integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
+			"version": "1.29.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.2.tgz",
+			"integrity": "sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
-				"playwright-core": "1.26.1"
+				"playwright-core": "1.29.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -5176,9 +5176,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.26.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-			"integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
+			"version": "1.29.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
+			"integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
 			"dev": true,
 			"bin": {
 				"playwright": "cli.js"
@@ -6978,13 +6978,13 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.26.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
-			"integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
+			"version": "1.29.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.2.tgz",
+			"integrity": "sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
-				"playwright-core": "1.26.1"
+				"playwright-core": "1.29.2"
 			}
 		},
 		"@protobufjs/aspromise": {
@@ -10199,9 +10199,9 @@
 			}
 		},
 		"playwright-core": {
-			"version": "1.26.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-			"integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
+			"version": "1.29.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
+			"integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
 			"dev": true
 		},
 		"pretty-format": {

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -31,7 +31,7 @@
     "@grpc/grpc-js": "^1.6.7",
     "@grpc/proto-loader": "^0.6.11",
     "@jest/globals": "^28.1.0",
-    "@playwright/test": "^1.29.2",
+    "@playwright/test": "^1.30.0-alpha-jan-17-2023",
     "@ravanallc/grpc-server-reflection": "^0.1.6",
     "@types/concurrently": "^6.0.1",
     "@types/express": "^4.17.11",

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -31,7 +31,7 @@
     "@grpc/grpc-js": "^1.6.7",
     "@grpc/proto-loader": "^0.6.11",
     "@jest/globals": "^28.1.0",
-    "@playwright/test": "^1.26.1",
+    "@playwright/test": "^1.29.2",
     "@ravanallc/grpc-server-reflection": "^0.1.6",
     "@types/concurrently": "^6.0.1",
     "@types/express": "^4.17.11",

--- a/packages/insomnia-smoke-test/playwright.config.ts
+++ b/packages/insomnia-smoke-test/playwright.config.ts
@@ -36,6 +36,6 @@ const config: PlaywrightTestConfig = {
   expect: {
     timeout: process.env.CI ? 25 * 1000 : 10 * 1000,
   },
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
 };
 export default config;


### PR DESCRIPTION
Bumping to ~~[1.29.2](https://github.com/microsoft/playwright/releases/tag/v1.29.2)~~ 1.30 canary

`test:build` works - but `test:dev` doesn't ⚠️ 