### PR TITLE
chore: fix vscode debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,14 +13,14 @@
         "order": 1
       },
       "cwd": "${workspaceFolder}/packages/insomnia",
-      "runtimeExecutable": "${workspaceFolder}/packages/insomnia/node_modules/.bin/electron",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
       "runtimeArgs": ["--remote-debugging-port=9222", "."],
       "outputCapture": "std",
       "windows": {
         "type": "node",
         "request": "launch",
         "name": "Electron: main",
-        "runtimeExecutable": "${workspaceFolder}/packages/insomnia/node_modules/.bin/electron.cmd"
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
       },
       "env": {
         "NODE_ENV": "development",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,7 @@
           "NODE_ENV": "development",
         }
       },
-      "command": "${workspaceRoot}/packages/insomnia/node_modules/.bin/esr esbuild.main.ts"
+      "command": "${workspaceRoot}/node_modules/.bin/esr esbuild.main.ts"
     },
     {
       "label": "Insomnia: Compile Renderer (Watch)",


### PR DESCRIPTION
Paths for VSCode debugging were not updated from when we removed lerna and started using npm workspaces. This PR fixes that.

### Pending

- [ ] Sourcemaps are not working correctly, so breakpoints don't work yet. Not sure how to fix that part. Any pointers @gatzjames @jackkav ?

![image](https://github.com/Kong/insomnia/assets/11976836/cd2e49ef-b3d6-4bbd-8446-f7ba794a7b72)
