### PR TITLE
fix #6490 portable .exe is not actually portable

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -47,7 +47,6 @@ jobs:
         shell: bash
         run: |
           mv ./artifacts/windows-latest-artifacts/insomnia/dist/squirrel-windows/Insomnia.Core-${{ env.RELEASE_VERSION }}.exe ./artifacts/
-          mv ./artifacts/windows-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}-portable.exe ./artifacts/
 
       - name: Code-sign Windows .exe artifact
         uses: sslcom/actions-codesigner@develop
@@ -60,16 +59,16 @@ jobs:
           file_path: ${GITHUB_WORKSPACE}/artifacts/Insomnia.Core-${{ env.RELEASE_VERSION }}.exe
           output_path: ${GITHUB_WORKSPACE}/artifacts/windows-latest-artifacts/insomnia/dist/squirrel-windows
 
-      - name: Code-sign Windows portable .exe artifact
-        uses: sslcom/actions-codesigner@develop
-        with:
-          command: sign
-          username: ${{secrets.ES_USERNAME}}
-          password: ${{secrets.ES_PASSWORD}}
-          credential_id: ${{secrets.ES_CREDENTIAL_ID}}
-          totp_secret: ${{secrets.ES_TOTP_SECRET}}
-          file_path: ${GITHUB_WORKSPACE}/artifacts/Insomnia.Core-${{ env.RELEASE_VERSION }}-portable.exe
-          output_path: ${GITHUB_WORKSPACE}/artifacts/windows-latest-artifacts/insomnia/dist
+      # - name: Code-sign Windows portable .exe artifact
+      #   uses: sslcom/actions-codesigner@develop
+      #   with:
+      #     command: sign
+      #     username: ${{secrets.ES_USERNAME}}
+      #     password: ${{secrets.ES_PASSWORD}}
+      #     credential_id: ${{secrets.ES_CREDENTIAL_ID}}
+      #     totp_secret: ${{secrets.ES_TOTP_SECRET}}
+      #     file_path: ${GITHUB_WORKSPACE}/artifacts/Insomnia.Core-${{ env.RELEASE_VERSION }}-portable.exe
+      #     output_path: ${GITHUB_WORKSPACE}/artifacts/windows-latest-artifacts/insomnia/dist
 
       - name: Set Inso CLI version on Github Env
         run:

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   build-and-upload-artifacts:
     # Skip jobs for release PRs
+    # windows on recurring should be portable
     if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -27,7 +28,7 @@ jobs:
           - os: "macos-latest"
             build-targets: "zip"
           - os: "windows-latest"
-            build-targets: "squirrel"
+            build-targets: "portable"
           - os: "ubuntu-latest"
             build-targets: "tar.gz"
     steps:

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -27,7 +27,7 @@ jobs:
           - os: "macos-latest"
             build-targets: "zip"
           - os: "windows-latest"
-            build-targets: "portable"
+            build-targets: "squirrel"
           - os: "ubuntu-latest"
             build-targets: "tar.gz"
     steps:

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -98,6 +98,9 @@ const config = {
     iconUrl:
       'https://github.com/kong/insomnia/blob/develop/packages/insomnia/src/icons/icon.ico?raw=true',
   },
+  portable: {
+    artifactName: `${BINARY_PREFIX}-\${version}-portable.\${ext}`,
+  },
   linux: {
     artifactName: `${BINARY_PREFIX}-\${version}.\${ext}`,
     executableName: 'insomnia',

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -91,18 +91,12 @@ const config = {
       {
         target: 'squirrel',
       },
-      {
-        target: 'portable',
-      },
     ],
   },
   squirrelWindows: {
     artifactName: `${BINARY_PREFIX}-\${version}.\${ext}`,
     iconUrl:
       'https://github.com/kong/insomnia/blob/develop/packages/insomnia/src/icons/icon.ico?raw=true',
-  },
-  portable: {
-    artifactName: `${BINARY_PREFIX}-\${version}-portable.\${ext}`,
   },
   linux: {
     artifactName: `${BINARY_PREFIX}-\${version}.\${ext}`,


### PR DESCRIPTION
Closes #6490 

The current portable.exe we use for Release Recurring and that we also publish on releases in not actually portable (see #6490). Since from 8.0 onwards unfortunately portability is also not possible, in this PR we remove the portable builds to reduce release pipelines time.

> note: we should keep `portable` for release-recurring 