### PR TITLE
O2K add deprecation warnings

### DIFF
--- a/packages/insomnia-inso/src/commands/generate-config.ts
+++ b/packages/insomnia-inso/src/commands/generate-config.ts
@@ -61,6 +61,7 @@ export const generateConfig = async (
   identifier?: string | null,
   options: Partial<GenerateConfigOptions> = {},
 ) => {
+  logger.warn('Kong config generation has been moved to decK CLI, https://github.com/Kong/deck');
   if (!validateOptions(options)) {
     return false;
   }

--- a/packages/insomnia/src/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/generate-config-modal.tsx
@@ -94,6 +94,11 @@ export const GenerateConfigModal = forwardRef<GenerateConfigModalHandle, ModalPr
     <Modal ref={modalRef} tall>
       <ModalHeader>Generate Config</ModalHeader>
       <ModalBody className="wide">
+        <div className="notice warning">
+          <p>
+            Kong config generation has been moved to decK CLI, <Link href={'https://github.com/Kong/deck'}>https://github.com/Kong/deck</Link>.
+          </p>
+        </div>
         <Tabs
           aria-label="General configuration tabs"
           defaultSelectedKey={activeTab}


### PR DESCRIPTION
In order to improve quality for our users we have decided to move this functionality into [decK](https://github.com/Kong/deck).

This includes 
- inso config generate
- app config generation
<img width="284" alt="image" src="https://github.com/Kong/insomnia/assets/3679927/e8eac488-b473-4279-862f-221d1de9e3bc">

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
