### PR TITLE
Add Scratch Pad collection

### DIFF
--- a/packages/insomnia/src/models/project.ts
+++ b/packages/insomnia/src/models/project.ts
@@ -89,8 +89,8 @@ export async function seed() {
     }
 
     if (!scratchPad) {
-      console.log('Initializing scratchPad');
-      await workspace.create({ _id: 'wrk_scratchpad', name: 'Scratchpad', parentId: DEFAULT_PROJECT_ID, scope: 'collection' });
+      console.log('Initializing Scratch Pad');
+      await workspace.create({ _id: 'wrk_scratchpad', name: 'Scratch Pad', parentId: DEFAULT_PROJECT_ID, scope: 'collection' });
     }
   } catch (err) {
     console.warn('Failed to create default project. It probably already exists', err);

--- a/packages/insomnia/src/models/project.ts
+++ b/packages/insomnia/src/models/project.ts
@@ -1,6 +1,7 @@
+import { getProductName } from '../common/constants';
 import { database as db } from '../common/database';
 import { generateId } from '../common/misc';
-import type { BaseModel } from './index';
+import { type BaseModel, workspace } from './index';
 
 export const name = 'Project';
 export const type = 'Project';
@@ -76,4 +77,22 @@ export function update(project: Project, patch: Partial<Project>) {
 export async function all() {
   const projects = await db.all<Project>(type);
   return projects;
+}
+
+export async function seed() {
+  try {
+    const defaultProject = await getById(DEFAULT_PROJECT_ID);
+    const scratchPad = await workspace.getById('wrk_scratchpad');
+    if (!defaultProject) {
+      console.log('Initializing Default Project');
+      await create({ _id: DEFAULT_PROJECT_ID, name: getProductName(), remoteId: null });
+    }
+
+    if (!scratchPad) {
+      console.log('Initializing scratchPad');
+      await workspace.create({ _id: 'wrk_scratchpad', name: 'Scratchpad', parentId: DEFAULT_PROJECT_ID, scope: 'collection' });
+    }
+  } catch (err) {
+    console.warn('Failed to create default project. It probably already exists', err);
+  }
 }

--- a/packages/insomnia/src/models/workspace.ts
+++ b/packages/insomnia/src/models/workspace.ts
@@ -161,3 +161,7 @@ function expectParentToBeProject(parentId?: string | null) {
     throw new Error('Expected the parent of a Workspace to be a Project');
   }
 }
+
+export function isScratchpad(workspace: Workspace) {
+  return workspace._id === 'wrk_scratchpad';
+}

--- a/packages/insomnia/src/sync/vcs/migrate-to-cloud-projects.ts
+++ b/packages/insomnia/src/sync/vcs/migrate-to-cloud-projects.ts
@@ -2,7 +2,7 @@ import { getCurrentSessionId } from '../../account/session';
 import { database } from '../../common/database';
 import * as models from '../../models';
 import { isRemoteProject } from '../../models/project';
-import { Workspace } from '../../models/workspace';
+import { isScratchpad, Workspace } from '../../models/workspace';
 import { invariant } from '../../utils/invariant';
 import { initializeLocalBackendProjectAndMarkForSync, pushSnapshotOnInitialize } from './initialize-backend-project';
 import { getVCS } from './vcs';
@@ -77,9 +77,9 @@ export const migrateLocalToCloudProjects = async () => {
       });
 
       // For each workspace in the local project
-      const projectWorkspaces = await database.find<Workspace>(models.workspace.type, {
+      const projectWorkspaces = (await database.find<Workspace>(models.workspace.type, {
         parentId: localProject._id,
-      });
+      })).filter(isScratchpad);
 
       for (const workspace of projectWorkspaces) {
         // Update the workspace to point to the newly created project

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import React from 'react';
 import { useRouteLoaderData } from 'react-router-dom';
 
+import { isLoggedIn } from '../../../account/session';
 import { isRemoteProject } from '../../../models/project';
 import { useVCS } from '../../hooks/use-vcs';
 import { WorkspaceLoaderData } from '../../routes/workspace';
@@ -21,6 +22,10 @@ export const WorkspaceSyncDropdown: FC = () => {
   const vcs = useVCS({
     workspaceId: activeWorkspace?._id,
   });
+
+  if (!isLoggedIn()) {
+    return null;
+  }
 
   if (isRemoteProject(activeProject) && vcs && !activeWorkspaceMeta?.gitRepositoryId) {
     return (

--- a/packages/insomnia/src/ui/components/organizations-navbar.tsx
+++ b/packages/insomnia/src/ui/components/organizations-navbar.tsx
@@ -3,7 +3,7 @@ import { Link, useParams, useRouteLoaderData } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { getAppWebsiteBaseURL } from '../../common/constants';
-import { OrganizationLoaderData } from '../routes/organization';
+import { isPersonalOrganization, OrganizationLoaderData } from '../routes/organization';
 import { Dropdown, DropdownButton, DropdownItem, ItemContent } from './base/dropdown';
 import { SvgIcon } from './svg-icon';
 import { Tooltip } from './tooltip';
@@ -77,13 +77,13 @@ export const OrganizationsNav: FC = () => {
       <NavbarList>
         {organizations.map(organization => {
           return (
-            <li key={organization._id}>
-              <Tooltip position='right' message={organization.name}>
+            <li key={organization.id}>
+              <Tooltip position='right' message={organization.display_name}>
                 <NavbarItem
-                  to={`/organization/${organization._id}`}
-                  $isActive={organizationId === organization._id}
+                  to={`/organization/${organization.id}`}
+                  $isActive={organizationId === organization.id}
                 >
-                  {organization.isPersonal ? (<i className='fa fa-home' />) : getNameInitials(organization.name)}
+                  {isPersonalOrganization(organization) ? (<i className='fa fa-home' />) : getNameInitials(organization.display_name)}
 
                 </NavbarItem>
               </Tooltip>

--- a/packages/insomnia/src/ui/components/settings/account.tsx
+++ b/packages/insomnia/src/ui/components/settings/account.tsx
@@ -1,12 +1,13 @@
 import React, { FC, Fragment, useCallback, useState } from 'react';
-import { useFetcher } from 'react-router-dom';
+import { useFetcher, useNavigate } from 'react-router-dom';
 
 import * as session from '../../../account/session';
 import { Link } from '../base/link';
 import { PromptButton } from '../base/prompt-button';
 import { HelpTooltip } from '../help-tooltip';
+import { Button } from '../themed-button';
 
-export const Account: FC = () => {
+export const AccountSettings: FC = () => {
   const [codeSent, setCodeSent] = useState(false);
   const [error, setError] = useState('');
   const [showChangePassword, setShowChangePassword] = useState(false);
@@ -152,5 +153,38 @@ export const Account: FC = () => {
         </form>
       )}
     </Fragment>
+  );
+};
+
+export const Account = () => {
+  const navigate = useNavigate();
+  if (session.isLoggedIn()) {
+    return <AccountSettings />;
+  }
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className="border-solid border-[--hl-md] notice surprise p-4 rounded-md">
+        Log in to Insomnia to manage your Account
+      </div>
+      <div className='flex gap-2'>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={
+            () => navigate('/auth/login')
+          }
+        >
+          Log in
+        </Button>
+        <Button
+          onClick={() => navigate('/auth/login')}
+          size="small"
+          variant="contained"
+        >
+          Sign Up
+        </Button>
+      </div>
+    </div>
   );
 };

--- a/packages/insomnia/src/ui/components/settings/ai.tsx
+++ b/packages/insomnia/src/ui/components/settings/ai.tsx
@@ -63,14 +63,9 @@ export const AI = () => {
   return (
     <Fragment>
       <div
-        className="notice pad surprise"
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}
+        className="notice pad surprise flex flex-col items-center gap-2"
       >
-        <h1 className="no-margin-top">Try Insomnia AI <InsomniaAI /></h1>
+        <h1 className="mt-0 flex items-center gap-2 text-xl">Try Insomnia AI <InsomniaAI /></h1>
         <p>
           Improve your productivity with Insomnia AI and perform complex operations in 1-click, like auto-generating API tests for your documents and collections.
           <br />

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -100,17 +100,18 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
             </Dropdown>) : (<Button onClick={handleExportAllToFile}>{`Export files from the "${projectName}" ${strings.project.singular}`}</Button>)
           }
 
-          {workspaceData?.activeWorkspace && isScratchpad(workspaceData?.activeWorkspace) ? null : <Button
+          <Button
             style={{
               display: 'flex',
               alignItems: 'center',
               gap: 'var(--padding-sm)',
             }}
+            disabled={workspaceData?.activeWorkspace && isScratchpad(workspaceData?.activeWorkspace)}
             onClick={() => setIsImportModalOpen(true)}
           >
             <i className="fa fa-file-import" />
             {`Import to the "${projectName}" ${strings.project.singular}`}
-          </Button>}
+          </Button>
 
           <Button
             style={{

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -3,12 +3,14 @@ import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { useRouteLoaderData } from 'react-router-dom';
 
+import { isLoggedIn } from '../../../account/session';
 import { getProductName } from '../../../common/constants';
 import { docsImportExport } from '../../../common/documentation';
 import { exportAllToFile } from '../../../common/export';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
 import { strings } from '../../../common/strings';
 import { isRequestGroup } from '../../../models/request-group';
+import { isScratchpad } from '../../../models/workspace';
 import { selectWorkspaceRequestsAndRequestGroups, selectWorkspacesForActiveProject } from '../../redux/selectors';
 import { WorkspaceLoaderData } from '../../routes/workspace';
 import { Dropdown, DropdownButton, DropdownItem, DropdownSection, ItemContent } from '../base/dropdown';
@@ -63,8 +65,11 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
         <p>
           Your format isn't supported? <Link href={docsImportExport}>Add Your Own</Link>.
         </p>
-        <div className="pad-top">
+        <div className="flex pt-4 gap-4">
           {workspaceData?.activeWorkspace ?
+            isScratchpad(workspaceData.activeWorkspace) ?
+              <Button onClick={showExportRequestsModal}>Export the "{activeWorkspaceName}" {getWorkspaceLabel(workspaceData.activeWorkspace).singular}</Button>
+              :
             (<Dropdown
               aria-label='Export Data Dropdown'
               triggerButton={
@@ -94,8 +99,8 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
               </DropdownSection>
             </Dropdown>) : (<Button onClick={handleExportAllToFile}>{`Export files from the "${projectName}" ${strings.project.singular}`}</Button>)
           }
-        &nbsp;&nbsp;
-          <Button
+
+          {workspaceData?.activeWorkspace && isScratchpad(workspaceData?.activeWorkspace) ? null : <Button
             style={{
               display: 'flex',
               alignItems: 'center',
@@ -105,11 +110,20 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
           >
             <i className="fa fa-file-import" />
             {`Import to the "${projectName}" ${strings.project.singular}`}
-          </Button>
-        &nbsp;&nbsp;
-          <Link href="https://insomnia.rest/create-run-button" className="btn btn--compact" button>
+          </Button>}
+
+          <Button
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--padding-sm)',
+            }}
+            disabled={!isLoggedIn()}
+            onClick={() => window.main.openInBrowser('https://insomnia.rest/create-run-button')}
+          >
+            <i className="fa fa-file-import" />
             Create Run Button
-          </Link>
+          </Button>
         </div>
         <p className="italic faint">* Tip: You can also paste Curl commands into the URL bar</p>
       </div>

--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -1,7 +1,8 @@
 import * as path from 'path';
 import React, { FC, useEffect, useState } from 'react';
-import { useRouteLoaderData } from 'react-router-dom';
+import { useNavigate, useRouteLoaderData } from 'react-router-dom';
 
+import { isLoggedIn } from '../../../account/session';
 import {
   NPM_PACKAGE_BASE,
   PLUGIN_HUB_BASE,
@@ -26,7 +27,8 @@ interface State {
   isInstallingFromNpm: boolean;
   isRefreshingPlugins: boolean;
 }
-export const Plugins: FC = () => {
+
+export const PluginsSettings: FC = () => {
   const [state, setState] = useState<State>({
     plugins: [],
     npmPluginValue: '',
@@ -265,6 +267,39 @@ export const Plugins: FC = () => {
         >
           Reload Plugins
           {isRefreshingPlugins && <i className="fa fa-refresh fa-spin space-left" />}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export const Plugins = () => {
+  const navigate = useNavigate();
+  if (isLoggedIn()) {
+    return <PluginsSettings />;
+  }
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className="border-solid border-[--hl-md] notice surprise p-4 rounded-md">
+        Log in to Insomnia to enable Plugins
+      </div>
+      <div className='flex gap-2'>
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={
+            () => navigate('/auth/login')
+          }
+        >
+          Log in
+        </Button>
+        <Button
+          onClick={() => navigate('/auth/login')}
+          size="small"
+          variant="contained"
+        >
+          Sign Up
         </Button>
       </div>
     </div>

--- a/packages/insomnia/src/ui/components/statusbar.tsx
+++ b/packages/insomnia/src/ui/components/statusbar.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
+import { isLoggedIn, onLoginLogout } from '../../account/session';
 import { SettingsButton } from './buttons/settings-button';
 import { SvgIcon } from './svg-icon';
 import { Tooltip } from './tooltip';
@@ -28,13 +29,17 @@ const KongLink = styled.a({
 });
 
 export const NetworkStatus = () => {
-  const [status, setStatus] = useState<'online' | 'offline'>('online');
+  const [status, setStatus] = useState<'online' | 'offline' | 'unauthorized'>(isLoggedIn() ? 'online' : 'unauthorized');
 
   useEffect(() => {
     const handleOnline = () => setStatus('online');
     const handleOffline = () => setStatus('offline');
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
+
+    onLoginLogout(isLoggedIn => {
+      setStatus(status => isLoggedIn ? status : 'unauthorized');
+    });
 
     return () => {
       window.removeEventListener('online', handleOnline);
@@ -78,7 +83,8 @@ export const NetworkStatus = () => {
             fontSize: 'var(--font-size-xs)',
           }}
         >
-          {status.charAt(0).toUpperCase() + status.slice(1)}
+          {status === 'unauthorized' && 'Log in to sync your data'}
+          {status !== 'unauthorized' && status.charAt(0).toUpperCase() + status.slice(1)}
         </span>
       </div>
     </Tooltip>

--- a/packages/insomnia/src/ui/components/workspace-card.tsx
+++ b/packages/insomnia/src/ui/components/workspace-card.tsx
@@ -33,7 +33,7 @@ const LabelIcon = styled.div({
   alignItems: 'center',
   justifyContent: 'center',
   padding: '0.2rem',
-  height: '1rem',
+  height: '1.5rem',
 });
 
 export interface WorkspaceCardProps {

--- a/packages/insomnia/src/ui/css/main.css
+++ b/packages/insomnia/src/ui/css/main.css
@@ -823,9 +823,6 @@ a {
   font-weight: 600 !important;
   text-decoration: none;
 }
-a:not(.a--nocolor) {
-  color: var(--color-surprise);
-}
 a:hover {
   text-decoration: underline;
 }

--- a/packages/insomnia/src/ui/css/main.css
+++ b/packages/insomnia/src/ui/css/main.css
@@ -3487,3 +3487,11 @@ input.editable {
   bottom: 0;
   z-index: 9999;
 }
+
+.servers {
+  margin-top: 1rem;
+}
+
+.pane-two {
+  z-index: 0;
+}

--- a/packages/insomnia/src/ui/css/styles.css
+++ b/packages/insomnia/src/ui/css/styles.css
@@ -11,7 +11,6 @@
 .app-grid-template {
   grid-template:
     'Header Header' auto
-    'Banner Banner' 30px
     'Navbar Content' 1fr
     'Statusbar Statusbar' 30px [row-end]
     / 50px 1fr;
@@ -20,6 +19,7 @@
 .app-grid-template-with-banner {
   grid-template: 
     'Header Header' auto
+    'Banner Banner' 30px
     'Navbar Content' 1fr
     'Statusbar Statusbar' 30px [row-end]
     / 50px 1fr;

--- a/packages/insomnia/src/ui/css/styles.css
+++ b/packages/insomnia/src/ui/css/styles.css
@@ -8,6 +8,23 @@
 @import './lib/codemirror/material.css';
 @import './main.css';
 
+.app-grid-template {
+  grid-template:
+    'Header Header' auto
+    'Banner Banner' 30px
+    'Navbar Content' 1fr
+    'Statusbar Statusbar' 30px [row-end]
+    / 50px 1fr;
+}
+
+.app-grid-template-with-banner {
+  grid-template: 
+    'Header Header' auto
+    'Navbar Content' 1fr
+    'Statusbar Statusbar' 30px [row-end]
+    / 50px 1fr;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -21,6 +21,7 @@ import {
 import { database } from '../common/database';
 import { initializeLogging } from '../common/log';
 import * as models from '../models';
+import { DEFAULT_PROJECT_ID } from '../models/project';
 import { initNewOAuthSession } from '../network/o-auth-2/get-token';
 import { init as initPlugins } from '../plugins';
 import { applyColorScheme } from '../plugins/misc';
@@ -546,7 +547,7 @@ const router = createMemoryRouter(
     },
   ],
   {
-    initialEntries: ['/organization'],
+    initialEntries: [`/organization/${DEFAULT_PROJECT_ID}/project/${DEFAULT_PROJECT_ID}/workspace/wrk_scratchpad/debug`],
   }
 );
 
@@ -633,8 +634,10 @@ function updateReduxNavigationState(store: Store, pathname: string) {
 }
 
 async function renderApp() {
+  // Create Redux store
+  const store = await initStore();
   await database.initClient();
-
+  await models.project.seed();
   await initPlugins();
 
   const settings = await models.settings.getOrCreate();
@@ -645,8 +648,6 @@ async function renderApp() {
 
   await applyColorScheme(settings);
 
-  // Create Redux store
-  const store = await initStore();
   // Synchronizes the Redux store with the router history
   // @HACK: This is temporary until we completely remove navigation through Redux
   const synchronizeRouterState = () => {

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-router-dom';
 import { Store } from 'redux';
 
+import { isLoggedIn } from '../account/session';
 import {
   ACTIVITY_DEBUG,
   ACTIVITY_HOME,
@@ -51,6 +52,19 @@ initializeLogging();
 // Handy little helper
 document.body.setAttribute('data-platform', process.platform);
 document.title = getProductName();
+
+let initialEntry = isLoggedIn() ? '/organization' : `/organization/${DEFAULT_PROJECT_ID}/project/${DEFAULT_PROJECT_ID}/workspace/wrk_scratchpad/debug`;
+
+try {
+  const hasUserLoggedInBefore = window.localStorage.getItem('hasUserLoggedInBefore');
+
+  if (hasUserLoggedInBefore) {
+    initialEntry = '/auth/login';
+  }
+
+} catch (e) {
+  console.log('User has not logged in before.');
+}
 
 const router = createMemoryRouter(
   // @TODO - Investigate file based routing to generate these routes:
@@ -547,7 +561,7 @@ const router = createMemoryRouter(
     },
   ],
   {
-    initialEntries: [`/organization/${DEFAULT_PROJECT_ID}/project/${DEFAULT_PROJECT_ID}/workspace/wrk_scratchpad/debug`],
+    initialEntries: [initialEntry],
   }
 );
 

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -30,7 +30,7 @@ export const createNewProjectAction: ActionFunction = async ({ request, params }
 
   const sessionId = session.getCurrentSessionId();
   invariant(sessionId, 'User must be logged in to create a project');
-  const response = await window.main.insomniaFetch<{ id: string }>({
+  const newProject = await window.main.insomniaFetch<{ id: string }>({
     path: `/v1/teams/${organizationId}/team-projects`,
     method: 'POST',
     data: {
@@ -39,7 +39,7 @@ export const createNewProjectAction: ActionFunction = async ({ request, params }
     sessionId,
   });
 
-  return redirect(`/organization/${organizationId}/project/${response.id}`);
+  return redirect(`/organization/${organizationId}/project/${newProject.id}`);
 };
 
 export const renameProjectAction: ActionFunction = async ({

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -19,6 +19,7 @@ export const action: ActionFunction = async ({
   await submitAuthCode(data.code);
 
   console.log('Login successful');
+  window.localStorage.setItem('hasLoggedIn', 'true');
 
   const driver = FileSystemDriver.create(process.env['INSOMNIA_DATA_PATH'] || window.app.getPath('userData'));
   await migrateCollectionsIntoRemoteProject(new VCS(driver));

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -57,7 +57,7 @@ const Authorize = () => {
       </p>
       <p>
         A new page should have opened in your default web browser.
-        To continue, please login via the browser.
+        To continue, please log in via the browser.
       </p>
       <div
         style={{
@@ -142,7 +142,7 @@ const Authorize = () => {
               }}
             >
               <i className="fa fa-sign-in" aria-hidden="true" />
-              Login
+              Log in
             </button>
           </div>
         </form>

--- a/packages/insomnia/src/ui/routes/auth.login.tsx
+++ b/packages/insomnia/src/ui/routes/auth.login.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { ActionFunction, Form, redirect } from 'react-router-dom';
+import { ActionFunction, Form, Link, redirect } from 'react-router-dom';
 
+import { DEFAULT_PROJECT_ID } from '../../models/project';
 import { getLoginUrl } from '../auth-session-provider';
 import { Button } from '../components/themed-button';
 
@@ -44,173 +45,189 @@ export const action: ActionFunction = async ({
   return redirect('/auth/authorize');
 };
 
-const Login = () => {
-  return (
-    <Form
+const Login = () => (
+  <Form
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 'var(--padding-md)',
+    }}
+    method="POST"
+  >
+    <p
+      style={{
+        textAlign: 'center',
+        color: 'var(--color-font)',
+        fontSize: 'var(--font-size-xl)',
+        padding: '0 var(--padding-md)',
+      }}
+    >
+      Welcome to Insomnia
+    </p>
+    <Button
+      name="provider"
+      variant='outlined'
+      size="medium"
+      type="submit"
+      value="google"
+      style={{
+        width: '100%',
+        padding: 0,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          width: '100%',
+          height: '100%',
+          gap: 'var(--padding-md)',
+        }}
+      >
+        <div
+          style={{
+            width: '40px',
+            height: '100%',
+            borderRight: '1px solid var(--hl-sm)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'var(--hl-xs)',
+          }}
+        >
+          <GoogleIcon width="1em" />
+        </div>
+        <span>
+          Continue with Google
+        </span>
+      </div>
+    </Button>
+    <Button
+      name="provider"
+      value="github"
+      variant='outlined'
+      size="medium"
+      type="submit"
+      style={{
+        width: '100%',
+        padding: 0,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          width: '100%',
+          height: '100%',
+          gap: 'var(--padding-md)',
+        }}
+      >
+        <div
+          style={{
+            width: '40px',
+            height: '100%',
+            borderRight: '1px solid var(--hl-sm)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'var(--hl-xs)',
+          }}
+        >
+          <i className='fa fa-github' />
+        </div>
+        <span>
+          Continue with GitHub
+        </span>
+      </div>
+    </Button>
+    <Button
+      name="provider"
+      value="email"
+      variant='outlined'
+      size="medium"
+      type="submit"
+      style={{
+        width: '100%',
+        padding: 0,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          width: '100%',
+          height: '100%',
+          gap: 'var(--padding-md)',
+        }}
+      >
+        <div
+          style={{
+            width: '40px',
+            height: '100%',
+            borderRight: '1px solid var(--hl-sm)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'var(--hl-xs)',
+          }}
+        >
+          <i className='fa fa-envelope' />
+        </div>
+        <span>
+          Continue with Email
+        </span>
+      </div>
+    </Button>
+
+    <Link
+      to={`/organization/${DEFAULT_PROJECT_ID}/project/${DEFAULT_PROJECT_ID}/workspace/wrk_scratchpad/debug`}
       style={{
         display: 'flex',
-        flexDirection: 'column',
-        gap: 'var(--padding-md)',
+        justifyContent: 'center',
+        color: 'var(--color-font)',
+        gap: 'var(--padding-xs)',
+        paddingTop: '2rem',
       }}
-      method="POST"
     >
-      <p
-        style={{
-          textAlign: 'center',
-          color: 'var(--color-font)',
-          fontSize: 'var(--font-size-xl)',
-          padding: '0 var(--padding-md)',
-        }}
-      >
-        Welcome to Insomnia
-      </p>
-      <Button
-        name="provider"
-        variant='outlined'
-        size="medium"
-        type="submit"
-        value="google"
-        style={{
-          width: '100%',
-          padding: 0,
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            width: '100%',
-            height: '100%',
-            gap: 'var(--padding-md)',
-          }}
-        >
-          <div
-            style={{
-              width: '40px',
-              height: '100%',
-              borderRight: '1px solid var(--hl-sm)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              background: 'var(--hl-xs)',
-            }}
-          >
-            <GoogleIcon width="1em" />
-          </div>
-          <span>
-            Continue with Google
-          </span>
-        </div>
-      </Button>
-      <Button
-        name="provider"
-        value="github"
-        variant='outlined'
-        size="medium"
-        type="submit"
-        style={{
-          width: '100%',
-          padding: 0,
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            width: '100%',
-            height: '100%',
-            gap: 'var(--padding-md)',
-          }}
-        >
-          <div
-            style={{
-              width: '40px',
-              height: '100%',
-              borderRight: '1px solid var(--hl-sm)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              background: 'var(--hl-xs)',
-            }}
-          >
-            <i className='fa fa-github' />
-          </div>
-          <span>
-            Continue with GitHub
-          </span>
-        </div>
-      </Button>
-      <Button
-        name="provider"
-        value="email"
-        variant='outlined'
-        size="medium"
-        type="submit"
-        style={{
-          width: '100%',
-          padding: 0,
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            width: '100%',
-            height: '100%',
-            gap: 'var(--padding-md)',
-          }}
-        >
-          <div
-            style={{
-              width: '40px',
-              height: '100%',
-              borderRight: '1px solid var(--hl-sm)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              background: 'var(--hl-xs)',
-            }}
-          >
-            <i className='fa fa-envelope' />
-          </div>
-          <span>
-            Continue with Email
-          </span>
-        </div>
-      </Button>
-      <p
+      <div>
+        <i className='fa fa-edit' />
+      </div>
+      <span>
+        Or continue to Scratch Pad
+      </span>
+    </Link>
+    <p
+      style={{
+        color: 'rgba(var(--color-font-rgb), 0.8)',
+        fontSize: 'var(--font-size-sm)',
+        textAlign: 'center',
+      }}
+    >
+      By signing up, you agree to the{' '}
+      <a
         style={{
           color: 'rgba(var(--color-font-rgb), 0.8)',
-          fontSize: 'var(--font-size-sm)',
-          textAlign: 'center',
         }}
+        target="_blank"
+        href="https://insomnia.rest/terms"
+        rel="noreferrer"
       >
-        By signing up, you agree to the{' '}
-        <a
-          style={{
-            color: 'rgba(var(--color-font-rgb), 0.8)',
-          }}
-          target="_blank"
-          href="https://insomnia.rest/terms"
-          rel="noreferrer"
-        >
-          Terms of Service
-        </a>{' '}
-        and{' '}
-        <a
-          style={{
-            color: 'rgba(var(--color-font-rgb), 0.8)',
-          }}
-          target="_blank"
-          href="https://insomnia.rest/privacy"
-          rel="noreferrer"
-        >
-          Privacy Policy agreement
-        </a>
-        .
-      </p>
-    </Form>
-  );
-};
+        Terms of Service
+      </a>{' '}
+      and{' '}
+      <a
+        style={{
+          color: 'rgba(var(--color-font-rgb), 0.8)',
+        }}
+        target="_blank"
+        href="https://insomnia.rest/privacy"
+        rel="noreferrer"
+      >
+        Privacy Policy agreement
+      </a>
+      .
+    </p>
+  </Form>
+);
 
 export default Login;

--- a/packages/insomnia/src/ui/routes/auth.tsx
+++ b/packages/insomnia/src/ui/routes/auth.tsx
@@ -12,7 +12,6 @@ const Background = styled('div')({
   textAlign: 'center',
   display: 'flex',
   background: 'var(--color-bg)',
-  // background: 'linear-gradient(0deg, #35007F 0%, #4000BF 50%, #35007F 60.81%, #000000 93.75%)',
 });
 
 const Auth = () => {

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -35,8 +35,8 @@ import { SidebarLayout } from '../components/sidebar-layout';
 import { RealtimeResponsePane } from '../components/websockets/realtime-response-pane';
 import { WebSocketRequestPane } from '../components/websockets/websocket-request-pane';
 import { useRequestMetaPatcher } from '../hooks/use-request';
+import { OrganizationLoaderData } from './organization';
 import { RequestLoaderData } from './request';
-import { OrganizationLoaderData } from './root';
 import { WorkspaceLoaderData } from './workspace';
 export interface GrpcMessage {
   id: string;

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -61,19 +61,19 @@ export interface Metadata {
   organizationType: string;
 }
 
-const isPersonalOrganization = (organization: Organization) => organization.metadata.organizationType === 'personal';
+export const isPersonalOrganization = (organization: Organization) => organization.metadata.organizationType === 'personal';
 
 export const indexLoader: LoaderFunction = async () => {
   const sessionId = getCurrentSessionId();
   if (sessionId) {
     try {
-      const response = await window.main.insomniaFetch<OrganizationsResponse>({
+      const { organizations } = await window.main.insomniaFetch<OrganizationsResponse>({
         method: 'GET',
         path: '/v1/organizations',
         sessionId,
       });
 
-      const personalOrganization = response.organizations.find(isPersonalOrganization);
+      const personalOrganization = organizations.find(isPersonalOrganization);
 
       if (personalOrganization) {
         return redirect(`/organization/${personalOrganization.id}`);

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -1,13 +1,14 @@
 import { IpcRendererEvent } from 'electron';
-import React, { useEffect, useState } from 'react';
-import { LoaderFunction, Outlet, redirect, useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
+import React, { Fragment, useEffect, useState } from 'react';
+import { Link, LoaderFunction, Outlet, redirect, useFetcher, useNavigate, useParams, useRouteLoaderData } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { getCurrentSessionId } from '../../account/session';
+import { getCurrentSessionId, isLoggedIn } from '../../account/session';
 import { isDevelopment } from '../../common/constants';
 import * as models from '../../models';
 import { Organization } from '../../models/organization';
 import { Settings } from '../../models/settings';
+import { isScratchpad } from '../../models/workspace';
 import { reloadPlugins } from '../../plugins';
 import { createPlugin } from '../../plugins/create';
 import { setTheme } from '../../plugins/misc';
@@ -27,6 +28,7 @@ import { SettingsModal, TAB_INDEX_PLUGINS, TAB_INDEX_THEMES } from '../component
 import { SyncMergeModal } from '../components/modals/sync-merge-modal';
 import { OrganizationsNav } from '../components/organizations-navbar';
 import { StatusBar } from '../components/statusbar';
+import { Button } from '../components/themed-button';
 import { Toast } from '../components/toast';
 import { WorkspaceHeader } from '../components/workspace-header';
 import { AppHooks } from '../containers/app-hooks';
@@ -38,74 +40,9 @@ import { WorkspaceLoaderData } from './workspace';
 
 export const indexLoader: LoaderFunction = async () => {
   const sessionId = getCurrentSessionId();
-  if (!sessionId) {
-    throw redirect('/auth/login');
-  }
-
-  const teams = await window.main.insomniaFetch<{
-    created: string;
-    id: string;
-    ownerAccountId: string;
-    name: string;
-    isPersonal: boolean;
-    accounts: {
-      firstName: string;
-      lastName: string;
-      email: string;
-      id: string;
-      isAdmin: boolean;
-      dateAccepted: string;
-    }[];
-  }[]>({
-    method: 'GET',
-    path: '/api/teams',
-    sessionId,
-  });
-
-  const personalTeam = teams.find(team => team.isPersonal);
-
-  if (personalTeam) {
-    return redirect(`/organization/${personalTeam.id}`);
-  }
-
-  return null;
-};
-
-export interface OrganizationLoaderData {
-  organizations: Organization[];
-  user: {
-    name: string;
-    picture: string;
-  };
-  settings: Settings;
-}
-
-export const loader: LoaderFunction = async () => {
-  const sessionId = getCurrentSessionId();
-
-  if (!sessionId) {
-    throw redirect('/auth/login');
-  }
-
-  // await migrateLocalToCloudProjects();
-  try {
-    let vcs = getVCS();
-    if (!vcs) {
-      const driver = FileSystemDriver.create(process.env['INSOMNIA_DATA_PATH'] || window.app.getPath('userData'));
-
-      console.log('Initializing VCS');
-      vcs = await initVCS(driver, async conflicts => {
-        return new Promise(resolve => {
-          showModal(SyncMergeModal, {
-            conflicts,
-            handleDone: (conflicts?: MergeConflict[]) => resolve(conflicts || []),
-          });
-        });
-      });
-    }
-
-    // Teams are now organizations
-    const teams = await window.main.insomniaFetch<{
+  if (sessionId) {
+    try {
+      const teams = await window.main.insomniaFetch<{
         created: string;
         id: string;
         ownerAccountId: string;
@@ -125,7 +62,71 @@ export const loader: LoaderFunction = async () => {
         sessionId,
       });
 
-    const user = await window.main.insomniaFetch<{
+      const personalTeam = teams.find(team => team.isPersonal);
+
+      if (personalTeam) {
+        return redirect(`/organization/${personalTeam.id}`);
+      }
+    } catch (error) {
+      console.log('Failed to load Teams', error);
+      return null;
+    }
+  }
+
+  return null;
+};
+
+export interface OrganizationLoaderData {
+  organizations: Organization[];
+  user: {
+    name: string;
+    picture: string;
+  };
+  settings: Settings;
+}
+
+export const loader: LoaderFunction = async () => {
+  const sessionId = getCurrentSessionId();
+
+  if (sessionId) {
+    try {
+      let vcs = getVCS();
+      if (!vcs) {
+        const driver = FileSystemDriver.create(process.env['INSOMNIA_DATA_PATH'] || window.app.getPath('userData'));
+
+        console.log('Initializing VCS');
+        vcs = await initVCS(driver, async conflicts => {
+          return new Promise(resolve => {
+            showModal(SyncMergeModal, {
+              conflicts,
+              handleDone: (conflicts?: MergeConflict[]) => resolve(conflicts || []),
+            });
+          });
+        });
+      }
+
+      // Teams are now organizations
+      const teams = await window.main.insomniaFetch<{
+        created: string;
+        id: string;
+        ownerAccountId: string;
+        name: string;
+        isPersonal: boolean;
+        accounts: {
+          firstName: string;
+          lastName: string;
+          email: string;
+          id: string;
+          isAdmin: boolean;
+          dateAccepted: string;
+        }[];
+      }[]>({
+        method: 'GET',
+        path: '/api/teams',
+        sessionId,
+      });
+
+      const user = await window.main.insomniaFetch<{
         name: string;
         picture: string;
       }>({
@@ -134,49 +135,45 @@ export const loader: LoaderFunction = async () => {
         sessionId,
       });
 
-    return {
-      user,
-      settings: await models.settings.getOrCreate(),
-      organizations: teams.map(team => ({
-        _id: team.id,
-        name: team.name,
-        isPersonal: team.isPersonal,
-      })).sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => {
-        if (a.isPersonal && !b.isPersonal) {
-          return -1;
-        } else if (!a.isPersonal && b.isPersonal) {
-          return 1;
-        } else {
-          return 0;
-        }
-      }),
-    };
-  } catch (err) {
-    console.log('Failed to load Teams', err);
-    return {
-      user: {
-        name: '',
-        picture: '',
-      },
-      settings: await models.settings.getOrCreate(),
-      organizations: [],
-    };
+      return {
+        user,
+        settings: await models.settings.getOrCreate(),
+        organizations: teams.map(team => ({
+          _id: team.id,
+          name: team.name,
+          isPersonal: team.isPersonal,
+        })).sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => {
+          if (a.isPersonal && !b.isPersonal) {
+            return -1;
+          } else if (!a.isPersonal && b.isPersonal) {
+            return 1;
+          } else {
+            return 0;
+          }
+        }),
+      };
+    } catch (err) {
+      console.log('Failed to load Teams', err);
+      return {
+        user: {
+          name: '',
+          picture: '',
+        },
+        settings: await models.settings.getOrCreate(),
+        organizations: [],
+      };
+    }
   }
-};
 
-const Layout = styled.div({
-  position: 'relative',
-  height: '100%',
-  width: '100%',
-  display: 'grid',
-  backgroundColor: 'var(--color-bg)',
-  gridTemplate: `
-    'Header Header' auto
-    'Navbar Content' 1fr
-    'Statusbar Statusbar' 30px [row-end]
-    / 50px 1fr;
-  `,
-});
+  return {
+    user: {
+      name: '',
+      picture: '',
+    },
+    settings: await models.settings.getOrCreate(),
+    organizations: [],
+  };
+};
 
 const OrganizationRoute = () => {
   const { organizationId } = useParams() as {
@@ -340,10 +337,7 @@ const OrganizationRoute = () => {
     ':workspaceId'
   ) as WorkspaceLoaderData | null;
 
-  const sessionId = getCurrentSessionId();
-  if (!sessionId) {
-    return null;
-  }
+  const navigate = useNavigate();
 
   return (
     <PresenceProvider>
@@ -362,17 +356,57 @@ const OrganizationRoute = () => {
                 />
               )}
               <Modals />
-              <Layout>
+              <div className={`relative h-full w-full grid ${isLoggedIn() ? 'app-grid-template-with-banner' : 'app-grid-template'}`}>
                 <OrganizationsNav />
                 <AppHeader
                   gridCenter={
-                    workspaceData ? <WorkspaceHeader {...workspaceData} /> : null
+                    isLoggedIn() && workspaceData ? <WorkspaceHeader {...workspaceData} /> : null
                   }
-                  gridRight={<AccountToolbar />}
+                  gridRight={isLoggedIn() ? <AccountToolbar /> : (
+                    <Fragment>
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        onClick={
+                          () => navigate('/auth/login')
+                        }
+                      >
+                        Login
+                      </Button>
+                      <Button
+                        onClick={() => navigate('/auth/login')}
+                        size="small"
+                        variant="contained"
+                      >
+                        Sign Up
+                      </Button>
+                    </Fragment>
+                  )
+                  }
                 />
+                {workspaceData?.activeWorkspace && isScratchpad(workspaceData.activeWorkspace) ? (
+                  <div className='flex items-center [grid-area:Banner] text-white bg-gradient-to-r from-[#7400e1] to-[#4000bf]'>
+                    <div className='flex basis-[50px] h-full'>
+                      <div
+                        className='border-r-[--hl-xl] border-r border-l border-l-[--hl-xl] box-border flex items-center justify-center w-full h-full'
+                      >
+                        <i className="fa fa-edit" />
+                      </div>
+                    </div>
+                    <div className='flex items-center px-[--padding-md] gap-[--padding-xs]'>
+                      Welcome to the Scratch Pad. To get the most out of Insomnia
+                      <Link
+                        to="/auth/login"
+                        className="font-bold text-white"
+                      >
+                        go to your projects →
+                      </Link>
+                    </div>
+                  </div>
+                ) : null}
                 <Outlet />
                 <StatusBar />
-              </Layout>
+              </div>
             </ErrorBoundary>
 
             <ErrorBoundary showAlert>

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -338,6 +338,8 @@ const OrganizationRoute = () => {
 
   const navigate = useNavigate();
 
+  const isScratchpadWorkspace = workspaceData?.activeWorkspace && isScratchpad(workspaceData.activeWorkspace);
+
   return (
     <PresenceProvider>
       <AIProvider>
@@ -355,7 +357,7 @@ const OrganizationRoute = () => {
                 />
               )}
               <Modals />
-              <div className={`relative h-full w-full grid ${isLoggedIn() ? 'app-grid-template-with-banner' : 'app-grid-template'}`}>
+              <div className={`relative h-full w-full grid ${isScratchpadWorkspace ? 'app-grid-template-with-banner' : 'app-grid-template'}`}>
                 <OrganizationsNav />
                 <AppHeader
                   gridCenter={
@@ -383,7 +385,7 @@ const OrganizationRoute = () => {
                   )
                   }
                 />
-                {workspaceData?.activeWorkspace && isScratchpad(workspaceData.activeWorkspace) ? (
+                {isScratchpadWorkspace ? (
                   <div className='flex items-center [grid-area:Banner] text-white bg-gradient-to-r from-[#7400e1] to-[#4000bf]'>
                     <div className='flex basis-[50px] h-full'>
                       <div

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -370,7 +370,7 @@ const OrganizationRoute = () => {
                           () => navigate('/auth/login')
                         }
                       >
-                        Login
+                        Log in
                       </Button>
                       <Button
                         onClick={() => navigate('/auth/login')}

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -1,7 +1,6 @@
 import { IpcRendererEvent } from 'electron';
 import React, { Fragment, useEffect, useState } from 'react';
 import { Link, LoaderFunction, Outlet, redirect, useFetcher, useNavigate, useParams, useRouteLoaderData } from 'react-router-dom';
-import styled from 'styled-components';
 
 import { getCurrentSessionId, isLoggedIn } from '../../account/session';
 import { isDevelopment } from '../../common/constants';
@@ -388,7 +387,7 @@ const OrganizationRoute = () => {
                   <div className='flex items-center [grid-area:Banner] text-white bg-gradient-to-r from-[#7400e1] to-[#4000bf]'>
                     <div className='flex basis-[50px] h-full'>
                       <div
-                        className='border-r-[--hl-xl] border-r border-l border-l-[--hl-xl] box-border flex items-center justify-center w-full h-full'
+                        className='border-solid border-r-[--hl-xl] border-r border-l border-l-[--hl-xl] box-border flex items-center justify-center w-full h-full'
                       >
                         <i className="fa fa-edit" />
                       </div>

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -307,12 +307,12 @@ const OrganizationProjectsSidebar: FC<{
         >
           <DropdownSection items={organizations}>
             {organization => (
-              <DropdownItem key={organization._id}>
+              <DropdownItem key={organization.id}>
                 <ItemContent
-                  label={organization.name}
-                  isSelected={organization._id === organizationId}
+                  label={organization.display_name}
+                  isSelected={organization.id === organizationId}
                   onClick={() => {
-                    navigate(`/organization/${organization._id}`);
+                    navigate(`/organization/${organization.id}`);
                   }}
                 />
               </DropdownItem>
@@ -726,8 +726,6 @@ export const loader: LoaderFunction = async ({
   const filter = search.get('filter') || '';
   const scope = search.get('scope') || 'all';
   const projectName = search.get('projectName') || '';
-  const project = await models.project.getById(projectId);
-  invariant(project, 'Project was not found');
 
   try {
     console.log('Fetching projects for team', organizationId);
@@ -755,6 +753,9 @@ export const loader: LoaderFunction = async ({
     console.log(err);
     throw redirect('/organization');
   }
+
+  const project = await models.project.getById(projectId);
+  invariant(project, 'Project was not found');
 
   const projectWorkspaces = await models.workspace.findByParentId(projectId);
 
@@ -882,7 +883,10 @@ const ProjectRoute: FC = () => {
     collectionsCount,
     documentsCount,
   } = useLoaderData() as ProjectLoaderData;
+
   const { organizationId } = useParams() as { organizationId: string };
+  const organizationData = useRouteLoaderData('/organization') as OrganizationLoaderData;
+  const activeOrganization = organizationData?.organizations.find(org => org.id === organizationId);
   const [searchParams] = useSearchParams();
   const [isGitRepositoryCloneModalOpen, setIsGitRepositoryCloneModalOpen] =
     useState(false);
@@ -955,7 +959,7 @@ const ProjectRoute: FC = () => {
           renderPageSidebar={
             <OrganizationProjectsSidebar
               organizationId={organizationId}
-              title={'TODO'}
+              title={activeOrganization?.display_name || ''}
               projects={projects}
               workspaces={workspaces.map(w => w.workspace)}
               activeProject={activeProject}

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -24,7 +24,7 @@ import {
 import { Item, ListProps, ListState, useListState } from 'react-stately';
 import styled from 'styled-components';
 
-import { getAccountId, getCurrentSessionId } from '../../account/session';
+import { getCurrentSessionId } from '../../account/session';
 import { parseApiSpec, ParsedApiSpec } from '../../common/api-specs';
 import {
   ACTIVITY_DEBUG,
@@ -48,6 +48,7 @@ import {
 } from '../../models/project';
 import { isDesign, Workspace } from '../../models/workspace';
 import { WorkspaceMeta } from '../../models/workspace-meta';
+import { Team } from '../../sync/types';
 import { invariant } from '../../utils/invariant';
 import {
   Dropdown,
@@ -88,7 +89,7 @@ async function getAllTeamProjects(teamId: string) {
     sessionId,
   });
 
-  return response.data;
+  return response.data as Team[];
 }
 
 const StyledDropdownButton = styled(DropdownButton).attrs({
@@ -442,7 +443,6 @@ const OrganizationProjectsSidebar: FC<{
 
       <ProjectListContainer>
         <List
-          aria-label="files-list"
           key="files-list"
           aria-label='Files List'
           selectionMode="single"

--- a/packages/insomnia/src/ui/routes/workspace.tsx
+++ b/packages/insomnia/src/ui/routes/workspace.tsx
@@ -31,11 +31,14 @@ export interface WorkspaceLoaderData {
 export const workspaceLoader: LoaderFunction = async ({
   params,
 }): Promise<WorkspaceLoaderData> => {
-  const { projectId, workspaceId, organizationId } = params;
+  const { projectId, workspaceId } = params;
   invariant(workspaceId, 'Workspace ID is required');
   invariant(projectId, 'Project ID is required');
 
+  console.log({ workspaceId });
+
   const activeWorkspace = await models.workspace.getById(workspaceId);
+
   invariant(activeWorkspace, 'Workspace not found');
 
   // I don't know what to say man, this is just how it is


### PR DESCRIPTION
Adds the Scratch Pad collection.

This works with signed out users and is placed under `/organization/default_org/project/default_proj/workspace/scratchpad`.

Highlights:
- [x] The Scratch Pad is a collection and supports all the features of a collection as it works in  the current version.
- [x] Settings:
  - [x] Export works as expected. Import and Create Run button are not supported since we don't have the concept of the default project anymore in the UI/UX.
  - [x] Account, Plugins and AI are disabled since they require login

Closes INS-2848