### PR TITLE
Fix URLTag in request history

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -140,7 +140,7 @@ export const ResponseHistoryDropdown = <GenericResponse extends Response | WebSo
         />
         <URLTag
           small
-          url={response.url}
+          url={request.url}
           method={request ? request.method : ''}
           tooltipDelay={1000}
         />


### PR DESCRIPTION
changelog(Improvements): URLs are now displayed on request history for failed requests

Closes #5708 
URLTag in request history was not displaying url for failed requests, the history dropdown was using `response.url` - changed to `request.url`.