### PR TITLE
upgrade electron to 25.8.1 to fix CVE-2023-4863

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11168,9 +11168,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.2.0.tgz",
-      "integrity": "sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==",
+      "version": "25.8.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.8.1.tgz",
+      "integrity": "sha512-GtcP1nMrROZfFg0+mhyj1hamrHvukfF6of2B/pcWxmWkd5FVY1NJib0tlhiorFZRzQN5Z+APLPr7aMolt7i2AQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -24648,7 +24648,7 @@
         "cross-env": "^7.0.3",
         "date-fns": "^2.28.0",
         "deep-equal": "^1.0.1",
-        "electron": "25.2.0",
+        "electron": "25.8.1",
         "electron-builder": "24.4.0",
         "electron-builder-squirrel-windows": "24.4.0",
         "electron-devtools-installer": "^3.2.0",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -141,7 +141,7 @@
     "cross-env": "^7.0.3",
     "date-fns": "^2.28.0",
     "deep-equal": "^1.0.1",
-    "electron": "25.2.0",
+    "electron": "25.8.1",
     "electron-builder": "24.4.0",
     "electron-builder-squirrel-windows": "24.4.0",
     "electron-devtools-installer": "^3.2.0",


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

changelog(Fixes): Upgraded Electron to 25.8.1 to address CVE-2023-4863