### PR TITLE
fix: Issue with incorrect OperationName applied on GraphQL request

### DIFF
--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -291,6 +291,10 @@ export const GraphQLEditor: FC<Props> = ({
         }
       }
 
+      if (!operationName) {
+        delete state.body.operationName;
+      }
+
       const content = getGraphQLContent(state.body, query);
       onChange(content);
 

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -295,7 +295,7 @@ export const GraphQLEditor: FC<Props> = ({
         delete state.body.operationName;
       }
 
-      const content = getGraphQLContent(state.body, query);
+      const content = getGraphQLContent(state.body, query, operationName);
       onChange(content);
 
       setState(state => ({


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where the Operation Name wasn't being correctly transferred to the GraphQL Body when modifying the GraphQL Query


I've made changes to correct an issue where the Operation Name wasn't being correctly transferred to the GraphQL Body when modifying the GraphQL Query.

There might be a connection with issue #5752 
## There were two primary issues:

- an issue was observed where the previous Operation Name was passed to the GraphQL Body, even when the Operation Name in the GraphQL Query was empty. To address this, we've adjusted the logic so that if the Operation Name is absent, the state.body.operationName deleted, preventing it from being transferred.

- there was a delay in the application of changes to the Operation Name in the GraphQL Query. To rectify this, the getGraphQLContent function has been updated to include the current Operation Name as an argument when called, ensuring its immediate application.
