### PR TITLE
Support charset information on swagger2 data import (#5781)

### DIFF
--- a/packages/insomnia/src/common/__tests__/constants.test.ts
+++ b/packages/insomnia/src/common/__tests__/constants.test.ts
@@ -6,6 +6,7 @@ import {
   ACTIVITY_SPEC,
   ACTIVITY_UNIT_TEST,
   FLEXIBLE_URL_REGEX,
+  getContentTypeName,
   isValidActivity,
   isWorkspaceActivity,
 } from '../constants';
@@ -62,5 +63,26 @@ describe('isValidActivity', () => {
     expect(isValidActivity(null)).toBe(false);
     // @ts-expect-error intentionally invalid
     expect(isValidActivity(undefined)).toBe(false);
+  });
+});
+
+describe('getContentTypeName', () => {
+  it('should return empty content type name', () => {
+    expect(getContentTypeName()).toBe('');
+  });
+  it('should return content type name', () => {
+    expect(getContentTypeName('application/json')).toBe('JSON');
+    expect(getContentTypeName('application/json; charset=utf-8')).toBe('JSON');
+    expect(getContentTypeName('text/plain')).toBe('Plain');
+    expect(getContentTypeName('application/xml')).toBe('XML');
+    expect(getContentTypeName('text/yaml')).toBe('YAML');
+    expect(getContentTypeName('application/edn')).toBe('EDN');
+    expect(getContentTypeName('application/x-www-form-urlencoded')).toBe('Form');
+    expect(getContentTypeName('multipart/form-data')).toBe('Multipart');
+    expect(getContentTypeName('application/graphql')).toBe('GraphQL');
+    expect(getContentTypeName('application/octet-stream')).toBe('File');
+  });
+  it('should return unknown content type as other content type name name', () => {
+    expect(getContentTypeName('unknown')).toBe('Other');
   });
 });

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -383,9 +383,10 @@ export function getContentTypeName(contentType?: string | null, useLong = false)
   if (typeof contentType !== 'string') {
     return '';
   }
-
-  if (contentTypesMap.hasOwnProperty(contentType)) {
-    return useLong ? contentTypesMap[contentType][1] : contentTypesMap[contentType][0];
+  for (const contentTypeKey in contentTypesMap) {
+    if (contentType.includes(contentTypeKey) && contentTypeKey.length > 0) {
+      return useLong ? contentTypesMap[contentTypeKey][1] : contentTypesMap[contentTypeKey][0];
+    }
   }
 
   return useLong ? contentTypesMap[CONTENT_TYPE_OTHER][1] : contentTypesMap[CONTENT_TYPE_OTHER][0];

--- a/packages/insomnia/src/utils/importers/importers/swagger-2.ts
+++ b/packages/insomnia/src/utils/importers/importers/swagger-2.ts
@@ -358,11 +358,13 @@ const prepareBody = (
 ) => {
   const mimeTypes = endpointSchema.consumes || globalMimeTypes || [];
 
-  const supportedMimeType = SUPPORTED_MIME_TYPES.find(mimeType =>
-    mimeTypes.includes(mimeType),
-  );
+  const supportedMimeType = mimeTypes.find(reqMimeType => {
+    return SUPPORTED_MIME_TYPES.some(supportedMimeType => {
+      return reqMimeType.includes(supportedMimeType);
+    });
+  });
 
-  if (supportedMimeType === MIMETYPE_JSON) {
+  if (supportedMimeType && supportedMimeType.includes(MIMETYPE_JSON)) {
     const parameters = endpointSchema.parameters || [];
     const bodyParameter = parameters.find(
       parameter => (parameter as OpenAPIV2.Parameter).in === 'body',
@@ -394,10 +396,7 @@ const prepareBody = (
     };
   }
 
-  if (
-    supportedMimeType === MIMETYPE_URLENCODED ||
-    supportedMimeType === MIMETYPE_MULTIPART
-  ) {
+  if (supportedMimeType && (supportedMimeType.includes(MIMETYPE_URLENCODED) || supportedMimeType.includes(MIMETYPE_MULTIPART))) {
     const parameters = endpointSchema.parameters || [];
     const formDataParameters = ((parameters as unknown) as OpenAPIV2.Parameter[]).filter(
       parameter => parameter.in === 'formData',


### PR DESCRIPTION
changelog(Fixes): Fixed and issue where request body data was not properly set if charset information is set in "consumes" field for Swagger files

Closes #5781 