### PR TITLE
feat/SEC-921: edit the dyld env variables and library validation for macos security

### DIFF
--- a/packages/insomnia/src/static/entitlements.mac.inherit.plist
+++ b/packages/insomnia/src/static/entitlements.mac.inherit.plist
@@ -9,6 +9,6 @@
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <false/>
     <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
+    <false/>
   </dict>
 </plist>

--- a/packages/insomnia/src/static/entitlements.mac.inherit.plist
+++ b/packages/insomnia/src/static/entitlements.mac.inherit.plist
@@ -7,7 +7,7 @@
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
+    <false/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
   </dict>


### PR DESCRIPTION
- SEC-921: disable allow-dyld-environment-variables
- SEC-921: set disable-library-validation as false

testing on https://github.com/Kong/insomnia/pull/6218

Alpha release was working ok, should be good to merge into develop
![codesign-entitlements](https://github.com/Kong/insomnia/assets/11976836/1924642f-9e3c-4564-820f-7311adefa062)

