### PR TITLE
fix(ci): entrypoint path for pkg upload

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -165,7 +165,6 @@ jobs:
           release: ${{ contains(github.event.inputs.version, 'beta') && 'beta' || 'stable' }}
 
       - name: Upload .deb to pulp and/or cloudsmith (stable only)
-        if: ${{ env.IS_PRERELEASE == 'false' }}
         uses: docker://kong/release-script:latest
         env:
           PULP_USERNAME: ${{ secrets.PULP_USERNAME }}
@@ -185,6 +184,7 @@ jobs:
             --dist-name ubuntu
             --dist-version focal
             --package-type insomnia
+            ${{ env.IS_PRERELEASE == 'true' && '--internal' || '' }}
             --publish
 
       - name: Push Inso CLI docker image tags to Docker Hub

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -164,15 +164,21 @@ jobs:
           snap: artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.snap
           release: ${{ contains(github.event.inputs.version, 'beta') && 'beta' || 'stable' }}
 
-      - name: Upload .deb to pulp (stable only)
+      - name: Upload .deb to pulp and/or cloudsmith (stable only)
         if: ${{ env.IS_PRERELEASE == 'false' }}
         uses: docker://kong/release-script:latest
         env:
           PULP_USERNAME: ${{ secrets.PULP_USERNAME }}
           PULP_PASSWORD: ${{ secrets.PULP_PASSWORD }}
           PULP_HOST: ${{ secrets.PULP_HOST }}
+          VERBOSE: ${{ runner.debug == '1' && '1' || '' }}
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          CLOUDSMITH_DRY_RUN: ''
+          IGNORE_CLOUDSMITH_FAILURES: ${{ vars.IGNORE_CLOUDSMITH_FAILURES }}
+          USE_CLOUDSMITH: ${{ vars.USE_CLOUDSMITH }}
+          USE_PULP: ${{ vars.USE_PULP }}
         with:
-          entrypoint: /usr/src/code/entrypoint.sh
+          entrypoint: /entrypoint.sh
           args: >
             release
             --file artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.deb


### PR DESCRIPTION
I noticed a recent upload to pulp failed: https://github.com/Kong/insomnia/actions/runs/5456396374/jobs/9929147559
This PR fixes what I think went wrong with that.

And also adds functionality to upload pre-release packages to an "internal" repo-- which we can use to test these changes outside of an official release.