### PR TITLE
Add stats on app start event

### DIFF
--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -9,6 +9,7 @@ import { userDataFolder } from '../config/config.json';
 import { changelogUrl, getAppVersion, getProductName, isDevelopment, isMac } from './common/constants';
 import { database } from './common/database';
 import log, { initializeLogging } from './common/log';
+import { SegmentEvent, trackSegmentEvent } from './main/analytics';
 import { registerInsomniaStreamProtocol } from './main/api.protocol';
 import { backupIfNewerVersionAvailable } from './main/backup';
 import { registerElectronHandlers } from './main/ipc/electron';
@@ -21,6 +22,7 @@ import { checkIfRestartNeeded } from './main/squirrel-startup';
 import * as updates from './main/updates';
 import * as windowUtils from './main/window-utils';
 import * as models from './models/index';
+import { Project, RemoteProject } from './models/project';
 import type { Stats } from './models/stats';
 import type { ToastNotification } from './ui/components/toast';
 
@@ -245,6 +247,22 @@ async function _trackStats() {
     currentVersion: getAppVersion(),
     lastVersion: oldStats.currentVersion,
     launches: oldStats.launches + 1,
+  });
+
+  const localProjectCount = await database.count<Project>(models.project.type, {
+    remoteId: null,
+    parentId: { $ne: null },
+    _id: { $ne: models.project.SCRATCHPAD_PROJECT_ID },
+  });
+
+  const remoteProjectCount = await database.count<RemoteProject>(models.project.type, {
+    remoteId: { $ne: null },
+    parentId: { $ne: null },
+  });
+
+  await trackSegmentEvent(SegmentEvent.appStarted, {
+    localProjects: localProjectCount,
+    remoteProjects: remoteProjectCount,
   });
 
   ipcMain.once('halfSecondAfterAppStart', async () => {

--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -249,20 +249,23 @@ async function _trackStats() {
     launches: oldStats.launches + 1,
   });
 
-  const localProjectCount = await database.count<Project>(models.project.type, {
+  const localProjects = await database.count<Project>(models.project.type, {
     remoteId: null,
     parentId: { $ne: null },
     _id: { $ne: models.project.SCRATCHPAD_PROJECT_ID },
   });
 
-  const remoteProjectCount = await database.count<RemoteProject>(models.project.type, {
+  const remoteProjects = await database.count<RemoteProject>(models.project.type, {
     remoteId: { $ne: null },
     parentId: { $ne: null },
   });
 
   await trackSegmentEvent(SegmentEvent.appStarted, {
-    localProjects: localProjectCount,
-    remoteProjects: remoteProjectCount,
+    localProjects,
+    remoteProjects,
+    createdRequests: stats.createdRequests,
+    deletedRequests: stats.deletedRequests,
+    executedRequests: stats.executedRequests,
   });
 
   ipcMain.once('halfSecondAfterAppStart', async () => {

--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -260,7 +260,7 @@ async function _trackStats() {
     parentId: { $ne: null },
   });
 
-  await trackSegmentEvent(SegmentEvent.appStarted, {
+  trackSegmentEvent(SegmentEvent.appStarted, {
     localProjects,
     remoteProjects,
     createdRequests: stats.createdRequests,

--- a/packages/insomnia/src/ui/rendererListeners.ts
+++ b/packages/insomnia/src/ui/rendererListeners.ts
@@ -5,7 +5,6 @@ import * as models from '../models';
 import * as plugins from '../plugins';
 import * as themes from '../plugins/misc';
 import * as templating from '../templating';
-import { SegmentEvent } from './analytics';
 import { showModal } from './components/modals';
 import { AskModal } from './components/modals/ask-modal';
 import { SelectModal } from './components/modals/select-modal';
@@ -75,5 +74,3 @@ window.main.on('reload-plugins', async () => {
 window.main.on('toggle-preferences-shortcuts', () => {
   showModal(SettingsModal, { tab: TAB_INDEX_SHORTCUTS });
 });
-
-window.main.trackSegmentEvent({ event: SegmentEvent.appStarted });


### PR DESCRIPTION
Adds some stats on the app start event and moves the event to fire in main

Future work:
- [ ] Wire up the router with navigation stats 