### PR TITLE
workspace migration logs

### DIFF
--- a/packages/insomnia/src/models/cookie-jar.ts
+++ b/packages/insomnia/src/models/cookie-jar.ts
@@ -49,8 +49,13 @@ export function init() {
 }
 
 export function migrate(doc: CookieJar) {
-  doc = migrateCookieId(doc);
-  return doc;
+  try {
+    doc = migrateCookieId(doc);
+    return doc;
+  } catch (e) {
+    console.log('[db] Error during cookie jar migration', e);
+    throw e;
+  }
 }
 
 export async function create(patch: Partial<CookieJar>) {

--- a/packages/insomnia/src/models/request.ts
+++ b/packages/insomnia/src/models/request.ts
@@ -224,10 +224,15 @@ export function newAuth(type: string, oldAuth: RequestAuthentication = {}): Requ
 }
 
 export function migrate(doc: Request): Request {
-  doc = migrateBody(doc);
-  doc = migrateWeirdUrls(doc);
-  doc = migrateAuthType(doc);
-  return doc;
+  try {
+    doc = migrateBody(doc);
+    doc = migrateWeirdUrls(doc);
+    doc = migrateAuthType(doc);
+    return doc;
+  } catch (e) {
+    console.log('[db] Error during request migration', e);
+    throw e;
+  }
 }
 
 export function create(patch: Partial<Request> = {}) {

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -84,8 +84,13 @@ export function init(): BaseResponse {
 }
 
 export async function migrate(doc: Response) {
-  doc = await migrateBodyCompression(doc);
-  return doc;
+  try {
+    doc = await migrateBodyCompression(doc);
+    return doc;
+  } catch (e) {
+    console.log('[db] Error during response migration', e);
+    throw e;
+  }
 }
 
 export function hookDatabaseInit(consoleLog: typeof console.log = console.log) {

--- a/packages/insomnia/src/models/settings.ts
+++ b/packages/insomnia/src/models/settings.ts
@@ -78,8 +78,13 @@ export function init(): BaseSettings {
 }
 
 export function migrate(doc: Settings) {
-  doc = migrateEnsureHotKeys(doc);
-  return doc;
+  try {
+    doc = migrateEnsureHotKeys(doc);
+    return doc;
+  } catch (e) {
+    console.log('[db] Error during settings migration', e);
+    throw e;
+  }
 }
 
 export async function all() {

--- a/packages/insomnia/src/models/workspace.ts
+++ b/packages/insomnia/src/models/workspace.ts
@@ -51,14 +51,21 @@ export const init = (): BaseWorkspace => ({
 });
 
 export async function migrate(doc: Workspace) {
-  doc = await _migrateExtractClientCertificates(doc);
-  doc = await _migrateEnsureName(doc);
-  await models.apiSpec.getOrCreateForParentId(doc._id, {
-    fileName: doc.name,
-  });
-  doc = _migrateScope(doc);
-  doc = _migrateIntoDefaultProject(doc);
-  return doc;
+  try {
+    console.log('[db] Workspace migrating', doc._id);
+    doc = await _migrateExtractClientCertificates(doc);
+    doc = await _migrateEnsureName(doc);
+    await models.apiSpec.getOrCreateForParentId(doc._id, {
+      fileName: doc.name,
+    });
+    doc = _migrateScope(doc);
+    doc = _migrateIntoDefaultProject(doc);
+    console.log('[db] Workspace migrated', doc._id);
+    return doc;
+  } catch (e) {
+    console.log('[db] Error during workspace migration', e);
+    return doc;
+  }
 }
 
 export function getById(id?: string) {

--- a/packages/insomnia/src/models/workspace.ts
+++ b/packages/insomnia/src/models/workspace.ts
@@ -52,7 +52,6 @@ export const init = (): BaseWorkspace => ({
 
 export async function migrate(doc: Workspace) {
   try {
-    console.log('[db] Workspace migrating', doc._id);
     doc = await _migrateExtractClientCertificates(doc);
     doc = await _migrateEnsureName(doc);
     await models.apiSpec.getOrCreateForParentId(doc._id, {
@@ -60,11 +59,10 @@ export async function migrate(doc: Workspace) {
     });
     doc = _migrateScope(doc);
     doc = _migrateIntoDefaultProject(doc);
-    console.log('[db] Workspace migrated', doc._id);
     return doc;
   } catch (e) {
     console.log('[db] Error during workspace migration', e);
-    return doc;
+    throw e;
   }
 }
 


### PR DESCRIPTION
closes INS-2658

motivation:
we have seen workspaces disappearing and changing from collection to document, the aim of this PR is to provide richer information for reproduction when this occurs.

options:
1. log to file somewhere
1. just dump in the app log
1. only log caught exceptions

todo:
- [x] add error log to other migrations


dumps something like this in the logs 
<img width="753" alt="image" src="https://github.com/Kong/insomnia/assets/3679927/9bafa1e5-cf59-4a91-81fd-be9c70d780f3">

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
