### PR TITLE
fix: await promise on protoLoader.load

### DIFF
--- a/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
@@ -42,9 +42,9 @@ const tryToSelectFolderPath = async () => {
   }
   return;
 };
-const isProtofileValid = (filePath: string) => {
+const isProtofileValid = async (filePath: string) => {
   try {
-    protoLoader.load(filePath, {
+    await protoLoader.load(filePath, {
       keepCase: true,
       longs: String,
       enums: String,
@@ -55,7 +55,7 @@ const isProtofileValid = (filePath: string) => {
   } catch (error) {
     showError({
       title: 'Invalid Proto File',
-      message: `The file ${filePath} and could not be parsed`,
+      message: `The file ${filePath} could not be parsed`,
       error,
     });
     return false;
@@ -205,7 +205,7 @@ export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave, reloadRe
     if (!filePath) {
       return;
     }
-    if (!isProtofileValid(filePath)) {
+    if (!await isProtofileValid(filePath)) {
       return;
     }
     const contents = await fs.promises.readFile(filePath, 'utf-8');
@@ -256,7 +256,7 @@ export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave, reloadRe
     if (!filePath) {
       return;
     }
-    if (!isProtofileValid(filePath)) {
+    if (!await isProtofileValid(filePath)) {
       return;
     }
     const contents = await fs.promises.readFile(filePath, 'utf-8');


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

`protoLoader.load` returns a promise, but it was not being awaited, so the error message was being lost.

https://github.com/Kong/insomnia/discussions/6195


