### PR TITLE
Fix dropdown closing early issue

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -138,6 +138,7 @@ export const RequestGroupActionsDropdown = forwardRef<RequestGroupActionsDropdow
       ref={dropdownRef}
       onOpen={onOpen}
       dataTestId={`Dropdown-${toKebabCase(requestGroup.name)}`}
+      closeOnSelect={false}
       triggerButton={
         <DropdownButton>
           <i className="fa fa-caret-down" />

--- a/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/response-history-dropdown.tsx
@@ -177,6 +177,7 @@ export const ResponseHistoryDropdown = <GenericResponse extends Response | WebSo
       ref={dropdownRef}
       aria-label="Response history dropdown"
       key={activeResponse ? activeResponse._id : 'n/a'}
+      closeOnSelect={false}
       className={className}
       triggerButton={
         <DropdownButton className="btn btn--super-compact tall" title="Response history">

--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -408,6 +408,7 @@ export const SyncDropdown: FC<Props> = ({ vcs, workspace, project }) => {
         style={{ marginLeft: 'var(--padding-md)' }}
         className="wide tall"
         onOpen={() => refreshVCSAndRefetchRemote()}
+        closeOnSelect={false}
         isDisabled={initializing}
         triggerButton={
           currentBranch === null ?

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -399,6 +399,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
               ref={dropdownRef}
               aria-label="Request Options"
               onClose={handleSendDropdownHide}
+              closeOnSelect={false}
               triggerButton={
                 <StyledDropdownButton
                   className="urlbar__send-context"

--- a/packages/insomnia/src/ui/components/settings/shortcuts.tsx
+++ b/packages/insomnia/src/ui/components/settings/shortcuts.tsx
@@ -56,6 +56,7 @@ export const Shortcuts: FC = () => {
                 <td className="text-right options" style={{ verticalAlign: 'middle' }}>
                   <Dropdown
                     aria-label='Select a mode'
+                    closeOnSelect={false}
                     triggerButton={
                       <DropdownButton
                         removePaddings={false}


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where some dropdown options no longer worked (e.g. deleting a folder, deleting request history, ...).


When we have an `ItemContent`/`DropdownItem` inside a `DropdownSection` and the item has both an `onClick` call and also a `withPrompt` property, we need to set the `closeOnSelect={false}` value on the parent Dropdown so it doesn't exit early when a prompt is opened.

Closes INS-2359
