### PR TITLE
 INS-2434: basic Kong 3.x support on Inso CLI 

### DIFF
--- a/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
+++ b/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
@@ -95,13 +95,16 @@ exports[`Snapshot for "inso generate config -h" 1`] = `
 Generate configuration from an api spec.
 
 Options:
-  -t, --type <value>    type of configuration to generate, options are
-                        [declarative, kubernetes] (default: declarative)
-  -f, --format <value>  format of configuration to generate, options are [yaml,
-                        json] (default: yaml)
-  --tags <tags>         comma separated list of tags to apply to each entity
-  -o, --output <path>   save the generated config to a file
-  -h, --help            display help for command"
+  -t, --type <value>         type of configuration to generate, options are
+                             [declarative, kubernetes] (default: declarative)
+  -f, --format <value>       format of configuration to generate, options are
+                             [yaml, json] (default: yaml)
+  -k, --kongVersion <value>  version of target Kong instance, options are
+                             [legacy, 3] (default: legacy)
+  --tags <tags>              comma separated list of tags to apply to each
+                             entity
+  -o, --output <path>        save the generated config to a file
+  -h, --help                 display help for command"
 `;
 
 exports[`Snapshot for "inso help" 1`] = `

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -10,6 +10,8 @@ import {
   formatOptions,
   generateConfig,
   GenerateConfigOptions,
+  KongVersion,
+  kongVersionOptions,
 } from './commands/generate-config';
 import type { LintSpecificationOptions } from './commands/lint-specification';
 import { lintSpecification } from './commands/lint-specification';
@@ -33,6 +35,7 @@ const makeGenerateCommand = (commandCreator: CreateCommand) => {
   const command = commandCreator('generate').description('Code generation utilities');
   const defaultType: ConversionOption = 'declarative';
   const defaultFormat: FormatOption = 'yaml';
+  const defaultKongVersion: KongVersion = 'legacy';
 
   // inso generate config -t kubernetes config.yaml
   command
@@ -45,6 +48,10 @@ const makeGenerateCommand = (commandCreator: CreateCommand) => {
     .option(
       '-f, --format <value>',
       `format of configuration to generate, options are [${formatOptions.join(', ')}] (default: ${defaultFormat})`,
+    )
+    .option(
+      '-k, --kongVersion <value>',
+      `version of target Kong instance, options are [${kongVersionOptions.join(', ')}] (default: ${defaultKongVersion})`,
     )
     .option('--tags <tags>', 'comma separated list of tags to apply to each entity')
     .option('-o, --output <path>', 'save the generated config to a file')

--- a/packages/insomnia-inso/src/commands/generate-config.test.ts
+++ b/packages/insomnia-inso/src/commands/generate-config.test.ts
@@ -69,7 +69,7 @@ describe('generateConfig()', () => {
 
     await generateConfig(filePath, { type: 'kubernetes', tags: 'tag' });
 
-    expect(generate).toHaveBeenCalledWith(`${path.join(process.cwd(), filePath)}`, conversionTypeMap.kubernetes, ['tag']);
+    expect(generate).toHaveBeenCalledWith(`${path.join(process.cwd(), filePath)}`, conversionTypeMap.kubernetes, ['tag'], true);
     expect(logger.__getLogs().log).toEqual(['a\n---\nb\n']);
   });
 
@@ -135,7 +135,8 @@ describe('generateConfig()', () => {
     expect(generate).toHaveBeenCalledWith(
       path.normalize('test/dir/file.yaml'),
       conversionTypeMap.kubernetes,
-      undefined
+      undefined,
+      true
     );
     expect(logger.__getLogs().log).toEqual([
       `Configuration generated to "${outputPath}".`,
@@ -158,7 +159,8 @@ describe('generateConfig()', () => {
     expect(generate).toHaveBeenCalledWith(
       absolutePath,
       conversionTypeMap.kubernetes,
-      undefined
+      undefined,
+      true
     );
     expect(logger.__getLogs().log).toEqual([
       `Configuration generated to "${outputPath}".`,

--- a/packages/insomnia-inso/src/commands/generate-config.test.ts
+++ b/packages/insomnia-inso/src/commands/generate-config.test.ts
@@ -85,6 +85,7 @@ describe('generateConfig()', () => {
       expect.stringMatching(/.+/),
       conversionTypeMap.kubernetes,
       ['first', 'second'],
+      true
     );
     expect(logger.__getLogs().log).toEqual(['a\n---\nb\n']);
   });

--- a/packages/insomnia-smoke-test/tests/prerelease/plugins-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/plugins-interactions.test.ts
@@ -27,7 +27,7 @@ test.describe('Plugins', async () => {
 
     // Open declarative config
     await page.getByRole('button', { name: 'New Document' }).click();
-    await page.getByRole('menuitem', { name: 'Declarative Config' }).click();
+    await page.getByRole('menuitem', { name: 'Declarative Config (Legacy)' }).click();
     // Check for declarative config contents
     await page.click('text=/.*"_format_version".*/');
 

--- a/packages/openapi-2-kong/src/common.ts
+++ b/packages/openapi-2-kong/src/common.ts
@@ -65,13 +65,20 @@ export function generateSlug(str: string, options: SlugifyOptions = {}) {
 /** characters in curly braces not immediately followed by `://`, e.g. `{foo}` will match but `{foo}://` will not. */
 const pathVariableSearchValue = /{([^}]+)}(?!:\/\/)/g;
 
-export function pathVariablesToRegex(p: string) {
+export function pathVariablesToRegex(p: string, legacy: Boolean = true) {
   // escape URL special characters except the curly braces
   p = p.replace(/[$()]/g, '\\$&');
   // match anything except whitespace and '/'
-  const result = p.replace(pathVariableSearchValue, '(?<$1>[^/]+)');
+  let result = p.replace(pathVariableSearchValue, '(?<$1>[^/]+)');
   // add a line ending because it is a regex
+
+  // Prepend ~ to regex for Kong 3.X
+  if (!legacy && !result.startsWith('~')) {
+    result = '~' + result;
+  }
+
   return result + '$';
+
 }
 
 export function getPluginNameFromKey(key: string) {

--- a/packages/openapi-2-kong/src/declarative-config/generate.ts
+++ b/packages/openapi-2-kong/src/declarative-config/generate.ts
@@ -8,11 +8,13 @@ import { generateUpstreams } from './upstreams';
 export async function generateDeclarativeConfigFromSpec(
   api: OpenApi3Spec,
   tags: string[],
+  legacy: Boolean = true
 ) {
   try {
+    const formatVersion = legacy ? '1.1' : '3.0';
     const document: DeclarativeConfig = {
-      _format_version: '1.1',
-      services: await generateServices(api, tags),
+      _format_version: formatVersion,
+      services: await generateServices(api, tags, legacy),
     };
 
     if (hasUpstreams(api)) {

--- a/packages/openapi-2-kong/src/declarative-config/services.ts
+++ b/packages/openapi-2-kong/src/declarative-config/services.ts
@@ -19,7 +19,7 @@ import {
 import { generateSecurityPlugins } from './security-plugins';
 import { appendUpstreamToName } from './upstreams';
 
-export async function generateServices(api: OpenApi3Spec, tags: string[]) {
+export async function generateServices(api: OpenApi3Spec, tags: string[], legacy: Boolean = true) {
   const servers = getAllServers(api);
 
   if (servers.length === 0) {
@@ -27,11 +27,11 @@ export async function generateServices(api: OpenApi3Spec, tags: string[]) {
   }
 
   // only support one service for now
-  const service = await generateService(servers[0], api, tags);
+  const service = await generateService(servers[0], api, tags, legacy);
   return [service];
 }
 
-export async function generateService(server: OA3Server, api: OpenApi3Spec, tags: string[]) {
+export async function generateService(server: OA3Server, api: OpenApi3Spec, tags: string[], legacy: Boolean = true) {
   const serverUrl = fillServerVariables(server);
   const name = getName(api);
   const parsedUrl = parseUrl(serverUrl);
@@ -110,7 +110,7 @@ export async function generateService(server: OA3Server, api: OpenApi3Spec, tags
       }
 
       // Create the base route object
-      const fullPathRegex = pathVariablesToRegex(routePath);
+      const fullPathRegex = pathVariablesToRegex(routePath, legacy);
       const route: DCRoute = {
         ...routeDefaultsOperation as DCRoute,
         tags,

--- a/packages/openapi-2-kong/src/generate.ts
+++ b/packages/openapi-2-kong/src/generate.ts
@@ -47,12 +47,13 @@ export const generateFromSpec = async (
   api: OpenApi3Spec,
   type: ConversionResultType,
   tags: string[] = [],
+  legacy: Boolean = true
 ) => {
   const allTags = [...defaultTags, ...tags];
 
   switch (type) {
     case 'kong-declarative-config':
-      return await generateDeclarativeConfigFromSpec(api, allTags);
+      return await generateDeclarativeConfigFromSpec(api, allTags, legacy);
 
     case 'kong-for-kubernetes':
       return generateKongForKubernetesConfigFromSpec(api);
@@ -66,15 +67,17 @@ export const generateFromString = async (
   specStr: string,
   type: ConversionResultType,
   tags: string[] = [],
+  legacy: Boolean = true,
 ) => {
   const api = await parseSpec(specStr);
-  return generateFromSpec(api, type, tags);
+  return generateFromSpec(api, type, tags, legacy);
 };
 
 export const generate = (
   filePath: string,
   type: ConversionResultType,
   tags: string[] = [],
+  legacy: Boolean = true,
 ) => new Promise<ConversionResult>((resolve, reject) => {
   fs.readFile(path.resolve(filePath), 'utf8', (err, contents) => {
     if (err != null) {
@@ -84,6 +87,6 @@ export const generate = (
 
     const fileSlug = path.basename(filePath);
     const allTags = [`OAS3file_${fileSlug}`, ...tags];
-    resolve(generateFromString(contents, type, allTags));
+    resolve(generateFromString(contents, type, allTags, legacy));
   });
 });

--- a/packages/openapi-2-kong/src/types/declarative-config.ts
+++ b/packages/openapi-2-kong/src/types/declarative-config.ts
@@ -33,7 +33,7 @@ export interface DCUpstream extends Taggable {
 }
 
 export interface DeclarativeConfig {
-  _format_version: '1.1';
+  _format_version: string;
   services: DCService[];
   upstreams?: DCUpstream[];
 }

--- a/plugins/insomnia-plugin-kong-declarative-config/index.js
+++ b/plugins/insomnia-plugin-kong-declarative-config/index.js
@@ -1,1 +1,1 @@
-module.exports.configGenerators = [require('./src/generate')];
+module.exports.configGenerators = [require('./src/generate'), require('./src/generate-kong3')];

--- a/plugins/insomnia-plugin-kong-declarative-config/src/generate-kong3.js
+++ b/plugins/insomnia-plugin-kong-declarative-config/src/generate-kong3.js
@@ -1,7 +1,7 @@
 const o2k = require('openapi-2-kong');
 
 module.exports = {
-  label: 'Declarative Config (Legacy)',
+  label: 'Declarative Config (Kong 3.x)',
   docsLink: 'https://docs.insomnia.rest/insomnia/declarative-config',
   generate: async ({ contents, formatVersion }) => {
     const isSupported = formatVersion && formatVersion.match(/^3./);
@@ -14,7 +14,7 @@ module.exports = {
     }
 
     try {
-      const result = await o2k.generateFromString(contents, 'kong-declarative-config');
+      const result = await o2k.generateFromString(contents, 'kong-declarative-config', [], false);
       // We know for certain the result.documents has only one entry for declarative config: packages/openapi-2-kong/src/declarative-config/generate.ts#L20
       const declarativeConfig = result.documents?.[0]
       return {


### PR DESCRIPTION
changelog(Inso CLI): Added basic support for Kong 3.0 for `inso generate config` with new `--kongVersion` option.
changelog(Improvements): Added basic support for Kong 3.0 declarative config generation from OpenAPI specs.

Adds basic support for Kong 3.0 on Inso CLI:
- Changes `_format_version` to `3.0` when `--kongVersion` is `3`
- Prepends `~` to routes' path regex

Usage:
```shell
inso generate config <...> --kongVersion <value>  # version of target Kong instance, options are [legacy, 3] (default: legacy)
```

Insomnia Docs update PR - https://github.com/Kong/insomnia-docs/pull/136


### How to test

(Local build) 
- Checkout branch, run `npm run bootstrap`, run `npm run inso-package`. You should get a binary of inso cli that you can use under `packages/insomnia-inso/binaries/inso`

Or download the `inso` artifact from the [GH Test Action artifacts](https://github.com/Kong/insomnia/actions/runs/4367842928)

Example of the new binary running:
<img width="952" alt="image" src="https://user-images.githubusercontent.com/11976836/223825227-2595b8ae-07e4-4c9e-bc60-d8ca455dedf0.png">

### How to test on Insomnia app

- Checkout branch, run `npm run bootstrap`, run `npm run dev`

Or download the [recurring build artifact](https://github.com/Kong/insomnia/actions/runs/4385673091) and try it out:

![Screenshot 2023-03-10 at 14 50 43](https://user-images.githubusercontent.com/11976836/224347121-fb42cc07-95f9-4fa0-9d7d-ec8d97d6a685.jpg)

![Screenshot 2023-03-10 at 14 50 48](https://user-images.githubusercontent.com/11976836/224347145-594d7374-4dfa-4efe-a76b-cc89beeca11c.jpg)



cc @mheap @rspurgeon 