### PR TITLE
Fix default theme text colors

### DIFF
--- a/packages/insomnia/src/ui/css/main.css
+++ b/packages/insomnia/src/ui/css/main.css
@@ -1656,6 +1656,10 @@ html {
 .editor .CodeMirror-cursor {
   border-left: 1px solid var(--color-font);
 }
+
+[theme="default"] .editor .CodeMirror-foldmarker {
+  color: var(--color-font-surprise);
+}
 .editor .CodeMirror-foldmarker {
   color: var(--color-surprise);
   text-shadow: none;
@@ -1673,6 +1677,14 @@ html {
 .editor .cm-meta,
 .editor .cm-qualifier {
   color: var(--color-font);
+}
+[theme="default"] .editor .cm-atom,
+[theme="default"] .editor .cm-number,
+[theme="default"] .editor .cm-keyword,
+[theme="default"] .editor .cm-variable-3,
+[theme="default"] .editor .cm-link,
+[theme="default"] .editor .cm-header {
+  color: var(--color-font-surprise);
 }
 .editor .cm-atom {
   color: var(--color-surprise);
@@ -1967,6 +1979,12 @@ html {
 .CodeMirror-info .info-description > * {
   margin: var(--padding-xs) 0 var(--padding-sm) 0;
 }
+
+[theme="default"] .CodeMirror-info .type-name,
+[theme="default"] .CodeMirror-info .arg-name {
+  color: var(--color-font-surprise);
+}
+
 .CodeMirror-info .type-name {
   color: var(--color-surprise);
 }
@@ -2363,6 +2381,15 @@ input.editable {
 .markdown-preview__content .hljs .hljs-builtin-name,
 .markdown-preview__content .hljs .hljs-type,
 .markdown-preview__content .hljs .hljs-tag .hljs-attr {
+  color: var(--color-surprise);
+}
+[theme="default"] .markdown-preview__content .hljs .hljs-literal,
+[theme="default"] .markdown-preview__content .hljs .hljs-template-variable,
+[theme="default"] .markdown-preview__content .hljs .hljs-built_in,
+[theme="default"] .markdown-preview__content .hljs .hljs-keyword,
+[theme="default"] .markdown-preview__content .hljs .hljs-builtin-name,
+[theme="default"] .markdown-preview__content .hljs .hljs-type,
+[theme="default"] .markdown-preview__content .hljs .hljs-tag .hljs-attr {
   color: var(--color-surprise);
 }
 .markdown-preview__content .hljs .hljs-symbol,


### PR DESCRIPTION
changelog(Fixes): Fixed default theme text colors where in some cases text was a dark purple that was hard to read.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
