### PR TITLE
fix: curl transform - allow header without value

### DIFF
--- a/packages/insomnia/src/utils/importers/importers/curl.ts
+++ b/packages/insomnia/src/utils/importers/importers/curl.ts
@@ -123,9 +123,15 @@ const importCommand = (parseEntries: ParseEntry[]): ImportRequest => {
     ...((pairsByName.H as string[] | undefined) || []),
   ].map(header => {
     const [name, value] = header.split(/:(.*)$/);
+    // remove final colon from header name if present
+    if (!value) {
+      return {
+        name: name.trim().replace(/;$/, ''),
+      };
+    }
     return {
       name: name.trim(),
-      value: value.trim(),
+      value: value?.trim() || '',
     };
   });
 

--- a/packages/insomnia/src/utils/importers/importers/curl.ts
+++ b/packages/insomnia/src/utils/importers/importers/curl.ts
@@ -131,7 +131,7 @@ const importCommand = (parseEntries: ParseEntry[]): ImportRequest => {
     }
     return {
       name: name.trim(),
-      value: value?.trim() || '',
+      value: value.trim(),
     };
   });
 

--- a/packages/insomnia/src/utils/importers/importers/curl.ts
+++ b/packages/insomnia/src/utils/importers/importers/curl.ts
@@ -127,6 +127,7 @@ const importCommand = (parseEntries: ParseEntry[]): ImportRequest => {
     if (!value) {
       return {
         name: name.trim().replace(/;$/, ''),
+        value: '',
       };
     }
     return {


### PR DESCRIPTION
fixes bug where import would fail if a curl is provided with a header in the form of `my-header;` without a value eg. `my-header:myvalue`
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
