### PR TITLE
Add support for multiple remote projects per Team

### DIFF
--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -98,7 +98,7 @@ export async function changePasswordWithToken(rawNewPassphrase: string, confirma
   const symmetricKey = JSON.stringify(_getSymmetricKey());
   const newEncSymmetricKeyJSON = crypt.encryptAES(newSecret, symmetricKey);
   const newEncSymmetricKey = JSON.stringify(newEncSymmetricKeyJSON);
-  return window.main.insomniaFetch({
+  await window.main.insomniaFetch({
     method: 'POST',
     path: '/auth/change-password',
     data: {
@@ -113,7 +113,7 @@ export async function changePasswordWithToken(rawNewPassphrase: string, confirma
 }
 
 export function sendPasswordChangeCode() {
-  return window.main.insomniaFetch({
+  window.main.insomniaFetch({
     method: 'POST',
     path: '/auth/send-password-code',
     sessionId: getCurrentSessionId(),
@@ -219,13 +219,6 @@ export function setSessionData(
   window.localStorage.setItem('currentSessionId', id);
   return sessionData;
 }
-export async function listTeams() {
-  return window.main.insomniaFetch({
-    method: 'GET',
-    path: '/api/teams',
-    sessionId: getCurrentSessionId(),
-  });
-}
 
 // ~~~~~~~~~~~~~~~~ //
 // Helper Functions //
@@ -247,7 +240,7 @@ async function _whoami(sessionId: string | null = null): Promise<WhoamiResponse>
 }
 
 function _getAuthSalts(email: string) {
-  return window.main.insomniaFetch({
+  return window.main.insomniaFetch<{ saltKey: string; saltAuth: string }>({
     method: 'POST',
     path: '/auth/login-s',
     data: { email },

--- a/packages/insomnia/src/common/log.ts
+++ b/packages/insomnia/src/common/log.ts
@@ -14,7 +14,7 @@ export const initializeLogging = () => {
     // When the log file exceeds this limit, it will be rotated to {file name}.old.log file.
     fileTransport.maxSize = 1024 * 1024 * 10;
     // Rotate the log file every time we start the app
-    fileTransport.archiveLog(logFile.path);
+    fileTransport.archiveLog(logFile);
     logFile.clear();
   }
 

--- a/packages/insomnia/src/common/log.ts
+++ b/packages/insomnia/src/common/log.ts
@@ -14,7 +14,7 @@ export const initializeLogging = () => {
     // When the log file exceeds this limit, it will be rotated to {file name}.old.log file.
     fileTransport.maxSize = 1024 * 1024 * 10;
     // Rotate the log file every time we start the app
-    fileTransport.archiveLog(logFile);
+    fileTransport.archiveLog(logFile.path);
     logFile.clear();
   }
 

--- a/packages/insomnia/src/main/analytics.ts
+++ b/packages/insomnia/src/main/analytics.ts
@@ -4,14 +4,13 @@ import { v4 as uuidv4 } from 'uuid';
 import * as session from '../account/session';
 import { getAccountId } from '../account/session';
 import {
-  getApiBaseURL,
   getAppPlatform,
   getAppVersion,
   getProductName,
   getSegmentWriteKey,
 } from '../common/constants';
 import * as models from '../models/index';
-import { axiosRequest } from './network/axios-request';
+import { insomniaFetch } from './insomniaFetch';
 
 const analytics = new Analytics({ writeKey: getSegmentWriteKey() });
 
@@ -101,12 +100,10 @@ export async function trackPageView(name: string) {
 
 export async function sendTelemetry() {
   if (session.isLoggedIn()) {
-    axiosRequest({
+    insomniaFetch({
       method: 'POST',
-      url: `${getApiBaseURL()}/v1/telemetry/`,
-      headers: {
-        'X-Session-Id': session.getCurrentSessionId(),
-      },
+      path: '/v1/telemetry/',
+      sessionId: session.getCurrentSessionId(),
     }).catch((error: unknown) => {
       console.warn('[analytics] Unexpected error while sending telemetry', error);
     });

--- a/packages/insomnia/src/main/insomniaFetch.ts
+++ b/packages/insomnia/src/main/insomniaFetch.ts
@@ -30,6 +30,8 @@ const exponentialBackOff = async (url: string, init: RequestInit, retries = 0): 
       return exponentialBackOff(url, init, retries);
     }
     if (!response.ok) {
+      // TODO: review error status code behaviour with backend, should we parse errors here and return response
+      // or should we rethrow an error with a response object inside? should we be exposing errors to the app UI?
       console.log(`Response not OK: ${response.status} for ${url}`);
     }
     return response;
@@ -38,7 +40,7 @@ const exponentialBackOff = async (url: string, init: RequestInit, retries = 0): 
   }
 };
 
-export async function insomniaFetch<T = any>({ method, path, data, sessionId, origin }: FetchConfig): Promise<T> {
+export async function insomniaFetch<T = void>({ method, path, data, sessionId, origin }: FetchConfig): Promise<T> {
   const config: RequestInit = {
     method,
     headers: {

--- a/packages/insomnia/src/main/insomniaFetch.ts
+++ b/packages/insomnia/src/main/insomniaFetch.ts
@@ -4,7 +4,7 @@ import { getApiBaseURL, getClientString } from '../common/constants';
 import { delay } from '../common/misc';
 
 interface FetchConfig {
-  method: 'POST' | 'PUT' | 'GET';
+  method: 'POST' | 'PUT' | 'GET' | 'DELETE' | 'PATCH';
   path: string;
   sessionId: string | null;
   data?: unknown;

--- a/packages/insomnia/src/sync/vcs/__tests__/initialize-backend-project.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/initialize-backend-project.test.ts
@@ -79,7 +79,7 @@ describe('initialize-backend-project', () => {
 
       await pushSnapshotOnInitialize({ vcs, project, workspace, workspaceMeta });
 
-      expect(pushSpy).toHaveBeenCalledWith('team_abc', project.remoteId);
+      expect(pushSpy).toHaveBeenCalledWith({ teamId: 'team_abc', teamProjectId: project.remoteId });
       const updatedMeta = await models.workspaceMeta.getByParentId(workspace._id);
       expect(updatedMeta?.pushSnapshotOnInitialize).toBe(false);
     });

--- a/packages/insomnia/src/sync/vcs/__tests__/initialize-backend-project.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/initialize-backend-project.test.ts
@@ -72,14 +72,14 @@ describe('initialize-backend-project', () => {
     });
 
     it('should push snapshot if conditions are met', async () => {
-      const project = await models.project.create({ remoteId: 'abc', parentId: 'abc' });
+      const project = await models.project.create({ remoteId: 'abc', parentId: 'team_abc' });
       const workspace = await models.workspace.create({ parentId: project._id });
       const workspaceMeta = await models.workspaceMeta.create({ parentId: workspace._id, pushSnapshotOnInitialize: true });
       vcs.switchAndCreateBackendProjectIfNotExist(workspace._id, workspace.name);
 
       await pushSnapshotOnInitialize({ vcs, project, workspace, workspaceMeta });
 
-      expect(pushSpy).toHaveBeenCalledWith(project.remoteId);
+      expect(pushSpy).toHaveBeenCalledWith('team_abc', project.remoteId);
       const updatedMeta = await models.workspaceMeta.getByParentId(workspace._id);
       expect(updatedMeta?.pushSnapshotOnInitialize).toBe(false);
     });

--- a/packages/insomnia/src/sync/vcs/__tests__/initialize-backend-project.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/initialize-backend-project.test.ts
@@ -72,7 +72,7 @@ describe('initialize-backend-project', () => {
     });
 
     it('should push snapshot if conditions are met', async () => {
-      const project = await models.project.create({ remoteId: 'abc' });
+      const project = await models.project.create({ remoteId: 'abc', parentId: 'abc' });
       const workspace = await models.workspace.create({ parentId: project._id });
       const workspaceMeta = await models.workspaceMeta.create({ parentId: workspace._id, pushSnapshotOnInitialize: true });
       vcs.switchAndCreateBackendProjectIfNotExist(workspace._id, workspace.name);

--- a/packages/insomnia/src/sync/vcs/__tests__/pull-backend-project.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/pull-backend-project.test.ts
@@ -49,7 +49,7 @@ describe('pullBackendProject()', () => {
       });
 
       // Act
-      await pullBackendProject({ vcs, backendProject, remoteProjects: [project].filter(isRemoteProject) });
+      await pullBackendProject({ vcs, backendProject, remoteProjects: [project].filter(isRemoteProject), teamProjectId: project._id });
 
       // Assert
       expect(project?.name).not.toBe(backendProject.team.name); // should not rename if the project already exists
@@ -57,17 +57,19 @@ describe('pullBackendProject()', () => {
       const workspaces = await models.workspace.all();
       expect(workspaces).toHaveLength(1);
       const workspace = workspaces[0];
-      expect(workspace).toStrictEqual(expect.objectContaining<Partial<Workspace>>({
+      const expectedWorkspace: Partial<Workspace> = {
         _id: backendProject.rootDocumentId,
         name: backendProject.name,
         parentId: project._id,
         scope: 'collection',
-      }));
+      };
+
+      expect(workspace).toEqual(expect.objectContaining(expectedWorkspace));
     });
 
     it('should insert a project and workspace with parent', async () => {
       // Act
-      await pullBackendProject({ vcs, backendProject, remoteProjects: [] });
+      await pullBackendProject({ vcs, backendProject, remoteProjects: [], teamProjectId: backendProject.team.id });
 
       // Assert
       const project = await models.project.getByRemoteId(backendProject.team.id);
@@ -76,12 +78,14 @@ describe('pullBackendProject()', () => {
       const workspaces = await models.workspace.all();
       expect(workspaces).toHaveLength(1);
       const workspace = workspaces[0];
-      expect(workspace).toStrictEqual(expect.objectContaining<Partial<Workspace>>({
+      const expectedWorkspace: Partial<Workspace> = {
         _id: backendProject.rootDocumentId,
         name: backendProject.name,
         parentId: project?._id,
         scope: 'collection',
-      }));
+      };
+
+      expect(workspace).toStrictEqual(expect.objectContaining(expectedWorkspace));
     });
 
     it('should update a workspace if the name or parentId is different', async () => {
@@ -89,7 +93,7 @@ describe('pullBackendProject()', () => {
       await models.workspace.create({ _id: backendProject.rootDocumentId, name: 'someName' });
 
       // Act
-      await pullBackendProject({ vcs, backendProject, remoteProjects: [] });
+      await pullBackendProject({ vcs, backendProject, remoteProjects: [], teamProjectId: backendProject.team.id });
 
       // Assert
       const project = await models.project.getByRemoteId(backendProject.team.id);
@@ -97,11 +101,13 @@ describe('pullBackendProject()', () => {
       const workspaces = await models.workspace.all();
       expect(workspaces).toHaveLength(1);
       const workspace = workspaces[0];
-      expect(workspace).toStrictEqual(expect.objectContaining<Partial<Workspace>>({
+      const expectedWorkspace: Partial<Workspace> = {
         _id: backendProject.rootDocumentId,
         name: backendProject.name,
         parentId: project?._id,
-      }));
+      };
+
+      expect(workspace).toStrictEqual(expect.objectContaining(expectedWorkspace));
     });
   });
 
@@ -115,7 +121,7 @@ describe('pullBackendProject()', () => {
       vcs.allDocuments.mockResolvedValue([existingWrk, existingReq]);
 
       // Act
-      await pullBackendProject({ vcs, backendProject, remoteProjects: [] });
+      await pullBackendProject({ vcs, backendProject, remoteProjects: [], teamProjectId: backendProject.team.id });
 
       // Assert
       const project = await models.project.getByRemoteId(backendProject.team.id);
@@ -123,18 +129,20 @@ describe('pullBackendProject()', () => {
       const workspaces = await models.workspace.all();
       expect(workspaces).toHaveLength(1);
       const workspace = workspaces[0];
-      expect(workspace).toStrictEqual(expect.objectContaining<Partial<Workspace>>({
+      const expectedWorkspace: Partial<Workspace> = {
         _id: backendProject.rootDocumentId,
         name: backendProject.name,
         parentId: project?._id,
-      }));
+      };
+
+      expect(workspace).toStrictEqual(expect.objectContaining(expectedWorkspace));
 
       const requests = await models.request.all();
       expect(requests).toHaveLength(1);
       const request = requests[0];
       expect(request).toStrictEqual(existingReq);
 
-      expect(vcs.pull).toHaveBeenCalledWith([], project?.remoteId);
+      expect(vcs.pull).toHaveBeenCalledWith([], project?.parentId, project?._id);
     });
   });
 
@@ -143,7 +151,7 @@ describe('pullBackendProject()', () => {
     vcs.getRemoteBranches.mockRejectedValue(new Error('invalid access to project'));
 
     // Act
-    const action = () => pullBackendProject({ vcs, backendProject, remoteProjects: [] });
+    const action = () => pullBackendProject({ vcs, backendProject, remoteProjects: [], teamProjectId: '' });
 
     // Assert
     expect(vcs.pull).not.toHaveBeenCalled();

--- a/packages/insomnia/src/sync/vcs/__tests__/pull-backend-project.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/pull-backend-project.test.ts
@@ -142,7 +142,7 @@ describe('pullBackendProject()', () => {
       const request = requests[0];
       expect(request).toStrictEqual(existingReq);
 
-      expect(vcs.pull).toHaveBeenCalledWith([], project?.parentId, project?._id);
+      expect(vcs.pull).toHaveBeenCalledWith({ candidates: [], teamId: project?.parentId, teamProjectId: project?._id });
     });
   });
 

--- a/packages/insomnia/src/sync/vcs/initialize-backend-project.ts
+++ b/packages/insomnia/src/sync/vcs/initialize-backend-project.ts
@@ -30,7 +30,7 @@ export const pushSnapshotOnInitialize = async ({
   vcs,
   workspace,
   workspaceMeta,
-  project: { _id: projectId, remoteId: projectRemoteId },
+  project: { _id: projectId, remoteId: projectRemoteId, parentId },
 }: {
   vcs: VCS;
   workspace: Workspace;
@@ -48,6 +48,6 @@ export const pushSnapshotOnInitialize = async ({
 
   if (markedForPush && projectIsForWorkspace && projectRemoteId && hasProject) {
     await models.workspaceMeta.updateByParentId(workspace._id, { pushSnapshotOnInitialize: false });
-    await vcs.push(projectRemoteId);
+    await vcs.push(parentId, projectRemoteId);
   }
 };

--- a/packages/insomnia/src/sync/vcs/initialize-backend-project.ts
+++ b/packages/insomnia/src/sync/vcs/initialize-backend-project.ts
@@ -48,6 +48,6 @@ export const pushSnapshotOnInitialize = async ({
 
   if (markedForPush && projectIsForWorkspace && projectRemoteId && hasProject) {
     await models.workspaceMeta.updateByParentId(workspace._id, { pushSnapshotOnInitialize: false });
-    await vcs.push(parentId, projectRemoteId);
+    await vcs.push({ teamId: parentId, teamProjectId: projectRemoteId });
   }
 };

--- a/packages/insomnia/src/sync/vcs/pull-backend-project.ts
+++ b/packages/insomnia/src/sync/vcs/pull-backend-project.ts
@@ -14,13 +14,10 @@ interface Options {
   vcs: VCS;
   backendProject: BackendProjectWithTeam;
   remoteProjects: RemoteProject[];
+  teamProjectId: string;
 }
 
-export const pullBackendProject = async ({
-  vcs,
-  backendProject,
-  remoteProjects,
-}: Options) => {
+export const pullBackendProject = async ({ vcs, backendProject, remoteProjects, teamProjectId }: Options) => {
   // Set backend project, checkout master, and pull
   await vcs.setBackendProject(backendProject);
   await vcs.checkout([], DEFAULT_BRANCH_NAME);
@@ -33,9 +30,7 @@ export const pullBackendProject = async ({
   const defaultBranchMissing = !remoteBranches.includes(DEFAULT_BRANCH_NAME);
 
   // Find or create the remote project locally
-  let project = remoteProjects.find(
-    ({ remoteId }) => remoteId === backendProject.team.id
-  );
+  let project = remoteProjects.find(({ _id }) => _id === teamProjectId);
   if (!project) {
     project = await initializeProjectFromTeam(backendProject.team);
     await database.upsert(project);
@@ -53,7 +48,7 @@ export const pullBackendProject = async ({
 
     workspaceId = workspace._id;
   } else {
-    await vcs.pull([], project.remoteId); // There won't be any existing docs since it's a new pull
+    await vcs.pull([], project.parentId, project._id); // There won't be any existing docs since it's a new pull
 
     const flushId = await database.bufferChanges();
 

--- a/packages/insomnia/src/sync/vcs/pull-backend-project.ts
+++ b/packages/insomnia/src/sync/vcs/pull-backend-project.ts
@@ -48,7 +48,7 @@ export const pullBackendProject = async ({ vcs, backendProject, remoteProjects, 
 
     workspaceId = workspace._id;
   } else {
-    await vcs.pull([], project.parentId, project._id); // There won't be any existing docs since it's a new pull
+    await vcs.pull({ candidates: [], teamId: project.parentId, teamProjectId: project._id }); // There won't be any existing docs since it's a new pull
 
     const flushId = await database.bufferChanges();
 

--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -1169,8 +1169,6 @@ export class VCS {
       });
     }
 
-    console.log(teamKeys);
-
     const { projectCreate } = await this._runGraphQL(
       `
         mutation (

--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -126,7 +126,7 @@ export class VCS {
     return this._allBackendProjects();
   }
 
-  async remoteBackendProjects(teamId: string, teamProjectId: string) {
+  async remoteBackendProjects({ teamId, teamProjectId }: { teamId: string; teamProjectId: string }) {
     return this._queryBackendProjects(teamId, teamProjectId);
   }
 
@@ -492,8 +492,8 @@ export class VCS {
     console.log(`[sync] Created snapshot ${snapshot.id} (${name})`);
   }
 
-  async pull(candidates: StatusCandidate[], teamId: string, teamProjectId: string) {
-    await this._getOrCreateRemoteBackendProject(teamId, teamProjectId);
+  async pull({ candidates, teamId, teamProjectId }: { candidates: StatusCandidate[]; teamId: string; teamProjectId: string }) {
+    await this._getOrCreateRemoteBackendProject({ teamId, teamProjectId });
     const localBranch = await this._getCurrentBranch();
     const tmpBranchForRemote = await this.customFetch(localBranch.name + '.hidden', localBranch.name);
     // Merge branch and ensure that we use the remote's history when merging
@@ -511,19 +511,19 @@ export class VCS {
     return delta;
   }
 
-  async _getOrCreateRemoteBackendProject(teamId: string, teamProjectId: string) {
+  async _getOrCreateRemoteBackendProject({ teamId, teamProjectId }: { teamId: string; teamProjectId: string }) {
     const localProject = await this._assertBackendProject();
     let remoteProject = await this._queryProject();
 
     if (!remoteProject) {
-      remoteProject = await this._createRemoteProject(localProject, teamId, teamProjectId);
+      remoteProject = await this._createRemoteProject({ ...localProject, teamId, teamProjectId });
     }
 
     await this._storeBackendProject(remoteProject);
     return remoteProject;
   }
 
-  async _createRemoteProject({ rootDocumentId, name }: BackendProject, teamId: string, teamProjectId: string) {
+  async _createRemoteProject({ rootDocumentId, name, teamId, teamProjectId }: BackendProject & { teamId: string; teamProjectId: string }) {
     if (!teamId) {
       throw new Error('teamId should be defined');
     }
@@ -532,8 +532,8 @@ export class VCS {
     return this._queryCreateProject(rootDocumentId, name, teamId, teamProjectId, teamKeys.memberKeys);
   }
 
-  async push(teamId: string, teamProjectId: string) {
-    await this._getOrCreateRemoteBackendProject(teamId, teamProjectId);
+  async push({ teamId, teamProjectId }: { teamId: string; teamProjectId: string }) {
+    await this._getOrCreateRemoteBackendProject({ teamId, teamProjectId });
     const branch = await this._getCurrentBranch();
     // Check branch history to make sure there are no conflicts
     let lastMatchingIndex = 0;

--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -126,12 +126,33 @@ export class VCS {
     return this._allBackendProjects();
   }
 
-  async remoteBackendProjects(teamId: string) {
-    return this._queryBackendProjects(teamId);
+  async remoteBackendProjects(teamId: string, teamProjectId: string) {
+    return this._queryBackendProjects(teamId, teamProjectId);
   }
 
   async remoteBackendProjectsInAnyTeam() {
-    return this._queryBackendProjects();
+    const { projects } = await this._runGraphQL(
+      `
+        query ($teamId: ID, $teamProjectId: ID) {
+          projects(teamId: $teamId, teamProjectId: $teamProjectId) {
+            id
+            name
+            rootDocumentId
+            teams {
+              id
+              name
+            }
+          }
+        }
+      `,
+      {
+        teamId: '',
+        teamProjectId: '',
+      },
+      'projects',
+    );
+
+    return (projects as BackendProjectWithTeams[]).map(normalizeBackendProjectTeam);
   }
 
   async blobFromLastSnapshot(key: string) {
@@ -471,8 +492,8 @@ export class VCS {
     console.log(`[sync] Created snapshot ${snapshot.id} (${name})`);
   }
 
-  async pull(candidates: StatusCandidate[], teamId: string | undefined | null) {
-    await this._getOrCreateRemoteBackendProject(teamId || '');
+  async pull(candidates: StatusCandidate[], teamId: string, teamProjectId: string) {
+    await this._getOrCreateRemoteBackendProject(teamId, teamProjectId);
     const localBranch = await this._getCurrentBranch();
     const tmpBranchForRemote = await this.customFetch(localBranch.name + '.hidden', localBranch.name);
     // Merge branch and ensure that we use the remote's history when merging
@@ -490,29 +511,29 @@ export class VCS {
     return delta;
   }
 
-  async _getOrCreateRemoteBackendProject(teamId: string) {
+  async _getOrCreateRemoteBackendProject(teamId: string, teamProjectId: string) {
     const localProject = await this._assertBackendProject();
     let remoteProject = await this._queryProject();
 
     if (!remoteProject) {
-      remoteProject = await this._createRemoteProject(localProject, teamId);
+      remoteProject = await this._createRemoteProject(localProject, teamId, teamProjectId);
     }
 
     await this._storeBackendProject(remoteProject);
     return remoteProject;
   }
 
-  async _createRemoteProject({ rootDocumentId, name }: BackendProject, teamId: string) {
+  async _createRemoteProject({ rootDocumentId, name }: BackendProject, teamId: string, teamProjectId: string) {
     if (!teamId) {
       throw new Error('teamId should be defined');
     }
 
     const teamKeys = await this._queryTeamMemberKeys(teamId);
-    return this._queryCreateProject(rootDocumentId, name, teamId, teamKeys.memberKeys);
+    return this._queryCreateProject(rootDocumentId, name, teamId, teamProjectId, teamKeys.memberKeys);
   }
 
-  async push(teamId: string | undefined | null) {
-    await this._getOrCreateRemoteBackendProject(teamId || '');
+  async push(teamId: string, teamProjectId: string) {
+    await this._getOrCreateRemoteBackendProject(teamId, teamProjectId);
     const branch = await this._getCurrentBranch();
     // Check branch history to make sure there are no conflicts
     let lastMatchingIndex = 0;
@@ -1019,11 +1040,11 @@ export class VCS {
     return teams as Team[];
   }
 
-  async _queryBackendProjects(teamId?: string) {
+  async _queryBackendProjects(teamId: string, teamProjectId: string) {
     const { projects } = await this._runGraphQL(
       `
-        query ($teamId: ID) {
-          projects(teamId: $teamId) {
+        query ($teamId: ID, $teamProjectId: ID) {
+          projects(teamId: $teamId, teamProjectId: $teamProjectId) {
             id
             name
             rootDocumentId
@@ -1036,6 +1057,7 @@ export class VCS {
       `,
       {
         teamId,
+        teamProjectId,
       },
       'projects',
     );
@@ -1095,6 +1117,11 @@ export class VCS {
       publicKey: string;
     }[];
   }> {
+    console.log('[sync] Fetching team member keys', {
+      teamId,
+      sessionId: session.getCurrentSessionId(),
+    });
+
     const { teamMemberKeys } = await this._runGraphQL(
       `
         query ($teamId: ID!) {
@@ -1118,6 +1145,7 @@ export class VCS {
     workspaceId: string,
     workspaceName: string,
     teamId: string,
+    teamProjectId: string,
     teamPublicKeys?: {
       accountId: string;
       publicKey: string;
@@ -1141,6 +1169,8 @@ export class VCS {
       });
     }
 
+    console.log(teamKeys);
+
     const { projectCreate } = await this._runGraphQL(
       `
         mutation (
@@ -1148,6 +1178,7 @@ export class VCS {
           $id: ID!,
           $rootDocumentId: ID!,
           $teamId: ID,
+          $teamProjectId: ID,
           $teamKeys: [ProjectCreateKeyInput!],
         ) {
           projectCreate(
@@ -1156,6 +1187,7 @@ export class VCS {
             rootDocumentId: $rootDocumentId,
             teamId: $teamId,
             teamKeys: $teamKeys,
+            teamProjectId: $teamProjectId
           ) {
             id
             name
@@ -1169,6 +1201,7 @@ export class VCS {
         rootDocumentId: workspaceId,
         teamId: teamId,
         teamKeys: teamKeys,
+        teamProjectId,
       },
       'createProject',
     );

--- a/packages/insomnia/src/ui/components/codemirror/extensions/clickable.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/clickable.ts
@@ -1,7 +1,7 @@
 import 'codemirror/addon/mode/overlay';
 
 import CodeMirror, { CodeMirrorLinkClickCallback } from 'codemirror';
-import { decode } from 'html-entities';
+import { Html5Entities } from 'html-entities';
 
 import { FLEXIBLE_URL_REGEX } from '../../../../common/constants';
 
@@ -32,16 +32,17 @@ CodeMirror.defineExtension('makeLinksClickable', function(this: CodeMirror.Edito
     movedDuringClick = false;
   });
   el.addEventListener('mouseup', event => {
-    if (movedDuringClick) {
+    if (movedDuringClick || !event.target) {
       return;
     }
 
-    // @ts-expect-error -- type unsoundness
-    const cls = event.target.className;
+    if (event.target instanceof HTMLElement) {
+      const cls = event.target.className;
 
-    if (cls.indexOf('cm-clickable') >= 0) {
-      // @ts-expect-error -- mapping unsoundness
-      handleClick(decode(event.target.innerHTML));
+      if (cls.indexOf('cm-clickable') >= 0) {
+        handleClick(Html5Entities.decode(event.target.innerHTML));
+      }
     }
+
   });
 });

--- a/packages/insomnia/src/ui/components/codemirror/extensions/clickable.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/clickable.ts
@@ -1,7 +1,7 @@
 import 'codemirror/addon/mode/overlay';
 
 import CodeMirror, { CodeMirrorLinkClickCallback } from 'codemirror';
-import { Html5Entities } from 'html-entities';
+import { decode } from 'html-entities';
 
 import { FLEXIBLE_URL_REGEX } from '../../../../common/constants';
 
@@ -40,7 +40,7 @@ CodeMirror.defineExtension('makeLinksClickable', function(this: CodeMirror.Edito
       const cls = event.target.className;
 
       if (cls.indexOf('cm-clickable') >= 0) {
-        handleClick(Html5Entities.decode(event.target.innerHTML));
+        handleClick(decode(event.target.innerHTML));
       }
     }
 

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -27,29 +27,33 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId }) => {
             <i className="fa fa-ellipsis space-left" />
           </DropdownButton>
         }
+        items={[{
+          label: `${strings.project.singular} Settings`,
+          onClick: () => setIsSettingsModalOpen(true),
+          icon: 'gear',
+          iconStyle: { width: 'unset', fill: 'var(--hl)' },
+          style: { gap: 'var(--padding-sm)' },
+        }, ...!project._id.startsWith('proj_team') ? [{
+          label: 'Delete',
+          onClick: () =>
+            deleteProjectFetcher.submit(
+              {},
+              { method: 'post', action: `/organization/${organizationId}/project/${project._id}/delete` }
+            ),
+          icon: 'trash-o',
+          withPrompt: true,
+        }] : [],
+        ]}
       >
-        <DropdownItem aria-label={`${strings.project.singular} Settings`}>
-          <ItemContent
-            icon="gear"
-            style={{ gap: 'var(--padding-sm)' }}
-            iconStyle={{ width: 'unset', fill: 'var(--hl)' }}
-            label={`${strings.project.singular} Settings`}
-            onClick={() => setIsSettingsModalOpen(true)}
-          />
-        </DropdownItem>
-        {!project._id.startsWith('proj_team') && <DropdownItem aria-label='Delete'>
-          <ItemContent
-            icon="trash-o"
-            label="Delete"
-            withPrompt
-            onClick={() =>
-              deleteProjectFetcher.submit(
-                {},
-                { method: 'post', action: `/organization/${organizationId}/project/${project._id}/delete` }
-              )
-            }
-          />
-        </DropdownItem>}
+        {item => (
+
+          <DropdownItem aria-label={`${strings.project.singular} Settings`}>
+            <ItemContent
+              key={item.label}
+              {...item}
+            />
+          </DropdownItem>
+        )}
       </Dropdown>
       {isSettingsModalOpen && (
         <ProjectSettingsModal

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -37,7 +37,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId }) => {
             onClick={() => setIsSettingsModalOpen(true)}
           />
         </DropdownItem>
-        <DropdownItem aria-label='Delete'>
+        {!project._id.startsWith('proj_team') && <DropdownItem aria-label='Delete'>
           <ItemContent
             icon="trash-o"
             label="Delete"
@@ -49,7 +49,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId }) => {
               )
             }
           />
-        </DropdownItem>
+        </DropdownItem>}
       </Dropdown>
       {isSettingsModalOpen && (
         <ProjectSettingsModal

--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -164,7 +164,7 @@ export const SyncDropdown: FC<Props> = ({ vcs, workspace, project }) => {
       ...state,
       loadingProjectPull: true,
     }));
-    const pulledIntoProject = await pullBackendProject({ vcs, backendProject, remoteProjects });
+    const pulledIntoProject = await pullBackendProject({ vcs, backendProject, remoteProjects, teamProjectId: project._id });
     if (pulledIntoProject.project._id !== project._id) {
       // If pulled into a different project, reactivate the workspace
       dispatch(activateWorkspace({ workspaceId: workspace._id }));
@@ -185,7 +185,7 @@ export const SyncDropdown: FC<Props> = ({ vcs, workspace, project }) => {
     try {
       const branch = await vcs.getBranch();
       await interceptAccessError({
-        callback: () => vcs.push(project.remoteId),
+        callback: () => vcs.push(project.parentId, project._id),
         action: 'push',
         resourceName: branch,
         resourceType: 'branch',
@@ -214,7 +214,7 @@ export const SyncDropdown: FC<Props> = ({ vcs, workspace, project }) => {
     try {
       const branch = await vcs.getBranch();
       const delta = await interceptAccessError({
-        callback: () => vcs.pull(syncItems, project.remoteId),
+        callback: () => vcs.pull(syncItems, project.parentId, project._id),
         action: 'pull',
         resourceName: branch,
         resourceType: 'branch',

--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -185,7 +185,7 @@ export const SyncDropdown: FC<Props> = ({ vcs, workspace, project }) => {
     try {
       const branch = await vcs.getBranch();
       await interceptAccessError({
-        callback: () => vcs.push(project.parentId, project._id),
+        callback: () => vcs.push({ teamId: project.parentId, teamProjectId: project._id }),
         action: 'push',
         resourceName: branch,
         resourceType: 'branch',
@@ -214,7 +214,7 @@ export const SyncDropdown: FC<Props> = ({ vcs, workspace, project }) => {
     try {
       const branch = await vcs.getBranch();
       const delta = await interceptAccessError({
-        callback: () => vcs.pull(syncItems, project.parentId, project._id),
+        callback: () => vcs.pull({ candidates: syncItems, teamId: project.parentId, teamProjectId: project._id }),
         action: 'pull',
         resourceName: branch,
         resourceType: 'branch',

--- a/packages/insomnia/src/ui/components/modals/project-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/project-settings-modal.tsx
@@ -1,14 +1,13 @@
-import React, { FC, useEffect, useRef } from 'react';
+import React, { FC, Fragment, useEffect, useRef } from 'react';
 import { OverlayContainer } from 'react-aria';
 import { useFetcher, useParams } from 'react-router-dom';
 
 import { strings } from '../../../common/strings';
-import { isRemoteProject, Project } from '../../../models/project';
+import { Project } from '../../../models/project';
 import { Modal, type ModalHandle, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { PromptButton } from '../base/prompt-button';
-import { HelpTooltip } from '../help-tooltip';
 
 export interface ProjectSettingsModalProps extends ModalProps {
   project: Project;
@@ -17,13 +16,11 @@ export interface ProjectSettingsModalProps extends ModalProps {
 export const ProjectSettingsModal: FC<ProjectSettingsModalProps> = ({ project, onHide }) => {
   const modalRef = useRef<ModalHandle>(null);
   const { organizationId } = useParams<{organizationId: string}>();
-  const { submit } = useFetcher();
+  const { submit, Form } = useFetcher();
 
   useEffect(() => {
     modalRef.current?.show();
   });
-
-  const isRemote = isRemoteProject(project);
 
   return (
     <OverlayContainer>
@@ -33,55 +30,41 @@ export const ProjectSettingsModal: FC<ProjectSettingsModalProps> = ({ project, o
           <div className="txt-sm selectable faint monospace">{project._id}</div>
         </ModalHeader>
         <ModalBody key={`body::${project._id}`} className="pad">
-          <div className="form-control form-control--outlined">
+          <Form
+            method="post"
+            action={`/organization/${organizationId}/project/${project._id}/rename`}
+            className="form-control form-control--outlined"
+          >
             <label>
               Name
-              {isRemote && (
-                <>
-                  <HelpTooltip className="space-left">
-                    To rename a {strings.remoteProject.singular.toLowerCase()}{' '}
-                    {strings.project.singular.toLowerCase()} please visit{' '}
-                    <a href="https://app.insomnia.rest/app/teams">
-                      the insomnia website.
-                    </a>
-                  </HelpTooltip>
-                  <input disabled readOnly defaultValue={project.name} />
-                </>
-              )}
-              {!isRemote && (
-                <input
-                  type="text"
-                  placeholder={`My ${strings.project.singular}`}
-                  defaultValue={project.name}
-                  onChange={e => {
-                    submit(
-                      {
-                        name: e.currentTarget.value,
-                      },
-                      {
-                        action: `/organization/${organizationId}/project/${project._id}/rename`,
-                        method: 'post',
-                      }
-                    );
-                  }}
-                />
-              )}
+              <input
+                type="text"
+                name="name"
+                placeholder={`My ${strings.project.singular}`}
+                defaultValue={project.name}
+              />
             </label>
-          </div>
-          <h2>Actions</h2>
-          <div className="form-control form-control--padded">
-            <PromptButton
-              onClick={() =>
-                submit(
-                  {},
-                  { method: 'post', action: `/organization/${organizationId}/project/${project._id}/delete` }
-                )
-              }
-              className="width-auto btn btn--clicky inline-block"
-            >
-              <i className="fa fa-trash-o" /> Delete
-            </PromptButton>
-          </div>
+            <button type="submit" className="btn btn--clicky">
+              Update
+            </button>
+          </Form>
+          {!project._id.startsWith('proj_team') && <Fragment>
+            <h2>Actions</h2>
+            <div className="form-control form-control--padded">
+              <PromptButton
+                onClick={() =>
+                  submit(
+                    {},
+                    { method: 'post', action: `/organization/${organizationId}/project/${project._id}/delete` }
+                  )
+                }
+                className="width-auto btn btn--clicky inline-block"
+              >
+                <i className="fa fa-trash-o" /> Delete
+              </PromptButton>
+            </div>
+          </Fragment>}
+
         </ModalBody>
       </Modal>
     </OverlayContainer>

--- a/packages/insomnia/src/ui/components/modals/workspace-duplicate-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-duplicate-modal.tsx
@@ -4,7 +4,7 @@ import { useFetcher, useParams } from 'react-router-dom';
 
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
 import { strings } from '../../../common/strings';
-import { isDefaultProject, isLocalProject, Project } from '../../../models/project';
+import { Project } from '../../../models/project';
 import { Workspace } from '../../../models/workspace';
 import { Modal, type ModalHandle, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
@@ -49,7 +49,7 @@ export const WorkspaceDuplicateModal: FC<WorkspaceDuplicateModalProps> = ({ work
                 <select defaultValue={workspace.parentId} name="projectId">
                   {projects.map(project => (
                     <option key={project._id} value={project._id}>
-                      {project.name} ({isDefaultProject(project) ? strings.defaultProject.singular : isLocalProject(project) ? strings.localProject.singular : strings.remoteProject.singular})
+                      {project.name}
                     </option>
                   ))}
                 </select>

--- a/packages/insomnia/src/ui/components/settings/account.tsx
+++ b/packages/insomnia/src/ui/components/settings/account.tsx
@@ -38,6 +38,7 @@ export const Account: FC = () => {
       setError('Code was not provided');
       return;
     }
+
     try {
       await session.changePasswordWithToken(password, code);
     } catch (err) {

--- a/packages/insomnia/src/ui/components/statusbar.tsx
+++ b/packages/insomnia/src/ui/components/statusbar.tsx
@@ -1,8 +1,9 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { SettingsButton } from './buttons/settings-button';
 import { SvgIcon } from './svg-icon';
+import { Tooltip } from './tooltip';
 
 const Bar = styled.div({
   position: 'relative',
@@ -26,10 +27,74 @@ const KongLink = styled.a({
   },
 });
 
+export const NetworkStatus = () => {
+  const [status, setStatus] = useState<'online' | 'offline'>('online');
+
+  useEffect(() => {
+    const handleOnline = () => setStatus('online');
+    const handleOffline = () => setStatus('offline');
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return (
+    <Tooltip
+      delay={1000}
+      position="bottom"
+      message={
+        <>
+          You are {status === 'online' ? 'securely connected to Insomnia Cloud' : 'offline. Connect to sync your data.'}
+        </>
+      }
+    >
+      {
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--padding-xs)',
+          }}
+        >
+          <span
+            style={{
+              backgroundColor: status === 'online' ? 'var(--color-success)' : 'var(--color-danger)',
+              width: '8px',
+              height: '8px',
+              borderRadius: '100%',
+              display: 'inline-block',
+            }}
+          />
+          <span
+            style={{
+              color: 'var(--color-font)',
+              fontSize: 'var(--font-size-xs)',
+            }}
+          >
+            {status.charAt(0).toUpperCase() + status.slice(1)}
+          </span>
+        </div>
+      }
+    </Tooltip>
+  );
+};
+
 export const StatusBar: FC = () => {
   return (
     <Bar>
-      <SettingsButton />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--padding-md)',
+        }}
+      >
+        <SettingsButton />
+        <NetworkStatus />
+      </div>
       <KongLink className="made-with-love" href="https://konghq.com/">
         Made with&nbsp; <SvgIcon icon="heart" /> &nbsp;by Kong
       </KongLink>

--- a/packages/insomnia/src/ui/components/statusbar.tsx
+++ b/packages/insomnia/src/ui/components/statusbar.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
+import { isLoggedIn, onLoginLogout } from '../../account/session';
 import { SettingsButton } from './buttons/settings-button';
 import { SvgIcon } from './svg-icon';
 import { Tooltip } from './tooltip';
@@ -28,13 +29,18 @@ const KongLink = styled.a({
 });
 
 export const NetworkStatus = () => {
-  const [status, setStatus] = useState<'online' | 'offline'>('online');
+  const [status, setStatus] = useState<'online' | 'offline' | 'unauthorized'>(isLoggedIn() ? 'online' : 'unauthorized');
 
   useEffect(() => {
     const handleOnline = () => setStatus('online');
     const handleOffline = () => setStatus('offline');
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
+
+    onLoginLogout(isLoggedIn => {
+      setStatus(isLoggedIn ? status : 'unauthorized');
+    });
+
     return () => {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
@@ -74,7 +80,8 @@ export const NetworkStatus = () => {
               fontSize: 'var(--font-size-xs)',
             }}
           >
-            {status.charAt(0).toUpperCase() + status.slice(1)}
+            {status === 'unauthorized' && 'Log in to Insomnia Cloud to sync your data'}
+            {status !== 'unauthorized' && status.charAt(0).toUpperCase() + status.slice(1)}
           </span>
         </div>
       }

--- a/packages/insomnia/src/ui/components/statusbar.tsx
+++ b/packages/insomnia/src/ui/components/statusbar.tsx
@@ -38,7 +38,7 @@ export const NetworkStatus = () => {
     window.addEventListener('offline', handleOffline);
 
     onLoginLogout(isLoggedIn => {
-      setStatus(isLoggedIn ? status : 'unauthorized');
+      setStatus(status => isLoggedIn ? status : 'unauthorized');
     });
 
     return () => {
@@ -57,34 +57,36 @@ export const NetworkStatus = () => {
         </>
       }
     >
-      {
-        <div
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--padding-xs)',
+        }}
+      >
+        <span
           style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 'var(--padding-xs)',
+            backgroundColor: {
+              online: 'var(--color-success)',
+              offline: 'var(--color-danger)',
+              unauthorized: 'var(--color-warning)',
+            }[status],
+            width: '8px',
+            height: '8px',
+            borderRadius: '100%',
+            display: 'inline-block',
+          }}
+        />
+        <span
+          style={{
+            color: 'var(--color-font)',
+            fontSize: 'var(--font-size-xs)',
           }}
         >
-          <span
-            style={{
-              backgroundColor: status === 'online' ? 'var(--color-success)' : 'var(--color-danger)',
-              width: '8px',
-              height: '8px',
-              borderRadius: '100%',
-              display: 'inline-block',
-            }}
-          />
-          <span
-            style={{
-              color: 'var(--color-font)',
-              fontSize: 'var(--font-size-xs)',
-            }}
-          >
-            {status === 'unauthorized' && 'Log in to Insomnia Cloud to sync your data'}
-            {status !== 'unauthorized' && status.charAt(0).toUpperCase() + status.slice(1)}
-          </span>
-        </div>
-      }
+          {status === 'unauthorized' && 'Log in to sync your data'}
+          {status !== 'unauthorized' && status.charAt(0).toUpperCase() + status.slice(1)}
+        </span>
+      </div>
     </Tooltip>
   );
 };

--- a/packages/insomnia/src/ui/components/sync-pull-button.tsx
+++ b/packages/insomnia/src/ui/components/sync-pull-button.tsx
@@ -27,7 +27,7 @@ export const SyncPullButton: FC<Props> = props => {
     try {
       // Clone old VCS so we don't mess anything up while working on other projects
       await newVCS.checkout([], branch);
-      await newVCS.pull([], project.remoteId);
+      await newVCS.pull([], project.parentId, project._id);
     } catch (err) {
       showError({
         title: 'Pull Error',

--- a/packages/insomnia/src/ui/components/sync-pull-button.tsx
+++ b/packages/insomnia/src/ui/components/sync-pull-button.tsx
@@ -27,7 +27,7 @@ export const SyncPullButton: FC<Props> = props => {
     try {
       // Clone old VCS so we don't mess anything up while working on other projects
       await newVCS.checkout([], branch);
-      await newVCS.pull([], project.parentId, project._id);
+      await newVCS.pull({ candidates: [], teamId: project.parentId, teamProjectId: project._id });
     } catch (err) {
       showError({
         title: 'Pull Error',

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -566,7 +566,7 @@ async function renderApp() {
       const activity = state.global.activeActivity;
 
       const activeProject = selectActiveProject(state);
-      const organizationId = activeProject && isRemoteProject(activeProject) ? activeProject._id : DEFAULT_ORGANIZATION_ID;
+      const organizationId = activeProject && isRemoteProject(activeProject) ? activeProject.parentId : DEFAULT_ORGANIZATION_ID;
 
       if (activity !== currentActivity) {
         currentActivity = activity;

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -69,14 +69,30 @@ export const renameProjectAction: ActionFunction = async ({
 
   invariant(project, 'Project not found');
 
-  invariant(
-    !isRemoteProject(project),
-    'Cannot rename remote project',
-  );
+  if (isRemoteProject(project)) {
+    try {
+      await axiosRequest({
+        url: `${getApiBaseURL()}/v1/teams/${project.parentId}/team-projects/${projectId}`,
+        method: 'PATCH',
+        headers: {
+          'X-Session-Id': session.getCurrentSessionId() || '',
+        },
+        data: {
+          name,
+        },
+      });
+      await models.project.update(project, { name });
+      return null;
+    } catch (err) {
+      console.log(err);
+      return null;
+    }
+  } else {
 
-  await models.project.update(project, { name });
+    await models.project.update(project, { name });
 
-  return null;
+    return null;
+  }
 };
 
 export const deleteProjectAction: ActionFunction = async ({ params }) => {

--- a/packages/insomnia/src/ui/routes/error.tsx
+++ b/packages/insomnia/src/ui/routes/error.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { isDevelopment } from '../../common/constants';
 import { DEFAULT_ORGANIZATION_ID } from '../../models/organization';
 import { DEFAULT_PROJECT_ID } from '../../models/project';
 import { Button } from '../components/themed-button';
@@ -36,6 +37,14 @@ export const ErrorRoute: FC = () => {
     return err?.message || 'Unknown error';
   };
 
+  const getErrorStack = (err: any) => {
+    if (isRouteErrorResponse(err)) {
+      return err.error?.stack;
+    }
+
+    return err?.stack;
+  };
+
   const navigate = useNavigate();
   const navigation = useNavigation();
 
@@ -54,6 +63,9 @@ export const ErrorRoute: FC = () => {
         Try to reload the app{' '}
         <span>{navigation.state === 'loading' ? <Spinner /> : null}</span>
       </Button>
+      {isDevelopment() && (
+        <code className="selectable" style={{ wordBreak: 'break-word', margin: 'var(--padding-sm)' }}>{getErrorStack(error)}</code>
+      )}
     </Container>
   );
 };

--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -1,4 +1,4 @@
-import { ActionFunction, LoaderFunction, redirect } from 'react-router-dom';
+import { ActionFunction, LoaderFunction } from 'react-router-dom';
 
 import { database } from '../../common/database';
 import { isNotNullOrUndefined } from '../../common/misc';
@@ -11,6 +11,8 @@ import { invariant } from '../../utils/invariant';
 
 export const pullRemoteCollectionAction: ActionFunction = async ({ request, params }) => {
   const { organizationId, projectId } = params;
+  invariant(typeof projectId === 'string', 'Project Id is required');
+  invariant(typeof organizationId === 'string', 'Organization Id is required');
   const formData = await request.formData();
 
   const backendProjectId = formData.get('backendProjectId');
@@ -21,7 +23,8 @@ export const pullRemoteCollectionAction: ActionFunction = async ({ request, para
   const vcs = getVCS();
   invariant(vcs, 'VCS is not defined');
 
-  const remoteBackendProjects = await vcs.remoteBackendProjects(remoteId);
+  const remoteBackendProjects = await vcs.remoteBackendProjects(organizationId, projectId);
+
   const backendProject = remoteBackendProjects.find(p => p.id === backendProjectId);
 
   invariant(backendProject, 'Backend project not found');
@@ -29,6 +32,7 @@ export const pullRemoteCollectionAction: ActionFunction = async ({ request, para
   const remoteProjects = await database.find<RemoteProject>(models.project.type, {
     // @ts-expect-error -- Improve database query typing
     $not: {
+      parentId: null,
       remoteId: null,
     },
   });
@@ -38,11 +42,7 @@ export const pullRemoteCollectionAction: ActionFunction = async ({ request, para
   // Remove all backend projects for workspace first
   await newVCS.removeBackendProjectsForRoot(backendProject.rootDocumentId);
 
-  const { workspaceId } = await pullBackendProject({ vcs: newVCS, backendProject, remoteProjects });
-
-  if (workspaceId) {
-    return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug`);
-  }
+  await pullBackendProject({ vcs: newVCS, backendProject, remoteProjects, teamProjectId: projectId });
 
   return null;
 };
@@ -52,7 +52,8 @@ export interface RemoteCollectionsLoaderData {
 }
 
 export const remoteCollectionsLoader: LoaderFunction = async ({ params }): Promise<RemoteCollectionsLoaderData> => {
-  const { projectId } = params;
+  const { organizationId, projectId } = params;
+  invariant(typeof organizationId === 'string', 'Organization Id is required');
   invariant(typeof projectId === 'string', 'Project Id is required');
 
   try {
@@ -79,7 +80,7 @@ export const remoteCollectionsLoader: LoaderFunction = async ({ params }): Promi
     // Map the backend projects to ones with workspaces in parallel
     const localBackendProjects = (await Promise.all(getWorkspacesByLocalProjects)).filter(isNotNullOrUndefined);
 
-    const remoteBackendProjects = (await vcs.remoteBackendProjects(remoteId)).filter(({ id, rootDocumentId }) => {
+    const remoteBackendProjects = (await vcs.remoteBackendProjects(organizationId, project._id)).filter(({ id, rootDocumentId }) => {
       const localBackendProjectExists = localBackendProjects.find(p => p.id === id);
       const workspaceExists = Boolean(models.workspace.getById(rootDocumentId));
       // Mark as missing if:

--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -23,7 +23,7 @@ export const pullRemoteCollectionAction: ActionFunction = async ({ request, para
   const vcs = getVCS();
   invariant(vcs, 'VCS is not defined');
 
-  const remoteBackendProjects = await vcs.remoteBackendProjects(organizationId, projectId);
+  const remoteBackendProjects = await vcs.remoteBackendProjects({ teamId: organizationId, teamProjectId: projectId });
 
   const backendProject = remoteBackendProjects.find(p => p.id === backendProjectId);
 
@@ -80,7 +80,7 @@ export const remoteCollectionsLoader: LoaderFunction = async ({ params }): Promi
     // Map the backend projects to ones with workspaces in parallel
     const localBackendProjects = (await Promise.all(getWorkspacesByLocalProjects)).filter(isNotNullOrUndefined);
 
-    const remoteBackendProjects = (await vcs.remoteBackendProjects(organizationId, project._id)).filter(({ id, rootDocumentId }) => {
+    const remoteBackendProjects = (await vcs.remoteBackendProjects({ teamId: organizationId, teamProjectId: project._id })).filter(({ id, rootDocumentId }) => {
       const localBackendProjectExists = localBackendProjects.find(p => p.id === id);
       const workspaceExists = Boolean(models.workspace.getById(rootDocumentId));
       // Mark as missing if:

--- a/packages/insomnia/src/ui/routes/root.tsx
+++ b/packages/insomnia/src/ui/routes/root.tsx
@@ -9,19 +9,18 @@ import {
 } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { isLoggedIn, onLoginLogout } from '../../account/session';
+import { getCurrentSessionId, isLoggedIn, onLoginLogout } from '../../account/session';
 import { isDevelopment } from '../../common/constants';
-import { database } from '../../common/database';
 import * as models from '../../models';
 import { defaultOrganization, Organization } from '../../models/organization';
-import { isRemoteProject } from '../../models/project';
 import { reloadPlugins } from '../../plugins';
 import { createPlugin } from '../../plugins/create';
 import { setTheme } from '../../plugins/misc';
 import { exchangeCodeForToken } from '../../sync/git/github-oauth-provider';
 import { exchangeCodeForGitLabToken } from '../../sync/git/gitlab-oauth-provider';
-import { initializeProjectFromTeam } from '../../sync/vcs/initialize-model-from';
-import { getVCS } from '../../sync/vcs/vcs';
+import FileSystemDriver from '../../sync/store/drivers/file-system-driver';
+import { MergeConflict, Team } from '../../sync/types';
+import { getVCS, initVCS } from '../../sync/vcs/vcs';
 import { submitAuthCode } from '../auth-session-provider';
 import { AccountToolbar } from '../components/account-toolbar';
 import { AppHeader } from '../components/app-header';
@@ -36,6 +35,7 @@ import {
   TAB_INDEX_PLUGINS,
   TAB_INDEX_THEMES,
 } from '../components/modals/settings-modal';
+import { SyncMergeModal } from '../components/modals/sync-merge-modal';
 import { OrganizationsNav } from '../components/organizations-navbar';
 import { StatusBar } from '../components/statusbar';
 import { Toast } from '../components/toast';
@@ -52,29 +52,69 @@ export interface RootLoaderData {
 }
 
 export const loader: LoaderFunction = async (): Promise<RootLoaderData> => {
-  // Load all projects
-  try {
-    const vcs = getVCS();
-    if (vcs && isLoggedIn()) {
-      const teams = await vcs.teams();
-      const projects = await Promise.all(teams.map(initializeProjectFromTeam));
-      await database.batchModifyDocs({ upsert: projects });
-    }
-  } catch {
-    console.log('Failed to load projects');
-  }
-  const allProjects = await models.project.all();
+  // Load all projects if the user is logged in
+  if (isLoggedIn()) {
+    try {
+      let vcs = getVCS();
+      if (!vcs) {
+        const driver = FileSystemDriver.create(process.env['INSOMNIA_DATA_PATH'] || window.app.getPath('userData'));
 
-  const remoteOrgs = allProjects
-    .filter(isRemoteProject)
-    .map(({ _id, name }) => ({
-      _id,
-      name,
-    }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+        console.log('Initializing VCS');
+        vcs = await initVCS(driver, async conflicts => {
+          return new Promise(resolve => {
+            showModal(SyncMergeModal, {
+              conflicts,
+              handleDone: (conflicts?: MergeConflict[]) => resolve(conflicts || []),
+            });
+          });
+        });
+      }
+
+      const sessionId = getCurrentSessionId();
+
+      // Teams are now organizations
+      const response = await window.main.insomniaFetch<{
+        data: {
+          teams: Team[];
+        };
+        errors?: {
+          message: string;
+        }[];
+      }>({
+        method: 'POST',
+        path: '/graphql',
+        sessionId,
+        data: {
+          query: `
+          query {
+            teams {
+              id
+              name
+            }
+          }
+        `,
+          variables: {},
+        },
+      });
+
+      const teams = response.data.teams as Team[];
+
+      return {
+        organizations: [defaultOrganization, ...teams.map(team => ({
+          _id: team.id,
+          name: team.name,
+        })).sort((a, b) => a.name.localeCompare(b.name))],
+      };
+    } catch (err) {
+      console.log('Failed to load Teams', err);
+      return {
+        organizations: [defaultOrganization],
+      };
+    }
+  }
 
   return {
-    organizations: [defaultOrganization, ...remoteOrgs],
+    organizations: [defaultOrganization],
   };
 };
 


### PR DESCRIPTION
Removes the limitation of 1 remote project per Team and allows users to create multiple remote projects.

Highlights:
- [x] Updates the team/project/workspace APIs to fetch data based on the current project include the teamProjectId.
- [x] Update the UI to allow CRUD for remote Projects inside an Organization.
- [x] Disable deleting the default remote project for backwards compatibility with previous versions.
- [x] Error handling and offline UX

Future work:
- [x] Replace account/fetch.ts with fetch API.
- [ ] Move organization/project/workspace fetching logic outside of vcs.
- [x] Cleanup naming conventions in the app once we have Organizations in the API.
Currently there is mismatch between the app and the API terminology:

| App           | API               |
|---------------|-------------------|
| Organization  | Team              |
| Project (also RemoteProject)   | TeamProject |
| Workspace (also BackendProject)       | Project |


Closes INS-2661