### PR TITLE
oauth2: optional redirect uri fix

### DIFF
--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -76,7 +76,6 @@ export const getOAuth2Token = async (
   invariant(authentication.accessTokenUrl, 'Missing access token URL');
   let params: RequestHeader[] = [];
   if (authentication.grantType === 'authorization_code') {
-    invariant(authentication.redirectUrl, 'Missing redirect URL');
     invariant(authentication.authorizationUrl, 'Invalid authorization URL');
 
     const codeVerifier = authentication.usePkce ? encodePKCE(crypto.randomBytes(32)) : '';
@@ -98,8 +97,8 @@ export const getOAuth2Token = async (
     ].forEach(p => p.value && authCodeUrl.searchParams.append(p.name, p.value));
     const redirectedTo = await window.main.authorizeUserInWindow({
       url: authCodeUrl.toString(),
-      urlSuccessRegex: new RegExp(`${escapeRegex(authentication.redirectUrl)}.*(code=)`, 'i'),
-      urlFailureRegex: new RegExp(`${escapeRegex(authentication.redirectUrl)}.*(error=)`, 'i'),
+      urlSuccessRegex: /(code=)/,
+      urlFailureRegex: /(error=)/,
       sessionId: getOAuthSession(),
     });
     console.log('[oauth2] Detected redirect ' + redirectedTo);

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -1,7 +1,6 @@
 import crypto from 'crypto';
 import querystring from 'querystring';
 
-import { escapeRegex } from '../../common/misc';
 import * as models from '../../models';
 import type { OAuth2Token } from '../../models/o-auth-2-token';
 import type { AuthTypeOAuth2, RequestHeader, RequestParameter } from '../../models/request';


### PR DESCRIPTION
changelog(Improvements): OAuth2 is now looser, not requiring the server to respond with redirect url / allowing to unset it

uses a looser auth code regex in order to allow unset redirect_uri
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
