### PR TITLE
Fix scope filter on project view.

### DIFF
--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -450,7 +450,9 @@ const OrganizationProjectsSidebar: FC<{
 
       <ProjectListContainer>
         <List
+          key="files-list"
           selectionMode="single"
+          disallowEmptySelection
           selectedKeys={[searchParams.get('scope') || 'all']}
           onSelectionChange={selection => {
             const scope = [...selection]?.[0]?.toString();

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -451,16 +451,19 @@ const OrganizationProjectsSidebar: FC<{
       <ProjectListContainer>
         <List
           selectionMode="single"
-          selectionBehavior="toggle"
-          selectedKeys={[searchParams.get('scope') || '']}
+          selectedKeys={[searchParams.get('scope') || 'all']}
           onSelectionChange={selection => {
-            submit({
-              ...Object.fromEntries(searchParams.entries()),
-              scope: [...selection][0].toString(),
-            });
+            const scope = [...selection]?.[0]?.toString();
+
+            if (scope) {
+              submit({
+                ...Object.fromEntries(searchParams.entries()),
+                scope,
+              });
+            }
           }}
         >
-          <Item key="" aria-label="All Files">
+          <Item key="all" aria-label="All Files">
             <SidebarListItemContent level={1}>
               <SidebarListItemTitle
                 icon="folder"
@@ -639,7 +642,7 @@ export const loader: LoaderFunction = async ({
 
   const sortOrder = search.get('sortOrder') || 'modified-desc';
   const filter = search.get('filter') || '';
-  const scope = search.get('scope') || '';
+  const scope = search.get('scope') || 'all';
   const projectName = search.get('projectName') || '';
 
   const project = await models.project.getById(projectId);
@@ -779,7 +782,7 @@ export const loader: LoaderFunction = async ({
   );
 
   const workspaces = workspacesWithMetaData
-    .filter(w => (scope ? w.workspace.scope === scope : true))
+    .filter(w => (scope !== 'all' ? w.workspace.scope === scope : true))
     .filter(filterWorkspace)
     .sort(sortWorkspaces);
 


### PR DESCRIPTION
After changing the selection of the workspace filter (all/document/collection) a couple of times it can go into an error state.
This PR adds the disallowEmptySelection prop to the list component and makes sure no empty value can be set by the list to avoid potential race condition issues.
