### PR TITLE
Local vault or remote project option for migration

### DIFF
--- a/packages/insomnia/src/models/helpers/project.ts
+++ b/packages/insomnia/src/models/helpers/project.ts
@@ -1,7 +1,79 @@
-import { isDefaultOrganizationProject, Project } from '../project';
+import { database } from '../../common/database';
+import { initializeLocalBackendProjectAndMarkForSync, pushSnapshotOnInitialize } from '../../sync/vcs/initialize-backend-project';
+import { VCS } from '../../sync/vcs/vcs';
+import { invariant } from '../../utils/invariant';
+import { isDefaultOrganizationProject, Project, update as updateProject } from '../project';
+import { Workspace } from '../workspace';
+import { getOrCreateByParentId as getOrCreateWorkspaceMeta } from '../workspace-meta';
 export const sortProjects = (projects: Project[]) => [
   ...projects.filter(p => isDefaultOrganizationProject(p))
     .sort((a, b) => a.name.localeCompare(b.name)),
   ...projects.filter(p => !isDefaultOrganizationProject(p))
     .sort((a, b) => a.name.localeCompare(b.name)),
 ];
+
+export async function updateLocalProjectToRemote({
+  project,
+  vcs,
+  sessionId,
+  organizationId,
+}: {
+  project: Project;
+  vcs: VCS;
+  sessionId: string;
+  organizationId: string;
+}) {
+  const newCloudProject = await window.main.insomniaFetch<{
+    id: string;
+    name: string;
+  } | {
+    error: string;
+    message?: string;
+  }>({
+    path: `/v1/organizations/${organizationId}/team-projects`,
+    method: 'POST',
+    data: {
+      name: project.name,
+    },
+    sessionId,
+  });
+
+  if (!newCloudProject || 'error' in newCloudProject) {
+    let error = 'An unexpected error occurred while creating the project. Please try again.';
+    if (newCloudProject.error === 'FORBIDDEN' || newCloudProject.error === 'NEEDS_TO_UPGRADE') {
+      error = newCloudProject.error;
+    }
+
+    return {
+      error,
+    };
+  }
+
+  const updatedProject = await updateProject(project, { name: newCloudProject.name, remoteId: newCloudProject.id });
+
+  // For each workspace in the local project
+  const projectWorkspaces = (await database.find<Workspace>('Workspace', {
+    parentId: updatedProject._id,
+  }));
+
+  for (const workspace of projectWorkspaces) {
+    const workspaceMeta = await getOrCreateWorkspaceMeta(workspace._id);
+
+    // Initialize Sync on the workspace if it's not using Git sync
+    try {
+      if (!workspaceMeta.gitRepositoryId) {
+        invariant(vcs, 'VCS must be initialized');
+
+        await initializeLocalBackendProjectAndMarkForSync({ vcs, workspace });
+        await pushSnapshotOnInitialize({ vcs, workspace, project: updatedProject });
+      }
+    } catch (e) {
+      console.warn('Failed to initialize sync on workspace. This will be retried when the workspace is opened on the app.', e);
+      // TODO: here we should show the try again dialog
+    }
+  }
+
+  return {
+    error: null,
+  };
+};

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -183,7 +183,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId }) => {
                       <div className="flex gap-2">
                         <Radio
                           value="remote"
-                          className="data-[selected]:border-[--color-surprise] data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
+                          className="data-[selected]:border-[--color-surprise] flex-1 data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
                         >
                           <Icon icon="globe" />
                           <Heading className="text-lg font-bold">Secure Cloud</Heading>
@@ -194,7 +194,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId }) => {
                         <Radio
                           isDisabled={isDefaultOrganizationProject(project)}
                           value="local"
-                          className="data-[selected]:border-[--color-surprise] data-[disabled]:opacity-25 data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
+                          className="data-[selected]:border-[--color-surprise] flex-1 data-[disabled]:opacity-25 data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
                         >
                           <Icon icon="laptop" />
                           <Heading className="text-lg font-bold">Local Vault</Heading>

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -31,6 +31,7 @@ import Authorize from './routes/auth.authorize';
 import Login from './routes/auth.login';
 import { ErrorRoute } from './routes/error';
 import Onboarding from './routes/onboarding';
+import { Migrate } from './routes/onboarding.migrate';
 import { shouldOrganizationsRevalidate } from './routes/organization';
 import Root from './routes/root';
 import { initializeSentry } from './sentry';
@@ -118,6 +119,12 @@ const router = createMemoryRouter(
         {
           path: 'onboarding/*',
           element: <Onboarding />,
+        },
+        {
+          path: 'onboarding/migrate',
+          loader: async (...args) => (await import('./routes/onboarding.migrate')).loader(...args),
+          action: async (...args) => (await import('./routes/onboarding.migrate')).action(...args),
+          element: <Migrate />,
         },
         {
           path: 'import',

--- a/packages/insomnia/src/ui/routes/onboarding.migrate.tsx
+++ b/packages/insomnia/src/ui/routes/onboarding.migrate.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { Button, Heading, Radio, RadioGroup } from 'react-aria-components';
+import { ActionFunction, LoaderFunction, redirect, useFetcher } from 'react-router-dom';
+
+import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-projects-into-organization';
+import { invariant } from '../../utils/invariant';
+import { Icon } from '../components/icon';
+import { InsomniaLogo } from '../components/insomnia-icon';
+import { TrailLinesContainer } from '../components/trail-lines-container';
+
+export const loader: LoaderFunction = async () => {
+  if (!shouldMigrateProjectUnderOrganization()) {
+    return redirect('/organization');
+  }
+
+  return null;
+};
+
+interface MigrationActionData {
+  error?: string;
+}
+
+export const action: ActionFunction = async ({ request }) => {
+  const formData = await request.formData();
+  const type = formData.get('type');
+  invariant(type === 'local' || type === 'remote', 'Expected type to be either local or remote');
+
+  localStorage.setItem('prefers-project-type', type);
+
+  return redirect('/organization');
+};
+
+export const Migrate = () => {
+  const { Form, state } = useFetcher<MigrationActionData>();
+
+  return (
+    <div className='relative h-full w-full text-left text-base flex bg-[--color-bg]'>
+      <TrailLinesContainer>
+        <div
+          className='flex justify-center items-center flex-col h-full w-[540px] min-h-[min(450px,90%)]'
+        >
+          <div
+            className='flex flex-col gap-[var(--padding-sm)] items-center justify-center p-[--padding-lg] pt-12 w-full h-full bg-[--hl-xs] rounded-[var(--radius-md)] border-solid border border-[--hl-sm] relative'
+          >
+            <InsomniaLogo
+              className='transform translate-x-[-50%] translate-y-[-50%] absolute top-0 left-1/2 w-16 h-16'
+            />
+            <div
+              className='flex justify-center items-center flex-col h-full pt-2'
+            >
+              <div className='text-[--color-font] flex flex-col gap-4'>
+                <h1 className='text-xl font-bold text-center'>Collaboration with Cloud Sync now available</h1>
+                <div className='flex flex-col gap-4'>
+                  <p>
+                    Cloud Sync - which used to be a premium feature - is now available on every plan including the Free plan. With Cloud Sync your projects will be automatically synchronized to the cloud in an end-to-end encrypted way (E2EE) and available on every Insomnia client after logging in.
+                  </p>
+
+                </div>
+                <Form method='POST' className='gap-4 flex flex-col text-left'>
+                  <RadioGroup aria-label='Project type' name="type" defaultValue={'local'} className="flex flex-col gap-2">
+                    <div className="flex gap-2">
+                      <Radio
+                        value="local"
+                        className="data-[selected]:border-[--color-surprise] flex-1 data-[disabled]:opacity-25 data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
+                      >
+                        <Icon icon="laptop" />
+                        <Heading className="text-lg font-bold">Keep storing locally in Local Vault</Heading>
+                        <p className="pt-2">
+                          Stored locally only with no cloud. Ideal when collaboration is not needed.
+                        </p>
+                      </Radio>
+                      <Radio
+                        value="remote"
+                        className="data-[selected]:border-[--color-surprise] flex-1 data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
+                      >
+                        <Icon icon="globe" />
+                        <Heading className="text-lg font-bold">Enable Cloud Sync in Secure Cloud</Heading>
+                        <p className='pt-2'>
+                          End-to-end encrypted (E2EE) and synced securely to the cloud, ideal for collaboration.
+                        </p>
+                      </Radio>
+                    </div>
+                  </RadioGroup>
+                  <div className='flex justify-end gap-2 items-center'>
+                    <Button
+                      type="submit"
+                      isDisabled={state !== 'idle'}
+                      className={'hover:no-underline font-bold bg-[--color-surprise] text-sm hover:bg-opacity-90 py-2 px-3 text-[--color-font] transition-colors rounded-sm' + (state !== 'idle' ? 'animate-pulse cursor-not-allowed' : '')}
+                    >
+                      Continue
+                    </Button>
+                  </div>
+                </Form>
+              </div>
+            </div>
+          </div>
+        </div>
+      </TrailLinesContainer>
+    </div>
+  );
+};

--- a/packages/insomnia/src/ui/routes/onboarding.tsx
+++ b/packages/insomnia/src/ui/routes/onboarding.tsx
@@ -203,7 +203,7 @@ const Onboarding = () => {
                 )}
                 <Link
                   className="hover:no-underline bg-[#4000BF] text-sm hover:bg-opacity-90 border border-solid border-[--hl-md] py-2 px-3 text-[--color-font] transition-colors rounded-sm"
-                  to="/auth/login"
+                  to="/onboarding/migrate"
                   onClick={() => window.localStorage.setItem('hasSeenOnboarding', 'true')}
                 >
                   Continue


### PR DESCRIPTION
changelog(Improvements): Show an option for how the migration should happen.
- [x] Local vault (default)
- [x] Cloud projects

Highlights:
- [x] We keep using the existing migration logic to make sure all projects are moved under the organization locally.
- [x] After that we check the user preference (local/remote) and if remote try to move the local projects to remote. If anything fails (Api error,offline etc) projects are still under the org as local and users can turn them into remote from the project settings.