### PR TITLE
add critical smoke tests to avoid broken beta deploy

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   parse-version:
-    if: "startsWith(github.head_ref, 'release/') || github.event_name == 'workflow_dispatch'"
+    if: ${{ startsWith(github.head_ref, 'release/') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -29,7 +29,7 @@ jobs:
           echo "RELEASE_VERSION=${{ github.event.inputs.version }} " >> $GITHUB_ENV
 
       - name: Set release version Env (pull_request)
-        if: "startsWith(github.head_ref, 'release/')"
+        if: ${{ startsWith(github.head_ref, 'release/') }}
         shell: bash
         run: |
           echo "RELEASE_VERSION=${BRANCH/release\//} " >> $GITHUB_ENV

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -52,9 +52,6 @@ jobs:
         shell: bash
         run: NODE_OPTIONS='--max_old_space_size=6144' BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
 
-      - name: Remove me
-        run: ls -al /Users/runner/work/insomnia/insomnia/packages/insomnia/dist
-
       - name: Run critical test on packaged app
         run: npm run test:package --prefix packages/insomnia-smoke-test -- --project=Critical
 

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build-and-upload-artifacts:
     # Skip jobs for release PRs
-    if: "!startsWith(github.head_ref, 'release/')"
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -52,6 +52,9 @@ jobs:
         shell: bash
         run: NODE_OPTIONS='--max_old_space_size=6144' BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
 
+      - name: Remove me
+        run: ls -al /Users/runner/work/insomnia/insomnia/packages/insomnia/dist
+
       - name: Run critical test on packaged app
         run: npm run test:package --prefix packages/insomnia-smoke-test -- --project=Critical
 

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -52,6 +52,16 @@ jobs:
         shell: bash
         run: NODE_OPTIONS='--max_old_space_size=6144' BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
 
+      - name: Run critical test on packaged app
+        run: npm run test:package --prefix packages/insomnia-smoke-test -- --project=Critical
+
+      - name: Upload smoke test traces
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: ignore
+          name: ${{ matrix.os }}-package-critical-test-traces-${{ github.run_number }}
+          path: packages/insomnia-smoke-test/traces
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,15 +49,15 @@ jobs:
       - name: Build app for smoke tests
         run: npm run app-build
 
-      - name: Run Smoke tests (CI)
+      - name: Run Smoke tests
         # Partial Smoke test run, for regular CI triggers
         if: ${{ !startsWith(github.head_ref, 'release/') }}
         run: npm run test:build --prefix packages/insomnia-smoke-test -- --project=Smoke
 
-      - name: Run Smoke tests (Release)
+      - name: Run Prerelease tests
         # Full Smoke test run, for Release PRs
         if: ${{ startsWith(github.head_ref, 'release/') }}
-        run: npm run test:build --prefix packages/insomnia-smoke-test
+        run: npm run test:build --prefix packages/insomnia-smoke-test -- --project=Default
 
       - name: Set Inso CLI variables
         id: inso-variables

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,12 +54,12 @@ jobs:
 
       - name: Run Smoke tests (CI)
         # Partial Smoke test run, for regular CI triggers
-        if: "!startsWith(github.head_ref, 'release/')"
+        if: ${{ !startsWith(github.head_ref, 'release/') }}
         run: npm run test:build --prefix packages/insomnia-smoke-test -- --project=Smoke
 
       - name: Run Smoke tests (Release)
         # Full Smoke test run, for Release PRs
-        if: "startsWith(github.head_ref, 'release/')"
+        if: ${{ startsWith(github.head_ref, 'release/') }}
         run: npm run test:build --prefix packages/insomnia-smoke-test
 
       - name: Set Inso CLI variables

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,15 +35,12 @@ jobs:
         run: npm ci
 
       - name: Lint
-        if: matrix.os == 'ubuntu-latest'
         run: npm run lint
 
       - name: Lint markdown
-        if: matrix.os == 'ubuntu-latest'
         run: npm run lint:markdown
 
       - name: Type checks
-        if: matrix.os == 'ubuntu-latest'
         run: npm run type-check
 
       - name: Run tests
@@ -67,7 +64,7 @@ jobs:
         shell: bash
         run: |
           INSO_VERSION="$(jq .version packages/insomnia-inso/package.json -rj)-run.${{ github.run_number }}"
-          PKG_NAME="inso-${{ matrix.os }}-$INSO_VERSION"
+          PKG_NAME="inso-ubuntu-latest-$INSO_VERSION"
 
           echo "pkg-name=$PKG_NAME" >> $GITHUB_OUTPUT
           echo "inso-version=$INSO_VERSION" >> $GITHUB_OUTPUT
@@ -100,8 +97,7 @@ jobs:
 
       - name: Upload smoke test traces
         uses: actions/upload-artifact@v3
-        if: always()
         with:
           if-no-files-found: ignore
-          name: ${{ matrix.os }}-smoke-test-traces-${{ github.run_number }}
+          name: ubuntu-smoke-test-traces-${{ github.run_number }}
           path: packages/insomnia-smoke-test/traces

--- a/packages/insomnia-smoke-test/playwright.config.ts
+++ b/packages/insomnia-smoke-test/playwright.config.ts
@@ -3,15 +3,21 @@ import { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   projects: [
     {
-      // Run all tests
+      // Run all tests, runs only on Release PR test workflow
       name: 'Default',
-      testMatch: /.*.test.ts/,
+      testMatch: /prerelease\/.*.test.ts/,
       retries: 0,
     },
     {
-      // High-confidence smoke/sanity checks
+      // High-confidence smoke/sanity checks, runs on non-release PR test workflow
       name: 'Smoke',
       testMatch: /smoke\/.*.test.ts/,
+      retries: 0,
+    },
+    {
+      // Single critical path test, runs on release recurring
+      name: 'Critical',
+      testMatch: /critical\/.*.test.ts/,
       retries: 0,
     },
   ],

--- a/packages/insomnia-smoke-test/playwright/paths.ts
+++ b/packages/insomnia-smoke-test/playwright/paths.ts
@@ -17,7 +17,7 @@ export const INSOMNIA_DATA_PATH = randomDataPath();
 
 const pathLookup: Record<string, string> = {
   win32: path.join('win-unpacked', 'Insomnia.exe'),
-  darwin: path.join('mac', 'Insomnia.app', 'Contents', 'MacOS', 'Insomnia'),
+  darwin: path.join(process.env.CI ? 'mac' : 'mac-universal', 'Insomnia.app', 'Contents', 'MacOS', 'Insomnia'),
   linux: path.join('linux-unpacked', 'insomnia'),
 };
 export const cwd = path.resolve(__dirname, '..', '..', 'insomnia');

--- a/packages/insomnia-smoke-test/playwright/paths.ts
+++ b/packages/insomnia-smoke-test/playwright/paths.ts
@@ -15,10 +15,10 @@ export const loadFixture = async (fixturePath: string) => {
 export const randomDataPath = () => path.join(os.tmpdir(), 'insomnia-smoke-test', `${uuidv4()}`);
 export const INSOMNIA_DATA_PATH = randomDataPath();
 
-const macAppPath = bundleType() === 'package' ? 'mac-universal' : 'mac';
+// Packaged app paths
 const pathLookup: Record<string, string> = {
   win32: path.join('win-unpacked', 'Insomnia.exe'),
-  darwin: path.join(macAppPath, 'Insomnia.app', 'Contents', 'MacOS', 'Insomnia'),
+  darwin: path.join('mac-universal', 'Insomnia.app', 'Contents', 'MacOS', 'Insomnia'),
   linux: path.join('linux-unpacked', 'insomnia'),
 };
 export const cwd = path.resolve(__dirname, '..', '..', 'insomnia');

--- a/packages/insomnia-smoke-test/playwright/paths.ts
+++ b/packages/insomnia-smoke-test/playwright/paths.ts
@@ -15,9 +15,10 @@ export const loadFixture = async (fixturePath: string) => {
 export const randomDataPath = () => path.join(os.tmpdir(), 'insomnia-smoke-test', `${uuidv4()}`);
 export const INSOMNIA_DATA_PATH = randomDataPath();
 
+const macAppPath = bundleType() === 'package' ? 'mac-universal' : 'mac';
 const pathLookup: Record<string, string> = {
   win32: path.join('win-unpacked', 'Insomnia.exe'),
-  darwin: path.join(process.env.CI ? 'mac' : 'mac-universal', 'Insomnia.app', 'Contents', 'MacOS', 'Insomnia'),
+  darwin: path.join(macAppPath, 'Insomnia.app', 'Contents', 'MacOS', 'Insomnia'),
   linux: path.join('linux-unpacked', 'insomnia'),
 };
 export const cwd = path.resolve(__dirname, '..', '..', 'insomnia');

--- a/packages/insomnia-smoke-test/tests/critical/app-start.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/app-start.test.ts
@@ -1,0 +1,28 @@
+import { expect } from '@playwright/test';
+
+import { loadFixture } from '../../playwright/paths';
+import { test } from '../../playwright/test';
+
+test('can send requests', async ({ app, page }) => {
+  const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+  const responseBody = page.locator('[data-testid="CodeEditor"]:visible', {
+    has: page.locator('.CodeMirror-activeline'),
+  });
+  await page.getByRole('button', { name: 'Create' }).click();
+  const text = await loadFixture('smoke-test-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+  await page.getByRole('menuitem', { name: 'Import' }).click();
+  await page.getByText('Clipboard').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await page.getByText('CollectionSmoke testsjust now').click();
+
+  await page.getByRole('button', { name: 'send JSON request' }).click();
+  await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+  await expect(statusTag).toContainText('200 OK');
+  await expect(responseBody).toContainText('"id": "1"');
+  await page.getByRole('button', { name: 'Preview' }).click();
+  await page.getByRole('menuitem', { name: 'Raw Data' }).click();
+  await expect(responseBody).toContainText('{"id":"1"}');
+});


### PR DESCRIPTION
found a class of bug that can occur only in the packaged app where a dependency (chai) needed to be moved from /insomnia-testing package.json to /insomnia
Not sure why it worked so we're adding tests to ensure app starts and node-libcurl is wired up in all OS's since we have changes PR tests to only run ubuntu.
This decision is based on over a year of experience running playwright tests against windows mac and linux on github actions free tier and seeing/fighting consistent decline in action runner performance on macos and windows.
Sanity prevails.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
