### PR TITLE
Do not package build-id metadata for RPM target

### DIFF
--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -135,8 +135,8 @@ const config = {
     // same across all electron-builder applications, which causes package
     // conflicts
     fpm: [
-      '--rpm-rpmbuild-define=_build_id_links none'
-    ]
+      '--rpm-rpmbuild-define=_build_id_links none',
+    ],
   },
   snap: {
     base: 'core22',

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -130,6 +130,14 @@ const config = {
       },
     ],
   },
+  rpm: {
+    // Prevents RPM from packaging build-id metadata, some of which is the
+    // same across all electron-builder applications, which causes package
+    // conflicts
+    fpm: [
+      '--rpm-rpmbuild-define=_build_id_links none'
+    ]
+  },
   snap: {
     base: 'core22',
   },


### PR DESCRIPTION
fixes #6687

changelog(Fixes): Fixed issue #6687 where Insomnia RPM conflicts with other eletron-builder built RPMs