### PR TITLE
make all migration functions non-async

### DIFF
--- a/packages/insomnia-smoke-test/tests/prerelease/cookie-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/cookie-editor-interactions.test.ts
@@ -4,7 +4,6 @@ import { test } from '../../playwright/test';
 test.describe('Cookie editor', async () => {
 
   test.beforeEach(async ({ app, page }) => {
-    await page.getByTestId('project').click();
     await page.getByRole('button', { name: 'Create' }).click();
     const text = await loadFixture('simple.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);

--- a/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
@@ -7,8 +7,6 @@ test.describe('Dashboard', async () => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
   test.describe('Projects', async () => {
     test('Can create, rename and delete new project', async ({ page }) => {
-      // Return to Dashboard
-      await page.getByTestId('project').click();
       await expect(page.locator('.app')).toContainText('All Files (1)');
       await expect(page.locator('.app')).not.toContainText('Setup Git Sync');
 
@@ -50,7 +48,6 @@ test.describe('Dashboard', async () => {
   test.describe('Interactions', async () => { // Not sure about the name here
     // TODO(INS-2504) - we don't support importing multiple collections at this time
     test.skip('Can filter through multiple collections', async ({ app, page }) => {
-      await page.getByTestId('project').click();
       await expect(page.locator('.app')).toContainText('All Files (1)');
       await expect(page.locator('.app')).not.toContainText('Setup Git Sync');
 
@@ -88,7 +85,6 @@ test.describe('Dashboard', async () => {
     });
 
     test('Can create, rename and delete a document', async ({ page }) => {
-      await page.getByTestId('project').click();
       await expect(page.locator('.app')).toContainText('All Files (1)');
       await expect(page.locator('.app')).not.toContainText('Setup Git Sync');
 
@@ -97,9 +93,7 @@ test.describe('Dashboard', async () => {
       await page.getByRole('menuitem', { name: 'Design Document' }).click();
       await page.locator('text=Create').nth(1).click();
 
-      // Return to dashboard
-      await page.getByTestId('project').click();
-      await expect(page.locator('.app')).toContainText('My Document');
+      // Return to dashboardawait expect(page.locator('.app')).toContainText('My Document');
 
       // Rename document
       await page.click('text=DocumentMy Documentjust now >> button');
@@ -114,9 +108,7 @@ test.describe('Dashboard', async () => {
       await page.locator('input[name="name"]').fill('test123-duplicate');
       await page.click('[role="dialog"] button:has-text("Duplicate")');
 
-      // Return to dashboard
-      await page.getByTestId('project').click();
-      await expect(page.locator('.app')).toContainText('test123-duplicate');
+      // Return to dashboardawait expect(page.locator('.app')).toContainText('test123-duplicate');
 
       const workspaceCards = page.locator('.card-badge');
       await expect(workspaceCards).toHaveCount(3);
@@ -129,7 +121,6 @@ test.describe('Dashboard', async () => {
     });
 
     test('Can create, rename and delete a collection', async ({ page }) => {
-      await page.getByTestId('project').click();
       await expect(page.locator('.app')).toContainText('All Files (1)');
       await expect(page.locator('.app')).not.toContainText('Setup Git Sync');
 
@@ -138,9 +129,7 @@ test.describe('Dashboard', async () => {
       await page.getByRole('menuitem', { name: 'Request Collection' }).click();
       await page.locator('text=Create').nth(1).click();
 
-      // Return to dashboard
-      await page.getByTestId('project').click();
-      await expect(page.locator('.app')).toContainText('My Collection');
+      // Return to dashboardawait expect(page.locator('.app')).toContainText('My Collection');
 
       // Rename collection
       await page.click('text=CollectionMy Collectionjust now >> button');
@@ -155,9 +144,7 @@ test.describe('Dashboard', async () => {
       await page.locator('input[name="name"]').fill('test123-duplicate');
       await page.click('[role="dialog"] button:has-text("Duplicate")');
 
-      // Return to dashboard
-      await page.getByTestId('project').click();
-      await expect(page.locator('.app')).toContainText('test123-duplicate');
+      // Return to dashboardawait expect(page.locator('.app')).toContainText('test123-duplicate');
       const workspaceCards = page.locator('.card-badge');
       await expect(workspaceCards).toHaveCount(3);
 

--- a/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
@@ -99,10 +99,10 @@ test.describe('Dashboard', async () => {
 
       // Return to dashboard
       await page.getByTestId('project').click();
-      await expect(page.locator('.app')).toContainText('my-spec.yaml');
+      await expect(page.locator('.app')).toContainText('My Document');
 
       // Rename document
-      await page.click('text=Documentmy-spec.yamljust now >> button');
+      await page.click('text=DocumentMy Documentjust now >> button');
       await page.getByRole('menuitem', { name: 'Rename' }).click();
       await page.locator('text=Rename DocumentName Rename >> input[type="text"]').fill('test123');
       await page.click('#root button:has-text("Rename")');

--- a/packages/insomnia-smoke-test/tests/prerelease/debug-sidebar-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/debug-sidebar-interactions.test.ts
@@ -6,7 +6,6 @@ import { test } from '../../playwright/test';
 test.describe('Debug-Sidebar', async () => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
   test.beforeEach(async ({ app, page }) => {
-    await page.getByTestId('project').click();
     await page.getByRole('button', { name: 'Create' }).click();
     const text = await loadFixture('simple.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);

--- a/packages/insomnia-smoke-test/tests/prerelease/design-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/design-interactions.test.ts
@@ -5,21 +5,9 @@ import { test } from '../../playwright/test';
 
 test.describe('Design interactions', async () => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
-  test.fixme('Requests are auto-generated when switching tabs', async ({ page }) => {
-    // TODO(filipe) - this is currently not working
-    await page.getByTestId('project').click();
-    await expect(true).toBeTruthy();
-  });
-
-  test.fixme('Can filter values in Design sidebar', async ({ page }) => {
-    // TODO(filipe) implement in another PR
-    await page.getByTestId('project').click();
-    await expect(true).toBeTruthy();
-  });
 
   test('Unit Test interactions', async ({ app, page }) => {
     // Setup
-    await page.getByTestId('project').click();
     await page.getByRole('button', { name: 'Create' }).click();
     const text = await loadFixture('unit-test.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);

--- a/packages/insomnia-smoke-test/tests/prerelease/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/environment-editor-interactions.test.ts
@@ -4,7 +4,6 @@ import { test } from '../../playwright/test';
 test.describe('Environment Editor', async () => {
 
   test.beforeEach(async ({ app, page }) => {
-    await page.getByTestId('project').click();
     await page.getByRole('button', { name: 'Create' }).click();
     const text = await loadFixture('environments.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);

--- a/packages/insomnia-smoke-test/tests/prerelease/git-sync-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/git-sync-interactions.test.ts
@@ -3,7 +3,6 @@ import { expect } from '@playwright/test';
 import { test } from '../../playwright/test';
 
 test('Clone Repo with bad values', async ({ page }) => {
-  await page.click('[data-testid="project"] >> text=Insomnia');
   await page.getByRole('button', { name: 'Create' }).click();
   await page.getByRole('menuitem', { name: 'Git Clone' }).click();
   await page.getByRole('tab', { name: 'Git' }).nth(2).click();
@@ -52,7 +51,6 @@ test('Clone Repo with bad values', async ({ page }) => {
 });
 
 test('Clone Bitbucket Repo with bad values', async ({ page }) => {
-  await page.click('[data-testid="project"] >> text=Insomnia');
   await page.getByRole('button', { name: 'Create' }).click();
   await page.getByRole('menuitem', { name: 'Git Clone' }).click();
   await page.getByRole('tab', { name: 'Git' }).nth(2).click();
@@ -78,7 +76,6 @@ test('Clone Bitbucket Repo with bad values', async ({ page }) => {
 });
 
 test('Clone Gitlab Repo with bad values', async ({ page }) => {
-  await page.click('[data-testid="project"] >> text=Insomnia');
   await page.getByRole('button', { name: 'Create' }).click();
   await page.getByRole('menuitem', { name: 'Git Clone' }).click();
   await page.getByRole('tab', { name: 'Git' }).nth(2).click();

--- a/packages/insomnia-smoke-test/tests/prerelease/grpc-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/grpc-interactions.test.ts
@@ -11,7 +11,6 @@ test.describe('gRPC interactions', () => {
   let streamMessage: Locator;
 
   test.beforeEach(async ({ app, page }) => {
-    await page.getByTestId('project').click();
     await page.getByRole('button', { name: 'Create' }).click();
 
     const text = await loadFixture('grpc.yaml');

--- a/packages/insomnia-smoke-test/tests/prerelease/preferences-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/preferences-interactions.test.ts
@@ -17,14 +17,13 @@ test('Preferences through keyboard shortcut', async ({ page }) => {
 
 // Quick reproduction for Kong/insomnia#5664 and INS-2267
 test('Check filter responses by environment preference', async ({ app, page }) => {
-  await page.getByTestId('project').click();
   await page.getByRole('button', { name: 'Create' }).click();
   const text = await loadFixture('simple.yaml');
   await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
   await page.getByRole('menuitem', { name: 'Import' }).click();
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
-  await page.getByRole('button', { name: 'Import' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('Collectionsimplejust now').click();
 
   // Send a request

--- a/packages/insomnia-smoke-test/tests/smoke/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/app.test.ts
@@ -10,7 +10,6 @@ test('can send requests', async ({ app, page }) => {
     has: page.locator('.CodeMirror-activeline'),
   });
 
-  await page.getByTestId('project').click();
   await page.getByRole('button', { name: 'Create' }).click();
 
   const text = await loadFixture('smoke-test-collection.yaml');
@@ -19,7 +18,7 @@ test('can send requests', async ({ app, page }) => {
   await page.getByRole('menuitem', { name: 'Import' }).click();
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
-  await page.getByRole('button', { name: 'Import' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionSmoke testsjust now').click();
 
   await page.getByRole('button', { name: 'send JSON request' }).click();
@@ -65,7 +64,6 @@ test('can send requests', async ({ app, page }) => {
 // This feature is unsafe to place beside other tests, cancelling a request can cause network code to block
 // related to https://linear.app/insomnia/issue/INS-973
 test('can cancel requests', async ({ app, page }) => {
-  await page.getByTestId('project').click();
   await page.getByRole('button', { name: 'Create' }).click();
 
   const text = await loadFixture('smoke-test-collection.yaml');
@@ -74,7 +72,7 @@ test('can cancel requests', async ({ app, page }) => {
   await page.getByRole('menuitem', { name: 'Import' }).click();
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
-  await page.getByRole('button', { name: 'Import' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionSmoke testsjust now').click();
 
   await page.getByRole('button', { name: 'delayed request' }).click();
@@ -82,10 +80,4 @@ test('can cancel requests', async ({ app, page }) => {
 
   await page.getByRole('button', { name: 'Cancel Request' }).click();
   await page.click('text=Request was cancelled');
-});
-
-test('url field is focused for first time users', async ({ page }) => {
-  const urlInput = ':nth-match(textarea, 2)';
-  const locator = page.locator(urlInput);
-  await expect(locator).toBeFocused();
 });

--- a/packages/insomnia-smoke-test/tests/smoke/git-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/git-sync.test.ts
@@ -1,6 +1,8 @@
 import { test } from '../../playwright/test';
 
 test('Sign in with GitHub', async ({ app, page }) => {
+  await page.getByRole('button', { name: 'New Document' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click();
   await page.getByRole('button', { name: 'Setup Git Sync' }).click();
 
   await page.getByRole('tab', { name: 'Github' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -6,8 +6,6 @@ import { test } from '../../playwright/test';
 test('can render schema and send GraphQL requests', async ({ app, page }) => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
 
-  // Create a new the project
-  await page.getByTestId('project').click();
   await page.getByRole('button', { name: 'Create' }).click();
 
   // Copy the collection with the graphql query to clipboard
@@ -18,7 +16,7 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
   await page.getByRole('menuitem', { name: 'Import' }).click();
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
-  await page.getByRole('button', { name: 'Import' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionSmoke GraphQLjust now').click();
   // Open the graphql request
   await page.getByRole('button', { name: 'GraphQL request' }).click();
@@ -48,8 +46,6 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
 test('can send GraphQL requests after editing and prettifying query', async ({ app, page }) => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
 
-  // Create a new the project
-  await page.getByTestId('project').click();
   await page.getByRole('button', { name: 'Create' }).click();
 
   const text = await loadFixture('graphql.yaml');
@@ -57,7 +53,7 @@ test('can send GraphQL requests after editing and prettifying query', async ({ a
   await page.getByRole('menuitem', { name: 'Import' }).click();
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
-  await page.getByRole('button', { name: 'Import' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionSmoke GraphQLjust now').click();
   await page.getByRole('button', { name: 'GraphQL request' }).click();
 

--- a/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
@@ -10,7 +10,6 @@ test('can send gRPC requests with reflection', async ({ app, page }) => {
     has: page.locator('.CodeMirror-activeline'),
   });
 
-  await page.getByTestId('project').click();
   await page.getByRole('button', { name: 'Create' }).click();
 
   const text = await loadFixture('grpc.yaml');
@@ -19,7 +18,7 @@ test('can send gRPC requests with reflection', async ({ app, page }) => {
   await page.getByRole('menuitem', { name: 'Import' }).click();
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
-  await page.getByRole('button', { name: 'Import' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionPreRelease gRPCjust now').click();
 
   await page.getByRole('button', { name: 'Route Guide Example' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/oauth-gitlab.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth-gitlab.test.ts
@@ -1,7 +1,8 @@
 import { test } from '../../playwright/test';
 
 test('Sign in with Gitlab', async ({ app, page }) => {
-  await page.getByRole('button', { name: 'Setup Git Sync' }).click();
+  await page.getByRole('button', { name: 'New Document' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click();
   await page.getByRole('tab', { name: 'GitLab' }).click();
 
   const fakeGitLabOAuthWebFlow = app.evaluate(electron => {

--- a/packages/insomnia-smoke-test/tests/smoke/oauth-gitlab.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth-gitlab.test.ts
@@ -3,6 +3,7 @@ import { test } from '../../playwright/test';
 test('Sign in with Gitlab', async ({ app, page }) => {
   await page.getByRole('button', { name: 'New Document' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click();
+  await page.getByRole('button', { name: 'Setup Git Sync' }).click();
   await page.getByRole('tab', { name: 'GitLab' }).click();
 
   const fakeGitLabOAuthWebFlow = app.evaluate(electron => {

--- a/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
@@ -16,7 +16,6 @@ test('can make oauth2 requests', async ({ app, page }) => {
     has: page.locator('.CodeMirror-activeline'),
   });
 
-  await page.getByTestId('project').click();
   const projectView = page.locator('#wrapper');
   await projectView.getByRole('button', { name: 'Create' }).click();
 
@@ -26,7 +25,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await page.getByRole('menuitem', { name: 'Import' }).click();
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
-  await page.getByRole('button', { name: 'Import' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionOAuth Testingjust now').click();
 
   // Authorization code

--- a/packages/insomnia-smoke-test/tests/smoke/openapi.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/openapi.test.ts
@@ -3,6 +3,8 @@ import { expect } from '@playwright/test';
 import { test } from '../../playwright/test';
 
 test('can render Spectral OpenAPI lint errors', async ({ page }) => {
+  await page.getByRole('button', { name: 'New Document' }).click();
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
   await page.click('text=Design');
   await page.click('text=start from an example');
 

--- a/packages/insomnia-smoke-test/tests/smoke/openapi.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/openapi.test.ts
@@ -4,7 +4,7 @@ import { test } from '../../playwright/test';
 
 test('can render Spectral OpenAPI lint errors', async ({ page }) => {
   await page.getByRole('button', { name: 'New Document' }).click();
-  await page.getByRole('button', { name: 'Create', exact: true }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click();
   await page.click('text=Design');
   await page.click('text=start from an example');
 

--- a/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
@@ -10,7 +10,6 @@ test('can make websocket connection', async ({ app, page }) => {
     has: page.locator('.CodeMirror-activeline'),
   });
 
-  await page.getByTestId('project').click();
   await page.getByRole('button', { name: 'Create' }).click();
 
   const text = await loadFixture('websockets.yaml');
@@ -19,7 +18,7 @@ test('can make websocket connection', async ({ app, page }) => {
   await page.getByRole('menuitem', { name: 'Import' }).click();
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
-  await page.getByRole('button', { name: 'Import' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionWebSocketsjust now').click();
 
   await page.getByRole('button', { name: 'localhost:4010' }).click();

--- a/packages/insomnia/src/common/__tests__/database.test.ts
+++ b/packages/insomnia/src/common/__tests__/database.test.ts
@@ -270,8 +270,6 @@ describe('_repairDatabase()', () => {
       _id: 'w1',
       parentId: project._id,
     });
-    const spec = await models.apiSpec.getByParentId(workspace._id);
-    expect((await db.withDescendants(workspace)).length).toBe(2);
     // Create one set of sub environments
     await models.environment.create({
       _id: 'b1',
@@ -318,8 +316,8 @@ describe('_repairDatabase()', () => {
         foo: '4',
       },
     });
-    // Make sure we have everything
-    expect((await db.withDescendants(workspace)).length).toBe(8);
+    // Make sure we have 6 environments and one workspace
+    expect((await db.withDescendants(workspace)).length).toBe(7);
     const descendants = (await db.withDescendants(workspace)).map(d => ({
       _id: d._id,
       parentId: d.parentId,
@@ -348,10 +346,6 @@ describe('_repairDatabase()', () => {
         },
         parentId: 'w1',
       },
-      expect.objectContaining({
-        _id: spec?._id,
-        parentId: 'w1',
-      }),
       {
         _id: 'b1_sub1',
         data: {
@@ -407,10 +401,7 @@ describe('_repairDatabase()', () => {
         },
         parentId: 'w1',
       },
-      expect.objectContaining({
-        _id: spec?._id,
-        parentId: 'w1',
-      }), // Extra base environments should have been deleted
+      // Extra base environments should have been deleted
       // {_id: 'b2', data: {foo: 'bar'}, parentId: 'w1'},
       // Sub environments should have been moved to new "master" base environment
       {
@@ -451,8 +442,7 @@ describe('_repairDatabase()', () => {
       _id: 'w1',
       parentId: project._id,
     });
-    const spec = await models.apiSpec.getByParentId(workspace._id);
-    expect((await db.withDescendants(workspace)).length).toBe(2);
+    expect((await db.withDescendants(workspace)).length).toBe(1);
     // Create one set of sub environments
     await models.cookieJar.create({
       _id: 'j1',
@@ -490,8 +480,8 @@ describe('_repairDatabase()', () => {
         },
       ],
     });
-    // Make sure we have everything
-    expect((await db.withDescendants(workspace)).length).toBe(4);
+    // Make sure we have 2 cookie jars and one workspace
+    expect((await db.withDescendants(workspace)).length).toBe(3);
     const descendants = (await db.withDescendants(workspace)).map(d => ({
       _id: d._id,
       // @ts-expect-error -- TSCONVERSION
@@ -536,10 +526,6 @@ describe('_repairDatabase()', () => {
           },
         ],
       },
-      expect.objectContaining({
-        _id: spec?._id,
-        parentId: 'w1',
-      }),
     ]);
     // Run the fix algorithm
     await _repairDatabase();
@@ -577,10 +563,6 @@ describe('_repairDatabase()', () => {
           },
         ],
       },
-      expect.objectContaining({
-        _id: spec?._id,
-        parentId: 'w1',
-      }),
     ]);
   });
 

--- a/packages/insomnia/src/common/__tests__/export.test.ts
+++ b/packages/insomnia/src/common/__tests__/export.test.ts
@@ -216,8 +216,6 @@ describe('export', () => {
     const w = await models.workspace.create({
       name: 'Workspace',
     });
-    const spec = await models.apiSpec.getByParentId(w._id); // Created by workspace migration
-
     const jar = await models.cookieJar.getOrCreateForParentId(w._id);
     const r1 = await models.request.create({
       name: 'Request 1',
@@ -278,9 +276,6 @@ describe('export', () => {
       resources: expect.arrayContaining([
         expect.objectContaining({
           _id: w._id,
-        }),
-        expect.objectContaining({
-          _id: spec?._id,
         }),
         expect.objectContaining({
           _id: eBase._id,

--- a/packages/insomnia/src/common/__tests__/export.test.ts
+++ b/packages/insomnia/src/common/__tests__/export.test.ts
@@ -312,7 +312,7 @@ describe('export', () => {
         }),
       ]),
     });
-    expect(exportWorkspacesDataJson.resources.length).toBe(13);
+    expect(exportWorkspacesDataJson.resources.length).toBe(12);
     // Test export some requests only.
     const exportRequestsJson = await exportRequestsData([r1, gr1], false, 'json');
     const exportRequestsYaml = await exportRequestsData([r1, gr1], false, 'yaml');
@@ -350,8 +350,8 @@ describe('export', () => {
         }),
       ]),
     });
-    expect(exportRequestsDataJSON.resources.length).toBe(10);
-    expect(exportRequestsDataYAML.resources.length).toBe(10);
+    expect(exportRequestsDataJSON.resources.length).toBe(9);
+    expect(exportRequestsDataYAML.resources.length).toBe(9);
     // Ensure JSON and YAML are the same
     expect(exportRequestsDataJSON.resources).toEqual(exportRequestsDataYAML.resources);
   });

--- a/packages/insomnia/src/models/__tests__/workspace.test.ts
+++ b/packages/insomnia/src/models/__tests__/workspace.test.ts
@@ -68,18 +68,6 @@ describe('migrate()', () => {
     expect(certsAgain.length).toBe(2);
   });
 
-  it('creates api spec for workspace id', async () => {
-    const workspace = await models.workspace.create({
-      name: 'My Workspace',
-    });
-    await models.apiSpec.removeWhere(workspace._id);
-    expect(await models.apiSpec.getByParentId(workspace._id)).toBe(null);
-    await models.workspace.migrate(workspace);
-    const spec = await models.apiSpec.getByParentId(workspace._id);
-    expect(spec).not.toBe(null);
-    expect(spec?.fileName).toBe(workspace.name);
-  });
-
   it('translates the scope correctly', async () => {
     const specW = await models.workspace.create({
       // @ts-expect-error intentionally incorrect - old scope type

--- a/packages/insomnia/src/models/api-spec.ts
+++ b/packages/insomnia/src/models/api-spec.ts
@@ -32,7 +32,7 @@ export function init(): BaseApiSpec {
   };
 }
 
-export async function migrate(doc: ApiSpec) {
+export function migrate(doc: ApiSpec) {
   return doc;
 }
 

--- a/packages/insomnia/src/models/ca-certificate.ts
+++ b/packages/insomnia/src/models/ca-certificate.ts
@@ -34,7 +34,7 @@ export const isCaCertificate = (model: Pick<BaseModel, 'type'>): model is CaCert
   model.type === type
 );
 
-export async function migrate(doc: CaCertificate) {
+export function migrate(doc: CaCertificate) {
   return doc;
 }
 

--- a/packages/insomnia/src/models/client-certificate.ts
+++ b/packages/insomnia/src/models/client-certificate.ts
@@ -42,7 +42,7 @@ export const isClientCertificate = (model: Pick<BaseModel, 'type'>): model is Cl
   model.type === type
 );
 
-export async function migrate(doc: ClientCertificate) {
+export function migrate(doc: ClientCertificate) {
   return doc;
 }
 

--- a/packages/insomnia/src/models/helpers/get-workspace-name.ts
+++ b/packages/insomnia/src/models/helpers/get-workspace-name.ts
@@ -1,6 +1,6 @@
 import type { ApiSpec } from '../api-spec';
 import { isDesign, Workspace } from '../workspace';
 
-export default function getWorkspaceName(w: Workspace, s: ApiSpec) {
-  return isDesign(w) ? s.fileName : w.name;
+export default function getWorkspaceName(w: Workspace, s?: ApiSpec) {
+  return isDesign(w) ? (s?.fileName || 'My Document') : w.name;
 }

--- a/packages/insomnia/src/models/helpers/get-workspace-name.ts
+++ b/packages/insomnia/src/models/helpers/get-workspace-name.ts
@@ -2,5 +2,5 @@ import type { ApiSpec } from '../api-spec';
 import { isDesign, Workspace } from '../workspace';
 
 export default function getWorkspaceName(w: Workspace, s?: ApiSpec) {
-  return isDesign(w) ? (s?.fileName || 'My Document') : w.name;
+  return isDesign(w) ? (s?.fileName || 'my-spec.yaml') : w.name;
 }

--- a/packages/insomnia/src/models/helpers/get-workspace-name.ts
+++ b/packages/insomnia/src/models/helpers/get-workspace-name.ts
@@ -1,6 +1,6 @@
 import type { ApiSpec } from '../api-spec';
 import { isDesign, Workspace } from '../workspace';
 
-export default function getWorkspaceName(w: Workspace, s?: ApiSpec) {
+export default function getWorkspaceName(w: Workspace, s: ApiSpec | null) {
   return isDesign(w) ? (s?.fileName || 'my-spec.yaml') : w.name;
 }

--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -206,7 +206,7 @@ export async function initModel<T extends BaseModel>(type: string, ...sources: R
 
   // Migrate the model
   // NOTE: Do migration before pruning because we might need to look at those fields
-  const migratedDoc = await model.migrate(fullObject);
+  const migratedDoc = model.migrate(fullObject);
 
   // Prune extra keys from doc
   for (const key of Object.keys(migratedDoc)) {

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -83,10 +83,9 @@ export function init(): BaseResponse {
   };
 }
 
-export async function migrate(doc: Response) {
+export function migrate(doc: Response) {
   try {
-    doc = await migrateBodyCompression(doc);
-    return doc;
+    return migrateBodyCompression(doc);
   } catch (e) {
     console.log('[db] Error during response migration', e);
     throw e;

--- a/packages/insomnia/src/models/websocket-response.ts
+++ b/packages/insomnia/src/models/websocket-response.ts
@@ -60,7 +60,7 @@ export function init(): BaseWebSocketResponse {
   };
 }
 
-export async function migrate(doc: Response) {
+export function migrate(doc: Response) {
   return doc;
 }
 

--- a/packages/insomnia/src/models/workspace.ts
+++ b/packages/insomnia/src/models/workspace.ts
@@ -28,7 +28,7 @@ export const WorkspaceScopeKeys = {
 
 export type Workspace = BaseModel & BaseWorkspace;
 
-export const isWorkspace = (model: Pick<BaseModel, 'type'>) => (
+export const isWorkspace = (model: Pick<BaseModel, 'type'>): model is Workspace => (
   model.type === type
 );
 

--- a/packages/insomnia/src/models/workspace.ts
+++ b/packages/insomnia/src/models/workspace.ts
@@ -54,10 +54,6 @@ export function migrate(doc: Workspace) {
   try {
     doc = _migrateExtractClientCertificates(doc);
     doc = _migrateEnsureName(doc);
-    // TODO: investigate this: Here we add a api spec to every collection on migrate, why?
-    models.apiSpec.getOrCreateForParentId(doc._id, {
-      fileName: doc.name,
-    });
     doc = _migrateScope(doc);
     doc = _migrateIntoDefaultProject(doc);
     return doc;

--- a/packages/insomnia/src/models/workspace.ts
+++ b/packages/insomnia/src/models/workspace.ts
@@ -12,16 +12,12 @@ export const prefix = 'wrk';
 export const canDuplicate = true;
 export const canSync = true;
 
-interface GenericWorkspace<Scope extends 'design' | 'collection'> {
+export interface BaseWorkspace {
   name: string;
   description: string;
   certificates?: any; // deprecated
-  scope: Scope;
+  scope: 'design' | 'collection';
 }
-
-export type DesignWorkspace = GenericWorkspace<'design'>;
-export type CollectionWorkspace = GenericWorkspace<'collection'>;
-export type BaseWorkspace = DesignWorkspace | CollectionWorkspace;
 
 export type WorkspaceScope = BaseWorkspace['scope'];
 
@@ -32,15 +28,15 @@ export const WorkspaceScopeKeys = {
 
 export type Workspace = BaseModel & BaseWorkspace;
 
-export const isWorkspace = (model: Pick<BaseModel, 'type'>): model is Workspace => (
+export const isWorkspace = (model: Pick<BaseModel, 'type'>) => (
   model.type === type
 );
 
-export const isDesign = (workspace: Pick<Workspace, 'scope'>): workspace is DesignWorkspace => (
+export const isDesign = (workspace: Pick<Workspace, 'scope'>) => (
   workspace.scope === WorkspaceScopeKeys.design
 );
 
-export const isCollection = (workspace: Pick<Workspace, 'scope'>): workspace is CollectionWorkspace => (
+export const isCollection = (workspace: Pick<Workspace, 'scope'>) => (
   workspace.scope === WorkspaceScopeKeys.collection
 );
 

--- a/packages/insomnia/src/models/workspace.ts
+++ b/packages/insomnia/src/models/workspace.ts
@@ -144,21 +144,13 @@ type MigrationWorkspace = Merge<Workspace, { scope: OldScopeTypes | Workspace['s
  * Ensure workspace scope is set to a valid entry
  */
 function _migrateScope(workspace: MigrationWorkspace) {
-  switch (workspace.scope) {
-    case WorkspaceScopeKeys.collection:
-    case WorkspaceScopeKeys.design:
-      break;
-
-    case 'designer':
-    case 'spec':
-      workspace.scope = WorkspaceScopeKeys.design;
-      break;
-
-    case 'debug':
-    case null:
-    default:
-      workspace.scope = WorkspaceScopeKeys.collection;
-      break;
+  if (workspace.scope === WorkspaceScopeKeys.design || workspace.scope === WorkspaceScopeKeys.collection) {
+    return workspace as Workspace;
+  }
+  if (workspace.scope === 'designer' || workspace.scope === 'spec') {
+    workspace.scope = WorkspaceScopeKeys.design;
+  } else {
+    workspace.scope = WorkspaceScopeKeys.collection;
   }
   return workspace as Workspace;
 }

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -21,7 +21,7 @@ import { SvgIcon } from '../svg-icon';
 
 interface Props {
   workspace: Workspace;
-  apiSpec?: ApiSpec;
+  apiSpec: ApiSpec | null;
   project: Project;
   projects: Project[];
 }

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -21,7 +21,7 @@ import { SvgIcon } from '../svg-icon';
 
 interface Props {
   workspace: Workspace;
-  apiSpec: ApiSpec;
+  apiSpec?: ApiSpec;
   project: Project;
   projects: Project[];
 }
@@ -46,7 +46,7 @@ const useDocumentActionPlugins = ({ workspace, apiSpec, project }: Props) => {
         ...pluginContexts.data.init(project._id),
         ...pluginContexts.store.init(p.plugin),
       };
-      await p.action(context, parseApiSpec(apiSpec.contents));
+      await p.action(context, parseApiSpec(apiSpec?.contents || ''));
     } catch (err) {
       showError({
         title: 'Document Action Failed',
@@ -55,7 +55,7 @@ const useDocumentActionPlugins = ({ workspace, apiSpec, project }: Props) => {
     } finally {
       stopLoading(p.label);
     }
-  }, [apiSpec.contents, project._id, startLoading, stopLoading]);
+  }, [apiSpec?.contents, project._id, startLoading, stopLoading]);
 
   const renderPluginDropdownItems: any = useCallback(() => actionPlugins.map(p => (
     <DropdownItem

--- a/packages/insomnia/src/ui/components/workspace-card.tsx
+++ b/packages/insomnia/src/ui/components/workspace-card.tsx
@@ -35,7 +35,7 @@ const LabelIcon = styled.div({
 });
 
 export interface WorkspaceCardProps {
-  apiSpec: ApiSpec;
+  apiSpec?: ApiSpec;
   workspace: Workspace;
   filter: string;
   activeProject: Project;
@@ -137,7 +137,7 @@ export const WorkspaceCard: FC<WorkspaceCardProps> = ({
     }
 
     defaultActivity = ACTIVITY_SPEC;
-    title = apiSpec.fileName || title;
+    title = apiSpec?.fileName || title;
   }
 
   // Filter the card by multiple different properties

--- a/packages/insomnia/src/ui/components/workspace-card.tsx
+++ b/packages/insomnia/src/ui/components/workspace-card.tsx
@@ -35,7 +35,7 @@ const LabelIcon = styled.div({
 });
 
 export interface WorkspaceCardProps {
-  apiSpec?: ApiSpec;
+  apiSpec: ApiSpec | null;
   workspace: Workspace;
   filter: string;
   activeProject: Project;

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -585,6 +585,8 @@ async function renderApp() {
 
     const request = await models.request.create({ parentId: workspaceId });
 
+    await models.apiSpec.getOrCreateForParentId(workspaceId);
+
     const unitTestSuite = await models.unitTestSuite.create({
       parentId: workspaceId,
       name: 'Example Test Suite',

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -20,7 +20,6 @@ import {
 } from '../common/constants';
 import { database } from '../common/database';
 import { initializeLogging } from '../common/log';
-import { strings } from '../common/strings';
 import * as models from '../models';
 import { DEFAULT_ORGANIZATION_ID } from '../models/organization';
 import { DEFAULT_PROJECT_ID, isRemoteProject } from '../models/project';
@@ -564,42 +563,6 @@ async function renderApp() {
   };
 
   synchronizeRouterState();
-  // Create an empty workspace with a request if the app is launched for the first time
-  const stats = await models.stats.get();
-
-  const isFirstLaunch = !(stats.launches > 1);
-
-  if (isFirstLaunch) {
-    const workspace = await models.workspace.create({
-      scope: 'design',
-      name: `New ${strings.document.singular}`,
-      parentId: DEFAULT_PROJECT_ID,
-    });
-
-    const { _id: workspaceId } = workspace;
-
-    // Create default env, cookie jar, and meta
-    await models.environment.getOrCreateForParentId(workspace._id);
-    await models.cookieJar.getOrCreateForParentId(workspace._id);
-    await models.workspaceMeta.getOrCreateByParentId(workspace._id);
-
-    const request = await models.request.create({ parentId: workspaceId });
-
-    await models.apiSpec.getOrCreateForParentId(workspaceId);
-
-    const unitTestSuite = await models.unitTestSuite.create({
-      parentId: workspaceId,
-      name: 'Example Test Suite',
-    });
-
-    await models.workspaceMeta.updateByParentId(workspaceId, {
-      activeRequestId: request._id,
-      activeActivity: ACTIVITY_DEBUG,
-      activeUnitTestSuiteId: unitTestSuite._id,
-    });
-
-    router.navigate(`/organization/${DEFAULT_ORGANIZATION_ID}/project/${DEFAULT_PROJECT_ID}/workspace/${workspaceId}/${ACTIVITY_DEBUG}`);
-  }
 
   const root = document.getElementById('root');
 

--- a/packages/insomnia/src/ui/redux/__tests__/selectors.test.ts
+++ b/packages/insomnia/src/ui/redux/__tests__/selectors.test.ts
@@ -58,22 +58,6 @@ describe('selectors', () => {
       expect(selectActiveApiSpec(state)).toBe(undefined);
     });
 
-    it('will return throw when there is not an active apiSpec', async () => {
-      const workspace = await models.workspace.create({
-        name: 'workspace.name',
-        scope: WorkspaceScopeKeys.design,
-      });
-
-      const state = await reduxStateForTest({
-        activeActivity: ACTIVITY_DEBUG,
-        activeWorkspaceId: workspace._id,
-      });
-      state.entities.apiSpecs = {};
-
-      const execute = () => selectActiveApiSpec(state);
-      expect(execute).toThrowError(`an api spec not found for the workspace ${workspace._id} (workspace.name)`);
-    });
-
     it('will return the apiSpec for a given workspace', async () => {
       const workspace = await models.workspace.create({
         name: 'workspace.name',

--- a/packages/insomnia/src/ui/redux/selectors.ts
+++ b/packages/insomnia/src/ui/redux/selectors.ts
@@ -183,14 +183,7 @@ export const selectActiveApiSpec = createSelector(
       // There should never be an active api spec without an active workspace
       return undefined;
     }
-    const activeSpec = apiSpecs.find(apiSpec => apiSpec.parentId === activeWorkspace._id);
-
-    if (!activeSpec) {
-      // This case should never be reached; an api spec should always exist for a given workspace.
-      throw new Error(`an api spec not found for the workspace ${activeWorkspace._id} (${activeWorkspace.name})`);
-    }
-
-    return activeSpec;
+    return apiSpecs.find(apiSpec => apiSpec.parentId === activeWorkspace._id);
   }
 );
 

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -105,6 +105,10 @@ export const createNewWorkspaceAction: ActionFunction = async ({
     parentId: projectId,
   });
 
+  if (scope === 'design') {
+    await models.apiSpec.getOrCreateForParentId(workspace._id);
+  }
+
   // Create default env, cookie jar, and meta
   await models.environment.getOrCreateForParentId(workspace._id);
   await models.cookieJar.getOrCreateForParentId(workspace._id);

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -879,8 +879,8 @@ const ProjectRoute: FC = () => {
     showPrompt({
       title: 'Create New Design Document',
       submitName: 'Create',
-      placeholder: 'My Document',
-      defaultValue: 'My Document',
+      placeholder: 'my-spec.yaml',
+      defaultValue: 'my-spec.yaml',
       selectText: true,
       onComplete: async (name: string) => {
         fetcher.submit(


### PR DESCRIPTION
Possible fix for workspace data loss issue.

motivation: ws migration functions had updates inside them that could trigger an update loop, and a race condition.

- removes forced apiSpec creation with all workspaces, now only creates this entity for design document type workspaces

closes INS-2628
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
