### PR TITLE
clarify cert differences

### DIFF
--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -317,14 +317,15 @@ export const WorkspaceSettingsModal = ({ workspace, clientCertificates, caCertif
                     </PromptButton>
                   </div>
                 </PanelContainer>,
-              }, {
-                  title: 'Client Certificates',
+              },
+                {
+                  title: 'Certificates',
                   children: <PanelContainer className="pad">
                     <div className="form-control form-control--outlined">
                       <label>
                         CA Certificate
                         <HelpTooltip position="right" className="space-left">
-                          One or more PEM format certificates to trust when making requests.
+                          One or more PEM format certificates in a single file to pass to curl. Overrides the root CA certificate.
                         </HelpTooltip>
                       </label>
                       <div className="row-spaced">
@@ -362,6 +363,11 @@ export const WorkspaceSettingsModal = ({ workspace, clientCertificates, caCertif
                         </div>
                       </div>
                     </div>
+                  </PanelContainer>,
+                },
+                {
+                  title: 'Client Certificates',
+                  children: <PanelContainer className="pad">
                     {!showAddCertificateForm ? (
                       <div>
                         {clientCertificates.length === 0 ? (
@@ -399,7 +405,7 @@ export const WorkspaceSettingsModal = ({ workspace, clientCertificates, caCertif
                             className="btn btn--clicky auto"
                             onClick={_handleToggleCertificateForm}
                           >
-                            New Certificate
+                            New Client Certificate
                           </button>
                         </div>
                       </div>


### PR DESCRIPTION
changelog(Improvements): Added clarification on difference between certificates.

The difference between Root CA Certs and Client Certs was not clear in the UI. This PR breaks them into separate tabs, and makes the tooltip clearer for adding multiple Root CA certs in a single file.