### PR TITLE
show errors from the introspection

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -24,7 +24,7 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
   // Open the graphql request
   await page.getByRole('button', { name: 'GraphQL request' }).click();
   // Assert the schema is fetched after switching to GraphQL request
-  await expect(page.locator('.app')).toContainText('schema fetched just now');
+  await expect(page.locator('.graphql-editor__meta')).toContainText('schema fetched just now');
 
   // Assert schema documentation stuff
   await page.getByRole('button', { name: 'schema' }).click();

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -226,7 +226,6 @@ export const GraphQLEditor: FC<Props> = ({
         environmentId,
         url: request.url,
       });
-      console.log(newState?.schema, newState?.schemaFetchError);
       isMounted && setSchemaFetchError(newState?.schemaFetchError);
       isMounted && newState?.schema && setSchema(newState.schema);
       isMounted && newState?.schema && setSchemaLastFetchTime(Date.now());

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -120,7 +120,7 @@ const fetchGraphQLSchemaForRequest = async ({
     const bodyBuffer = models.response.getBodyBuffer(response);
     if (bodyBuffer) {
       const { data, errors } = JSON.parse(bodyBuffer.toString());
-      if (errors.length) {
+      if (errors?.length) {
         return { schemaFetchError: errors[0] };
       }
       return { schema: buildClientSchema(data) };

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -119,7 +119,10 @@ const fetchGraphQLSchemaForRequest = async ({
     }
     const bodyBuffer = models.response.getBodyBuffer(response);
     if (bodyBuffer) {
-      const { data } = JSON.parse(bodyBuffer.toString());
+      const { data, errors } = JSON.parse(bodyBuffer.toString());
+      if (errors.length) {
+        return { schemaFetchError: errors[0] };
+      }
       return { schema: buildClientSchema(data) };
     }
     return {
@@ -223,7 +226,7 @@ export const GraphQLEditor: FC<Props> = ({
         environmentId,
         url: request.url,
       });
-
+      console.log(newState?.schema, newState?.schemaFetchError);
       isMounted && setSchemaFetchError(newState?.schemaFetchError);
       isMounted && newState?.schema && setSchema(newState.schema);
       isMounted && newState?.schema && setSchemaLastFetchTime(Date.now());


### PR DESCRIPTION
introspection query gives better error messages than the one we were using previously

changelog(Improvements): Improved error messages that come from GraphQL introspection
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
