### PR TITLE
add support for multiple workspaces in one import file

### DIFF
--- a/packages/insomnia-smoke-test/tests/prerelease/cookie-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/cookie-editor-interactions.test.ts
@@ -12,8 +12,7 @@ test.describe('Cookie editor', async () => {
     await page.getByText('Clipboard').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('button', { name: 'Import' }).click();
-
-    await page.getByRole('link', { name: 'Debug' }).click();
+    await page.getByText('Collectionsimplejust now').click();
   });
 
   test('create and send a cookie', async ({ page }) => {

--- a/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
@@ -61,7 +61,7 @@ test.describe('Dashboard', async () => {
       await page.getByText('Clipboard').click();
       await page.getByRole('button', { name: 'Scan' }).click();
       await page.getByRole('button', { name: 'Import' }).click();
-
+      await page.getByText('CollectionSmoke testsjust now').click();
       // Check that 10 new workspaces are imported besides the default one
       const workspaceCards = page.locator('.card-badge');
       await expect(workspaceCards).toHaveCount(11);

--- a/packages/insomnia-smoke-test/tests/prerelease/debug-sidebar-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/debug-sidebar-interactions.test.ts
@@ -14,8 +14,7 @@ test.describe('Debug-Sidebar', async () => {
     await page.getByText('Clipboard').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('button', { name: 'Import' }).click();
-
-    await page.getByRole('link', { name: 'Debug' }).click();
+    await page.getByText('Collectionsimplejust now').click();
   });
 
   test.describe('Interact with sidebar', async () => {

--- a/packages/insomnia-smoke-test/tests/prerelease/design-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/design-interactions.test.ts
@@ -27,7 +27,7 @@ test.describe('Design interactions', async () => {
     await page.getByText('Clipboard').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('button', { name: 'Import' }).click();
-
+    await page.getByText('CollectionSmoke testsjust now').click();
     // Switch to Test tab
     await page.click('a:has-text("Test")');
 

--- a/packages/insomnia-smoke-test/tests/prerelease/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/environment-editor-interactions.test.ts
@@ -12,8 +12,7 @@ test.describe('Environment Editor', async () => {
     await page.getByText('Clipboard').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('button', { name: 'Import' }).click();
-
-    await page.getByRole('link', { name: 'Debug' }).click();
+    await page.getByText('CollectionSmoke testsjust now').click();
   });
 
   test('create a new environment', async ({ page }) => {

--- a/packages/insomnia-smoke-test/tests/prerelease/grpc-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/grpc-interactions.test.ts
@@ -21,7 +21,7 @@ test.describe('gRPC interactions', () => {
     await page.getByText('Clipboard').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('button', { name: 'Import' }).click();
-    await page.getByText('CollectionSmoke testsjust now').click();
+    await page.getByText('CollectionPreRelease gRPCjust now').click();
     statusTag = page.locator('[data-testid="response-status-tag"]:visible');
     responseBody = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
       has: page.locator('.CodeMirror-activeline'),

--- a/packages/insomnia-smoke-test/tests/prerelease/grpc-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/grpc-interactions.test.ts
@@ -21,8 +21,7 @@ test.describe('gRPC interactions', () => {
     await page.getByText('Clipboard').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('button', { name: 'Import' }).click();
-
-    await page.getByRole('link', { name: 'Debug' }).click();
+    await page.getByText('CollectionSmoke testsjust now').click();
     statusTag = page.locator('[data-testid="response-status-tag"]:visible');
     responseBody = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
       has: page.locator('.CodeMirror-activeline'),

--- a/packages/insomnia-smoke-test/tests/prerelease/preferences-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/preferences-interactions.test.ts
@@ -25,8 +25,7 @@ test('Check filter responses by environment preference', async ({ app, page }) =
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-
-  await page.getByRole('link', { name: 'Debug' }).click();
+  await page.getByText('Collectionsimplejust now').click();
 
   // Send a request
   await page.getByRole('button', { name: 'example http' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/app.test.ts
@@ -20,8 +20,7 @@ test('can send requests', async ({ app, page }) => {
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-
-  await page.getByRole('link', { name: 'Debug' }).click();
+  await page.getByText('CollectionSmoke testsjust now').click();
 
   await page.getByRole('button', { name: 'send JSON request' }).click();
   await page.click('text=http://127.0.0.1:4010/pets/1Send >> button');
@@ -76,8 +75,7 @@ test('can cancel requests', async ({ app, page }) => {
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-
-  await page.getByRole('link', { name: 'Debug' }).click();
+  await page.getByText('CollectionSmoke testsjust now').click();
 
   await page.getByRole('button', { name: 'delayed request' }).click();
   await page.click('text=http://127.0.0.1:4010/delay/seconds/20Send >> button');

--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -19,8 +19,7 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-
-  await page.getByRole('link', { name: 'Debug' }).click();
+  await page.getByText('CollectionSmoke testsjust now').click();
   // Open the graphql request
   await page.getByRole('button', { name: 'GraphQL request' }).click();
   // Assert the schema is fetched after switching to GraphQL request
@@ -59,8 +58,7 @@ test('can send GraphQL requests after editing and prettifying query', async ({ a
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-
-  await page.getByRole('link', { name: 'Debug' }).click();
+  await page.getByText('CollectionSmoke testsjust now').click();
   await page.getByRole('button', { name: 'GraphQL request' }).click();
 
   // Edit and prettify query

--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -19,7 +19,7 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke testsjust now').click();
+  await page.getByText('CollectionSmoke GraphQLjust now').click();
   // Open the graphql request
   await page.getByRole('button', { name: 'GraphQL request' }).click();
   // Assert the schema is fetched after switching to GraphQL request
@@ -58,7 +58,7 @@ test('can send GraphQL requests after editing and prettifying query', async ({ a
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke testsjust now').click();
+  await page.getByText('CollectionSmoke GraphQLjust now').click();
   await page.getByRole('button', { name: 'GraphQL request' }).click();
 
   // Edit and prettify query

--- a/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
@@ -20,8 +20,7 @@ test('can send gRPC requests with reflection', async ({ app, page }) => {
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-
-  await page.getByRole('link', { name: 'Debug' }).click();
+  await page.getByText('CollectionSmoke testsjust now').click();
 
   await page.getByRole('button', { name: 'Route Guide Example' }).click();
 

--- a/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
@@ -20,7 +20,7 @@ test('can send gRPC requests with reflection', async ({ app, page }) => {
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke testsjust now').click();
+  await page.getByText('CollectionPreRelease gRPCjust now').click();
 
   await page.getByRole('button', { name: 'Route Guide Example' }).click();
 

--- a/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
@@ -27,8 +27,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-
-  await page.getByRole('link', { name: 'Debug' }).click();
+  await page.getByText('CollectionSmoke testsjust now').click();
 
   // Authorization code
   await projectView.getByRole('button', { name: 'Authorization Code' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
@@ -27,7 +27,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke testsjust now').click();
+  await page.getByText('CollectionOAuth Testingjust now').click();
 
   // Authorization code
   await projectView.getByRole('button', { name: 'Authorization Code' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
@@ -20,7 +20,7 @@ test('can make websocket connection', async ({ app, page }) => {
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke testsjust now').click();
+  await page.getByText('CollectionWebSocketsjust now').click();
 
   await page.getByRole('button', { name: 'localhost:4010' }).click();
   await expect(page.locator('.app')).toContainText('ws://localhost:4010');

--- a/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
@@ -20,8 +20,7 @@ test('can make websocket connection', async ({ app, page }) => {
   await page.getByText('Clipboard').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('button', { name: 'Import' }).click();
-
-  await page.getByRole('link', { name: 'Debug' }).click();
+  await page.getByText('CollectionSmoke testsjust now').click();
 
   await page.getByRole('button', { name: 'localhost:4010' }).click();
   await expect(page.locator('.app')).toContainText('ws://localhost:4010');

--- a/packages/insomnia/jest.config.js
+++ b/packages/insomnia/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
     'styled-components': '<rootDir>/node_modules/styled-components',
     'jsonpath-plus': '<rootDir>/node_modules/jsonpath-plus/dist/index-node-cjs.cjs',
   },
-  collectCoverage: true,
+  collectCoverage: process.env.CI,
   collectCoverageFrom: ['src/account/**/*.ts', 'src/common/**/*.ts', 'src/main/**/*.ts', 'src/models/**/*.ts', 'src/network/**/*.ts', 'src/sync/**/*.ts', 'src/templating/**/*.ts', 'src/utils/**/*.ts'],
   coverageThreshold: {
     global: {

--- a/packages/insomnia/jest.config.js
+++ b/packages/insomnia/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
     'styled-components': '<rootDir>/node_modules/styled-components',
     'jsonpath-plus': '<rootDir>/node_modules/jsonpath-plus/dist/index-node-cjs.cjs',
   },
-  collectCoverage: process.env.CI,
+  collectCoverage: !!process.env.CI,
   collectCoverageFrom: ['src/account/**/*.ts', 'src/common/**/*.ts', 'src/main/**/*.ts', 'src/models/**/*.ts', 'src/network/**/*.ts', 'src/sync/**/*.ts', 'src/templating/**/*.ts', 'src/utils/**/*.ts'],
   coverageThreshold: {
     global: {

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -54,7 +54,6 @@ describe('importRaw()', () => {
     const projectWorkspaces = await workspace.findByParentId(
       DEFAULT_PROJECT_ID
     );
-
     const curlRequests = await request.findByParentId(projectWorkspaces[0]._id);
 
     expect(workspacesCount).toBe(1);

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -46,7 +46,7 @@ describe('importRaw()', () => {
     expect(scanResult.type.id).toBe('curl');
     expect(scanResult.errors.length).toBe(0);
 
-    await importUtil.importResources({
+    await importUtil.importResourcesToProject({
       projectId: DEFAULT_PROJECT_ID,
     });
 
@@ -79,9 +79,8 @@ describe('importRaw()', () => {
     expect(scanResult.type?.id).toBe('curl');
     expect(scanResult.errors.length).toBe(0);
 
-    await importUtil.importResources({
+    await importUtil.importResourcesToWorkspace({
       workspaceId: existingWorkspace._id,
-      projectId: existingWorkspace.parentId,
     });
 
     const workspacesCount = await workspace.count();
@@ -107,7 +106,7 @@ describe('importRaw()', () => {
     expect(scanResult.type.id).toBe('postman');
     expect(scanResult.errors.length).toBe(0);
 
-    await importUtil.importResources({
+    await importUtil.importResourcesToProject({
       projectId: DEFAULT_PROJECT_ID,
     });
 
@@ -139,9 +138,8 @@ describe('importRaw()', () => {
     expect(scanResult.type?.id).toBe('postman');
     expect(scanResult.errors.length).toBe(0);
 
-    await importUtil.importResources({
+    await importUtil.importResourcesToWorkspace({
       workspaceId: existingWorkspace._id,
-      projectId: existingWorkspace.parentId,
     });
 
     const workspacesCount = await workspace.count();
@@ -169,9 +167,8 @@ describe('importRaw()', () => {
     expect(scanResult.type?.id).toBe('openapi3');
     expect(scanResult.errors.length).toBe(0);
 
-    await importUtil.importResources({
+    await importUtil.importResourcesToWorkspace({
       workspaceId: existingWorkspace._id,
-      projectId: existingWorkspace.parentId,
     });
 
     const workspacesCount = await workspace.count();

--- a/packages/insomnia/src/common/export.tsx
+++ b/packages/insomnia/src/common/export.tsx
@@ -392,7 +392,7 @@ export const exportAllToFile = (activeProjectName: string, workspacesForActivePr
       }
 
       const fileName = await showSaveExportedFileDialog({
-        exportedFileNamePrefix: 'Insomnia-All',
+        exportedFileNamePrefix: activeProjectName,
         selectedFormat,
       });
 

--- a/packages/insomnia/src/common/export.tsx
+++ b/packages/insomnia/src/common/export.tsx
@@ -9,7 +9,7 @@ import YAML from 'yaml';
 
 import { isApiSpec } from '../models/api-spec';
 import { isCookieJar } from '../models/cookie-jar';
-import { Environment, isEnvironment } from '../models/environment';
+import { isEnvironment } from '../models/environment';
 import { isGrpcRequest } from '../models/grpc-request';
 import * as requestOperations from '../models/helpers/request-operations';
 import type { BaseModel } from '../models/index';
@@ -430,9 +430,7 @@ export const exportRequestsToFile = (requestIds: string[]) => {
   showSelectExportTypeModal({
     onDone: async selectedFormat => {
       const requests: BaseModel[] = [];
-      const privateEnvironments: Environment[] = [];
       const workspaceLookup: any = {};
-
       for (const requestId of requestIds) {
         const request = await requestOperations.getById(requestId);
 
@@ -452,20 +450,8 @@ export const exportRequestsToFile = (requestIds: string[]) => {
         }
 
         workspaceLookup[workspace._id] = true;
-        const descendants = await database.withDescendants(workspace);
-        const privateEnvs = descendants.filter(isEnvironment).filter(
-          descendant => descendant.isPrivate,
-        );
-        privateEnvironments.push(...privateEnvs);
       }
-
-      let exportPrivateEnvironments = false;
-
-      if (privateEnvironments.length) {
-        const names = privateEnvironments.map(privateEnvironment => privateEnvironment.name).join(', ');
-        exportPrivateEnvironments = await showExportPrivateEnvironmentsModal(names);
-      }
-
+      const exportPrivateEnvironments = await showExportPrivateEnvironmentsModal();
       const fileName = await showSaveExportedFileDialog({
         exportedFileNamePrefix: 'Insomnia',
         selectedFormat,

--- a/packages/insomnia/src/common/export.tsx
+++ b/packages/insomnia/src/common/export.tsx
@@ -327,11 +327,11 @@ const showSelectExportTypeModal = ({ onDone }: {
   });
 };
 
-const showExportPrivateEnvironmentsModal = async (privateEnvNames: string) => {
+const showExportPrivateEnvironmentsModal = async () => {
   return new Promise<boolean>(resolve => {
     showModal(AskModal, {
       title: 'Export Private Environments?',
-      message: `Do you want to include private environments (${privateEnvNames}) in your export?`,
+      message: 'Do you want to include private environments in your export?',
       onDone: async (isYes: boolean) => {
         if (isYes) {
           resolve(true);
@@ -380,17 +380,7 @@ export const exportAllToFile = (activeProjectName: string, workspacesForActivePr
 
   showSelectExportTypeModal({
     onDone: async selectedFormat => {
-      // Check if we want to export private environments.
-      const environments = await models.environment.all();
-
-      let exportPrivateEnvironments = false;
-      const privateEnvironments = environments.filter(environment => environment.isPrivate);
-
-      if (privateEnvironments.length) {
-        const names = privateEnvironments.map(environment => environment.name).join(', ');
-        exportPrivateEnvironments = await showExportPrivateEnvironmentsModal(names);
-      }
-
+      const exportPrivateEnvironments = await showExportPrivateEnvironmentsModal();
       const fileName = await showSaveExportedFileDialog({
         exportedFileNamePrefix: activeProjectName,
         selectedFormat,

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -147,10 +147,11 @@ export async function importResourcesToProject({ projectId }: { projectId: strin
   const resources = ResourceCache.resources;
   const bufferId = await db.bufferChanges();
   if (!resources.find(isWorkspace)) {
-    await importToNewWorkspace(projectId);
+    await importResourcesToNewWorkspace(projectId);
     return { resources };
   }
-  const r = await Promise.all(resources.filter(isWorkspace).map(resource => importToNewWorkspace(projectId, resource)));
+  const r = await Promise.all(resources.filter(isWorkspace)
+    .map(resource => importResourcesToNewWorkspace(projectId, resource)));
 
   await db.flushChanges(bufferId);
   return { resources: r.flat() };
@@ -229,7 +230,7 @@ export const importResourcesToWorkspace = async ({ workspaceId }: { workspaceId:
   };
 };
 
-const importToNewWorkspace = async (projectId: string, workspaceToImport?: Workspace) => {
+const importResourcesToNewWorkspace = async (projectId: string, workspaceToImport?: Workspace) => {
   invariant(ResourceCache, 'No resources to import');
   const resources = ResourceCache.resources;
   const ResourceIdMap = new Map();

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -146,10 +146,8 @@ export async function scanResources({
 export async function importResources({
   workspaceId,
   projectId,
-  workspaceName,
 }: {
-  workspaceId?: string;
-  workspaceName?: string;
+    workspaceId?: string;
   projectId: string;
 }) {
   invariant(ResourceCache, 'No resources to import');
@@ -242,7 +240,7 @@ export async function importResources({
         ? 'design'
         : 'collection';
     const newWorkspace = await models.workspace.create({
-      name: workspaceName || workspace?.name,
+      name: workspace?.name,
       scope,
       parentId: projectId,
     });
@@ -253,7 +251,7 @@ export async function importResources({
       await models.apiSpec.updateOrCreateForParentId(newWorkspace._id, {
         ...apiSpec,
         _id: generateId(models.apiSpec.prefix),
-        fileName: workspaceName || workspace?.name,
+        fileName: workspace?.name,
       });
     }
 
@@ -262,7 +260,7 @@ export async function importResources({
       newWorkspace.scope === 'design'
     ) {
       await models.apiSpec.updateOrCreateForParentId(newWorkspace._id, {
-        fileName: workspaceName || workspace?.name,
+        fileName: workspace?.name,
         contents: ResourceCache.content,
         contentType: 'yaml',
       });

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -239,25 +239,17 @@ const importResourcesToNewWorkspace = async (projectId: string, workspaceToImpor
     scope: workspaceToImport?.scope || 'collection',
     parentId: projectId,
   });
-  const apiSpec = newWorkspace.scope === 'design' && resources.find(r => r.type === 'ApiSpec' && r.parentId === workspaceToImport?._id);
+  const apiSpec: ApiSpec | undefined = resources.find(r => r.type === 'ApiSpec' && r.parentId === workspaceToImport?._id) as ApiSpec;
+  const hasApiSpec = newWorkspace.scope === 'design' && isApiSpec(apiSpec);
   // if workspace is not in the resources, there will be no apiSpec, if resource type is set to api spec this could cause a bug
-  if (apiSpec) {
+  if (hasApiSpec) {
+    // TODO: will overwrite existing api spec, not needed after migrate hack is removed
     await models.apiSpec.updateOrCreateForParentId(newWorkspace._id, {
       ...apiSpec,
       _id: generateId(models.apiSpec.prefix),
       fileName: workspaceToImport?.name,
     });
-  }
 
-  if (
-    isApiSpecImport(ResourceCache?.type) &&
-    newWorkspace.scope === 'design'
-  ) {
-    await models.apiSpec.updateOrCreateForParentId(newWorkspace._id, {
-      fileName: newWorkspace.name,
-      contents: ResourceCache.content,
-      contentType: 'yaml',
-    });
   }
 
   // If we're importing into a new workspace

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -239,14 +239,14 @@ const importResourcesToNewWorkspace = async (projectId: string, workspaceToImpor
     scope: workspaceToImport?.scope || 'collection',
     parentId: projectId,
   });
-  const apiSpec: ApiSpec | undefined = resources.find(r => r.type === 'ApiSpec' && r.parentId === workspaceToImport?._id) as ApiSpec;
+  const apiSpec = resources.find(r => r.type === 'ApiSpec' && r.parentId === workspaceToImport?._id) as ApiSpec;
   const hasApiSpec = newWorkspace.scope === 'design' && isApiSpec(apiSpec);
   // if workspace is not in the resources, there will be no apiSpec, if resource type is set to api spec this could cause a bug
   if (hasApiSpec) {
     // TODO: will overwrite existing api spec, not needed after migrate hack is removed
     await models.apiSpec.updateOrCreateForParentId(newWorkspace._id, {
-      ...apiSpec,
-      _id: generateId(models.apiSpec.prefix),
+      contents: apiSpec.contents,
+      contentType: apiSpec.contentType,
       fileName: workspaceToImport?.name,
     });
 

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -66,10 +66,10 @@ export async function fetchImportContentFromURI({ uri }: { uri: string }) {
 
 export interface ScanResult {
   requests?: (Request | WebSocketRequest | GrpcRequest)[];
-  workspace?: Workspace;
+  workspaces?: Workspace[];
   environments?: BaseEnvironment[];
-  apiSpec?: ApiSpec;
-  cookieJar?: CookieJar;
+  apiSpecs?: ApiSpec[];
+  cookieJars?: CookieJar[];
   unitTests?: UnitTest[];
   unitTestSuites?: UnitTestSuite[];
   type?: ConvertResultType;
@@ -126,19 +126,19 @@ export async function scanResources({
   const environments = resources.filter(isEnvironment);
   const unitTests = resources.filter(isUnitTest);
   const unitTestSuites = resources.filter(isUnitTestSuite);
-  const apiSpec = resources.find(isApiSpec);
-  const workspace = resources.find(isWorkspace);
-  const cookieJar = resources.find(isCookieJar);
+  const apiSpecs = resources.filter(isApiSpec);
+  const workspaces = resources.filter(isWorkspace);
+  const cookieJars = resources.filter(isCookieJar);
 
   return {
     type,
     unitTests,
     unitTestSuites,
     requests: [...requests, ...websocketRequests, ...grpcRequests],
-    workspace,
+    workspaces,
     environments,
-    apiSpec,
-    cookieJar,
+    apiSpecs,
+    cookieJars,
     errors: [],
   };
 }

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -14,7 +14,7 @@ import {
   WebSocketRequest,
 } from '../models/websocket-request';
 import { isWorkspace, prefix as wsPrefix, Workspace } from '../models/workspace';
-import { convert, ConvertResultType } from '../utils/importers/convert';
+import { convert, InsomniaImporter } from '../utils/importers/convert';
 import { invariant } from '../utils/invariant';
 import { database as db } from './database';
 import { generateId } from './misc';
@@ -24,16 +24,16 @@ export interface ExportedModel extends BaseModel {
 }
 
 interface ConvertResult {
-  type: ConvertResultType;
+  type: InsomniaImporter;
   data: {
     resources: ExportedModel[];
   };
 }
 
-export const isApiSpecImport = ({ id }: Pick<ConvertResultType, 'id'>) =>
+export const isApiSpecImport = ({ id }: Pick<InsomniaImporter, 'id'>) =>
   id === 'openapi3' || id === 'swagger2';
 
-export const isInsomniaV4Import = ({ id }: Pick<ConvertResultType, 'id'>) =>
+export const isInsomniaV4Import = ({ id }: Pick<InsomniaImporter, 'id'>) =>
   id === 'insomnia-4';
 
 export async function fetchImportContentFromURI({ uri }: { uri: string }) {
@@ -71,14 +71,14 @@ export interface ScanResult {
   cookieJars?: CookieJar[];
   unitTests?: UnitTest[];
   unitTestSuites?: UnitTestSuite[];
-  type?: ConvertResultType;
+  type?: InsomniaImporter;
   errors: string[];
 }
 
 let ResourceCache: {
   content: string;
   resources: BaseModel[];
-  type: ConvertResultType;
+  type: InsomniaImporter;
 } | null = null;
 
 export async function scanResources({

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -13,7 +13,7 @@ import {
   isWebSocketRequest,
   WebSocketRequest,
 } from '../models/websocket-request';
-import { isWorkspace, prefix as wsPrefix, Workspace } from '../models/workspace';
+import { isWorkspace, Workspace } from '../models/workspace';
 import { convert, InsomniaImporter } from '../utils/importers/convert';
 import { invariant } from '../utils/invariant';
 import { database as db } from './database';

--- a/packages/insomnia/src/plugins/context/data.ts
+++ b/packages/insomnia/src/plugins/context/data.ts
@@ -1,12 +1,7 @@
 import { exportWorkspacesData, exportWorkspacesHAR } from '../../common/export';
-import { fetchImportContentFromURI, importResources, scanResources } from '../../common/import';
+import { fetchImportContentFromURI, importResourcesToProject, scanResources } from '../../common/import';
 import * as models from '../../models';
-import type { Workspace, WorkspaceScope } from '../../models/workspace';
-
-interface PluginImportOptions {
-  workspaceId?: string;
-  scope?: WorkspaceScope;
-}
+import type { Workspace } from '../../models/workspace';
 
 interface InsomniaExport {
   workspace?: Workspace;
@@ -31,7 +26,7 @@ const getWorkspaces = (activeProjectId?: string) => {
 export const init = (activeProjectId?: string) => ({
   data: {
     import: {
-      uri: async (uri: string, options: PluginImportOptions = {}) => {
+      uri: async (uri: string) => {
         if (!activeProjectId) {
           return;
         }
@@ -44,12 +39,11 @@ export const init = (activeProjectId?: string) => ({
           content,
         });
 
-        await importResources({
+        await importResourcesToProject({
           projectId: activeProjectId,
-          workspaceId: options.workspaceId,
         });
       },
-      raw: async (content: string, options: PluginImportOptions = {}) => {
+      raw: async (content: string) => {
         if (!activeProjectId) {
           return;
         }
@@ -57,9 +51,8 @@ export const init = (activeProjectId?: string) => ({
           content,
         });
 
-        await importResources({
+        await importResourcesToProject({
           projectId: activeProjectId,
-          workspaceId: options.workspaceId,
         });
       },
     },

--- a/packages/insomnia/src/ui/components/modals/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal.tsx
@@ -644,6 +644,9 @@ const ImportResourcesForm = ({
   const [isPending, startTransition] = useTransition();
 
   const id = useId();
+  // allow workspace import if there is only one workspace
+  const totalWorkspaces = scanResult?.workspaces?.length || 0;
+  const shouldImportToWorkspace = defaultWorkspaceId && totalWorkspaces <= 1;
 
   return (
     <Fragment>
@@ -667,7 +670,7 @@ const ImportResourcesForm = ({
         >
           <input hidden name="organizationId" readOnly value={organizationId} />
           <input hidden name="projectId" readOnly value={defaultProjectId} />
-          <input hidden name="workspaceId" readOnly value={defaultWorkspaceId} />
+          {shouldImportToWorkspace && <input hidden name="workspaceId" readOnly value={defaultWorkspaceId} />}
         </form>
         <table className="table--fancy table--outlined margin-top-sm">
           <thead>

--- a/packages/insomnia/src/ui/components/modals/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal.tsx
@@ -390,7 +390,9 @@ const CurlIcon = (props: React.SVGProps<SVGSVGElement>) => {
 interface ImportModalProps extends ModalProps {
   organizationId: string;
   projectName: string;
-  defaultProjectId: string;
+  // undefined when using insomnia://app/import
+  defaultProjectId?: string;
+  // undefined when in workspace selection page
   defaultWorkspaceId?: string;
   from:
   | {

--- a/packages/insomnia/src/ui/components/modals/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal.tsx
@@ -6,7 +6,6 @@ import React, {
   useId,
   useRef,
   useState,
-  useTransition,
 } from 'react';
 import { OverlayContainer, useDrop } from 'react-aria';
 import { useFetcher } from 'react-router-dom';
@@ -421,7 +420,7 @@ export const ImportModal: FC<ImportModalProps> = ({
   const modalRef = useRef<ModalHandle>(null);
   const scanResourcesFetcher = useFetcher<ScanForResourcesActionResult>();
   const importFetcher = useFetcher<ImportResourcesActionResult>();
-
+  console.log('fetcher', importFetcher.state);
   useEffect(() => {
     modalRef.current?.show();
   }, []);
@@ -452,7 +451,9 @@ export const ImportModal: FC<ImportModalProps> = ({
             defaultWorkspaceId={shouldImportToWorkspace ? defaultWorkspaceId : ''}
             scanResult={scanResourcesFetcher.data}
             errors={importFetcher.data?.errors}
+            disabled={importFetcher.state !== 'idle'}
             onSubmit={e => {
+              e.preventDefault();
               importFetcher.submit(e.currentTarget, {
                 method: 'post',
                 action: '/import/resources',
@@ -641,6 +642,7 @@ const ImportResourcesForm = ({
   organizationId,
   onSubmit,
   errors,
+  disabled,
 }: {
   scanResult: ScanForResourcesActionResult;
   organizationId: string;
@@ -648,9 +650,9 @@ const ImportResourcesForm = ({
   defaultWorkspaceId?: string;
   errors?: string[];
   onSubmit?: (e: React.FormEvent<HTMLFormElement>) => void;
-}) => {
-  const [isPending, startTransition] = useTransition();
-
+  disabled: boolean;
+}
+) => {
   const id = useId();
 
   return (
@@ -663,12 +665,7 @@ const ImportResourcesForm = ({
         }}
       >
         <form
-          onSubmit={e => {
-            e.preventDefault();
-            startTransition(() => {
-              onSubmit?.(e);
-            });
-          }}
+          onSubmit={onSubmit}
           method="post"
           action="/import/resources"
           id={id}
@@ -827,7 +824,7 @@ const ImportResourcesForm = ({
           variant="contained"
           bg="surprise"
           type="submit"
-          disabled={isPending}
+          disabled={disabled}
           style={{
             height: '40px',
             gap: 'var(--padding-sm)',
@@ -835,7 +832,7 @@ const ImportResourcesForm = ({
           form={id}
           className="btn"
         >
-          {isPending ? (
+          {disabled ? (
             <div>
               <i className="fa fa-spinner fa-spin" /> Importing
             </div>

--- a/packages/insomnia/src/ui/components/modals/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal.tsx
@@ -845,6 +845,17 @@ const ImportResourcesForm = ({
             </tr>
           </thead>
           <tbody>
+            {scanResult.workspaces && scanResult.workspaces?.length > 0 && (
+              <tr
+                key={scanResult.workspaces[0]._id}
+                className="table--no-outline-row"
+              >
+                <td>
+                  {scanResult.workspaces.length}{' '}
+                  {scanResult.workspaces.length === 1 ? 'Workspace' : 'Workspaces'}
+                </td>
+              </tr>
+            )}
             {scanResult.requests && scanResult.requests?.length > 0 && (
               <tr
                 key={scanResult.requests[0]._id}

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -116,6 +116,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
           onHide={() => setIsImportModalOpen(false)}
           from={{ type: 'file' }}
           projectName={projectName}
+          workspaceName={activeWorkspaceName}
           organizationId={organizationId}
           defaultProjectId={projectId}
           defaultWorkspaceId={workspaceId}

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -82,15 +82,15 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
                     onClick={showExportRequestsModal}
                   />
                 </DropdownItem>
-                <DropdownItem aria-label={`All ${strings.document.plural} and ${strings.collection.plural} from the "${projectName}" ${strings.project.singular}`}>
+                <DropdownItem aria-label={`Export files from the "${projectName}" ${strings.project.singular}`}>
                   <ItemContent
                     icon="empty"
-                    label={`All ${strings.document.plural} and ${strings.collection.plural} from the "${projectName}" ${strings.project.singular}`}
+                    label={`Export files from the "${projectName}" ${strings.project.singular}`}
                     onClick={handleExportAllToFile}
                   />
                 </DropdownItem>
               </DropdownSection>
-            </Dropdown>) : (<Button onClick={handleExportAllToFile}>Export all</Button>)
+            </Dropdown>) : (<Button onClick={handleExportAllToFile}>{`Export files from the "${projectName}" ${strings.project.singular}`}</Button>)
           }
         &nbsp;&nbsp;
           <Button
@@ -102,7 +102,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
             onClick={() => setIsImportModalOpen(true)}
           >
             <i className="fa fa-file-import" />
-            Import
+            {`Import to the "${projectName}" ${strings.project.singular}`}
           </Button>
         &nbsp;&nbsp;
           <Link href="https://insomnia.rest/create-run-button" className="btn btn--compact" button>
@@ -115,6 +115,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
         <ImportModal
           onHide={() => setIsImportModalOpen(false)}
           from={{ type: 'file' }}
+          projectName={projectName}
           organizationId={organizationId}
           defaultProjectId={projectId}
           defaultWorkspaceId={workspaceId}

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -27,7 +27,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
     organizationId,
     projectId,
     workspaceId,
-  } = useParams() as { organizationId: string; projectId: string; workspaceId: string };
+  } = useParams() as { organizationId: string; projectId: string; workspaceId?: string };
   const projectName = useSelector(selectActiveProjectName) ?? getProductName();
   const activeWorkspace = useSelector(selectActiveWorkspace);
   const activeWorkspaceName = useSelector(selectActiveWorkspaceName);

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -743,7 +743,6 @@ export const generateTestsAction: ActionFunction = async ({ params }) => {
 };
 
 export const accessAIApiAction: ActionFunction = async ({ params }) => {
-  console.log('AI');
   const { organizationId, projectId, workspaceId } = params;
 
   invariant(typeof organizationId === 'string', 'Organization ID is required');

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -7,7 +7,7 @@ import * as session from '../../account/session';
 import { parseApiSpec, resolveComponentSchemaRefs } from '../../common/api-specs';
 import { ACTIVITY_DEBUG, ACTIVITY_SPEC } from '../../common/constants';
 import { database } from '../../common/database';
-import { importResources, scanResources } from '../../common/import';
+import { importResourcesToWorkspace, scanResources } from '../../common/import';
 import { generateId } from '../../common/misc';
 import * as models from '../../models';
 import * as workspaceOperations from '../../models/helpers/workspace-operations';
@@ -512,8 +512,7 @@ export const generateCollectionFromApiSpecAction: ActionFunction = async ({
     content: apiSpec.contents,
   });
 
-  await importResources({
-    projectId,
+  await importResourcesToWorkspace({
     workspaceId,
   });
 

--- a/packages/insomnia/src/ui/routes/import.tsx
+++ b/packages/insomnia/src/ui/routes/import.tsx
@@ -71,13 +71,12 @@ export interface ImportResourcesActionResult {
 export const importResourcesAction: ActionFunction = async ({ request }): Promise<ImportResourcesActionResult | Response> => {
   const formData = await request.formData();
 
+  // TODO: get multiple workspaces
   const organizationId = formData.get('organizationId');
   const projectId = formData.get('projectId');
   const workspaceId = formData.get('workspaceId');
+  // Q: why do we need this? for postman imports
   const scope = formData.get('scope') || 'design';
-  const name = formData.get('name');
-
-  const workspaceName = typeof name === 'string' ? name : 'Untitled';
 
   invariant(typeof organizationId === 'string', 'OrganizationId is required.');
   invariant(typeof projectId === 'string', 'ProjectId is required.');
@@ -91,8 +90,7 @@ export const importResourcesAction: ActionFunction = async ({ request }): Promis
 
   const result = await importResources({
     projectId: project._id,
-    workspaceId,
-    workspaceName,
+    workspaceId: workspaceId || 'create-new-workspace-id',
   });
 
   return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${result.workspace._id}/${

--- a/packages/insomnia/src/ui/routes/import.tsx
+++ b/packages/insomnia/src/ui/routes/import.tsx
@@ -69,7 +69,6 @@ export const importResourcesAction: ActionFunction = async ({ request }): Promis
 
   invariant(typeof organizationId === 'string', 'OrganizationId is required.');
   invariant(typeof projectId === 'string', 'ProjectId is required.');
-  invariant(typeof workspaceId === 'string', 'WorkspaceId is required.');
   // when importing through insomnia://app/import, projectId is not provided
   if (!projectId) {
     projectId = DEFAULT_PROJECT_ID;
@@ -77,7 +76,7 @@ export const importResourcesAction: ActionFunction = async ({ request }): Promis
 
   const project = await models.project.getById(projectId);
   invariant(project, 'Project not found.');
-  if (workspaceId) {
+  if (typeof workspaceId === 'string' && workspaceId) {
     const result = await importResourcesToWorkspace({
       workspaceId: workspaceId,
     });

--- a/packages/insomnia/src/ui/routes/import.tsx
+++ b/packages/insomnia/src/ui/routes/import.tsx
@@ -68,9 +68,8 @@ export const importResourcesAction: ActionFunction = async ({ request }): Promis
   const workspaceId = formData.get('workspaceId');
 
   invariant(typeof organizationId === 'string', 'OrganizationId is required.');
-  invariant(typeof projectId === 'string', 'ProjectId is required.');
   // when importing through insomnia://app/import, projectId is not provided
-  if (!projectId) {
+  if (typeof projectId !== 'string' || !projectId) {
     projectId = DEFAULT_PROJECT_ID;
   }
 

--- a/packages/insomnia/src/ui/routes/import.tsx
+++ b/packages/insomnia/src/ui/routes/import.tsx
@@ -74,6 +74,7 @@ export const importResourcesAction: ActionFunction = async ({ request }): Promis
   const project = await models.project.getById(projectId);
   invariant(project, 'Project not found.');
   if (workspaceId) {
+    // NOTE: perhaps we don't need this
     const result = await importResourcesToWorkspace({
       workspaceId: workspaceId,
     });

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1072,6 +1072,7 @@ const ProjectRoute: FC = () => {
         {importModalType && (
           <ImportModal
             onHide={() => setImportModalType(null)}
+            projectName={activeProject.name}
             from={{ type: importModalType }}
             organizationId={organizationId}
             defaultProjectId={activeProject._id}

--- a/packages/insomnia/src/ui/routes/root.tsx
+++ b/packages/insomnia/src/ui/routes/root.tsx
@@ -242,10 +242,9 @@ const Root = () => {
     );
   }, []);
 
-  const { organizationId, projectId, workspaceId } = useParams() as {
+  const { organizationId, projectId } = useParams() as {
     organizationId: string;
     projectId?: string;
-    workspaceId?: string;
   };
 
   return (
@@ -260,8 +259,7 @@ const Root = () => {
                 onHide={() => setImportUri('')}
                 projectName="Insomnia"
                 organizationId={organizationId}
-                defaultProjectId={projectId || ''}
-                defaultWorkspaceId={workspaceId} // TODO: fall back to last active workspace, or first workspace
+                defaultProjectId={projectId || ''} // TODO: get default or lastactive
                 from={{ type: 'uri', defaultValue: importUri }}
               />
             )}

--- a/packages/insomnia/src/ui/routes/root.tsx
+++ b/packages/insomnia/src/ui/routes/root.tsx
@@ -242,9 +242,8 @@ const Root = () => {
     );
   }, []);
 
-  const { organizationId, projectId } = useParams() as {
+  const { organizationId } = useParams() as {
     organizationId: string;
-    projectId?: string;
   };
 
   return (
@@ -254,12 +253,12 @@ const Root = () => {
         <div className="app">
           <ErrorBoundary showAlert>
             <Modals />
+            {/* triggered by insomnia://app/import */}
             {importUri && (
               <ImportModal
                 onHide={() => setImportUri('')}
                 projectName="Insomnia"
                 organizationId={organizationId}
-                defaultProjectId={projectId || ''} // TODO: get default or lastactive
                 from={{ type: 'uri', defaultValue: importUri }}
               />
             )}

--- a/packages/insomnia/src/ui/routes/root.tsx
+++ b/packages/insomnia/src/ui/routes/root.tsx
@@ -258,9 +258,10 @@ const Root = () => {
             {importUri && (
               <ImportModal
                 onHide={() => setImportUri('')}
+                projectName="Insomnia"
                 organizationId={organizationId}
                 defaultProjectId={projectId || ''}
-                defaultWorkspaceId={workspaceId}
+                defaultWorkspaceId={workspaceId} // TODO: fall back to last active workspace, or first workspace
                 from={{ type: 'uri', defaultValue: importUri }}
               />
             )}

--- a/packages/insomnia/src/ui/routes/workspace.tsx
+++ b/packages/insomnia/src/ui/routes/workspace.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { LoaderFunction, Outlet, useLoaderData } from 'react-router-dom';
 
+import { database as db } from '../../common/database';
 import * as models from '../../models';
 import { GitRepository } from '../../models/git-repository';
+import { isGrpcRequest } from '../../models/grpc-request';
 import { Project } from '../../models/project';
+import { isRequest } from '../../models/request';
+import { isWebSocketRequest } from '../../models/websocket-request';
 import { Workspace } from '../../models/workspace';
 import { WorkspaceMeta } from '../../models/workspace-meta';
 import { invariant } from '../../utils/invariant';
-
 export interface WorkspaceLoaderData {
   activeWorkspace: Workspace;
   activeWorkspaceMeta?: WorkspaceMeta;
@@ -30,11 +33,18 @@ export const workspaceLoader: LoaderFunction = async ({
   await models.environment.getOrCreateForParentId(workspaceId);
   await models.cookieJar.getOrCreateForParentId(workspaceId);
   await models.workspaceMeta.getOrCreateByParentId(workspaceId);
-  const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(workspaceId);
+  let workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(workspaceId);
   const activeProject = await models.project.getById(projectId);
   invariant(activeProject, 'Project not found');
 
   const gitRepository = await models.gitRepository.getById(workspaceMeta.gitRepositoryId || '');
+  if (!workspaceMeta.activeRequestId) {
+    // TODO: review this
+    const requests = (await db.withDescendants(workspace, models.request.type)).filter(r => isRequest(r) || isWebSocketRequest(r) || isGrpcRequest(r)).sort((a, b) => b.metaSortKey - a.metaSortKey);
+    if (requests.length) {
+      workspaceMeta = await models.workspaceMeta.update(workspaceMeta, { activeRequestId: requests[0]._id });
+    }
+  }
   return {
     activeWorkspace: workspace,
     activeProject,

--- a/packages/insomnia/src/utils/importers/convert.ts
+++ b/packages/insomnia/src/utils/importers/convert.ts
@@ -2,14 +2,14 @@ import { ImportRequest } from './entities';
 import { importers } from './importers';
 import { setDefaults } from './utils';
 
-export interface ConvertResultType {
+export interface InsomniaImporter {
   id: string;
   name: string;
   description: string;
 }
 
 export interface ConvertResult<T = {}> {
-  type: ConvertResultType;
+  type: InsomniaImporter;
   data: {
     _type: 'export';
     __export_format: 4;


### PR DESCRIPTION
add support for multiple workspaces in one import file

### highlights

- removes project and workspace selection, in favour of context and duplication of workspaces
- removes import api spec import as a copy and paste would suffice
- when importing from a run button, its possible to include no project or workspace so we should fallback to the default project and create a new workspace using a title found in the import file.
- fixes incorrect logic which was importing collections as design documents
- you can now import a whole project backup into an existing project, duplicating any already existing resources.
- moves code coverage behind a CI flag

### todo

- [x] fix export file name
 - [x] remove selects
 - [x] update scan results for multiple workspaces
 - [x] update project name in title and labels to indicate context
 - [x] remove workspace name override
 - [x] decide on iteration approach to actual import

<img width="957" alt="image" src="https://github.com/Kong/insomnia/assets/3679927/4876f9ca-5a50-44b3-a602-f5a33848f9ac">

closes INS-2660
changelog(Improvements): Added support for importing multiple workspaces from one file.