### PR TITLE
fix initial cloning of git repo

### DIFF
--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -638,6 +638,7 @@ export const updateGitRepoAction: ActionFunction = async ({
     await models.gitRepository.update(repo, repoSettingsPatch);
     gitRepositoryId = repo._id;
   } else {
+    repoSettingsPatch.needsFullClone = true;
     const gitRepository = await models.gitRepository.create(repoSettingsPatch);
     gitRepositoryId = gitRepository._id;
   }


### PR DESCRIPTION
Fix an issue where cloning a repo for the first time wouldn't clone the repo initially.