### PR TITLE
fix: render fail on workspace dropdown in req group settings

### DIFF
--- a/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
@@ -120,16 +120,24 @@ export const RequestGroupSettingsModal = ({ requestGroup, onHide }: ModalProps &
                 </HelpTooltip>
                 <select
                   value={activeWorkspaceIdToCopyTo || '__NULL__'}
-                  onChange={event => setState(state => ({ ...state, activeWorkspaceIdToCopyTo: event.currentTarget.value === '__NULL__' ? null : event.currentTarget.value }))}
+                  onChange={event => {
+                    const { value } = event.currentTarget;
+                    const workspaceId = value === '__NULL__' ? null : value;
+                    setState(state => ({ ...state, activeWorkspaceIdToCopyTo: workspaceId }));
+                  }}
                 >
                   <option value="__NULL__">-- Select Workspace --</option>
-                  {workspacesForActiveProject
-                    .filter(w => workspaceId !== w._id)
-                    .map(w => (
+                  {workspacesForActiveProject.map(w => {
+                    if (workspaceId === w._id) {
+                      return null;
+                    }
+
+                    return (
                       <option key={w._id} value={w._id}>
                         {w.name}
                       </option>
-                    ))}
+                    );
+                  })}
                 </select>
               </label>
             </div>

--- a/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
@@ -18,7 +18,7 @@ export interface RequestGroupSettingsModalOptions {
 }
 interface State {
   defaultPreviewMode: boolean;
-  activeWorkspaceIdToCopyTo: string | null;
+  activeWorkspaceIdToCopyTo: string;
 }
 export const RequestGroupSettingsModal = ({ requestGroup, onHide }: ModalProps & {
   requestGroup: RequestGroup;
@@ -36,7 +36,7 @@ export const RequestGroupSettingsModal = ({ requestGroup, onHide }: ModalProps &
   const projectLoaderData = workspacesFetcher?.data as ProjectLoaderData;
   const workspacesForActiveProject = projectLoaderData?.workspaces.map(w => w.workspace) || [];
   const [state, setState] = useState<State>({
-    activeWorkspaceIdToCopyTo: null,
+    activeWorkspaceIdToCopyTo: '',
     defaultPreviewMode: !!requestGroup.description,
   });
   const patchRequestGroup = useRequestGroupPatcher();
@@ -119,25 +119,24 @@ export const RequestGroupSettingsModal = ({ requestGroup, onHide }: ModalProps &
                   placed at the root of the new workspace's folder structure.
                 </HelpTooltip>
                 <select
-                  value={activeWorkspaceIdToCopyTo || '__NULL__'}
+                  value={activeWorkspaceIdToCopyTo}
                   onChange={event => {
-                    const { value } = event.currentTarget;
-                    const workspaceId = value === '__NULL__' ? null : value;
-                    setState(state => ({ ...state, activeWorkspaceIdToCopyTo: workspaceId }));
+                    const activeWorkspaceIdToCopyTo = event.currentTarget.value;
+                    setState(state => ({
+                      ...state,
+                      activeWorkspaceIdToCopyTo,
+                    }));
                   }}
                 >
-                  <option value="__NULL__">-- Select Workspace --</option>
-                  {workspacesForActiveProject.map(w => {
-                    if (workspaceId === w._id) {
-                      return null;
-                    }
-
-                    return (
+                  <option value="">-- Select Workspace --</option>
+                  {workspacesForActiveProject
+                    .filter(w => workspaceId !== w._id)
+                    .map(w => (
                       <option key={w._id} value={w._id}>
                         {w.name}
                       </option>
-                    );
-                  })}
+                    ))
+                  }
                 </select>
               </label>
             </div>

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -21,7 +21,7 @@ export interface RequestSettingsModalOptions {
 }
 interface State {
   defaultPreviewMode: boolean;
-  activeWorkspaceIdToCopyTo: string | null;
+  activeWorkspaceIdToCopyTo: string;
 }
 export interface RequestSettingsModalHandle {
   show: (options: RequestSettingsModalOptions) => void;
@@ -42,7 +42,7 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
   const workspacesForActiveProject = projectLoaderData?.workspaces.map(w => w.workspace) || [];
   const [state, setState] = useState<State>({
     defaultPreviewMode: !!request?.description,
-    activeWorkspaceIdToCopyTo: null,
+    activeWorkspaceIdToCopyTo: '',
   });
   useEffect(() => {
     modalRef.current?.show();
@@ -162,14 +162,13 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                         the new workspace's folder structure.
                       </HelpTooltip>
                       <select
-                        value={activeWorkspaceIdToCopyTo || '__NULL__'}
+                        value={activeWorkspaceIdToCopyTo}
                         onChange={event => {
-                          const { value } = event.currentTarget;
-                          const workspaceId = value === '__NULL__' ? null : value;
-                          setState(state => ({ ...state, activeWorkspaceIdToCopyTo: workspaceId }));
+                          const activeWorkspaceIdToCopyTo = event.currentTarget.value;
+                          setState(state => ({ ...state, activeWorkspaceIdToCopyTo }));
                         }}
                       >
-                        <option value="__NULL__">-- Select Workspace --</option>
+                        <option value="">-- Select Workspace --</option>
                         {workspacesForActiveProject.map(w => {
                           if (workspaceId === w._id) {
                             return null;
@@ -320,14 +319,13 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                         the new workspace's folder structure.
                       </HelpTooltip>
                       <select
-                        value={activeWorkspaceIdToCopyTo || '__NULL__'}
+                        value={activeWorkspaceIdToCopyTo}
                         onChange={event => {
-                          const { value } = event.currentTarget;
-                          const workspaceId = value === '__NULL__' ? null : value;
-                          setState(state => ({ ...state, activeWorkspaceIdToCopyTo: workspaceId }));
+                          const activeWorkspaceIdToCopyTo = event.currentTarget.value;
+                          setState(state => ({ ...state, activeWorkspaceIdToCopyTo }));
                         }}
                       >
-                        <option value="__NULL__">-- Select Workspace --</option>
+                        <option value="">-- Select Workspace --</option>
                         {workspacesForActiveProject.map(w => {
                           if (workspaceId === w._id) {
                             return null;

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { OverlayContainer } from 'react-aria';
-import { useFetcher, useParams } from 'react-router-dom';
+import { useFetcher, useNavigate, useParams } from 'react-router-dom';
 
 import * as models from '../../../models';
 import { GrpcRequest, isGrpcRequest } from '../../../models/grpc-request';
@@ -50,7 +50,7 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
 
   const requestFetcher = useFetcher();
   const patchRequest = useRequestPatcher();
-
+  const navigate = useNavigate();
   const duplicateRequest = (r: Partial<Request>) => {
     requestFetcher.submit(JSON.stringify(r),
       {
@@ -63,6 +63,7 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
     invariant(state.activeWorkspaceIdToCopyTo, 'Workspace ID is required');
     patchRequest(request._id, { parentId: state.activeWorkspaceIdToCopyTo });
     modalRef.current?.hide();
+    navigate(`/organization/${organizationId}/project/${projectId}/workspace/${state.activeWorkspaceIdToCopyTo}/debug`);
   }
 
   async function handleCopyToWorkspace() {


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where the workspace dropdown in the request folder settings would sometimes return an render fail error when picking through different workspaces to move/copy to.


### Steps to reproduce:
- checkout latest develop
- make sure you have a handful of collections and design docs in your current project
- in one of the collections/design docs go the the settings of a request folder
- in the settings - on the workspace dropdown - try to click through a couple of workspace (e.g. picking on, re-opening the dropdown, pick another, reopen dropdown, ... repeat) until you get a render error


Copying the approach we do for the same dropdown in request settings was enough to fix the issue.

![Pasted_Image_22_08_2023__09_57](https://github.com/Kong/insomnia/assets/11976836/cb571bc3-51ff-424f-adff-668362f59210)

