### PR TITLE
Improve clarity of network proxy settings to include SOCKS4/5 proxy

### DIFF
--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -284,7 +284,7 @@ export const General: FC = () => {
 
       <hr className="pad-top" />
 
-      <h2>HTTP Network Proxy</h2>
+      <h2>Network Proxy</h2>
 
       <BooleanSetting
         label="Enable proxy"
@@ -294,14 +294,16 @@ export const General: FC = () => {
 
       <div className="form-row pad-top-sm">
         <MaskedSetting
-          label='HTTP proxy'
+          label='Proxy for HTTP'
           setting='httpProxy'
+          help="Enter a HTTP or SOCKS4/5 proxy starting with appropriate prefix from the following (http://, socks4://, socks5://)"
           placeholder="localhost:8005"
           disabled={!settings.proxyEnabled}
         />
         <MaskedSetting
-          label='HTTPS proxy'
+          label='Proxy for HTTPS'
           setting='httpsProxy'
+          help="Enter a HTTPS or SOCKS4/5 proxy starting with appropriate prefix from the following (https://, socks4://, socks5://)"
           placeholder="localhost:8005"
           disabled={!settings.proxyEnabled}
         />


### PR DESCRIPTION
### Summary
This merge request add vsual improvements to the network proxy section, The changes contains added support for SOCKS4/5 proxy which is already supported by Insomnia but never mentioned in the UI.


Usufal links: 
- https://github.com/Kong/insomnia-docs/pull/149
- https://everything.curl.dev/usingcurl/proxies/socks


### Reason
Visual improvements take a look at this
https://github.com/Kong/insomnia/issues/1085

### Testing
I ran the project locally and everything seems to work, the changes are minor and can be tested by just reviwing the code.
