### PR TITLE
Add 'Cookie' attribute to `{% response %}` template tag

### DIFF
--- a/plugins/insomnia-plugin-response/__tests__/index.test.js
+++ b/plugins/insomnia-plugin-response/__tests__/index.test.js
@@ -100,7 +100,9 @@ describe('Response tag', () => {
         await tag.run(context, 'body', 'req_1', '$.foo');
         fail('JSON should have failed');
       } catch (err) {
-        expect(err.message).toContain('Invalid JSON: Unexpected end of JSON input');
+        expect(err.message).toContain(
+          'Invalid JSON: Unexpected end of JSON input'
+        );
       }
     });
 
@@ -165,7 +167,6 @@ describe('Response tag', () => {
 
       const context = _genTestContext(requests, responses);
 
-
       const result = await tag.run(context, 'body', 'req_1', '$.array');
       expect(result).toBe('["bar","baz"]');
     });
@@ -184,7 +185,6 @@ describe('Response tag', () => {
       ];
 
       const context = _genTestContext(requests, responses);
-
 
       const result = await tag.run(context, 'body', 'req_1', '$.array');
       expect(result).toBe('[1,2]');
@@ -262,7 +262,12 @@ describe('Response tag', () => {
       ];
 
       const context = _genTestContext(requests, responses);
-      const result = await tag.run(context, 'body', 'req_1', 'substring(/foo/bar, 7)');
+      const result = await tag.run(
+        context,
+        'body',
+        'req_1',
+        'substring(/foo/bar, 7)'
+      );
 
       expect(result).toBe('World!');
     });
@@ -379,12 +384,18 @@ describe('Response tag', () => {
 
       const context = _genTestContext(requests, responses);
 
-      expect(await tag.run(context, 'header', 'req_1', 'content-type')).toBe('application/json');
-      expect(await tag.run(context, 'header', 'req_1', 'Content-Type')).toBe('application/json');
-      expect(await tag.run(context, 'header', 'req_1', 'CONTENT-type')).toBe('application/json');
-      expect(await tag.run(context, 'header', 'req_1', 'CONTENT-type    ')).toBe(
-        'application/json',
+      expect(await tag.run(context, 'header', 'req_1', 'content-type')).toBe(
+        'application/json'
       );
+      expect(await tag.run(context, 'header', 'req_1', 'Content-Type')).toBe(
+        'application/json'
+      );
+      expect(await tag.run(context, 'header', 'req_1', 'CONTENT-type')).toBe(
+        'application/json'
+      );
+      expect(
+        await tag.run(context, 'header', 'req_1', 'CONTENT-type    ')
+      ).toBe('application/json');
     });
 
     it('no results on missing header', async () => {
@@ -410,7 +421,7 @@ describe('Response tag', () => {
       } catch (err) {
         expect(err.message).toBe(
           'No header with name "missing".\n' +
-            'Choices are [\n\t"Content-Type",\n\t"Content-Length"\n]',
+            'Choices are [\n\t"Content-Type",\n\t"Content-Length"\n]'
         );
       }
     });
@@ -442,7 +453,9 @@ describe('Response tag', () => {
       const responses = [];
       const context = _genTestContext(requests, responses);
 
-      expect(await tag.run(context, 'raw', 'req_1', '', 'always')).toBe('Response res_1');
+      expect(await tag.run(context, 'raw', 'req_1', '', 'always')).toBe(
+        'Response res_1'
+      );
     });
 
     it('sends when behavior=always and some responses', async () => {
@@ -458,7 +471,9 @@ describe('Response tag', () => {
       ];
       const context = _genTestContext(requests, responses);
 
-      expect(await tag.run(context, 'raw', 'req_1', '', 'always')).toBe('Response res_2');
+      expect(await tag.run(context, 'raw', 'req_1', '', 'always')).toBe(
+        'Response res_2'
+      );
     });
 
     it('sends when behavior=no-history and no responses', async () => {
@@ -466,7 +481,9 @@ describe('Response tag', () => {
       const responses = [];
       const context = _genTestContext(requests, responses);
 
-      expect(await tag.run(context, 'raw', 'req_1', '', 'no-history')).toBe('Response res_1');
+      expect(await tag.run(context, 'raw', 'req_1', '', 'no-history')).toBe(
+        'Response res_1'
+      );
     });
 
     it('does not send when behavior=no-history and some responses', async () => {
@@ -483,7 +500,7 @@ describe('Response tag', () => {
       const context = _genTestContext(requests, responses);
 
       expect(await tag.run(context, 'raw', 'req_1', '', 'no-history')).toBe(
-        'Response res_existing',
+        'Response res_existing'
       );
     });
 
@@ -492,7 +509,9 @@ describe('Response tag', () => {
       const responses = [];
       const context = _genTestContext(requests, responses);
 
-      expect(await tag.run(context, 'raw', 'req_1', '', 'when-expired', 60)).toBe('Response res_1');
+      expect(
+        await tag.run(context, 'raw', 'req_1', '', 'when-expired', 60)
+      ).toBe('Response res_1');
     });
 
     it('sends when behavior=when-expired and response is old', async () => {
@@ -504,7 +523,9 @@ describe('Response tag', () => {
       ];
       const context = _genTestContext(requests, responses);
 
-      expect(await tag.run(context, 'raw', 'req_1', '', 'when-expired', 30)).toBe('Response res_2');
+      expect(
+        await tag.run(context, 'raw', 'req_1', '', 'when-expired', 30)
+      ).toBe('Response res_2');
     });
 
     it('does not send when behavior=when-expired and response is new', async () => {
@@ -521,9 +542,9 @@ describe('Response tag', () => {
       ];
       const context = _genTestContext(requests, responses);
 
-      expect(await tag.run(context, 'raw', 'req_1', '', 'when-expired', 90)).toBe(
-        'Response res_existing',
-      );
+      expect(
+        await tag.run(context, 'raw', 'req_1', '', 'when-expired', 90)
+      ).toBe('Response res_existing');
     });
 
     it('does not send when behavior=never and no responses', async () => {
@@ -532,7 +553,9 @@ describe('Response tag', () => {
       const context = _genTestContext(requests, responses);
 
       try {
-        expect(await tag.run(context, 'raw', 'req_1', '', 'never')).toBe('Response res_1');
+        expect(await tag.run(context, 'raw', 'req_1', '', 'never')).toBe(
+          'Response res_1'
+        );
       } catch (err) {
         expect(err.message).toBe('No responses for request');
         return;
@@ -554,13 +577,17 @@ describe('Response tag', () => {
       ];
       const context = _genTestContext(requests, responses);
 
-      expect(await tag.run(context, 'raw', 'req_1', '', 'never')).toBe('Response res_existing');
+      expect(await tag.run(context, 'raw', 'req_1', '', 'never')).toBe(
+        'Response res_existing'
+      );
     });
 
     it('does not resend if request has already sent in recursive chain', async () => {
       const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
       const responses = [];
-      const context = _genTestContext(requests, responses, { requestChain: ['req_1']});
+      const context = _genTestContext(requests, responses, {
+        requestChain: ['req_1'],
+      });
 
       try {
         await tag.run(context, 'raw', 'req_1', '', 'always');
@@ -570,22 +597,24 @@ describe('Response tag', () => {
       }
 
       throw new Error('Running tag should have thrown exception');
+    });
+
+    it('does send if request has not been sent in recursive chain', async () => {
+      const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
+      const responses = [];
+
+      const context = _genTestContext(requests, responses, {
+        requestChain: ['req_2'],
+      });
+
+      const response = await tag.run(context, 'raw', 'req_1', '', 'always');
+      expect(response).toBe('Response res_1');
+    });
   });
-
-  it('does send if request has not been sent in recursive chain', async () => {
-    const requests = [{ _id: 'req_1', parentId: 'wrk_1' }];
-    const responses = [];
-
-    const context = _genTestContext(requests, responses, { requestChain: ['req_2']});
-
-    const response = await tag.run(context, 'raw', 'req_1', '', 'always');
-      expect(response).toBe('Response res_1')
-  });
-});
 
   describe('Max Age', () => {
     const maxAgeArg = tag.args[4];
-    const toValueObj = value => ({ value });
+    const toValueObj = (value) => ({ value });
 
     it('should ensure fourth argument is maxAge', () => {
       expect(maxAgeArg.displayName).toBe('Max age (seconds)');
@@ -664,9 +693,9 @@ function _genTestContext(requests, responses, extraInfoRoot) {
       },
     },
     store: {
-      hasItem: key => Object.prototype.hasOwnProperty.call(store, key),
-      getItem: key => store[key],
-      removeItem: key => {
+      hasItem: (key) => Object.prototype.hasOwnProperty.call(store, key),
+      getItem: (key) => store[key],
+      removeItem: (key) => {
         delete store[key];
       },
       setItem: (key, value) => {
@@ -677,12 +706,12 @@ function _genTestContext(requests, responses, extraInfoRoot) {
       models: {
         request: {
           getById(requestId) {
-            return requests.find(r => r._id === requestId) || null;
+            return requests.find((r) => r._id === requestId) || null;
           },
         },
         response: {
           getLatestForRequestId(requestId, environmentId) {
-            return responses.find(r => r.parentId === requestId) || null;
+            return responses.find((r) => r.parentId === requestId) || null;
           },
           getBodyBuffer(response) {
             const strOrBuffer = bodies[response._id];

--- a/plugins/insomnia-plugin-response/package-lock.json
+++ b/plugins/insomnia-plugin-response/package-lock.json
@@ -1,89 +1,189 @@
 {
-	"name": "insomnia-plugin-response",
-	"version": "3.16.0",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "insomnia-plugin-response",
-			"version": "3.16.0",
-			"license": "MIT",
-			"dependencies": {
-				"iconv-lite": "^0.6.3",
-				"jsonpath-plus": "^6.0.1",
-				"xmldom": "^0.5.0",
-				"xpath": "0.0.32"
-			}
-		},
-		"node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/jsonpath-plus": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
-			"integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"node_modules/xmldom": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-			"integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/xpath": {
-			"version": "0.0.32",
-			"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
-			"integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
-			"engines": {
-				"node": ">=0.6.0"
-			}
-		}
-	},
-	"dependencies": {
-		"iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			}
-		},
-		"jsonpath-plus": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
-			"integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw=="
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"xmldom": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-			"integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
-		},
-		"xpath": {
-			"version": "0.0.32",
-			"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
-			"integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
-		}
-	}
+  "name": "insomnia-plugin-response",
+  "version": "3.16.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "insomnia-plugin-response",
+      "version": "3.16.0",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "jsonpath-plus": "^6.0.1",
+        "tough-cookie": "^4.0.0",
+        "xmldom": "^0.5.0",
+        "xpath": "0.0.32"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
+      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/xmldom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/xpath": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    }
+  },
+  "dependencies": {
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "jsonpath-plus": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
+      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw=="
+    },
+    "psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
+    "punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "tough-cookie": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      }
+    },
+    "universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "xmldom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
+    },
+    "xpath": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
+    }
+  }
 }

--- a/plugins/insomnia-plugin-response/package.json
+++ b/plugins/insomnia-plugin-response/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "iconv-lite": "^0.6.3",
     "jsonpath-plus": "^6.0.1",
+    "tough-cookie": "^4.0.0",
     "xmldom": "^0.5.0",
     "xpath": "0.0.32"
   }


### PR DESCRIPTION
This allow the user to pick the value of a specific cookie from a previous request, using request chaining to automatically re-send the request when it becomes stale.

Useful for certain APIs which for example requires a bearer token that is returned as a cookie.

Closes #5802