### PR TITLE
update test to expose bug in regex generation

### DIFF
--- a/packages/openapi-2-kong/src/common.test.ts
+++ b/packages/openapi-2-kong/src/common.test.ts
@@ -253,8 +253,8 @@ describe('common', () => {
       );
     });
     it('converts illegal chars in regex path variables for non legacy Kong', () => {
-      expect(pathVariablesToRegex('/foo/{bar-test}/{baz-test}', false)).toBe(
-        '~/foo/(?<bar_test>[^/]+)/(?<baz_test>[^/]+)$',
+      expect(pathVariablesToRegex('/foo-bar/{bar-test}/{baz-test}', false)).toBe(
+        '~/foo-bar/(?<bar_test>[^/]+)/(?<baz_test>[^/]+)$',
       );
     });
   });

--- a/packages/openapi-2-kong/src/common.test.ts
+++ b/packages/openapi-2-kong/src/common.test.ts
@@ -257,6 +257,11 @@ describe('common', () => {
         '~/foo-bar/(?<bar_test>[^/]+)/(?<baz_test>[^/]+)$',
       );
     });
+    it('converts illegal chars in regex with multiple paths and path variables for non legacy Kong', () => {
+      expect(pathVariablesToRegex('/foo-bar/{bar-test}/bar-bar/{bar-bar}/{baz-test}', false)).toBe(
+        '~/foo-bar/(?<bar_test>[^/]+)/bar-bar/(?<bar_bar>[^/]+)/(?<baz_test>[^/]+)$',
+      );
+    });
   });
 
   describe('getPluginNameFromKey()', () => {

--- a/packages/openapi-2-kong/src/common.ts
+++ b/packages/openapi-2-kong/src/common.ts
@@ -69,19 +69,20 @@ export function pathVariablesToRegex(p: string, legacy: Boolean = true) {
   // escape URL special characters except the curly braces
   p = p.replace(/[$()]/g, '\\$&');
   // match anything except whitespace and '/'
-  let result = p.replace(pathVariableSearchValue, '(?<$1>[^/]+)');
-  // add a line ending because it is a regex
-
-  // Prepend ~ to regex for Kong 3.X
-  if (!legacy && !result.startsWith('~')) {
-    result = '~' + result;
-  }
-
-  if (!legacy) {
-    result = sanitizeRegexCapture(result);
+  let result = '';
+  if (legacy) {
+    result = p.replace(pathVariableSearchValue, '(?<$1>[^/]+)');
+  } else {
+    // If it's not legacy (e.g. Kong 3.0+), first replace path variable with sanitized name
+    result = p.replace(pathVariableSearchValue, sanitizeRegexCapture);
+    // Then replace sanitized name with regex
+    result = result.replace(pathVariableSearchValue, '(?<$1>[^/]+)');
+    // Finally, prepend ~ to regex
+    if (!result.startsWith('~')) {
+      result = '~' + result;
+    }
   }
   return result + '$';
-
 }
 
 // Remove illegal chars from path-variable name.


### PR DESCRIPTION
sanitizing the path-variable name is not done correctly, as it sanitizes the entire path. So it also makes unintended changes.

changelog(Fixes): Fixed an issue when sanitizing the path-variable names in Inso CLI which was not done correctly, as it sanitized the entire path. So it also makes unintended changes. Now only matched path-variables are sanitized.
