### PR TITLE
fix: add external event emitter for debug pane [INS-3251]

### DIFF
--- a/packages/insomnia/src/models/graphql-request.ts
+++ b/packages/insomnia/src/models/graphql-request.ts
@@ -1,0 +1,4 @@
+import type { BaseModel } from '.';
+
+export const typeName = 'GraphQLRequest';
+export type GraphqlRequest = BaseModel;

--- a/packages/insomnia/src/ui/components/keydown-binder.ts
+++ b/packages/insomnia/src/ui/components/keydown-binder.ts
@@ -43,6 +43,11 @@ export function useDocBodyKeyboardShortcuts(listeners: { [key in KeyboardShortcu
   useKeyboardShortcuts(() => document.body, listeners);
 }
 
+export interface ConstrainedEmitter {
+  emitter: React.RefObject<HTMLElement>;
+  shouldTrigger: (event: KeyboardEvent | null) => boolean;
+}
+
 export function createConstrainedKeyBindingsHandler(
   hotKeyRegistry: HotKeyRegistry,
   shortcut: KeyboardShortcut,

--- a/packages/insomnia/src/ui/components/keydown-binder.ts
+++ b/packages/insomnia/src/ui/components/keydown-binder.ts
@@ -4,7 +4,7 @@ import tinykeys, { createKeybindingsHandler as _createKeybindingsHandler, KeyBin
 
 import { getPlatformKeyCombinations } from '../../common/hotkeys';
 import { keyboardKeys } from '../../common/keyboard-keys';
-import { KeyboardShortcut, KeyCombination } from '../../common/settings';
+import { HotKeyRegistry, KeyboardShortcut, KeyCombination } from '../../common/settings';
 import { RootLoaderData } from '../routes/root';
 
 const keyCombinationToTinyKeyString = ({ ctrl, alt, shift, meta, keyCode }: KeyCombination): string =>
@@ -41,6 +41,24 @@ export function useKeyboardShortcuts(getTarget: () => HTMLElement, listeners: { 
 
 export function useDocBodyKeyboardShortcuts(listeners: { [key in KeyboardShortcut]?: (event: KeyboardEvent) => any }) {
   useKeyboardShortcuts(() => document.body, listeners);
+}
+
+export function createConstrainedKeyBindingsHandler(
+  hotKeyRegistry: HotKeyRegistry,
+  shortcut: KeyboardShortcut,
+  handler: (event: KeyboardEvent) => void,
+  canTrigger: (event: KeyboardEvent | null) => boolean,
+) {
+  const keyCombos = getPlatformKeyCombinations(hotKeyRegistry[shortcut]);
+  const tinykeysCombo = keyCombinationToTinyKeyString(keyCombos[0]);
+  return createKeybindingsHandler({
+    [tinykeysCombo]: (event: KeyboardEvent) => {
+      if (canTrigger(event)) { // event is checked before handeling
+        handler(event);
+        event.stopPropagation();
+      }
+    },
+  });
 }
 
 export function createKeybindingsHandler(

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -62,6 +62,7 @@ interface Props {
   settings: Settings;
   setLoading: (l: boolean) => void;
   onPaste: (text: string) => void;
+  eventEmitter:  {emitter: React.RefObject<HTMLElement>, shouldTrigger: (event: KeyboardEvent | null) => boolean};
 }
 
 export const RequestPane: FC<Props> = ({
@@ -69,6 +70,7 @@ export const RequestPane: FC<Props> = ({
   settings,
   setLoading,
   onPaste,
+  eventEmitter,
 }) => {
   const { activeRequest, activeRequestMeta } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
   const { workspaceId, requestId } = useParams() as { organizationId: string; projectId: string; workspaceId: string; requestId: string };
@@ -132,6 +134,7 @@ export const RequestPane: FC<Props> = ({
             nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             setLoading={setLoading}
             onPaste={onPaste}
+            eventEmitter={eventEmitter}
           />
         </ErrorBoundary>
       </PaneHeader>

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -37,6 +37,7 @@ const HeaderContainer = styled.div({
   height: '100%',
   overflowY: 'auto',
 });
+import { ConstrainedEmitter } from '../keydown-binder';
 
 export const TabPanelFooter = styled.div({
   boxSizing: 'content-box',
@@ -62,7 +63,7 @@ interface Props {
   settings: Settings;
   setLoading: (l: boolean) => void;
   onPaste: (text: string) => void;
-  eventEmitter:  {emitter: React.RefObject<HTMLElement>, shouldTrigger: (event: KeyboardEvent | null) => boolean};
+  eventEmitter: ConstrainedEmitter;
 }
 
 export const RequestPane: FC<Props> = ({

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -22,6 +22,7 @@ import { Dropdown, DropdownButton, type DropdownHandle, DropdownItem, DropdownSe
 import { OneLineEditor, OneLineEditorHandle } from './codemirror/one-line-editor';
 import { MethodDropdown } from './dropdowns/method-dropdown';
 import { createConstrainedKeyBindingsHandler, createKeybindingsHandler, useDocBodyKeyboardShortcuts } from './keydown-binder';
+import { ConstrainedEmitter } from './keydown-binder';
 import { GenerateCodeModal } from './modals/generate-code-modal';
 import { showAlert, showModal, showPrompt } from './modals/index';
 
@@ -41,7 +42,7 @@ interface Props {
   uniquenessKey: string;
   setLoading: (l: boolean) => void;
   onPaste: (text: string) => void;
-  eventEmitter: { emitter: React.RefObject<HTMLElement>; shouldTrigger: (event: KeyboardEvent | null) => boolean };
+  eventEmitter: ConstrainedEmitter;
 }
 
 export interface RequestUrlBarHandle {

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -22,6 +22,7 @@ import { QueryEditorContainer, QueryEditorPreview } from '../editors/query-edito
 import { RequestHeadersEditor } from '../editors/request-headers-editor';
 import { RequestParametersEditor } from '../editors/request-parameters-editor';
 import { ErrorBoundary } from '../error-boundary';
+import { ConstrainedEmitter } from '../keydown-binder';
 import { MarkdownPreview } from '../markdown-preview';
 import { showAlert, showModal } from '../modals';
 import { RequestRenderErrorModal } from '../modals/request-render-error-modal';
@@ -199,13 +200,14 @@ const WebSocketRequestForm: FC<FormProps> = ({
 
 interface Props {
   environment: Environment | null;
+  eventEmitter: ConstrainedEmitter;
 }
 
 // requestId is something we can read from the router params in the future.
 // essentially we can lift up the states and merge request pane and response pane into a single page and divide the UI there.
 // currently this is blocked by the way page layout divide the panes with dragging functionality
 // TODO: @gatzjames discuss above assertion in light of request and settings drills
-export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
+export const WebSocketRequestPane: FC<Props> = ({ environment, eventEmitter }) => {
   const { activeRequest, activeRequestMeta } = useRouteLoaderData('request/:requestId') as WebSocketRequestLoaderData;
 
   const { workspaceId, requestId } = useParams() as { organizationId: string; projectId: string; workspaceId: string; requestId: string };
@@ -269,6 +271,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
           defaultValue={activeRequest.url}
           readyState={readyState}
           onChange={url => patchRequest(requestId, { url })}
+          eventEmitter={eventEmitter}
         />
       </PaneHeader>
       <Tabs aria-label="Websocket request pane tabs">

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -1,7 +1,7 @@
 import { IconName } from '@fortawesome/fontawesome-svg-core';
 import { ServiceError, StatusObject } from '@grpc/grpc-js';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import React, { FC, Fragment, useEffect, useRef, useState, useCallback } from 'react';
+import React, { FC, Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import {
   Breadcrumbs,
   Button,
@@ -61,6 +61,7 @@ import { EditableInput } from '../components/editable-input';
 import { ErrorBoundary } from '../components/error-boundary';
 import { Icon } from '../components/icon';
 import { useDocBodyKeyboardShortcuts } from '../components/keydown-binder';
+import { ConstrainedEmitter } from '../components/keydown-binder';
 import { showModal, showPrompt } from '../components/modals';
 import { AskModal } from '../components/modals/ask-modal';
 import { CookiesModal } from '../components/modals/cookies-modal';
@@ -94,7 +95,6 @@ import {
 } from './request';
 import { useRootLoaderData } from './root';
 import { Child, WorkspaceLoaderData } from './workspace';
-import { ConstrainedEmitter } from '../components/keydown-binder';
 
 export interface GrpcMessage {
   id: string;


### PR DESCRIPTION
Changes:
- enable triggering "send_request" shortcut from the sidebar (only request pane at the moment for proving the concept)

Basically it works as follows:
- `createConstrainedKeyBindingsHandler` it used to create `handler`, but it requires `canTrigger` which is used to check if the `handler` is the right one to handle this event, or it is ignored:  https://github.com/Kong/insomnia/pull/6741/files#diff-aa935df29d21cc7483dd6774e7ae9b94360a38f8af4de3559b6b1c6a2f98f758R46
- the parent container ref of the request pane is passed down to the `requestUrlBar` component: https://github.com/Kong/insomnia/pull/6741/files#diff-90289a1dd4d5e1f790d27cbaac39ac31d4047cdaaca08db27519d74a7be54a75R627
- the checking function is also passed down to request url ref, which checks if event should be handled: https://github.com/Kong/insomnia/pull/6741/files#diff-90289a1dd4d5e1f790d27cbaac39ac31d4047cdaaca08db27519d74a7be54a75R628
- in the ``requestUrlBar` component, `sendOrConnect` is registered as the handlers, but it only handles events from request pane: https://github.com/Kong/insomnia/pull/6741/files#diff-3e17ed01baf08f2cd291be25e10fe30f7c181d29bfcee97b8f91d1e6652cbbc8R204
- furthermore, we can check if any modal is active to prevent listener handling "CMD+Enter": https://github.com/Kong/insomnia/pull/6741/files#diff-90289a1dd4d5e1f790d27cbaac39ac31d4047cdaaca08db27519d74a7be54a75R632
