### PR TITLE
fix: show the request settings modal in the local scratch pad.

### DIFF
--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -31,7 +31,8 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
   const workspacesFetcher = useFetcher();
   useEffect(() => {
     const isIdleAndUninitialized = workspacesFetcher.state === 'idle' && !workspacesFetcher.data;
-    if (isIdleAndUninitialized) {
+    const isScratchPad = organizationId === "org_scratchpad" && projectId === "proj_scratchpad" && workspaceId === "wrk_scratchpad";
+    if (isIdleAndUninitialized && !isScratchPad) {
       workspacesFetcher.load(`/organization/${organizationId}/project/${projectId}`);
     }
   }, [organizationId, projectId, workspacesFetcher]);


### PR DESCRIPTION
Closes #6698
