### PR TITLE
INS-2639: add kong 3.x support for inso generate k8s config

### DIFF
--- a/packages/openapi-2-kong/src/kubernetes/generate.test.ts
+++ b/packages/openapi-2-kong/src/kubernetes/generate.test.ts
@@ -304,6 +304,11 @@ describe('index', () => {
       expect(generateServicePath(serverBasePath)).toBe('/api/.*/.*');
     });
 
+    it('adds /~ for kong 3.+ non legacy configs', () => {
+      const serverBasePath = '/api/.*';
+      expect(generateServicePath(serverBasePath, '', false)).toBe('/~/api/.*/.*');
+    });
+
     it.each(['/', '/specificPath'])(
       'does not add closing wildcard if using specific path: [%o]',
       specificPath => {

--- a/packages/openapi-2-kong/src/kubernetes/generate.test.ts
+++ b/packages/openapi-2-kong/src/kubernetes/generate.test.ts
@@ -305,8 +305,8 @@ describe('index', () => {
     });
 
     it('adds /~ for kong 3.+ non legacy configs', () => {
-      const serverBasePath = '/api/.*';
-      expect(generateServicePath(serverBasePath, '', false)).toBe('/~/api/.*');
+      const serverBasePath = '/api/v1';
+      expect(generateServicePath(serverBasePath, '', false)).toBe('/~/api/v1/.*');
     });
 
     it.each(['/', '/specificPath'])(

--- a/packages/openapi-2-kong/src/kubernetes/generate.test.ts
+++ b/packages/openapi-2-kong/src/kubernetes/generate.test.ts
@@ -306,7 +306,7 @@ describe('index', () => {
 
     it('adds /~ for kong 3.+ non legacy configs', () => {
       const serverBasePath = '/api/.*';
-      expect(generateServicePath(serverBasePath, '', false)).toBe('/~/api/.*/.*');
+      expect(generateServicePath(serverBasePath, '', false)).toBe('/~/api/.*');
     });
 
     it.each(['/', '/specificPath'])(


### PR DESCRIPTION
changelog(Improvements): Added minor Kong 3.x support for generating k8s configs using Inso CLI

While ApiOps v2 is not in full GA/production yet, adding this small QoL improvement to config generation to unblock folks still using Inso CLI for kong on k8s config generation cc @mheap @rspurgeon 