### PR TITLE
fix: only prettify if is a valid JSON #2506

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -221,7 +221,13 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
           jsonString = '[]';
         }
       }
-      return jsonPrettify(jsonString, indentChars, autoPrettify);
+      try {
+        // Try to parse the JSON to make sure it's valid
+        JSON.parse(jsonString);
+        return jsonPrettify(jsonString, indentChars, autoPrettify);
+      } catch (_) {
+        return jsonString;
+      }
     } catch (error) {
       // That's Ok, just leave it
       return code;

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -221,16 +221,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
           jsonString = '[]';
         }
       }
-
-      // Check if it's stringified JSON or just a string
-      jsonString = jsonString.trim();
-      const isBaseString = jsonString.startsWith('"') && jsonString.endsWith('"');
-      const isBaseJson = jsonString.startsWith('{') && jsonString.endsWith('}');
-      if (isBaseString || isBaseJson) {
-        return jsonPrettify(jsonString, indentChars, autoPrettify);
-      } else {
-        return jsonPrettify(JSON.stringify(jsonString, null, 2), indentChars, autoPrettify);
-      }
+      return jsonPrettify(jsonString, indentChars, autoPrettify);
     } catch (error) {
       // That's Ok, just leave it
       return code;

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -221,12 +221,15 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
           jsonString = '[]';
         }
       }
-      try {
-        // Try to parse the JSON to make sure it's valid
-        JSON.parse(jsonString);
+
+      // Check if it's stringified JSON or just a string
+      jsonString = jsonString.trim();
+      const isBaseString = jsonString.startsWith('"') && jsonString.endsWith('"');
+      const isBaseJson = jsonString.startsWith('{') && jsonString.endsWith('}');
+      if (isBaseString || isBaseJson) {
         return jsonPrettify(jsonString, indentChars, autoPrettify);
-      } catch (_) {
-        return jsonString;
+      } else {
+        return jsonPrettify(JSON.stringify(jsonString, null, 2), indentChars, autoPrettify);
       }
     } catch (error) {
       // That's Ok, just leave it

--- a/packages/insomnia/src/utils/prettify/fixtures/root-quoted-string-input.json
+++ b/packages/insomnia/src/utils/prettify/fixtures/root-quoted-string-input.json
@@ -1,0 +1,1 @@
+"Hello World!"

--- a/packages/insomnia/src/utils/prettify/fixtures/root-quoted-string-output.json
+++ b/packages/insomnia/src/utils/prettify/fixtures/root-quoted-string-output.json
@@ -1,0 +1,1 @@
+"Hello World!"

--- a/packages/insomnia/src/utils/prettify/fixtures/root-string-input.json
+++ b/packages/insomnia/src/utils/prettify/fixtures/root-string-input.json
@@ -1,1 +1,1 @@
-"Hello World!"
+Hello World!

--- a/packages/insomnia/src/utils/prettify/fixtures/root-string-output.json
+++ b/packages/insomnia/src/utils/prettify/fixtures/root-string-output.json
@@ -1,1 +1,1 @@
-"Hello World!"
+Hello World!

--- a/packages/insomnia/src/utils/prettify/json.ts
+++ b/packages/insomnia/src/utils/prettify/json.ts
@@ -36,6 +36,10 @@ export const jsonPrettify = (json?: string, indentChars = '\t', replaceUnicode =
     return '';
   }
 
+  if (!json.includes('{') && !json.includes('[') && !json.includes('"')) {
+    return json;
+  }
+
   // Convert the unicode. To correctly mimic JSON.stringify(JSON.parse(json), null, indentChars)
   // we need to convert all escaped unicode characters to proper unicode characters.
   if (replaceUnicode) {


### PR DESCRIPTION
changelog(Fixes): Fixed an issue that affected prettifying JSON request bodies

It was checked whether the return is a valid JSON, if so, it maintains the embellishment, if not, it directly returns the value obtained.

Following @johanhammar suggestion

Closes #2506