### PR TITLE
Fix #5923: keybind action for switch environments

### DIFF
--- a/packages/insomnia/src/ui/components/base/dropdown/dropdown.tsx
+++ b/packages/insomnia/src/ui/components/base/dropdown/dropdown.tsx
@@ -2,7 +2,7 @@ import { PressResponder } from '@react-aria/interactions';
 import type { AriaMenuProps, MenuTriggerProps } from '@react-types/menu';
 import type { Placement } from '@react-types/overlays';
 import classnames from 'classnames';
-import React, { CSSProperties, forwardRef, ReactNode, useImperativeHandle, useRef } from 'react';
+import React, { CSSProperties, forwardRef, ReactNode, useRef } from 'react';
 import { mergeProps, useMenuTrigger } from 'react-aria';
 import { MenuTriggerState, useMenuTriggerState } from 'react-stately';
 import styled from 'styled-components';
@@ -44,22 +44,13 @@ export const Dropdown = forwardRef<DropdownHandle, DropdownProps>((props: Dropdo
     dataTestId = 'DropdownButton',
     isDisabled = false,
     onOpen,
+    onClose,
   } = props;
 
   const state: MenuTriggerState = useMenuTriggerState({
     ...props,
-    onOpenChange: isOpen => isOpen && onOpen?.(),
+    onOpenChange: isOpen => isOpen ? onOpen?.() : onClose?.(),
   });
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      show: state.open,
-      hide: state.close,
-      toggle: state.toggle,
-    }),
-    [state.close, state.open, state.toggle]
-  );
 
   const triggerRef = useRef<HTMLButtonElement>(ref);
 

--- a/packages/insomnia/src/ui/components/base/dropdown/dropdown.tsx
+++ b/packages/insomnia/src/ui/components/base/dropdown/dropdown.tsx
@@ -2,7 +2,7 @@ import { PressResponder } from '@react-aria/interactions';
 import type { AriaMenuProps, MenuTriggerProps } from '@react-types/menu';
 import type { Placement } from '@react-types/overlays';
 import classnames from 'classnames';
-import React, { CSSProperties, forwardRef, ReactNode, useRef } from 'react';
+import React, { CSSProperties, forwardRef, ReactNode, useImperativeHandle, useRef } from 'react';
 import { mergeProps, useMenuTrigger } from 'react-aria';
 import { MenuTriggerState, useMenuTriggerState } from 'react-stately';
 import styled from 'styled-components';
@@ -50,6 +50,16 @@ export const Dropdown = forwardRef<DropdownHandle, DropdownProps>((props: Dropdo
     ...props,
     onOpenChange: isOpen => isOpen && onOpen?.(),
   });
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      show: state.open,
+      hide: state.close,
+      toggle: state.toggle,
+    }),
+    [state.close, state.open, state.toggle]
+  );
 
   const triggerRef = useRef<HTMLButtonElement>(ref);
 

--- a/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/environments-dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useRef } from 'react';
+import React, { FC, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
@@ -28,13 +28,10 @@ export const EnvironmentsDropdown: FC<Props> = () => {
   const hotKeyRegistry = useSelector(selectHotKeyRegistry);
   const setActiveEnvironmentFetcher = useFetcher();
   const dropdownRef = useRef<DropdownHandle>(null);
-
-  const toggleSwitchMenu = useCallback(() => {
-    dropdownRef.current?.toggle(true);
-  }, []);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   useDocBodyKeyboardShortcuts({
-    environment_showSwitchMenu: toggleSwitchMenu,
+    environment_showSwitchMenu: () => setIsDropdownOpen(true),
   });
 
   // NOTE: Base environment might not exist if the users hasn't managed environments yet.
@@ -43,6 +40,9 @@ export const EnvironmentsDropdown: FC<Props> = () => {
   return (
     <Dropdown
       ref={dropdownRef}
+      isOpen={isDropdownOpen}
+      onOpen={() => setIsDropdownOpen(true)}
+      onClose={() => setIsDropdownOpen(false)}
       triggerButton={
         <DropdownButton
           className="btn btn--super-compact no-wrap"


### PR DESCRIPTION
changelog(Fixes): Fixed an issue with the keybind action to switch between environments

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

# Description

Fix keybind (`Ctrl+Shift+E`) action: open environments dropdown when keybind is used.

Closes issue: https://github.com/Kong/insomnia/issues/5923

## Type of change

Trivial change.

The keybind broke in patch: [e38ece1ab7a45671778fef9326fe4c18c4554154](https://github.com/Kong/insomnia/commit/e38ece1ab7a45671778fef9326fe4c18c4554154).  I used previous commit ([90e014a0057322eddbc9f729a4a505d8063ceb8d](https://github.com/Kong/insomnia/commit/90e014a0057322eddbc9f729a4a505d8063ceb8d)) as reference to restore the behavior of the keybind.

## How Has This Been Tested?

Manually tested using Insomnia UI on Ubuntu 22.04:

1. Open insomnia
2. Run keybind `Ctrl` + `Shift` + `E`

On develop branch: 
- Does nothing

On this branch:
- Opens environments dropdown

