### PR TITLE
Improve error handling for failed git fetch

### DIFF
--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -184,7 +184,14 @@ export const gitFetchAction: ActionFunction = async ({ params }): Promise<GitFet
   const gitRepository = await models.gitRepository.getById(workspaceMeta?.gitRepositoryId);
   invariant(gitRepository, 'Git Repository not found');
 
-  await GitVCS.fetch({ singleBranch: true, depth: 1, credentials: gitRepository?.credentials });
+  try {
+    await GitVCS.fetch({ singleBranch: true, depth: 1, credentials: gitRepository?.credentials });
+  } catch (e) {
+    console.error(e);
+    return {
+      errors: ['Failed to fetch from remote'],
+    };
+  }
 
   return {};
 };


### PR DESCRIPTION
changelog(Improvements): Added better error handling for Git Sync related edge cases

Currently a failed fetch will default to the closest error boundary.

This adds a try-catch in the fetch action to return the errors instead and allow for displaying the alert message