### PR TITLE
feat: api mocking

### DIFF
--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -28,6 +28,7 @@ import * as _project from './project';
 import * as _protoDirectory from './proto-directory';
 import * as _protoFile from './proto-file';
 import * as _request from './request';
+import * as _requestBin from './request-bin';
 import * as _requestGroup from './request-group';
 import * as _requestGroupMeta from './request-group-meta';
 import * as _requestMeta from './request-meta';
@@ -67,6 +68,7 @@ export const gitRepository = _gitRepository;
 export const oAuth2Token = _oAuth2Token;
 export const pluginData = _pluginData;
 export const request = _request;
+export const requestBin = _requestBin;
 export const requestGroup = _requestGroup;
 export const requestGroupMeta = _requestGroupMeta;
 export const requestMeta = _requestMeta;
@@ -106,6 +108,7 @@ export function all() {
     requestGroup,
     requestGroupMeta,
     request,
+    requestBin,
     requestVersion,
     requestMeta,
     response,

--- a/packages/insomnia/src/models/request-bin.ts
+++ b/packages/insomnia/src/models/request-bin.ts
@@ -1,0 +1,50 @@
+import { database as db } from '../common/database';
+import type { BaseModel } from './index';
+
+export const name = 'Request Bin';
+
+export const type = 'RequestBin';
+
+export const prefix = 'bin';
+
+export const canDuplicate = true;
+
+export const canSync = true;
+
+export interface BaseRequestBin {
+  url: string;
+  remoteId: string;
+}
+
+export type RequestBin = BaseModel & BaseRequestBin;
+
+export const isRequestBin = (model: Pick<BaseModel, 'type'>): model is RequestBin => (
+  model.type === type
+);
+
+export function init(): BaseRequestBin {
+  return {
+    url: '',
+    remoteId: '',
+  };
+}
+
+export function migrate(doc: RequestBin) {
+  return doc;
+}
+
+export function getByParentId(parentId: string) {
+  return db.getWhere<RequestBin>(type, { parentId });
+}
+
+export async function all() {
+  return db.all<RequestBin>(type);
+}
+
+export function update(requestBin: RequestBin, patch: Partial<RequestBin> = {}) {
+  return db.docUpdate(requestBin, patch);
+}
+
+export function removeWhere(parentId: string) {
+  return db.removeWhere(type, { parentId });
+}

--- a/packages/insomnia/src/models/request-bin.ts
+++ b/packages/insomnia/src/models/request-bin.ts
@@ -37,6 +37,10 @@ export function getByParentId(parentId: string) {
   return db.getWhere<RequestBin>(type, { parentId });
 }
 
+export function findByParentId(parentId: string) {
+  return db.find<RequestBin>(type, { parentId });
+}
+
 export async function all() {
   return db.all<RequestBin>(type);
 }

--- a/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
@@ -102,28 +102,7 @@ export const PreviewModeDropdown: FC<Props> = ({
     }
     const { statusCode, statusMessage, headers, httpVersion, bytesContent, contentType } = activeResponse;
     const body = await readFile(activeResponse.bodyPath, 'utf8');
-    console.log(activeResponse, {
-      'status': statusCode,
-      'statusText': statusMessage,
-      'httpVersion': httpVersion,
-      'headers': headers,
-      // todo: cookies
-      'cookies': [
-        {
-          'name': 'a',
-          'value': 'a',
-        },
-      ],
-      'content': {
-        'size': bytesContent,
-        'mimeType': contentType,
-        'text': body,
-      },
-      'redirectURL': '',
-      'headersSize': 323,
-      'bodySize': bytesContent,
-    });
-    // create bin and get id
+    // transform response to mockbin format
     const bin = await window.main.axiosRequest({
       url: 'http://mockbin.org/bin/create',
       method: 'post',
@@ -132,6 +111,7 @@ export const PreviewModeDropdown: FC<Props> = ({
         'statusText': statusMessage,
         'httpVersion': httpVersion,
         'headers': headers,
+        // NOTE: cookies are sent as headers by insomnia
         'cookies': [],
         'content': {
           'size': bytesContent,
@@ -140,13 +120,17 @@ export const PreviewModeDropdown: FC<Props> = ({
         },
       },
     });
-    console.log('here is your bin', bin?.data);
+    // todo: record bin id in insomnia db
+    // todo: list all bins
+    // todo: show bin logs
+    // todo: handle error
     if (bin?.data) {
       const id = bin.data;
       createRequest({
         requestType: 'HTTP',
         parentId: workspaceId,
         req: {
+          ...activeRequest,
           name: 'Mock Response of ' + activeRequest.name,
           method: activeRequest.method,
           url: `https://mockbin.org/bin/${id}`,

--- a/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/preview-mode-dropdown.tsx
@@ -127,7 +127,7 @@ export const PreviewModeDropdown: FC<Props> = ({
     if (bin?.data) {
       const id = bin.data;
       createRequest({
-        requestType: 'HTTP',
+        requestType: 'RequestBin',
         parentId: workspaceId,
         req: {
           ...activeRequest,
@@ -172,10 +172,10 @@ export const PreviewModeDropdown: FC<Props> = ({
         aria-label='Action Section'
         title="Action"
       >
-        <DropdownItem aria-label='Mock response'>
+        <DropdownItem aria-label='Create example mock'>
           <ItemContent
             icon="copy"
-            label="Mock response"
+            label="Create example mock"
             onClick={mockResponse}
           />
         </DropdownItem>

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -2,6 +2,7 @@ import fs from 'fs';
 import { extension as mimeExtension } from 'mime-types';
 import React, { FC, useCallback } from 'react';
 import { useRouteLoaderData } from 'react-router-dom';
+import styled from 'styled-components';
 
 import { PREVIEW_MODE_SOURCE } from '../../../common/constants';
 import { getSetCookieHeaders } from '../../../common/misc';
@@ -34,7 +35,7 @@ interface Props {
 export const ResponsePane: FC<Props> = ({
   runningRequests,
 }) => {
-  const { activeRequest, activeRequestMeta, activeResponse } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const { activeRequest, activeRequestMeta, activeResponse, requestBins } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
   const filterHistory = activeRequestMeta.responseFilterHistory || [];
   const filter = activeRequestMeta.responseFilter || '';
   const patchRequestMeta = useRequestMetaPatcher();
@@ -223,6 +224,28 @@ export const ResponsePane: FC<Props> = ({
             />
           </ErrorBoundary>
         </TabItem>
+        <TabItem key="Mocks" title="Mocks">
+          <ErrorBoundary key={activeResponse._id} errorClassName="font-error pad text-center">
+            <table className="table--fancy table--striped table--compact">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {requestBins.map(requestBin => (<tr className="selectable" key={requestBin.url}>
+                  <StyledTableDataCell>
+                    {requestBin.url}
+                  </StyledTableDataCell>
+                  <StyledTableDataCell>
+                    <button>[+][delete][log]</button>
+                  </StyledTableDataCell>
+                </tr>))}
+              </tbody>
+            </table>
+          </ErrorBoundary>
+        </TabItem>
       </Tabs>
       <ErrorBoundary errorClassName="font-error pad text-center">
         {runningRequests[activeRequest._id] && <ResponseTimer
@@ -232,3 +255,8 @@ export const ResponsePane: FC<Props> = ({
     </Pane>
   );
 };
+const StyledTableDataCell = styled.td.attrs({
+  className: 'force-wrap',
+})({
+  width: '50%',
+});

--- a/packages/insomnia/src/ui/hooks/use-request.ts
+++ b/packages/insomnia/src/ui/hooks/use-request.ts
@@ -82,4 +82,4 @@ export const useWorkspaceMetaPatcher = () => {
   };
 };
 
-export type CreateRequestType = 'HTTP' | 'gRPC' | 'GraphQL' | 'WebSocket' | 'Event Stream' | 'From Curl';
+export type CreateRequestType = 'HTTP' | 'gRPC' | 'GraphQL' | 'WebSocket' | 'Event Stream' | 'From Curl' | 'RequestBin';

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -347,8 +347,8 @@ export const loader: LoaderFunction = async ({
 
     const hasUnsavedChanges = Boolean(
       isDesign(workspace) &&
-        workspaceMeta?.cachedGitLastCommitTime &&
-        modifiedLocally > workspaceMeta?.cachedGitLastCommitTime
+      workspaceMeta?.cachedGitLastCommitTime &&
+      modifiedLocally > workspaceMeta?.cachedGitLastCommitTime
     );
 
     const clientCertificates = await models.clientCertificate.findByParentId(
@@ -387,20 +387,20 @@ export const loader: LoaderFunction = async ({
     .filter(workspace =>
       filter
         ? Boolean(
-            fuzzyMatchAll(
-              filter,
-              // Use the filter string to match against these properties
-              [
-                workspace.name,
-                workspace.workspace.scope === 'design'
-                  ? 'document'
-                  : 'collection',
-                workspace.lastActiveBranch || '',
-                workspace.specFormatVersion || '',
-              ],
-              { splitSpace: true, loose: true }
-            )?.indexes
-          )
+          fuzzyMatchAll(
+            filter,
+            // Use the filter string to match against these properties
+            [
+              workspace.name,
+              workspace.workspace.scope === 'design'
+                ? 'document'
+                : 'collection',
+              workspace.lastActiveBranch || '',
+              workspace.specFormatVersion || '',
+            ],
+            { splitSpace: true, loose: true }
+          )?.indexes
+        )
         : true
     )
     .sort((a, b) => sortMethodMap[sortOrder as DashboardSortOrder](a, b));
@@ -612,33 +612,33 @@ const ProjectRoute: FC = () => {
     icon: IconName;
     action: () => void;
   }[] = [
-    {
-      id: 'new-collection',
-      name: 'Request collection',
-      icon: 'bars',
-      action: createNewCollection,
-    },
-    {
-      id: 'new-document',
-      name: 'Design document',
-      icon: 'file',
-      action: createNewDocument,
-    },
-    {
-      id: 'import',
-      name: 'Import',
-      icon: 'file-import',
-      action: () => {
-        setImportModalType('file');
+      {
+        id: 'new-collection',
+        name: 'Request collection',
+        icon: 'bars',
+        action: createNewCollection,
       },
-    },
-    {
-      id: 'git-clone',
-      name: 'Git Clone',
-      icon: 'code-fork',
-      action: importFromGit,
-    },
-  ];
+      {
+        id: 'new-document',
+        name: 'Design document',
+        icon: 'file',
+        action: createNewDocument,
+      },
+      {
+        id: 'import',
+        name: 'Import',
+        icon: 'file-import',
+        action: () => {
+          setImportModalType('file');
+        },
+      },
+      {
+        id: 'git-clone',
+        name: 'Git Clone',
+        icon: 'code-fork',
+        action: importFromGit,
+      },
+    ];
 
   const scopeActionList: {
     id: string;
@@ -651,35 +651,46 @@ const ProjectRoute: FC = () => {
       run: () => void;
     };
   }[] = [
-    {
-      id: 'all',
-      label: `All files (${allFilesCount})`,
-      icon: 'folder',
-      level: 0,
-    },
-    {
-      id: 'design',
-      label: `Documents (${documentsCount})`,
-      level: 1,
-      icon: 'file',
-      action: {
-        icon: 'plus',
-        label: 'New design document',
-        run: createNewDocument,
+      {
+        id: 'all',
+        label: `All files (${allFilesCount})`,
+        icon: 'folder',
+        level: 0,
       },
-    },
-    {
-      id: 'collection',
-      label: `Collections (${collectionsCount})`,
-      level: 1,
-      icon: 'bars',
-      action: {
-        icon: 'plus',
-        label: 'New request collection',
-        run: createNewCollection,
+      {
+        id: 'design',
+        label: `Documents (${documentsCount})`,
+        level: 1,
+        icon: 'file',
+        action: {
+          icon: 'plus',
+          label: 'New design document',
+          run: createNewDocument,
+        },
       },
-    },
-  ];
+      {
+        id: 'collection',
+        label: `Collections (${collectionsCount})`,
+        level: 1,
+        icon: 'bars',
+        action: {
+          icon: 'plus',
+          label: 'New request collection',
+          run: createNewCollection,
+        },
+      },
+      {
+        id: 'bin',
+        label: `mockbins (${collectionsCount})`,
+        level: 1,
+        icon: 'terminal',
+        action: {
+          icon: 'plus',
+          label: 'New mockbin',
+          run: createNewCollection,
+        },
+      },
+    ];
 
   return (
     <ErrorBoundary>

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -104,8 +104,10 @@ export const createRequestAction: ActionFunction = async ({ request, params }) =
     activeRequestId = (await models.request.create({
       parentId: parentId || workspaceId,
       method: METHOD_GET,
-      name: 'New Request',
-      headers: [{ name: 'User-Agent', value: `insomnia/${version}` }],
+      name: req?.name || 'New Request',
+      headers: [{ name: 'User-Agent', value: `insomnia/${version}` }, ...req?.headers || []],
+      url: req?.url || '',
+
     }))._id;
   }
   if (requestType === 'gRPC') {

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -101,14 +101,19 @@ export const createRequestAction: ActionFunction = async ({ request, params }) =
 
   let activeRequestId;
   if (requestType === 'HTTP') {
-    activeRequestId = (await models.request.create({
-      parentId: parentId || workspaceId,
-      method: METHOD_GET,
-      name: req?.name || 'New Request',
-      headers: [{ name: 'User-Agent', value: `insomnia/${version}` }, ...req?.headers || []],
-      url: req?.url || '',
-
-    }))._id;
+    if (!req) {
+      activeRequestId = (await models.request.create({
+        parentId: parentId || workspaceId,
+        method: METHOD_GET,
+        headers: [{ name: 'User-Agent', value: `insomnia/${version}` }],
+      }))._id;
+    } else {
+      activeRequestId = (await models.request.create({
+        ...req,
+        _id: undefined,
+        parentId: parentId || workspaceId,
+      }))._id;
+    }
   }
   if (requestType === 'gRPC') {
     activeRequestId = (await models.grpcRequest.create({

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -50,6 +50,7 @@ export interface RequestLoaderData {
   activeResponse: Response | null;
   responses: Response[];
   requestVersions: RequestVersion[];
+  requestBins: RequestBin[];
 }
 
 export const loader: LoaderFunction = async ({ params }): Promise<RequestLoaderData | WebSocketRequestLoaderData | GrpcRequestLoaderData> => {
@@ -92,6 +93,7 @@ export const loader: LoaderFunction = async ({ params }): Promise<RequestLoaderD
     activeResponse,
     responses,
     requestVersions: await models.requestVersion.findByParentId(requestId),
+    requestBins: await models.requestBin.findByParentId(workspaceId),
   } as RequestLoaderData | WebSocketRequestLoaderData;
 };
 


### PR DESCRIPTION
ux experiment to determine the minimum viable api mocking feature

first pass ux idea: 
- send a request to my api, get a desirable response which is difficult to reproduce, perhaps because of something time related.
- click the response dropdown and then the mock button which will create a bin at a remote url and then create a new request pointing at the remote.
- when this new request is sent it will always return the identical response from the original request, effectively making insomnia a UI for mockbin.

<img width="276" alt="image" src="https://github.com/Kong/insomnia/assets/3679927/e386328e-27ab-4bbd-9eaa-e3558855096e">

pros

- quick cloning of existing api responses
- flexible
- minimal ux impact
- conceptually close to response in ux

cons

- hard to separate regular requests from mocked requests
- discoverability is quite low


notes:

haven't done a great deal of analysis of alternatives yet but this appears to be the path of least resistance.
Based on other features we would like to support this ux will probably change or be added to but the request response transformation logic will likely stay the same.


future work

- show request logs somewhere
- manage created bins somewhere
- link mocked requests to created bins somehow

closes INS-3246
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
