### PR TITLE
chore: smoke-test stage for app-package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,10 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=6144'
           BUILD_TARGETS: 'dir'
 
+      - name: debug check dist folder after package
+        if: matrix.os == 'macos-latest'
+        run: ls -la packages/insomnia/dist
+
       - name: Run Smoke tests on Package (CI)
         # Partial Smoke test run, for regular CI triggers
         if: "!startsWith(github.head_ref, 'release/')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  OS:
+  LintTypeCheckTestAndSmokeTest:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -107,3 +107,38 @@ jobs:
           if-no-files-found: ignore
           name: ${{ matrix.os }}-smoke-test-screenshots-${{ github.run_number }}
           path: packages/insomnia-smoke-test/screenshots
+  SmokeTestPackagedInsomnia:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Package app for smoke tests
+        run: npm run app-package
+        env:
+          NODE_OPTIONS: '--max_old_space_size=6144'
+          BUILD_TARGETS: 'dir'
+
+      - name: Run Smoke tests on Package (CI)
+        # Partial Smoke test run, for regular CI triggers
+        if: "!startsWith(github.head_ref, 'release/')"
+        run: npm run test:package --prefix packages/insomnia-smoke-test -- --project=Smoke
+
+      - name: Run Smoke tests on Package (Release)
+        # Full Smoke test run, for Release PRs
+        if: "startsWith(github.head_ref, 'release/')"
+        run: npm run test:package --prefix packages/insomnia-smoke-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,33 @@ jobs:
         if: "startsWith(github.head_ref, 'release/')"
         run: npm run test:build --prefix packages/insomnia-smoke-test
 
+      - name: Upload smoke test screenshots
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          if-no-files-found: ignore
+          name: ${{ matrix.os }}-smoke-test-screenshots-${{ github.run_number }}
+          path: packages/insomnia-smoke-test/screenshots
+  InsoTestCLISmokeTest:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install packages
+        run: npm ci
+
       - name: Set Inso CLI variables
         id: inso-variables
         shell: bash
@@ -100,13 +127,6 @@ jobs:
       - name: Run Inso CLI smoke tests
         run: npm run test:smoke:cli
 
-      - name: Upload smoke test screenshots
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          if-no-files-found: ignore
-          name: ${{ matrix.os }}-smoke-test-screenshots-${{ github.run_number }}
-          path: packages/insomnia-smoke-test/screenshots
   SmokeTestPackagedInsomnia:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -142,3 +162,11 @@ jobs:
         # Full Smoke test run, for Release PRs
         if: "startsWith(github.head_ref, 'release/')"
         run: npm run test:package --prefix packages/insomnia-smoke-test
+
+      - name: Upload smoke test screenshots
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          if-no-files-found: ignore
+          name: ${{ matrix.os }}-package-smoke-test-screenshots-${{ github.run_number }}
+          path: packages/insomnia-smoke-test/screenshots

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,6 @@ jobs:
 
       - name: Run Inso CLI smoke tests
         run: npm run test:smoke:cli
-
   SmokeTestPackagedInsomnia:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "inso-start": "npm start --workspace=packages/insomnia-inso",
     "inso-package": "npm run build:sr --workspace=packages/insomnia && npm run package --workspace=packages/insomnia-inso",
     "inso-package:artifacts": "npm run artifacts --workspace=packages/insomnia-inso",
-    "test:bundled-inso": "npm run build --workspace=packages/insomnia-inso && npm run test:bundled-inso --workspace=packages/insomnia-inso",
+    "test:bundled-inso": "npm run build:sr --workspace=packages/insomnia && npm run build --workspace=packages/insomnia-inso && npm run test:bundled-inso --workspace=packages/insomnia-inso",
     "watch:app": "npm run build:main.min.js --workspace=packages/insomnia && npm run start:dev-server --workspace=packages/insomnia",
     "app-build": "npm run build --workspace=packages/insomnia",
     "app-package": "npm run package --workspace=packages/insomnia",

--- a/packages/insomnia-smoke-test/playwright/paths.ts
+++ b/packages/insomnia-smoke-test/playwright/paths.ts
@@ -15,9 +15,10 @@ export const loadFixture = async (fixturePath: string) => {
 export const randomDataPath = () => path.join(os.tmpdir(), 'insomnia-smoke-test', `${uuidv4()}`);
 export const INSOMNIA_DATA_PATH = randomDataPath();
 
+const macDistFolderParent = process.env.CI ? 'mac' : 'mac-universal';
 const pathLookup: Record<string, string> = {
   win32: path.join('win-unpacked', 'Insomnia.exe'),
-  darwin: path.join('mac-universal', 'Insomnia.app', 'Contents', 'MacOS', 'Insomnia'),
+  darwin: path.join(macDistFolderParent, 'Insomnia.app', 'Contents', 'MacOS', 'Insomnia'),
   linux: path.join('linux-unpacked', 'insomnia'),
 };
 export const cwd = path.resolve(__dirname, '..', '..', 'insomnia');

--- a/packages/insomnia-smoke-test/playwright/paths.ts
+++ b/packages/insomnia-smoke-test/playwright/paths.ts
@@ -17,7 +17,7 @@ export const INSOMNIA_DATA_PATH = randomDataPath();
 
 const pathLookup: Record<string, string> = {
   win32: path.join('win-unpacked', 'Insomnia.exe'),
-  darwin: path.join('mac', 'Insomnia.app', 'Contents', 'MacOS', 'Insomnia'),
+  darwin: path.join('mac-universal', 'Insomnia.app', 'Contents', 'MacOS', 'Insomnia'),
   linux: path.join('linux-unpacked', 'insomnia'),
 };
 export const cwd = path.resolve(__dirname, '..', '..', 'insomnia');


### PR DESCRIPTION
Exploration on spliting up the test.yml and adding smoke tests run against Packaged version of the app

by spliting up:
- "lint+typecheck+test+smoketest"
- "inso build and tests"
- "package and smoketest on package"