### PR TITLE
Add feature: synchronization to workspace

### DIFF
--- a/packages/insomnia/src/common/__fixtures__/insomnia/basic-import.json
+++ b/packages/insomnia/src/common/__fixtures__/insomnia/basic-import.json
@@ -1,0 +1,76 @@
+{
+    "_type": "export",
+    "__export_format": 4,
+    "__export_date": "2017-11-24T16:14:14.805Z",
+    "__export_source": "insomnia.desktop.app:v5.12.0-beta.3",
+    "resources": [
+        {
+            "_id": "wrk_imported_1",
+            "created": 888,
+            "modified": 999,
+            "description": "",
+            "name": "New",
+            "parentId": null,
+            "_type": "workspace"
+        },
+        {
+            "_id": "env_imported_0",
+            "parentId": "wrk_imported_1",
+            "modified": 777,
+            "created": 666,
+            "name": "Base Environment",
+            "data": {
+                "test": "value"
+            },
+            "dataPropertyOrder": {
+                "&": [
+                    "test"
+                ]
+            },
+            "color": null,
+            "isPrivate": false,
+            "metaSortKey": 1687966554558,
+            "_type": "environment"
+        },
+        {
+            "_id": "env_imported_1",
+            "parentId": "env_imported_0",
+            "modified": 555,
+            "created": 444,
+            "name": "Sub Environment",
+            "data": {
+                "test-2": "value-2"
+            },
+            "dataPropertyOrder": {
+                "&": [
+                    "test-2"
+                ]
+            },
+            "color": null,
+            "isPrivate": false,
+            "metaSortKey": 1687966554558,
+            "_type": "environment"
+        },
+        {
+            "_id": "req_imported_1",
+            "authentication": {},
+            "body": {},
+            "created": 111,
+            "modified": 222,
+            "metaSortKey": 0,
+            "description": "",
+            "headers": [],
+            "method": "GET",
+            "name": "Test",
+            "parameters": [],
+            "parentId": "wrk_imported_1",
+            "settingDisableRenderRequestBody": false,
+            "settingEncodeUrl": true,
+            "settingSendCookies": true,
+            "settingStoreCookies": true,
+            "settingFollowRedirects": "global",
+            "url": "https://insomnia.rest/api/tests/0",
+            "_type": "request"
+        }
+    ]
+}

--- a/packages/insomnia/src/common/__fixtures__/insomnia/placeholders-import.json
+++ b/packages/insomnia/src/common/__fixtures__/insomnia/placeholders-import.json
@@ -1,0 +1,76 @@
+{
+    "_type": "export",
+    "__export_format": 4,
+    "__export_date": "2017-11-24T16:14:14.805Z",
+    "__export_source": "insomnia.desktop.app:v5.12.0-beta.3",
+    "resources": [
+        {
+            "_id": "__WORKSPACE_ID__",
+            "created": 888,
+            "modified": 999,
+            "description": "",
+            "name": "New",
+            "parentId": null,
+            "_type": "workspace"
+        },
+        {
+            "_id": "__BASE_ENVIRONMENT_ID__",
+            "parentId": "__WORKSPACE_ID__",
+            "modified": 777,
+            "created": 666,
+            "name": "Base Environment",
+            "data": {
+                "test": "value"
+            },
+            "dataPropertyOrder": {
+                "&": [
+                    "test"
+                ]
+            },
+            "color": null,
+            "isPrivate": false,
+            "metaSortKey": 1687966554558,
+            "_type": "environment"
+        },
+        {
+            "_id": "env_imported_1",
+            "parentId": "__BASE_ENVIRONMENT_ID__",
+            "modified": 555,
+            "created": 444,
+            "name": "Sub Environment",
+            "data": {
+                "test-2": "value-2"
+            },
+            "dataPropertyOrder": {
+                "&": [
+                    "test-2"
+                ]
+            },
+            "color": null,
+            "isPrivate": false,
+            "metaSortKey": 1687966554558,
+            "_type": "environment"
+        },
+        {
+            "_id": "req_imported_1",
+            "authentication": {},
+            "body": {},
+            "created": 111,
+            "modified": 222,
+            "metaSortKey": 0,
+            "description": "",
+            "headers": [],
+            "method": "GET",
+            "name": "Test",
+            "parameters": [],
+            "parentId": "__WORKSPACE_ID__",
+            "settingDisableRenderRequestBody": false,
+            "settingEncodeUrl": true,
+            "settingSendCookies": true,
+            "settingStoreCookies": true,
+            "settingFollowRedirects": "global",
+            "url": "https://insomnia.rest/api/tests/0",
+            "_type": "request"
+        }
+    ]
+}

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -1,9 +1,9 @@
-import { beforeEach, describe, expect, it } from '@jest/globals';
+import { beforeEach, describe, expect, it, test } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 
 import { globalBeforeEach } from '../../__jest__/before-each';
-import { request, requestGroup, workspace } from '../../models';
+import { request, requestGroup, workspace, environment } from '../../models';
 import { DEFAULT_PROJECT_ID } from '../../models/project';
 import * as importUtil from '../import';
 
@@ -178,4 +178,176 @@ describe('importRaw()', () => {
     expect(requests.length).toBe(12);
   });
 
+});
+
+describe('syncToWorkspaceRaw()', () => {
+  beforeEach(globalBeforeEach);
+  const fixtures = ['basic-import.json', 'placeholders-import.json'];
+
+  test.each(fixtures)('should syncronize insomnia collection to an existing workspace (%s)', async (fixture) => {
+    // arrange
+    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'insomnia', fixture);
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const existingWorkspace = await workspace.create();
+    const existingBaseEnvironment = await environment.create({ parentId: existingWorkspace._id, name: 'Base Environment' });
+    //TODO: add sub environment
+    const existsRequestGroup = await requestGroup.create({ parentId: existingWorkspace._id, name: 'Request Group 1' });
+    const request1 = await request.create({ parentId: existsRequestGroup._id, name: 'Request 1', url: 'https://insomnia.rest/api/tests/1' });
+    const request2 = await request.create({ parentId: existsRequestGroup._id, name: 'Request 2', url: 'https://insomnia.rest/api/tests/2' });
+
+    expect((await workspace.all()).length).toBe(1);
+    expect((await environment.all()).length).toBe(1);
+    expect((await requestGroup.all()).length).toBe(1);
+    expect((await request.all()).length).toBe(2);
+
+    // act
+    const scanResult = await importUtil.scanResources({
+      content,
+    });
+
+    expect(scanResult.type?.id).toBe('insomnia-4');
+    expect(scanResult.errors.length).toBe(0);
+
+    await importUtil.syncResourcesToWorkspace({
+      workspaceId: existingWorkspace._id,
+    });
+
+    // assert
+    const workspacesCount = await workspace.count();
+    expect(workspacesCount).toBe(1);
+
+    const environments = await environment.all();
+    const requestGroups = await requestGroup.all();
+    const requests = await request.all();
+
+    // expected environments
+    expect(environments.length).toBe(2);
+    [existingBaseEnvironment._id, existingBaseEnvironment._id].every(expectedid =>
+      expect(environments.find(environment => environment._id === expectedid)));
+
+    // expected request groups
+    expect(requestGroups.length).toBe(1);
+    expect(requestGroups[0].parentId).toBe(existingWorkspace._id);
+
+    // expected requests with specific parents
+    expect(requests.length).toBe(3);
+    const requestParentIds = requests.map(r => r.parentId).filter((v, i, a) => a.indexOf(v) === i);
+    expect(requestParentIds.length).toBe(2);
+    expect(requestParentIds).toContain(existsRequestGroup._id);
+    expect(requestParentIds).toContain(existingWorkspace._id);
+
+    // all requests should be pointed to expected urls
+    [
+      { id: 'req_imported_1', url: 'https://insomnia.rest/api/tests/0' },
+      { id: request1._id, url: request1.url },
+      { id: request2._id, url: request2.url },
+    ].forEach(expected => {
+      expect(requests.find(request => request._id === expected.id)).toMatchObject({
+        url: expected.url,
+      });
+    });
+  });
+
+  test.each(fixtures)('should syncronize insomnia collection to empty workspace (%s)', async (fixture) => {
+    // arrange
+    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'insomnia', fixture);
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const existingWorkspace = await workspace.create();
+    const existingBaseEnvironment = await environment.create({ parentId: existingWorkspace._id, name: 'Base Environment' });
+
+    expect((await workspace.all()).length).toBe(1);
+    expect((await environment.all()).length).toBe(1);
+    expect((await requestGroup.all()).length).toBe(0);
+    expect((await request.all()).length).toBe(0);
+
+    // act
+    const scanResult = await importUtil.scanResources({
+      content,
+    });
+
+    expect(scanResult.type?.id).toBe('insomnia-4');
+    expect(scanResult.errors.length).toBe(0);
+
+    await importUtil.syncResourcesToWorkspace({
+      workspaceId: existingWorkspace._id,
+    });
+
+    // assert
+    const workspacesCount = await workspace.count();
+    expect(workspacesCount).toBe(1);
+
+    const environments = await environment.all();
+    const requestGroups = await requestGroup.all();
+    const requests = await request.all();
+
+    // expected environments
+    expect(environments.length).toBe(2);
+    [existingBaseEnvironment._id, existingBaseEnvironment._id].every(expectedid =>
+      expect(environments.find(environment => environment._id === expectedid)));
+
+    // no request groups should be created 
+    expect(requestGroups.length).toBe(0);
+
+    // expected one specific request
+    expect(requests.length).toBe(1);
+    expect(requests[0].parentId).toBe(existingWorkspace._id);
+    expect(requests[0]).toMatchObject({
+      url: 'https://insomnia.rest/api/tests/0',
+    });
+  });
+
+  test.each(fixtures)('should not syncronize insomnia collection to workspace not exists (%s)', async (fixture) => {
+    // arrange
+    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'insomnia', fixture);
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const existingWorkspace = await workspace.create();
+    await environment.create({ parentId: existingWorkspace._id, name: 'Base Environment' });
+
+    expect((await workspace.all()).length).toBe(1);
+    expect((await environment.all()).length).toBe(1);
+
+    // act & assert
+    const scanResult = await importUtil.scanResources({
+      content,
+    });
+
+    expect(scanResult.type?.id).toBe('insomnia-4');
+    expect(scanResult.errors.length).toBe(0);
+
+    expect(async () => {
+      await importUtil.syncResourcesToWorkspace({
+        workspaceId: existingWorkspace._id + '_not_exists',
+      });
+    }).rejects
+      .toThrow("Could not find workspace");
+  });
+
+  test.each(fixtures)('should not syncronize insomnia collection to workspace without base environment (%s)', async (fixture) => {
+    // arrange
+    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'insomnia', fixture);
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const existingWorkspace = await workspace.create();
+
+    expect((await workspace.all()).length).toBe(1);
+    expect((await environment.all()).length).toBe(0);
+
+    // act & assert
+    const scanResult = await importUtil.scanResources({
+      content,
+    });
+
+    expect(scanResult.type?.id).toBe('insomnia-4');
+    expect(scanResult.errors.length).toBe(0);
+
+    expect(async () => {
+      await importUtil.syncResourcesToWorkspace({
+        workspaceId: existingWorkspace._id,
+      });
+    }).rejects
+      .toThrow("Could not find base environment");
+  });
 });

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -124,6 +124,19 @@ export const database = {
     return database.update<T>(doc);
   },
 
+  docUpsert: async <T extends BaseModel>(type: string, ...patches: Patch<T>[]) => {
+    const doc = await models.initModel<T>(
+      type,
+      ...patches,
+      // Fields that the user can't touch
+      {
+        type: type,
+        modified: Date.now(),
+      },
+    );
+    return database.upsert<T>(doc);
+  },
+
   duplicate: async function<T extends BaseModel>(originalDoc: T, patch: Patch<T> = {}) {
     if (db._empty) {
       return _send<T>('duplicate', ...arguments);

--- a/packages/insomnia/src/plugins/context/__tests__/data.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/data.test.ts
@@ -129,7 +129,6 @@ describe('app.import.*', () => {
     ]);
   });
 
-  // TODO: add test for syncToWorkspace 
   it('syncToWorkspaceRaw', async () => {
     // arrange
     // prepare workspace, base environment and make sure no requests stored
@@ -181,6 +180,44 @@ describe('app.import.*', () => {
         url: 'https://insomnia.rest',
       },
     ]);
+  });
+
+  it('syncToWorkspaceRaw.emptyContent', async () => {
+    // arrange
+    // prepare workspace, base environment and make sure no requests stored
+    const workspace = await models.workspace.getById('wrk_1');
+    expect(workspace).toBeDefined();
+    expect(await db.all(models.workspace.type)).toEqual([workspace]);
+    const baseEnvironment = await models.environment.create({ parentId: workspace!._id, data: {} });
+    expect(baseEnvironment).toBeDefined();
+    expect(await db.all(models.environment.type)).toEqual([baseEnvironment]);
+    expect(await db.count(models.request.type)).toBe(0);
+
+    // get data service as for a plugin
+    const { data } = plugin.init(project._id);
+
+    // act
+    expect(async () => {
+      await data.syncToWorkspace.raw('', workspace!._id);
+    }).rejects
+      .toThrow('No content found')
+  });
+
+  it('syncToWorkspaceRaw.emptyWorkspaceId', async () => {
+    // arrange
+    const { data } = plugin.init(project._id);
+
+    // prepare content will be used to syncronize with workspace
+    const filename = path.resolve(__dirname, '../__fixtures__/basic-import.json');
+    const content = fs.readFileSync(filename, 'utf8');
+    expect(content).toBeDefined();
+    expect(content.length).toBeGreaterThan(0);
+
+    // act
+    expect(async () => {
+      await data.syncToWorkspace.raw(content, '');
+    }).rejects
+      .toThrow('No workspace found')
   });
 });
 

--- a/packages/insomnia/src/plugins/context/data.ts
+++ b/packages/insomnia/src/plugins/context/data.ts
@@ -60,7 +60,7 @@ export const init = (activeProjectId?: string) => ({
     syncToWorkspace: {
       raw: async (content: string, workspaceId: string) => {
         invariant(content, 'No content found')
-        invariant(workspaceId, 'No content found')
+        invariant(workspaceId, 'No workspace found')
         invariant(activeProjectId, 'No active project found');
 
         const workspace = (await models.workspace.findByParentId(activeProjectId)).find(workspace => workspace._id === workspaceId);


### PR DESCRIPTION
These changes will allow plugins to synchronize a workspace as before - without generating new IDs for everything, and include environments, cookies, API spec, etc.

Nothing existing was touched, so it should be safe and not break anything. I was trying to be careful and save consistency in the code, but if you see anything to refactor - I'm open to updating it. I added tests with a few negative as well, I hope covered most of the cases.

Idea discussion can be found here #6077 