### PR TITLE
fix windows pdf request smoke test flake

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/app.test.ts
@@ -43,9 +43,9 @@ test('can send requests', async ({ app, page }) => {
   await page.getByRole('button', { name: 'sends dummy.pdf request and shows rich response' }).click();
   await page.click('text=http://127.0.0.1:4010/file/dummy.pdfSend >> button');
   await expect(statusTag).toContainText('200 OK');
-  await page.getByRole('button', { name: 'Preview' }).click();
-  await page.getByRole('menuitem', { name: 'Raw Data' }).click();
-  await expect(responseBody).toContainText('PDF-1.4');
+  // TODO(filipe): re-add a check for the preview that is less flaky
+  await page.getByRole('tab', { name: 'Timeline' }).click();
+  await page.locator('pre').filter({ hasText: '< Content-Type: application/pdf' }).click();
 
   await page.getByRole('button', { name: 'sends request with basic authentication' }).click();
   await page.click('text=http://127.0.0.1:4010/auth/basicSend >> button');


### PR DESCRIPTION
The pdf preview load causes the click on the dropdown `Raw Data` option to be missed due to focus loss.

Dropdown opening
![Screenshot 2023-01-26 at 17 31 01](https://user-images.githubusercontent.com/11976836/214907161-a7a7a103-34ed-412d-8bff-ab86d5b6657f.jpg)

Dropdown closes when preview opens
![Screenshot 2023-01-26 at 17 31 09](https://user-images.githubusercontent.com/11976836/214907159-f5d3f9d8-f49c-434f-903a-41adbb66c361.jpg)


