### PR TITLE
Adding support for multiple windows

### DIFF
--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -149,6 +149,7 @@ const _launchApp = async () => {
     console.log('[main] Window ready, handling command line arguments', process.argv);
     const args = process.argv.slice(1).filter(a => a !== '.');
     if (args.length) {
+      window = windowUtils.getWindow();
       window.webContents.send('shell:open', args.join());
     }
   });
@@ -163,6 +164,7 @@ const _launchApp = async () => {
       // Called when second instance launched with args (Windows/Linux)
       app.on('second-instance', (_1, args) => {
         console.log('Second instance listener received:', args.join('||'));
+        window = windowUtils.getWindow();
         if (window) {
           if (window.isMinimized()) {
             window.restore();
@@ -173,15 +175,24 @@ const _launchApp = async () => {
         console.log('[main] Open Deep Link URL sent from second instance', lastArg);
         window.webContents.send('shell:open', lastArg);
       });
-      window = windowUtils.createWindow();
+      window = windowUtils.getWindow();
 
       app.on('open-url', (_event, url) => {
         console.log('[main] Open Deep Link URL', url);
+        window = windowUtils.getWindow();
+        if (window) {
+          if (window.isMinimized()) {
+            window.restore();
+          }
+          window.focus();
+        } else {
+          window = windowUtils.getWindow();
+        }
         window.webContents.send('shell:open', url);
       });
     }
   } else {
-    window = windowUtils.createWindow();
+    window = windowUtils.getWindow();
   }
 
   // Don't send origin header from Insomnia because we're not technically using CORS

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -290,8 +290,13 @@ export function createWindow() {
       {
         label: `Toggle ${MNEMONIC_SYM}DevTools`,
         accelerator: 'Alt+CmdOrCtrl+I',
-        // @ts-expect-error -- TSCONVERSION needs global module augmentation
-        click: () => mainWindow?.toggleDevTools(),
+        click: () => {
+          const window = BrowserWindow.getFocusedWindow();
+          if (window) {
+            // @ts-expect-error -- TSCONVERSION needs global module augmentation
+            window.toggleDevTools();
+          }
+        },
       },
     ],
   };
@@ -440,7 +445,12 @@ export function createWindow() {
       {
         label: `${MNEMONIC_SYM}Reload`,
         accelerator: 'Shift+F5',
-        click: () => newWindow?.reload(),
+        click: () => {
+          const window = BrowserWindow.getFocusedWindow();
+          if (window) {
+            window.reload();
+          }
+        },
       },
       {
         label: `Take ${MNEMONIC_SYM}Screenshot`,

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -302,7 +302,6 @@ export function createWindow() {
     submenu: [
       {
         label: `${MNEMONIC_SYM}New`,
-        accelerator: 'Alt+CmdOrCtrl+N',
         click: () => {
           createWindow();
         },

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -26,7 +26,8 @@ const DEFAULT_HEIGHT = 720;
 const MINIMUM_WIDTH = 500;
 const MINIMUM_HEIGHT = 400;
 
-let mainWindow: ElectronBrowserWindow | null = null;
+let newWindow: ElectronBrowserWindow | null = null;
+const windows = new Set<ElectronBrowserWindow>();
 let localStorage: LocalStorage | null = null;
 
 interface Bounds {
@@ -63,7 +64,7 @@ export function createWindow() {
     }
   }
 
-  mainWindow = new BrowserWindow({
+  newWindow = new BrowserWindow({
     // Make sure we don't initialize the window outside the bounds
     x: isVisibleOnAnyDisplay ? x : undefined,
     y: isVisibleOnAnyDisplay ? y : undefined,
@@ -91,19 +92,19 @@ export function createWindow() {
 
   // BrowserWindow doesn't have an option for this, so we have to do it manually :(
   if (maximize) {
-    mainWindow?.maximize();
+    newWindow?.maximize();
   }
 
-  mainWindow?.on('resize', () => saveBounds());
-  mainWindow?.on('maximize', () => saveBounds());
-  mainWindow?.on('unmaximize', () => saveBounds());
-  mainWindow?.on('move', () => saveBounds());
-  mainWindow?.on('unresponsive', () => {
+  newWindow?.on('resize', () => saveBounds());
+  newWindow?.on('maximize', () => saveBounds());
+  newWindow?.on('unmaximize', () => saveBounds());
+  newWindow?.on('move', () => saveBounds());
+  newWindow?.on('unresponsive', () => {
     showUnresponsiveModal();
   });
 
   // Open generic links (<a .../>) in default browser
-  mainWindow?.webContents.on('will-navigate', (event, url) => {
+  newWindow?.webContents.on('will-navigate', (event, url) => {
     // Prevents local dev full-reload events from opening browser window, see https://github.com/Kong/insomnia/pull/4925
     if (url.startsWith(appUrl)) {
       return;
@@ -114,7 +115,7 @@ export function createWindow() {
     clickLink(url);
   });
 
-  mainWindow?.webContents.setWindowOpenHandler(() => {
+  newWindow?.webContents.setWindowOpenHandler(() => {
     return { action: 'deny' };
   });
 
@@ -123,13 +124,13 @@ export function createWindow() {
   const appUrl = process.env.APP_RENDER_URL || pathToFileURL(appPath).href;
 
   console.log(`[main] Loading ${appUrl}`);
-  mainWindow?.loadURL(appUrl);
+  newWindow?.loadURL(appUrl);
   // Emitted when the window is closed.
-  mainWindow?.on('closed', () => {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
-    mainWindow = null;
+  newWindow?.on('closed', () => {
+    if (newWindow) {
+      windows.delete(newWindow);
+      newWindow = windows.values().next().value || null;
+    }
   });
 
   const applicationMenu: MenuItemConstructorOptions = {
@@ -250,7 +251,7 @@ export function createWindow() {
       {
         label: `Resize to ${MNEMONIC_SYM}Small (qHD 540)`,
         click: () =>
-          mainWindow?.setBounds({
+          newWindow?.setBounds({
             width: 960,
             height: 540,
           }),
@@ -258,7 +259,7 @@ export function createWindow() {
       {
         label: `Resize to Defaul${MNEMONIC_SYM}t (HD 720)`,
         click: () =>
-          mainWindow?.setBounds({
+          newWindow?.setBounds({
             width: DEFAULT_WIDTH,
             height: DEFAULT_HEIGHT,
           }),
@@ -266,7 +267,7 @@ export function createWindow() {
       {
         label: `Resize to ${MNEMONIC_SYM}Large (FHD 1080)`,
         click: () =>
-          mainWindow?.setBounds({
+          newWindow?.setBounds({
             width: 1920,
             height: 1080,
           }),
@@ -299,6 +300,13 @@ export function createWindow() {
     label: `${MNEMONIC_SYM}Window`,
     role: 'window',
     submenu: [
+      {
+        label: `${MNEMONIC_SYM}New`,
+        accelerator: 'Alt+CmdOrCtrl+N',
+        click: () => {
+          createWindow();
+        },
+      },
       {
         label: `${MNEMONIC_SYM}Minimize`,
         role: 'minimize',
@@ -433,13 +441,13 @@ export function createWindow() {
       {
         label: `${MNEMONIC_SYM}Reload`,
         accelerator: 'Shift+F5',
-        click: () => mainWindow?.reload(),
+        click: () => newWindow?.reload(),
       },
       {
         label: `Take ${MNEMONIC_SYM}Screenshot`,
         click: function() {
           // @ts-expect-error -- TSCONVERSION not accounted for in the electron types to provide a function
-          mainWindow?.capturePage(image => {
+          newWindow?.capturePage(image => {
             const buffer = image.toPNG();
             const dir = app.getPath('desktop');
             fs.writeFileSync(path.join(dir, `Screenshot-${new Date()}.png`), buffer);
@@ -465,7 +473,7 @@ export function createWindow() {
       {
         label: `Set window for ${MNEMONIC_SYM}FHD Screenshot`,
         click: () => {
-          mainWindow?.setBounds({
+          newWindow?.setBounds({
             width: 1920,
             height: 1080,
           });
@@ -504,7 +512,8 @@ export function createWindow() {
   }
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
-  return mainWindow;
+  windows.add(newWindow);
+  return newWindow;
 }
 
 async function showUnresponsiveModal() {
@@ -519,22 +528,32 @@ async function showUnresponsiveModal() {
 
   // @ts-expect-error -- TSCONVERSION appears to be a genuine error
   if (id === 1) {
-    mainWindow?.destroy();
+    const browserWindow = BrowserWindow.getFocusedWindow();
+
+    if (!browserWindow || !browserWindow.webContents) {
+      return;
+    }
+    browserWindow?.destroy();
     createWindow();
   }
 }
 
 function saveBounds() {
-  if (!mainWindow) {
+  const browserWindow = BrowserWindow.getFocusedWindow();
+
+  if (!browserWindow || !browserWindow.webContents) {
+    return;
+  }
+  if (!browserWindow) {
     return;
   }
 
-  const fullscreen = mainWindow?.isFullScreen();
+  const fullscreen = browserWindow?.isFullScreen();
 
   // Only save the size if we're not in fullscreen
   if (!fullscreen) {
-    localStorage?.setItem('bounds', mainWindow?.getBounds());
-    localStorage?.setItem('maximize', mainWindow?.isMaximized());
+    localStorage?.setItem('bounds', browserWindow?.getBounds());
+    localStorage?.setItem('maximize', browserWindow?.isMaximized());
     localStorage?.setItem('fullscreen', false);
   } else {
     localStorage?.setItem('fullscreen', true);
@@ -595,4 +614,8 @@ export const setZoom = (transformer: (current: number) => number) => () => {
 function initLocalStorage() {
   const localStoragePath = path.join(getDataDirectory(), 'localStorage');
   localStorage = new LocalStorage(localStoragePath);
+}
+
+export function getWindow() {
+  return newWindow ?? createWindow();
 }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

This PR relates to #5601 and fixes a regression (reported in #5761 ) caused by #5377 
Work is being tracked internally by [INS-2235](https://linear.app/insomnia/issue/INS-2235) as well.

I've tested deep links on mac and they still work fine.  I'm unable to test CLI arguments on Mac, as it always attempts to open a second instance, instead of hitting the `second-instance` event of Electron.  Another thing I wasn't able to test is changing titles of different windows.

There may be more esoteric features of Insomnia I didn't test, but the basic collection creation and request functionality seems to work.  Editing two things at the same time isn't supported, but also doesn't cause any errors.  For example, editing an environment will save the environment that is closed/edited last.

Unfortunately in my second commit I had to remove the accelerator for a new window, since it would also send Cmd+N (creating a new request) at the same time it created a new window.  I suspect this is a current issue in the release branch, though, if you change hotkeys to match accelerators.