### PR TITLE
gRPC: Support JSONPath filter for response body

### DIFF
--- a/packages/insomnia/src/ui/components/editors/grpc-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/grpc-editor.tsx
@@ -1,5 +1,10 @@
 import React, { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
 
+import * as models from '../../../models';
+import type { Response } from '../../../models/response';
+import { updateRequestMetaByParentId } from '../../hooks/create-request';
+import { selectActiveResponse } from '../../redux/selectors';
 import { CodeEditor } from '../codemirror/code-editor';
 
 interface Props {
@@ -12,8 +17,27 @@ export const GRPCEditor: FunctionComponent<Props> = ({
   content,
   handleChange,
   readOnly,
-}) => (
-  <CodeEditor
+}) => {
+  const response = useSelector(selectActiveResponse) as Response | null;
+  const handleSetFilter = async (responseFilter: string) => {
+    if (!response) {
+      return;
+    }
+    const requestId = response.parentId;
+    await updateRequestMetaByParentId(requestId, { responseFilter });
+    const meta = await models.requestMeta.getByParentId(requestId);
+    if (!meta) {
+      return;
+    }
+    const responseFilterHistory = meta.responseFilterHistory.slice(0, 10);
+    // Already in history or empty?
+    if (!responseFilter || responseFilterHistory.includes(responseFilter)) {
+      return;
+    }
+    responseFilterHistory.unshift(responseFilter);
+    updateRequestMetaByParentId(requestId, { responseFilterHistory });
+  };
+  return (<CodeEditor
     defaultValue={content}
     onChange={handleChange}
     mode="application/json"
@@ -21,5 +45,6 @@ export const GRPCEditor: FunctionComponent<Props> = ({
     readOnly={readOnly}
     autoPrettify={readOnly}
     showPrettifyButton={!readOnly}
-  />
-);
+    updateFilter={handleSetFilter}
+  />);
+};


### PR DESCRIPTION
changelog(Improvements): Added support for JSONPath queries for gRPC responses.


<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

# Description

Add support for JSONPath queries for gRPC responses bodies.

Currently the JSONPath filter input is rendered in the gRPC response tab, but does not apply the entered filter. This PR adds support for JSONPath filter by copying the current behavior of the response pane for http requests.

## Type of change

Trivial change. Everything was already in place, just needed to copy the handler for applying the query.

## How Has This Been Tested?

Manually tested using Insomnia UI on Ubuntu 22.04:

1. Make gRPC request (that returns a json payload)
2. Insert filter in the JSONData input field

Using develop branch: 
 - Filter is not applied 

Checking out this PR:
- Filter is applied on response data