### PR TITLE
Added the ability to escape percent character

### DIFF
--- a/packages/insomnia/src/utils/url/querystring.test.ts
+++ b/packages/insomnia/src/utils/url/querystring.test.ts
@@ -120,6 +120,15 @@ describe('querystring', () => {
 
       expect(str).toBe('foo=bar%3F%3F&hello=&hi%20there=bar%3F%3F&=bar%3F%3F&=');
     });
+
+    it('builds from params handle escaped %', () => {
+      const str = buildQueryStringFromParams([
+        { name: 'foo', value: '\\%30\\%' },
+        { name: 'bar', value: '%30\\%' },
+      ]);
+
+      expect(str).toBe('foo=%2530%25&bar=%30%25');
+    });
   });
 
   describe('deconstructToParams()', () => {

--- a/packages/insomnia/src/utils/url/querystring.ts
+++ b/packages/insomnia/src/utils/url/querystring.ts
@@ -217,6 +217,9 @@ export const flexibleEncodeComponent = (str = '', ignore = '') => {
   // Sometimes spaces screw things up because of url.parse
   str = str.replace(/%20/g, ' ');
 
+  // Handle an escape % character
+  str = str.replace(/\\%/g, '%25');
+
   // Handle all already-encoded characters so we don't touch them
   str = str.replace(/%([0-9a-fA-F]{2})/g, '__ENC__$1');
 


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where url encoding couldn't handle % with two digits behind it without perceiving it as an escape code.

This PR adds the ability to escape percent character (%) with the backslash (\\).

e.g. \\% is converted to %25

I'm also open to any other ideas on how to handle this issue.

This closes #4818 
<img width="485" alt="Screen Shot 2023-03-17 at 4 55 02 PM" src="https://user-images.githubusercontent.com/24848445/226044018-08df7d95-1c86-412c-bbf8-8769c24fbed1.png">
