### PR TITLE
Repro and fix for #5740 - handle git sync of empty repositories/no previous .insomnia folder

### DIFF
--- a/packages/insomnia-smoke-test/tests/prerelease/git-sync-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/git-sync-interactions.test.ts
@@ -51,7 +51,7 @@ test('Clone Repo with bad values', async ({ page }) => {
   await expect(page.locator('.app')).toContainText('Error Pushing Repository');
 });
 
-test('Clone an empty repository', async ({ page }) => {
+test('Clone an empty repository - Kong/insomnia#5740', async ({ page }) => {
   // Clone an empty repository
   await page.click('[data-testid="project"] >> text=Insomnia');
   await page.getByRole('button', { name: 'Create' }).click();

--- a/packages/insomnia-smoke-test/tests/prerelease/git-sync-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/git-sync-interactions.test.ts
@@ -51,6 +51,36 @@ test('Clone Repo with bad values', async ({ page }) => {
   await expect(page.locator('.app')).toContainText('Error Pushing Repository');
 });
 
+test('Clone an empty repository', async ({ page }) => {
+  // Clone an empty repository
+  await page.click('[data-testid="project"] >> text=Insomnia');
+  await page.getByRole('button', { name: 'Create' }).click();
+  await page.getByRole('menuitem', { name: 'Git Clone' }).click();
+  await page.getByRole('tab', { name: 'Git' }).nth(2).click();
+  // TODO(Filipe) - replace with kong/empty-repo
+  await page.getByPlaceholder('https://github.com/org/repo.git').fill('https://github.com/filfreire/empty-repo');
+  await page.getByText('Author Name').fill('test');
+  await page.getByText('Author Email').fill('test');
+  await page.getByText('Username').fill('test');
+  await page.getByText('Authentication Token').fill('test');
+  await page.getByRole('button', { name: 'Clone' }).click();
+
+  // Get no document found dialogue
+  await page.getByText('No document found', { exact: true }).click();
+  await page.getByText('No document found in the repository for import. Would you like to create a new one?').click();
+
+  // Create a new Design Doc
+  await page.getByRole('button', { name: 'Yes' }).click();
+  await page.getByText('Create New Design Document').click();
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
+
+  // Check branch history
+  await page.getByRole('button', { name: 'main' }).click();
+  await page.getByRole('menuitem', { name: 'History' }).click();
+  await page.locator('text=Git History').click();
+  // TODO(Filipe) add check for empty git history
+});
+
 // TODO(kreosus): more git sync prerelease tests will be added when gh auth secrets are properly setup for CI use
 
 // TODO(kreosus): more preferences scenarios will be added in the followup iterations of increasing app test coverage


### PR DESCRIPTION
changelog(Fixes): Fixes an issue where cloning repositories that are empty or previously unused by insomnia didn't suggest users to create an empty insomnia project.

## TODO

- [x] reproduce issue in a smoke test
- [ ] add a fix/workaround

## Investigation

Seems that when we added [routes for git](https://github.com/Kong/insomnia/pull/5523/) we didn't re-include the previous code paths that handled the "empty repo" or "repo without previously a `.insomnia` cases.

```typescript
const noDocumentFound = (gitRepo: GitRepository) => {
  return (dispatch: any) => {
    showAlert({
      title: `No ${strings.document.singular.toLowerCase()} found`,
      okLabel: 'Yes',
      addCancel: true,
      message: `No ${strings.document.singular.toLowerCase()} found in the repository for import. Would you like to create a new one?`,
      onConfirm: () => dispatch(createWorkspaceWithGitRepo(gitRepo)),
    });
  };
};

// (...)

// If no workspace exists, user should be prompted to create a document
if (!(await containsInsomniaWorkspaceDir(fsClient))) {
  dispatch(noDocumentFound(repoSettingsPatch));
  trackSegmentEvent(SegmentEvent.vcsSyncComplete, { ...vcsSegmentEventProperties('git', 'clone', 'no directory found'), providerName });
  return;
}
```


Closes #5740 