### PR TITLE
fix disabled user-agent

### DIFF
--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -36,6 +36,7 @@ export type RenderedRequest = Request & {
     disabled?: boolean;
   }[];
   cookieJar: CookieJar;
+  suppressUserAgent: boolean;
 };
 
 export type RenderedGrpcRequest = GrpcRequest;
@@ -495,6 +496,7 @@ export async function getRenderedRequestAndContext(
   const renderedRequest = renderResult._request;
   const renderedCookieJar = renderResult._cookieJar;
   renderedRequest.description = await render(description, renderContext, null, KEEP_ON_ERROR);
+  const suppressUserAgent = request.headers.some(h => h.name.toLowerCase() === 'user-agent' && h.disabled === true);
   // Remove disabled params
   renderedRequest.parameters = renderedRequest.parameters.filter(p => !p.disabled);
   // Remove disabled headers
@@ -515,6 +517,7 @@ export async function getRenderedRequestAndContext(
   return {
     context: renderContext,
     request: {
+      suppressUserAgent,
       cookieJar: renderedCookieJar,
       cookies: [],
       isPrivate: false,

--- a/packages/insomnia/src/main/network/curl.ts
+++ b/packages/insomnia/src/main/network/curl.ts
@@ -90,6 +90,7 @@ interface OpenCurlRequestOptions {
   authentication: RequestAuthentication;
   cookieJar: CookieJar;
   initialPayload?: string;
+  suppressUserAgent: boolean;
 }
 const openCurlConnection = async (
   _event: Electron.IpcMainInvokeEvent,
@@ -137,7 +138,7 @@ const openCurlConnection = async (
     const clientCertificates = await models.clientCertificate.findByParentId(options.workspaceId);
     const filteredClientCertificates = clientCertificates.filter(c => !c.disabled && urlMatchesCertHost(setDefaultProtocol(c.host, 'https:'), options.url));
     const { curl, debugTimeline } = createConfiguredCurlInstance({
-      req: { ...request, cookieJar: options.cookieJar, cookies: [] },
+      req: { ...request, cookieJar: options.cookieJar, cookies: [], suppressUserAgent: options.suppressUserAgent },
       finalUrl: options.url,
       settings,
       caCert: caCertificate,

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -41,6 +41,7 @@ interface RequestUsedHere {
   url: string;
   cookieJar: any;
   cookies: { name: string; value: string }[];
+  suppressUserAgent: boolean;
 }
 interface SettingsUsedHere {
   preferredHttpVersion: string;
@@ -376,6 +377,9 @@ export const createConfiguredCurlInstance = ({
   const userAgent: RequestHeader | null = headers.find((h: any) => h.name.toLowerCase() === 'user-agent') || null;
   const userAgentOrFallback = typeof userAgent?.value === 'string' ? userAgent?.value : 'insomnia/' + version;
   curl.setOpt(Curl.option.USERAGENT, userAgentOrFallback);
+  if (req.suppressUserAgent) {
+    curl.setOpt(Curl.option.USERAGENT, '');
+  }
 
   const { username, password, disabled } = authentication;
   const isDigest = authentication.type === AUTH_DIGEST;

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -140,6 +140,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
           headers: rendered.headers,
           authentication: rendered.authentication,
           cookieJar: rendered.workspaceCookieJar,
+          suppressUserAgent: rendered.suppressUserAgent,
         });
       };
       startListening();

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -106,6 +106,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, environmentId,
       headers: rendered.headers,
       authentication: rendered.authentication,
       cookieJar: rendered.workspaceCookieJar,
+      suppressUserAgent: rendered.suppressUserAgent,
     });
 
   };

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -248,6 +248,7 @@ export interface ConnectActionParams {
   headers: RequestHeader[];
   authentication: RequestAuthentication;
   cookieJar: CookieJar;
+  suppressUserAgent: boolean;
 }
 export const connectAction: ActionFunction = async ({ request, params }) => {
   const { requestId, workspaceId } = params;
@@ -274,6 +275,7 @@ export const connectAction: ActionFunction = async ({ request, params }) => {
       headers: rendered.headers,
       authentication: rendered.authentication,
       cookieJar: rendered.cookieJar,
+      suppressUserAgent: rendered.suppressUserAgent,
     });
   }
   // HACK: even more elaborate hack to get the request to update


### PR DESCRIPTION
changelog(Improvements): If user-agent header is defined and is disabled, it is now supressed. Otherwise the default is sent.

if headers exist and are disabled then suppress user agent 
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
