### PR TITLE
Update ApiSpec when importing

### DIFF
--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -250,8 +250,6 @@ export const deleteWorkspaceAction: ActionFunction = async ({
     if (vcs) {
       const backendProject = await vcs._getBackendProjectByRootDocument(workspace._id);
       await vcs._removeProject(backendProject);
-
-      console.log({ projectsLOCAL: await vcs.localBackendProjects() });
     }
   } catch (err) {
     console.warn('Failed to remove project from VCS', err);


### PR DESCRIPTION
In order to make imports deterministic and more reliable we had to avoid updating existing data.

This checks if the user is importing an ApiSpec and adds it to the workspace or **replaces** the existing one.

TODO:
- [ ] Display that an ApiSpec is about to be imported (will overwrite the current one) on the import modal
- [ ] If we import to a collection should it become a design document?

Explore:
- [ ] Another approach is to only import the requests and not update the existing ApiSpec

Closes #6547