### PR TITLE
chore: try macos-latest-xlarge

### DIFF
--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: "macos-latest"
+          - os: "macos-latest-xlarge"
             build-targets: "zip"
           - os: "windows-latest"
             build-targets: "portable"


### PR DESCRIPTION
trying https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/

results:
- regular free macos - 13 mins
- macos xlarge - 5 mins 30secs ish


related PR - when we tried with x64 large instances - https://github.com/Kong/insomnia/pull/6030