### PR TITLE
Fix INS-2275 db not defined creating team branch

### DIFF
--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -29,7 +29,7 @@ export interface Query {
 
 type Sort = Record<string, any>;
 
-interface Operation {
+export interface Operation {
   upsert?: BaseModel[];
   remove?: BaseModel[];
 }

--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -5,7 +5,7 @@ import { useInterval, useMount } from 'react-use';
 
 import * as session from '../../../account/session';
 import { DEFAULT_BRANCH_NAME } from '../../../common/constants';
-import { database as db } from '../../../common/database';
+import { database as db, Operation } from '../../../common/database';
 import { docsVersionControl } from '../../../common/documentation';
 import { strings } from '../../../common/strings';
 import * as models from '../../../models';
@@ -216,8 +216,7 @@ export const SyncDropdown: FC<Props> = ({ vcs, workspace, project }) => {
         resourceName: branch,
         resourceType: 'branch',
       });
-      // @ts-expect-error -- TSCONVERSION
-      await db.batchModifyDocs(delta);
+      await db.batchModifyDocs(delta as unknown as Operation);
     } catch (err) {
       showError({
         title: 'Pull Error',
@@ -235,8 +234,7 @@ export const SyncDropdown: FC<Props> = ({ vcs, workspace, project }) => {
   async function handleRevert() {
     try {
       const delta = await vcs.rollbackToLatest(syncItems);
-      // @ts-expect-error -- TSCONVERSION
-      await db.batchModifyDocs(delta);
+      await db.batchModifyDocs(delta as unknown as Operation);
     } catch (err) {
       showError({
         title: 'Revert Error',
@@ -258,8 +256,7 @@ export const SyncDropdown: FC<Props> = ({ vcs, workspace, project }) => {
           delta.remove = delta.remove.filter(e => e?.type !== models.workspace.type);
         }
       }
-      // @ts-expect-error -- TSCONVERSION
-      await db.batchModifyDocs(delta);
+      await db.batchModifyDocs(delta as unknown as Operation);
     } catch (err) {
       showError({
         title: 'Branch Switch Error',

--- a/packages/insomnia/src/ui/components/modals/sync-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-branches-modal.tsx
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 import React, { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { database as db, Operation } from '../../../common/database';
 import { interceptAccessError } from '../../../sync/vcs/util';
 import { VCS } from '../../../sync/vcs/vcs';
 import { selectSyncItems } from '../../redux/selectors';
@@ -83,8 +84,7 @@ export const SyncBranchesModal = forwardRef<SyncBranchesModalHandle, Props>(({ v
   async function handleCheckout(branch: string) {
     try {
       const delta = await vcs.checkout(syncItems, branch);
-      // @ts-expect-error -- TSCONVERSION
-      await db.batchModifyDocs(delta);
+      await db.batchModifyDocs(delta as Operation);
       await refreshState();
     } catch (err) {
       console.log('Failed to checkout', err.stack);
@@ -97,8 +97,7 @@ export const SyncBranchesModal = forwardRef<SyncBranchesModalHandle, Props>(({ v
   const handleMerge = async (branch: string) => {
     const delta = await vcs.merge(syncItems, branch);
     try {
-      // @ts-expect-error -- TSCONVERSION
-      await db.batchModifyDocs(delta);
+      await db.batchModifyDocs(delta as Operation);
       await refreshState();
     } catch (err) {
       console.log('Failed to merge', err.stack);
@@ -143,8 +142,7 @@ export const SyncBranchesModal = forwardRef<SyncBranchesModalHandle, Props>(({ v
       await vcs.fork(newBranchName);
       // Checkout new branch
       const delta = await vcs.checkout(syncItems, newBranchName);
-      // @ts-expect-error -- TSCONVERSION
-      await db.batchModifyDocs(delta);
+      await db.batchModifyDocs(delta as Operation);
       // Clear branch name and refresh things
       await refreshState();
       setState(state => ({


### PR DESCRIPTION
changelog(Fixes): Fixed an issue that cause a `db not defined` error to show up when creating a new branch on Insomnia Cloud sync

Closes INS-2275

We were missing `db` import on the team sync. This doesn't get caught in local development, only on the packaged app.

I went ahead and added the missing import and also tried cleanup a bit to avoid  using the ts-expect error on similar function calls for team sync  and git sync by forcing the type. In some cases had  to do the `as unknown as <something>` trick. Open to improvement  suggestions.
