### PR TITLE
filter out blank operations

### DIFF
--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -201,7 +201,7 @@ export const GraphQLEditor: FC<Props> = ({
   } catch (error) {
     documentAST = null;
   }
-  const operations = documentAST?.definitions.filter(isOperationDefinition)?.map(def => def.name?.value || '') || [];
+  const operations = documentAST?.definitions.filter(isOperationDefinition)?.map(def => def.name?.value || '').filter(Boolean) || [];
   const operationName = requestBody.operationName || operations[0] || '';
   const [state, setState] = useState<State>({
     body: {
@@ -297,7 +297,7 @@ export const GraphQLEditor: FC<Props> = ({
   const changeQuery = (query: string) => {
     try {
       const documentAST = parse(query);
-      const operations = documentAST.definitions.filter(isOperationDefinition)?.map(def => def.name?.value || '');
+      const operations = documentAST.definitions.filter(isOperationDefinition)?.map(def => def.name?.value || '').filter(Boolean) || [];
       // default to first operation when none selected
       let operationName = state.body.operationName || operations[0] || '';
       if (operations.length && state.body.operationName) {


### PR DESCRIPTION
changelog(Fixes): Fixed issue #5752 where in some cases a GraphQL error with Unknown operation message would be thrown

closes #5752

future work
- clear the operations list when named queries are removed
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
