### PR TITLE
improve in-app update experience

### DIFF
--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -223,7 +223,7 @@ async function _trackStats() {
     if (!justUpdated || !currentVersion) {
       return;
     }
-
+    console.log('[main] App update detected', currentVersion, lastVersion);
     const notification: ToastNotification = {
       key: `updated-${currentVersion}`,
       url: changelogUrl(),

--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -145,7 +145,7 @@ const _launchApp = async () => {
   await _trackStats();
   let window: BrowserWindow;
   // Handle URLs sent via command line args
-  ipcMain.once('window-ready', () => {
+  ipcMain.once('halfSecondAfterAppStart', () => {
     console.log('[main] Window ready, handling command line arguments', process.argv);
     const args = process.argv.slice(1).filter(a => a !== '.');
     if (args.length) {
@@ -215,7 +215,7 @@ async function _trackStats() {
     launches: oldStats.launches + 1,
   });
 
-  ipcMain.once('window-ready', () => {
+  ipcMain.once('halfSecondAfterAppStart', () => {
     const { currentVersion, launches, lastVersion } = stats;
 
     const firstLaunch = launches === 1;

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -17,7 +17,8 @@ import { gRPCBridgeAPI } from './grpc';
 
 export interface MainBridgeAPI {
   restart: () => void;
-  checkForUpdates: () => void;
+  halfSecondAfterAppStart: () => void;
+  manualUpdateCheck: () => void;
   exportAllWorkspaces: () => Promise<void>;
   spectralRun: (options: { contents: string; rulesetPath: string }) => Promise<ISpectralDiagnostic[]>;
   authorizeUserInWindow: typeof authorizeUserInWindow;

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -17,6 +17,7 @@ import { gRPCBridgeAPI } from './grpc';
 
 export interface MainBridgeAPI {
   restart: () => void;
+  checkForUpdates: () => void;
   exportAllWorkspaces: () => Promise<void>;
   spectralRun: (options: { contents: string; rulesetPath: string }) => Promise<ISpectralDiagnostic[]>;
   authorizeUserInWindow: typeof authorizeUserInWindow;

--- a/packages/insomnia/src/main/updates.ts
+++ b/packages/insomnia/src/main/updates.ts
@@ -101,6 +101,8 @@ export async function init() {
   autoUpdater.on('update-downloaded', async (_error, _releaseNotes, releaseName) => {
     console.log(`[updater] Downloaded ${releaseName}`);
 
+    _sendUpdateStatus('Performing backup...');
+
     await exportAllWorkspaces();
 
     _sendUpdateComplete(true, 'Updated (Restart Required)');

--- a/packages/insomnia/src/main/updates.ts
+++ b/packages/insomnia/src/main/updates.ts
@@ -5,7 +5,6 @@ import {
   getAppId,
   getAppVersion,
   isDevelopment,
-  updatesSupported,
   UpdateURL,
 } from '../common/constants';
 import { delay } from '../common/misc';
@@ -13,16 +12,28 @@ import * as models from '../models/index';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from '../utils/url/querystring';
 import { exportAllWorkspaces } from './export';
 const { autoUpdater, BrowserWindow, ipcMain } = electron;
-
-async function getUpdateUrl(force: boolean): Promise<string | null> {
-  const platform = process.platform;
-  const settings = await models.settings.getOrCreate();
-  let updateUrl: string | null = null;
-
-  if (!updatesSupported()) {
-    return null;
+const canUpdate = () => {
+  if (process.platform === 'linux') {
+    console.log('[updater] Not supported on this platform', process.platform);
+    return false;
   }
-
+  if (process.platform === 'win32' && process.env['PORTABLE_EXECUTABLE_DIR']) {
+    console.log('[updater] Not supported on portable windows binary');
+    return false;
+  }
+  if (process.env.INSOMNIA_DISABLE_AUTOMATIC_UPDATES) {
+    console.log('[updater] Disabled by INSOMNIA_DISABLE_AUTOMATIC_UPDATES environment variable');
+    return false;
+  }
+  if (isDevelopment()) {
+    console.log('[updater] Disabled in dev mode');
+    return false;
+  }
+  return true;
+};
+const getUpdateUrl = (updateChannel: string): string | null => {
+  const platform = process.platform;
+  let updateUrl: string | null = null;
   if (platform === 'win32') {
     updateUrl = UpdateURL.windows;
   } else if (platform === 'darwin') {
@@ -30,7 +41,6 @@ async function getUpdateUrl(force: boolean): Promise<string | null> {
   } else {
     return null;
   }
-
   const params = [
     {
       name: 'v',
@@ -42,126 +52,96 @@ async function getUpdateUrl(force: boolean): Promise<string | null> {
     },
     {
       name: 'channel',
-      value: settings.updateChannel,
+      value: updateChannel,
     },
   ];
   const qs = buildQueryStringFromParams(params);
   const fullUrl = joinUrlAndQueryString(updateUrl, qs);
   console.log(`[updater] Using url ${fullUrl}`);
-
-  if (process.env.INSOMNIA_DISABLE_AUTOMATIC_UPDATES) {
-    console.log('[updater] Disabled by INSOMNIA_DISABLE_AUTOMATIC_UPDATES environment variable');
-    return null;
-  }
-
-  if (isDevelopment()) {
-    return null;
-  }
-
-  if (!force && !settings.updateAutomatically) {
-    return null;
-  }
-
   return fullUrl;
-}
+};
 
-function _sendUpdateStatus(status: string) {
+const _sendUpdateStatus = (status: string) => {
   for (const window of BrowserWindow.getAllWindows()) {
     window.webContents.send('updater.check.status', status);
   }
-}
+};
 
-function _sendUpdateComplete(msg: string) {
+const _sendUpdateComplete = (msg: string) => {
   for (const window of BrowserWindow.getAllWindows()) {
     window.webContents.send('updater.check.complete', msg);
   }
-}
+};
 
-let hasPromptedForUpdates = false;
-export async function init() {
+let hasDownloadedUpdateAndShownPrompt = false;
+export const init = async () => {
   autoUpdater.on('error', error => {
     console.warn(`[updater] Error: ${error.message}`);
   });
   autoUpdater.on('update-not-available', () => {
     console.log('[updater] Not Available');
-
     _sendUpdateComplete('Up to Date');
   });
   autoUpdater.on('update-available', () => {
     console.log('[updater] Update Available');
-
     _sendUpdateStatus('Downloading...');
   });
-  autoUpdater.on('update-downloaded', async (_error, _releaseNotes, releaseName) => {
-    console.log(`[updater] Downloaded ${releaseName}`);
-
+  autoUpdater.on('update-downloaded', async (_event, releaseNotes, releaseName) => {
+    console.log(`[updater] Downloaded ${releaseName}`, releaseNotes);
     _sendUpdateStatus('Performing backup...');
-
     await exportAllWorkspaces();
-
     _sendUpdateComplete('Updated (Restart Required)');
-
-    _showUpdateNotification();
+    if (hasDownloadedUpdateAndShownPrompt) {
+      return;
+    }
+    const windows = BrowserWindow.getAllWindows();
+    if (windows.length && windows[0].webContents) {
+      windows[0].webContents.send('update-available');
+    }
+    hasDownloadedUpdateAndShownPrompt = true;
   });
-  ipcMain.on('updater.check', async () => {
-    await _checkForUpdates(true);
+
+  // on app start
+  const settings = await models.settings.getOrCreate();
+  const updateUrl = getUpdateUrl(settings.updateChannel);
+  if (settings.updateAutomatically && updateUrl) {
+    _checkForUpdates(updateUrl);
+  }
+  // on check now button pushed
+  ipcMain.on('manualUpdateCheck', async () => {
+    const settings = await models.settings.getOrCreate();
+    const updateUrl = getUpdateUrl(settings.updateChannel);
+    if (!canUpdate() || !updateUrl) {
+      _sendUpdateComplete('Updates Not Supported');
+      return;
+    }
+    _sendUpdateStatus('Checking');
+    await delay(300); // Pacing
+    _checkForUpdates(updateUrl);
   });
-  // Check for updates on an interval
-  setInterval(async () => {
-    await _checkForUpdates(false);
-  }, CHECK_FOR_UPDATES_INTERVAL);
-  // Check for updates immediately
-  await _checkForUpdates(false);
-}
+  // on an interval (3h)
+  if (canUpdate()) {
+    setInterval(async () => {
+      const settings = await models.settings.getOrCreate();
+      const updateUrl = getUpdateUrl(settings.updateChannel);
+      if (settings.updateAutomatically && updateUrl) {
+        _checkForUpdates(updateUrl);
+      }
 
-function _showUpdateNotification() {
-  if (hasPromptedForUpdates) {
+    }, CHECK_FOR_UPDATES_INTERVAL);
+  }
+};
+
+const _checkForUpdates = (updateUrl: string) => {
+  if (hasDownloadedUpdateAndShownPrompt) {
     return;
   }
-
-  const windows = BrowserWindow.getAllWindows();
-
-  if (windows.length && windows[0].webContents) {
-    windows[0].webContents.send('update-available');
-  }
-
-  hasPromptedForUpdates = true;
-}
-
-async function _checkForUpdates(force: boolean) {
-  _sendUpdateStatus('Checking');
-
-  await delay(500);
-
-  if (force) {
-    hasPromptedForUpdates = false;
-  }
-
-  if (hasPromptedForUpdates) {
-    // We've already prompted for updates. Don't bug the user anymore
-    return;
-  }
-
-  const updateUrl = await getUpdateUrl(force);
-
-  if (updateUrl === null) {
-    console.log(
-      `[updater] Updater not running platform=${process.platform} dev=${isDevelopment()}`,
-    );
-
-    _sendUpdateComplete(false, 'Updates Not Supported');
-
-    return;
-  }
-
   try {
     console.log(`[updater] Checking for updates url=${updateUrl}`);
-    // @ts-expect-error -- TSCONVERSION appears to be a genuine error
-    autoUpdater.setFeedURL(updateUrl);
+    autoUpdater.setFeedURL({ url: updateUrl });
     autoUpdater.checkForUpdates();
   } catch (err) {
     console.warn('[updater] Failed to check for updates:', err.message);
-
-    _sendUpdateComplete(false, 'Update Error');
+    _sendUpdateComplete('Update Error');
   }
-}
+};

--- a/packages/insomnia/src/main/updates.ts
+++ b/packages/insomnia/src/main/updates.ts
@@ -66,20 +66,14 @@ async function getUpdateUrl(force: boolean): Promise<string | null> {
 }
 
 function _sendUpdateStatus(status: string) {
-  const windows = BrowserWindow.getAllWindows();
-
-  for (const window of windows) {
-    // @ts-expect-error -- TSCONVERSION seems to be a genuine error
-    window.send('updater.check.status', status);
+  for (const window of BrowserWindow.getAllWindows()) {
+    window.webContents.send('updater.check.status', status);
   }
 }
 
-function _sendUpdateComplete(success: boolean, msg: string) {
-  const windows = BrowserWindow.getAllWindows();
-
-  for (const window of windows) {
-    // @ts-expect-error -- TSCONVERSION seems to be a genuine error
-    window.send('updater.check.complete', success, msg);
+function _sendUpdateComplete(msg: string) {
+  for (const window of BrowserWindow.getAllWindows()) {
+    window.webContents.send('updater.check.complete', msg);
   }
 }
 
@@ -91,7 +85,7 @@ export async function init() {
   autoUpdater.on('update-not-available', () => {
     console.log('[updater] Not Available');
 
-    _sendUpdateComplete(false, 'Up to Date');
+    _sendUpdateComplete('Up to Date');
   });
   autoUpdater.on('update-available', () => {
     console.log('[updater] Update Available');
@@ -105,7 +99,7 @@ export async function init() {
 
     await exportAllWorkspaces();
 
-    _sendUpdateComplete(true, 'Updated (Restart Required)');
+    _sendUpdateComplete('Updated (Restart Required)');
 
     _showUpdateNotification();
   });

--- a/packages/insomnia/src/main/updates.ts
+++ b/packages/insomnia/src/main/updates.ts
@@ -11,7 +11,7 @@ import { delay } from '../common/misc';
 import * as models from '../models/index';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from '../utils/url/querystring';
 import { exportAllWorkspaces } from './export';
-const { autoUpdater, BrowserWindow, ipcMain } = electron;
+const { autoUpdater, BrowserWindow, ipcMain, Notification } = electron;
 const canUpdate = () => {
   if (process.platform === 'linux') {
     console.log('[updater] Not supported on this platform', process.platform);
@@ -94,10 +94,14 @@ export const init = async () => {
     if (hasDownloadedUpdateAndShownPrompt) {
       return;
     }
-    const windows = BrowserWindow.getAllWindows();
-    if (windows.length && windows[0].webContents) {
-      windows[0].webContents.send('update-available');
-    }
+    setTimeout(() => {
+      console.log('[app] Update Downloaded and ready to install over existing app');
+      new Notification({
+        title: 'Insomnia Update Ready',
+        body: 'Relaunch the app for it to take effect',
+        silent: true,
+      }).show();
+    }, 1000 * 2);
     hasDownloadedUpdateAndShownPrompt = true;
   });
 

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -26,6 +26,7 @@ const grpc: gRPCBridgeAPI = {
 };
 const main: Window['main'] = {
   restart: () => ipcRenderer.send('restart'),
+  manualUpdateCheck: () => ipcRenderer.send('manualUpdateCheck'),
   exportAllWorkspaces: () => ipcRenderer.invoke('exportAllWorkspaces'),
   authorizeUserInWindow: options => ipcRenderer.invoke('authorizeUserInWindow', options),
   spectralRun: options => ipcRenderer.invoke('spectralRun', options),

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -26,6 +26,7 @@ const grpc: gRPCBridgeAPI = {
 };
 const main: Window['main'] = {
   restart: () => ipcRenderer.send('restart'),
+  halfSecondAfterAppStart: () => ipcRenderer.send('halfSecondAfterAppStart'),
   manualUpdateCheck: () => ipcRenderer.send('manualUpdateCheck'),
   exportAllWorkspaces: () => ipcRenderer.invoke('exportAllWorkspaces'),
   authorizeUserInWindow: options => ipcRenderer.invoke('authorizeUserInWindow', options),

--- a/packages/insomnia/src/ui/components/check-for-updates-button.tsx
+++ b/packages/insomnia/src/ui/components/check-for-updates-button.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 export const CheckForUpdatesButton: FC<Props> = ({ children, className }) => {
-  const [checking, setChecking] = useState(false);
+  const [disabled, setDisabled] = useState(false);
   const [status, setStatus] = useState('');
 
   useEffect(() => {
@@ -19,10 +19,12 @@ export const CheckForUpdatesButton: FC<Props> = ({ children, className }) => {
   return (
     <button
       className={className ?? ''}
-      disabled={checking}
+      disabled={disabled}
       onClick={() => {
         window.main.manualUpdateCheck();
-        setChecking(true);
+        // this is to prevent initiating update multiple times
+        // if it errors user can restart the app and try again
+        setDisabled(true);
       }}
     >
       {status || children}

--- a/packages/insomnia/src/ui/components/check-for-updates-button.tsx
+++ b/packages/insomnia/src/ui/components/check-for-updates-button.tsx
@@ -10,17 +10,10 @@ export const CheckForUpdatesButton: FC<Props> = ({ children, className }) => {
   const [status, setStatus] = useState('');
 
   useEffect(() => {
-    const statusUnsubscribe = window.main.on('updater.check.status', (_e: Electron.IpcRendererEvent, status: string) => {
-      if (checking) {
-        setStatus(status);
-      }
-    });
-    const completeUnsubscribe = window.main.on('updater.check.complete', (_e: Electron.IpcRendererEvent, status: string) => {
-      setStatus(status);
-    });
+    const unsubscribe = window.main.on('updaterStatus',
+      (_e: Electron.IpcRendererEvent, status: string) => setStatus(status));
     return () => {
-      statusUnsubscribe();
-      completeUnsubscribe();
+      unsubscribe();
     };
   });
   return (

--- a/packages/insomnia/src/ui/components/check-for-updates-button.tsx
+++ b/packages/insomnia/src/ui/components/check-for-updates-button.tsx
@@ -9,24 +9,19 @@ interface Props {
 export const CheckForUpdatesButton: FC<Props> = ({ children, className }) => {
   const [checking, setChecking] = useState(false);
   const [status, setStatus] = useState('');
-  const [, setUpdateAvailable] = useState(false);
 
-  const listenerCheckComplete = (_e: Electron.IpcRendererEvent, updateAvailable: true, status: string) => {
-    setStatus(status);
-    setUpdateAvailable(updateAvailable);
-  };
-
-  const listenerCheckStatus = (_e: Electron.IpcRendererEvent, status: string) => {
-    if (checking) {
-      setStatus(status);
-    }
-  };
   useEffect(() => {
-    electron.ipcRenderer.on('updater.check.status', listenerCheckStatus);
-    electron.ipcRenderer.on('updater.check.complete', listenerCheckComplete);
+    const statusUnsubscribe = window.main.on('updater.check.status', (_e: Electron.IpcRendererEvent, status: string) => {
+      if (checking) {
+        setStatus(status);
+      }
+    });
+    const completeUnsubscribe = window.main.on('updater.check.complete', (_e: Electron.IpcRendererEvent, status: string) => {
+      setStatus(status);
+    });
     return () => {
-      electron.ipcRenderer.removeListener('updater.check.complete', listenerCheckComplete);
-      electron.ipcRenderer.removeListener('updater.check.status', listenerCheckStatus);
+      statusUnsubscribe();
+      completeUnsubscribe();
     };
   });
   return (

--- a/packages/insomnia/src/ui/components/check-for-updates-button.tsx
+++ b/packages/insomnia/src/ui/components/check-for-updates-button.tsx
@@ -1,4 +1,3 @@
-import * as electron from 'electron';
 import React, { FC, ReactNode, useEffect, useState } from 'react';
 
 interface Props {
@@ -29,7 +28,7 @@ export const CheckForUpdatesButton: FC<Props> = ({ children, className }) => {
       className={className ?? ''}
       disabled={checking}
       onClick={() => {
-        electron.ipcRenderer.send('updater.check');
+        window.main.manualUpdateCheck();
         setChecking(true);
       }}
     >

--- a/packages/insomnia/src/ui/components/toast.tsx
+++ b/packages/insomnia/src/ui/components/toast.tsx
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import type { IpcRendererEvent } from 'electron';
-import { ipcRenderer } from 'electron';
 import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
@@ -124,11 +123,8 @@ export const Toast: FC = () => {
   };
 
   useEffect(() => {
-    const showNotification = (_: IpcRendererEvent, notification: ToastNotification) => handleNotification(notification);
-    ipcRenderer.on('show-notification', showNotification);
-    return () => {
-      ipcRenderer.removeListener('show-notification', showNotification);
-    };
+    const unsubscribe = window.main.on('show-notification', (_: IpcRendererEvent, notification: ToastNotification) => handleNotification(notification));
+    return () => unsubscribe();
   }, []);
 
   const productName = getProductName();

--- a/packages/insomnia/src/ui/containers/app-hooks.tsx
+++ b/packages/insomnia/src/ui/containers/app-hooks.tsx
@@ -1,4 +1,3 @@
-import { ipcRenderer } from 'electron';
 import { FC, useEffect } from 'react';
 
 import { useGlobalKeyboardShortcuts } from '../hooks/use-global-keyboard-shortcuts';
@@ -11,9 +10,9 @@ export const AppHooks: FC = () => {
   useSettingsSideEffects();
   useGlobalKeyboardShortcuts();
   useThemeChange();
-  // Give it a bit before letting the backend know it's ready
+  // Used for detecting if we just updated Insomnia and app --args or insomnia:// and
   useEffect(() => {
-    setTimeout(() => ipcRenderer.send('window-ready'), 500);
+    setTimeout(() => window.main.halfSecondAfterAppStart(), 500);
   }, []);
 
   return null;

--- a/packages/insomnia/src/ui/rendererListeners.ts
+++ b/packages/insomnia/src/ui/rendererListeners.ts
@@ -1,6 +1,4 @@
 
-import { ipcRenderer } from 'electron';
-
 import { isDevelopment } from '../common/constants';
 import { database } from '../common/database';
 import * as models from '../models';
@@ -14,7 +12,7 @@ import { AskModal } from './components/modals/ask-modal';
 import { SelectModal } from './components/modals/select-modal';
 import { SettingsModal, TAB_INDEX_SHORTCUTS } from './components/modals/settings-modal';
 
-ipcRenderer.on('update-available', () => {
+window.main.on('update-available', () => {
   // Give it a few seconds before showing this. Sometimes, when
   // you relaunch too soon it doesn't work the first time.
   setTimeout(() => {
@@ -29,12 +27,12 @@ ipcRenderer.on('update-available', () => {
   }, 1000 * 10);
 });
 
-ipcRenderer.on('toggle-preferences', () => {
+window.main.on('toggle-preferences', () => {
   showModal(SettingsModal);
 });
 
 if (isDevelopment()) {
-  ipcRenderer.on('clear-model', () => {
+  window.main.on('clear-model', () => {
     const options = models
       .types()
       .filter(t => t !== models.settings.type) // don't clear settings
@@ -59,7 +57,7 @@ if (isDevelopment()) {
     });
   });
 
-  ipcRenderer.on('clear-all-models', () => {
+  window.main.on('clear-all-models', () => {
     showModal(AskModal, {
       title: 'Clear all models',
       message: 'Are you sure you want to clear all models? This operation cannot be undone.',
@@ -86,7 +84,7 @@ if (isDevelopment()) {
   });
 }
 
-ipcRenderer.on('reload-plugins', async () => {
+window.main.on('reload-plugins', async () => {
   const settings = await models.settings.getOrCreate();
   await plugins.reloadPlugins();
   await themes.applyColorScheme(settings);
@@ -94,7 +92,7 @@ ipcRenderer.on('reload-plugins', async () => {
   console.log('[plugins] reloaded');
 });
 
-ipcRenderer.on('toggle-preferences-shortcuts', () => {
+window.main.on('toggle-preferences-shortcuts', () => {
   showModal(SettingsModal, { tab: TAB_INDEX_SHORTCUTS });
 });
 

--- a/packages/insomnia/src/ui/rendererListeners.ts
+++ b/packages/insomnia/src/ui/rendererListeners.ts
@@ -12,21 +12,6 @@ import { AskModal } from './components/modals/ask-modal';
 import { SelectModal } from './components/modals/select-modal';
 import { SettingsModal, TAB_INDEX_SHORTCUTS } from './components/modals/settings-modal';
 
-window.main.on('update-available', () => {
-  // Give it a few seconds before showing this. Sometimes, when
-  // you relaunch too soon it doesn't work the first time.
-  setTimeout(() => {
-    console.log('[app] Update Available');
-    // eslint-disable-next-line no-new
-    new window.Notification('Insomnia Update Ready', {
-      body: 'Relaunch the app for it to take effect',
-      silent: true,
-      // @ts-expect-error -- TSCONVERSION
-      sticky: true,
-    });
-  }, 1000 * 10);
-});
-
 window.main.on('toggle-preferences', () => {
   showModal(SettingsModal);
 });


### PR DESCRIPTION
Highlights
- moves all remaining non-database IPC methods to preload
- simplifies auto update logic
- removes unnecessary IPC calls
- noticed there is OS notification after download and in app notification after restart

todo
- [x] fix update getting stuck on `checking...`
- [x] fix update not happening after restart
- [x] move delay to downloaded event


risks
- macos notification may need a permission

future
- add toast notification, instead of OS notification for when download finishes

closes INS-2766

changelog(Improvement): Simplified app update experience:

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
