### PR TITLE
fix: user should be able to quickly rename requests by clicking [INS-3250]

### DIFF
--- a/packages/insomnia-smoke-test/tests/critical/app-start.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/app-start.test.ts
@@ -18,15 +18,15 @@ test('can send requests', async ({ app, page }) => {
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionSmoke testsjust now').click();
 
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'send JSON request' }).click();
+  await page.getByLabel('Request Collection').getByTestId('send JSON request').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect(statusTag).toContainText('200 OK');
   await expect(responseBody).toContainText('"id": "1"');
   await page.getByRole('button', { name: 'Preview' }).click();
   await page.getByRole('menuitem', { name: 'Raw Data' }).click();
   await expect(responseBody).toContainText('{"id":"1"}');
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'send JSON request' }).click();
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'send JSON request' }).getByLabel('Request Actions').click();
+  await page.getByLabel('Request Collection').getByTestId('send JSON request').press('Enter');
+  await page.getByLabel('Request Collection').getByTestId('send JSON request').getByLabel('Request Actions').click();
   await page.getByRole('menuitemradio', { name: 'Generate Code' }).click();
   await page.getByText('curl --request GET \\').click();
   await page.getByRole('button', { name: 'Done' }).click();

--- a/packages/insomnia-smoke-test/tests/prerelease/design-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/design-interactions.test.ts
@@ -29,6 +29,7 @@ test.describe('Design interactions', async () => {
     await page.click('text=New test suite');
 
     // Rename test suite
+    await page.getByLabel('Request Collection').getByText('New Suite');
     await page.getByRole('button', { name: 'New Suite' }).click();
     await page.getByRole('textbox').fill('New Suite 2');
     await page.getByRole('textbox').press('Enter');

--- a/packages/insomnia-smoke-test/tests/prerelease/grpc-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/grpc-interactions.test.ts
@@ -40,7 +40,7 @@ test.describe('gRPC interactions', () => {
   });
 
   test('can send bidirectional requests', async ({ page }) => {
-    await page.getByLabel('Request Collection').getByRole('row', { name: 'Bidirectional Stream' }).click();
+    await page.getByLabel('Request Collection').getByTestId('Bidirectional Stream').press('Enter');
     await page.locator('text=Bi-directional Streaming').click();
     await page.click('text=Start');
 
@@ -59,7 +59,7 @@ test.describe('gRPC interactions', () => {
   });
 
   test('can send client stream requests', async ({ page }) => {
-    await page.getByLabel('Request Collection').getByRole('row', { name: 'Client Stream' }).click();
+    await page.getByLabel('Request Collection').getByTestId('Client Stream').press('Enter');
     await page.click('text=Client Streaming');
     await page.click('text=Start');
 
@@ -77,7 +77,7 @@ test.describe('gRPC interactions', () => {
   });
 
   test('can send server stream requests', async ({ page }) => {
-    await page.getByLabel('Request Collection').getByRole('row', { name: 'Server Stream' }).click();
+    await page.getByLabel('Request Collection').getByTestId('Server Stream').press('Enter');
     await page.click('text=Server Streaming');
     await page.click('text=Start');
 

--- a/packages/insomnia-smoke-test/tests/prerelease/preferences-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/preferences-interactions.test.ts
@@ -27,7 +27,7 @@ test('Check filter responses by environment preference', async ({ app, page }) =
   await page.getByText('Collectionsimplejust now').click();
 
   // Send a request
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'example http' }).click();
+  await page.getByLabel('Request Collection').getByTestId('example http').press('Enter');
   await page.click('[data-testid="request-pane"] button:has-text("Send")');
   await page.click('text=Timeline');
   await page.locator('text=HTTP/1.1 200 OK').click();

--- a/packages/insomnia-smoke-test/tests/smoke/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/app.test.ts
@@ -37,7 +37,7 @@ test('can send requests', async ({ app, page }) => {
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect(statusTag).toContainText('200 OK');
 
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'send JSON request' }).click();
+  await page.getByLabel('Request Collection').getByTestId('send JSON request').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect(statusTag).toContainText('200 OK');
   await expect(responseBody).toContainText('"id": "1"');
@@ -45,39 +45,39 @@ test('can send requests', async ({ app, page }) => {
   await page.getByRole('menuitem', { name: 'Raw Data' }).click();
   await expect(responseBody).toContainText('{"id":"1"}');
 
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'connects to event stream and shows ping response' }).click();
+  await page.getByLabel('Request Collection').getByTestId('connects to event stream and shows ping response').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Connect' }).click();
   await expect(statusTag).toContainText('200 OK');
   await page.getByRole('tab', { name: 'Timeline' }).click();
   await expect(responseBody).toContainText('Connected to 127.0.0.1');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Disconnect' }).click();
 
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'sends dummy.csv request and shows rich response' }).click();
+  await page.getByLabel('Request Collection').getByTestId('sends dummy.csv request and shows rich response').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect(statusTag).toContainText('200 OK');
   await page.getByRole('button', { name: 'Preview' }).click();
   await page.getByRole('menuitem', { name: 'Raw Data' }).click();
   await expect(responseBody).toContainText('a,b,c');
 
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'sends dummy.xml request and shows raw response' }).click();
+  await page.getByLabel('Request Collection').getByTestId('sends dummy.xml request and shows raw response').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect(statusTag).toContainText('200 OK');
   await expect(responseBody).toContainText('xml version="1.0"');
   await expect(responseBody).toContainText('<LoginResult>');
 
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'sends dummy.pdf request and shows rich response' }).click();
+  await page.getByLabel('Request Collection').getByTestId('sends dummy.pdf request and shows rich response').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect(statusTag).toContainText('200 OK');
   // TODO(filipe): re-add a check for the preview that is less flaky
   await page.getByRole('tab', { name: 'Timeline' }).click();
   await page.locator('pre').filter({ hasText: '< Content-Type: application/pdf' }).click();
 
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'sends request with basic authentication' }).click();
+  await page.getByLabel('Request Collection').getByTestId('sends request with basic authentication').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect(statusTag).toContainText('200 OK');
   await expect(responseBody).toContainText('basic auth received');
 
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'sends request with cookie and get cookie in response' }).click();
+  await page.getByLabel('Request Collection').getByTestId('sends request with cookie and get cookie in response').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect(statusTag).toContainText('200 OK');
   await page.getByRole('tab', { name: 'Timeline' }).click();
@@ -98,7 +98,7 @@ test('can cancel requests', async ({ app, page }) => {
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionSmoke testsjust now').click();
 
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'delayed request' }).click();
+  await page.getByLabel('Request Collection').getByTestId('delayed request').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 
   await page.getByRole('button', { name: 'Cancel Request' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/cookie-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cookie-editor-interactions.test.ts
@@ -40,7 +40,7 @@ test.describe('Cookie editor', async () => {
     await page.click('text=Done');
 
     // Send http request
-    await page.getByLabel('Request Collection').getByRole('row', { name: 'example http' }).click();
+    await page.getByLabel('Request Collection').getByTestId('example http').press('Enter');
     await page.click('[data-testid="request-pane"] button:has-text("Send")');
 
     // Check in the timeline that the cookie was sent
@@ -48,7 +48,7 @@ test.describe('Cookie editor', async () => {
     await page.click('text=foo2=bar2; foo=b123ar');
 
     // Send ws request
-    await page.getByLabel('Request Collection').getByRole('row', { name: 'example websocket' }).click();
+    await page.getByLabel('Request Collection').getByTestId('example websocket').press('Enter');
     await page.click('text=ws://localhost:4010');
     await page.click('[data-testid="request-pane"] >> text=Connect');
 

--- a/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
@@ -129,6 +129,13 @@ test.describe('Debug-Sidebar', async () => {
       await page.getByLabel('Request Collection').getByRole('row', { name: 'test folder1' }).click();
     });
 
+    test('Rename a request by clicking', async ({ page }) => {
+      await page.getByTestId('example http').getByLabel('request name').click();
+      await page.getByRole('textbox', { name: 'request name' }).fill('new name');
+      await page.getByLabel('Request Collection').click();
+      await expect(page.getByTestId('new name').getByLabel('request name')).toContainText('new name');
+    });
+
     test('Create a new HTTP request', async ({ page }) => {
       await page.getByLabel('Create in collection').click();
       await page.getByRole('menuitemradio', { name: 'Http Request' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
@@ -24,7 +24,7 @@ test.describe('Environment Editor', async () => {
     await page.getByRole('button', { name: 'Close' }).click();
 
     // Send a request check variables defaulted to base env since new env is empty
-    await page.getByLabel('Request Collection').getByRole('row', { name: 'New Request' }).click();
+    await page.getByLabel('Request Collection').getByTestId('New Request').press('Enter');
     await page.getByRole('button', { name: 'Send' }).click();
     await page.getByRole('tab', { name: 'Timeline' }).click();
     await page.getByText('baseenv0').click();
@@ -41,7 +41,7 @@ test.describe('Environment Editor', async () => {
     await page.getByRole('button', { name: 'Close' }).click();
 
     // Send a request check variables defaulted to base env since new env is empty
-    await page.getByLabel('Request Collection').getByRole('row', { name: 'New Request' }).click();
+    await page.getByLabel('Request Collection').getByTestId('New Request').press('Enter');
     await page.getByRole('button', { name: 'Send' }).click();
     await page.getByRole('tab', { name: 'Timeline' }).click();
     await page.getByText('subenvB0').click();
@@ -61,7 +61,7 @@ test.describe('Environment Editor', async () => {
 
     // Open request
     await page.getByRole('button', { name: 'Close' }).click();
-    await page.getByLabel('Request Collection').getByRole('row', { name: 'New Request' }).click();
+    await page.getByLabel('Request Collection').getByTestId('New Request').press('Enter');
 
     // Add number variable to request body
     await page.locator('pre').filter({ hasText: '_.exampleObject.anotherNumber' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -19,7 +19,7 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionSmoke GraphQLjust now').click();
   // Open the graphql request
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'GraphQL request' }).click();
+  await page.getByLabel('Request Collection').getByTestId('GraphQL request').press('Enter');
   // Assert the schema is fetched after switching to GraphQL request
   await expect(page.locator('.graphql-editor__meta')).toContainText('schema fetched just now');
 
@@ -55,7 +55,7 @@ test('can send GraphQL requests after editing and prettifying query', async ({ a
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionSmoke GraphQLjust now').click();
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'GraphQL request' }).click();
+  await page.getByLabel('Request Collection').getByTestId('GraphQL request').press('Enter');
 
   // Edit and prettify query
   await page.locator('pre[role="presentation"]:has-text("bearer")').click();

--- a/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
@@ -21,7 +21,7 @@ test('can send gRPC requests with reflection', async ({ app, page }) => {
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionPreRelease gRPCjust now').click();
 
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'UnaryWithOutProtoFile' }).click();
+  await page.getByLabel('Request Collection').getByTestId('UnaryWithOutProtoFile').press('Enter');
   await expect(page.getByRole('button', { name: 'Select Method' })).toBeDisabled();
   await page.getByTestId('button-server-reflection').click();
 

--- a/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
@@ -29,7 +29,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await page.getByText('CollectionOAuth Testingjust now').click();
 
   // No PKCE
-  await projectView.getByLabel('Request Collection').getByRole('row', { name: 'No PKCE' }).click();
+  await projectView.getByLabel('Request Collection').getByTestId('No PKCE').press('Enter');
   await expect(page.locator('.app')).toContainText('http://127.0.0.1:4010/oidc/me');
 
   const [authorizationCodePage] = await Promise.all([
@@ -74,7 +74,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await expect(tokenInput).not.toHaveValue('');
 
   // PKCE SHA256
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'PKCE SHA256' }).click();
+  await page.getByLabel('Request Collection').getByTestId('PKCE SHA256').press('Enter');
   await expect(page.locator('.app')).toContainText('http://127.0.0.1:4010/oidc/me');
   await expect(page.locator('#Grant-Type')).toHaveValue('authorization_code');
   await expect(page.locator('#Code-Challenge-Method')).toHaveValue('S256');
@@ -83,7 +83,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await expect(responseBody).toContainText('"sub": "admin"');
 
   // PKCE Plain
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'PKCE Plain' }).click();
+  await page.getByLabel('Request Collection').getByTestId('PKCE Plain').press('Enter');
   await expect(page.locator('.app')).toContainText('http://127.0.0.1:4010/oidc/me');
   await expect(page.locator('#Grant-Type')).toHaveValue('authorization_code');
   await expect(page.locator('#Code-Challenge-Method')).toHaveValue('plain');
@@ -101,7 +101,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await page.keyboard.press('Escape');
 
   // ID Token
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'ID Token' }).click();
+  await page.getByLabel('Request Collection').getByTestId('ID Token').press('Enter');
   await expect(page.locator('.app')).toContainText('http://127.0.0.1:4010/oidc/id-token');
   await expect(page.locator('#Grant-Type')).toHaveValue('implicit');
 
@@ -119,7 +119,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await expect(responseBody).toContainText('"sub": "admin"');
 
   // ID and Access Token
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'ID and Access Token' }).click();
+  await page.getByLabel('Request Collection').getByTestId('ID and Access Token').press('Enter');
   await expect(page.locator('.app')).toContainText('http://127.0.0.1:4010/oidc/me');
   await expect(page.locator('#Grant-Type')).toHaveValue('implicit');
   await sendButton.click();
@@ -136,7 +136,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await page.keyboard.press('Escape');
 
   // Client Credentials
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'Client Credentials' }).click();
+  await page.getByLabel('Request Collection').getByTestId('Client Credentials').press('Enter');
   await expect(page.locator('.app')).toContainText('http://127.0.0.1:4010/oidc/client-credential');
   await expect(page.locator('#Grant-Type')).toHaveValue('client_credentials');
   await sendButton.click();
@@ -153,7 +153,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await page.keyboard.press('Escape');
 
   // Resource Owner Password Credentials
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'Resource Owner Password Credentials' }).click();
+  await page.getByLabel('Request Collection').getByTestId('Resource Owner Password Credentials').press('Enter');
   await expect(page.locator('.app')).toContainText('http://127.0.0.1:4010/oidc/me');
   await expect(page.locator('#Grant-Type')).toHaveValue('password');
   await sendButton.click();

--- a/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
@@ -21,7 +21,7 @@ test('can make websocket connection', async ({ app, page }) => {
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionWebSocketsjust now').click();
 
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'localhost:4010' }).click();
+  await page.getByLabel('Request Collection').getByTestId('localhost:4010').press('Enter');
   await expect(page.locator('.app')).toContainText('ws://localhost:4010');
   await page.click('text=Connect');
   await expect(statusTag).toContainText('101 Switching Protocols');
@@ -31,7 +31,7 @@ test('can make websocket connection', async ({ app, page }) => {
   await expect(responseBody).toContainText('Closing connection with code 1005');
 
   // Can connect with Basic Auth
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'basic-auth' }).click();
+  await page.getByLabel('Request Collection').getByTestId('basic-auth').press('Enter');
   await expect(page.locator('.app')).toContainText('ws://localhost:4010/basic-auth');
   await page.click('text=Connect');
   await expect(statusTag).toContainText('101 Switching Protocols');
@@ -39,7 +39,7 @@ test('can make websocket connection', async ({ app, page }) => {
   await expect(responseBody).toContainText('> authorization: Basic dXNlcjpwYXNzd29yZA==');
 
   // Can connect with Bearer Auth
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'bearer' }).click();
+  await page.getByLabel('Request Collection').getByTestId('bearer').press('Enter');
   await expect(page.locator('.app')).toContainText('ws://localhost:4010/bearer');
   await page.click('text=Connect');
   await expect(statusTag).toContainText('101 Switching Protocols');
@@ -47,7 +47,7 @@ test('can make websocket connection', async ({ app, page }) => {
   await expect(responseBody).toContainText('> authorization: Bearer insomnia-cool-token-!!!1112113243111');
 
   // Can handle redirects
-  await page.getByLabel('Request Collection').getByRole('row', { name: 'redirect' }).click();
+  await page.getByLabel('Request Collection').getByTestId('redirect').press('Enter');
   await expect(page.locator('.app')).toContainText('ws://localhost:4010/redirect');
   await page.click('text=Connect');
   await expect(statusTag).toContainText('101 Switching Protocols');

--- a/packages/insomnia/src/ui/components/editable-input.tsx
+++ b/packages/insomnia/src/ui/components/editable-input.tsx
@@ -6,11 +6,13 @@ export const EditableInput = ({
   value = 'Untitled',
   ariaLabel,
   name,
+  paddingClass,
   onChange,
 }: {
   value: string;
   ariaLabel?: string;
   name?: string;
+    paddingClass?: string;
   onChange: (value: string) => void;
 }) => {
   const [isEditable, setIsEditable] = useState(false);
@@ -44,13 +46,19 @@ export const EditableInput = ({
     };
   }, [isEditable]);
 
+  const defaultPaddingClass = paddingClass != null && paddingClass.startsWith('px-') ? paddingClass : 'px-2';
+
   return (
     <>
+
       <Button
-        className={`items-center truncate justify-center px-2 data-[pressed]:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all ${
-          isEditable ? 'hidden' : ''
-        }`}
-        onPress={() => {
+        className={
+          `items-center truncate justify-center px-2 data-[pressed]:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all
+            ${isEditable ? 'hidden' : ''}
+            ${defaultPaddingClass}
+          `
+        }
+        onPress={e => {
           setIsEditable(true);
         }}
         name={name}

--- a/packages/insomnia/src/ui/components/editable-input.tsx
+++ b/packages/insomnia/src/ui/components/editable-input.tsx
@@ -12,7 +12,7 @@ export const EditableInput = ({
   value: string;
   ariaLabel?: string;
   name?: string;
-    paddingClass?: string;
+  paddingClass?: string;
   onChange: (value: string) => void;
 }) => {
   const [isEditable, setIsEditable] = useState(false);

--- a/packages/insomnia/src/ui/components/editable-input.tsx
+++ b/packages/insomnia/src/ui/components/editable-input.tsx
@@ -58,7 +58,7 @@ export const EditableInput = ({
             ${defaultPaddingClass}
           `
         }
-        onPress={e => {
+        onPress={() => {
           setIsEditable(true);
         }}
         name={name}

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -57,6 +57,7 @@ import { RequestActionsDropdown } from '../components/dropdowns/request-actions-
 import { RequestGroupActionsDropdown } from '../components/dropdowns/request-group-actions-dropdown';
 import { WorkspaceDropdown } from '../components/dropdowns/workspace-dropdown';
 import { WorkspaceSyncDropdown } from '../components/dropdowns/workspace-sync-dropdown';
+import { EditableInput } from '../components/editable-input';
 import { ErrorBoundary } from '../components/error-boundary';
 import { Icon } from '../components/icon';
 import { useDocBodyKeyboardShortcuts } from '../components/keydown-binder';
@@ -628,28 +629,6 @@ export const Debug: FC = () => {
     getItemKey: index => visibleCollection[index].doc._id,
   });
 
-  const onDoubleClickRequest = (item: Child) => {
-    if (isRequestGroup(item.doc)) {
-      showPrompt({
-        title: 'Rename Folder',
-        defaultValue: item.doc.name,
-        submitName: 'Rename',
-        selectText: true,
-        label: 'Name',
-        onComplete: name => patchGroup(item.doc._id, { name }),
-      });
-    } else {
-      showPrompt({
-        title: 'Rename Request',
-        defaultValue: item.doc.name,
-        submitName: 'Rename',
-        selectText: true,
-        label: 'Name',
-        onComplete: name => patchRequest(item.doc._id, { name }),
-      });
-    }
-  };
-
   return (
     <SidebarLayout
       className="new-sidebar"
@@ -931,10 +910,11 @@ export const Debug: FC = () => {
                     key={item.doc._id}
                     id={item.doc._id}
                     className="group outline-none select-none"
+                    textValue={item.doc.name}
+                    data-testid={item.doc.name}
                   >
                     <div
                       className="flex select-none outline-none group-aria-selected:text-[--color-font] relative group-hover:bg-[--hl-xs] group-focus:bg-[--hl-sm] transition-colors gap-2 px-4 items-center h-[--line-height-xs] w-full overflow-hidden text-[--hl]"
-                      onDoubleClick={() => onDoubleClickRequest(item)}
                     >
                       <span className="group-aria-selected:bg-[--color-surprise] transition-colors top-0 left-0 absolute h-full w-[2px] bg-transparent" />
                       {isRequest(item.doc) && (
@@ -965,7 +945,19 @@ export const Debug: FC = () => {
                           gRPC
                         </span>
                       )}
-                      <span className="truncate">{getRequestNameOrFallback(item.doc)}</span>
+                      <EditableInput
+                        value={getRequestNameOrFallback(item.doc)}
+                        name="request name"
+                        ariaLabel="request name"
+                        paddingClass="px-0"
+                        onChange={name => {
+                          if (isRequestGroup(item.doc)) {
+                            patchGroup(item.doc._id, { name });
+                          } else {
+                            patchRequest(item.doc._id, { name });
+                          }
+                        }}
+                      />
                       <span className="flex-1" />
                       {item.pinned && (
                         <Icon className='text-[--font-size-sm]' icon="thumb-tack" />
@@ -984,7 +976,7 @@ export const Debug: FC = () => {
               }}
             </GridList>
 
-            <div className='flex-1 overflow-y-auto' ref={parentRef}>
+            <div className='flex-1 overflow-y-auto' ref={parentRef} >
               <GridList
                 style={{ height: virtualizer.getTotalSize() }}
                 items={virtualizer.getVirtualItems()}
@@ -1018,6 +1010,7 @@ export const Debug: FC = () => {
                     <Item
                       className="group outline-none absolute top-0 left-0 select-none w-full"
                       textValue={item.doc.name}
+                      data-testid={item.doc.name}
                       style={{
                         height: `${virtualItem.size}`,
                         transform: `translateY(${virtualItem.start}px)`,
@@ -1028,7 +1021,6 @@ export const Debug: FC = () => {
                         style={{
                           paddingLeft: `${item.level + 1}rem`,
                         }}
-                        onDoubleClick={() => onDoubleClickRequest(item)}
                       >
                         <span className="group-aria-selected:bg-[--color-surprise] transition-colors top-0 left-0 absolute h-full w-[2px] bg-transparent" />
                         <Button slot="drag" className="hidden" />
@@ -1066,7 +1058,19 @@ export const Debug: FC = () => {
                             icon={item.collapsed ? 'folder' : 'folder-open'}
                           />
                         )}
-                        <span className="truncate">{getRequestNameOrFallback(item.doc)}</span>
+                        <EditableInput
+                          value={getRequestNameOrFallback(item.doc)}
+                          name="request name"
+                          ariaLabel="request name"
+                          paddingClass="px-0"
+                          onChange={name => {
+                            if (isRequestGroup(item.doc)) {
+                              patchGroup(item.doc._id, { name });
+                            } else {
+                              patchRequest(item.doc._id, { name });
+                            }
+                          }}
+                        />
                         <span className="flex-1" />
                         {isWebSocketRequest(item.doc) && <WebSocketSpinner requestId={item.doc._id} />}
                         {isEventStreamRequest(item.doc) && <EventStreamSpinner requestId={item.doc._id} />}

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -82,7 +82,9 @@ import { useReadyState } from '../hooks/use-ready-state';
 import {
   CreateRequestType,
   useRequestGroupMetaPatcher,
+  useRequestGroupPatcher,
   useRequestMetaPatcher,
+  useRequestPatcher,
 } from '../hooks/use-request';
 import {
   GrpcRequestLoaderData,
@@ -188,6 +190,8 @@ export const Debug: FC = () => {
     useState(false);
   const [isEnvironmentModalOpen, setEnvironmentModalOpen] = useState(false);
 
+  const patchRequest = useRequestPatcher();
+  const patchGroup = useRequestGroupPatcher();
   const patchRequestMeta = useRequestMetaPatcher();
   useEffect(() => {
     db.onChange(async (changes: ChangeBufferEvent[]) => {
@@ -1000,6 +1004,27 @@ export const Debug: FC = () => {
                         className="flex select-none outline-none group-aria-selected:text-[--color-font] relative group-hover:bg-[--hl-xs] group-focus:bg-[--hl-sm] transition-colors gap-2 px-4 items-center h-[--line-height-xs] w-full overflow-hidden text-[--hl]"
                         style={{
                           paddingLeft: `${item.level + 1}rem`,
+                        }}
+                        onDoubleClick={() => {
+                          if (isRequestGroup(item.doc)) {
+                            showPrompt({
+                              title: 'Rename Folder',
+                              defaultValue: item.doc.name,
+                              submitName: 'Rename',
+                              selectText: true,
+                              label: 'Name',
+                              onComplete: name => patchGroup(item.doc._id, { name }),
+                            });
+                          } else {
+                            showPrompt({
+                              title: 'Rename Request',
+                              defaultValue: item.doc.name,
+                              submitName: 'Rename',
+                              selectText: true,
+                              label: 'Name',
+                              onComplete: name => patchRequest(item.doc._id, { name }),
+                            });
+                          }
                         }}
                       >
                         <span className="group-aria-selected:bg-[--color-surprise] transition-colors top-0 left-0 absolute h-full w-[2px] bg-transparent" />

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -628,6 +628,28 @@ export const Debug: FC = () => {
     getItemKey: index => visibleCollection[index].doc._id,
   });
 
+  const onDoubleClickRequest = (item: Child) => {
+    if (isRequestGroup(item.doc)) {
+      showPrompt({
+        title: 'Rename Folder',
+        defaultValue: item.doc.name,
+        submitName: 'Rename',
+        selectText: true,
+        label: 'Name',
+        onComplete: name => patchGroup(item.doc._id, { name }),
+      });
+    } else {
+      showPrompt({
+        title: 'Rename Request',
+        defaultValue: item.doc.name,
+        submitName: 'Rename',
+        selectText: true,
+        label: 'Name',
+        onComplete: name => patchRequest(item.doc._id, { name }),
+      });
+    }
+  };
+
   return (
     <SidebarLayout
       className="new-sidebar"
@@ -912,6 +934,7 @@ export const Debug: FC = () => {
                   >
                     <div
                       className="flex select-none outline-none group-aria-selected:text-[--color-font] relative group-hover:bg-[--hl-xs] group-focus:bg-[--hl-sm] transition-colors gap-2 px-4 items-center h-[--line-height-xs] w-full overflow-hidden text-[--hl]"
+                      onDoubleClick={() => onDoubleClickRequest(item)}
                     >
                       <span className="group-aria-selected:bg-[--color-surprise] transition-colors top-0 left-0 absolute h-full w-[2px] bg-transparent" />
                       {isRequest(item.doc) && (
@@ -1005,27 +1028,7 @@ export const Debug: FC = () => {
                         style={{
                           paddingLeft: `${item.level + 1}rem`,
                         }}
-                        onDoubleClick={() => {
-                          if (isRequestGroup(item.doc)) {
-                            showPrompt({
-                              title: 'Rename Folder',
-                              defaultValue: item.doc.name,
-                              submitName: 'Rename',
-                              selectText: true,
-                              label: 'Name',
-                              onComplete: name => patchGroup(item.doc._id, { name }),
-                            });
-                          } else {
-                            showPrompt({
-                              title: 'Rename Request',
-                              defaultValue: item.doc.name,
-                              submitName: 'Rename',
-                              selectText: true,
-                              label: 'Name',
-                              onComplete: name => patchRequest(item.doc._id, { name }),
-                            });
-                          }
-                        }}
+                        onDoubleClick={() => onDoubleClickRequest(item)}
                       >
                         <span className="group-aria-selected:bg-[--color-surprise] transition-colors top-0 left-0 absolute h-full w-[2px] bg-transparent" />
                         <Button slot="drag" className="hidden" />


### PR DESCRIPTION
changelog(Improvements): Added a quicker way for users to quickly rename requests by clicking on them

Changes:
- enable quick renaming request by clicking