### PR TITLE
chore: try macos xl runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest-xl, macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest-xl, windows-latest, ubuntu-latest]
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest-xl, macos-latest, windows-latest, ubuntu-latest]
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3


### PR DESCRIPTION
trying github macos xl runners (see the [post](https://github.blog/2023-03-01-github-actions-introducing-faster-github-hosted-x64-macos-runners/))