### PR TITLE
chore: Add test to check for backups on new version to critical tests

### DIFF
--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -53,7 +53,9 @@ jobs:
         run: NODE_OPTIONS='--max_old_space_size=6144' BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
 
       - name: Test critical path on packaged electron app
-        run: INSOMNIA_UPDATES_URL=http://localhost:4010 npm run test:package -w packages/insomnia-smoke-test -- --project=Critical
+        run: npm run test:package -w packages/insomnia-smoke-test -- --project=Critical
+        env:
+          INSOMNIA_UPDATES_URL: http://localhost:4010
 
       - name: Upload smoke test traces
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -53,7 +53,7 @@ jobs:
         run: NODE_OPTIONS='--max_old_space_size=6144' BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
 
       - name: Test critical path on packaged electron app
-        run: npm run test:package -w packages/insomnia-smoke-test -- --project=Critical
+        run: INSOMNIA_UPDATES_URL=http://localhost:4010 npm run test:package -w packages/insomnia-smoke-test -- --project=Critical
 
       - name: Upload smoke test traces
         uses: actions/upload-artifact@v3

--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -16,6 +16,7 @@ interface EnvOptions {
   INSOMNIA_APP_WEBSITE_URL: string;
   INSOMNIA_GITHUB_API_URL: string;
   INSOMNIA_GITLAB_API_URL: string;
+  INSOMNIA_UPDATES_URL: string;
 }
 
 export const test = baseTest.extend<{
@@ -30,6 +31,7 @@ export const test = baseTest.extend<{
       INSOMNIA_APP_WEBSITE_URL: webServerUrl + '/website',
       INSOMNIA_GITHUB_API_URL: webServerUrl + '/github-api/graphql',
       INSOMNIA_GITLAB_API_URL: webServerUrl + '/gitlab-api',
+      INSOMNIA_UPDATES_URL: webServerUrl || 'https://updates.insomnia.rest',
     };
 
     const electronApp = await playwright._electron.launch({

--- a/packages/insomnia-smoke-test/server/index.ts
+++ b/packages/insomnia-smoke-test/server/index.ts
@@ -23,6 +23,13 @@ app.get('/pets/:id', (req, res) => {
   res.status(200).send({ id: req.params.id });
 });
 
+app.get('/builds/check/*', (_req, res) => {
+  res.status(200).send({
+    url: 'https://github.com/Kong/insomnia/releases/download/core@2023.5.6/Insomnia.Core-2023.5.6.zip',
+    name: '2099.1.0',
+  });
+});
+
 app.get('/sleep', (_req, res) => {
   res.status(200).send({ sleep: true });
 });

--- a/packages/insomnia-smoke-test/tests/critical/backup.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/backup.test.ts
@@ -1,0 +1,27 @@
+import { expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+// import { loadFixture } from '../../playwright/paths';
+import { test } from '../../playwright/test';
+
+test('can backup data on new version available', async ({ app, page }) => {
+
+    const dataPath = await app.evaluate(async ({ app }) => app.getPath('userData'));
+
+    let foundBackups = false;
+    // retry 5 times
+    for (let i = 0; i < 5; i++) {
+        console.log('Retry', i);
+        if (fs.existsSync(path.join(dataPath, 'backups'))) {
+            console.log('Backups exists!');
+            foundBackups = true;
+            break;
+        } else {
+            console.log('backups not found. Waiting 5 seconds...');
+            await page.waitForTimeout(5000);
+        }
+    }
+
+    await expect(foundBackups).toBe(true);
+});

--- a/packages/insomnia-smoke-test/tests/critical/backup.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/backup.test.ts
@@ -2,7 +2,6 @@ import { expect } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 
-// import { loadFixture } from '../../playwright/paths';
 import { test } from '../../playwright/test';
 
 test('can backup data on new version available', async ({ app, page }) => {

--- a/packages/insomnia-smoke-test/tests/critical/backup.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/backup.test.ts
@@ -8,14 +8,17 @@ import { test } from '../../playwright/test';
 test('can backup data on new version available', async ({ app, page }) => {
 
     const dataPath = await app.evaluate(async ({ app }) => app.getPath('userData'));
-
     let foundBackups = false;
     // retry 5 times
     for (let i = 0; i < 5; i++) {
         console.log('Retry', i);
         if (fs.existsSync(path.join(dataPath, 'backups'))) {
             console.log('Backups exists!');
-            foundBackups = true;
+            const rootBackupsFolder = fs.readdirSync(path.join(dataPath, 'backups'));
+            const backupDir = fs.readdirSync(path.join(dataPath, 'backups', rootBackupsFolder[0]));
+            const hasFilesInsideBackup = backupDir.length > 0;
+            const hasProjectDbFile = backupDir.includes('insomnia.Project.db');
+            foundBackups = hasFilesInsideBackup && hasProjectDbFile;
             break;
         } else {
             console.log('backups not found. Waiting 5 seconds...');

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -133,6 +133,8 @@ export enum UpdateURL {
 // API
 export const getApiBaseURL = () => env.INSOMNIA_API_URL || 'https://api.insomnia.rest';
 
+export const getUpdatesBaseURL = () => env.INSOMNIA_UPDATES_URL || 'https://updates.insomnia.rest';
+
 // App website
 export const getAppWebsiteBaseURL = () => env.INSOMNIA_APP_WEBSITE_URL || 'https://app.insomnia.rest';
 

--- a/packages/insomnia/src/main/backup.ts
+++ b/packages/insomnia/src/main/backup.ts
@@ -5,6 +5,7 @@ import electron from 'electron';
 
 import appConfig from '../../config/config.json';
 import { version } from '../../package.json';
+import { getUpdatesBaseURL } from '../common/constants';
 import * as models from '../models';
 import { insomniaFetch } from './insomniaFetch';
 
@@ -14,7 +15,7 @@ export async function backupIfNewerVersionAvailable() {
     console.log('[main] Checking for newer version than ', version);
     const response = await insomniaFetch<{ url: string }>({
       method: 'GET',
-      origin: 'https://updates.insomnia.rest',
+      origin: getUpdatesBaseURL(),
       path: `/builds/check/mac?v=${version}&app=${appConfig.appId}&channel=${settings.updateChannel}`,
       sessionId: null,
     });


### PR DESCRIPTION
Adds a simple test to check the contents of the backups folder assuming that a new version exists. Added to the critical tests  for now