### PR TITLE
remove reloadMethods

### DIFF
--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useAsync } from 'react-use';
+import { useMount } from 'react-use';
 import styled from 'styled-components';
 
 import { getCommonHeaderNames, getCommonHeaderValues } from '../../../common/common-headers';
@@ -75,20 +75,15 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
   reloadRequests,
 }) => {
   const [isProtoModalOpen, setIsProtoModalOpen] = useState(false);
-  const { requestMessages, running, reloadMethods, methods } = grpcState;
-  useAsync(async () => {
-    // don't actually reload until the request has stopped running or if methods do not need to be reloaded
-    if (!reloadMethods || running) {
-      return;
-    }
-
+  const { requestMessages, running, methods } = grpcState;
+  useMount(async () => {
     if (!activeRequest.protoFileId) {
       return;
     }
     console.log(`[gRPC] loading proto file methods pf=${activeRequest.protoFileId}`);
     const methods = await window.main.grpc.loadMethods(activeRequest.protoFileId);
-    setGrpcState({ ...grpcState, methods, reloadMethods: false });
-  }, [reloadMethods, running, setGrpcState, grpcState, activeRequest.protoFileId]);
+    setGrpcState({ ...grpcState, methods });
+  });
 
   const gitVersion = useGitVCSVersion();
   const activeRequestSyncVersion = useActiveRequestSyncVCSVersion();
@@ -187,7 +182,7 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                     metadata: request.metadata,
                   }, renderContext);
                   const methods = await window.main.grpc.loadMethodsFromReflection(rendered);
-                  setGrpcState({ ...grpcState, methods, reloadMethods: false });
+                  setGrpcState({ ...grpcState, methods });
                 }}
               >
                 <Tooltip message="Click to use server reflection" position="bottom" delay={500}>
@@ -288,7 +283,8 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
               },
               protoMethodName: '',
             });
-            setGrpcState({ ...grpcState, reloadMethods: true });
+            const methods = await window.main.grpc.loadMethods(protoFileId);
+            setGrpcState({ ...grpcState, methods });
             setIsProtoModalOpen(false);
           }
         }}

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -59,7 +59,6 @@ export interface GrpcRequestState {
   status?: StatusObject;
   error?: ServiceError;
   methods: GrpcMethodInfo[];
-  reloadMethods: boolean;
 }
 const INITIAL_GRPC_REQUEST_STATE = {
   running: false,
@@ -68,7 +67,6 @@ const INITIAL_GRPC_REQUEST_STATE = {
   status: undefined,
   error: undefined,
   methods: [],
-  reloadMethods: true,
 };
 export const Debug: FC = () => {
   const activeEnvironment = useSelector(selectActiveEnvironment);
@@ -111,7 +109,7 @@ export const Debug: FC = () => {
   const grpcState = grpcStates.find(s => s.requestId === activeRequest?._id);
   const setGrpcState = (newState:GrpcRequestState) => setGrpcStates(state => state.map(s => s.requestId === activeRequest?._id ? newState : s));
   const reloadRequests = (requestIds:string[]) => {
-    setGrpcStates(state => state.map(s => requestIds.includes(s.requestId) ? { ...s, reloadMethods: true } : s));
+    setGrpcStates(state => state.map(s => requestIds.includes(s.requestId) ? { ...s, methods: [] } : s));
   };
   useEffect(() => window.main.on('grpc.start', (_, id) => {
     setGrpcStates(state => state.map(s => s.requestId === id ? { ...s, running: true } : s));


### PR DESCRIPTION
motivation: in order to make route state less imperative, I am duplicating the load proto method rather than setting a flag
note: when a proto is updated and it is connected to other grpc requests the methods list will be cleared
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
