### PR TITLE
Fix processing of DOM nodes during the production build (minified names)

### DIFF
--- a/packages/insomnia/src/utils/xpath/query.ts
+++ b/packages/insomnia/src/utils/xpath/query.ts
@@ -24,22 +24,22 @@ export const queryXPath = (xml: string, query?: string) => {
     });
   } else {
     for (const selectedValue of selectedValues || []) {
-      switch (selectedValue.constructor.name) {
-        case 'Attr':
+      switch ((<Node>selectedValue).nodeType) {
+        case Node.ATTRIBUTE_NODE:
           output.push({
             outer: (selectedValue as Attr).toString().trim(),
             inner: (selectedValue as Attr).nodeValue,
           });
           break;
 
-        case 'Element':
+        case Node.ELEMENT_NODE:
           output.push({
             outer: (selectedValue as Node).toString().trim(),
             inner: (selectedValue as Node).childNodes.toString(),
           });
           break;
 
-        case 'Text':
+        case Node.TEXT_NODE:
           output.push({
             outer: (selectedValue as Text).toString().trim(),
             inner: (selectedValue as Text).toString().trim(),

--- a/packages/insomnia/src/utils/xpath/query.ts
+++ b/packages/insomnia/src/utils/xpath/query.ts
@@ -15,41 +15,27 @@ export const queryXPath = (xml: string, query?: string) => {
   } catch (err) {
     throw new Error(`Invalid XPath query: ${query}`);
   }
-  const output = [];
   // Functions return plain strings
   if (typeof selectedValues === 'string') {
-    output.push({
-      outer: selectedValues,
-      inner: selectedValues,
-    });
-  } else {
-    for (const selectedValue of selectedValues || []) {
-      switch ((<Node>selectedValue).nodeType) {
-        case Node.ATTRIBUTE_NODE:
-          output.push({
-            outer: (selectedValue as Attr).toString().trim(),
-            inner: (selectedValue as Attr).nodeValue,
-          });
-          break;
-
-        case Node.ELEMENT_NODE:
-          output.push({
-            outer: (selectedValue as Node).toString().trim(),
-            inner: (selectedValue as Node).childNodes.toString(),
-          });
-          break;
-
-        case Node.TEXT_NODE:
-          output.push({
-            outer: (selectedValue as Text).toString().trim(),
-            inner: (selectedValue as Text).toString().trim(),
-          });
-          break;
-
-        default:
-          break;
-      }
-    }
+    return [{ outer: selectedValues, inner: selectedValues }];
   }
-  return output;
+
+  return (selectedValues as Node[])
+    .filter(sv => sv.nodeType === Node.ATTRIBUTE_NODE
+      || sv.nodeType === Node.ELEMENT_NODE
+      || sv.nodeType === Node.TEXT_NODE)
+    .map(selectedValue => {
+      const outer = selectedValue.toString().trim();
+      if (selectedValue.nodeType === Node.ATTRIBUTE_NODE) {
+        return { outer, inner: selectedValue.nodeValue };
+      }
+      if (selectedValue.nodeType === Node.ELEMENT_NODE) {
+        return { outer, inner: selectedValue.childNodes.toString() };
+      }
+      if (selectedValue.nodeType === Node.TEXT_NODE) {
+        return { outer, inner: selectedValue.toString().trim() };
+      }
+      return { outer, inner: null };
+    });
+
 };


### PR DESCRIPTION
changelog(Fixes): Fixed issue #5808 where XPath queries were not working properly

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Closes #5808 

On the Electron release build, nodes created by `xmldom` have minified class/object/constructor names, causing the `queryXPath` to return empty. This PR changes the iteration method to inspect the node's `nodeType`, rather than its constructor name
