### PR TITLE
oauth2 fix

### DIFF
--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -74,7 +74,8 @@ export const getOAuth2Token = async (
     invariant(authentication.authorizationUrl, 'Invalid authorization URL');
 
     const codeVerifier = authentication.usePkce ? encodePKCE(crypto.randomBytes(32)) : '';
-    const codeChallenge = authentication.pkceMethod !== PKCE_CHALLENGE_S256 ? codeVerifier : encodePKCE(crypto.createHash('sha256').update(codeVerifier).digest());
+    const usePkceAnd256 = authentication.usePkce && authentication.pkceMethod === PKCE_CHALLENGE_S256;
+    const codeChallenge = usePkceAnd256 ? encodePKCE(crypto.createHash('sha256').update(codeVerifier).digest()) : codeVerifier;
     const authCodeUrl = new URL(authentication.authorizationUrl);
     [
       { name: 'response_type', value: RESPONSE_TYPE_CODE },

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -59,7 +59,7 @@ export const getOAuth2Token = async (
     console.log('[oauth2] Detected redirect ' + redirectedTo);
 
     const hash = new URL(redirectedTo).hash.slice(1);
-    invariant(hash, 'No hash found in redirect URL');
+    invariant(hash, 'No hash found in response URL from OAuth2 provider');
     const data = Object.fromEntries(new URLSearchParams(hash));
     const old = await models.oAuth2Token.getOrCreateByParentId(requestId);
     return models.oAuth2Token.update(old, transformNewAccessTokenToOauthModel({


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where code challenge and code verify was not properly sent for Authorization Code grant type in OAuth 2.0 and also surfaced Implicit Grant type errors that were only being logged on console

Closes #5670

- only set code challenge with usePkce
- show implicit response error params in ui
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
