### PR TITLE
fix sidebar colors

### DIFF
--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -583,6 +583,7 @@ export const Debug: FC = () => {
   const environmentsList = [baseEnvironment, ...subEnvironments].map(e => ({
     id: e._id,
     name: e.name,
+    color: e.color,
   }));
 
   return (


### PR DESCRIPTION
closes #6366

changelog(Fixes): Fixed issue #6366 where environment colors were missing from the environments dropdown.