### PR TITLE
INS-2627: sanitize path-variable name regex capture for kong 3.x

### DIFF
--- a/packages/openapi-2-kong/src/common.test.ts
+++ b/packages/openapi-2-kong/src/common.test.ts
@@ -246,6 +246,17 @@ describe('common', () => {
     it('escape special characters not present in curly braces', () => {
       expect(pathVariablesToRegex('/foo/bar/$baz')).toBe('/foo/bar/\\$baz$');
     });
+
+    it('prefix ~ to regex path for non legacy Kong', () => {
+      expect(pathVariablesToRegex('/foo/{bar}/{baz}', false)).toBe(
+        '~/foo/(?<bar>[^/]+)/(?<baz>[^/]+)$',
+      );
+    });
+    it('converts illegal chars in regex path variables for non legacy Kong', () => {
+      expect(pathVariablesToRegex('/foo/{bar-test}/{baz-test}', false)).toBe(
+        '~/foo/(?<bar_test>[^/]+)/(?<baz_test>[^/]+)$',
+      );
+    });
   });
 
   describe('getPluginNameFromKey()', () => {

--- a/packages/openapi-2-kong/src/common.ts
+++ b/packages/openapi-2-kong/src/common.ts
@@ -77,6 +77,15 @@ export function pathVariablesToRegex(p: string, legacy: Boolean = true) {
     result = '~' + result;
   }
 
+  // Remove illegal chars from path-variable name.
+  // see https://github.com/Kong/go-apiops/blob/8842f7b0ecf3654f62f8e0bd867b5b67766794c9/convertoas3/oas3.go#L50
+  if (!legacy) {
+    result = result.replace(/-/g, '_');
+    if (result.startsWith('_')) {
+      result = 'a' + result;
+    }
+  }
+
   return result + '$';
 
 }

--- a/packages/openapi-2-kong/src/common.ts
+++ b/packages/openapi-2-kong/src/common.ts
@@ -77,17 +77,22 @@ export function pathVariablesToRegex(p: string, legacy: Boolean = true) {
     result = '~' + result;
   }
 
-  // Remove illegal chars from path-variable name.
-  // see https://github.com/Kong/go-apiops/blob/8842f7b0ecf3654f62f8e0bd867b5b67766794c9/convertoas3/oas3.go#L50
   if (!legacy) {
-    result = result.replace(/-/g, '_');
-    if (result.startsWith('_')) {
-      result = 'a' + result;
-    }
+    result = sanitizeRegexCapture(result);
   }
-
   return result + '$';
 
+}
+
+// Remove illegal chars from path-variable name.
+// see https://github.com/Kong/go-apiops/blob/8842f7b0ecf3654f62f8e0bd867b5b67766794c9/convertoas3/oas3.go#L50
+export function sanitizeRegexCapture(p: string) {
+  let result = slugify(p);
+  result = p.replace(/-/g, '_');
+  if (result.startsWith('_')) {
+    result = 'a' + result;
+  }
+  return result;
 }
 
 export function getPluginNameFromKey(key: string) {

--- a/packages/openapi-2-kong/src/declarative-config/plugins.ts
+++ b/packages/openapi-2-kong/src/declarative-config/plugins.ts
@@ -2,7 +2,7 @@ import SwaggerParser from '@apidevtools/swagger-parser';
 import { OpenAPIV3 } from 'openapi-types';
 import type { Entry } from 'type-fest';
 
-import { distinctByProperty, getPluginNameFromKey, isPluginKey } from '../common';
+import { distinctByProperty, getPluginNameFromKey, isPluginKey, sanitizeRegexCapture } from '../common';
 import { DCPlugin } from '../types/declarative-config';
 import { isBodySchema, isParameterSchema, ParameterSchema, RequestValidatorPlugin, XKongPluginRequestValidator, xKongPluginRequestValidator } from '../types/kong';
 import type { OA3Operation, OpenApi3Spec } from '../types/openapi3';
@@ -67,6 +67,11 @@ const resolveParameter = ($refs: SwaggerParser.$Refs, parameter: OpenAPIV3.Param
       in: dereferenced?.in || '',
       schema,
     };
+
+    // Remove illegal chars from path-variable name.
+    if (resolvedParam.in === 'path') {
+      resolvedParam.name = sanitizeRegexCapture(resolvedParam.name);
+    }
 
     const components = resolveComponents($refs, resolvedParam);
     return {


### PR DESCRIPTION
Closes INS-2627
Closes FTI-5060

changelog(Fixes): Added a fix to handle an edge of how path variable names are captured from regex when parsing OAS specs for Kong 3.x.

Minor change, to mimic what was done in `kced` - see https://github.com/Kong/go-apiops/blob/8842f7b0ecf3654f62f8e0bd867b5b67766794c9/convertoas3/oas3.go#L50