### PR TITLE
Fix issue where editing a Nunjucks variable/tag didn't update environment variables

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -449,12 +449,15 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
           console.log('Failed to set CodeMirror option', err.message);
         }
         onChange(doc.getValue() || '');
+        if (onBlur && !codeMirror.current?.hasFocus()) {
+          onBlur();
+        }
         setOriginalCode(doc.getValue() || '');
       }
     }, DEBOUNCE_MILLIS);
     codeMirror.current?.on('changes', fn);
     return () => codeMirror.current?.off('changes', fn);
-  }, [lintOptions, noLint, onChange]);
+  }, [lintOptions, noLint, onChange, onBlur]);
 
   useEffect(() => {
     const handleOnBlur = () => onBlur?.();

--- a/packages/insomnia/src/ui/components/editors/environment-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/environment-editor.tsx
@@ -116,9 +116,6 @@ export const EnvironmentEditor = forwardRef<EnvironmentEditorHandle, Props>(({
                 setError(err);
               }
             }
-            if (!error) {
-              onBlur?.();
-            }
           } catch (err) {
             setError(err.message);
           }

--- a/packages/insomnia/src/ui/components/editors/environment-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/environment-editor.tsx
@@ -116,6 +116,9 @@ export const EnvironmentEditor = forwardRef<EnvironmentEditorHandle, Props>(({
                 setError(err);
               }
             }
+            if (!error) {
+              onBlur?.();
+            }
           } catch (err) {
             setError(err.message);
           }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

This is a small PR that fixes behavior when setting environment variables via the tag/variable modal.
Reproduction steps:

1. Create a new environment
2. Add a property whose value is a variable (e.g. I used a timestamp)
3. Create a request using the new property, observe the request is using your property correctly
4. Edit the environment again, and click the value to open the tag modal
5. Change the value to something different/invalid, close the modal by clicking Done
6. Close the environment modal by clicking Done
7. Observe the property in your request did not change

This is somewhat of a naive solution, so I'm open to suggestions to fix this better.  Notably, why is this component not simply saving `onChange` if there are no errors instead of `onBlur` if there are no errors?
