### PR TITLE
fix: Ignore oAuth2 exception on redirect of initial url load (#5926)

### DIFF
--- a/packages/insomnia/src/main/authorizeUserInWindow.ts
+++ b/packages/insomnia/src/main/authorizeUserInWindow.ts
@@ -140,17 +140,15 @@ export function authorizeUserInWindow({
     try {
       await child.loadURL(url);
     } catch (error) {
-      switch (error.errno) {
-        case URLLoadErrorCodes.ERR_ABORTED:
-          //Ignore the error as the initial url load was aborted on redirect.
-          break;
-        default:
-          // Reject with error to show result in OAuth2 tab
-          reject(error);
-          // Need to close child window here since an exception in loadURL precludes normal call in
-          // _parseUrl
-          child.close();
+      // Ignore the error as the initial url load was aborted on redirect.
+      if (error.errno === URLLoadErrorCodes.ERR_ABORTED) {
+        return;
       }
+      // Reject with error to show result in OAuth2 tab
+      reject(error);
+      // Need to close child window here since an exception in loadURL precludes normal call in
+      // _parseUrl
+      child.close();
     }
   });
 }


### PR DESCRIPTION
Ignore exception on child.loadURL(url) where the exception is caused by a redirect. Closes #5926.

changelog(Fixes): Fixed an issue where Insomnia would crash when opening an OAuth2 authorization window.