### PR TITLE
WIP: add response content type

### DIFF
--- a/packages/insomnia/src/main/network/curl.ts
+++ b/packages/insomnia/src/main/network/curl.ts
@@ -222,6 +222,7 @@ const openCurlConnection = async (
         settingSendCookies: request.settingSendCookies,
         settingStoreCookies: request.settingStoreCookies,
         bodyCompression: null,
+        contentType: CurlConnections.get(options.requestId)?.getInfo(Curl.info.CONTENT_TYPE) as string || '',
       };
       const settings = await models.settings.get();
       const res = await models.response.create(responsePatch, settings.maxHistoryResponses);

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -205,6 +205,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
         bytesRead: curl.getInfo(Curl.info.SIZE_DOWNLOAD) as number,
         elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000,
         url: curl.getInfo(Curl.info.EFFECTIVE_URL) as string,
+        contentType: curl.getInfo(Curl.info.CONTENT_TYPE) as string,
       };
       curl.close();
       await waitForStreamToFinish(responseBodyWriteStream);

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -297,6 +297,8 @@ const openWebSocketConnection = async (
         eventLogPath: responseBodyPath,
         settingSendCookies: request.settingSendCookies,
         settingStoreCookies: request.settingStoreCookies,
+        // TODO: decide if this is the right thing to do, ws doesn't have a content type
+        contentType: 'text/event-stream',
       };
       const settings = await models.settings.get();
       const res = await models.webSocketResponse.create(responsePatch, settings.maxHistoryResponses);

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -16,6 +16,7 @@ import { ResponseHistoryDropdown } from '../dropdowns/response-history-dropdown'
 import { ErrorBoundary } from '../error-boundary';
 import { Pane, PaneHeader as OriginalPaneHeader } from '../panes/pane';
 import { PlaceholderResponsePane } from '../panes/placeholder-response-pane';
+import { ResponsePane } from '../panes/response-pane';
 import { SvgIcon } from '../svg-icon';
 import { SizeTag } from '../tags/size-tag';
 import { StatusTag } from '../tags/status-tag';
@@ -94,6 +95,9 @@ export const RealtimeResponsePane: FC<{ requestId: string }> = () => {
         <PlaceholderResponsePane />
       </Pane>
     );
+  }
+  if (activeResponse.contentType !== 'text/event-stream') {
+    return <ResponsePane runningRequests={{}} />;
   }
   return <RealtimeActiveResponsePane response={activeResponse} />;
 };


### PR DESCRIPTION



 add response content type into response object


motivation: use content type to select appropriate response pane ux (editor or table)
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
