### PR TITLE
Sync Organizations

### DIFF
--- a/packages/insomnia/src/main/insomniaFetch.ts
+++ b/packages/insomnia/src/main/insomniaFetch.ts
@@ -27,6 +27,7 @@ const exponentialBackOff = async (url: string, init: RequestInit, retries = 0): 
     if (response.status === 502 && retries < 5) {
       retries++;
       await delay(retries * 1000);
+      console.log(`Received 502 from ${url} retrying`);
       return exponentialBackOff(url, init, retries);
     }
     if (!response.ok) {

--- a/packages/insomnia/src/ui/components/avatar.tsx
+++ b/packages/insomnia/src/ui/components/avatar.tsx
@@ -3,9 +3,9 @@ import styled, { keyframes } from 'styled-components';
 
 import { Tooltip } from './tooltip';
 
-const getNameInitials = (name: string) => {
+const getNameInitials = (name?: string) => {
   // Split on whitespace and take first letter of each word
-  const words = name.toUpperCase().split(' ');
+  const words = name?.toUpperCase().split(' ') || [];
   const firstWord = words[0];
   const lastWord = words[words.length - 1];
 

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -157,12 +157,15 @@ const router = createMemoryRouter(
           path: 'organization',
           id: '/organization',
           loader: async (...args) => (await import('./routes/organization')).loader(...args),
-          shouldRevalidate: shouldOrganizationsRevalidate,
           element: <Suspense fallback={<AppLoadingIndicator />}><Organization /></Suspense>,
           children: [
             {
               index: true,
               loader: async (...args) => (await import('./routes/organization')).indexLoader(...args),
+            },
+            {
+              path: 'sync',
+              action: async (...args) => (await import('./routes/organization')).syncOrganizationsAction(...args),
             },
             {
               path: ':organizationId',

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -94,45 +94,24 @@ const organizationsData: OrganizationLoaderData = {
 
 function sortOrganizations(organizations: Organization[]) {
   const accountId = getAccountId();
-
-  return organizations
-    .sort((organizationA, organizationB) => organizationA.name.localeCompare(organizationB.name))
-    .sort((organizationA, organizationB) => {
-      if (isPersonalOrganization(organizationA) && !isPersonalOrganization(organizationB)) {
-        return -1;
-      } else if (
-        !isPersonalOrganization(organizationA) &&
-        isPersonalOrganization(organizationB)
-      ) {
-        return 1;
-      } else {
-        return 0;
-      }
-    })
-    .sort((organizationA, organizationB) => {
-      if (isOwnerOfOrganization({
-        organization: organizationA,
-        accountId: accountId || '',
-      }) && !isOwnerOfOrganization({
-        organization: organizationB,
-        accountId: accountId || '',
-      })) {
-        return -1;
-      } else if (
-        !isOwnerOfOrganization({
-          organization: organizationA,
-          accountId: accountId || '',
-        }) &&
-        isOwnerOfOrganization({
-          organization: organizationB,
-          accountId: accountId || '',
-        })
-      ) {
-        return 1;
-      } else {
-        return 0;
-      }
-    });
+  invariant(accountId, 'Account ID is not defined');
+  const home = organizations.find(organization => isPersonalOrganization(organization) && isOwnerOfOrganization({
+    organization,
+    accountId,
+  }));
+  const myOrgs = organizations.filter(organization => !isPersonalOrganization(organization) && isOwnerOfOrganization({
+    organization,
+    accountId,
+  })).sort((a, b) => a.name.localeCompare(b.name));
+  const notMyOrgs = organizations.filter(organization => !isOwnerOfOrganization({
+    organization,
+    accountId,
+  })).sort((a, b) => a.name.localeCompare(b.name));
+  return [
+    home,
+    ...myOrgs,
+    ...notMyOrgs,
+  ];
 }
 
 export const indexLoader: LoaderFunction = async () => {
@@ -385,279 +364,279 @@ const OrganizationRoute = () => {
 
   return (
     <PresenceProvider>
-        <div className="w-full h-full">
-          <div className={`w-full h-full divide-x divide-solid divide-y divide-[--hl-md] ${workspaceData?.activeWorkspace && isScratchpad(workspaceData?.activeWorkspace) ? 'grid-template-app-layout-with-banner' : 'grid-template-app-layout'} grid relative bg-[--color-bg]`}>
-            <header className="[grid-area:Header] grid grid-cols-3 items-center">
-              <div className="flex items-center">
-                <div className="flex w-[50px] py-2">
-                  <InsomniaAILogo />
-                </div>
-                {!user ? <GitHubStarsButton /> : null}
+      <div className="w-full h-full">
+        <div className={`w-full h-full divide-x divide-solid divide-y divide-[--hl-md] ${workspaceData?.activeWorkspace && isScratchpad(workspaceData?.activeWorkspace) ? 'grid-template-app-layout-with-banner' : 'grid-template-app-layout'} grid relative bg-[--color-bg]`}>
+          <header className="[grid-area:Header] grid grid-cols-3 items-center">
+            <div className="flex items-center">
+              <div className="flex w-[50px] py-2">
+                <InsomniaAILogo />
               </div>
+              {!user ? <GitHubStarsButton /> : null}
+            </div>
             <div className="flex place-content-stretch gap-2 flex-nowrap items-center justify-center">
-                {workspaceData && isDesign(workspaceData?.activeWorkspace) && (
-                  <nav className="flex rounded-full justify-between content-evenly font-semibold bg-[--hl-xs] p-[--padding-xxs]">
-                    {[
-                      { id: 'spec', name: 'spec' },
-                      { name: 'collection', id: 'debug' },
-                      { id: 'test', name: 'tests' },
-                    ].map(item => (
-                      <NavLink
-                        key={item.id}
-                        to={`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/${item.id}`}
-                        className={({ isActive, isPending }) =>
-                          `${isActive
-                            ? 'text-[--color-font] bg-[--color-bg]'
-                            : ''
-                          } ${isPending ? 'animate-pulse' : ''} no-underline transition-colors text-center outline-none min-w-[4rem] uppercase text-[--color-font] text-xs px-[--padding-xs] py-[--padding-xxs] rounded-full`
-                        }
-                      >
-                        {item.name}
-                      </NavLink>
-                    ))}
-                  </nav>
-                )}
-              </div>
-              <div className="flex gap-[--padding-sm] items-center justify-end p-2">
-                {user ? (
-                  <Fragment>
-                    <PresentUsers />
-                    <MenuTrigger>
-                    <Button className="px-1 py-1 flex-shrink-0 flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-full text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm">
-                        <Avatar
-                          src={user.picture}
-                          alt={user.name}
-                        />
-                        <span className="pr-2">
-                          {user.name}
-                        </span>
-                      </Button>
-                      <Popover className="min-w-max">
-                        <Menu
-                          onAction={action => {
-                            if (action === 'logout') {
-                              logoutFetcher.submit(
-                                {},
-                                {
-                                  action: '/auth/logout',
-                                  method: 'POST',
-                                },
-                              );
-                            }
-
-                            if (action === 'account-settings') {
-                              window.main.openInBrowser(
-                                `${getAppWebsiteBaseURL()}/app/settings/account`,
-                              );
-                            }
-                          }}
-                          className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
-                        >
-                          <Item
-                            id="account-settings"
-                            className="flex gap-2 px-[--padding-md] aria-selected:font-bold items-center text-[--color-font] h-[--line-height-xs] w-full text-md whitespace-nowrap bg-transparent hover:bg-[--hl-sm] disabled:cursor-not-allowed focus:bg-[--hl-xs] focus:outline-none transition-colors"
-                            aria-label="Account settings"
-                          >
-                            <Icon icon="gear" />
-                            <span>Account Settings</span>
-                          </Item>
-                          <Item
-                            id="logout"
-                            className="flex gap-2 px-[--padding-md] aria-selected:font-bold items-center text-[--color-font] h-[--line-height-xs] w-full text-md whitespace-nowrap bg-transparent hover:bg-[--hl-sm] disabled:cursor-not-allowed focus:bg-[--hl-xs] focus:outline-none transition-colors"
-                            aria-label="logout"
-                          >
-                            <Icon icon="sign-out" />
-                            <span>Logout</span>
-                          </Item>
-                        </Menu>
-                      </Popover>
-                    </MenuTrigger>
-                  <UpgradeButton />
-                  </Fragment>
-                ) : (
-                  <Fragment>
+              {workspaceData && isDesign(workspaceData?.activeWorkspace) && (
+                <nav className="flex rounded-full justify-between content-evenly font-semibold bg-[--hl-xs] p-[--padding-xxs]">
+                  {[
+                    { id: 'spec', name: 'spec' },
+                    { name: 'collection', id: 'debug' },
+                    { id: 'test', name: 'tests' },
+                  ].map(item => (
                     <NavLink
-                      to="/auth/login"
-                      className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
-                    >
-                      Login
-                    </NavLink>
-                    <NavLink
-                      className="px-4 py-1 flex items-center justify-center gap-2 aria-pressed:bg-[rgba(var(--color-surprise-rgb),0.8)] focus:bg-[rgba(var(--color-surprise-rgb),0.9)] bg-[--color-surprise] font-semibold rounded-sm text-[--color-font-surprise] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
-                      to="/auth/login"
-                    >
-                      Sign Up
-                    </NavLink>
-                  </Fragment>
-              )}
-              </div>
-            </header>
-            {isScratchpadWorkspace ? (
-              <div className="flex h-[30px] items-center [grid-area:Banner] text-white bg-gradient-to-r from-[#7400e1] to-[#4000bf]">
-                <div className="flex flex-shrink-0 basis-[50px] h-full">
-                  <div className="border-solid border-r-[--hl-xl] border-r border-l border-l-[--hl-xl] box-border flex items-center justify-center w-full h-full">
-                    <Icon icon="edit" />
-                  </div>
-                </div>
-                <div className="py-[--padding-xs] overflow-hidden px-[--padding-md] w-full h-full flex items-center text-xs">
-                  <p className='w-full truncate leading-normal'>
-                    Welcome to the local Scratch Pad. To get the most out of
-                    Insomnia and see your projects{' '}
-                    <NavLink
-                      to="/auth/login"
-                      className="font-bold text-white inline-flex"
-                    >
-                      login or create an account →
-                    </NavLink>
-                  </p>
-                </div>
-              </div>
-            ) : null}
-            <div className="[grid-area:Navbar]">
-              <nav className="flex flex-col items-center place-content-stretch gap-[--padding-md] w-full h-full overflow-y-auto py-[--padding-md]">
-                {organizations.map(organization => (
-                  <TooltipTrigger key={organization.id}>
-                    <Link>
-                      <NavLink
-                        className={({ isActive, isPending }) =>
-                          `select-none text-[--color-font-surprise] hover:no-underline transition-all duration-150 bg-gradient-to-br box-border from-[#4000BF] to-[#154B62] font-bold outline-[3px] rounded-md w-[28px] h-[28px] flex items-center justify-center active:outline overflow-hidden outline-offset-[3px] outline ${isActive
-                            ? 'outline-[--color-font]'
-                            : 'outline-transparent focus:outline-[--hl-md] hover:outline-[--hl-md]'
-                          } ${isPending ? 'animate-pulse' : ''}`
-                        }
-                        to={`/organization/${organization.id}`}
-                      >
-                        {isPersonalOrganization(organization) && isOwnerOfOrganization({
-                          organization,
-                          accountId: getAccountId() || '',
-                        }) ? (
-                          <Icon icon="home" />
-                        ) : (
-                          <OrganizationAvatar
-                            alt={organization.display_name}
-                            src={organization.branding?.logo_url || ''}
-                          />
-                        )}
-                      </NavLink>
-                    </Link>
-                    <Tooltip
-                      placement="right"
-                      offset={8}
-                      className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] text-[--color-font] px-4 py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
-                    >
-                      <span>{organization.display_name}</span>
-                    </Tooltip>
-                  </TooltipTrigger>
-                ))}
-                <MenuTrigger>
-                  <Button className="select-none text-[--color-font] hover:no-underline transition-all duration-150 box-border p-[--padding-sm] font-bold outline-none rounded-md w-[28px] h-[28px] flex items-center justify-center overflow-hidden">
-                    <Icon icon="plus" />
-                  </Button>
-                  <Popover placement="left" className="min-w-max">
-                    <Menu
-                      onAction={action => {
-                        if (action === 'join-organization') {
-                          window.main.openInBrowser(
-                            getLoginUrl(),
-                          );
-                        }
-
-                        if (action === 'new-organization') {
-                          window.main.openInBrowser(
-                            `${getAppWebsiteBaseURL()}/app/organization/create`,
-                          );
-                        }
-                      }}
-                      className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
-                    >
-                      <Item
-                        id="join-organization"
-                        className="flex gap-2 px-[--padding-md] aria-selected:font-bold items-center text-[--color-font] h-[--line-height-xs] w-full text-md whitespace-nowrap bg-transparent hover:bg-[--hl-sm] disabled:cursor-not-allowed focus:bg-[--hl-xs] focus:outline-none transition-colors"
-                        aria-label="Join an organization"
-                      >
-                        <Icon icon="city" />
-                        <span>Join an organization</span>
-                      </Item>
-                      <Item
-                        id="new-organization"
-                        className="flex gap-2 px-[--padding-md] aria-selected:font-bold items-center text-[--color-font] h-[--line-height-xs] w-full text-md whitespace-nowrap bg-transparent hover:bg-[--hl-sm] disabled:cursor-not-allowed focus:bg-[--hl-xs] focus:outline-none transition-colors"
-                        aria-label="Create new organization"
-                      >
-                        <Icon icon="sign-out" />
-                        <span>Create a new organization</span>
-                      </Item>
-                    </Menu>
-                  </Popover>
-                </MenuTrigger>
-              </nav>
-            </div>
-            <Outlet />
-            <div className="relative [grid-area:Statusbar] flex items-center justify-between overflow-hidden">
-              <div className="flex h-full">
-                <TooltipTrigger>
-                  <Button
-                    data-testid="settings-button"
-                    className="px-4 py-1 h-full flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] text-[--color-font] text-xs hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all"
-                    onPress={showSettingsModal}
-                  >
-                    <Icon icon="gear" /> Preferences
-                  </Button>
-                  <Tooltip
-                    placement="top"
-                    offset={8}
-                    className="border flex items-center gap-2 select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] text-[--color-font] px-4 py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
-                  >
-                    Preferences
-                    <Hotkey
-                      keyBindings={
-                        settings.hotKeyRegistry.preferences_showGeneral
-                      }
-                    />
-                  </Tooltip>
-                </TooltipTrigger>
-                <TooltipTrigger>
-                  <Button className="px-4 py-1 h-full flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] text-[--color-font] text-xs hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all">
-                    <Icon
-                      icon="circle"
-                      className={
-                        user
-                          ? status === 'online'
-                            ? 'text-[--color-success]'
-                            : 'text-[--color-danger]'
+                      key={item.id}
+                      to={`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/${item.id}`}
+                      className={({ isActive, isPending }) =>
+                        `${isActive
+                          ? 'text-[--color-font] bg-[--color-bg]'
                           : ''
+                        } ${isPending ? 'animate-pulse' : ''} no-underline transition-colors text-center outline-none min-w-[4rem] uppercase text-[--color-font] text-xs px-[--padding-xs] py-[--padding-xxs] rounded-full`
                       }
-                    />{' '}
-                    {user
-                      ? status.charAt(0).toUpperCase() + status.slice(1)
-                      : 'Log in to sync your data'}
-                  </Button>
-                  <Tooltip
-                    placement="top"
-                    offset={8}
-                    className="border flex items-center gap-2 select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] text-[--color-font] px-4 py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                    >
+                      {item.name}
+                    </NavLink>
+                  ))}
+                </nav>
+              )}
+            </div>
+            <div className="flex gap-[--padding-sm] items-center justify-end p-2">
+              {user ? (
+                <Fragment>
+                  <PresentUsers />
+                  <MenuTrigger>
+                    <Button className="px-1 py-1 flex-shrink-0 flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-full text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm">
+                      <Avatar
+                        src={user.picture}
+                        alt={user.name}
+                      />
+                      <span className="pr-2">
+                        {user.name}
+                      </span>
+                    </Button>
+                    <Popover className="min-w-max">
+                      <Menu
+                        onAction={action => {
+                          if (action === 'logout') {
+                            logoutFetcher.submit(
+                              {},
+                              {
+                                action: '/auth/logout',
+                                method: 'POST',
+                              },
+                            );
+                          }
+
+                          if (action === 'account-settings') {
+                            window.main.openInBrowser(
+                              `${getAppWebsiteBaseURL()}/app/settings/account`,
+                            );
+                          }
+                        }}
+                        className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                      >
+                        <Item
+                          id="account-settings"
+                          className="flex gap-2 px-[--padding-md] aria-selected:font-bold items-center text-[--color-font] h-[--line-height-xs] w-full text-md whitespace-nowrap bg-transparent hover:bg-[--hl-sm] disabled:cursor-not-allowed focus:bg-[--hl-xs] focus:outline-none transition-colors"
+                          aria-label="Account settings"
+                        >
+                          <Icon icon="gear" />
+                          <span>Account Settings</span>
+                        </Item>
+                        <Item
+                          id="logout"
+                          className="flex gap-2 px-[--padding-md] aria-selected:font-bold items-center text-[--color-font] h-[--line-height-xs] w-full text-md whitespace-nowrap bg-transparent hover:bg-[--hl-sm] disabled:cursor-not-allowed focus:bg-[--hl-xs] focus:outline-none transition-colors"
+                          aria-label="logout"
+                        >
+                          <Icon icon="sign-out" />
+                          <span>Logout</span>
+                        </Item>
+                      </Menu>
+                    </Popover>
+                  </MenuTrigger>
+                  <UpgradeButton />
+                </Fragment>
+              ) : (
+                <Fragment>
+                  <NavLink
+                    to="/auth/login"
+                    className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
                   >
-                    {user
-                      ? `You are ${status === 'online'
-                        ? 'securely connected to Insomnia Cloud'
-                        : 'offline. Connect to sync your data.'
-                      }`
-                      : 'Log in to Insomnia to sync your data.'}
+                    Login
+                  </NavLink>
+                  <NavLink
+                    className="px-4 py-1 flex items-center justify-center gap-2 aria-pressed:bg-[rgba(var(--color-surprise-rgb),0.8)] focus:bg-[rgba(var(--color-surprise-rgb),0.9)] bg-[--color-surprise] font-semibold rounded-sm text-[--color-font-surprise] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+                    to="/auth/login"
+                  >
+                    Sign Up
+                  </NavLink>
+                </Fragment>
+              )}
+            </div>
+          </header>
+          {isScratchpadWorkspace ? (
+            <div className="flex h-[30px] items-center [grid-area:Banner] text-white bg-gradient-to-r from-[#7400e1] to-[#4000bf]">
+              <div className="flex flex-shrink-0 basis-[50px] h-full">
+                <div className="border-solid border-r-[--hl-xl] border-r border-l border-l-[--hl-xl] box-border flex items-center justify-center w-full h-full">
+                  <Icon icon="edit" />
+                </div>
+              </div>
+              <div className="py-[--padding-xs] overflow-hidden px-[--padding-md] w-full h-full flex items-center text-xs">
+                <p className='w-full truncate leading-normal'>
+                  Welcome to the local Scratch Pad. To get the most out of
+                  Insomnia and see your projects{' '}
+                  <NavLink
+                    to="/auth/login"
+                    className="font-bold text-white inline-flex"
+                  >
+                    login or create an account →
+                  </NavLink>
+                </p>
+              </div>
+            </div>
+          ) : null}
+          <div className="[grid-area:Navbar]">
+            <nav className="flex flex-col items-center place-content-stretch gap-[--padding-md] w-full h-full overflow-y-auto py-[--padding-md]">
+              {organizations.map(organization => (
+                <TooltipTrigger key={organization.id}>
+                  <Link>
+                    <NavLink
+                      className={({ isActive, isPending }) =>
+                        `select-none text-[--color-font-surprise] hover:no-underline transition-all duration-150 bg-gradient-to-br box-border from-[#4000BF] to-[#154B62] font-bold outline-[3px] rounded-md w-[28px] h-[28px] flex items-center justify-center active:outline overflow-hidden outline-offset-[3px] outline ${isActive
+                          ? 'outline-[--color-font]'
+                          : 'outline-transparent focus:outline-[--hl-md] hover:outline-[--hl-md]'
+                        } ${isPending ? 'animate-pulse' : ''}`
+                      }
+                      to={`/organization/${organization.id}`}
+                    >
+                      {isPersonalOrganization(organization) && isOwnerOfOrganization({
+                        organization,
+                        accountId: getAccountId() || '',
+                      }) ? (
+                        <Icon icon="home" />
+                      ) : (
+                        <OrganizationAvatar
+                          alt={organization.display_name}
+                          src={organization.branding?.logo_url || ''}
+                        />
+                      )}
+                    </NavLink>
+                  </Link>
+                  <Tooltip
+                    placement="right"
+                    offset={8}
+                    className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] text-[--color-font] px-4 py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                  >
+                    <span>{organization.display_name}</span>
                   </Tooltip>
                 </TooltipTrigger>
-              </div>
-              <Link>
-                <a
-                  className="flex focus:outline-none focus:underline gap-1 items-center text-xs text-[--color-font] px-[--padding-md]"
-                  href="https://konghq.com/"
-                >
-                  Made with
-                  <Icon className="text-[--color-surprise]" icon="heart" /> by
-                  Kong
-                </a>
-              </Link>
-            </div>
+              ))}
+              <MenuTrigger>
+                <Button className="select-none text-[--color-font] hover:no-underline transition-all duration-150 box-border p-[--padding-sm] font-bold outline-none rounded-md w-[28px] h-[28px] flex items-center justify-center overflow-hidden">
+                  <Icon icon="plus" />
+                </Button>
+                <Popover placement="left" className="min-w-max">
+                  <Menu
+                    onAction={action => {
+                      if (action === 'join-organization') {
+                        window.main.openInBrowser(
+                          getLoginUrl(),
+                        );
+                      }
+
+                      if (action === 'new-organization') {
+                        window.main.openInBrowser(
+                          `${getAppWebsiteBaseURL()}/app/organization/create`,
+                        );
+                      }
+                    }}
+                    className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                  >
+                    <Item
+                      id="join-organization"
+                      className="flex gap-2 px-[--padding-md] aria-selected:font-bold items-center text-[--color-font] h-[--line-height-xs] w-full text-md whitespace-nowrap bg-transparent hover:bg-[--hl-sm] disabled:cursor-not-allowed focus:bg-[--hl-xs] focus:outline-none transition-colors"
+                      aria-label="Join an organization"
+                    >
+                      <Icon icon="city" />
+                      <span>Join an organization</span>
+                    </Item>
+                    <Item
+                      id="new-organization"
+                      className="flex gap-2 px-[--padding-md] aria-selected:font-bold items-center text-[--color-font] h-[--line-height-xs] w-full text-md whitespace-nowrap bg-transparent hover:bg-[--hl-sm] disabled:cursor-not-allowed focus:bg-[--hl-xs] focus:outline-none transition-colors"
+                      aria-label="Create new organization"
+                    >
+                      <Icon icon="sign-out" />
+                      <span>Create a new organization</span>
+                    </Item>
+                  </Menu>
+                </Popover>
+              </MenuTrigger>
+            </nav>
           </div>
-          <Toast />
+          <Outlet />
+          <div className="relative [grid-area:Statusbar] flex items-center justify-between overflow-hidden">
+            <div className="flex h-full">
+              <TooltipTrigger>
+                <Button
+                  data-testid="settings-button"
+                  className="px-4 py-1 h-full flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] text-[--color-font] text-xs hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all"
+                  onPress={showSettingsModal}
+                >
+                  <Icon icon="gear" /> Preferences
+                </Button>
+                <Tooltip
+                  placement="top"
+                  offset={8}
+                  className="border flex items-center gap-2 select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] text-[--color-font] px-4 py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                >
+                  Preferences
+                  <Hotkey
+                    keyBindings={
+                      settings.hotKeyRegistry.preferences_showGeneral
+                    }
+                  />
+                </Tooltip>
+              </TooltipTrigger>
+              <TooltipTrigger>
+                <Button className="px-4 py-1 h-full flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] text-[--color-font] text-xs hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all">
+                  <Icon
+                    icon="circle"
+                    className={
+                      user
+                        ? status === 'online'
+                          ? 'text-[--color-success]'
+                          : 'text-[--color-danger]'
+                        : ''
+                    }
+                  />{' '}
+                  {user
+                    ? status.charAt(0).toUpperCase() + status.slice(1)
+                    : 'Log in to sync your data'}
+                </Button>
+                <Tooltip
+                  placement="top"
+                  offset={8}
+                  className="border flex items-center gap-2 select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] text-[--color-font] px-4 py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                >
+                  {user
+                    ? `You are ${status === 'online'
+                      ? 'securely connected to Insomnia Cloud'
+                      : 'offline. Connect to sync your data.'
+                    }`
+                    : 'Log in to Insomnia to sync your data.'}
+                </Tooltip>
+              </TooltipTrigger>
+            </div>
+            <Link>
+              <a
+                className="flex focus:outline-none focus:underline gap-1 items-center text-xs text-[--color-font] px-[--padding-md]"
+                href="https://konghq.com/"
+              >
+                Made with
+                <Icon className="text-[--color-surprise]" icon="heart" /> by
+                Kong
+              </a>
+            </Link>
+          </div>
+        </div>
+        <Toast />
       </div>
     </PresenceProvider>
   );


### PR DESCRIPTION
Currently we refetch organizations on navigation.

This caches the results in memory and only updates the organizations when:
- we navigate to `/organization` (currently redirected there after logging in) **OR**
- when there is an `OrganizationChanged` event in the presence API

Closes INS-3024, INS-3094, INS-3023