### PR TITLE
fix: switch flags for children in export request tree

### DIFF
--- a/packages/insomnia/src/ui/components/modals/export-requests-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/export-requests-modal.tsx
@@ -88,13 +88,14 @@ export const ExportRequestsModal = ({ workspace, onHide }: { workspace: Workspac
     return node.children.map(child => getSelectedRequestIds(child)).reduce((acc, reqIds) => [...acc, ...reqIds], []);
   };
 
-  const setItemSelected = (node: Node, isSelected: boolean, id?: string) => {
+  const setItemSelected = (node: Node, isSelected: boolean, id?: string | null) => {
     if (id === null || node.doc._id === id) {
       // Switch the flags of all children in this subtree.
-      node.children.forEach(child => setItemSelected(child, isSelected));
+      node.children.forEach(child => setItemSelected(child, isSelected, null));
       node.selectedRequests = isSelected ? node.totalRequests : 0;
       return true;
     }
+
     for (const child of node.children) {
       const found = setItemSelected(child, isSelected, id);
       if (found) {


### PR DESCRIPTION
Closes https://github.com/Kong/insomnia/issues/6385

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Fix: While exporting requests, choosing a folder did not deselect the subtree

Before:
![before-gif](https://github.com/Kong/insomnia/assets/74865626/889b2d6e-720e-498e-a409-c82ca9585fff)

After:
![after-gif](https://github.com/Kong/insomnia/assets/74865626/ac849c8e-b507-43b4-95fe-9cc234d1ab95)
