### PR TITLE
fix: inso cli via docker issue on Mac M1 [INS-3245]

### DIFF
--- a/packages/insomnia-inso/Dockerfile
+++ b/packages/insomnia-inso/Dockerfile
@@ -2,16 +2,17 @@
 
 # This Dockerfile is intended for CI use only
 # It assumes inso-linux-VERSION.tar.xz exists in /packages/insomnia-inso/artifacts
-# You can run `npm run inso-package:artifacts` on a linux host OR
+# You can run `npm run inso-package && npm run inso-package:artifacts` on a linux host OR
 # `curl -LO "https://github.com/Kong/insomnia/releases/download/lib%40<version>/inso-linux-<version>.tar.xz"`
 
-FROM docker.io/alpine:3.15.4 AS fetch
+FROM docker.io/ubuntu:22.04 AS fetch
 
 COPY ./artifacts/inso-linux-*.tar.xz /tmp/inso.tar.xz
+RUN apt-get update && apt-get install -y xz-utils && rm -rf /var/lib/apt/lists/*
 RUN tar -C /usr/bin -xvf /tmp/inso.tar.xz
 
-FROM docker.io/alpine:3.15.4 AS binary
+FROM --platform=linux/amd64 docker.io/ubuntu:22.04
 COPY --chmod=+x --from=fetch /usr/bin/inso /usr/bin/inso
-RUN apk add --no-cache gcompat libstdc++
+RUN apt-get update && apt-get install -y libstdc++6 && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/usr/bin/inso"]


### PR DESCRIPTION
changelog(Inso CLI):  Added a workaround for running inso docker image on Apple Silicon hosts.


closes INS-3245

Tested locally with Mac M1

### How to test

On a Mac with Apple sillicon chip:

- Download latest inso for linux,`curl -LO "https://github.com/Kong/insomnia/releases/download/lib%408.3.0/inso-linux-8.3.0.tar.xz"` and save it into `packages/insomnia-inso/artifacts/`
- `cd packages/insomnia-inso`
- Run ` DOCKER_BUILDKIT=1 docker build --tag insomnia-inso:temp .`   
- Run `docker run -it --platform linux/amd64 --rm -v $(pwd):/var/temp insomnia-inso:temp --version`, and check if you see output of  `8.3.0` without any errors.