### PR TITLE
oauth2: implicit default response type to token

### DIFF
--- a/packages/insomnia/src/models/request.ts
+++ b/packages/insomnia/src/models/request.ts
@@ -31,6 +31,7 @@ export const canDuplicate = true;
 export const canSync = true;
 
 export type RequestAuthentication = Record<string, any>;
+export type OAuth2ResponseType = 'code' | 'id_token' | 'id_token token' | 'none' | 'token';
 export interface AuthTypeOAuth2 {
   type: 'oauth2';
   grantType: 'authorization_code' | 'client_credentials' | 'password' | 'implicit' | 'refresh_token';
@@ -52,7 +53,7 @@ export interface AuthTypeOAuth2 {
   tokenPrefix?: string;
   usePkce?: boolean;
   pkceMethod?: string;
-  responseType?: string;
+  responseType?: OAuth2ResponseType;
   origin?: string;
 }
 export interface RequestHeader {

--- a/packages/insomnia/src/network/o-auth-2/constants.ts
+++ b/packages/insomnia/src/network/o-auth-2/constants.ts
@@ -3,10 +3,6 @@ export const GRANT_TYPE_IMPLICIT = 'implicit';
 export const GRANT_TYPE_PASSWORD = 'password';
 export const GRANT_TYPE_CLIENT_CREDENTIALS = 'client_credentials';
 export const GRANT_TYPE_REFRESH = 'refresh_token';
-export const RESPONSE_TYPE_CODE = 'code';
-export const RESPONSE_TYPE_ID_TOKEN = 'id_token';
-export const RESPONSE_TYPE_TOKEN = 'token';
-export const RESPONSE_TYPE_ID_TOKEN_TOKEN = 'id_token token';
 export type AuthKeys =
     'access_token' |
     'id_token' |

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -5,7 +5,7 @@ import accessTokenUrls from '../../../../datasets/access-token-urls';
 import authorizationUrls from '../../../../datasets/authorization-urls';
 import * as models from '../../../../models';
 import type { OAuth2Token } from '../../../../models/o-auth-2-token';
-import type { AuthTypeOAuth2, Request } from '../../../../models/request';
+import type { AuthTypeOAuth2, OAuth2ResponseType, Request } from '../../../../models/request';
 import {
   GRANT_TYPE_AUTHORIZATION_CODE,
   GRANT_TYPE_CLIENT_CREDENTIALS,
@@ -13,9 +13,6 @@ import {
   GRANT_TYPE_PASSWORD,
   PKCE_CHALLENGE_PLAIN,
   PKCE_CHALLENGE_S256,
-  RESPONSE_TYPE_ID_TOKEN,
-  RESPONSE_TYPE_ID_TOKEN_TOKEN,
-  RESPONSE_TYPE_TOKEN,
 } from '../../../../network/o-auth-2/constants';
 import { getOAuth2Token } from '../../../../network/o-auth-2/get-token';
 import { initNewOAuthSession } from '../../../../network/o-auth-2/misc';
@@ -65,18 +62,18 @@ const pkceMethodOptions = [
   },
 ];
 
-const responseTypeOptions = [
+const responseTypeOptions: { name: string; value: OAuth2ResponseType }[] = [
   {
     name: 'Access Token',
-    value: RESPONSE_TYPE_TOKEN,
+    value: 'token',
   },
   {
     name: 'ID Token',
-    value: RESPONSE_TYPE_ID_TOKEN,
+    value: 'id_token',
   },
   {
     name: 'ID and Access Token',
-    value: RESPONSE_TYPE_ID_TOKEN_TOKEN,
+    value: 'id_token token',
   },
 ];
 


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where implicit grant type OAuth2 requests did not have a default response type

fixes #5700
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
