### PR TITLE
[KAG-1582] fix(ci): standardize release-script usage

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -172,8 +172,14 @@ jobs:
           PULP_PASSWORD: ${{ secrets.PULP_PASSWORD }}
           PULP_HOST: ${{ secrets.PULP_HOST }}
         with:
-          entrypoint: python3
-          args: '/usr/src/code/main.py release --file artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.deb --dist-name ubuntu --dist-version focal --package-type insomnia --publish'
+          entrypoint: /usr/src/code/entrypoint.sh
+          args: >
+            release
+            --file artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.deb
+            --dist-name ubuntu
+            --dist-version focal
+            --package-type insomnia
+            --publish
 
       - name: Push Inso CLI docker image tags to Docker Hub
         run: |


### PR DESCRIPTION
This repo was previously using a non-standard way invoking the `kong/release-script` container.
Updating this to use `entrypoint.sh` in this fashion will allow Insomnia more readily to benefit from internal changes to `kong/release-scripts`.

This changes to the github action(s) will need to be replicated across any release branch(es) that might run them.