### PR TITLE
Revert "fix(ci): entrypoint path for pkg upload (#6129)"

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -172,14 +172,8 @@ jobs:
           PULP_PASSWORD: ${{ secrets.PULP_PASSWORD }}
           PULP_HOST: ${{ secrets.PULP_HOST }}
         with:
-          entrypoint: /usr/src/code/entrypoint.sh
-          args: >
-            release
-            --file artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.deb
-            --dist-name ubuntu
-            --dist-version focal
-            --package-type insomnia
-            --publish
+          entrypoint: python3
+          args: '/usr/src/code/main.py release --file artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.deb --dist-name ubuntu --dist-version focal --package-type insomnia --publish'
 
       - name: Push Inso CLI docker image tags to Docker Hub
         run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -164,27 +164,21 @@ jobs:
           snap: artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.snap
           release: ${{ contains(github.event.inputs.version, 'beta') && 'beta' || 'stable' }}
 
-      - name: Upload .deb to pulp and/or cloudsmith (stable only)
+      - name: Upload .deb to pulp (stable only)
+        if: ${{ env.IS_PRERELEASE == 'false' }}
         uses: docker://kong/release-script:latest
         env:
           PULP_USERNAME: ${{ secrets.PULP_USERNAME }}
           PULP_PASSWORD: ${{ secrets.PULP_PASSWORD }}
           PULP_HOST: ${{ secrets.PULP_HOST }}
-          VERBOSE: ${{ runner.debug == '1' && '1' || '' }}
-          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
-          CLOUDSMITH_DRY_RUN: ''
-          IGNORE_CLOUDSMITH_FAILURES: ${{ vars.IGNORE_CLOUDSMITH_FAILURES }}
-          USE_CLOUDSMITH: ${{ vars.USE_CLOUDSMITH }}
-          USE_PULP: ${{ vars.USE_PULP }}
         with:
-          entrypoint: /entrypoint.sh
+          entrypoint: /usr/src/code/entrypoint.sh
           args: >
             release
             --file artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.deb
             --dist-name ubuntu
             --dist-version focal
             --package-type insomnia
-            ${{ env.IS_PRERELEASE == 'true' && '--internal' || '' }}
             --publish
 
       - name: Push Inso CLI docker image tags to Docker Hub


### PR DESCRIPTION
This reverts commit fe63357a93f35676d0269b627c88a44aba0e8c25 and commit bc1fef2b71441f0bbc71e6d92d531ac39f388f4a.

Current failure:
```
 ignoring "release"/"rel" positional argument for pulp
specifying both --publish and --internal is invalid for pulp upload
refusing to proceed
```

@curiositycasualty not sure if revert would fix this one, as we also had a failure before:
```
docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/usr/src/code/entrypoint.sh": stat /usr/src/code/entrypoint.sh: no such file or directory: unknown.
``` 

@curiositycasualty Feel free to push fix to this PR.
