### PR TITLE
Fix/response-hook-plugin-exception

### DIFF
--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -167,6 +167,7 @@ export async function getLatestForRequest(
 
 export async function create(patch: Partial<Response> = {}, maxResponses = 20): Promise<Response> {
   if (!patch.parentId) {
+    console.log('[db] Attempted to create response without `parentId`', patch);
     throw new Error('New Response missing `parentId`');
   }
 

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -284,7 +284,6 @@ async function _applyResponsePluginHooks(
   try {
     const newResponse = clone(response);
     const newRequest = clone(renderedRequest);
-
     for (const { plugin, hook } of await plugins.getResponseHooks()) {
       const context = {
         ...(pluginContexts.app.init(RENDER_PURPOSE_NO_RENDER) as Record<string, any>),
@@ -305,9 +304,10 @@ async function _applyResponsePluginHooks(
 
     return newResponse;
   } catch (err) {
+    console.log('[plugin] Response hook failed', err, response);
     return {
       url: renderedRequest.url,
-      error: `[plugin] Response hook failed plugin=${err.plugin.name} err=${err.message}`,
+      error: `[plugin] Response hook failed plugin=${err.plugin?.name} err=${err.message}`,
       elapsedTime: 0, // 0 because this path is hit during plugin calls
       statusMessage: 'Error',
       settingSendCookies: renderedRequest.settingSendCookies,

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -157,7 +157,6 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
       renderedRequest && send({
         renderedRequest,
         shouldPromptForPathAfterResponse,
-        context: renderResult.context,
       });
     } catch (err) {
       showAlert({

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -278,7 +278,6 @@ const writeToDownloadPath = (downloadPathAndName: string, responsePatch: Respons
   const to = createWriteStream(downloadPathAndName);
   const readStream = models.response.getBodyStream(responsePatch);
   if (!readStream || typeof readStream === 'string') {
-    // setLoading(false);
     return null;
   }
   readStream.pipe(to);
@@ -288,14 +287,12 @@ const writeToDownloadPath = (downloadPathAndName: string, responsePatch: Respons
       responsePatch.error = `Saved to ${downloadPathAndName}`;
       const response = await models.response.create(responsePatch, maxHistoryResponses);
       await models.requestMeta.update(requestMeta, { activeResponseId: response._id });
-      // setLoading(false);
       resolve(null);
     });
     readStream.on('error', async err => {
       console.warn('Failed to download request after sending', responsePatch.bodyPath, err);
       const response = await models.response.create(responsePatch, maxHistoryResponses);
       await models.requestMeta.update(requestMeta, { activeResponseId: response._id });
-      // setLoading(false);
       resolve(null);
     });
   });
@@ -407,26 +404,3 @@ export const deleteResponseAction: ActionFunction = async ({ request, params }) 
 
   return null;
 };
-
-// const RequestRoute = () => {
-//   const { requestId } = useParams() as { requestId: string };
-//   const activeEnvironment = useSelector(selectActiveEnvironment);
-//   return (<>
-//     <ErrorBoundary showAlert>
-//       {isGrpcRequestId(requestId) ? (
-//         <GrpcRequestPane />
-//       ) : (
-//         isWebSocketRequestId(requestId) ? (
-//           <WebSocketRequestPane
-//             environment={activeEnvironment}
-//           />
-//         ) : (
-//           <RequestPane
-//             environmentId={activeEnvironment ? activeEnvironment._id : ''}
-//           />
-//         )
-//       )}
-//     </ErrorBoundary>
-//   </>);
-// };
-// export default RequestRoute;

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -8,7 +8,7 @@ import { ActionFunction, LoaderFunction, redirect } from 'react-router-dom';
 import { CONTENT_TYPE_EVENT_STREAM, CONTENT_TYPE_GRAPHQL, CONTENT_TYPE_JSON, METHOD_GET, METHOD_POST } from '../../common/constants';
 import { ChangeBufferEvent, database } from '../../common/database';
 import { getContentDispositionHeader } from '../../common/misc';
-import { RenderedRequest } from '../../common/render';
+import { RENDER_PURPOSE_SEND, RenderedRequest } from '../../common/render';
 import { ResponsePatch } from '../../main/network/libcurl-promise';
 import * as models from '../../models';
 import { BaseModel } from '../../models';
@@ -22,7 +22,7 @@ import { RequestVersion } from '../../models/request-version';
 import { Response } from '../../models/response';
 import { isWebSocketRequestId, WebSocketRequest } from '../../models/websocket-request';
 import { WebSocketResponse } from '../../models/websocket-response';
-import { fetchRequestData, responseTransform, sendCurlAndWriteTimeline } from '../../network/network';
+import { fetchRequestData, responseTransform, sendCurlAndWriteTimeline, tryToInterpolateRequest } from '../../network/network';
 import { invariant } from '../../utils/invariant';
 import { SegmentEvent } from '../analytics';
 import { updateMimeType } from '../components/dropdowns/content-type-dropdown';
@@ -304,20 +304,22 @@ const writeToDownloadPath = (downloadPathAndName: string, responsePatch: Respons
 export interface SendActionParams {
   renderedRequest: RenderedRequest;
   shouldPromptForPathAfterResponse?: boolean;
-  context: Record<string, any>;
 }
 export const sendAction: ActionFunction = async ({ request, params }) => {
   const { requestId, workspaceId } = params;
   invariant(typeof requestId === 'string', 'Request ID is required');
-  const req = await requestOperations.getById(requestId);
+  const req = await requestOperations.getById(requestId) as Request;
   invariant(req, 'Request not found');
   invariant(workspaceId, 'Workspace ID is required');
   const {
+    environment,
     settings,
     clientCertificates,
     caCert,
     activeEnvironmentId } = await fetchRequestData(requestId);
-  const { renderedRequest, shouldPromptForPathAfterResponse, context } = await request.json() as SendActionParams;
+  const { renderedRequest, shouldPromptForPathAfterResponse } = await request.json() as SendActionParams;
+  const renderResult = await tryToInterpolateRequest(req, environment._id, RENDER_PURPOSE_SEND);
+
   const response = await sendCurlAndWriteTimeline(
     renderedRequest,
     clientCertificates,
@@ -326,7 +328,7 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
   );
   const requestMeta = await models.requestMeta.getByParentId(requestId);
   invariant(requestMeta, 'RequestMeta not found');
-  const responsePatch = await responseTransform(response, activeEnvironmentId, renderedRequest, context);
+  const responsePatch = await responseTransform(response, activeEnvironmentId, renderedRequest, renderResult.context);
   const is2XXWithBodyPath = responsePatch.statusCode && responsePatch.statusCode >= 200 && responsePatch.statusCode < 300 && responsePatch.bodyPath;
   const shouldWriteToFile = shouldPromptForPathAfterResponse && is2XXWithBodyPath;
   if (!shouldWriteToFile) {
@@ -355,7 +357,7 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
     }
     window.localStorage.setItem('insomnia.sendAndDownloadLocation', filePath);
     return writeToDownloadPath(filePath, responsePatch, requestMeta, settings.maxHistoryResponses);
-  };
+  }
 };
 export const deleteAllResponsesAction: ActionFunction = async ({ params }) => {
   const { workspaceId, requestId } = params;


### PR DESCRIPTION
changelog(Fixes): Fixed issue #6277 that caused an error when using plugins which saved responses

Addresses #6277

Caused by passing request context as json through a remix fetcher and losing the getProjectId function in the stringification, now we just get the render context again in the remix action
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
