### PR TITLE
fix: show confirm modal in deleting team project [INS-3227]

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/dashboard-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/dashboard-interactions.test.ts
@@ -35,6 +35,7 @@ test.describe('Dashboard', async () => {
       // Delete project
       await page.getByRole('row', { name: 'My Project' }).getByRole('button', { name: 'Project Actions' }).click();
       await page.getByRole('menuitemradio', { name: 'Delete' }).click();
+      await page.getByRole('button', { name: 'Delete' }).click();
 
       // After deleting project, return to default Insomnia Dashboard
       await expect(page.locator('.app')).toContainText('Personal Workspace');

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -23,7 +23,8 @@ import {
   Project,
 } from '../../../models/project';
 import { Icon } from '../icon';
-import { showAlert } from '../modals';
+import { showAlert, showModal } from '../modals';
+import { AskModal } from '../modals/ask-modal';
 
 interface Props {
   project: Project;
@@ -34,7 +35,7 @@ interface ProjectActionItem {
   id: string;
   name: string;
   icon: IconName;
-  action: (projectId: string) => void;
+  action: (projectId: string, projectName: string) => void;
 }
 
 export const ProjectDropdown: FC<Props> = ({ project, organizationId }) => {
@@ -55,14 +56,25 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId }) => {
       id: 'delete',
       name: 'Delete',
       icon: 'trash',
-      action: projectId =>
-        deleteProjectFetcher.submit(
-          {},
-          {
-            method: 'post',
-            action: `/organization/${organizationId}/project/${projectId}/delete`,
-          }
-        ),
+      action: (projectId: string, projectName: string) => {
+        showModal(AskModal, {
+          title: 'Delete Project',
+          message: `Do you really want to delete "${projectName}"?`,
+          yesText: 'Delete',
+          noText: 'Cancel',
+          onDone: async (isYes: boolean) => {
+            if (isYes) {
+              deleteProjectFetcher.submit(
+                {},
+                {
+                  method: 'post',
+                  action: `/organization/${organizationId}/project/${projectId}/delete`,
+                }
+              );
+            }
+          },
+        });
+      },
     }] satisfies ProjectActionItem[] : [],
   ];
 
@@ -89,7 +101,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId }) => {
             aria-label="Project Actions Menu"
             selectionMode="single"
             onAction={key => {
-              projectActionList.find(({ id }) => key === id)?.action(project._id);
+              projectActionList.find(({ id }) => key === id)?.action(project._id, project.name);
             }}
             items={projectActionList}
             className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -59,7 +59,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId }) => {
       action: (projectId: string, projectName: string) => {
         showModal(AskModal, {
           title: 'Delete Project',
-          message: `Do you really want to delete "${projectName}"? It will permanently remove all data for this project.`,
+          message: `You are deleting the project "${projectName}" that may have collaborators. As a result of this, the project will be permanently deleted for every collaborator of the organization. Do you really want to continue?`,
           yesText: 'Delete',
           noText: 'Cancel',
           onDone: async (isYes: boolean) => {

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -59,7 +59,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId }) => {
       action: (projectId: string, projectName: string) => {
         showModal(AskModal, {
           title: 'Delete Project',
-          message: `Do you really want to delete "${projectName}"?`,
+          message: `Do you really want to delete "${projectName}"? It will permanently remove all data for this project.`,
           yesText: 'Delete',
           noText: 'Cancel',
           onDone: async (isYes: boolean) => {


### PR DESCRIPTION
change(Improvements): Added a confirmation dialog when deleting a team project.

Changes
- add confirm modal in deleting team project
- fix smoke test to confirm deletion

![image](https://github.com/Kong/insomnia/assets/24986718/155c6632-94d3-4df9-b9d5-e6477bfce508)
