### PR TITLE
Fix right click on row to show request actions

### DIFF
--- a/packages/insomnia/src/ui/components/base/dropdown/dropdown.tsx
+++ b/packages/insomnia/src/ui/components/base/dropdown/dropdown.tsx
@@ -2,7 +2,7 @@ import { PressResponder } from '@react-aria/interactions';
 import type { AriaMenuProps, MenuTriggerProps } from '@react-types/menu';
 import type { Placement } from '@react-types/overlays';
 import classnames from 'classnames';
-import React, { CSSProperties, forwardRef, ReactNode, useRef } from 'react';
+import React, { CSSProperties, forwardRef, ReactNode, useImperativeHandle, useRef } from 'react';
 import { mergeProps, useMenuTrigger } from 'react-aria';
 import { MenuTriggerState, useMenuTriggerState } from 'react-stately';
 import styled from 'styled-components';
@@ -52,6 +52,12 @@ export const Dropdown = forwardRef<DropdownHandle, DropdownProps>((props: Dropdo
     ...props,
     onOpenChange: isOpen => isOpen ? onOpen?.() : onClose?.(),
   });
+
+  useImperativeHandle(ref, () => ({
+    show: () => state.open(),
+    hide: () => state.close(),
+    toggle: () => state.toggle(),
+  }));
 
   const triggerRef = useRef<HTMLButtonElement>(ref);
 


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where request actions can be opened with a right-click.

Currently the actions of a request can only be opened by directly clicking the ▾ symbol. It would enhance the UX to also show this context menu on right click.

Upon checking the code, it seems like this was originally / earlier also intended as there already exists [this snippet](https://github.com/Kong/insomnia/blob/6b5fcbad1a54a2ec29aa7b04d08dbfcb11cce0de/packages/insomnia/src/ui/components/sidebar/sidebar-request-row.tsx#L120-L124) in `sidebar-request-row.tsx` which is called upon right clicking on a row. 
Therefore I assume this is rather a fix than a feature - but please let me know if I should rather open an issue before.