### PR TITLE
autocomplete revision

### DIFF
--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -18,13 +18,6 @@ export function registerElectronHandlers() {
         role: 'paste',
       },
       { type: 'separator' },
-      {
-        label: 'Menu Item 1',
-        click: () => {
-          event.sender.send('context-menu-command', 'menu-item-1');
-        },
-      },
-      { type: 'separator' },
       ...localTemplateTags.map(l => {
         const hasSubmenu = l.templateTag.args?.[0]?.options?.length;
         const r = {
@@ -38,7 +31,7 @@ export function registerElectronHandlers() {
             submenu: l.templateTag.args?.[0]?.options?.map(s => ({
               label: fnOrString(s.displayName),
               click: () => {
-                event.sender.send('context-menu-command', 'open tag editor with parent settings');
+                event.sender.send('context-menu-command', 'open tag editor with child settings');
               },
             })),
           } : {}),

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -24,14 +24,14 @@ export function registerElectronHandlers() {
           label: fnOrString(l.templateTag.displayName),
           ...(hasSubmenu ? {} : {
             click: () => {
-              event.sender.send('context-menu-command', 'open tag editor with parent settings');
+              event.sender.send('context-menu-command', l.templateTag.displayName);
             },
           }),
           ...(hasSubmenu ? {
             submenu: l.templateTag.args?.[0]?.options?.map(s => ({
               label: fnOrString(s.displayName),
               click: () => {
-                event.sender.send('context-menu-command', 'open tag editor with child settings');
+                event.sender.send('context-menu-command', s.displayName);
               },
             })),
           } : {}),

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -5,6 +5,16 @@ export function registerElectronHandlers() {
   ipcMain.on('show-context-menu', event => {
     const template: MenuItemConstructorOptions[] = [
       {
+        role: 'cut',
+      },
+      {
+        role: 'copy',
+      },
+      {
+        role: 'paste',
+      },
+      { type: 'separator' },
+      {
         label: 'Menu Item 1',
         click: () => {
           event.sender.send('context-menu-command', 'menu-item-1');

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -6,7 +6,8 @@ import { localTemplateTags } from '../../ui/components/templating/local-template
 import { invariant } from '../../utils/invariant';
 
 export function registerElectronHandlers() {
-  ipcMain.on('show-context-menu', event => {
+  ipcMain.on('show-context-menu', (event, options) => {
+    console.log('key', options.key);
     try {
       const template: MenuItemConstructorOptions[] = [
         {
@@ -27,7 +28,7 @@ export function registerElectronHandlers() {
             ...(hasSubmenu ? {} : {
               click: () => {
                 const tag = `{% ${l.templateTag.name} 'encode', 'normal', '' %}`;
-                event.sender.send('context-menu-command', tag);
+                event.sender.send('context-menu-command', { key: options.key, tag });
               },
             }),
             ...(hasSubmenu ? {
@@ -36,7 +37,7 @@ export function registerElectronHandlers() {
                 click: () => {
                   console.log(l.templateTag.args);
                   const tag = `{% ${l.templateTag.name} '${action.value}', 'normal', '' %}`;
-                  event.sender.send('context-menu-command', tag);
+                  event.sender.send('context-menu-command', { key: options.key, tag });
                 },
               })),
             } : {}),

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -1,7 +1,21 @@
-import type { OpenDialogOptions, SaveDialogOptions } from 'electron';
-import { app, BrowserWindow, clipboard, dialog, ipcMain, shell } from 'electron';
+import type { MenuItemConstructorOptions, OpenDialogOptions, SaveDialogOptions } from 'electron';
+import { app, BrowserWindow, clipboard, dialog, ipcMain, Menu, shell } from 'electron';
 
 export function registerElectronHandlers() {
+  ipcMain.on('show-context-menu', event => {
+    const template: MenuItemConstructorOptions[] = [
+      {
+        label: 'Menu Item 1',
+        click: () => {
+          event.sender.send('context-menu-command', 'menu-item-1');
+        },
+      },
+      { type: 'separator' },
+      { label: 'Menu Item 2', type: 'checkbox', checked: true },
+    ];
+    const menu = Menu.buildFromTemplate(template);
+    menu.popup({ window: BrowserWindow.fromWebContents(event.sender) });
+  });
   ipcMain.on('setMenuBarVisibility', (_, visible: boolean) => {
     BrowserWindow.getAllWindows()
       .forEach(window => {

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -30,7 +30,8 @@ export function registerElectronHandlers() {
           role: 'paste',
         },
         { type: 'separator' },
-        ...localTemplateTags.map(l => {
+        ...localTemplateTags.sort((a, b) => fnOrString(a.templateTag.displayName).localeCompare(fnOrString(b.templateTag.displayName)))
+          .map(l => {
           const actions = l.templateTag.args?.[0];
           const otherArgs = l.templateTag.args?.slice(1);
           const hasSubmenu = actions?.options?.length;

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -26,9 +26,22 @@ export function registerElectronHandlers() {
       },
       { type: 'separator' },
       ...localTemplateTags.map(l => {
+        const hasSubmenu = l.templateTag.args?.[0]?.options?.length;
         const r = {
           label: fnOrString(l.templateTag.displayName),
-          submenu: l.templateTag.args?.[0]?.options?.map(s => ({ label: fnOrString(s.displayName) })) || [],
+          ...(hasSubmenu ? {} : {
+            click: () => {
+              event.sender.send('context-menu-command', 'open tag editor with parent settings');
+            },
+          }),
+          ...(hasSubmenu ? {
+            submenu: l.templateTag.args?.[0]?.options?.map(s => ({
+              label: fnOrString(s.displayName),
+              click: () => {
+                event.sender.send('context-menu-command', 'open tag editor with parent settings');
+              },
+            })),
+          } : {}),
         };
         return r;
       }),

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -40,6 +40,7 @@ export interface MainBridgeAPI {
   trackPageView: (options: { name: string }) => void;
   axiosRequest: typeof axiosRequest;
   insomniaFetch: typeof insomniaFetch;
+  showContentMenu: () => void;
 }
 export function registerMainHandlers() {
   ipcMain.handle('insomniaFetch', async (_, options: Parameters<typeof insomniaFetch>[0]) => {

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -40,7 +40,7 @@ export interface MainBridgeAPI {
   trackPageView: (options: { name: string }) => void;
   axiosRequest: typeof axiosRequest;
   insomniaFetch: typeof insomniaFetch;
-  showContextMenu: () => void;
+  showContextMenu: (options: { key: string }) => void;
 }
 export function registerMainHandlers() {
   ipcMain.handle('insomniaFetch', async (_, options: Parameters<typeof insomniaFetch>[0]) => {

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -40,7 +40,7 @@ export interface MainBridgeAPI {
   trackPageView: (options: { name: string }) => void;
   axiosRequest: typeof axiosRequest;
   insomniaFetch: typeof insomniaFetch;
-  showContentMenu: () => void;
+  showContextMenu: () => void;
 }
 export function registerMainHandlers() {
   ipcMain.handle('insomniaFetch', async (_, options: Parameters<typeof insomniaFetch>[0]) => {

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -62,7 +62,7 @@ const main: Window['main'] = {
   trackPageView: options => ipcRenderer.send('trackPageView', options),
   axiosRequest: options => ipcRenderer.invoke('axiosRequest', options),
   insomniaFetch: options => ipcRenderer.invoke('insomniaFetch', options),
-  showContextMenu: () => ipcRenderer.send('show-context-menu'),
+  showContextMenu: options => ipcRenderer.send('show-context-menu', options),
 };
 const dialog: Window['dialog'] = {
   showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -62,6 +62,7 @@ const main: Window['main'] = {
   trackPageView: options => ipcRenderer.send('trackPageView', options),
   axiosRequest: options => ipcRenderer.invoke('axiosRequest', options),
   insomniaFetch: options => ipcRenderer.invoke('insomniaFetch', options),
+  showContentMenu: () => ipcRenderer.send('show-context-menu'),
 };
 const dialog: Window['dialog'] = {
   showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -62,7 +62,7 @@ const main: Window['main'] = {
   trackPageView: options => ipcRenderer.send('trackPageView', options),
   axiosRequest: options => ipcRenderer.invoke('axiosRequest', options),
   insomniaFetch: options => ipcRenderer.invoke('insomniaFetch', options),
-  showContentMenu: () => ipcRenderer.send('show-context-menu'),
+  showContextMenu: () => ipcRenderer.send('show-context-menu'),
 };
 const dialog: Window['dialog'] = {
   showOpenDialog: options => ipcRenderer.invoke('showOpenDialog', options),

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -485,7 +485,10 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
       console.log('Failed to set CodeMirror option', err.message, { key, value });
     }
   };
-
+  useEffect(() => window.main.on('context-menu-command', (e, command) => {
+    // TODO ensure this is the correct code mirror instance to listen to
+    codeMirror.current?.replaceSelection(command);
+  }), []);
   useEffect(() => tryToSetOption('hintOptions', hintOptions), [hintOptions]);
   useEffect(() => tryToSetOption('info', infoOptions), [infoOptions]);
   useEffect(() => tryToSetOption('jump', jumpOptions), [jumpOptions]);

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -525,6 +525,9 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
       data-editor-type="text"
       data-testid="CodeEditor"
       onContextMenu={event => {
+        if (readOnly) {
+          return;
+        }
         event.preventDefault();
         window.main.showContextMenu({ key: id });
       }}

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -528,7 +528,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
       data-testid="CodeEditor"
       onContextMenu={event => {
         event.preventDefault();
-        window.main.showContentMenu();
+        window.main.showContextMenu();
       }}
     >
       <div

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -523,6 +523,10 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
       style={style}
       data-editor-type="text"
       data-testid="CodeEditor"
+      onContextMenu={event => {
+        event.preventDefault();
+        window.main.showContentMenu();
+      }}
     >
       <div
         className={classnames('editor__container', 'input', className)}

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -81,7 +81,7 @@ export interface CodeEditorProps {
   hideGutters?: boolean;
   hideLineNumbers?: boolean;
   hintOptions?: ShowHintOptions;
-  id?: string;
+  id: string;
   infoOptions?: GraphQLInfoOptions;
   jumpOptions?: ModifiedGraphQLJumpOptions;
   lintOptions?: Record<string, any>;
@@ -485,10 +485,8 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
       console.log('Failed to set CodeMirror option', err.message, { key, value });
     }
   };
-  useEffect(() => window.main.on('context-menu-command', (e, command) => {
-    // TODO ensure this is the correct code mirror instance to listen to
-    codeMirror.current?.replaceSelection(command);
-  }), []);
+  useEffect(() => window.main.on('context-menu-command', (_, { key, tag }) =>
+    id === key && codeMirror.current?.replaceSelection(tag)), [id]);
   useEffect(() => tryToSetOption('hintOptions', hintOptions), [hintOptions]);
   useEffect(() => tryToSetOption('info', infoOptions), [infoOptions]);
   useEffect(() => tryToSetOption('jump', jumpOptions), [jumpOptions]);
@@ -528,7 +526,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
       data-testid="CodeEditor"
       onContextMenu={event => {
         event.preventDefault();
-        window.main.showContextMenu();
+        window.main.showContextMenu({ key: id });
       }}
     >
       <div

--- a/packages/insomnia/src/ui/components/codemirror/extensions/autocomplete.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/autocomplete.ts
@@ -344,7 +344,6 @@ function hint(cm: CodeMirror.Editor, options: ShowHintOptions) {
     (arr, v) => (arr.find(a => a.text === v.text) ? arr : [...arr, v]),
     [] as Hint[], // Default value
   );
-  console.log(uniqueMatches);
   return {
     list: uniqueMatches,
     from: CodeMirror.Pos(cur.line, cur.ch - segment.length),

--- a/packages/insomnia/src/ui/components/codemirror/extensions/autocomplete.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/autocomplete.ts
@@ -344,6 +344,7 @@ function hint(cm: CodeMirror.Editor, options: ShowHintOptions) {
     (arr, v) => (arr.find(a => a.text === v.text) ? arr : [...arr, v]),
     [] as Hint[], // Default value
   );
+  console.log(uniqueMatches);
   return {
     list: uniqueMatches,
     from: CodeMirror.Pos(cur.line, cur.ch - segment.length),

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -214,7 +214,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       data-testid="OneLineEditor"
       onContextMenu={event => {
         event.preventDefault();
-        window.main.showContentMenu();
+        window.main.showContextMenu();
       }}
     >
       <div className="editor__container input editor--single-line">

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -212,6 +212,10 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       })}
       data-editor-type={type || 'text'}
       data-testid="OneLineEditor"
+      onContextMenu={event => {
+        event.preventDefault();
+        window.main.showContentMenu();
+      }}
     >
       <div className="editor__container input editor--single-line">
         <textarea

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -216,6 +216,9 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       data-editor-type={type || 'text'}
       data-testid="OneLineEditor"
       onContextMenu={event => {
+        if (readOnly) {
+          return;
+        }
         event.preventDefault();
         window.main.showContextMenu({ key: id });
       }}

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -18,7 +18,7 @@ import { isKeyCombinationInRegistry } from '../settings/shortcuts';
 export interface OneLineEditorProps {
   defaultValue: string;
   getAutocompleteConstants?: () => string[] | PromiseLike<string[]>;
-  id?: string;
+  id: string;
   onChange: (value: string) => void;
   onKeyDown?: (event: KeyboardEvent, value: string) => void;
   onPaste?: (event: ClipboardEvent) => void;
@@ -194,6 +194,9 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     return () => codeMirror.current?.on('paste', handlePaste);
   }, [onPaste]);
 
+  useEffect(() => window.main.on('context-menu-command', (_, { key, tag }) =>
+    id === key && codeMirror.current?.replaceSelection(tag)), [id]);
+
   useImperativeHandle(ref, () => ({
     selectAll: () => codeMirror.current?.setSelection({ line: 0, ch: 0 }, { line: codeMirror.current.lineCount(), ch: 0 }),
     focusEnd: () => {
@@ -214,7 +217,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       data-testid="OneLineEditor"
       onContextMenu={event => {
         event.preventDefault();
-        window.main.showContextMenu();
+        window.main.showContextMenu({ key: id });
       }}
     >
       <div className="editor__container input editor--single-line">

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -581,6 +581,7 @@ export const GraphQLEditor: FC<Props> = ({
 
       <div className="graphql-editor__query">
         <CodeEditor
+          id="graphql-editor"
           ref={editorRef}
           dynamicHeight
           showPrettifyButton
@@ -627,6 +628,7 @@ export const GraphQLEditor: FC<Props> = ({
       </h2>
       <div className="graphql-editor__variables">
         <CodeEditor
+          id="graphql-editor-variables"
           dynamicHeight
           enableNunjucks
           uniquenessKey={uniquenessKey ? uniquenessKey + '::variables' : undefined}

--- a/packages/insomnia/src/ui/components/editors/body/raw-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/raw-editor.tsx
@@ -19,6 +19,7 @@ export const RawEditor: FC<Props> = ({
 }) => (
   <Fragment>
     <CodeEditor
+      id="raw-editor"
       showPrettifyButton
       uniquenessKey={uniquenessKey}
       defaultValue={content}

--- a/packages/insomnia/src/ui/components/editors/environment-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/environment-editor.tsx
@@ -101,6 +101,7 @@ export const EnvironmentEditor = forwardRef<EnvironmentEditorHandle, Props>(({
   return (
     <div className="environment-editor">
       <CodeEditor
+        id="environment-editor"
         ref={editorRef}
         autoPrettify
         enableNunjucks

--- a/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
@@ -68,6 +68,7 @@ export const RequestHeadersEditor: FC<Props> = ({
     return (
       <div className="tall">
         <CodeEditor
+          id="request-headers-editor"
           onChange={handleBulkUpdate}
           defaultValue={headersString}
           enableNunjucks

--- a/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
@@ -64,6 +64,7 @@ export const RequestParametersEditor: FC<Props> = ({
   if (bulk) {
     return (
       <CodeEditor
+        id="request-parameters-editor"
         onChange={handleBulkUpdate}
         defaultValue={paramsString}
         enableNunjucks

--- a/packages/insomnia/src/ui/components/key-value-editor/row.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/row.tsx
@@ -86,6 +86,7 @@ export const Row: FC<Props> = ({
           })}
         >
           <OneLineEditor
+            id={'key-value-editor__name' + pair.id}
             placeholder={namePlaceholder || 'Name'}
             defaultValue={pair.name}
             getAutocompleteConstants={() => handleGetAutocompleteNameConstants?.(pair) || []}
@@ -124,15 +125,16 @@ export const Row: FC<Props> = ({
             </button>
           ) : (
             <OneLineEditor
-              readOnly={readOnly}
-
+              id={'key-value-editor__value' + pair.id}
               type="text"
+              readOnly={readOnly}
               placeholder={valuePlaceholder || 'Value'}
               defaultValue={pair.value}
               onChange={value => onChange({ ...pair, value })}
               getAutocompleteConstants={() => handleGetAutocompleteValueConstants?.(pair) || []}
             />
-          )}
+          )
+          }
         </div>
         {showDescription ? (
           <div
@@ -142,8 +144,8 @@ export const Row: FC<Props> = ({
             )}
           >
             <OneLineEditor
+              id={'key-value-editor__description' + pair.id}
               readOnly={readOnly}
-
               placeholder={descriptionPlaceholder || 'Description'}
               defaultValue={pair.description || ''}
               onChange={description => onChange({ ...pair, description })}

--- a/packages/insomnia/src/ui/components/markdown-editor.tsx
+++ b/packages/insomnia/src/ui/components/markdown-editor.tsx
@@ -80,6 +80,7 @@ export const MarkdownEditor = forwardRef<CodeEditorHandle, Props>(({
           <MarkdownEdit withDynamicHeight={!tall}>
             <div className='form-control form-control--outlined'>
               <CodeEditor
+                id="markdown-editor"
                 ref={ref}
                 hideGutters
                 hideLineNumbers

--- a/packages/insomnia/src/ui/components/modals/code-prompt-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/code-prompt-modal.tsx
@@ -118,6 +118,7 @@ export const CodePromptModal = forwardRef<CodePromptModalHandle, ModalProps>((_,
             <div className="pad-sm pad-bottom tall">
               <div className="form-control form-control--outlined form-control--tall tall">
                 <CodeEditor
+                  id="code-prompt-modal"
                   hideLineNumbers
                   showPrettifyButton
                   className="tall"

--- a/packages/insomnia/src/ui/components/modals/cookie-modify-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookie-modify-modal.tsx
@@ -89,6 +89,7 @@ export const CookieModifyModal = ((props: ModalProps & CookieModifyModalOptions)
                       <label data-testid="CookieKey">
                         Key
                         <OneLineEditor
+                          id="cookie-key"
                           defaultValue={(cookie && cookie.key || '').toString()}
                           onChange={value => handleCookieUpdate(Object.assign({}, cookie, { key: value.trim() }))}
                         />
@@ -98,6 +99,7 @@ export const CookieModifyModal = ((props: ModalProps & CookieModifyModalOptions)
                       <label data-testid="CookieValue">
                         Value
                         <OneLineEditor
+                          id="cookie-value"
                           defaultValue={(cookie && cookie.value || '').toString()}
                           onChange={value => handleCookieUpdate(Object.assign({}, cookie, { value: value.trim() }))}
                         />
@@ -109,6 +111,7 @@ export const CookieModifyModal = ((props: ModalProps & CookieModifyModalOptions)
                       <label data-testid="CookieDomain">
                         Domain
                         <OneLineEditor
+                          id="cookie-domain"
                           defaultValue={(cookie && cookie.domain || '').toString()}
                           onChange={value => handleCookieUpdate(Object.assign({}, cookie, { domain: value.trim() }))}
                         />
@@ -118,6 +121,7 @@ export const CookieModifyModal = ((props: ModalProps & CookieModifyModalOptions)
                       <label data-testid="CookiePath">
                         Path
                         <OneLineEditor
+                          id="cookie-path"
                           defaultValue={(cookie && cookie.path || '').toString()}
                           onChange={value => handleCookieUpdate(Object.assign({}, cookie, { path: value.trim() }))}
                         />

--- a/packages/insomnia/src/ui/components/modals/generate-code-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/generate-code-modal.tsx
@@ -173,6 +173,7 @@ export const GenerateCodeModal = forwardRef<GenerateCodeModalHandle, Props>((pro
           <CopyButton content={cmd} className="pull-right" />
         </div>
         {target && <CodeEditor
+          id="generate-code-modal-content"
           placeholder="Generating code snippet..."
           className="border-top"
           key={Date.now()}

--- a/packages/insomnia/src/ui/components/modals/generate-config-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/generate-config-modal.tsx
@@ -147,37 +147,38 @@ export const GenerateConfigModal = forwardRef<GenerateConfigModalHandle, ModalPr
           onSelectionChange={onSelect}
         >
           {configs.map(config =>
-            (<TabItem
-              key={config.label}
-              title={
-                <>
-                  {config.label}
-                  {config.docsLink ?
-                    <>
-                      {' '}
-                      <HelpTooltip>
-                        To learn more about {config.label}
-                        <br />
-                        <Link href={config.docsLink}>Documentation {<i className="fa fa-external-link-square" />}</Link>
-                      </HelpTooltip>
-                    </> : null}
-                </>
-              }
-            >
-              <PanelContainer key={config.label}>
-                {config.error ?
-                  <p className="notice error margin-md">
-                    {config.error}
-                    {config.docsLink ? <><br /><Link href={config.docsLink}>Documentation {<i className="fa fa-external-link-square" />}</Link></> : null}
-                  </p> :
-                  <CodeEditor
-                    className="tall pad-top-sm"
-                    defaultValue={config.content}
-                    mode={config.mimeType}
-                    readOnly
-                  />}
-              </PanelContainer>
-            </TabItem>)
+          (<TabItem
+            key={config.label}
+            title={
+              <>
+                {config.label}
+                {config.docsLink ?
+                  <>
+                    {' '}
+                    <HelpTooltip>
+                      To learn more about {config.label}
+                      <br />
+                      <Link href={config.docsLink}>Documentation {<i className="fa fa-external-link-square" />}</Link>
+                    </HelpTooltip>
+                  </> : null}
+              </>
+            }
+          >
+            <PanelContainer key={config.label}>
+              {config.error ?
+                <p className="notice error margin-md">
+                  {config.error}
+                  {config.docsLink ? <><br /><Link href={config.docsLink}>Documentation {<i className="fa fa-external-link-square" />}</Link></> : null}
+                </p> :
+                <CodeEditor
+                  id="generate-config-modal"
+                  className="tall pad-top-sm"
+                  defaultValue={config.content}
+                  mode={config.mimeType}
+                  readOnly
+                />}
+            </PanelContainer>
+          </TabItem>)
           )}
         </Tabs>
       </ModalBody>

--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
@@ -152,6 +152,7 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
             <div className="method-grpc pad-right pad-left vertically-center">gRPC</div>
             <StyledUrlEditor title={activeRequest.url}>
               <OneLineEditor
+                id="grpc-url"
                 key={uniquenessKey}
                 type="text"
                 defaultValue={activeRequest.url}
@@ -270,6 +271,7 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                     {[
                       <TabItem key="body" title="Body">
                         <CodeEditor
+                          id="grpc-request-editor"
                           ref={editorRef}
                           defaultValue={activeRequest.body.text}
                           onChange={text => patchRequest(requestId, { body: { text } })}
@@ -281,6 +283,7 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                       ...requestMessages.sort((a, b) => a.created - b.created).map((m, index) => (
                         <TabItem key={m.id} title={`Stream ${index + 1}`}>
                           <CodeEditor
+                            id={'grpc-request-editor-tab' + m.id}
                             defaultValue={m.text}
                             mode="application/json"
                             enableNunjucks

--- a/packages/insomnia/src/ui/components/panes/grpc-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-response-pane.tsx
@@ -25,6 +25,7 @@ export const GrpcResponsePane: FunctionComponent<Props> = ({ grpcState: { runnin
             {responseMessages.sort((a, b) => a.created - b.created).map((m, index) => (
               <TabItem key={m.id} title={`Response ${index + 1}`}>
                 <CodeEditor
+                  id="grpc-response"
                   defaultValue={m.text}
                   mode="application/json"
                   enableNunjucks

--- a/packages/insomnia/src/ui/components/viewers/response-timeline-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-timeline-viewer.tsx
@@ -43,6 +43,7 @@ export const ResponseTimelineViewer: FC<Props> = ({ timeline, pinToBottom }) => 
 
   return (
     <CodeEditor
+      id="response-timeline-viewer"
       ref={editorRef}
       hideLineNumbers
       readOnly

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -330,6 +330,7 @@ export const ResponseViewer = ({
   if (previewMode === PREVIEW_MODE_RAW) {
     return (
       <CodeEditor
+        id="raw-response-viewer"
         key={responseId}
         ref={editorRef}
         className="raw-editor"
@@ -347,6 +348,7 @@ export const ResponseViewer = ({
   // Show everything else as "source"
   return (
     <CodeEditor
+      id="response-viewer"
       key={disablePreviewLinks ? 'links-disabled' : 'links-enabled'}
       ref={editorRef}
       autoPrettify

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -136,6 +136,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, environmentId,
       >
         <StyledUrlBar>
           <OneLineEditor
+            id="websocket-url-bar"
             ref={oneLineEditorRef}
             onKeyDown={createKeybindingsHandler({
               'Enter': () => handleSubmit(),

--- a/packages/insomnia/src/ui/components/websockets/event-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-view.tsx
@@ -104,30 +104,14 @@ export const MessageEventView: FC<Props<CurlMessageEvent | WebSocketMessageEvent
         />
       </PreviewPaneButtons>
       <PreviewPaneContents>
-        {previewMode === PREVIEW_MODE_FRIENDLY &&
-          <CodeEditor
-            hideLineNumbers
-            mode={'text/json'}
-            defaultValue={pretty}
-            uniquenessKey={event._id}
-            readOnly
-          />}
-        {previewMode === PREVIEW_MODE_SOURCE &&
-          <CodeEditor
-            hideLineNumbers
-            mode={'text/json'}
-            defaultValue={raw}
-            uniquenessKey={event._id}
-            readOnly
-          />}
-        {previewMode === PREVIEW_MODE_RAW &&
-          <CodeEditor
-            hideLineNumbers
-            mode={'text/plain'}
-            defaultValue={raw}
-            uniquenessKey={event._id}
-            readOnly
-          />}
+        <CodeEditor
+          id="websocket-body-preview"
+          hideLineNumbers
+          mode={previewMode === PREVIEW_MODE_RAW ? 'text/plain' : 'text/json'}
+          defaultValue={previewMode === PREVIEW_MODE_FRIENDLY ? pretty : raw}
+          uniquenessKey={event._id}
+          readOnly
+        />
       </PreviewPaneContents>
     </PreviewPane>
   );

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -185,6 +185,7 @@ const WebSocketRequestForm: FC<FormProps> = ({
       }}
     >
       <CodeEditor
+        id="websocketMessageEditor"
         showPrettifyButton
         uniquenessKey={request._id}
         mode={previewMode}

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -185,7 +185,7 @@ const WebSocketRequestForm: FC<FormProps> = ({
       }}
     >
       <CodeEditor
-        id="websocketMessageEditor"
+        id="websocket-message-editor"
         showPrettifyButton
         uniquenessKey={request._id}
         mode={previewMode}

--- a/packages/insomnia/src/ui/rendererListeners.ts
+++ b/packages/insomnia/src/ui/rendererListeners.ts
@@ -12,10 +12,6 @@ import { AskModal } from './components/modals/ask-modal';
 import { SelectModal } from './components/modals/select-modal';
 import { SettingsModal, TAB_INDEX_SHORTCUTS } from './components/modals/settings-modal';
 
-window.main.on('context-menu-command', (e, command) => {
-  console.log('c', command);
-});
-
 window.main.on('toggle-preferences', () => {
   showModal(SettingsModal);
 });

--- a/packages/insomnia/src/ui/rendererListeners.ts
+++ b/packages/insomnia/src/ui/rendererListeners.ts
@@ -12,6 +12,15 @@ import { AskModal } from './components/modals/ask-modal';
 import { SelectModal } from './components/modals/select-modal';
 import { SettingsModal, TAB_INDEX_SHORTCUTS } from './components/modals/settings-modal';
 
+window.addEventListener('contextmenu', e => {
+  e.preventDefault();
+  window.main.showContentMenu();
+});
+
+window.main.on('context-menu-command', (e, command) => {
+  console.log('c', command);
+});
+
 window.main.on('toggle-preferences', () => {
   showModal(SettingsModal);
 });

--- a/packages/insomnia/src/ui/rendererListeners.ts
+++ b/packages/insomnia/src/ui/rendererListeners.ts
@@ -12,11 +12,6 @@ import { AskModal } from './components/modals/ask-modal';
 import { SelectModal } from './components/modals/select-modal';
 import { SettingsModal, TAB_INDEX_SHORTCUTS } from './components/modals/settings-modal';
 
-window.addEventListener('contextmenu', e => {
-  e.preventDefault();
-  window.main.showContentMenu();
-});
-
 window.main.on('context-menu-command', (e, command) => {
   console.log('c', command);
 });

--- a/packages/insomnia/src/ui/routes/design.tsx
+++ b/packages/insomnia/src/ui/routes/design.tsx
@@ -282,6 +282,7 @@ const Design: FC = () => {
           <div className="column tall theme--pane__body">
             <div className="tall relative overflow-hidden">
               <CodeEditor
+                id="spec-editor"
                 key={uniquenessKey}
                 showPrettifyButton
                 ref={editor}

--- a/packages/insomnia/src/ui/routes/test-suite.tsx
+++ b/packages/insomnia/src/ui/routes/test-suite.tsx
@@ -132,6 +132,7 @@ const UnitTestItemView = ({
       }
     >
       <CodeEditor
+        id="unit-test-editor"
         ref={editorRef}
         dynamicHeight
         showPrettifyButton


### PR DESCRIPTION
changelog(Improvements): Added the auto-complete templating features in the right-click menu

Motivation: the insomnia templating features have low discovery because of the unintuitive way the user needs to open the autocomplete dialog. If a user comes from postman they may expect to write a template variable themselves. The editing experience in insomnia should be somewhat familiar to a vscode user but currently deviates in many ways.

Goal: show templating features in the right click dialog.

### limitations 
Code mirror api is unfamiliar 

### highlights
- adds ids into all code editors
- uses id to filter right click events to insert text using codemirror replaceSelection feature
- create text from local template tags and context
- works exactly like the control+space autocomplete

### future work
- open modal immediately
- open autocomplete when typing open bracket
- decide on a better visual style for autocomplete dialog
- env variables



### ideas:
- right click menu
- tree rather than flat list

<img width="168" alt="image" src="https://github.com/Kong/insomnia/assets/3679927/512b29a6-3778-469a-b682-3f7a1ee3cdac">


### considerations
- current behavior first inserts a variable tag into the code editor then the user must click on it to edit it
- a better alternative ux with fewer clicks and confusion would be when the option is clicked we could first open the tag editor dialog and only insert the tab if done is clicked

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
