### PR TITLE
adds workspace count to root

### DIFF
--- a/packages/insomnia/src/common/export-all-data.ts
+++ b/packages/insomnia/src/common/export-all-data.ts
@@ -1,12 +1,11 @@
 import { mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
 
-import { apiSpec, cookieJar, environment, grpcRequest, project, protoDirectory, protoFile, request, requestGroup, unitTest, unitTestSuite, webSocketPayload, webSocketRequest, workspace } from '../models';
+import { apiSpec, cookieJar, environment, grpcRequest, protoDirectory, protoFile, request, requestGroup, unitTest, unitTestSuite, webSocketPayload, webSocketRequest, workspace } from '../models';
 import { ApiSpec } from '../models/api-spec';
 import { CookieJar } from '../models/cookie-jar';
 import { Environment } from '../models/environment';
 import { GrpcRequest } from '../models/grpc-request';
-import type { Project } from '../models/project';
 import { ProtoDirectory } from '../models/proto-directory';
 import { ProtoFile } from '../models/proto-file';
 import { Request } from '../models/request';

--- a/packages/insomnia/src/common/export-all-data.ts
+++ b/packages/insomnia/src/common/export-all-data.ts
@@ -214,18 +214,13 @@ export async function exportAllData({
 }): Promise<void> {
   const insomniaExportFolder = join(dirPath, `insomnia-export.${Date.now()}`);
   await mkdir(insomniaExportFolder);
-  const projects = await database.all<Project>(project.type);
 
-  for (const project of projects) {
-    const workspaces = await database.find<Workspace>(workspace.type, {
-      parentId: project._id,
+  const workspaces = await database.find<Workspace>(workspace.type);
+
+  for (const workspace of workspaces) {
+    await exportWorkspaceData({
+      workspaceId: workspace._id,
+      dirPath: insomniaExportFolder,
     });
-
-    for (const workspace of workspaces) {
-      await exportWorkspaceData({
-        workspaceId: workspace._id,
-        dirPath: insomniaExportFolder,
-      });
-    }
   }
 }

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -344,7 +344,8 @@ const UpgradeButton = () => {
 };
 
 const OrganizationRoute = () => {
-  const { settings } = useRootLoaderData();
+  const { settings, workspaceCount } = useRootLoaderData();
+
   const { organizations, user } =
     useLoaderData() as OrganizationLoaderData;
   const workspaceData = useRouteLoaderData(
@@ -638,7 +639,7 @@ const OrganizationRoute = () => {
                   />{' '}
                   {user
                     ? status.charAt(0).toUpperCase() + status.slice(1)
-                    : 'Log in to sync your data'}
+                    : `Log in to sync your data (${workspaceCount} files)`}
                 </Button>
                 <Tooltip
                   placement="top"

--- a/packages/insomnia/src/ui/routes/root.tsx
+++ b/packages/insomnia/src/ui/routes/root.tsx
@@ -28,11 +28,8 @@ import { NunjucksEnabledProvider } from '../context/nunjucks/nunjucks-enabled-co
 import Modals from './modals';
 
 export interface RootLoaderData {
-  user?: {
-    name: string;
-    picture: string;
-  };
   settings: Settings;
+  workspaceCount: number;
 }
 
 export const useRootLoaderData = () => {
@@ -41,9 +38,10 @@ export const useRootLoaderData = () => {
 
 export const loader: LoaderFunction = async (): Promise<RootLoaderData> => {
   const settings = await models.settings.get();
-
+  const workspaceCount = await models.workspace.count();
   return {
     settings,
+    workspaceCount,
   };
 };
 


### PR DESCRIPTION
clarifies how many local files/worspaces/documents exist for export and ensures they are exported

changelog(Improvements): Added clarification of how many local files/worspaces/documents exist for export and/or cloud migration and ensures they are exported

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
