### PR TITLE
feat: template tag to encode hex to base64

### DIFF
--- a/packages/insomnia/src/ui/components/templating/__tests__/local-template-tags.test.ts
+++ b/packages/insomnia/src/ui/components/templating/__tests__/local-template-tags.test.ts
@@ -1,23 +1,21 @@
 import { type PluginTemplateTagContext } from '../../../../templating/extensions';
-import { base64EncoderTag } from '../local-template-tags';
-
+import { invariant } from '../../../../utils/invariant';
+import { localTemplateTags } from '../local-template-tags';
 describe('base64 tag', () => {
   describe('encoder', () => {
-
+    const base64EncoderTag = localTemplateTags.find(p => p.templateTag.name === 'base64')?.templateTag;
+    invariant(base64EncoderTag, 'missing tag in localTemplateTags');
     it('encodes from normal', () => {
       const encoded = base64EncoderTag.run({} as PluginTemplateTagContext, 'encode', 'normal', 'hello');
       expect(encoded).toBe('aGVsbG8=');
     });
-
     it('encodes from hex', () => {
       const encoded = base64EncoderTag.run({} as PluginTemplateTagContext, 'encode', 'hex', 'abc123');
       expect(encoded).toBe('q8Ej');
     });
-
     it('errors on invalid action', () => {
       expect(() => base64EncoderTag.run({} as PluginTemplateTagContext, 'transform', 'normal', 'hello')).toThrowError();
     });
-
     it('errors on invalid kind', () => {
       expect(() => base64EncoderTag.run({} as PluginTemplateTagContext, 'encode', 'klingon', 'hello')).toThrowError();
     });

--- a/packages/insomnia/src/ui/components/templating/__tests__/local-template-tags.test.ts
+++ b/packages/insomnia/src/ui/components/templating/__tests__/local-template-tags.test.ts
@@ -1,0 +1,26 @@
+import { type PluginTemplateTagContext } from '../../../../templating/extensions';
+import { base64EncoderTag } from '../local-template-tags';
+
+describe('base64 tag', () => {
+  describe('encoder', () => {
+
+    it('encodes from normal', () => {
+      const encoded = base64EncoderTag.run({} as PluginTemplateTagContext, 'encode', 'normal', 'hello');
+      expect(encoded).toBe('aGVsbG8=');
+    });
+
+    it('encodes from hex', () => {
+      const encoded = base64EncoderTag.run({} as PluginTemplateTagContext, 'encode', 'hex', 'abc123');
+      expect(encoded).toBe('q8Ej');
+    });
+
+    it('errors on invalid action', () => {
+      expect(() => base64EncoderTag.run({} as PluginTemplateTagContext, 'transform', 'normal', 'hello')).toThrowError();
+    });
+
+    it('errors on invalid kind', () => {
+      expect(() => base64EncoderTag.run({} as PluginTemplateTagContext, 'encode', 'klingon', 'hello')).toThrowError();
+    });
+  });
+
+});

--- a/packages/insomnia/src/ui/components/templating/local-template-tags.ts
+++ b/packages/insomnia/src/ui/components/templating/local-template-tags.ts
@@ -15,53 +15,73 @@ import { PluginTemplateTag } from '../../../templating/extensions';
 import { invariant } from '../../../utils/invariant';
 import { buildQueryStringFromParams, joinUrlAndQueryString, smartEncodeUrl } from '../../../utils/url/querystring';
 
-const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
-  {
-    templateTag: {
-      name: 'base64',
-      displayName: 'Base64',
-      description: 'encode or decode values',
-      args: [
-        {
-          displayName: 'Action',
-          type: 'enum',
-          options: [
-            { displayName: 'Encode', value: 'encode' },
-            { displayName: 'Decode', value: 'decode' },
-          ],
-        },
-        {
-          displayName: 'Kind',
-          type: 'enum',
-          options: [
-            { displayName: 'Normal', value: 'normal' },
-            { displayName: 'URL', value: 'url' },
-          ],
-        },
-        {
-          displayName: 'Value',
-          type: 'string',
-          placeholder: 'My text',
-        },
+const encode = 'encode';
+const decode = 'decode';
+
+const normal = 'normal';
+const url = 'url';
+const hex = 'hex';
+
+/**
+ * @internal exported only for testing
+ */
+export const base64EncoderTag: PluginTemplateTag = {
+  name: 'base64',
+  displayName: 'Base64',
+  description: 'encode or decode values',
+  args: [
+    {
+      displayName: 'Action',
+      type: 'enum',
+      options: [
+        { displayName: 'Encode', value: encode },
+        { displayName: 'Decode', value: decode },
       ],
-      run(_context, action, kind, text) {
-        text = text || '';
-        invariant(action === 'encode' || action === 'decode', 'invalid action');
-        if (action === 'encode') {
-          if (kind === 'normal') {
-            return Buffer.from(text, 'utf8').toString('base64');
-          } else if (kind === 'url') {
-            return Buffer.from(text, 'utf8')
-              .toString('base64')
-              .replace(/\+/g, '-')
-              .replace(/\//g, '_')
-              .replace(/=/g, '');
-          }
-        }
-        return Buffer.from(text, 'base64').toString('utf8');
-      },
     },
+    {
+      displayName: 'Kind',
+      type: 'enum',
+      options: [
+        { displayName: 'Normal', value: normal },
+        { displayName: 'URL', value: url },
+        { displayName: 'Hex', value: hex },
+      ],
+    },
+    {
+      displayName: 'Value',
+      type: 'string',
+      placeholder: 'My text',
+    },
+  ],
+  run(_context, action, kind, text) {
+    text = text || '';
+    invariant(action === encode || action === decode, 'invalid action');
+    invariant(kind === normal || kind === url || kind === hex, 'invalid kind');
+    if (action === encode) {
+      if (kind === normal) {
+        return Buffer.from(text, 'utf8').toString('base64');
+      } else if (kind === hex) {
+        return Buffer.from(text, 'hex').toString('base64');
+      } else if (kind === url) {
+        return Buffer.from(text, 'utf8')
+          .toString('base64')
+          .replace(/\+/g, '-')
+          .replace(/\//g, '_')
+          .replace(/=/g, '');
+      }
+    } else if (action === decode) {
+      if (kind === hex) {
+        return Buffer.from(text, 'base64').toString('hex');
+      } else {
+        return Buffer.from(text, 'base64').toString('utf8');
+      }
+    }
+    throw new Error('unknown options');
   },
+};
+
+const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
+  { templateTag: base64EncoderTag },
   {
     templateTag: {
       name: 'now',

--- a/packages/insomnia/src/ui/components/templating/local-template-tags.ts
+++ b/packages/insomnia/src/ui/components/templating/local-template-tags.ts
@@ -15,73 +15,62 @@ import { PluginTemplateTag } from '../../../templating/extensions';
 import { invariant } from '../../../utils/invariant';
 import { buildQueryStringFromParams, joinUrlAndQueryString, smartEncodeUrl } from '../../../utils/url/querystring';
 
-const encode = 'encode';
-const decode = 'decode';
-
-const normal = 'normal';
-const url = 'url';
-const hex = 'hex';
-
-/**
- * @internal exported only for testing
- */
-export const base64EncoderTag: PluginTemplateTag = {
-  name: 'base64',
-  displayName: 'Base64',
-  description: 'encode or decode values',
-  args: [
-    {
-      displayName: 'Action',
-      type: 'enum',
-      options: [
-        { displayName: 'Encode', value: encode },
-        { displayName: 'Decode', value: decode },
-      ],
-    },
-    {
-      displayName: 'Kind',
-      type: 'enum',
-      options: [
-        { displayName: 'Normal', value: normal },
-        { displayName: 'URL', value: url },
-        { displayName: 'Hex', value: hex },
-      ],
-    },
-    {
-      displayName: 'Value',
-      type: 'string',
-      placeholder: 'My text',
-    },
-  ],
-  run(_context, action, kind, text) {
-    text = text || '';
-    invariant(action === encode || action === decode, 'invalid action');
-    invariant(kind === normal || kind === url || kind === hex, 'invalid kind');
-    if (action === encode) {
-      if (kind === normal) {
-        return Buffer.from(text, 'utf8').toString('base64');
-      } else if (kind === hex) {
-        return Buffer.from(text, 'hex').toString('base64');
-      } else if (kind === url) {
-        return Buffer.from(text, 'utf8')
-          .toString('base64')
-          .replace(/\+/g, '-')
-          .replace(/\//g, '_')
-          .replace(/=/g, '');
-      }
-    } else if (action === decode) {
-      if (kind === hex) {
-        return Buffer.from(text, 'base64').toString('hex');
-      } else {
-        return Buffer.from(text, 'base64').toString('utf8');
-      }
-    }
-    throw new Error('unknown options');
-  },
-};
-
 const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
-  { templateTag: base64EncoderTag },
+  {
+    templateTag: {
+      name: 'base64',
+      displayName: 'Base64',
+      description: 'encode or decode values',
+      args: [
+        {
+          displayName: 'Action',
+          type: 'enum',
+          options: [
+            { displayName: 'Encode', value: 'encode' },
+            { displayName: 'Decode', value: 'decode' },
+          ],
+        },
+        {
+          displayName: 'Kind',
+          type: 'enum',
+          options: [
+            { displayName: 'Normal', value: 'normal' },
+            { displayName: 'URL', value: 'url' },
+            { displayName: 'Hex', value: 'hex' },
+          ],
+        },
+        {
+          displayName: 'Value',
+          type: 'string',
+          placeholder: 'My text',
+        },
+      ],
+      run(_context, action: 'encode' | 'decode', kind: 'normal' | 'url' | 'hex', text) {
+        text = text || '';
+        invariant(action === 'encode' || action === 'decode', 'invalid action');
+        invariant(kind === 'normal' || kind === 'url' || kind === 'hex', 'invalid kind');
+        if (action === 'encode') {
+          if (kind === 'normal') {
+            return Buffer.from(text, 'utf8').toString('base64');
+          }
+          if (kind === 'hex') {
+            return Buffer.from(text, 'hex').toString('base64');
+          }
+          if (kind === 'url') {
+            return Buffer.from(text, 'utf8')
+              .toString('base64')
+              .replace(/\+/g, '-')
+              .replace(/\//g, '_')
+              .replace(/=/g, '');
+          }
+        }
+        if (kind === 'hex') {
+          return Buffer.from(text, 'base64').toString('hex');
+        }
+        return Buffer.from(text, 'base64').toString('utf8');
+      },
+    },
+  },
   {
     templateTag: {
       name: 'now',


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Adds a new "kind" to the existing bae64 encoding template tag to support encoding from hex values to base 64.

I have a use-case for passing in hex strings as bytes to gRPC and the sender client expects base64 encoded strings, which makes it very difficult to test.


The diff is really not that big, I just pulled out the base64tag into it's own object so I could export it for testing. I added comments with the changed lines.
