### PR TITLE
Closes #5722 : if redirectUrl is unset, do not match on it, but still match on it if set

### DIFF
--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import querystring from 'querystring';
-
+import { escapeRegex } from '../../common/misc';
 import * as models from '../../models';
 import type { OAuth2Token } from '../../models/o-auth-2-token';
 import type { AuthTypeOAuth2, OAuth2ResponseType, RequestHeader, RequestParameter } from '../../models/request';
@@ -95,8 +95,10 @@ export const getOAuth2Token = async (
     ].forEach(p => p.value && authCodeUrl.searchParams.append(p.name, p.value));
     const redirectedTo = await window.main.authorizeUserInWindow({
       url: authCodeUrl.toString(),
-      urlSuccessRegex: /(code=)/,
-      urlFailureRegex: /(error=)/,
+      urlSuccessRegex: authentication.redirectUrl ?
+        new RegExp(`${escapeRegex(authentication.redirectUrl)}.*([?&]code=)`, 'i') : /([?&]code=)/i,
+      urlFailureRegex: authentication.redirectUrl ?
+        new RegExp(`${escapeRegex(authentication.redirectUrl)}.*([?&]error=)`, 'i') : /([?&]error=)/i,
       sessionId: getOAuthSession(),
     });
     console.log('[oauth2] Detected redirect ' + redirectedTo);

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import querystring from 'querystring';
+
 import { escapeRegex } from '../../common/misc';
 import * as models from '../../models';
 import type { OAuth2Token } from '../../models/o-auth-2-token';


### PR DESCRIPTION
changelog(Fixes): Added a fix for an issue where a match regex was still being applied if redirectUrl was not set on OAuth2 (related to #5722)

Closes #5722 

If redirectUrl is unset, do not match on it, but still match on it if set.
Also check that 'code' and 'error' are not part of parameters name, but the full name of the parameter in URI

