### PR TITLE
re add user-agent

### DIFF
--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -12,13 +12,14 @@ import tls from 'tls';
 import { parse as urlParse } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 
+import { version } from '../../../package.json';
 import { AUTH_AWS_IAM, AUTH_DIGEST, AUTH_NETRC, AUTH_NTLM, CONTENT_TYPE_FORM_DATA, CONTENT_TYPE_FORM_URLENCODED } from '../../common/constants';
 import { describeByteSize, hasAuthHeader } from '../../common/misc';
 import { ClientCertificate } from '../../models/client-certificate';
+import { RequestHeader } from '../../models/request';
 import { ResponseHeader } from '../../models/response';
 import { buildMultipart } from './multipart';
 import { parseHeaderStrings } from './parse-header-strings';
-
 export interface CurlRequestOptions {
   requestId: string; // for cancellation
   req: RequestUsedHere;
@@ -370,10 +371,12 @@ export const createConfiguredCurlInstance = ({
       }
     }
   }
-
-  // suppress node-libcurl default user-agent
-  curl.setOpt(Curl.option.USERAGENT, '');
   const { headers, authentication } = req;
+
+  const userAgent: RequestHeader | null = headers.find((h: any) => h.name.toLowerCase() === 'user-agent') || null;
+  const userAgentOrFallback = typeof userAgent?.value === 'string' ? userAgent?.value : 'Insomnia/' + version;
+  curl.setOpt(Curl.option.USERAGENT, userAgentOrFallback);
+
   const { username, password, disabled } = authentication;
   const isDigest = authentication.type === AUTH_DIGEST;
   const isNLTM = authentication.type === AUTH_NTLM;

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -374,7 +374,7 @@ export const createConfiguredCurlInstance = ({
   const { headers, authentication } = req;
 
   const userAgent: RequestHeader | null = headers.find((h: any) => h.name.toLowerCase() === 'user-agent') || null;
-  const userAgentOrFallback = typeof userAgent?.value === 'string' ? userAgent?.value : 'Insomnia/' + version;
+  const userAgentOrFallback = typeof userAgent?.value === 'string' ? userAgent?.value : 'insomnia/' + version;
   curl.setOpt(Curl.option.USERAGENT, userAgentOrFallback);
 
   const { username, password, disabled } = authentication;

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -4,6 +4,7 @@ import electron from 'electron';
 import fs from 'fs';
 import { join as pathJoin, resolve as pathResolve } from 'path';
 
+import { version } from '../../../package.json';
 import { globalBeforeEach } from '../../__jest__/before-each';
 import {
   AUTH_AWS_IAM,
@@ -137,7 +138,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         PROXY: '',
         TIMEOUT_MS: 30000,
         URL: 'http://localhost/?foo%20bar=hello%26world',
-        USERAGENT: '',
+        USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
       },
     });
@@ -207,7 +208,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         PROXY: '',
         TIMEOUT_MS: 30000,
         URL: 'http://localhost/',
-        USERAGENT: '',
+        USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
       },
     });
@@ -308,7 +309,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         PROXY: '',
         TIMEOUT_MS: 30000,
         URL: 'http://localhost/?foo%20bar=hello%26world',
-        USERAGENT: '',
+        USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
       },
     });
@@ -372,7 +373,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         TIMEOUT_MS: 30000,
         UPLOAD: 1,
         URL: 'http://localhost/',
-        USERAGENT: '',
+        USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
       },
     });
@@ -465,7 +466,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         TIMEOUT_MS: 30000,
         URL: 'http://localhost/',
         UPLOAD: 1,
-        USERAGENT: '',
+        USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
       },
     });
@@ -506,7 +507,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         TIMEOUT_MS: 30000,
         URL: 'http://my/path',
         UNIX_SOCKET_PATH: '/my/socket',
-        USERAGENT: '',
+        USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
       },
     });
@@ -546,7 +547,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         PROXY: '',
         TIMEOUT_MS: 30000,
         URL: 'http://localhost:3000/foo/bar',
-        USERAGENT: '',
+        USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
       },
     });
@@ -586,7 +587,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         PROXY: '',
         TIMEOUT_MS: 30000,
         URL: 'http://unix:3000/my/path',
-        USERAGENT: '',
+        USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
       },
     });
@@ -628,7 +629,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         TIMEOUT_MS: 30000,
         NETRC: CurlNetrc.Required,
         URL: '',
-        USERAGENT: '',
+        USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
       },
     });
@@ -740,7 +741,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         SSL_VERIFYPEER: 0, // should disable SSL
         TIMEOUT_MS: 30000,
         URL: 'http://localhost/?foo%20bar=hello%26world',
-        USERAGENT: '',
+        USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
       },
     });

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -304,7 +304,6 @@ const sendAccessTokenRequest = async (requestId: string, authentication: AuthTyp
     headers: [
       { name: 'Content-Type', value: 'application/x-www-form-urlencoded' },
       { name: 'Accept', value: 'application/x-www-form-urlencoded, application/json' },
-      { name: 'User-Agent', value: 'insomnia/' + version },
       ...headers,
     ],
     url: setDefaultProtocol(authentication.accessTokenUrl),

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -2,7 +2,6 @@ import crypto from 'crypto';
 import querystring from 'querystring';
 import { v4 as uuidv4 } from 'uuid';
 
-import { version } from '../../../package.json';
 import { escapeRegex } from '../../common/misc';
 import * as models from '../../models';
 import type { OAuth2Token } from '../../models/o-auth-2-token';

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -105,7 +105,7 @@ export const createRequestAction: ActionFunction = async ({ request, params }) =
       parentId: parentId || workspaceId,
       method: METHOD_GET,
       name: 'New Request',
-      headers: [{ name: 'User-Agent', value: `Insomnia/${version}` }],
+      headers: [{ name: 'User-Agent', value: `insomnia/${version}` }],
     }))._id;
   }
   if (requestType === 'gRPC') {
@@ -119,7 +119,7 @@ export const createRequestAction: ActionFunction = async ({ request, params }) =
       parentId: parentId || workspaceId,
       method: METHOD_POST,
       headers: [
-        { name: 'User-Agent', value: `Insomnia/${version}` },
+        { name: 'User-Agent', value: `insomnia/${version}` },
         { name: 'Content-Type', value: CONTENT_TYPE_JSON },
       ],
       body: {
@@ -135,7 +135,7 @@ export const createRequestAction: ActionFunction = async ({ request, params }) =
       method: METHOD_GET,
       url: '',
       headers: [
-        { name: 'User-Agent', value: `Insomnia/${version}` },
+        { name: 'User-Agent', value: `insomnia/${version}` },
         { name: 'Accept', value: CONTENT_TYPE_EVENT_STREAM },
       ],
       name: 'New Event Stream',
@@ -145,7 +145,7 @@ export const createRequestAction: ActionFunction = async ({ request, params }) =
     activeRequestId = (await models.webSocketRequest.create({
       parentId: parentId || workspaceId,
       name: 'New WebSocket Request',
-      headers: [{ name: 'User-Agent', value: `Insomnia/${version}` }],
+      headers: [{ name: 'User-Agent', value: `insomnia/${version}` }],
     }))._id;
   }
   if (requestType === 'From Curl') {


### PR DESCRIPTION
changelog(Fixes): Added a fallback to always have user-agent to deal with unforeseen consequences of allowing user-agent removal.

user-agent was added to the ui for new requests but not old ones and default user-agent was suppressed.
This caused unintended consequences with existing requests, which had a user-agent but now dont.

this PR should fix that issue by falling back to always have user-agent.

If we want to remove user-agent when it is disabled in headers tab for a request we will need to look at request rendering as disabled headers are filtered out there before they make it to curlRequest.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
