### PR TITLE
import project from file

### DIFF
--- a/packages/insomnia/src/common/export.tsx
+++ b/packages/insomnia/src/common/export.tsx
@@ -392,7 +392,7 @@ export const exportAllToFile = (activeProjectName: string, workspacesForActivePr
       }
 
       const fileName = await showSaveExportedFileDialog({
-        exportedFileNamePrefix: 'Insomnia-All',
+        exportedFileNamePrefix: activeProjectName,
         selectedFormat,
       });
 

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -146,10 +146,8 @@ export async function scanResources({
 export async function importResources({
   workspaceId,
   projectId,
-  workspaceName,
 }: {
-  workspaceId?: string;
-  workspaceName?: string;
+    workspaceId?: string;
   projectId: string;
 }) {
   invariant(ResourceCache, 'No resources to import');
@@ -237,7 +235,7 @@ export async function importResources({
         ? 'design'
         : 'collection';
     const newWorkspace = await models.workspace.create({
-      name: workspaceName || workspace?.name,
+      name: workspace?.name,
       scope,
       parentId: projectId,
     });
@@ -248,7 +246,7 @@ export async function importResources({
       await models.apiSpec.updateOrCreateForParentId(newWorkspace._id, {
         ...apiSpec,
         _id: generateId(models.apiSpec.prefix),
-        fileName: workspaceName || workspace?.name,
+        fileName: workspace?.name,
       });
     }
 
@@ -257,7 +255,7 @@ export async function importResources({
       newWorkspace.scope === 'design'
     ) {
       await models.apiSpec.updateOrCreateForParentId(newWorkspace._id, {
-        fileName: workspaceName || workspace?.name,
+        fileName: workspace?.name,
         contents: ResourceCache.content,
         contentType: 'yaml',
       });

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -66,10 +66,10 @@ export async function fetchImportContentFromURI({ uri }: { uri: string }) {
 
 export interface ScanResult {
   requests?: (Request | WebSocketRequest | GrpcRequest)[];
-  workspace?: Workspace;
+  workspaces?: Workspace[];
   environments?: BaseEnvironment[];
-  apiSpec?: ApiSpec;
-  cookieJar?: CookieJar;
+  apiSpecs?: ApiSpec[];
+  cookieJars?: CookieJar[];
   unitTests?: UnitTest[];
   unitTestSuites?: UnitTestSuite[];
   type?: ConvertResultType;
@@ -126,19 +126,19 @@ export async function scanResources({
   const environments = resources.filter(isEnvironment);
   const unitTests = resources.filter(isUnitTest);
   const unitTestSuites = resources.filter(isUnitTestSuite);
-  const apiSpec = resources.find(isApiSpec);
-  const workspace = resources.find(isWorkspace);
-  const cookieJar = resources.find(isCookieJar);
+  const apiSpecs = resources.filter(isApiSpec);
+  const workspaces = resources.filter(isWorkspace);
+  const cookieJars = resources.filter(isCookieJar);
 
   return {
     type,
     unitTests,
     unitTestSuites,
     requests: [...requests, ...websocketRequests, ...grpcRequests],
-    workspace,
+    workspaces,
     environments,
-    apiSpec,
-    cookieJar,
+    apiSpecs,
+    cookieJars,
     errors: [],
   };
 }

--- a/packages/insomnia/src/ui/components/modals/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal.tsx
@@ -646,30 +646,6 @@ const ImportResourcesForm = ({
   onSubmit?: (e: React.FormEvent<HTMLFormElement>) => void;
 }) => {
   const [isPending, startTransition] = useTransition();
-  const projectFetcher = useFetcher<ProjectLoaderData>();
-
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(
-    defaultWorkspaceId || 'create-new-workspace-id'
-  );
-
-  const isCreatingNewWorkspace =
-    selectedWorkspaceId === 'create-new-workspace-id';
-
-  useEffect(() => {
-    if (projectFetcher.state === 'idle' && !projectFetcher.data) {
-      projectFetcher.load(
-        `/organization/${organizationId}/project/${defaultProjectId}`
-      );
-    }
-  }, [defaultProjectId, organizationId, selectedWorkspaceId, projectFetcher]);
-
-  const workspaces: Partial<Workspace>[] = [
-    ...(projectFetcher?.data?.workspaces || []),
-    {
-      _id: 'create-new-workspace-id',
-      name: '+ Create New File',
-    },
-  ];
 
   const id = useId();
 
@@ -693,61 +669,6 @@ const ImportResourcesForm = ({
           action="/import/resources"
           id={id}
         >
-          <div
-            style={{
-              border: '1px solid var(--hl-sm)',
-              borderRadius: 'var(--radius-md)',
-              overflow: 'hidden',
-              display: 'flex',
-            }}
-          >
-            <div
-              style={{
-                margin: 0,
-              }}
-              className="form-control form-control--outlined"
-            >
-              <select
-                style={{
-                  border: 'none',
-                  borderRadius: 0,
-                  margin: 0,
-                }}
-                onChange={e => {
-                  setSelectedWorkspaceId(e.target.value);
-                }}
-                value={selectedWorkspaceId}
-                name="workspaceId"
-              >
-                {workspaces.map(workspace => (
-                  <option key={workspace._id} value={workspace._id}>
-                    {workspace.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-            {isCreatingNewWorkspace && (
-              <Fragment>
-                <div
-                  style={{
-                    margin: 0,
-                  }}
-                  className="form-control form-control--outlined"
-                >
-                  <input
-                    style={{
-                      border: 'none',
-                      margin: 0,
-                    }}
-                    autoFocus
-                    type="text"
-                    name="name"
-                    defaultValue="Untitled"
-                  />
-                </div>
-              </Fragment>
-            )}
-          </div>
           <input hidden name="organizationId" readOnly value={organizationId} />
         </form>
         <table className="table--fancy table--outlined margin-top-sm">
@@ -825,9 +746,9 @@ const ImportResourcesForm = ({
                 </td>
               </tr>
             )}
-            {isCreatingNewWorkspace && scanResult.apiSpec && (
+            {scanResult.apiSpecs && scanResult.apiSpecs?.length > 0 && (
               <tr
-                key={scanResult.apiSpec._id}
+                key={scanResult.apiSpecs[0]._id}
                 className="table--no-outline-row"
               >
                 <td>
@@ -838,14 +759,13 @@ const ImportResourcesForm = ({
                       gap: 'var(--padding-md)',
                     }}
                   >
-                    OpenAPI Spec:{' '}
-                    {scanResult.apiSpec.name || scanResult.apiSpec.fileName}
+                    {scanResult.apiSpecs.length}{' '}
+                    {scanResult.apiSpecs.length === 1 ? 'OpenAPI Spec' : 'OpenAPI Specs'}
                   </div>
                 </td>
               </tr>
             )}
-            {isCreatingNewWorkspace &&
-              scanResult.environments &&
+            {scanResult.environments &&
               scanResult.environments.length > 0 && (
               <tr className="table--no-outline-row">
                 <td>
@@ -853,7 +773,8 @@ const ImportResourcesForm = ({
                   {scanResult.environments.length === 1
                     ? 'Environment'
                     : 'Environments'}
-                  {scanResult.cookieJar ? ' and a Cookie Jar' : ''}
+                  {scanResult.cookieJars?.length}{' '}
+                  {scanResult.cookieJars?.length === 1 ? 'Cookie Jar' : 'Cookie Jars'}
                 </td>
               </tr>
             )}

--- a/packages/insomnia/src/ui/components/modals/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal.tsx
@@ -13,14 +13,10 @@ import { useFetcher } from 'react-router-dom';
 import { usePrevious } from 'react-use';
 import styled from 'styled-components';
 
-import { strings } from '../../../common/strings';
-import { isDefaultProject, isLocalProject } from '../../../models/project';
-import { Workspace } from '../../../models/workspace';
 import {
   ImportResourcesActionResult,
   ScanForResourcesActionResult,
 } from '../../routes/import';
-import { ProjectLoaderData } from '../../routes/project';
 import { Modal, ModalHandle, ModalProps } from '../base/modal';
 import { ModalHeader } from '../base/modal-header';
 import { Button } from '../themed-button';
@@ -670,6 +666,8 @@ const ImportResourcesForm = ({
           id={id}
         >
           <input hidden name="organizationId" readOnly value={organizationId} />
+          <input hidden name="projectId" readOnly value={defaultProjectId} />
+          <input hidden name="workspaceId" readOnly value={defaultWorkspaceId} />
         </form>
         <table className="table--fancy table--outlined margin-top-sm">
           <thead>
@@ -773,6 +771,7 @@ const ImportResourcesForm = ({
                   {scanResult.environments.length === 1
                     ? 'Environment'
                     : 'Environments'}
+                  {' with '}
                   {scanResult.cookieJars?.length}{' '}
                   {scanResult.cookieJars?.length === 1 ? 'Cookie Jar' : 'Cookie Jars'}
                 </td>

--- a/packages/insomnia/src/ui/components/modals/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal.tsx
@@ -671,8 +671,6 @@ const ImportResourcesForm = ({
     },
   ];
 
-  const projects = projectFetcher?.data?.projects || [];
-
   const id = useId();
 
   return (
@@ -697,54 +695,12 @@ const ImportResourcesForm = ({
         >
           <div
             style={{
-              fontSize: 'var(--font-size-sm)',
-              fontWeight: '500',
-              paddingBottom: 'var(--padding-sm)',
-            }}
-          >
-            Import to:
-          </div>
-          <div
-            style={{
               border: '1px solid var(--hl-sm)',
               borderRadius: 'var(--radius-md)',
               overflow: 'hidden',
               display: 'flex',
             }}
           >
-            <div
-              style={{
-                margin: 0,
-              }}
-              className="form-control form-control--outlined"
-            >
-              <select
-                style={{
-                  border: 'none',
-                  borderRadius: 0,
-                  margin: 0,
-                }}
-                onChange={e =>
-                  projectFetcher.load(
-                    `/organization/${organizationId}/project/${e.currentTarget.value}`
-                  )
-                }
-                defaultValue={defaultProjectId}
-                name="projectId"
-              >
-                {projects.map(project => (
-                  <option key={project._id} value={project._id}>
-                    {project.name} (
-                    {isDefaultProject(project)
-                      ? strings.defaultProject.singular
-                      : isLocalProject(project)
-                        ? strings.localProject.singular
-                        : strings.remoteProject.singular}
-                    )
-                  </option>
-                ))}
-              </select>
-            </div>
             <div
               style={{
                 margin: 0,

--- a/packages/insomnia/src/ui/components/modals/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal.tsx
@@ -393,6 +393,7 @@ const CurlIcon = (props: React.SVGProps<SVGSVGElement>) => {
 
 interface ImportModalProps extends ModalProps {
   organizationId: string;
+  projectName: string;
   defaultProjectId: string;
   defaultWorkspaceId?: string;
   from:
@@ -409,6 +410,7 @@ interface ImportModalProps extends ModalProps {
 }
 
 export const ImportModal: FC<ImportModalProps> = ({
+  projectName,
   defaultProjectId,
   defaultWorkspaceId,
   organizationId,
@@ -438,7 +440,7 @@ export const ImportModal: FC<ImportModalProps> = ({
   return (
     <OverlayContainer>
       <Modal {...modalProps} ref={modalRef}>
-        <ModalHeader>Import to Insomnia</ModalHeader>
+        <ModalHeader>Import to {projectName}</ModalHeader>
         {scanResourcesFetcher.data && scanResourcesFetcher.data.errors.length === 0 ? (
           <ImportResourcesForm
             organizationId={organizationId}

--- a/packages/insomnia/src/ui/components/modals/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal.tsx
@@ -845,6 +845,17 @@ const ImportResourcesForm = ({
             </tr>
           </thead>
           <tbody>
+            {scanResult.workspaces && scanResult.workspaces?.length > 0 && (
+              <tr
+                key={scanResult.workspaces[0]._id}
+                className="table--no-outline-row"
+              >
+                <td>
+                  {scanResult.workspaces.length}{' '}
+                  {scanResult.workspaces.length === 1 ? 'Workspace' : 'Workspaces'}
+                </td>
+              </tr>
+            )}
             {scanResult.requests && scanResult.requests?.length > 0 && (
               <tr
                 key={scanResult.requests[0]._id}

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -82,15 +82,15 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
                     onClick={showExportRequestsModal}
                   />
                 </DropdownItem>
-                <DropdownItem aria-label={`All ${strings.document.plural} and ${strings.collection.plural} from the "${projectName}" ${strings.project.singular}`}>
+                <DropdownItem aria-label={`Export files from the "${projectName}" ${strings.project.singular}`}>
                   <ItemContent
                     icon="empty"
-                    label={`All ${strings.document.plural} and ${strings.collection.plural} from the "${projectName}" ${strings.project.singular}`}
+                    label={`Export files from the "${projectName}" ${strings.project.singular}`}
                     onClick={handleExportAllToFile}
                   />
                 </DropdownItem>
               </DropdownSection>
-            </Dropdown>) : (<Button onClick={handleExportAllToFile}>Export all</Button>)
+            </Dropdown>) : (<Button onClick={handleExportAllToFile}>{`Export files from the "${projectName}" ${strings.project.singular}`}</Button>)
           }
         &nbsp;&nbsp;
           <Button
@@ -102,7 +102,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
             onClick={() => setIsImportModalOpen(true)}
           >
             <i className="fa fa-file-import" />
-            Import
+            {`Import to the "${projectName}" ${strings.project.singular}`}
           </Button>
         &nbsp;&nbsp;
           <Link href="https://insomnia.rest/create-run-button" className="btn btn--compact" button>
@@ -115,6 +115,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
         <ImportModal
           onHide={() => setIsImportModalOpen(false)}
           from={{ type: 'file' }}
+          projectName={projectName}
           organizationId={organizationId}
           defaultProjectId={projectId}
           defaultWorkspaceId={workspaceId}

--- a/packages/insomnia/src/ui/routes/import.tsx
+++ b/packages/insomnia/src/ui/routes/import.tsx
@@ -71,13 +71,12 @@ export interface ImportResourcesActionResult {
 export const importResourcesAction: ActionFunction = async ({ request }): Promise<ImportResourcesActionResult | Response> => {
   const formData = await request.formData();
 
+  // TODO: get multiple workspaces
   const organizationId = formData.get('organizationId');
   const projectId = formData.get('projectId');
   const workspaceId = formData.get('workspaceId');
+  // Q: why do we need this? for postman imports
   const scope = formData.get('scope') || 'design';
-  const name = formData.get('name');
-
-  const workspaceName = typeof name === 'string' ? name : 'Untitled';
 
   invariant(typeof organizationId === 'string', 'OrganizationId is required.');
   invariant(typeof projectId === 'string', 'ProjectId is required.');
@@ -91,8 +90,7 @@ export const importResourcesAction: ActionFunction = async ({ request }): Promis
 
   const result = await importResources({
     projectId: project._id,
-    workspaceId,
-    workspaceName,
+    workspaceId: workspaceId || 'create-new-workspace-id',
   });
 
   return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${result.workspace._id}/${

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1072,6 +1072,7 @@ const ProjectRoute: FC = () => {
         {importModalType && (
           <ImportModal
             onHide={() => setImportModalType(null)}
+            projectName={activeProject.name}
             from={{ type: importModalType }}
             organizationId={organizationId}
             defaultProjectId={activeProject._id}

--- a/packages/insomnia/src/ui/routes/root.tsx
+++ b/packages/insomnia/src/ui/routes/root.tsx
@@ -256,6 +256,7 @@ const Root = () => {
           {importUri && (
             <ImportModal
               onHide={() => setImportUri('')}
+              projectName="Insomnia"
               organizationId={organizationId}
               defaultProjectId={projectId || ''}
               defaultWorkspaceId={workspaceId}


### PR DESCRIPTION
add support for multiple workspaces in one import file

### highlights

- removes project and workspace selection, in favour of context and duplication or workspaces
- when importing from a run button, its possible to include no project or workspace so we should fallback to the first project and create a new workspace using a title found in the import ifle or the name "Imported Collection"? (TBD)

### todo

 - [x] remove selects
 - [x] update scan results for multiple workspaces
 - [x] update labels to indicate context
 - [ ] decide on iteration approach to actual import

<img width="957" alt="image" src="https://github.com/Kong/insomnia/assets/3679927/4876f9ca-5a50-44b3-a602-f5a33848f9ac">

closes INS-2660