### PR TITLE
fix: duplicate methods from gRPC reflection

### DIFF
--- a/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
+++ b/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as grpcReflection from 'grpc-reflection-js';
+import protobuf from 'protobufjs';
+
+import { globalBeforeEach } from '../../../__jest__/before-each';
+import { loadMethodsFromReflection } from '../grpc';
+
+jest.mock('grpc-reflection-js');
+
+describe('loadMethodsFromReflection', () => {
+  beforeEach(globalBeforeEach);
+
+  describe('one service reflection', () => {
+    beforeEach(() => {
+      globalBeforeEach();
+      // we want to test that the values that are passed to axios are returned in the config key
+      (grpcReflection.Client as unknown as jest.Mock).mockImplementation(() => ({
+        listServices: () => Promise.resolve(['FooService']),
+        fileContainingSymbol: async () => {
+          const parsed = protobuf.parse(`
+            syntax = "proto3";
+
+            message FooRequest {
+                string foo = 1;
+            }
+
+            message FooResponse {
+                string foo = 1;
+            }
+
+            service FooService {
+                rpc Foo (FooRequest) returns (FooResponse);
+            }`);
+          return parsed.root;
+        },
+      }));
+    });
+
+    it('parses methods', async () => {
+      const methods = await loadMethodsFromReflection({ url: 'foo.com', metadata: [] });
+      expect(methods).toStrictEqual([{
+        type: 'unary',
+        fullPath: '/FooService/Foo',
+      }]);
+    });
+  });
+
+  describe('multiple service reflection', () => {
+    beforeEach(() => {
+      globalBeforeEach();
+      // we want to test that the values that are passed to axios are returned in the config key
+      (grpcReflection.Client as unknown as jest.Mock).mockImplementation(() => ({
+        listServices: () => Promise.resolve(['FooService', 'BarService']),
+        fileContainingSymbol: async () => {
+          const parsed = protobuf.parse(`
+            syntax = "proto3";
+
+            message FooRequest {
+                string foo = 1;
+            }
+
+            message FooResponse {
+                string foo = 1;
+            }
+
+            message BarRequest {
+                string bar = 1;
+            }
+
+            message BarResponse {
+                string bar = 1;
+            }
+
+            service FooService {
+                rpc Foo (FooRequest) returns (FooResponse);
+            }
+
+            service BarService {
+                rpc Bar (BarRequest) returns (BarResponse);
+            }`);
+          return parsed.root;
+        },
+      }));
+    });
+
+    it('parses methods', async () => {
+      const methods = await loadMethodsFromReflection({ url: 'foo-bar.com', metadata: [] });
+      expect(methods).toStrictEqual([{
+        type: 'unary',
+        fullPath: '/FooService/Foo',
+      }, {
+        type: 'unary',
+        fullPath: '/BarService/Bar',
+      }]);
+    });
+  });
+
+});


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->


Closes #5891 

When getting the available gRPC methods through server reflection, the code checks service by service.
However, for each service, it was grabbing _all_ the methods in the file that the service was defined, so if multiple services were defined in one file, it would duplicate those methods.
I updated the code to only retrieve the methods applicable to each service to avoid duplicate methods.