### PR TITLE
fix #5969 cannot select base environment

### DIFF
--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -354,7 +354,8 @@ export const WorkspaceEnvironmentsEditModal = forwardRef<WorkspaceEnvironmentsEd
           >
             <button
               onClick={() => {
-                if (environmentEditorRef.current?.isValid() && selectedEnvironmentId === baseEnvironment?._id) {
+                if (environmentEditorRef.current?.isValid() && selectedEnvironmentId !== baseEnvironment?._id) {
+                  // @ts-expect-error -- ??
                   setState(state => ({
                     ...state,
                     selectedEnvironmentId: baseEnvironment?._id,

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -355,8 +355,7 @@ export const WorkspaceEnvironmentsEditModal = forwardRef<WorkspaceEnvironmentsEd
             <button
               onClick={() => {
                 if (environmentEditorRef.current?.isValid() && selectedEnvironmentId !== baseEnvironment?._id) {
-                  // @ts-expect-error -- ??
-baseEnvironment?.id && setState(state => ({
+                  baseEnvironment?.id && setState(state => ({
                     ...state,
                     selectedEnvironmentId: baseEnvironment?._id,
                   }));

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -355,7 +355,7 @@ export const WorkspaceEnvironmentsEditModal = forwardRef<WorkspaceEnvironmentsEd
             <button
               onClick={() => {
                 if (environmentEditorRef.current?.isValid() && selectedEnvironmentId !== baseEnvironment?._id) {
-                  baseEnvironment?.id && setState(state => ({
+                  baseEnvironment?._id && setState(state => ({
                     ...state,
                     selectedEnvironmentId: baseEnvironment?._id,
                   }));

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -356,7 +356,7 @@ export const WorkspaceEnvironmentsEditModal = forwardRef<WorkspaceEnvironmentsEd
               onClick={() => {
                 if (environmentEditorRef.current?.isValid() && selectedEnvironmentId !== baseEnvironment?._id) {
                   // @ts-expect-error -- ??
-                  setState(state => ({
+baseEnvironment?.id && setState(state => ({
                     ...state,
                     selectedEnvironmentId: baseEnvironment?._id,
                   }));


### PR DESCRIPTION
Closes #5969 

changelog(Fixes): Fixed a regression where folks could no longer open the base environment on the Environments Editor