### PR TITLE
Render webviews in UTF-8

### DIFF
--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -253,7 +253,6 @@ export const ResponseViewer = ({
     return (
       <ResponseWebView
         body={getBodyAsString()}
-        contentType={contentType}
         key={disableHtmlPreviewJs ? 'no-js' : 'yes-js'}
         url={url}
         webpreferences={`disableDialogs=true, javascript=${disableHtmlPreviewJs ? 'no' : 'yes'

--- a/packages/insomnia/src/ui/components/viewers/response-web-view.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-web-view.tsx
@@ -2,11 +2,10 @@ import React, { FC, useEffect, useRef } from 'react';
 
 interface Props {
   body: string;
-  contentType: string;
   url: string;
   webpreferences: string;
 }
-export const ResponseWebView: FC<Props> = ({ webpreferences, body, contentType, url }) => {
+export const ResponseWebView: FC<Props> = ({ webpreferences, body, url }) => {
   const webviewRef = useRef<Electron.WebviewTag>(null);
 
   useEffect(() => {
@@ -15,7 +14,7 @@ export const ResponseWebView: FC<Props> = ({ webpreferences, body, contentType, 
       if (webview) {
         webview.removeEventListener('dom-ready', handleDOMReady);
         const bodyWithBase = body.replace('<head>', `<head><base href="${url}">`);
-        webview.loadURL(`data:${contentType},${encodeURIComponent(bodyWithBase)}`);
+        webview.loadURL(`data:text/html; charset=utf-8,${encodeURIComponent(bodyWithBase)}`);
       }
     };
     if (webview) {
@@ -26,7 +25,7 @@ export const ResponseWebView: FC<Props> = ({ webpreferences, body, contentType, 
         webview.removeEventListener('dom-ready', handleDOMReady);
       }
     };
-  }, [body, contentType, url]);
+  }, [body, url]);
   return (
     <webview
       data-testid="ResponseWebView"


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where response previews were not properly decoded and rendered in UTF-8
 
This pull request renders webviews in UTF-8 as they are decoded in https://github.com/Kong/insomnia/blob/4612ef7/packages/insomnia/src/ui/components/viewers/response-viewer.tsx#L155, the content type is no longer needed as JavaScript will store the strings internally as UTF-16.

Closes #5803.