### PR TITLE
fix httpsnippet validation error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24698,7 +24698,7 @@
         "hawk": "9.0.1",
         "hkdf": "0.0.2",
         "html-entities": "^2.4.0",
-        "httpsnippet": "^1.22.0",
+        "httpsnippet": "^2.0.0",
         "isomorphic-git": "^1.5.0",
         "jshint": "^2.13.6",
         "jsonlint-mod-fixed": "1.7.7",
@@ -24717,135 +24717,12 @@
       },
       "devDependencies": {}
     },
-    "packages/insomnia-send-request/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/insomnia-send-request/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/insomnia-send-request/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "packages/insomnia-send-request/node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "packages/insomnia-send-request/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "packages/insomnia-send-request/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "packages/insomnia-send-request/node_modules/form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "packages/insomnia-send-request/node_modules/httpsnippet": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-1.25.0.tgz",
-      "integrity": "sha512-jobE6S923cLuf5BPG6Jf+oLBRkPzv2RPp0dwOHcWwj/t9FwV/t9hyZ46kpT3Q5DHn9iFNmGhrcmmFUBqyjoTQg==",
-      "dependencies": {
-        "chalk": "^1.1.1",
-        "commander": "^2.9.0",
-        "debug": "^2.2.0",
-        "event-stream": "3.3.4",
-        "form-data": "3.0.0",
-        "fs-readfile-promise": "^2.0.1",
-        "fs-writefile-promise": "^1.0.3",
-        "har-validator": "^5.0.0",
-        "pinkie-promise": "^2.0.0",
-        "stringify-object": "^3.3.0"
-      },
-      "bin": {
-        "httpsnippet": "bin/httpsnippet"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/insomnia-send-request/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "packages/insomnia-send-request/node_modules/pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/insomnia-send-request/node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/insomnia-send-request/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/insomnia-send-request/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "packages/insomnia-send-request/node_modules/yaml": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24364,7 +24364,6 @@
         "@stoplight/spectral-formats": "^1.5.0",
         "@stoplight/spectral-ruleset-bundler": "1.5.2",
         "@stoplight/spectral-rulesets": "^1.16.0",
-        "ajv": "^8.12.0",
         "apiconnect-wsdl": "1.8.31",
         "aws4": "^1.12.0",
         "axios": "^1.4.0",
@@ -25203,6 +25202,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -25271,7 +25271,8 @@
     "packages/insomnia/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "peer": true
     },
     "packages/insomnia/node_modules/lru-cache": {
       "version": "7.18.3",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -20,7 +20,7 @@
     "hawk": "9.0.1",
     "hkdf": "0.0.2",
     "html-entities": "^2.4.0",
-    "httpsnippet": "^1.22.0",
+    "httpsnippet": "^2.0.0",
     "isomorphic-git": "^1.5.0",
     "jshint": "^2.13.6",
     "jsonlint-mod-fixed": "1.7.7",

--- a/packages/insomnia-smoke-test/tests/critical/app-start.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/app-start.test.ts
@@ -25,4 +25,8 @@ test('can send requests', async ({ app, page }) => {
   await page.getByRole('button', { name: 'Preview' }).click();
   await page.getByRole('menuitem', { name: 'Raw Data' }).click();
   await expect(responseBody).toContainText('{"id":"1"}');
+  await page.getByRole('button', { name: 'send JSON request' }).click();
+  await page.locator('[data-testid="Dropdown-send-JSON-request"]').click();
+  await page.getByRole('menuitem', { name: 'Generate Code' }).click();
+  await page.getByRole('button', { name: 'Done' }).click();
 });

--- a/packages/insomnia-smoke-test/tests/critical/app-start.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/app-start.test.ts
@@ -28,5 +28,6 @@ test('can send requests', async ({ app, page }) => {
   await page.getByRole('button', { name: 'send JSON request' }).click();
   await page.locator('[data-testid="Dropdown-send-JSON-request"]').click();
   await page.getByRole('menuitem', { name: 'Generate Code' }).click();
+  await page.getByText('curl --request GET \\').click();
   await page.getByRole('button', { name: 'Done' }).click();
 });

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -46,7 +46,6 @@
     "@stoplight/spectral-formats": "^1.5.0",
     "@stoplight/spectral-ruleset-bundler": "1.5.2",
     "@stoplight/spectral-rulesets": "^1.16.0",
-    "ajv": "^8.12.0",
     "apiconnect-wsdl": "1.8.31",
     "aws4": "^1.12.0",
     "axios": "^1.4.0",


### PR DESCRIPTION
changelog(Fixes): Fixed issue #6279 where generating code from a request wasn't properly working due to how an external dependency was being packaged

Addresses: #6279

httpsnippet depends on ajv 6.12.3 but when packaged v8 is being resolved which has incompatible changes with har-schema/har-validator
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
