### PR TITLE
increase sidebar hl contrast in solarized

### DIFF
--- a/plugins/insomnia-plugin-core-themes/themes/solarized-dark.js
+++ b/plugins/insomnia-plugin-core-themes/themes/solarized-dark.js
@@ -23,5 +23,12 @@ module.exports = {
       lg: 'rgba(142, 149, 146, 0.6)',
       xl: 'rgba(142, 149, 146, 0.8)',
     },
+    styles: {
+      sidebar: {
+        highlight: {
+          default: 'rgb(88, 110, 117)',
+        },
+      }
+    },
   },
 };

--- a/plugins/insomnia-plugin-core-themes/themes/solarized.js
+++ b/plugins/insomnia-plugin-core-themes/themes/solarized.js
@@ -36,6 +36,9 @@ module.exports = {
         foreground: {
           default: '#839496',
         },
+        highlight: {
+          default: 'rgb(88, 110, 117)',
+        },
       },
     },
   },


### PR DESCRIPTION
Changelog(Fixes): Fixed the Solarized/Solarized Dark themes by increasing contrast between items in the Debug sidebar.

Fixes the Solarized/Solarized Dark themes to increase contrast between items in the Debug sidebar window. Non-selected item text is changed to the `base01` color in Solarized ([see here](https://github.com/altercation/solarized#the-values)).

Example below, where the selected request is inside "My Folder".

Old:
![image](https://user-images.githubusercontent.com/53380462/214477867-005b8ae0-ed2a-40dc-9642-4b832197c2ae.png)

New:
![image](https://user-images.githubusercontent.com/53380462/214478096-37d7e456-3b84-401a-a781-b8ad05b89c42.png)

Default for reference:
![image](https://user-images.githubusercontent.com/53380462/214478267-3e84ef3f-0af4-4253-b860-4fb24387453a.png)

Closes #5594
