### PR TITLE
fix #5976: set content-type on openapi3 imports

### DIFF
--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/dereferenced-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/dereferenced-output.json
@@ -49,7 +49,11 @@
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/json"
+      }],
       "method": "POST",
       "name": "Add a new pet to the store",
       "parameters": [],
@@ -71,7 +75,11 @@
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/json"
+      }],
       "method": "PUT",
       "name": "Update an existing pet",
       "parameters": [],
@@ -159,7 +167,11 @@
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/x-www-form-urlencoded"
+      }],
       "method": "POST",
       "name": "Updates a pet in the store with form data",
       "parameters": [],
@@ -205,7 +217,11 @@
       "body": {
         "mimeType": "multipart/form-data"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "multipart/form-data"
+      }],
       "method": "POST",
       "name": "uploads an image",
       "parameters": [],

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/dereferenced-with-tags-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/dereferenced-with-tags-output.json
@@ -73,7 +73,11 @@
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/json"
+      }],
       "method": "POST",
       "name": "Add a new pet to the store",
       "parameters": [],
@@ -95,7 +99,11 @@
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/json"
+      }],
       "method": "PUT",
       "name": "Update an existing pet",
       "parameters": [],
@@ -183,7 +191,11 @@
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/x-www-form-urlencoded"
+      }],
       "method": "POST",
       "name": "Updates a pet in the store with form data",
       "parameters": [],
@@ -229,7 +241,11 @@
       "body": {
         "mimeType": "multipart/form-data"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "multipart/form-data"
+      }],
       "method": "POST",
       "name": "uploads an image",
       "parameters": [],

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-output.json
@@ -63,7 +63,11 @@
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/json"
+      }],
       "method": "POST",
       "name": "Add a new pet to the store",
       "parameters": [],
@@ -85,7 +89,11 @@
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/json"
+      }],
       "method": "PUT",
       "name": "Update an existing pet",
       "parameters": [],
@@ -173,7 +181,11 @@
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/x-www-form-urlencoded"
+      }],
       "method": "POST",
       "name": "Updates a pet in the store with form data",
       "parameters": [],
@@ -219,7 +231,11 @@
       "body": {
         "mimeType": "multipart/form-data"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "multipart/form-data"
+      }],
       "method": "POST",
       "name": "uploads an image",
       "parameters": [],

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-readonly-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-readonly-output.json
@@ -57,7 +57,11 @@
         "mimeType": "application/json",
         "text": "{\n  \"name\": \"string\",\n  \"tag\": \"string\"\n}"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/json"
+      }],
       "method": "POST",
       "name": "Create a pet",
       "parameters": [],

--- a/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-with-tags-output.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/openapi3/petstore-with-tags-output.json
@@ -73,7 +73,11 @@
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/json"
+      }],
       "method": "POST",
       "name": "Add a new pet to the store",
       "parameters": [],
@@ -95,7 +99,11 @@
         "mimeType": "application/json",
         "text": "{\n  \"id\": 0,\n  \"category\": {\n    \"id\": 0,\n    \"name\": \"string\"\n  },\n  \"name\": \"doggie\",\n  \"photoUrls\": [\n    \"string\"\n  ],\n  \"tags\": [\n    {\n      \"id\": 0,\n      \"name\": \"string\"\n    }\n  ],\n  \"status\": \"string\"\n}"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/json"
+      }],
       "method": "PUT",
       "name": "Update an existing pet",
       "parameters": [],
@@ -183,7 +191,11 @@
       "body": {
         "mimeType": "application/x-www-form-urlencoded"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "application/x-www-form-urlencoded"
+      }],
       "method": "POST",
       "name": "Updates a pet in the store with form data",
       "parameters": [],
@@ -229,7 +241,11 @@
       "body": {
         "mimeType": "multipart/form-data"
       },
-      "headers": [],
+      "headers": [{
+        "disabled": false,
+        "name": "Content-Type",
+        "value": "multipart/form-data"
+      }],
       "method": "POST",
       "name": "uploads an image",
       "parameters": [],

--- a/packages/insomnia/src/utils/importers/importers/openapi-3.ts
+++ b/packages/insomnia/src/utils/importers/importers/openapi-3.ts
@@ -1,7 +1,6 @@
 import SwaggerParser from '@apidevtools/swagger-parser';
 import { camelCase } from 'change-case';
 import crypto from 'crypto';
-import { constants } from 'fs';
 import { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import { parse as urlParse } from 'url';
 import YAML from 'yaml';

--- a/packages/insomnia/src/utils/importers/importers/openapi-3.ts
+++ b/packages/insomnia/src/utils/importers/importers/openapi-3.ts
@@ -142,7 +142,7 @@ const parseEnvs = (baseEnv: ImportRequest, document?: OpenAPIV3.Document | null)
   }
 
   const securityVariables = getSecurityEnvVariables(
-      document.components?.securitySchemes as unknown as OpenAPIV3.SecuritySchemeObject,
+    document.components?.securitySchemes as unknown as OpenAPIV3.SecuritySchemeObject,
   );
 
   return servers
@@ -331,7 +331,7 @@ const prepareHeaders = (endpointSchema: OpenAPIV3.PathItemObject, body: any) => 
     header => header.name === 'Content-Type',
   );
 
-  if (body && body.mimeType  && noContentTypeHeader) {
+  if (body && body.mimeType && noContentTypeHeader) {
     paramHeaders = [
       {
         name: 'Content-Type',


### PR DESCRIPTION
Closes #5976 

Related to similar past change - https://github.com/Kong/insomnia/pull/5812

If mime type is set for bodies in the OpenAPI imported spec, we now set the content-type on the generated requests as well.

changelog(Fixes): Added a fix to help set Content-Type header when importing requests from OpenAPI 3 specs of which the mime-type was already specified