### PR TITLE
Fix: Allow empty name when duplicate request

### DIFF
--- a/packages/insomnia/src/ui/components/modals/prompt-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/prompt-modal.tsx
@@ -69,7 +69,7 @@ export const PromptModal = forwardRef<PromptModalHandle, ModalProps>((_, ref) =>
     event.preventDefault();
     if (inputRef.current) {
       const result = inputRef.current.type === 'checkbox' ? inputRef.current.checked.toString() : inputRef.current.value;
-      if (result) {
+      if (result || inputRef.current?.type === 'text') {
         state.onComplete?.(state.upperCase ? result?.toUpperCase() : result);
       }
       modalRef.current?.hide();


### PR DESCRIPTION
changelog(Improvements): Empty strings are now allowed when duplicating a request.

When duplicating request, an empty prompt with a name can be accepted but it's not processed. Insomnia handles empty names and displays the entire URL. Not handling empty names looks there like a bad user experience.

This PR allows proceeding with an empty string when duplicating a request.
 
<img width="799" alt="Screenshot 2023-07-11 at 23 08 19" src="https://github.com/Kong/insomnia/assets/10637666/7f58af0b-0dc2-40fc-acb9-6a0d2d5b027c">

