### PR TITLE
Import all available header properties from Postman

### DIFF
--- a/packages/insomnia/src/utils/importers/importers/postman.test.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.test.ts
@@ -33,6 +33,41 @@ describe('postman', () => {
   })) as HttpsSchemaGetpostmanComJsonCollectionV210;
 
   describe('headers', () => {
+    describe('properties', () => {
+      it('should import headers with all properties', () => {
+        const request: Request1 = {
+          header: [
+            {
+              key: 'X-Header1',
+              value: 'value1',
+              description: 'description1',
+            },
+            {
+              key: 'X-Header2',
+              value: 'value2',
+              disabled: true,
+            },
+          ],
+        };
+        const schema = postmanSchema({ requests: [request] });
+        const postman = new ImportPostman(schema);
+        const { headers } = postman.importRequestItem({ request }, 'n/a');
+
+        expect(headers).toEqual([
+          {
+            name: 'X-Header1',
+            value: 'value1',
+            description: 'description1'
+          },
+          {
+            name: 'X-Header2',
+            value: 'value2',
+            disabled: true,
+          },
+        ]);
+      });
+    });
+
     describe('awsv4', () => {
       it('should not duplicate headers', () => {
         const request: Request1 = {

--- a/packages/insomnia/src/utils/importers/importers/postman.test.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.test.ts
@@ -57,7 +57,7 @@ describe('postman', () => {
           {
             name: 'X-Header1',
             value: 'value1',
-            description: 'description1'
+            description: 'description1',
           },
           {
             name: 'X-Header2',

--- a/packages/insomnia/src/utils/importers/importers/postman.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.ts
@@ -136,9 +136,11 @@ export class ImportPostman {
       url: this.importUrl(request.url),
       parameters: parameters,
       method: request.method || 'GET',
-      headers: headers.map(({ key, value }) => ({
+      headers: headers.map(({ key, value, disabled, description }) => ({
         name: key,
         value,
+        ...(disabled ? { disabled } : {}),
+        ...(typeof description !== 'undefined' ? { description } : {}),
       })),
       body: this.importBody(request.body, headers.find(({ key }) => key === 'Content-Type')?.value),
       authentication,

--- a/packages/insomnia/src/utils/importers/importers/postman.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.ts
@@ -139,7 +139,7 @@ export class ImportPostman {
       headers: headers.map(({ key, value, disabled, description }) => ({
         name: key,
         value,
-        ...(disabled ? { disabled } : {}),
+        ...(typeof disabled !== 'undefined' ? { disabled } : {}),
         ...(typeof description !== 'undefined' ? { description } : {}),
       })),
       body: this.importBody(request.body, headers.find(({ key }) => key === 'Content-Type')?.value),

--- a/packages/insomnia/src/utils/importers/importers/wsdl.ts
+++ b/packages/insomnia/src/utils/importers/importers/wsdl.ts
@@ -48,17 +48,14 @@ const convertToPostman = (items: Swagger[]) => {
               {
                 key: 'SOAPAction',
                 value: api['x-ibm-soap']['soap-action'],
-                disabled: false,
               },
               {
                 key: 'Content-Type',
                 value: swagger.consumes[0],
-                disabled: false,
               },
               {
                 key: 'Accept',
                 value: swagger.produces[0],
-                disabled: false,
               },
             ],
             body: {


### PR DESCRIPTION
changelog(Improvements): Added support to import "disabled" and "description" header properties from Postman.


Importing header properties "disabled" and  "description" in Postman importer.