### PR TITLE
Add: 5xx unofficial HTTP codes and handle 'Unknown' status messages

### DIFF
--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -475,8 +475,11 @@ export const RESPONSE_CODE_DESCRIPTIONS: Record<number, string> = {
   506: 'The server has an internal configuration error: transparent content negotiation for the request results in a circular reference.',
   507: 'The server has an internal configuration error: the chosen variant resource is configured to engage in transparent content negotiation itself, and is therefore not a proper end point in the negotiation process.',
   508: 'The server detected an infinite loop while processing the request.',
+  509: 'The server has exceeded the bandwidth specified by the server administrator; this is often used by shared hosting providers to limit the bandwidth of customers.',
   510: 'Further extensions to the request are required for the server to fulfill it.',
   511: 'The 511 status code indicates that the client needs to authenticate to gain network access.',
+  598: 'Used by some HTTP proxies to signal a network read timeout behind the proxy to a client in front of the proxy.',
+  599: 'An error used by some HTTP proxies to signal a network connect timeout behind the proxy to a client in front of the proxy.',
 };
 
 export const RESPONSE_CODE_REASONS: Record<number, string> = {
@@ -546,8 +549,11 @@ export const RESPONSE_CODE_REASONS: Record<number, string> = {
   506: 'Variant Also Negotiates',
   507: 'Insufficient Storage',
   508: 'Loop Detected',
+  509: 'Bandwidth Limit Exceeded',
   510: 'Not Extended',
   511: 'Network Authentication Required',
+  598: 'Network read timeout error',
+  599: 'Network Connect Timeout Error',
 };
 
 export const WORKSPACE_ID_KEY = '__WORKSPACE_ID__';

--- a/packages/insomnia/src/ui/components/tags/status-tag.tsx
+++ b/packages/insomnia/src/ui/components/tags/status-tag.tsx
@@ -15,8 +15,8 @@ export const StatusTag: FC<Props> = memo(({ statusMessage, statusCode, small, to
   let colorClass;
   let statusCodeToDisplay: string | number = statusCode;
   const firstChar = (statusCode + '')[0] || '';
-  const unknownPattern = /^unknown$/i;
-  const isStatusMessageUnknown = statusMessage && unknownPattern.test(statusMessage);
+  const isStatusMessageUnknown = statusMessage === 'Unknown' || statusMessage === 'unknown';
+  const unknownStatusMessage = RESPONSE_CODE_REASONS[statusCode] || statusMessage;
 
   switch (firstChar) {
     case '1':
@@ -60,7 +60,7 @@ export const StatusTag: FC<Props> = memo(({ statusMessage, statusCode, small, to
     >
       <Tooltip message={description} position="bottom" delay={tooltipDelay}>
         <strong>{statusCodeToDisplay}</strong>{' '}
-        {isStatusMessageUnknown ? RESPONSE_CODE_REASONS[statusCode] || statusMessage : statusMessage || RESPONSE_CODE_REASONS[statusCode]}
+        {isStatusMessageUnknown ? unknownStatusMessage : statusMessage || RESPONSE_CODE_REASONS[statusCode]}
       </Tooltip>
     </div>
   );

--- a/packages/insomnia/src/ui/components/tags/status-tag.tsx
+++ b/packages/insomnia/src/ui/components/tags/status-tag.tsx
@@ -15,8 +15,6 @@ export const StatusTag: FC<Props> = memo(({ statusMessage, statusCode, small, to
   let colorClass;
   let statusCodeToDisplay: string | number = statusCode;
   const firstChar = (statusCode + '')[0] || '';
-  const isStatusMessageUnknown = statusMessage === 'Unknown' || statusMessage === 'unknown';
-  const unknownStatusMessage = RESPONSE_CODE_REASONS[statusCode] || statusMessage;
 
   switch (firstChar) {
     case '1':
@@ -51,16 +49,19 @@ export const StatusTag: FC<Props> = memo(({ statusMessage, statusCode, small, to
   }
 
   const description = RESPONSE_CODE_DESCRIPTIONS[statusCode] || 'Unknown Response Code';
+  const isStatusMessageUnknown = statusMessage === 'Unknown' || statusMessage === 'unknown';
+  let statusMessageToShow = statusMessage || RESPONSE_CODE_REASONS[statusCode];
+  if (isStatusMessageUnknown) {
+    statusMessageToShow = RESPONSE_CODE_REASONS[statusCode] || statusMessage;
+  }
   return (
     <div
-      className={classnames('tag', colorClass, {
-        'tag--small': small,
-      })}
+      className={classnames('tag', colorClass, { 'tag--small': small })}
       data-testid="response-status-tag"
     >
       <Tooltip message={description} position="bottom" delay={tooltipDelay}>
         <strong>{statusCodeToDisplay}</strong>{' '}
-        {isStatusMessageUnknown ? unknownStatusMessage : statusMessage || RESPONSE_CODE_REASONS[statusCode]}
+        {statusMessageToShow}
       </Tooltip>
     </div>
   );

--- a/packages/insomnia/src/ui/components/tags/status-tag.tsx
+++ b/packages/insomnia/src/ui/components/tags/status-tag.tsx
@@ -12,40 +12,20 @@ interface Props {
 }
 
 export const StatusTag: FC<Props> = memo(({ statusMessage, statusCode, small, tooltipDelay }) => {
-  let colorClass;
   let statusCodeToDisplay: string | number = statusCode;
   const firstChar = (statusCode + '')[0] || '';
 
-  switch (firstChar) {
-    case '1':
-      colorClass = 'bg-info';
-      break;
+  const colorClass = {
+    '1': 'bg-info',
+    '2': 'bg-success',
+    '3': 'bg-surprise',
+    '4': 'bg-warning',
+    '5': 'bg-danger',
+    '0': 'bg-danger',
+  }[firstChar] || 'bg-surprise';
 
-    case '2':
-      colorClass = 'bg-success';
-      break;
-
-    case '3':
-      colorClass = 'bg-surprise';
-      break;
-
-    case '4':
-      colorClass = 'bg-warning';
-      break;
-
-    case '5':
-      colorClass = 'bg-danger';
-      break;
-
-    case '0':
-      colorClass = 'bg-danger';
-      statusCodeToDisplay = '';
-      break;
-
-    default:
-      colorClass = 'bg-surprise';
-      statusCodeToDisplay = '';
-      break;
+  if (firstChar === '0') {
+    statusCodeToDisplay = '';
   }
 
   const description = RESPONSE_CODE_DESCRIPTIONS[statusCode] || 'Unknown Response Code';

--- a/packages/insomnia/src/ui/components/tags/status-tag.tsx
+++ b/packages/insomnia/src/ui/components/tags/status-tag.tsx
@@ -15,6 +15,8 @@ export const StatusTag: FC<Props> = memo(({ statusMessage, statusCode, small, to
   let colorClass;
   let statusCodeToDisplay: string | number = statusCode;
   const firstChar = (statusCode + '')[0] || '';
+  const unknownPattern = /^unknown$/i;
+  const isStatusMessageUnknown = statusMessage && unknownPattern.test(statusMessage);
 
   switch (firstChar) {
     case '1':
@@ -58,7 +60,7 @@ export const StatusTag: FC<Props> = memo(({ statusMessage, statusCode, small, to
     >
       <Tooltip message={description} position="bottom" delay={tooltipDelay}>
         <strong>{statusCodeToDisplay}</strong>{' '}
-        {statusMessage || RESPONSE_CODE_REASONS[statusCode]}
+        {isStatusMessageUnknown ? RESPONSE_CODE_REASONS[statusCode] || statusMessage : statusMessage || RESPONSE_CODE_REASONS[statusCode]}
       </Tooltip>
     </div>
   );


### PR DESCRIPTION
Closes #6068 

- Added the HTTP status codes 509, 598, and 599 to the constants. 
- Most unofficial HTTP codes return an 'Unknown' status message from the application server unless specifically configured. Therefore, I've made a change so that if an 'Unknown' status message is received, it will first check RESPONSE_CODE_REASONS, and if not found there, it will output the status message.
