### PR TITLE
remove the kong/protobuf.js fork

### DIFF
--- a/packages/insomnia/package-lock.json
+++ b/packages/insomnia/package-lock.json
@@ -32,7 +32,7 @@
 				"electron-context-menu": "^3.1.1",
 				"electron-log": "^4.4.3",
 				"fs-extra": "^5.0.0",
-				"grpc-reflection-js": "github:Kong/grpc-reflection-js#355c24c",
+				"grpc-reflection-js": "github:Kong/grpc-reflection-js#01fcce0",
 				"hawk": "9.0.1",
 				"hkdf": "^0.0.2",
 				"html-entities": "^1.2.0",
@@ -18521,10 +18521,10 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.1.2",
-			"resolved": "git+ssh://git@github.com/Kong/protobuf.js.git#eca9f0fcfc816460d5fe899c160e1462c2edf49b",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
+			"integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
 			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
@@ -23364,7 +23364,7 @@
 				"@types/long": "^4.0.1",
 				"lodash.camelcase": "^4.3.0",
 				"long": "^4.0.0",
-				"protobufjs": "github:Kong/protobuf.js#eca9f0f",
+				"protobufjs": "7.2.2",
 				"yargs": "^16.2.0"
 			}
 		},
@@ -31077,13 +31077,13 @@
 		},
 		"grpc-reflection-js": {
 			"version": "git+ssh://git@github.com/Kong/grpc-reflection-js.git#355c24cd062dcc9531f8dd702f04df4ac9a7180c",
-			"from": "grpc-reflection-js@github:Kong/grpc-reflection-js#355c24c",
+			"from": "grpc-reflection-js@github:Kong/grpc-reflection-js#01fcce0",
 			"requires": {
 				"@types/google-protobuf": "^3.7.2",
 				"@types/lodash.set": "^4.3.6",
 				"google-protobuf": "^3.12.2",
 				"lodash.set": "^4.3.2",
-				"protobufjs": "github:Kong/protobuf.js#eca9f0f"
+				"protobufjs": "7.2.2"
 			}
 		},
 		"har-schema": {
@@ -35933,8 +35933,9 @@
 			}
 		},
 		"protobufjs": {
-			"version": "git+ssh://git@github.com/Kong/protobuf.js.git#eca9f0fcfc816460d5fe899c160e1462c2edf49b",
-			"from": "protobufjs@github:Kong/protobuf.js#eca9f0f",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
+			"integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -66,7 +66,7 @@
     "electron-context-menu": "^3.1.1",
     "electron-log": "^4.4.3",
     "fs-extra": "^5.0.0",
-    "grpc-reflection-js": "github:Kong/grpc-reflection-js#355c24c",
+    "grpc-reflection-js": "github:Kong/grpc-reflection-js#01fcce0",
     "hawk": "9.0.1",
     "hkdf": "^0.0.2",
     "html-entities": "^1.2.0",
@@ -214,6 +214,6 @@
     "dev-server-port": 3334
   },
   "overrides": {
-    "protobufjs": "github:Kong/protobuf.js#eca9f0f"
+    "protobufjs": "7.2.2"
   }
 }


### PR DESCRIPTION
simplifies the grpc server reflection deps overrides. step 1 of 2.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
