### PR TITLE
chore: change electron-builder mac notarize config

### DIFF
--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -62,7 +62,7 @@ const config = {
       NSRequiresAquaSystemAppearance: false,
     },
     notarize: {
-      teamId: 'REPLACE_WITH_TEAM_ID',
+      teamId: 'FX44YY62GV',
     },
     asarUnpack: [
       'node_modules/@getinsomnia/node-libcurl',

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -62,7 +62,7 @@ const config = {
       NSRequiresAquaSystemAppearance: false,
     },
     notarize: {
-      appBundleId: 'com.insomnia.app',
+      teamId: 'REPLACE_WITH_TEAM_ID',
     },
     asarUnpack: [
       'node_modules/@getinsomnia/node-libcurl',


### PR DESCRIPTION
Related to 
```
2023-06-21 16:39:25.441 *** Warning: altool has been deprecated for notarization 
and starting in late 2023 will no longer be supported by the Apple notary service. 
You should start using notarytool to notarize your software. (-1030)
``` 

By setting `teamId` instead - it will make electron-builder use `notarytool`, see https://github.com/electron-userland/electron-builder/blob/46524169cefbfa18e342d7fa19e79e710aae848e/packages/app-builder-lib/src/macPackager.ts#L520

- see https://github.com/electron/notarize
- see https://github.com/electron-userland/electron-builder/blob/46524169cefbfa18e342d7fa19e79e710aae848e/packages/app-builder-lib/src/macPackager.ts#L520

### TODO
- [x] replace the `teamId` with our own

cc  @jackkav @gatzjames 