### PR TITLE
fix rerender

### DIFF
--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -29,7 +29,7 @@ import { Pane, PaneHeader } from './pane';
 import { PlaceholderResponsePane } from './placeholder-response-pane';
 
 interface Props {
-  runningRequests: Record<string, number>;
+  runningRequests: Record<string, boolean>;
 }
 export const ResponsePane: FC<Props> = ({
   runningRequests,

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -109,13 +109,15 @@ export const Debug: FC = () => {
     settings,
   } = useRouteLoaderData('root') as RootLoaderData;
   const { sidebarFilter } = activeWorkspaceMeta;
-  const [runningRequests, setRunningRequests] = useState({});
+  const [runningRequests, setRunningRequests] = useState<Record<string, boolean>>({});
   const setLoading = (isLoading: boolean) => {
     invariant(requestId, 'No active request');
-    setRunningRequests({
-      ...runningRequests,
-      [requestId]: isLoading ? true : false,
-    });
+    if (runningRequests?.[requestId] !== isLoading) {
+      setRunningRequests({
+        ...runningRequests,
+        [requestId]: isLoading ? true : false,
+      });
+    }
   };
 
   const grpcState = grpcStates.find(s => s.requestId === requestId);


### PR DESCRIPTION
loading watcher was triggering debug.tsx to constantly rerender
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
