### PR TITLE
only migrate local data under org

### DIFF
--- a/packages/insomnia/src/sync/vcs/migrate-to-cloud-projects.ts
+++ b/packages/insomnia/src/sync/vcs/migrate-to-cloud-projects.ts
@@ -39,6 +39,11 @@ export const shouldMigrateProjectUnderOrganization = async () => {
 // do we care about project or should we only care about the workspaces?
 // depends on the recovery, reassing project to org or just workspaces to different project
 
+// nice to have:
+// a way to clean up the old projects
+// import workspaces into personal org
+// move projects into current org
+
 const hasOrphanedProjects = async (projectIdsWithinMyOrg: string[]) => {
   const projectIdsWithinMyOrgAndScratchPad = [...projectIdsWithinMyOrg, models.project.SCRATCHPAD_PROJECT_ID];
   const orphanedProjectCount = await database.count<Project>(models.project.type, {

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -203,7 +203,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
         </div>
         {hiddenProjects.length > 0 && <div className='rounded-md border border-solid border-[--hl-md] p-4 flex flex-col gap-2'>
           <div className='flex flex-col gap-1'>
-            <Heading className='text-lg font-bold flex items-center gap-2'><Icon icon="cancel" /> Untracked projects ({hiddenProjects.length}) (FIXME: Currently showing all Projects)</Heading>
+            <Heading className='text-lg font-bold flex items-center gap-2'><Icon icon="cancel" /> Untracked projects ({hiddenProjects.length})</Heading>
             <p className='text-[--hl] text-sm'>
               <Icon icon="info-circle" /> These projects are not associated with any organization in your account.
             </p>
@@ -227,14 +227,11 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
                   onSubmit={e => {
                     e.preventDefault();
                     const data = new FormData(e.currentTarget);
-
                     const organizationId = data.get('organizationId') as string;
 
-                    console.log({ organizationId });
                     models.project.update(project, {
                       parentId: organizationId,
-                      // TODO: make the convert to local project work
-                      // remoteId: null,
+                      remoteId: null,
                     });
                     // @TODO Pass the organizationId to an action that will move the project to the organization.
                   }}

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -10,7 +10,8 @@ import { exportAllToFile } from '../../../common/export';
 import { exportAllData } from '../../../common/export-all-data';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
 import { strings } from '../../../common/strings';
-import { isScratchpadOrganizationId, Organization } from '../../../models/organization';
+import * as models from '../../../models';
+import { isScratchpadOrganizationId, Organization, SCRATCHPAD_ORGANIZATION_ID } from '../../../models/organization';
 import { Project } from '../../../models/project';
 import { isScratchpad } from '../../../models/workspace';
 import { SegmentEvent } from '../../analytics';
@@ -40,8 +41,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
   useEffect(() => {
     // @TODO - Move to a loader
     const getHiddenProjects = async () => {
-      // @TODO - Select only hidden projects.
-      const listOfOrganizationIds = organizations.map(o => o.id);
+      const listOfOrganizationIds = [...organizations.map(o => o.id), SCRATCHPAD_ORGANIZATION_ID];
       const projects = await database.find<Project>('Project', {
         parentId: { $nin: listOfOrganizationIds },
       });
@@ -62,7 +62,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
       setHiddenProjects(hiddenProjects);
     };
     getHiddenProjects();
-  }, []);
+  }, [organizations]);
 
   const workspaceData = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData | undefined;
   const activeWorkspaceName = workspaceData?.activeWorkspace.name;
@@ -231,7 +231,11 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
                     const organizationId = data.get('organizationId') as string;
 
                     console.log({ organizationId });
-
+                    models.project.update(project, {
+                      parentId: organizationId,
+                      // TODO: make the convert to local project work
+                      // remoteId: null,
+                    });
                     // @TODO Pass the organizationId to an action that will move the project to the organization.
                   }}
                 >

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -57,17 +57,12 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
   if (!organizationId) {
     return null;
   }
- // here we should list all the folders which contain insomnia.*.db files
- // and have some big red button to overwrite the current data with the backup
- // and once complete trigger an app restart?
+
   return (
     <Fragment>
       <div data-testid="import-export-tab">
-        <div className="no-margin-top">
-          Import format will be automatically detected.
-        </div>
         <p>
-          Your format isn't supported? <Link href={docsImportExport}>Add Your Own</Link>.
+          If you have reset your passphrase or signed in with a new account, you may have some projects without a known organization, you can export all to recover them.
         </p>
         <div className="flex flex-col pt-4 gap-4">
           {workspaceData?.activeWorkspace ?

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -205,7 +205,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
           <div className='flex flex-col gap-1'>
             <Heading className='text-lg font-bold flex items-center gap-2'><Icon icon="cancel" /> Untracked projects ({hiddenProjects.length})</Heading>
             <p className='text-[--hl] text-sm'>
-              <Icon icon="info-circle" /> These projects are not associated with any organization in your account.
+              <Icon icon="info-circle" /> These projects are not associated with any organization in your account. You can move them to an organization below.
             </p>
           </div>
           <div className='flex flex-col gap-1 overflow-y-auto divide-y divide-solid divide-[--hl-md]'>

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -1,27 +1,28 @@
 import React, { FC, Fragment, useEffect, useState } from 'react';
+import { Button, Heading, Item, ListBox, Popover, Select, SelectValue } from 'react-aria-components';
 import { useFetcher, useParams } from 'react-router-dom';
 import { useRouteLoaderData } from 'react-router-dom';
 
 import { isLoggedIn } from '../../../account/session';
 import { getProductName } from '../../../common/constants';
-import { docsImportExport } from '../../../common/documentation';
+import { database } from '../../../common/database';
 import { exportAllToFile } from '../../../common/export';
 import { exportAllData } from '../../../common/export-all-data';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
 import { strings } from '../../../common/strings';
-import { isScratchpadOrganizationId } from '../../../models/organization';
+import { isScratchpadOrganizationId, Organization } from '../../../models/organization';
+import { Project } from '../../../models/project';
 import { isScratchpad } from '../../../models/workspace';
 import { SegmentEvent } from '../../analytics';
+import { useOrganizationLoaderData } from '../../routes/organization';
 import { ProjectLoaderData } from '../../routes/project';
 import { useRootLoaderData } from '../../routes/root';
 import { WorkspaceLoaderData } from '../../routes/workspace';
-import { Dropdown, DropdownButton, DropdownItem, DropdownSection, ItemContent } from '../base/dropdown';
-import { Link } from '../base/link';
+import { Dropdown, DropdownItem, DropdownSection, ItemContent } from '../base/dropdown';
 import { Icon } from '../icon';
 import { showAlert } from '../modals';
 import { ExportRequestsModal } from '../modals/export-requests-modal';
 import { ImportModal } from '../modals/import-modal';
-import { Button } from '../themed-button';
 interface Props {
   hideSettingsModal: () => void;
 }
@@ -33,10 +34,37 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
     workspaceId,
   } = useParams() as { organizationId: string; projectId: string; workspaceId?: string };
 
+  const [hiddenProjects, setHiddenProjects] = useState<(Project & { workspacesCount: number })[]>([]);
+
+  useEffect(() => {
+    // @TODO - Move to a loader
+    const getHiddenProjects = async () => {
+      // @TODO - Select only hidden projects.
+      const projects = await database.all<Project>('Project');
+
+      const hiddenProjects = [];
+
+      for (const project of projects) {
+        const workspacesCount = await database.count('Workspace', {
+          parentId: project._id,
+        });
+
+        hiddenProjects.push({
+          ...project,
+          workspacesCount,
+        });
+      }
+
+      setHiddenProjects(hiddenProjects);
+    };
+    getHiddenProjects();
+  }, []);
+
   const workspaceData = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData | undefined;
   const activeWorkspaceName = workspaceData?.activeWorkspace.name;
   const projectName = workspaceData?.activeProject.name ?? getProductName();
   const { workspaceCount } = useRootLoaderData();
+  const { organizations } = useOrganizationLoaderData();
   const workspacesFetcher = useFetcher();
   useEffect(() => {
     const isIdleAndUninitialized = workspacesFetcher.state === 'idle' && !workspacesFetcher.data;
@@ -60,115 +88,214 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
 
   return (
     <Fragment>
-      <div data-testid="import-export-tab">
-        <p>
-          If you have reset your passphrase or signed in with a new account, you may have some projects without a known organization, you can export all to recover them.
-        </p>
-        <div className="flex flex-col pt-4 gap-4">
-          {workspaceData?.activeWorkspace ?
-            isScratchpad(workspaceData.activeWorkspace) ?
-              <Button onClick={() => setIsExportModalOpen(true)}>Export the "{activeWorkspaceName}" {getWorkspaceLabel(workspaceData.activeWorkspace).singular}</Button>
-              :
-            (<Dropdown
-              aria-label='Export Data Dropdown'
-              triggerButton={
-                <DropdownButton className="btn btn--clicky">
-                  Export Data <i className="fa fa-caret-down" />
-                </DropdownButton>
-              }
-            >
-              <DropdownSection
-                aria-label="Choose Export Type"
-                title="Choose Export Type"
-              >
-                <DropdownItem aria-label={`Export the "${activeWorkspaceName}" ${getWorkspaceLabel(workspaceData.activeWorkspace).singular}`}>
-                  <ItemContent
-                    icon="home"
-                    label={`Export the "${activeWorkspaceName}" ${getWorkspaceLabel(workspaceData.activeWorkspace).singular}`}
-                    onClick={() => setIsExportModalOpen(true)}
-                  />
-                </DropdownItem>
-                <DropdownItem aria-label={`Export files from the "${projectName}" ${strings.project.singular}`}>
-                  <ItemContent
-                    icon="empty"
-                    label={`Export files from the "${projectName}" ${strings.project.singular}`}
-                    onClick={handleExportAllToFile}
-                  />
-                </DropdownItem>
-              </DropdownSection>
-            </Dropdown>) : (<Button onClick={handleExportAllToFile}>{`Export files from the "${projectName}" ${strings.project.singular}`}</Button>)
-          }
-          <Button
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--padding-sm)',
-            }}
-            onClick={async () => {
-              const { filePaths, canceled } = await window.dialog.showOpenDialog({
-                properties: ['openDirectory', 'createDirectory', 'promptToCreate'],
-                buttonLabel: 'Select',
-                title: 'Export All Insomnia Data',
-              });
-
-              if (canceled) {
-                return;
-              }
-
-              const [dirPath] = filePaths;
-
-              try {
-                dirPath && await exportAllData({
-                  dirPath,
+      <div data-testid="import-export-tab" className='flex flex-col gap-4'>
+        <div className='rounded-md border border-solid border-[--hl-md] p-4 flex flex-col gap-2'>
+          <Heading className='text-lg font-bold flex items-center gap-2'><Icon icon="file-export" /> Export:</Heading>
+          <div className="flex gap-2 flex-wrap">
+            {workspaceData?.activeWorkspace ?
+              isScratchpad(workspaceData.activeWorkspace) ?
+                <Button className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm" onPress={() => setIsExportModalOpen(true)}>Export the "{activeWorkspaceName}" {getWorkspaceLabel(workspaceData.activeWorkspace).singular}</Button>
+                :
+                (
+                  <Dropdown
+                    aria-label='Export Data Dropdown'
+                    triggerButton={
+                      <Button className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm">
+                        Export Data <i className="fa fa-caret-down" />
+                      </Button>
+                    }
+                  >
+                    <DropdownSection
+                      aria-label="Choose Export Type"
+                      title="Choose Export Type"
+                    >
+                      <DropdownItem aria-label={`Export the "${activeWorkspaceName}" ${getWorkspaceLabel(workspaceData.activeWorkspace).singular}`}>
+                        <ItemContent
+                          icon="home"
+                          label={`Export the "${activeWorkspaceName}" ${getWorkspaceLabel(workspaceData.activeWorkspace).singular}`}
+                          onClick={() => setIsExportModalOpen(true)}
+                        />
+                      </DropdownItem>
+                      <DropdownItem aria-label={`Export files from the "${projectName}" ${strings.project.singular}`}>
+                        <ItemContent
+                          icon="empty"
+                          label={`Export files from the "${projectName}" ${strings.project.singular}`}
+                          onClick={handleExportAllToFile}
+                        />
+                      </DropdownItem>
+                    </DropdownSection>
+                  </Dropdown>
+                ) : (
+                <Button
+                  className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+                  onPress={handleExportAllToFile}
+                >
+                  {`Export files from the "${projectName}" ${strings.project.singular}`}
+                </Button>
+              )
+            }
+            <Button
+              className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+              onPress={async () => {
+                const { filePaths, canceled } = await window.dialog.showOpenDialog({
+                  properties: ['openDirectory', 'createDirectory', 'promptToCreate'],
+                  buttonLabel: 'Select',
+                  title: 'Export All Insomnia Data',
                 });
-              } catch (e) {
+
+                if (canceled) {
+                  return;
+                }
+
+                const [dirPath] = filePaths;
+
+                try {
+                  dirPath && await exportAllData({
+                    dirPath,
+                  });
+                } catch (e) {
+                  showAlert({
+                    title: 'Export Failed',
+                    message: 'An error occurred while exporting data. Please try again.',
+                  });
+                  console.error(e);
+                }
+
                 showAlert({
-                  title: 'Export Failed',
-                  message: 'An error occurred while exporting data. Please try again.',
+                  title: 'Export Complete',
+                  message: 'All your data have been successfully exported',
                 });
-                console.error(e);
-              }
+                window.main.trackSegmentEvent({
+                  event: SegmentEvent.exportAllCollections,
+                });
+              }}
+              aria-label='Export all data'
+            >
+              <Icon icon="file-export" />
+              <span>Export all data {`(${workspaceCount} files)`}</span>
+            </Button>
 
-              showAlert({
-                title: 'Export Complete',
-                message: 'All your data have been successfully exported',
-              });
-              window.main.trackSegmentEvent({
-                event: SegmentEvent.exportAllCollections,
-              });
-            }}
-            aria-label='Export all data'
-            className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-base"
-          >
-            <Icon icon="file-export" />
-            <span>Export all data {`(${workspaceCount} files)`}</span>
-          </Button>
-          <Button
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--padding-sm)',
-            }}
-            disabled={workspaceData?.activeWorkspace && isScratchpad(workspaceData?.activeWorkspace)}
-            onClick={() => setIsImportModalOpen(true)}
-          >
-            <i className="fa fa-file-import" />
-            {`Import to the "${projectName}" ${strings.project.singular}`}
-          </Button>
-
-          <Button
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--padding-sm)',
-            }}
-            disabled={!isLoggedIn()}
-            onClick={() => window.main.openInBrowser('https://insomnia.rest/create-run-button')}
-          >
-            <i className="fa fa-file-import" />
-            Create Run Button
-          </Button>
+            <Button
+              className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+              isDisabled={!isLoggedIn()}
+              onPress={() => window.main.openInBrowser('https://insomnia.rest/create-run-button')}
+            >
+              <i className="fa fa-file-import" />
+              Create Run Button
+            </Button>
+          </div>
         </div>
+        <div className='rounded-md border border-solid border-[--hl-md] p-4 flex flex-col gap-2'>
+          <Heading className='text-lg font-bold flex items-center gap-2'><Icon icon="file-import" /> Import:</Heading>
+          <div className="flex gap-2 flex-wrap">
+            <Button
+              className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+              isDisabled={workspaceData?.activeWorkspace && isScratchpad(workspaceData?.activeWorkspace)}
+              onPress={() => setIsImportModalOpen(true)}
+            >
+              <Icon icon="file-import" />
+            {`Import to the "${projectName}" ${strings.project.singular}`}
+            </Button>
+          </div>
+        </div>
+        {hiddenProjects.length > 0 && <div className='rounded-md border border-solid border-[--hl-md] p-4 flex flex-col gap-2'>
+          <div className='flex flex-col gap-1'>
+            <Heading className='text-lg font-bold flex items-center gap-2'><Icon icon="cancel" /> Untracked projects ({hiddenProjects.length}) (FIXME: Currently showing all Projects)</Heading>
+            <p className='text-[--hl] text-sm'>
+              <Icon icon="info-circle" /> These projects are not associated with any organization in your account.
+            </p>
+          </div>
+          <div className='flex flex-col gap-1 overflow-y-auto divide-y divide-solid divide-[--hl-md]'>
+            {hiddenProjects.map(project => (
+              <div key={project._id} className="flex items-center gap-2 justify-between py-2">
+                <div className='flex flex-col gap-1'>
+                  <Heading className='text-base font-semibold flex items-center gap-2'>
+                    {project.name}
+                    <span className='text-xs text-[--hl]'>
+                      Id: {project._id}
+                    </span>
+                  </Heading>
+                  <p className='text-sm'>
+                    This project contains {project.workspacesCount} {project.workspacesCount === 1 ? 'file' : 'files'}.
+                  </p>
+                </div>
+                <form
+                  className='flex items-center gap-2'
+                  onSubmit={e => {
+                    e.preventDefault();
+                    const data = new FormData(e.currentTarget);
+
+                    const organizationId = data.get('organizationId') as string;
+
+                    console.log({ organizationId });
+
+                    // @TODO Pass the organizationId to an action that will move the project to the organization.
+                  }}
+                >
+                  <Select
+                    aria-label="Select an organization"
+                    name="organizationId"
+                    items={organizations}
+                  >
+                    <Button className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm">
+                      <SelectValue<Organization> className="flex truncate items-center justify-center gap-2">
+                        {({ selectedItem }) => {
+                          if (!selectedItem) {
+                            return (
+                              <Fragment>
+                                <span>
+                                  Select an organization
+                                </span>
+                              </Fragment>
+                            );
+                          }
+
+                          return (
+                            <Fragment>
+                              {selectedItem.display_name}
+                            </Fragment>
+                          );
+                        }}
+                      </SelectValue>
+                      <Icon icon="caret-down" />
+                    </Button>
+                    <Popover className="min-w-max">
+                      <ListBox<Organization>
+                        className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                      >
+                        {item => (
+                          <Item
+                            id={item.id}
+                            key={item.id}
+                            className="flex gap-2 px-[--padding-md] aria-selected:font-bold items-center text-[--color-font] h-[--line-height-xs] w-full text-md whitespace-nowrap bg-transparent hover:bg-[--hl-sm] disabled:cursor-not-allowed focus:bg-[--hl-xs] focus:outline-none transition-colors"
+                            aria-label={item.name}
+                            textValue={item.name}
+                            value={item}
+                          >
+                            {({ isSelected }) => (
+                              <Fragment>
+                                {item.display_name}
+                                {isSelected && (
+                                  <Icon
+                                    icon="check"
+                                    className="text-[--color-success] justify-self-end"
+                                  />
+                                )}
+                              </Fragment>
+                            )}
+                          </Item>
+                        )}
+                      </ListBox>
+                    </Popover>
+                  </Select>
+                  <Button type="submit" className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm">
+                    Move
+                  </Button>
+                </form>
+              </div>
+            ))}
+          </div>
+        </div>}
       </div>
       {isImportModalOpen && (
         <ImportModal

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -33,6 +33,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
     projectId,
     workspaceId,
   } = useParams() as { organizationId: string; projectId: string; workspaceId?: string };
+  const { organizations } = useOrganizationLoaderData();
 
   const [hiddenProjects, setHiddenProjects] = useState<(Project & { workspacesCount: number })[]>([]);
 
@@ -40,7 +41,10 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
     // @TODO - Move to a loader
     const getHiddenProjects = async () => {
       // @TODO - Select only hidden projects.
-      const projects = await database.all<Project>('Project');
+      const listOfOrganizationIds = organizations.map(o => o.id);
+      const projects = await database.find<Project>('Project', {
+        parentId: { $nin: listOfOrganizationIds },
+      });
 
       const hiddenProjects = [];
 
@@ -64,7 +68,6 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
   const activeWorkspaceName = workspaceData?.activeWorkspace.name;
   const projectName = workspaceData?.activeProject.name ?? getProductName();
   const { workspaceCount } = useRootLoaderData();
-  const { organizations } = useOrganizationLoaderData();
   const workspacesFetcher = useFetcher();
   useEffect(() => {
     const isIdleAndUninitialized = workspacesFetcher.state === 'idle' && !workspacesFetcher.data;

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -197,7 +197,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
               onPress={() => setIsImportModalOpen(true)}
             >
               <Icon icon="file-import" />
-            {`Import to the "${projectName}" ${strings.project.singular}`}
+              {`Import to the "${projectName}" ${strings.project.singular}`}
             </Button>
           </div>
         </div>
@@ -228,11 +228,12 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
                     e.preventDefault();
                     const data = new FormData(e.currentTarget);
                     const organizationId = data.get('organizationId') as string;
-
-                    models.project.update(project, {
-                      parentId: organizationId,
-                      remoteId: null,
-                    });
+                    if (organizationId) {
+                      models.project.update(project, {
+                        parentId: organizationId,
+                        remoteId: null,
+                      });
+                    }
                     // @TODO Pass the organizationId to an action that will move the project to the organization.
                   }}
                 >

--- a/packages/insomnia/src/ui/hooks/use-global-keyboard-shortcuts.ts
+++ b/packages/insomnia/src/ui/hooks/use-global-keyboard-shortcuts.ts
@@ -19,12 +19,15 @@ export const useGlobalKeyboardShortcuts = () => {
   useDocBodyKeyboardShortcuts({
     plugin_reload:
       () => plugins.reloadPlugins(),
+    // TODO: move this to workspace route
     environment_showVariableSourceAndValue:
       () => patchSettings({ showVariableSourceAndValue: !settings.showVariableSourceAndValue }),
+    // TODO: move this to organization route
     preferences_showGeneral:
       () => showModal(SettingsModal),
     preferences_showKeyboardShortcuts:
       () => showModal(SettingsModal, { tab: TAB_INDEX_SHORTCUTS }),
+    // TODO: move this to workspace route
     sidebar_toggle:
       () => activeWorkspaceMeta && patchWorkspaceMeta(activeWorkspaceMeta.parentId, { sidebarHidden: !activeWorkspaceMeta.sidebarHidden }),
   });

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -152,6 +152,10 @@ const router = createMemoryRouter(
             (await import('./routes/actions')).updateSettingsAction(...args),
         },
         {
+          path: 'untracked-projects',
+          loader: async (...args) => (await import('./routes/untracked-projects')).loader(...args),
+        },
+        {
           path: 'organization',
           id: '/organization',
           loader: async (...args) => (await import('./routes/organization')).loader(...args),
@@ -208,6 +212,13 @@ const router = createMemoryRouter(
                             (
                               await import('./routes/actions')
                             ).deleteProjectAction(...args),
+                        },
+                        {
+                          path: 'move',
+                          action: async (...args) =>
+                            (
+                              await import('./routes/actions')
+                            ).moveProjectAction(...args),
                         },
                         {
                           path: 'rename',

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -28,7 +28,7 @@ export const createNewProjectAction: ActionFunction = async ({ request, params }
   const { organizationId } = params;
   invariant(organizationId, 'Organization ID is required');
   const formData = await request.formData();
-  const name = formData.get('name');
+  const name = formData.get('name') || 'My project';
   invariant(typeof name === 'string', 'Name is required');
   const projectType = formData.get('type');
   invariant(projectType === 'local' || projectType === 'remote', 'Project type is required');

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -30,13 +30,13 @@ export const createNewProjectAction: ActionFunction = async ({ request, params }
   const formData = await request.formData();
   const name = formData.get('name');
   invariant(typeof name === 'string', 'Name is required');
-  const localOrRemote = formData.get('localOrRemote') as 'local' | 'remote';
-  invariant(typeof localOrRemote === 'string', 'localOrRemote is required');
+  const projectType = formData.get('type');
+  invariant(projectType === 'local' || projectType === 'remote', 'Project type is required');
 
   const sessionId = session.getCurrentSessionId();
   invariant(sessionId, 'User must be logged in to create a project');
 
-  if (localOrRemote === 'local') {
+  if (projectType === 'local') {
     const project = await models.project.create({
       name,
       parentId: organizationId,

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -108,22 +108,24 @@ export const renameProjectAction: ActionFunction = async ({
   invariant(sessionId, 'User must be logged in to rename a project');
 
   try {
-    const response = await window.main.insomniaFetch<void | {
-      error: string;
-      message?: string;
-    }>({
-      path: `/v1/organizations/${project.parentId}/team-projects/${project.remoteId}`,
-      method: 'PATCH',
-      sessionId,
-      data: {
-        name,
-      },
-    });
+    if (project.remoteId) {
+      const response = await window.main.insomniaFetch<void | {
+        error: string;
+        message?: string;
+      }>({
+        path: `/v1/organizations/${project.parentId}/team-projects/${project.remoteId}`,
+        method: 'PATCH',
+        sessionId,
+        data: {
+          name,
+        },
+      });
 
-    if (response && 'error' in response) {
-      return {
-        error: response.error === 'FORBIDDEN' ? 'You do not have permission to rename this project.' : 'An unexpected error occurred while renaming the project. Please try again.',
-      };
+      if (response && 'error' in response) {
+        return {
+          error: response.error === 'FORBIDDEN' ? 'You do not have permission to rename this project.' : 'An unexpected error occurred while renaming the project. Please try again.',
+        };
+      }
     }
 
     await models.project.update(project, { name });

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -30,9 +30,20 @@ export const createNewProjectAction: ActionFunction = async ({ request, params }
   const formData = await request.formData();
   const name = formData.get('name');
   invariant(typeof name === 'string', 'Name is required');
+  const localOrRemote = formData.get('localOrRemote') as 'local' | 'remote';
+  invariant(typeof localOrRemote === 'string', 'localOrRemote is required');
 
   const sessionId = session.getCurrentSessionId();
   invariant(sessionId, 'User must be logged in to create a project');
+
+  if (localOrRemote === 'local') {
+    const project = await models.project.create({
+      name,
+      parentId: organizationId,
+    });
+
+    return redirect(`/organization/${organizationId}/project/${project._id}`);
+  }
 
   try {
     const newCloudProject = await window.main.insomniaFetch<{

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -147,19 +147,21 @@ export const deleteProjectAction: ActionFunction = async ({ params }) => {
   invariant(sessionId, 'User must be logged in to delete a project');
 
   try {
-    const response = await window.main.insomniaFetch<void | {
-      error: string;
-      message?: string;
-    }>({
-      path: `/v1/organizations/${organizationId}/team-projects/${project.remoteId}`,
-      method: 'DELETE',
-      sessionId,
-    });
+    if (project.remoteId) {
+      const response = await window.main.insomniaFetch<void | {
+        error: string;
+        message?: string;
+      }>({
+        path: `/v1/organizations/${organizationId}/team-projects/${project.remoteId}`,
+        method: 'DELETE',
+        sessionId,
+      });
 
-    if (response && 'error' in response) {
-      return {
-        error: response.error === 'FORBIDDEN' ? 'You do not have permission to delete this project.' : 'An unexpected error occurred while deleting the project. Please try again.',
-      };
+      if (response && 'error' in response) {
+        return {
+          error: response.error === 'FORBIDDEN' ? 'You do not have permission to delete this project.' : 'An unexpected error occurred while deleting the project. Please try again.',
+        };
+      }
     }
 
     await models.stats.incrementDeletedRequestsForDescendents(project);

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -178,6 +178,27 @@ export const deleteProjectAction: ActionFunction = async ({ params }) => {
   }
 };
 
+export const moveProjectAction: ActionFunction = async ({ request, params }) => {
+  const { projectId } = params as { projectId: string };
+  const formData = await request.formData();
+
+  const organizationId = formData.get('organizationId');
+
+  invariant(typeof organizationId === 'string', 'Organization ID is required');
+  invariant(typeof projectId === 'string', 'Project ID is required');
+
+  const project = await models.project.getById(projectId);
+  invariant(project, 'Project not found');
+
+  await models.project.update(project, {
+    parentId: organizationId,
+    // We move a project to another organization as local no matter what it was before
+    remoteId: null,
+  });
+
+  return null;
+};
+
 // Workspace
 export const createNewWorkspaceAction: ActionFunction = async ({
   params,

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -3,7 +3,7 @@ import { Heading } from 'react-aria-components';
 import { ActionFunction, redirect, useFetcher, useFetchers, useNavigate } from 'react-router-dom';
 
 import { isLoggedIn } from '../../account/session';
-import { shouldRunMigration } from '../../sync/vcs/migrate-to-cloud-projects';
+import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-to-cloud-projects';
 import { invariant } from '../../utils/invariant';
 import { getLoginUrl, submitAuthCode } from '../auth-session-provider';
 import { Icon } from '../components/icon';
@@ -26,7 +26,7 @@ export const action: ActionFunction = async ({
   console.log('Login successful');
   window.localStorage.setItem('hasUserLoggedInBefore', 'true');
 
-  if (isLoggedIn() && await shouldRunMigration()) {
+  if (isLoggedIn() && await shouldMigrateProjectUnderOrganization()) {
     throw redirect('/auth/migrate');
   }
 

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -3,7 +3,7 @@ import { Heading } from 'react-aria-components';
 import { ActionFunction, redirect, useFetcher, useFetchers, useNavigate } from 'react-router-dom';
 
 import { isLoggedIn } from '../../account/session';
-import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-to-cloud-projects';
+import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-projects-into-organization';
 import { invariant } from '../../utils/invariant';
 import { getLoginUrl, submitAuthCode } from '../auth-session-provider';
 import { Icon } from '../components/icon';

--- a/packages/insomnia/src/ui/routes/auth.login.tsx
+++ b/packages/insomnia/src/ui/routes/auth.login.tsx
@@ -4,7 +4,7 @@ import { ActionFunction, Link, LoaderFunction, redirect, useFetcher, useLoaderDa
 
 import { getAppWebsiteBaseURL } from '../../common/constants';
 import { exportAllData } from '../../common/export-all-data';
-import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-to-cloud-projects';
+import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-projects-into-organization';
 import { SegmentEvent } from '../analytics';
 import { getLoginUrl } from '../auth-session-provider';
 import { Icon } from '../components/icon';

--- a/packages/insomnia/src/ui/routes/auth.login.tsx
+++ b/packages/insomnia/src/ui/routes/auth.login.tsx
@@ -4,7 +4,7 @@ import { ActionFunction, Link, LoaderFunction, redirect, useFetcher, useLoaderDa
 
 import { getAppWebsiteBaseURL } from '../../common/constants';
 import { exportAllData } from '../../common/export-all-data';
-import { shouldRunMigration } from '../../sync/vcs/migrate-to-cloud-projects';
+import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-to-cloud-projects';
 import { SegmentEvent } from '../analytics';
 import { getLoginUrl } from '../auth-session-provider';
 import { Icon } from '../components/icon';
@@ -39,7 +39,7 @@ interface LoaderData {
 }
 
 export const loader: LoaderFunction = async () => {
-  const hasProjectsToMigrate = await shouldRunMigration();
+  const hasProjectsToMigrate = await shouldMigrateProjectUnderOrganization();
 
   return {
     hasProjectsToMigrate,

--- a/packages/insomnia/src/ui/routes/auth.migrate.tsx
+++ b/packages/insomnia/src/ui/routes/auth.migrate.tsx
@@ -5,7 +5,7 @@ import { ActionFunction, LoaderFunction, redirect, useFetcher } from 'react-rout
 import { getCurrentSessionId, logout } from '../../account/session';
 import FileSystemDriver from '../../sync/store/drivers/file-system-driver';
 import { migrateCollectionsIntoRemoteProject } from '../../sync/vcs/migrate-collections';
-import { migrateProjectsIntoOrganization, shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-to-cloud-projects';
+import { migrateProjectsIntoOrganization, shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-projects-into-organization';
 import { VCS } from '../../sync/vcs/vcs';
 import { Icon } from '../components/icon';
 
@@ -61,13 +61,13 @@ export const Migrate = () => {
   return (
     <div className="flex flex-col gap-[--padding-md] text-[--color-font]">
       <Heading className="text-2xl font-bold text-center px-3">
-        Migrating data to Insomnia Cloud
+        Initializing Organizations
       </Heading>
       {isMigrating && (
         <div className="flex flex-col gap-3 rounded-md bg-[--hl-sm] p-[--padding-md]">
           <Heading className="text-lg flex items-center p-8 gap-8">
             <Icon icon="spinner" className="fa-spin" />
-            <span>Running migration...</span>
+            <span>Fetching your organizations...</span>
           </Heading>
         </div>
       )}

--- a/packages/insomnia/src/ui/routes/auth.migrate.tsx
+++ b/packages/insomnia/src/ui/routes/auth.migrate.tsx
@@ -5,12 +5,12 @@ import { ActionFunction, LoaderFunction, redirect, useFetcher } from 'react-rout
 import { getCurrentSessionId, logout } from '../../account/session';
 import FileSystemDriver from '../../sync/store/drivers/file-system-driver';
 import { migrateCollectionsIntoRemoteProject } from '../../sync/vcs/migrate-collections';
-import { migrateLocalToCloudProjects, shouldRunMigration } from '../../sync/vcs/migrate-to-cloud-projects';
+import { migrateProjectsIntoOrganization, shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-to-cloud-projects';
 import { VCS } from '../../sync/vcs/vcs';
 import { Icon } from '../components/icon';
 
 export const loader: LoaderFunction = async () => {
-  if (!shouldRunMigration()) {
+  if (!shouldMigrateProjectUnderOrganization()) {
     return redirect('/organization');
   }
 
@@ -32,7 +32,7 @@ export const action: ActionFunction = async () => {
     const driver = FileSystemDriver.create(process.env['INSOMNIA_DATA_PATH'] || window.app.getPath('userData'));
     const vcs = new VCS(driver);
     await migrateCollectionsIntoRemoteProject(vcs);
-    await migrateLocalToCloudProjects();
+    await migrateProjectsIntoOrganization();
 
     return redirect('/organization');
   } catch (err) {

--- a/packages/insomnia/src/ui/routes/auth.migrate.tsx
+++ b/packages/insomnia/src/ui/routes/auth.migrate.tsx
@@ -32,7 +32,7 @@ export const action: ActionFunction = async () => {
     const driver = FileSystemDriver.create(process.env['INSOMNIA_DATA_PATH'] || window.app.getPath('userData'));
     const vcs = new VCS(driver);
     await migrateCollectionsIntoRemoteProject(vcs);
-    await migrateLocalToCloudProjects(vcs);
+    await migrateLocalToCloudProjects();
 
     return redirect('/organization');
   } catch (err) {

--- a/packages/insomnia/src/ui/routes/onboarding.cloud-migration.tsx
+++ b/packages/insomnia/src/ui/routes/onboarding.cloud-migration.tsx
@@ -4,7 +4,7 @@ import { ActionFunction, LoaderFunction, redirect, useFetcher } from 'react-rout
 
 import { logout } from '../../account/session';
 import { exportAllData } from '../../common/export-all-data';
-import { shouldRunMigration } from '../../sync/vcs/migrate-to-cloud-projects';
+import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-to-cloud-projects';
 import { SegmentEvent } from '../analytics';
 import { InsomniaLogo } from '../components/insomnia-icon';
 import { showAlert } from '../components/modals';
@@ -17,7 +17,7 @@ export const action: ActionFunction = async () => {
 };
 
 export const loader: LoaderFunction = async () => {
-  if (await shouldRunMigration()) {
+  if (await shouldMigrateProjectUnderOrganization()) {
     return null;
   }
 

--- a/packages/insomnia/src/ui/routes/onboarding.cloud-migration.tsx
+++ b/packages/insomnia/src/ui/routes/onboarding.cloud-migration.tsx
@@ -4,7 +4,7 @@ import { ActionFunction, LoaderFunction, redirect, useFetcher } from 'react-rout
 
 import { logout } from '../../account/session';
 import { exportAllData } from '../../common/export-all-data';
-import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-to-cloud-projects';
+import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-projects-into-organization';
 import { SegmentEvent } from '../analytics';
 import { InsomniaLogo } from '../components/insomnia-icon';
 import { showAlert } from '../components/modals';

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -90,7 +90,7 @@ interface CurrentPlan {
   type: PersonalPlanType;
 };
 
-const organizationsData: OrganizationLoaderData = {
+export const organizationsData: OrganizationLoaderData = {
   organizations: [],
   user: undefined,
   currentPlan: undefined,

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -35,7 +35,7 @@ import { isOwnerOfOrganization, isPersonalOrganization, isScratchpadOrganization
 import { isDesign, isScratchpad } from '../../models/workspace';
 import FileSystemDriver from '../../sync/store/drivers/file-system-driver';
 import { MergeConflict } from '../../sync/types';
-import { shouldRunMigration } from '../../sync/vcs/migrate-to-cloud-projects';
+import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-to-cloud-projects';
 import { getVCS, initVCS } from '../../sync/vcs/vcs';
 import { invariant } from '../../utils/invariant';
 import { SegmentEvent } from '../analytics';
@@ -121,7 +121,7 @@ export const indexLoader: LoaderFunction = async () => {
   if (sessionId) {
     // Check if there are any migrations to run before loading organizations.
     // If there are migrations, we need to log the user out and redirect them to the login page
-    if (await shouldRunMigration()) {
+    if (await shouldMigrateProjectUnderOrganization()) {
       await session.logout();
       return redirect('/auth/login');
     }

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -35,7 +35,7 @@ import { isOwnerOfOrganization, isPersonalOrganization, isScratchpadOrganization
 import { isDesign, isScratchpad } from '../../models/workspace';
 import FileSystemDriver from '../../sync/store/drivers/file-system-driver';
 import { MergeConflict } from '../../sync/types';
-import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-to-cloud-projects';
+import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-projects-into-organization';
 import { getVCS, initVCS } from '../../sync/vcs/vcs';
 import { invariant } from '../../utils/invariant';
 import { SegmentEvent } from '../analytics';

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -55,7 +55,7 @@ import { PresenceProvider } from '../context/app/presence-context';
 import { useRootLoaderData } from './root';
 import { WorkspaceLoaderData } from './workspace';
 
-interface OrganizationsResponse {
+export interface OrganizationsResponse {
   start: number;
   limit: number;
   length: number;
@@ -175,13 +175,12 @@ export const indexLoader: LoaderFunction = async () => {
       organizationsData.user = user;
       organizationsData.currentPlan = currentPlan;
 
-      const personalOrganization = organizations.filter(isPersonalOrganization).find(organization => {
-        const accountId = getAccountId();
-        return accountId && isOwnerOfOrganization({
-          organization,
-          accountId,
-        });
-      });
+      const personalOrganization = organizations.filter(isPersonalOrganization)
+        .find(organization =>
+          isOwnerOfOrganization({
+            organization,
+            accountId,
+          }));
 
       if (personalOrganization) {
         return redirect(`/organization/${personalOrganization.id}`);

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -778,31 +778,30 @@ const ProjectRoute: FC = () => {
                                 }}
                               >
                                 <TextField
-                                  aria-label="Project name"
                                   autoFocus
                                   name="name"
-                                  defaultValue='New project'
+                                  defaultValue="My project"
                                   className="group relative flex-1 flex flex-col gap-2"
                                 >
                                   <Label className='text-sm text-[--hl]'>
                                     Project name
                                   </Label>
                                   <Input
-                                    placeholder="New project"
+                                    placeholder="My project"
                                     className="py-1 placeholder:italic w-full pl-2 pr-7 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font] focus:outline-none focus:ring-1 focus:ring-[--hl-md] transition-colors"
                                   />
                                 </TextField>
-                                <RadioGroup name="type" defaultValue='remote' className="flex flex-col gap-2">
-                                  <Label className='text-sm text-[--hl]'>
+                                <RadioGroup name="type" defaultValue="remote" className="flex flex-col gap-2">
+                                  <Label className="text-sm text-[--hl]">
                                     Project type
                                   </Label>
-                                  <div className='flex gap-2'>
+                                  <div className="flex gap-2">
                                     <Radio
                                       value="remote"
                                       className="data-[selected]:border-[--color-surprise] data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
                                     >
                                       <Icon icon="globe" />
-                                      <Heading className='text-lg font-bold'>Secure Cloud</Heading>
+                                      <Heading className="text-lg font-bold">Secure Cloud</Heading>
                                       <p className='pt-2'>
                                         End-to-end encrypted (E2EE) and synced securely to the cloud, ideal for collaboration.
                                       </p>
@@ -812,14 +811,14 @@ const ProjectRoute: FC = () => {
                                       className="data-[selected]:border-[--color-surprise] data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
                                     >
                                       <Icon icon="laptop" />
-                                      <Heading className='text-lg font-bold'>Local Vault</Heading>
-                                      <p className='pt-2'>
+                                      <Heading className="text-lg font-bold">Local Vault</Heading>
+                                      <p className="pt-2">
                                         Stored locally only with no cloud. Ideal when collaboration is not needed.
                                       </p>
                                     </Radio>
                                   </div>
                                 </RadioGroup>
-                                <div className='flex justify-end'>
+                                <div className="flex justify-end">
                                   <Button
                                     type="submit"
                                     className="hover:no-underline bg-[#4000BF] hover:bg-opacity-90 border border-solid border-[--hl-md] py-2 px-3 text-[--color-font] transition-colors rounded-sm"

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -752,6 +752,7 @@ const ProjectRoute: FC = () => {
                           createNewProjectFetcher.submit(
                             {
                               name,
+                              localOrRemote: 'local',
                             },
                             {
                               action: `/organization/${organizationId}/project/new`,

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -161,18 +161,6 @@ async function syncTeamProjects({
       });
     }
   }));
-
-  // Remove any remote projects from the current organization that are not in the list of remote projects
-  const removedRemoteProjects = await database.find<Project>(models.project.type, {
-    // filter by this organization so no legacy data can be accidentally removed, because legacy had null parentId
-    parentId: organizationId,
-    // Remote ID is not in the list of remote projects
-    remoteId: { $nin: teamProjects.map(p => p.id) },
-  });
-
-  await Promise.all(removedRemoteProjects.map(async prj => {
-    await models.project.remove(prj);
-  }));
 }
 
 export const indexLoader: LoaderFunction = async ({ params }) => {

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -2,17 +2,25 @@ import { IconName } from '@fortawesome/fontawesome-svg-core';
 import React, { FC, Fragment, useEffect, useState } from 'react';
 import {
   Button,
+  Dialog,
+  DialogTrigger,
   GridList,
   Heading,
   Input,
   Item,
+  Label,
   ListBox,
   Menu,
   MenuTrigger,
+  Modal,
+  ModalOverlay,
   Popover,
+  Radio,
+  RadioGroup,
   SearchField,
   Select,
   SelectValue,
+  TextField,
 } from 'react-aria-components';
 import {
   LoaderFunction,
@@ -37,7 +45,6 @@ import {
 import { database } from '../../common/database';
 import { fuzzyMatchAll, isNotNullOrUndefined } from '../../common/misc';
 import { descendingNumberSort, sortMethodMap } from '../../common/sorting';
-import { strings } from '../../common/strings';
 import * as models from '../../models';
 import { ApiSpec } from '../../models/api-spec';
 import { CaCertificate } from '../../models/ca-certificate';
@@ -738,34 +745,95 @@ const ProjectRoute: FC = () => {
                       </Button>
                     </div>
                   </SearchField>
+                  <DialogTrigger>
+                    <Button
+                      aria-label="Create new Project"
+                      className="flex items-center justify-center h-full aspect-square aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+                    >
+                      <Icon icon="plus-circle" />
+                    </Button>
+                    <ModalOverlay isDismissable className="w-full h-[--visual-viewport-height] fixed z-10 top-0 left-0 flex items-center justify-center bg-black/30">
+                      <Modal className="max-w-2xl w-full rounded-md border border-solid border-[--hl-sm] p-[--padding-lg] max-h-full bg-[--color-bg] text-[--color-font]">
+                        <Dialog className="outline-none">
+                          {({ close }) => (
+                            <div className='flex flex-col gap-4'>
+                              <div className='flex gap-2 items-center justify-between'>
+                                <Heading className='text-2xl'>Create a new project</Heading>
+                                <Button
+                                  className="flex flex-shrink-0 items-center justify-center aspect-square h-6 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+                                  onPress={close}
+                                >
+                                  <Icon icon="x" />
+                                </Button>
+                              </div>
+                              <form
+                                className='flex flex-col gap-4'
+                                onSubmit={e => {
+                                  createNewProjectFetcher.submit(e.currentTarget, {
+                                    action: `/organization/${organizationId}/project/new`,
+                                    method: 'post',
+                                  });
 
-                  <Button
-                    onPress={() => {
-                      const defaultValue = `My ${strings.project.singular}`;
-                      showPrompt({
-                        title: `Create New ${strings.project.singular}`,
-                        submitName: 'Create',
-                        placeholder: defaultValue,
-                        defaultValue,
-                        selectText: true,
-                        onComplete: async name =>
-                          createNewProjectFetcher.submit(
-                            {
-                              name,
-                              localOrRemote: 'local',
-                            },
-                            {
-                              action: `/organization/${organizationId}/project/new`,
-                              method: 'post',
-                            }
-                          ),
-                      });
-                    }}
-                    aria-label="Create new Project"
-                    className="flex items-center justify-center h-full aspect-square aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
-                  >
-                    <Icon icon="plus-circle" />
-                  </Button>
+                                  close();
+                                }}
+                              >
+                                <TextField
+                                  aria-label="Project name"
+                                  autoFocus
+                                  name="name"
+                                  defaultValue='New project'
+                                  className="group relative flex-1 flex flex-col gap-2"
+                                >
+                                  <Label className='text-sm text-[--hl]'>
+                                    Project name
+                                  </Label>
+                                  <Input
+                                    placeholder="New project"
+                                    className="py-1 placeholder:italic w-full pl-2 pr-7 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font] focus:outline-none focus:ring-1 focus:ring-[--hl-md] transition-colors"
+                                  />
+                                </TextField>
+                                <RadioGroup name="type" defaultValue='remote' className="flex flex-col gap-2">
+                                  <Label className='text-sm text-[--hl]'>
+                                    Project type
+                                  </Label>
+                                  <div className='flex gap-2'>
+                                    <Radio
+                                      value="remote"
+                                      className="data-[selected]:border-[--color-surprise] data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
+                                    >
+                                      <Icon icon="globe" />
+                                      <Heading className='text-lg font-bold'>Secure Cloud</Heading>
+                                      <p className='pt-2'>
+                                        End-to-end encrypted (E2EE) and synced securely to the cloud, ideal for collaboration.
+                                      </p>
+                                    </Radio>
+                                    <Radio
+                                      value="local"
+                                      className="data-[selected]:border-[--color-surprise] data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
+                                    >
+                                      <Icon icon="laptop" />
+                                      <Heading className='text-lg font-bold'>Local Vault</Heading>
+                                      <p className='pt-2'>
+                                        Stored locally only with no cloud. Ideal when collaboration is not needed.
+                                      </p>
+                                    </Radio>
+                                  </div>
+                                </RadioGroup>
+                                <div className='flex justify-end'>
+                                  <Button
+                                    type="submit"
+                                    className="hover:no-underline bg-[#4000BF] hover:bg-opacity-90 border border-solid border-[--hl-md] py-2 px-3 text-[--color-font] transition-colors rounded-sm"
+                                  >
+                                    Create
+                                  </Button>
+                                </div>
+                              </form>
+                            </div>
+                          )}
+                        </Dialog>
+                      </Modal>
+                    </ModalOverlay>
+                  </DialogTrigger>
                 </div>
 
                 <GridList

--- a/packages/insomnia/src/ui/routes/untracked-projects.tsx
+++ b/packages/insomnia/src/ui/routes/untracked-projects.tsx
@@ -1,0 +1,36 @@
+import { LoaderFunction } from 'react-router-dom';
+
+import { database } from '../../common/database';
+import { SCRATCHPAD_ORGANIZATION_ID } from '../../models/organization';
+import { Project } from '../../models/project';
+import { organizationsData } from './organization';
+
+export interface LoaderData {
+  untrackedProjects: (Project & { workspacesCount: number })[];
+}
+
+export const loader: LoaderFunction = async () => {
+  const { organizations } = organizationsData;
+  const listOfOrganizationIds = [...organizations.map(o => o.id), SCRATCHPAD_ORGANIZATION_ID];
+
+  const projects = await database.find<Project>('Project', {
+    parentId: { $nin: listOfOrganizationIds },
+  });
+
+  const untrackedProjects = [];
+
+  for (const project of projects) {
+    const workspacesCount = await database.count('Workspace', {
+      parentId: project._id,
+    });
+
+    untrackedProjects.push({
+      ...project,
+      workspacesCount,
+    });
+  }
+
+  return {
+    untrackedProjects,
+  };
+};


### PR DESCRIPTION
changelog(Improvements): Allow local projects to be created and remove forced remote project migration


Motivation: Since we added social login to the insomnia website, we needed to migrate local and remote collections from:
**project -> workspace** to **org -> project -> workspace**
This creates a new cases where a user might log into a second account and not see workspaces that were visible in the first. This happens frequently in cases of forgotten password. After this change those users can recover those collections by reassigning their parentId to the logged in organization. Recovered remote collections will not support cloud sync features, as they were attached to the first account. However reinviting the second account to the remote collection from a team member with access will continue to work.

### highlights

- allow local projects to be created
- remove forced remote project migration

### todo

- [x] add local or remote create ui
- [x] loader and action

### later

 - [x] add convert to local project #6666
 - [ ] add convert to remote project
 - [ ] move keyboard shortcuts out of global
 - [ ] add untracked projects to migrate page? 
 - [x] remove migrate-collections #6664
 



<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
