### PR TITLE
Fix prerelease checks

### DIFF
--- a/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/dashboard-interactions.test.ts
@@ -99,7 +99,7 @@ test.describe('Dashboard', async () => {
       await page.getByTestId('project').click();
 
       // Rename document
-      await page.click('text=DocumentNew Documentjust now >> button');
+      await page.getByLabel('my-spec.yaml').getByRole('button').click();
       await page.getByRole('menuitem', { name: 'Rename' }).click();
       await page.locator('text=Rename DocumentName Rename >> input[type="text"]').fill('test123');
       await page.click('#root button:has-text("Rename")');

--- a/packages/insomnia-smoke-test/tests/prerelease/design-document-naming.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/design-document-naming.test.ts
@@ -1,11 +1,12 @@
+import { expect } from '@playwright/test';
+
 import { test } from '../../playwright/test';
 
 test('can name design documents', async ({ page }) => {
     await page.getByRole('button', { name: ' New Document' }).click();
     await page.getByPlaceholder('my-spec.yaml').fill('jurassic park');
     await page.getByPlaceholder('my-spec.yaml').press('Enter');
-    await page.getByLabel('jurassic park').click();
-    await page.getByRole('button', { name: 'jurassic park ' }).press('Escape');
+    expect(page.getByRole('button', { name: 'jurassic park' })).toHaveText('jurassic park');
     await page.getByTestId('project').click();
     await page.getByLabel('jurassic park').click();
 });


### PR DESCRIPTION
Some checks were still looking for the default name instead of the actual design name