### PR TITLE
Add ability to delete default project

### DIFF
--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -52,7 +52,7 @@ initializeLogging();
 document.body.setAttribute('data-platform', process.platform);
 document.title = getProductName();
 
-let locationHistoryEntry = `/organization/${DEFAULT_ORGANIZATION_ID}/project/${DEFAULT_PROJECT_ID}`;
+let locationHistoryEntry = `/organization/${DEFAULT_ORGANIZATION_ID}`;
 const prevLocationHistoryEntry = localStorage.getItem('locationHistoryEntry');
 
 if (prevLocationHistoryEntry && matchPath({ path: '/organization/:organizationId', end: false }, prevLocationHistoryEntry)) {
@@ -459,7 +459,6 @@ function updateReduxNavigationState(store: Store, pathname: string) {
 
 async function renderApp() {
   await database.initClient();
-  await models.project.seed();
 
   await initPlugins();
 

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -67,7 +67,11 @@ export const deleteProjectAction: ActionFunction = async ({ params }) => {
 
   trackSegmentEvent(SegmentEvent.projectLocalDelete);
 
-  return redirect(`/organization/${DEFAULT_ORGANIZATION_ID}/project/${DEFAULT_PROJECT_ID}`);
+  if (projectId !== DEFAULT_PROJECT_ID) {
+    return redirect(`/organization/${DEFAULT_ORGANIZATION_ID}/project/${DEFAULT_PROJECT_ID}`);
+  } else {
+    return redirect(`/organization/${organizationId}`);
+  }
 };
 
 // Workspace


### PR DESCRIPTION
Highlights:
- [x] Allows users to delete default project
- [x] A default project is created only the first time the user launches the app.

Future work:
- [ ] Empty View for organization/team without projects
- [ ] Add an Organization route above the project once we update the SidebarLayout component