### PR TITLE
Fix bug Explore Subscriptions shown when premium features are hidden …

### DIFF
--- a/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
+++ b/packages/insomnia-inso/src/__snapshots__/inso-snapshot.test.ts.snap
@@ -76,6 +76,17 @@ Options:
   -h, --help             display help for command"
 `;
 
+exports[`Snapshot for "inso export spec -h" 2`] = `
+"Usage: inso export spec [options] [identifier]
+
+Export an API Specification to a file
+
+Options:
+  -o, --output <path>    save the generated config to a file
+  -s, --skipAnnotations  remove all \\"x-kong-\\" annotations  (default: false)
+  -h, --help             display help for command"
+`;
+
 exports[`Snapshot for "inso generate -h" 1`] = `
 "Usage: inso generate [options] [command]
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -9,6 +9,7 @@ import {
   useGridList,
   useGridListItem,
 } from 'react-aria';
+import { useSelector } from 'react-redux';
 import {
   LoaderFunction,
   redirect,
@@ -66,6 +67,7 @@ import { EmptyStatePane } from '../components/panes/project-empty-state-pane';
 import { SidebarLayout } from '../components/sidebar-layout';
 import { Button } from '../components/themed-button/button';
 import { WorkspaceCard } from '../components/workspace-card';
+import { selectSettings } from '../redux/selectors';
 import { RootLoaderData } from './root';
 
 const StyledDropdownButton = styled(DropdownButton).attrs({
@@ -268,6 +270,7 @@ const OrganizationProjectsSidebar: FC<{
 
   // Only show the search in the default organization (local data) since other organizations (remote data) only have one project
   const shouldShowSearch = organizationId === DEFAULT_ORGANIZATION_ID;
+  const { disablePaidFeatureAds } = useSelector(selectSettings);
 
   return (
     <Sidebar
@@ -499,7 +502,7 @@ const OrganizationProjectsSidebar: FC<{
 
       <SidebarDivider />
 
-      <List
+      {!disablePaidFeatureAds && <List
         onAction={key => {
           clickLink(key.toString());
         }}
@@ -515,7 +518,7 @@ const OrganizationProjectsSidebar: FC<{
             />
           </SidebarListItemContent>
         </Item>
-      </List>
+      </List>}
     </Sidebar>
   );
 };


### PR DESCRIPTION
…#5764

The bug was there because, there was no check on the disablePaidFeatureAds settings option.

I added a check if disablePaidFeatureAds is false, If it is false then It'll show the "Explore Subscriptions" link, otherwise it won't.

It closes #5764 