### PR TITLE
[Importers] OpenAPI and Swagger use underscore-dot syntax for environment variables

### DIFF
--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/dereferenced-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/dereferenced-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -39,9 +39,9 @@
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -54,16 +54,16 @@
       "name": "Add a new pet to the store",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "req___WORKSPACE_ID__74a7a059",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -76,16 +76,16 @@
       "name": "Update an existing pet",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "req___WORKSPACE_ID__80ab0d08",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -101,16 +101,16 @@
         }
       ],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/findByStatus"
+      "url": "{{ _.base_url }}/pet/findByStatus"
     },
     {
       "_id": "req___WORKSPACE_ID__42a17980",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -126,7 +126,7 @@
         }
       ],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/findByTags"
+      "url": "{{ _.base_url }}/pet/findByTags"
     },
     {
       "_id": "req___WORKSPACE_ID__3d1a51d3",
@@ -135,7 +135,7 @@
         "addTo": "header",
         "key": "api_key",
         "type": "apikey",
-        "value": "{{ apiKey }}"
+        "value": "{{ _.apiKey }}"
       },
       "body": {},
       "headers": [],
@@ -143,16 +143,16 @@
       "name": "Find pet by ID",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__a4608701",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -164,16 +164,16 @@
       "name": "Updates a pet in the store with form data",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__e804bd05",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -189,16 +189,16 @@
       "name": "Deletes a pet",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__8081fb6f",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -210,7 +210,7 @@
       "name": "uploads an image",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}/uploadImage"
     },
     {
       "_id": "req___WORKSPACE_ID__443ac9e7",
@@ -219,7 +219,7 @@
         "addTo": "header",
         "key": "api_key",
         "type": "apikey",
-        "value": "{{ apiKey }}"
+        "value": "{{ _.apiKey }}"
       },
       "body": {},
       "headers": [],
@@ -227,7 +227,7 @@
       "name": "Returns pet inventories by status",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/store/inventory"
+      "url": "{{ _.base_url }}/store/inventory"
     },
     {
       "_id": "req___WORKSPACE_ID__e24a4f9e",
@@ -239,7 +239,7 @@
       "name": "Place an order for a pet",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/store/order"
+      "url": "{{ _.base_url }}/store/order"
     },
     {
       "_id": "req___WORKSPACE_ID__f021bcd3",
@@ -251,7 +251,7 @@
       "name": "Find purchase order by ID",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__15e47538",
@@ -263,7 +263,7 @@
       "name": "Delete purchase order by ID",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__fe3d55d0",
@@ -275,7 +275,7 @@
       "name": "Create user",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user"
+      "url": "{{ _.base_url }}/user"
     },
     {
       "_id": "req___WORKSPACE_ID__4cb83333",
@@ -287,7 +287,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/createWithArray"
+      "url": "{{ _.base_url }}/user/createWithArray"
     },
     {
       "_id": "req___WORKSPACE_ID__e94a615f",
@@ -299,7 +299,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/createWithList"
+      "url": "{{ _.base_url }}/user/createWithList"
     },
     {
       "_id": "req___WORKSPACE_ID__00ac9da2",
@@ -322,7 +322,7 @@
         }
       ],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/login"
+      "url": "{{ _.base_url }}/user/login"
     },
     {
       "_id": "req___WORKSPACE_ID__740025cb",
@@ -334,7 +334,7 @@
       "name": "Logs out current logged in user session",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/logout"
+      "url": "{{ _.base_url }}/user/logout"
     },
     {
       "_id": "req___WORKSPACE_ID__74f1d1d1",
@@ -346,7 +346,7 @@
       "name": "Get user by user name",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "req___WORKSPACE_ID__6d74493f",
@@ -358,7 +358,7 @@
       "name": "Updated user",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "req___WORKSPACE_ID__38e8e88f",
@@ -370,7 +370,7 @@
       "name": "Delete user",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/dereferenced-with-tags-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/dereferenced-with-tags-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -63,9 +63,9 @@
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -78,16 +78,16 @@
       "name": "Add a new pet to the store",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "req___WORKSPACE_ID__74a7a059",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -100,16 +100,16 @@
       "name": "Update an existing pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "req___WORKSPACE_ID__80ab0d08",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -125,16 +125,16 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/findByStatus"
+      "url": "{{ _.base_url }}/pet/findByStatus"
     },
     {
       "_id": "req___WORKSPACE_ID__42a17980",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -150,7 +150,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/findByTags"
+      "url": "{{ _.base_url }}/pet/findByTags"
     },
     {
       "_id": "req___WORKSPACE_ID__3d1a51d3",
@@ -159,7 +159,7 @@
         "addTo": "header",
         "key": "api_key",
         "type": "apikey",
-        "value": "{{ apiKey }}"
+        "value": "{{ _.apiKey }}"
       },
       "body": {},
       "headers": [],
@@ -167,16 +167,16 @@
       "name": "Find pet by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__a4608701",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -188,16 +188,16 @@
       "name": "Updates a pet in the store with form data",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__e804bd05",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -213,16 +213,16 @@
       "name": "Deletes a pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__8081fb6f",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -234,7 +234,7 @@
       "name": "uploads an image",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}/uploadImage"
     },
     {
       "_id": "req___WORKSPACE_ID__443ac9e7",
@@ -243,7 +243,7 @@
         "addTo": "header",
         "key": "api_key",
         "type": "apikey",
-        "value": "{{ apiKey }}"
+        "value": "{{ _.apiKey }}"
       },
       "body": {},
       "headers": [],
@@ -251,7 +251,7 @@
       "name": "Returns pet inventories by status",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/inventory"
+      "url": "{{ _.base_url }}/store/inventory"
     },
     {
       "_id": "req___WORKSPACE_ID__e24a4f9e",
@@ -263,7 +263,7 @@
       "name": "Place an order for a pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order"
+      "url": "{{ _.base_url }}/store/order"
     },
     {
       "_id": "req___WORKSPACE_ID__f021bcd3",
@@ -275,7 +275,7 @@
       "name": "Find purchase order by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__15e47538",
@@ -287,7 +287,7 @@
       "name": "Delete purchase order by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__fe3d55d0",
@@ -299,7 +299,7 @@
       "name": "Create user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user"
+      "url": "{{ _.base_url }}/user"
     },
     {
       "_id": "req___WORKSPACE_ID__4cb83333",
@@ -311,7 +311,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/createWithArray"
+      "url": "{{ _.base_url }}/user/createWithArray"
     },
     {
       "_id": "req___WORKSPACE_ID__e94a615f",
@@ -323,7 +323,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/createWithList"
+      "url": "{{ _.base_url }}/user/createWithList"
     },
     {
       "_id": "req___WORKSPACE_ID__00ac9da2",
@@ -346,7 +346,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/login"
+      "url": "{{ _.base_url }}/user/login"
     },
     {
       "_id": "req___WORKSPACE_ID__740025cb",
@@ -358,7 +358,7 @@
       "name": "Logs out current logged in user session",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/logout"
+      "url": "{{ _.base_url }}/user/logout"
     },
     {
       "_id": "req___WORKSPACE_ID__74f1d1d1",
@@ -370,7 +370,7 @@
       "name": "Get user by user name",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "req___WORKSPACE_ID__6d74493f",
@@ -382,7 +382,7 @@
       "name": "Updated user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "req___WORKSPACE_ID__38e8e88f",
@@ -394,7 +394,7 @@
       "name": "Delete user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/endpoint-security-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/endpoint-security-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -55,15 +55,15 @@
       "name": "/none",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/none"
+      "url": "{{ _.base_url }}/none"
     },
     {
       "_id": "req___WORKSPACE_ID__4112dc81",
       "_type": "request",
       "authentication": {
-        "password": "{{ httpPassword }}",
+        "password": "{{ _.httpPassword }}",
         "type": "basic",
-        "username": "{{ httpUsername }}"
+        "username": "{{ _.httpUsername }}"
       },
       "body": {},
       "headers": [],
@@ -71,15 +71,15 @@
       "name": "/none/basic",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/none/basic"
+      "url": "{{ _.base_url }}/none/basic"
     },
     {
       "_id": "req___WORKSPACE_ID__4a563129",
       "_type": "request",
       "authentication": {
-        "password": "{{ httpPassword }}",
+        "password": "{{ _.httpPassword }}",
         "type": "basic",
-        "username": "{{ httpUsername }}"
+        "username": "{{ _.httpUsername }}"
       },
       "body": {},
       "headers": [],
@@ -87,14 +87,14 @@
       "name": "/basic",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/basic"
+      "url": "{{ _.base_url }}/basic"
     },
     {
       "_id": "req___WORKSPACE_ID__6ecf1fc2",
       "_type": "request",
       "authentication": {
         "prefix": "",
-        "token": "{{bearerToken}}",
+        "token": "{{ _.bearerToken }}",
         "type": "bearer"
       },
       "body": {},
@@ -103,7 +103,7 @@
       "name": "/bearer",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/bearer"
+      "url": "{{ _.base_url }}/bearer"
     },
     {
       "_id": "req___WORKSPACE_ID__48bba8a5",
@@ -114,19 +114,19 @@
         {
           "disabled": false,
           "name": "x-api_key",
-          "value": "{{ xApiKey }}"
+          "value": "{{ _.xApiKey }}"
         },
         {
           "disabled": false,
           "name": "x-app-version",
-          "value": "{{ xAppVersion }}"
+          "value": "{{ _.xAppVersion }}"
         }
       ],
       "method": "GET",
       "name": "/key/header",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/key/header"
+      "url": "{{ _.base_url }}/key/header"
     },
     {
       "_id": "req___WORKSPACE_ID__2ea006cf",
@@ -137,14 +137,14 @@
         {
           "disabled": false,
           "name": "Cookie",
-          "value": "CookieName={{ cookieName }}; AnotherCookieName={{ anotherCookieName }}"
+          "value": "CookieName={{ _.cookieName }}; AnotherCookieName={{ _.anotherCookieName }}"
         }
       ],
       "method": "GET",
       "name": "/key/cookie",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/key/cookie"
+      "url": "{{ _.base_url }}/key/cookie"
     },
     {
       "_id": "req___WORKSPACE_ID__0a8d5285",
@@ -158,24 +158,24 @@
         {
           "disabled": false,
           "name": "key",
-          "value": "{{ key }}"
+          "value": "{{ _.key }}"
         },
         {
           "disabled": false,
           "name": "another_key",
-          "value": "{{ anotherKey }}"
+          "value": "{{ _.anotherKey }}"
         }
       ],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/key/query"
+      "url": "{{ _.base_url }}/key/query"
     },
     {
       "_id": "req___WORKSPACE_ID__028b5fb7",
       "_type": "request",
       "authentication": {
-          "clientId": "{{ oauth2ClientId }}",
-          "clientSecret": "{{ oauth2ClientSecret }}",
-          "redirectUrl": "{{ oauth2RedirectUrl }}",
+          "clientId": "{{ _.oauth2ClientId }}",
+          "clientSecret": "{{ _.oauth2ClientSecret }}",
+          "redirectUrl": "{{ _.oauth2RedirectUrl }}",
           "accessTokenUrl": "https://api.server.test/v1/token",
           "authorizationUrl": "https://api.server.test/v1/auth",
           "grantType": "authorization_code",
@@ -188,14 +188,14 @@
       "name": "/oauth2/authorization-code",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/oauth2/authorization-code"
+      "url": "{{ _.base_url }}/oauth2/authorization-code"
     },
     {
       "_id": "req___WORKSPACE_ID__e5d224de",
       "_type": "request",
       "authentication": {
-          "clientId": "{{ oauth2ClientId }}",
-          "redirectUrl": "{{ oauth2RedirectUrl }}",
+          "clientId": "{{ _.oauth2ClientId }}",
+          "redirectUrl": "{{ _.oauth2RedirectUrl }}",
           "authorizationUrl": "https://api.server.test/v1/auth",
           "grantType": "implicit",
           "scope": "read:something write:something",
@@ -207,14 +207,14 @@
       "name": "/oauth2/implicit",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/oauth2/implicit"
+      "url": "{{ _.base_url }}/oauth2/implicit"
     },
     {
       "_id": "req___WORKSPACE_ID__ef33c6a4",
       "_type": "request",
       "authentication": {
-          "clientId": "{{ oauth2ClientId }}",
-          "clientSecret": "{{ oauth2ClientSecret }}",
+          "clientId": "{{ _.oauth2ClientId }}",
+          "clientSecret": "{{ _.oauth2ClientSecret }}",
           "accessTokenUrl": "https://api.server.test/v1/token",
           "grantType": "client_credentials",
           "scope": "read:something write:something",
@@ -226,16 +226,16 @@
       "name": "/oauth2/client-credentials",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/oauth2/client-credentials"
+      "url": "{{ _.base_url }}/oauth2/client-credentials"
     },
     {
       "_id": "req___WORKSPACE_ID__06ba5946",
       "_type": "request",
       "authentication": {
-          "clientId": "{{ oauth2ClientId }}",
-          "clientSecret": "{{ oauth2ClientSecret }}",
-          "username": "{{ oauth2Username }}",
-          "password": "{{ oauth2Password }}",
+          "clientId": "{{ _.oauth2ClientId }}",
+          "clientSecret": "{{ _.oauth2ClientSecret }}",
+          "username": "{{ _.oauth2Username }}",
+          "password": "{{ _.oauth2Password }}",
           "accessTokenUrl": "https://api.server.test/v1/token",
           "grantType": "password",
           "scope": "read:something write:something",
@@ -247,27 +247,27 @@
       "name": "/oauth2/password",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/oauth2/password"
+      "url": "{{ _.base_url }}/oauth2/password"
     },
     {
       "_id": "req___WORKSPACE_ID__e285189c",
       "_type": "request",
       "authentication": {
-        "password": "{{ httpPassword }}",
+        "password": "{{ _.httpPassword }}",
         "type": "basic",
-        "username": "{{ httpUsername }}"
+        "username": "{{ _.httpUsername }}"
       },
       "body": {},
       "headers": [
         {
           "disabled": false,
           "name": "x-api_key",
-          "value": "{{ xApiKey }}"
+          "value": "{{ _.xApiKey }}"
         },
         {
           "disabled": false,
           "name": "Cookie",
-          "value": "CookieName={{ cookieName }}"
+          "value": "CookieName={{ _.cookieName }}"
         }
       ],
       "method": "GET",
@@ -276,11 +276,11 @@
         {
           "disabled": false,
           "name": "key",
-          "value": "{{ key }}"
+          "value": "{{ _.key }}"
         }
       ],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/all"
+      "url": "{{ _.base_url }}/all"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/example-with-server-variables-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/example-with-server-variables-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -41,7 +41,7 @@
       "name": "/files",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/files"
+      "url": "{{ _.base_url }}/files"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/example-without-servers-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/example-without-servers-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -41,7 +41,7 @@
       "name": "List API versions",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/"
+      "url": "{{ _.base_url }}/"
     },
     {
       "_id": "req___WORKSPACE_ID__4dd01204",
@@ -53,7 +53,7 @@
       "name": "Show API version details",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/v2"
+      "url": "{{ _.base_url }}/v2"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/global-security-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/global-security-output.json
@@ -15,7 +15,7 @@
       "parentId": "__WORKSPACE_ID__",
       "name": "Base environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "_type": "environment",
       "_id": "__BASE_ENVIRONMENT_ID__"
@@ -40,7 +40,7 @@
     {
       "parentId": "__WORKSPACE_ID__",
       "name": "/global",
-      "url": "{{ base_url }}/global",
+      "url": "{{ _.base_url }}/global",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -48,13 +48,13 @@
         {
           "name": "x-api_key",
           "disabled": false,
-          "value": "{{ xApiKey }}"
+          "value": "{{ _.xApiKey }}"
         }
       ],
       "authentication": {
         "type": "basic",
-        "username": "{{ httpUsername }}",
-        "password": "{{ httpPassword }}"
+        "username": "{{ _.httpUsername }}",
+        "password": "{{ _.httpPassword }}"
       },
       "_type": "request",
       "_id": "req___WORKSPACE_ID__21946b60"
@@ -62,7 +62,7 @@
     {
       "parentId": "__WORKSPACE_ID__",
       "name": "/override",
-      "url": "{{ base_url }}/override",
+      "url": "{{ _.base_url }}/override",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -71,7 +71,7 @@
         "addTo": "query",
         "key": "apiKeyHere",
         "type": "apikey",
-        "value": "{{ apiKeyHere }}"
+        "value": "{{ _.apiKeyHere }}"
       },
       "_type": "request",
       "_id": "req___WORKSPACE_ID__b410454b"

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/multiple-api-keys-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/multiple-api-keys-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -51,24 +51,24 @@
         {
           "disabled": false,
           "name": "X-API-KEY",
-          "value": "{{ xApiKey }}"
+          "value": "{{ _.xApiKey }}"
         },
         {
           "disabled": false,
           "name": "X-APP-ID",
-          "value": "{{ xAppId }}"
+          "value": "{{ _.xAppId }}"
         },
         {
           "disabled": false,
           "name": "X-APP-SECRET",
-          "value": "{{ xAppSecret }}"
+          "value": "{{ _.xAppSecret }}"
         }
       ],
       "method": "POST",
       "name": "Add a new pet to the store",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "req___WORKSPACE_ID__80ab0d08",
@@ -79,17 +79,17 @@
         {
           "disabled": false,
           "name": "X-API-KEY",
-          "value": "{{ xApiKey }}"
+          "value": "{{ _.xApiKey }}"
         },
         {
           "disabled": false,
           "name": "X-APP-ID",
-          "value": "{{ xAppId }}"
+          "value": "{{ _.xAppId }}"
         },
         {
           "disabled": false,
           "name": "X-APP-SECRET",
-          "value": "{{ xAppSecret }}"
+          "value": "{{ _.xAppSecret }}"
         }
       ],
       "method": "GET",
@@ -102,7 +102,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/findByStatus"
+      "url": "{{ _.base_url }}/pet/findByStatus"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/oauth2-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/oauth2-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -38,12 +38,12 @@
       "_id": "req___WORKSPACE_ID__028b5fb7",
       "_type": "request",
       "authentication": {
-          "clientId": "{{ oauth2ClientId }}",
-          "clientSecret": "{{ oauth2ClientSecret }}",
+          "clientId": "{{ _.oauth2ClientId }}",
+          "clientSecret": "{{ _.oauth2ClientSecret }}",
           "accessTokenUrl": "https://api.server.test/v1/token",
           "authorizationUrl": "https://api.server.test/v1/auth",
           "grantType": "authorization_code",
-          "redirectUrl": "{{ oauth2RedirectUrl }}",
+          "redirectUrl": "{{ _.oauth2RedirectUrl }}",
           "scope": "",
           "type": "oauth2"
       },
@@ -53,18 +53,18 @@
       "name": "/oauth2/authorization-code",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/oauth2/authorization-code"
+      "url": "{{ _.base_url }}/oauth2/authorization-code"
     },
     {
       "_id": "req___WORKSPACE_ID__cbd0a0fa",
       "_type": "request",
       "authentication": {
-        "clientId": "{{ oauth2ClientId }}",
-        "clientSecret": "{{ oauth2ClientSecret }}",
+        "clientId": "{{ _.oauth2ClientId }}",
+        "clientSecret": "{{ _.oauth2ClientSecret }}",
         "accessTokenUrl": "https://api.server.test/v1/token",
         "authorizationUrl": "https://api.server.test/v1/auth",
         "grantType": "authorization_code",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "read:something",
         "type": "oauth2"
       },
@@ -74,18 +74,18 @@
       "name": "/oauth2/authorization-code-read",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/oauth2/authorization-code-read"
+      "url": "{{ _.base_url }}/oauth2/authorization-code-read"
     },
     {
       "_id": "req___WORKSPACE_ID__d7972b84",
       "_type": "request",
       "authentication": {
-        "clientId": "{{ oauth2ClientId }}",
-        "clientSecret": "{{ oauth2ClientSecret }}",
+        "clientId": "{{ _.oauth2ClientId }}",
+        "clientSecret": "{{ _.oauth2ClientSecret }}",
         "accessTokenUrl": "https://api.server.test/v1/token",
         "authorizationUrl": "https://api.server.test/v1/auth",
         "grantType": "authorization_code",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "read:something write:something",
         "type": "oauth2"
       },
@@ -95,7 +95,7 @@
       "name": "/oauth2/authorization-code-read-write",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/oauth2/authorization-code-read-write"
+      "url": "{{ _.base_url }}/oauth2/authorization-code-read-write"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/path-plugin-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/path-plugin-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -41,7 +41,7 @@
       "name": "/path",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/path"
+      "url": "{{ _.base_url }}/path"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -53,9 +53,9 @@
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -68,16 +68,16 @@
       "name": "Add a new pet to the store",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "req___WORKSPACE_ID__74a7a059",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -90,16 +90,16 @@
       "name": "Update an existing pet",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "req___WORKSPACE_ID__80ab0d08",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -115,16 +115,16 @@
         }
       ],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/findByStatus"
+      "url": "{{ _.base_url }}/pet/findByStatus"
     },
     {
       "_id": "req___WORKSPACE_ID__42a17980",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -140,7 +140,7 @@
         }
       ],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/findByTags"
+      "url": "{{ _.base_url }}/pet/findByTags"
     },
     {
       "_id": "req___WORKSPACE_ID__3d1a51d3",
@@ -149,7 +149,7 @@
         "addTo": "header",
         "key": "api_key",
         "type": "apikey",
-        "value": "{{ apiKey }}"
+        "value": "{{ _.apiKey }}"
       },
       "body": {},
       "headers": [],
@@ -157,16 +157,16 @@
       "name": "Find pet by ID",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__a4608701",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -178,16 +178,16 @@
       "name": "Updates a pet in the store with form data",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__e804bd05",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -203,16 +203,16 @@
       "name": "Deletes a pet",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__8081fb6f",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -224,7 +224,7 @@
       "name": "uploads an image",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}/uploadImage"
     },
     {
       "_id": "req___WORKSPACE_ID__443ac9e7",
@@ -233,7 +233,7 @@
         "addTo": "header",
         "key": "api_key",
         "type": "apikey",
-        "value": "{{ apiKey }}"
+        "value": "{{ _.apiKey }}"
       },
       "body": {},
       "headers": [],
@@ -241,7 +241,7 @@
       "name": "Returns pet inventories by status",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/store/inventory"
+      "url": "{{ _.base_url }}/store/inventory"
     },
     {
       "_id": "req___WORKSPACE_ID__e24a4f9e",
@@ -253,7 +253,7 @@
       "name": "Place an order for a pet",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/store/order"
+      "url": "{{ _.base_url }}/store/order"
     },
     {
       "_id": "req___WORKSPACE_ID__f021bcd3",
@@ -265,7 +265,7 @@
       "name": "Find purchase order by ID",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__15e47538",
@@ -277,7 +277,7 @@
       "name": "Delete purchase order by ID",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__fe3d55d0",
@@ -289,7 +289,7 @@
       "name": "Create user",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user"
+      "url": "{{ _.base_url }}/user"
     },
     {
       "_id": "req___WORKSPACE_ID__4cb83333",
@@ -301,7 +301,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/createWithArray"
+      "url": "{{ _.base_url }}/user/createWithArray"
     },
     {
       "_id": "req___WORKSPACE_ID__e94a615f",
@@ -313,7 +313,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/createWithList"
+      "url": "{{ _.base_url }}/user/createWithList"
     },
     {
       "_id": "req___WORKSPACE_ID__00ac9da2",
@@ -336,7 +336,7 @@
         }
       ],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/login"
+      "url": "{{ _.base_url }}/user/login"
     },
     {
       "_id": "req___WORKSPACE_ID__740025cb",
@@ -348,7 +348,7 @@
       "name": "Logs out current logged in user session",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/logout"
+      "url": "{{ _.base_url }}/user/logout"
     },
     {
       "_id": "req___WORKSPACE_ID__74f1d1d1",
@@ -360,7 +360,7 @@
       "name": "Get user by user name",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "req___WORKSPACE_ID__6d74493f",
@@ -372,7 +372,7 @@
       "name": "Updated user",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "req___WORKSPACE_ID__38e8e88f",
@@ -384,7 +384,7 @@
       "name": "Delete user",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-readonly-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-readonly-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -47,7 +47,7 @@
         }
       ],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pets"
+      "url": "{{ _.base_url }}/pets"
     },
     {
       "_id": "req___WORKSPACE_ID__09e1157b",
@@ -62,7 +62,7 @@
       "name": "Create a pet",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pets"
+      "url": "{{ _.base_url }}/pets"
     },
     {
       "_id": "req___WORKSPACE_ID__3b13e39c",
@@ -74,7 +74,7 @@
       "name": "Info for a specific pet",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pets/{{ petId }}"
+      "url": "{{ _.base_url }}/pets/{{ _.petId }}"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-with-tags-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-with-tags-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -63,9 +63,9 @@
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -78,16 +78,16 @@
       "name": "Add a new pet to the store",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "req___WORKSPACE_ID__74a7a059",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -100,16 +100,16 @@
       "name": "Update an existing pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "req___WORKSPACE_ID__80ab0d08",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -125,16 +125,16 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/findByStatus"
+      "url": "{{ _.base_url }}/pet/findByStatus"
     },
     {
       "_id": "req___WORKSPACE_ID__42a17980",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -150,7 +150,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/findByTags"
+      "url": "{{ _.base_url }}/pet/findByTags"
     },
     {
       "_id": "req___WORKSPACE_ID__3d1a51d3",
@@ -159,7 +159,7 @@
         "addTo": "header",
         "key": "api_key",
         "type": "apikey",
-        "value": "{{ apiKey }}"
+        "value": "{{ _.apiKey }}"
       },
       "body": {},
       "headers": [],
@@ -167,16 +167,16 @@
       "name": "Find pet by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__a4608701",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -188,16 +188,16 @@
       "name": "Updates a pet in the store with form data",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__e804bd05",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -213,16 +213,16 @@
       "name": "Deletes a pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__8081fb6f",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ oauth2ClientId }}",
+        "clientId": "{{ _.oauth2ClientId }}",
         "grantType": "implicit",
-        "redirectUrl": "{{ oauth2RedirectUrl }}",
+        "redirectUrl": "{{ _.oauth2RedirectUrl }}",
         "scope": "write:pets read:pets",
         "type": "oauth2"
       },
@@ -234,7 +234,7 @@
       "name": "uploads an image",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}/uploadImage"
     },
     {
       "_id": "req___WORKSPACE_ID__443ac9e7",
@@ -243,7 +243,7 @@
         "addTo": "header",
         "key": "api_key",
         "type": "apikey",
-        "value": "{{ apiKey }}"
+        "value": "{{ _.apiKey }}"
       },
       "body": {},
       "headers": [],
@@ -251,7 +251,7 @@
       "name": "Returns pet inventories by status",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/inventory"
+      "url": "{{ _.base_url }}/store/inventory"
     },
     {
       "_id": "req___WORKSPACE_ID__e24a4f9e",
@@ -263,7 +263,7 @@
       "name": "Place an order for a pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order"
+      "url": "{{ _.base_url }}/store/order"
     },
     {
       "_id": "req___WORKSPACE_ID__f021bcd3",
@@ -275,7 +275,7 @@
       "name": "Find purchase order by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__15e47538",
@@ -287,7 +287,7 @@
       "name": "Delete purchase order by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "req___WORKSPACE_ID__fe3d55d0",
@@ -299,7 +299,7 @@
       "name": "Create user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user"
+      "url": "{{ _.base_url }}/user"
     },
     {
       "_id": "req___WORKSPACE_ID__4cb83333",
@@ -311,7 +311,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/createWithArray"
+      "url": "{{ _.base_url }}/user/createWithArray"
     },
     {
       "_id": "req___WORKSPACE_ID__e94a615f",
@@ -323,7 +323,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/createWithList"
+      "url": "{{ _.base_url }}/user/createWithList"
     },
     {
       "_id": "req___WORKSPACE_ID__00ac9da2",
@@ -346,7 +346,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/login"
+      "url": "{{ _.base_url }}/user/login"
     },
     {
       "_id": "req___WORKSPACE_ID__740025cb",
@@ -358,7 +358,7 @@
       "name": "Logs out current logged in user session",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/logout"
+      "url": "{{ _.base_url }}/user/logout"
     },
     {
       "_id": "req___WORKSPACE_ID__74f1d1d1",
@@ -370,7 +370,7 @@
       "name": "Get user by user name",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "req___WORKSPACE_ID__6d74493f",
@@ -382,7 +382,7 @@
       "name": "Updated user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "req___WORKSPACE_ID__38e8e88f",
@@ -394,7 +394,7 @@
       "name": "Delete user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-yml-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-yml-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -47,7 +47,7 @@
         }
       ],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pets"
+      "url": "{{ _.base_url }}/pets"
     },
     {
       "_id": "req___WORKSPACE_ID__09e1157b",
@@ -59,7 +59,7 @@
       "name": "Create a pet",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pets"
+      "url": "{{ _.base_url }}/pets"
     },
     {
       "_id": "req___WORKSPACE_ID__3b13e39c",
@@ -71,7 +71,7 @@
       "name": "Info for a specific pet",
       "parameters": [],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pets/{{ petId }}"
+      "url": "{{ _.base_url }}/pets/{{ _.petId }}"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-yml-with-tags-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-yml-with-tags-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -55,7 +55,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__a8acce24",
-      "url": "{{ base_url }}/pets"
+      "url": "{{ _.base_url }}/pets"
     },
     {
       "_id": "req___WORKSPACE_ID__26e3ae981",
@@ -73,7 +73,7 @@
         }
       ],
       "parentId": "__WORKSPACE_ID__",
-      "url": "{{ base_url }}/pets"
+      "url": "{{ _.base_url }}/pets"
     },
     {
       "_id": "req___WORKSPACE_ID__09e1157b",
@@ -85,7 +85,7 @@
       "name": "Create a pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__a8acce24",
-      "url": "{{ base_url }}/pets"
+      "url": "{{ _.base_url }}/pets"
     },
     {
       "_id": "req___WORKSPACE_ID__3b13e39c",
@@ -97,7 +97,7 @@
       "name": "Info for a specific pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__a8acce24",
-      "url": "{{ base_url }}/pets/{{ petId }}"
+      "url": "{{ _.base_url }}/pets/{{ _.petId }}"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/dereferenced-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/dereferenced-output.json
@@ -15,7 +15,7 @@
       "parentId": "__WORKSPACE_ID__",
       "name": "Base environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "_type": "environment",
       "_id": "__BASE_ENVIRONMENT_ID__"
@@ -59,7 +59,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Add a new pet to the store",
       "description": "",
-      "url": "{{ base_url }}/pet",
+      "url": "{{ _.base_url }}/pet",
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -68,7 +68,7 @@
       "parameters": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -88,7 +88,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Update an existing pet",
       "description": "",
-      "url": "{{ base_url }}/pet",
+      "url": "{{ _.base_url }}/pet",
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -97,7 +97,7 @@
       "parameters": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -117,7 +117,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Finds Pets by status",
       "description": "Multiple status values can be provided with comma separated strings",
-      "url": "{{ base_url }}/pet/findByStatus",
+      "url": "{{ _.base_url }}/pet/findByStatus",
       "body": {},
       "method": "GET",
       "parameters": [
@@ -130,7 +130,7 @@
       "headers": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -143,7 +143,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Finds Pets by tags",
       "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
-      "url": "{{ base_url }}/pet/findByTags",
+      "url": "{{ _.base_url }}/pet/findByTags",
       "body": {},
       "method": "GET",
       "parameters": [
@@ -156,7 +156,7 @@
       "headers": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -169,7 +169,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Find pet by ID",
       "description": "Returns a single pet",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -177,7 +177,7 @@
         {
           "disabled": false,
           "name": "api_key",
-          "value": "{{ api_key }}"
+          "value": "{{ _.api_key }}"
         }
       ],
       "authentication": {},
@@ -188,7 +188,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Updates a pet in the store with form data",
       "description": "",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}",
       "body": {
         "mimeType": "application/x-www-form-urlencoded",
         "params": [
@@ -208,7 +208,7 @@
       "parameters": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -228,7 +228,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Deletes a pet",
       "description": "",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}",
       "body": {},
       "method": "DELETE",
       "parameters": [],
@@ -241,7 +241,7 @@
       ],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -254,7 +254,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "uploads an image",
       "description": "",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage",
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}/uploadImage",
       "body": {
         "mimeType": "multipart/form-data",
         "params": [
@@ -274,7 +274,7 @@
       "parameters": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -294,7 +294,7 @@
       "parentId": "fld___WORKSPACE_ID__3a21295d",
       "name": "Returns pet inventories by status",
       "description": "Returns a map of status codes to quantities",
-      "url": "{{ base_url }}/store/inventory",
+      "url": "{{ _.base_url }}/store/inventory",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -302,7 +302,7 @@
         {
           "disabled": false,
           "name": "api_key",
-          "value": "{{ api_key }}"
+          "value": "{{ _.api_key }}"
         }
       ],
       "authentication": {},
@@ -313,7 +313,7 @@
       "parentId": "fld___WORKSPACE_ID__3a21295d",
       "name": "Place an order for a pet",
       "description": "",
-      "url": "{{ base_url }}/store/order",
+      "url": "{{ _.base_url }}/store/order",
       "body": {},
       "method": "POST",
       "parameters": [],
@@ -326,7 +326,7 @@
       "parentId": "fld___WORKSPACE_ID__3a21295d",
       "name": "Find purchase order by ID",
       "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -339,7 +339,7 @@
       "parentId": "fld___WORKSPACE_ID__3a21295d",
       "name": "Delete purchase order by ID",
       "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}",
       "body": {},
       "method": "DELETE",
       "parameters": [],
@@ -352,7 +352,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Create user",
       "description": "This can only be done by the logged in user.",
-      "url": "{{ base_url }}/user",
+      "url": "{{ _.base_url }}/user",
       "body": {},
       "method": "POST",
       "parameters": [],
@@ -365,7 +365,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Creates list of users with given input array",
       "description": "",
-      "url": "{{ base_url }}/user/createWithArray",
+      "url": "{{ _.base_url }}/user/createWithArray",
       "body": {},
       "method": "POST",
       "parameters": [],
@@ -378,7 +378,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Creates list of users with given input array",
       "description": "",
-      "url": "{{ base_url }}/user/createWithList",
+      "url": "{{ _.base_url }}/user/createWithList",
       "body": {},
       "method": "POST",
       "parameters": [],
@@ -391,7 +391,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Logs user into the system",
       "description": "",
-      "url": "{{ base_url }}/user/login",
+      "url": "{{ _.base_url }}/user/login",
       "body": {},
       "method": "GET",
       "parameters": [
@@ -415,7 +415,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Logs out current logged in user session",
       "description": "",
-      "url": "{{ base_url }}/user/logout",
+      "url": "{{ _.base_url }}/user/logout",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -428,7 +428,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Get user by user name",
       "description": "",
-      "url": "{{ base_url }}/user/{{ username }}",
+      "url": "{{ _.base_url }}/user/{{ _.username }}",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -441,7 +441,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Updated user",
       "description": "This can only be done by the logged in user.",
-      "url": "{{ base_url }}/user/{{ username }}",
+      "url": "{{ _.base_url }}/user/{{ _.username }}",
       "body": {},
       "method": "PUT",
       "parameters": [],
@@ -454,7 +454,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Delete user",
       "description": "This can only be done by the logged in user.",
-      "url": "{{ base_url }}/user/{{ username }}",
+      "url": "{{ _.base_url }}/user/{{ _.username }}",
       "body": {},
       "method": "DELETE",
       "parameters": [],

--- a/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/dereferenced-with-tags-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/dereferenced-with-tags-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -60,7 +60,7 @@
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -82,14 +82,14 @@
       "name": "Add a new pet to the store",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "updatePet",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -111,14 +111,14 @@
       "name": "Update an existing pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "findPetsByStatus",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -137,14 +137,14 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/findByStatus"
+      "url": "{{ _.base_url }}/pet/findByStatus"
     },
     {
       "_id": "findPetsByTags",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -163,7 +163,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/findByTags"
+      "url": "{{ _.base_url }}/pet/findByTags"
     },
     {
       "_id": "getPetById",
@@ -175,21 +175,21 @@
         {
           "disabled": false,
           "name": "api_key",
-          "value": "{{ api_key }}"
+          "value": "{{ _.api_key }}"
         }
       ],
       "method": "GET",
       "name": "Find pet by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "updatePetWithForm",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -222,14 +222,14 @@
       "name": "Updates a pet in the store with form data",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "deletePet",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -248,14 +248,14 @@
       "name": "Deletes a pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "uploadFile",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -288,7 +288,7 @@
       "name": "uploads an image",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}/uploadImage"
     },
     {
       "_id": "getInventory",
@@ -300,14 +300,14 @@
         {
           "disabled": false,
           "name": "api_key",
-          "value": "{{ api_key }}"
+          "value": "{{ _.api_key }}"
         }
       ],
       "method": "GET",
       "name": "Returns pet inventories by status",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/inventory"
+      "url": "{{ _.base_url }}/store/inventory"
     },
     {
       "_id": "placeOrder",
@@ -320,7 +320,7 @@
       "name": "Place an order for a pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order"
+      "url": "{{ _.base_url }}/store/order"
     },
     {
       "_id": "getOrderById",
@@ -333,7 +333,7 @@
       "name": "Find purchase order by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "deleteOrder",
@@ -346,7 +346,7 @@
       "name": "Delete purchase order by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "createUser",
@@ -359,7 +359,7 @@
       "name": "Create user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user"
+      "url": "{{ _.base_url }}/user"
     },
     {
       "_id": "createUsersWithArrayInput",
@@ -372,7 +372,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/createWithArray"
+      "url": "{{ _.base_url }}/user/createWithArray"
     },
     {
       "_id": "createUsersWithListInput",
@@ -385,7 +385,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/createWithList"
+      "url": "{{ _.base_url }}/user/createWithList"
     },
     {
       "_id": "loginUser",
@@ -409,7 +409,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/login"
+      "url": "{{ _.base_url }}/user/login"
     },
     {
       "_id": "logoutUser",
@@ -422,7 +422,7 @@
       "name": "Logs out current logged in user session",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/logout"
+      "url": "{{ _.base_url }}/user/logout"
     },
     {
       "_id": "getUserByName",
@@ -435,7 +435,7 @@
       "name": "Get user by user name",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "updateUser",
@@ -448,7 +448,7 @@
       "name": "Updated user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "deleteUser",
@@ -461,7 +461,7 @@
       "name": "Delete user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/petstore-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/petstore-output.json
@@ -15,7 +15,7 @@
       "parentId": "__WORKSPACE_ID__",
       "name": "Base environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "_type": "environment",
       "_id": "__BASE_ENVIRONMENT_ID__"
@@ -59,7 +59,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Add a new pet to the store",
       "description": "",
-      "url": "{{ base_url }}/pet",
+      "url": "{{ _.base_url }}/pet",
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -68,7 +68,7 @@
       "parameters": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -88,7 +88,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Update an existing pet",
       "description": "",
-      "url": "{{ base_url }}/pet",
+      "url": "{{ _.base_url }}/pet",
       "body": {
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
@@ -97,7 +97,7 @@
       "parameters": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -117,7 +117,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Finds Pets by status",
       "description": "Multiple status values can be provided with comma separated strings",
-      "url": "{{ base_url }}/pet/findByStatus",
+      "url": "{{ _.base_url }}/pet/findByStatus",
       "body": {},
       "method": "GET",
       "parameters": [
@@ -130,7 +130,7 @@
       "headers": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -143,7 +143,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Finds Pets by tags",
       "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
-      "url": "{{ base_url }}/pet/findByTags",
+      "url": "{{ _.base_url }}/pet/findByTags",
       "body": {},
       "method": "GET",
       "parameters": [
@@ -156,7 +156,7 @@
       "headers": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -169,7 +169,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Find pet by ID",
       "description": "Returns a single pet",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -177,7 +177,7 @@
         {
           "disabled": false,
           "name": "api_key",
-          "value": "{{ api_key }}"
+          "value": "{{ _.api_key }}"
         }
       ],
       "authentication": {},
@@ -188,7 +188,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Updates a pet in the store with form data",
       "description": "",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}",
       "body": {
         "mimeType": "application/x-www-form-urlencoded",
         "params": [
@@ -208,7 +208,7 @@
       "parameters": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -228,7 +228,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "Deletes a pet",
       "description": "",
-      "url": "{{ base_url }}/pet/{{ petId }}",
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}",
       "body": {},
       "method": "DELETE",
       "parameters": [],
@@ -241,7 +241,7 @@
       ],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -254,7 +254,7 @@
       "parentId": "fld___WORKSPACE_ID__1b034c38",
       "name": "uploads an image",
       "description": "",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage",
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}/uploadImage",
       "body": {
         "mimeType": "multipart/form-data",
         "params": [
@@ -274,7 +274,7 @@
       "parameters": [],
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -294,7 +294,7 @@
       "parentId": "fld___WORKSPACE_ID__3a21295d",
       "name": "Returns pet inventories by status",
       "description": "Returns a map of status codes to quantities",
-      "url": "{{ base_url }}/store/inventory",
+      "url": "{{ _.base_url }}/store/inventory",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -302,7 +302,7 @@
         {
           "disabled": false,
           "name": "api_key",
-          "value": "{{ api_key }}"
+          "value": "{{ _.api_key }}"
         }
       ],
       "authentication": {},
@@ -313,7 +313,7 @@
       "parentId": "fld___WORKSPACE_ID__3a21295d",
       "name": "Place an order for a pet",
       "description": "",
-      "url": "{{ base_url }}/store/order",
+      "url": "{{ _.base_url }}/store/order",
       "body": {},
       "method": "POST",
       "parameters": [],
@@ -326,7 +326,7 @@
       "parentId": "fld___WORKSPACE_ID__3a21295d",
       "name": "Find purchase order by ID",
       "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -339,7 +339,7 @@
       "parentId": "fld___WORKSPACE_ID__3a21295d",
       "name": "Delete purchase order by ID",
       "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
-      "url": "{{ base_url }}/store/order/{{ orderId }}",
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}",
       "body": {},
       "method": "DELETE",
       "parameters": [],
@@ -352,7 +352,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Create user",
       "description": "This can only be done by the logged in user.",
-      "url": "{{ base_url }}/user",
+      "url": "{{ _.base_url }}/user",
       "body": {},
       "method": "POST",
       "parameters": [],
@@ -365,7 +365,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Creates list of users with given input array",
       "description": "",
-      "url": "{{ base_url }}/user/createWithArray",
+      "url": "{{ _.base_url }}/user/createWithArray",
       "body": {},
       "method": "POST",
       "parameters": [],
@@ -378,7 +378,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Creates list of users with given input array",
       "description": "",
-      "url": "{{ base_url }}/user/createWithList",
+      "url": "{{ _.base_url }}/user/createWithList",
       "body": {},
       "method": "POST",
       "parameters": [],
@@ -391,7 +391,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Logs user into the system",
       "description": "",
-      "url": "{{ base_url }}/user/login",
+      "url": "{{ _.base_url }}/user/login",
       "body": {},
       "method": "GET",
       "parameters": [
@@ -415,7 +415,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Logs out current logged in user session",
       "description": "",
-      "url": "{{ base_url }}/user/logout",
+      "url": "{{ _.base_url }}/user/logout",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -428,7 +428,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Get user by user name",
       "description": "",
-      "url": "{{ base_url }}/user/{{ username }}",
+      "url": "{{ _.base_url }}/user/{{ _.username }}",
       "body": {},
       "method": "GET",
       "parameters": [],
@@ -441,7 +441,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Updated user",
       "description": "This can only be done by the logged in user.",
-      "url": "{{ base_url }}/user/{{ username }}",
+      "url": "{{ _.base_url }}/user/{{ _.username }}",
       "body": {},
       "method": "PUT",
       "parameters": [],
@@ -454,7 +454,7 @@
       "parentId": "fld___WORKSPACE_ID__12dea96f",
       "name": "Delete user",
       "description": "This can only be done by the logged in user.",
-      "url": "{{ base_url }}/user/{{ username }}",
+      "url": "{{ _.base_url }}/user/{{ _.username }}",
       "body": {},
       "method": "DELETE",
       "parameters": [],

--- a/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/petstore-with-tags-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/petstore-with-tags-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -60,7 +60,7 @@
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -82,14 +82,14 @@
       "name": "Add a new pet to the store",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "updatePet",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -111,14 +111,14 @@
       "name": "Update an existing pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet"
+      "url": "{{ _.base_url }}/pet"
     },
     {
       "_id": "findPetsByStatus",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -137,14 +137,14 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/findByStatus"
+      "url": "{{ _.base_url }}/pet/findByStatus"
     },
     {
       "_id": "findPetsByTags",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -163,7 +163,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/findByTags"
+      "url": "{{ _.base_url }}/pet/findByTags"
     },
     {
       "_id": "getPetById",
@@ -175,21 +175,21 @@
         {
           "disabled": false,
           "name": "api_key",
-          "value": "{{ api_key }}"
+          "value": "{{ _.api_key }}"
         }
       ],
       "method": "GET",
       "name": "Find pet by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "updatePetWithForm",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -222,14 +222,14 @@
       "name": "Updates a pet in the store with form data",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "deletePet",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -248,14 +248,14 @@
       "name": "Deletes a pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}"
     },
     {
       "_id": "uploadFile",
       "_type": "request",
       "authentication": {
         "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-        "clientId": "{{ client_id }}",
+        "clientId": "{{ _.client_id }}",
         "disabled": false,
         "grantType": "authorization_code",
         "scope": "write:pets read:pets",
@@ -288,7 +288,7 @@
       "name": "uploads an image",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__1b034c38",
-      "url": "{{ base_url }}/pet/{{ petId }}/uploadImage"
+      "url": "{{ _.base_url }}/pet/{{ _.petId }}/uploadImage"
     },
     {
       "_id": "getInventory",
@@ -300,14 +300,14 @@
         {
           "disabled": false,
           "name": "api_key",
-          "value": "{{ api_key }}"
+          "value": "{{ _.api_key }}"
         }
       ],
       "method": "GET",
       "name": "Returns pet inventories by status",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/inventory"
+      "url": "{{ _.base_url }}/store/inventory"
     },
     {
       "_id": "placeOrder",
@@ -320,7 +320,7 @@
       "name": "Place an order for a pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order"
+      "url": "{{ _.base_url }}/store/order"
     },
     {
       "_id": "getOrderById",
@@ -333,7 +333,7 @@
       "name": "Find purchase order by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "deleteOrder",
@@ -346,7 +346,7 @@
       "name": "Delete purchase order by ID",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__3a21295d",
-      "url": "{{ base_url }}/store/order/{{ orderId }}"
+      "url": "{{ _.base_url }}/store/order/{{ _.orderId }}"
     },
     {
       "_id": "createUser",
@@ -359,7 +359,7 @@
       "name": "Create user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user"
+      "url": "{{ _.base_url }}/user"
     },
     {
       "_id": "createUsersWithArrayInput",
@@ -372,7 +372,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/createWithArray"
+      "url": "{{ _.base_url }}/user/createWithArray"
     },
     {
       "_id": "createUsersWithListInput",
@@ -385,7 +385,7 @@
       "name": "Creates list of users with given input array",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/createWithList"
+      "url": "{{ _.base_url }}/user/createWithList"
     },
     {
       "_id": "loginUser",
@@ -409,7 +409,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/login"
+      "url": "{{ _.base_url }}/user/login"
     },
     {
       "_id": "logoutUser",
@@ -422,7 +422,7 @@
       "name": "Logs out current logged in user session",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/logout"
+      "url": "{{ _.base_url }}/user/logout"
     },
     {
       "_id": "getUserByName",
@@ -435,7 +435,7 @@
       "name": "Get user by user name",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "updateUser",
@@ -448,7 +448,7 @@
       "name": "Updated user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     },
     {
       "_id": "deleteUser",
@@ -461,7 +461,7 @@
       "name": "Delete user",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__12dea96f",
-      "url": "{{ base_url }}/user/{{ username }}"
+      "url": "{{ _.base_url }}/user/{{ _.username }}"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/petstore-yml-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/petstore-yml-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -56,7 +56,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__a8acce24",
-      "url": "{{ base_url }}/pets"
+      "url": "{{ _.base_url }}/pets"
     },
     {
       "_id": "createPets",
@@ -78,7 +78,7 @@
       "name": "Create a pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__a8acce24",
-      "url": "{{ base_url }}/pets"
+      "url": "{{ _.base_url }}/pets"
     },
     {
       "_id": "showPetById",
@@ -91,7 +91,7 @@
       "name": "Info for a specific pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__a8acce24",
-      "url": "{{ base_url }}/pets/{{ petId }}"
+      "url": "{{ _.base_url }}/pets/{{ _.petId }}"
     },
     {
       "_id": "updatePet",
@@ -119,7 +119,7 @@
       "name": "Update specific pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__a8acce24",
-      "url": "{{ base_url }}/pets/{{ petId }}"
+      "url": "{{ _.base_url }}/pets/{{ _.petId }}"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/petstore-yml-with-tags-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/petstore-yml-with-tags-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -56,7 +56,7 @@
         }
       ],
       "parentId": "fld___WORKSPACE_ID__a8acce24",
-      "url": "{{ base_url }}/pets"
+      "url": "{{ _.base_url }}/pets"
     },
     {
       "_id": "createPets",
@@ -69,7 +69,7 @@
       "name": "Create a pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__a8acce24",
-      "url": "{{ base_url }}/pets"
+      "url": "{{ _.base_url }}/pets"
     },
     {
       "_id": "showPetById",
@@ -82,7 +82,7 @@
       "name": "Info for a specific pet",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__a8acce24",
-      "url": "{{ base_url }}/pets/{{ petId }}"
+      "url": "{{ _.base_url }}/pets/{{ _.petId }}"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/user-example-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/swagger2/user-example-output.json
@@ -15,7 +15,7 @@
       "_id": "__BASE_ENVIRONMENT_ID__",
       "_type": "environment",
       "data": {
-        "base_url": "{{ scheme }}://{{ host }}{{ base_path }}"
+        "base_url": "{{ _.scheme }}://{{ _.host }}{{ _.base_path }}"
       },
       "name": "Base environment",
       "parentId": "__WORKSPACE_ID__"
@@ -50,7 +50,7 @@
       "name": "Some list",
       "parameters": [],
       "parentId": "fld___WORKSPACE_ID__e214b8a2",
-      "url": "{{ base_url }}/api/list"
+      "url": "{{ _.base_url }}/api/list"
     }
   ]
 }

--- a/packages/insomnia/src/utils/importers/importers/openapi-3.ts
+++ b/packages/insomnia/src/utils/importers/importers/openapi-3.ts
@@ -274,7 +274,7 @@ const importFolderItem = (parentId: string) => (
  * I.e. "/foo/:bar" => "/foo/{{ bar }}"
  */
 const pathWithParamsAsVariables = (path?: string) =>
-  path?.replace(VARIABLE_SEARCH_VALUE, '{{ $1 }}') ?? '';
+  path?.replace(VARIABLE_SEARCH_VALUE, '{{ _.$1 }}') ?? '';
 
 /**
  * Return Insomnia request
@@ -299,7 +299,7 @@ const importRequest = (
     parentId: parentId,
     name,
     method: endpointSchema.method?.toUpperCase(),
-    url: `{{ base_url }}${pathWithParamsAsVariables(endpointSchema.path)}`,
+    url: `{{ _.base_url }}${pathWithParamsAsVariables(endpointSchema.path)}`,
     body: prepareBody(endpointSchema),
     headers: [...paramHeaders, ...securityHeaders],
     authentication: authentication as Authentication,
@@ -366,14 +366,14 @@ const parseSecurity = (
       return {
         name: scheme.schemeDetails.name,
         disabled: false,
-        value: `{{ ${variableName} }}`,
+        value: `{{ _.${variableName} }}`,
       };
     });
   const apiKeyCookies = apiKeySchemes
     .filter(scheme => scheme.schemeDetails.in === 'cookie')
     .map(scheme => {
       const variableName = camelCase(scheme.schemeDetails.name);
-      return `${scheme.schemeDetails.name}={{ ${variableName} }}`;
+      return `${scheme.schemeDetails.name}={{ _.${variableName} }}`;
     });
   const apiKeyCookieHeader = {
     name: 'Cookie',
@@ -387,7 +387,7 @@ const parseSecurity = (
       return {
         name: scheme.schemeDetails.name,
         disabled: false,
-        value: `{{ ${variableName} }}`,
+        value: `{{ _.${variableName} }}`,
       };
     });
 
@@ -665,14 +665,14 @@ const parseHttpAuth = (scheme: string) => {
     case HTTP_AUTH_SCHEME.BASIC:
       return {
         type: 'basic',
-        username: '{{ httpUsername }}',
-        password: '{{ httpPassword }}',
+        username: '{{ _.httpUsername }}',
+        password: '{{ _.httpPassword }}',
       };
 
     case HTTP_AUTH_SCHEME.BEARER:
       return {
         type: 'bearer',
-        token: '{{bearerToken}}',
+        token: '{{ _.bearerToken }}',
         prefix: '',
       };
 
@@ -686,7 +686,7 @@ const parseApiKeyAuth = (schemeDetails: OpenAPIV3.ApiKeySecurityScheme) => {
   return {
     type: SECURITY_TYPE.API_KEY.toLowerCase(),
     key: schemeDetails.name,
-    value: `{{ ${variableName} }}`,
+    value: `{{ _.${variableName} }}`,
     addTo: schemeDetails.in,
   };
 };
@@ -732,7 +732,7 @@ const parseOAuth2 = (scheme: OpenAPIV3.OAuth2SecurityScheme, selectedScopes: str
   }
 
   const base = {
-    clientId: '{{ oauth2ClientId }}',
+    clientId: '{{ _.oauth2ClientId }}',
     grantType: mapOAuth2GrantType(grantType),
     scope: parseOAuth2Scopes(flow, selectedScopes),
     type: 'oauth2',
@@ -742,8 +742,8 @@ const parseOAuth2 = (scheme: OpenAPIV3.OAuth2SecurityScheme, selectedScopes: str
     case OAUTH_FLOWS.AUTHORIZATION_CODE:
       return {
         ...base,
-        clientSecret: '{{ oauth2ClientSecret }}',
-        redirectUrl: '{{ oauth2RedirectUrl }}',
+        clientSecret: '{{ _.oauth2ClientSecret }}',
+        redirectUrl: '{{ _.oauth2RedirectUrl }}',
         accessTokenUrl: (flow as OpenAPIV3.OAuth2SecurityScheme['flows'][typeof OAUTH_FLOWS.AUTHORIZATION_CODE])?.tokenUrl,
         authorizationUrl: (flow as OpenAPIV3.OAuth2SecurityScheme['flows'][typeof OAUTH_FLOWS.AUTHORIZATION_CODE])?.authorizationUrl,
       };
@@ -751,23 +751,23 @@ const parseOAuth2 = (scheme: OpenAPIV3.OAuth2SecurityScheme, selectedScopes: str
     case OAUTH_FLOWS.CLIENT_CREDENTIALS:
       return {
         ...base,
-        clientSecret: '{{ oauth2ClientSecret }}',
+        clientSecret: '{{ _.oauth2ClientSecret }}',
         accessTokenUrl: (flow as OpenAPIV3.OAuth2SecurityScheme['flows'][typeof OAUTH_FLOWS.CLIENT_CREDENTIALS])?.tokenUrl,
       };
 
     case OAUTH_FLOWS.IMPLICIT:
       return {
         ...base,
-        redirectUrl: '{{ oauth2RedirectUrl }}',
+        redirectUrl: '{{ _.oauth2RedirectUrl }}',
         authorizationUrl: (flow as OpenAPIV3.OAuth2SecurityScheme['flows'][typeof OAUTH_FLOWS.IMPLICIT])?.authorizationUrl,
       };
 
     case OAUTH_FLOWS.PASSWORD:
       return {
         ...base,
-        clientSecret: '{{ oauth2ClientSecret }}',
-        username: '{{ oauth2Username }}',
-        password: '{{ oauth2Password }}',
+        clientSecret: '{{ _.oauth2ClientSecret }}',
+        username: '{{ _.oauth2Username }}',
+        password: '{{ _.oauth2Password }}',
         accessTokenUrl: (flow as OpenAPIV3.OAuth2SecurityScheme['flows'][typeof OAUTH_FLOWS.PASSWORD])?.tokenUrl,
       };
 
@@ -812,7 +812,7 @@ export const convert: Converter = async rawData => {
     parentId: WORKSPACE_ID,
     name: 'Base environment',
     data: {
-      base_url: '{{ scheme }}://{{ host }}{{ base_path }}',
+      base_url: '{{ _.scheme }}://{{ _.host }}{{ _.base_path }}',
     },
   };
 

--- a/packages/insomnia/src/utils/importers/importers/swagger-2.ts
+++ b/packages/insomnia/src/utils/importers/importers/swagger-2.ts
@@ -166,7 +166,7 @@ const importRequest = (
     parentId: parentId,
     name,
     method: endpointSchema.method?.toUpperCase(),
-    url: `{{ base_url }}${pathWithParamsAsVariables(endpointSchema.path)}`,
+    url: `{{ _.base_url }}${pathWithParamsAsVariables(endpointSchema.path)}`,
     body,
     description: endpointSchema.description || '',
     headers,
@@ -222,8 +222,8 @@ const setupAuthentication = (
       request.authentication = {
         type: 'basic',
         disabled: false,
-        password: '{{ password }}',
-        username: '{{ username }}',
+        password: '{{ _.password }}',
+        username: '{{ _.username }}',
       };
     }
 
@@ -232,7 +232,7 @@ const setupAuthentication = (
         request.headers?.push({
           name: securityScheme.name,
           disabled: false,
-          value: '{{ api_key }}',
+          value: '{{ _.api_key }}',
         });
       }
 
@@ -240,7 +240,7 @@ const setupAuthentication = (
         request.parameters?.push({
           name: securityScheme.name,
           disabled: false,
-          value: '{{ api_key }}',
+          value: '{{ _.api_key }}',
         });
       }
     }
@@ -252,7 +252,7 @@ const setupAuthentication = (
           grantType: 'authorization_code',
           disabled: false,
           authorizationUrl: securityScheme.authorizationUrl,
-          clientId: '{{ client_id }}',
+          clientId: '{{ _.client_id }}',
           scope: scopes.join(' '),
         };
       }
@@ -263,10 +263,10 @@ const setupAuthentication = (
           grantType: 'password',
           disabled: false,
           accessTokenUrl: securityScheme.tokenUrl,
-          username: '{{ username }}',
-          password: '{{ password }}',
-          clientId: '{{ client_id }}',
-          clientSecret: '{{ client_secret }}',
+          username: '{{ _.username }}',
+          password: '{{ _.password }}',
+          clientId: '{{ _.client_id }}',
+          clientSecret: '{{ _.client_secret }}',
           scope: scopes.join(' '),
         };
       }
@@ -277,8 +277,8 @@ const setupAuthentication = (
           grantType: 'client_credentials',
           disabled: false,
           accessTokenUrl: securityScheme.tokenUrl,
-          clientId: '{{ client_id }}',
-          clientSecret: '{{ client_secret }}',
+          clientId: '{{ _.client_id }}',
+          clientSecret: '{{ _.client_secret }}',
           scope: scopes.join(' '),
         };
       }
@@ -290,8 +290,8 @@ const setupAuthentication = (
           disabled: false,
           accessTokenUrl: securityScheme.tokenUrl,
           authorizationUrl: securityScheme.authorizationUrl,
-          clientId: '{{ client_id }}',
-          clientSecret: '{{ client_secret }}',
+          clientId: '{{ _.client_id }}',
+          clientSecret: '{{ _.client_secret }}',
           scope: scopes.join(' '),
         };
       }
@@ -307,7 +307,7 @@ const setupAuthentication = (
  * I.e. "/foo/:bar" => "/foo/{{ bar }}"
  */
 const pathWithParamsAsVariables = (path?: string) => {
-  return path?.replace(/{([^}]+)}/g, '{{ $1 }}');
+  return path?.replace(/{([^}]+)}/g, '{{ _.$1 }}');
 };
 
 /**
@@ -571,7 +571,7 @@ export const convert: Converter = async rawData => {
     parentId: WORKSPACE_ID,
     name: 'Base environment',
     data: {
-      base_url: '{{ scheme }}://{{ host }}{{ base_path }}',
+      base_url: '{{ _.scheme }}://{{ _.host }}{{ _.base_path }}',
     },
   };
 


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where environment variables generated by OpenApi and Swagger importers now use underscore-dot syntax, instead of custom variable access.


Change environment variables generated by OpenApi and Swagger importers to use underscore-dot syntax, instead of custom variable access.