### PR TITLE
refactor: migration [INS-3248]

### DIFF
--- a/packages/insomnia/src/sync/vcs/__tests__/database.mock.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/database.mock.ts
@@ -1,0 +1,426 @@
+import { database as db } from '../../../common/database';
+import * as models from '../../../models';
+import { Project } from '../../../models/project';
+import { Request } from '../../../models/request';
+import { RequestGroup } from '../../../models/request-group';
+import { Workspace } from '../../../models/workspace';
+import { WorkspaceMeta } from '../../../models/workspace-meta';
+
+type MockModel = Partial<Project | Workspace | RequestGroup | Request | WorkspaceMeta>;
+const mocksWithoutParentIdProjects: Record<string, MockModel[]> = {
+    [models.project.type]: [
+        {
+            _id: 'proj_1',
+            name: 'Proj 1',
+            parentId: null,
+            remoteId: null,
+        } as unknown as Project,
+        {
+            _id: 'proj_2',
+            name: 'Proj 2',
+            parentId: null,
+            remoteId: null,
+        } as unknown as Project,
+        {
+            _id: 'proj_3',
+            name: 'Proj 3',
+            parentId: null,
+            remoteId: null,
+        } as unknown as Project,
+    ],
+    [models.workspace.type]: [
+        {
+            _id: 'wrk_1',
+            name: 'Wrk 1',
+            parentId: null,
+        } as unknown as Workspace,
+        {
+            _id: 'wrk_2',
+            name: 'Wrk 2',
+            parentId: 'proj_3',
+        },
+        {
+            _id: 'wrk_3',
+            name: 'Wrk 3',
+            parentId: 'proj_3',
+        },
+        {
+            _id: 'wrk_4',
+            name: 'Wrk 4',
+            parentId: 'proj_3',
+        },
+    ],
+    [models.requestGroup.type]: [
+        {
+            _id: 'fld_1',
+            parentId: 'wrk_1',
+            name: 'Fld 1',
+        },
+        {
+            _id: 'fld_2',
+            parentId: 'wrk_1',
+            name: 'Fld 2',
+        },
+        {
+            _id: 'fld_3',
+            parentId: 'fld_1',
+            name: 'Fld 3',
+        },
+    ],
+    [models.request.type]: [
+        {
+            _id: 'req_1',
+            parentId: 'fld_1',
+            name: 'Req 1',
+        },
+        {
+            _id: 'req_2',
+            parentId: 'fld_1',
+            name: 'Req 2',
+        },
+        {
+            _id: 'req_3',
+            parentId: 'wrk_1',
+            name: 'Req 3',
+        },
+        {
+            _id: 'req_4',
+            parentId: 'fld_3',
+            name: 'Req 4',
+        },
+        {
+            _id: 'req_5',
+            parentId: 'wrk_1',
+            name: 'Req 5',
+        },
+    ],
+};
+
+const mocksHiddenWorkspaces: Record<string, MockModel[]> = {
+    [models.project.type]: [
+        {
+            _id: 'proj_1',
+            name: 'Proj 1',
+            parentId: 'org_1',
+            remoteId: 'team_1',
+        },
+    ],
+    [models.workspace.type]: [
+        {
+            _id: 'wrk_1',
+            name: 'Wrk 1',
+            parentId: 'proj_1',
+        },
+        {
+            _id: 'wrk_2',
+            name: 'Wrk 2',
+            parentId: null,
+        } as unknown as Workspace,
+        {
+            _id: 'wrk_3',
+            name: 'Wrk 3',
+            parentId: null,
+        } as unknown as Workspace,
+        {
+            _id: 'wrk_4',
+            name: 'Wrk 4',
+            parentId: null,
+        } as unknown as Workspace,
+    ],
+    [models.requestGroup.type]: [
+        {
+            _id: 'fld_1',
+            parentId: 'wrk_1',
+            name: 'Fld 1',
+        },
+        {
+            _id: 'fld_2',
+            parentId: 'wrk_1',
+            name: 'Fld 2',
+        },
+        {
+            _id: 'fld_3',
+            parentId: 'fld_1',
+            name: 'Fld 3',
+        },
+    ],
+    [models.request.type]: [
+        {
+            _id: 'req_1',
+            parentId: 'fld_1',
+            name: 'Req 1',
+        },
+        {
+            _id: 'req_2',
+            parentId: 'fld_1',
+            name: 'Req 2',
+        },
+        {
+            _id: 'req_3',
+            parentId: 'wrk_1',
+            name: 'Req 3',
+        },
+        {
+            _id: 'req_4',
+            parentId: 'fld_3',
+            name: 'Req 4',
+        },
+        {
+            _id: 'req_5',
+            parentId: 'wrk_1',
+            name: 'Req 5',
+        },
+    ],
+};
+
+const mocksNoProblem: Record<string, MockModel[]> = {
+    [models.project.type]: [
+        {
+            _id: 'proj_1',
+            name: 'Proj 1',
+            parentId: 'org_1',
+            remoteId: null,
+        },
+        {
+            _id: 'proj_2',
+            name: 'Proj 2',
+            parentId: 'org_2',
+            remoteId: null,
+        },
+        {
+            _id: 'proj_3',
+            name: 'Proj 3',
+            parentId: 'org_3',
+            remoteId: 'team_proj_3',
+        },
+    ],
+    [models.workspace.type]: [
+        {
+            _id: 'wrk_1',
+            name: 'Wrk 1',
+            parentId: 'proj_1',
+        },
+        {
+            _id: 'wrk_2',
+            name: 'Wrk 2',
+            parentId: 'proj_3',
+        },
+    ],
+    [models.requestGroup.type]: [
+        {
+            _id: 'fld_1',
+            parentId: 'wrk_1',
+            name: 'Fld 1',
+        },
+        {
+            _id: 'fld_2',
+            parentId: 'wrk_1',
+            name: 'Fld 2',
+        },
+        {
+            _id: 'fld_3',
+            parentId: 'fld_1',
+            name: 'Fld 3',
+        },
+    ],
+    [models.request.type]: [
+        {
+            _id: 'req_1',
+            parentId: 'fld_1',
+            name: 'Req 1',
+        },
+        {
+            _id: 'req_2',
+            parentId: 'fld_1',
+            name: 'Req 2',
+        },
+        {
+            _id: 'req_3',
+            parentId: 'wrk_1',
+            name: 'Req 3',
+        },
+        {
+            _id: 'req_4',
+            parentId: 'fld_3',
+            name: 'Req 4',
+        },
+        {
+            _id: 'req_5',
+            parentId: 'wrk_1',
+            name: 'Req 5',
+        },
+    ],
+};
+
+const mocksToBeRepaired: Record<string, MockModel[]> = {
+    [models.project.type]: [
+        {
+            _id: 'proj_1',
+            name: 'Proj 1',
+            parentId: null,
+            remoteId: 'team_1',
+        } as unknown as Project,
+        {
+            _id: 'proj_2',
+            name: 'Proj 2',
+            parentId: null,
+            remoteId: 'team_2',
+        } as unknown as Project,
+        {
+            _id: 'proj_3',
+            name: 'Proj 3',
+            parentId: null,
+            remoteId: null,
+        } as unknown as Project,
+    ],
+    [models.workspace.type]: [
+        {
+            _id: 'wrk_1',
+            name: 'Wrk 1',
+            parentId: null,
+        } as unknown as Workspace,
+        {
+            _id: 'wrk_2',
+            name: 'Wrk 2',
+            parentId: 'proj_3',
+        },
+        {
+            _id: 'wrk_3',
+            name: 'Wrk 3',
+            parentId: 'proj_3',
+        },
+        {
+            _id: 'wrk_4',
+            name: 'Wrk 4',
+            parentId: 'proj_3',
+        },
+    ],
+    [models.requestGroup.type]: [
+        {
+            _id: 'fld_1',
+            parentId: 'wrk_1',
+            name: 'Fld 1',
+        },
+        {
+            _id: 'fld_2',
+            parentId: 'wrk_1',
+            name: 'Fld 2',
+        },
+        {
+            _id: 'fld_3',
+            parentId: 'fld_1',
+            name: 'Fld 3',
+        },
+    ],
+    [models.request.type]: [
+        {
+            _id: 'req_1',
+            parentId: 'fld_1',
+            name: 'Req 1',
+        },
+        {
+            _id: 'req_2',
+            parentId: 'fld_1',
+            name: 'Req 2',
+        },
+        {
+            _id: 'req_3',
+            parentId: 'wrk_1',
+            name: 'Req 3',
+        },
+        {
+            _id: 'req_4',
+            parentId: 'fld_3',
+            name: 'Req 4',
+        },
+        {
+            _id: 'req_5',
+            parentId: 'wrk_1',
+            name: 'Req 5',
+        },
+    ],
+};
+
+const mockRemoteBackgroundCheck = {
+    myWorkspaceId: 'org_my',
+    remoteFileSnapshot: {
+        'org_my': {
+            ownedByMe: true,
+            isPersonal: true,
+            fileIdMap: {
+                'wrk_1': 'team_1',
+                'wrk_2': 'team_1',
+                'wrk_3': 'team_2',
+                'wrk_4': 'team_3',
+            },
+            projectIds: ['team_1', 'team_2', 'team_3', 'team_4', 'team_5'],
+        },
+        'org_1': {
+            ownedByMe: false,
+            isPersonal: false,
+            fileIdMap: {},
+            projectIds: [],
+        },
+    },
+    byRemoteProjectId: new Map([
+        ['team_1', 'org_my'],
+        ['team_2', 'org_my'],
+        ['team_3', 'org_my'],
+        ['team_4', 'org_my'],
+        ['team_5', 'org_my'],
+        ['team_6', 'org_1'],
+    ]),
+    byRemoteFileId: new Map([
+        ['wrk_1', {
+            remoteOrgId: 'org_my',
+            remoteProjectId: 'team_1',
+        }],
+        ['wrk_2', {
+            remoteOrgId: 'org_my',
+            remoteProjectId: 'team_1',
+        }],
+        ['wrk_3', {
+            remoteOrgId: 'org_my',
+            remoteProjectId: 'team_2',
+        }],
+        ['wrk_4', {
+            remoteOrgId: 'org_my',
+            remoteProjectId: 'team_2',
+        }],
+    ]),
+};
+
+const mockRemoteBackgroundCheckMessedUp = {
+    myWorkspaceId: 'org_my',
+    remoteFileSnapshot: {
+        'org_my': {
+            ownedByMe: true,
+            isPersonal: true,
+            fileIdMap: {
+            },
+            projectIds: [],
+        },
+        'org_1': {
+            ownedByMe: false,
+            isPersonal: false,
+            fileIdMap: {},
+            projectIds: [],
+        },
+    },
+    byRemoteProjectId: new Map(),
+    byRemoteFileId: new Map(),
+};
+export function fakeDatabase(data: Record<string, MockModel[]>) {
+    const promises: Promise<models.BaseModel>[] = [];
+    for (const type of Object.keys(data)) {
+        for (const doc of data[type]) {
+            console.log(doc);
+            // @ts-expect-error -- TSCONVERSION
+            promises.push(db.insert<models.BaseModel>({ ...doc, type }));
+        }
+    }
+    return Promise.all(promises);
+}
+
+export { mocksWithoutParentIdProjects, mocksHiddenWorkspaces, mocksNoProblem, mocksToBeRepaired };
+export { mockRemoteBackgroundCheck, mockRemoteBackgroundCheckMessedUp };

--- a/packages/insomnia/src/sync/vcs/__tests__/database.mock.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/database.mock.ts
@@ -341,6 +341,194 @@ const mocksToBeRepaired: Record<string, MockModel[]> = {
     ],
 };
 
+const mocksToBeRepairedWithValidProjects: Record<string, MockModel[]> = {
+    [models.project.type]: [
+        {
+            _id: 'proj_1',
+            name: 'Proj 1',
+            parentId: null,
+            remoteId: 'team_1',
+        } as unknown as Project,
+        {
+            _id: 'proj_2',
+            name: 'Proj 2',
+            parentId: null,
+            remoteId: 'team_2',
+        } as unknown as Project,
+        {
+            _id: 'proj_3',
+            name: 'Proj 3',
+            parentId: null,
+            remoteId: null,
+        } as unknown as Project,
+    ],
+    [models.workspace.type]: [
+        {
+            _id: 'wrk_1',
+            name: 'Wrk 1',
+            parentId: null,
+        } as unknown as Workspace,
+        {
+            _id: 'wrk_2',
+            name: 'Wrk 2',
+            parentId: 'proj_3',
+        },
+        {
+            _id: 'wrk_3',
+            name: 'Wrk 3',
+            parentId: 'proj_3',
+        },
+        {
+            _id: 'wrk_4',
+            name: 'Wrk 4',
+            parentId: 'proj_3',
+        },
+    ],
+    [models.requestGroup.type]: [
+        {
+            _id: 'fld_1',
+            parentId: 'wrk_1',
+            name: 'Fld 1',
+        },
+        {
+            _id: 'fld_2',
+            parentId: 'wrk_1',
+            name: 'Fld 2',
+        },
+        {
+            _id: 'fld_3',
+            parentId: 'fld_1',
+            name: 'Fld 3',
+        },
+    ],
+    [models.request.type]: [
+        {
+            _id: 'req_1',
+            parentId: 'fld_1',
+            name: 'Req 1',
+        },
+        {
+            _id: 'req_2',
+            parentId: 'fld_1',
+            name: 'Req 2',
+        },
+        {
+            _id: 'req_3',
+            parentId: 'wrk_1',
+            name: 'Req 3',
+        },
+        {
+            _id: 'req_4',
+            parentId: 'fld_3',
+            name: 'Req 4',
+        },
+        {
+            _id: 'req_5',
+            parentId: 'wrk_1',
+            name: 'Req 5',
+        },
+    ],
+};
+
+const mocksToBeRepairedWithNoDupe: Record<string, MockModel[]> = {
+    [models.project.type]: [
+        {
+            _id: 'proj_1',
+            name: 'Proj 1',
+            parentId: null,
+            remoteId: 'team_1',
+        } as unknown as Project,
+        {
+            _id: 'proj_2',
+            name: 'Proj 2',
+            parentId: null,
+            remoteId: 'team_2',
+        } as unknown as Project,
+        {
+            _id: 'proj_3',
+            name: 'Proj 3',
+            parentId: null,
+            remoteId: null,
+        } as unknown as Project,
+    ],
+    [models.workspace.type]: [
+        {
+            _id: 'wrk_1',
+            name: 'Wrk 1',
+            parentId: 'proj_1',
+        },
+        {
+            _id: 'wrk_2',
+            name: 'Wrk 2',
+            parentId: 'proj_1',
+        },
+        {
+            _id: 'wrk_3',
+            name: 'Wrk 3',
+            parentId: 'proj_2',
+        },
+        {
+            _id: 'wrk_4',
+            name: 'Wrk 4',
+            parentId: 'proj_2',
+        },
+        {
+            _id: 'wrk_5',
+            name: 'Wrk 5',
+            parentId: 'proj_3',
+        },
+        {
+            _id: 'wrk_6',
+            name: 'Wrk 6',
+            parentId: 'proj_3',
+        },
+    ],
+    [models.requestGroup.type]: [
+        {
+            _id: 'fld_1',
+            parentId: 'wrk_1',
+            name: 'Fld 1',
+        },
+        {
+            _id: 'fld_2',
+            parentId: 'wrk_1',
+            name: 'Fld 2',
+        },
+        {
+            _id: 'fld_3',
+            parentId: 'fld_1',
+            name: 'Fld 3',
+        },
+    ],
+    [models.request.type]: [
+        {
+            _id: 'req_1',
+            parentId: 'fld_1',
+            name: 'Req 1',
+        },
+        {
+            _id: 'req_2',
+            parentId: 'fld_1',
+            name: 'Req 2',
+        },
+        {
+            _id: 'req_3',
+            parentId: 'wrk_1',
+            name: 'Req 3',
+        },
+        {
+            _id: 'req_4',
+            parentId: 'fld_3',
+            name: 'Req 4',
+        },
+        {
+            _id: 'req_5',
+            parentId: 'wrk_1',
+            name: 'Req 5',
+        },
+    ],
+};
+
 const mockRemoteBackgroundCheck = {
     myWorkspaceId: 'org_my',
     remoteFileSnapshot: {
@@ -410,11 +598,11 @@ const mockRemoteBackgroundCheckMessedUp = {
     byRemoteProjectId: new Map(),
     byRemoteFileId: new Map(),
 };
+
 export function fakeDatabase(data: Record<string, MockModel[]>) {
     const promises: Promise<models.BaseModel>[] = [];
     for (const type of Object.keys(data)) {
         for (const doc of data[type]) {
-            console.log(doc);
             // @ts-expect-error -- TSCONVERSION
             promises.push(db.insert<models.BaseModel>({ ...doc, type }));
         }
@@ -422,5 +610,5 @@ export function fakeDatabase(data: Record<string, MockModel[]>) {
     return Promise.all(promises);
 }
 
-export { mocksWithoutParentIdProjects, mocksHiddenWorkspaces, mocksNoProblem, mocksToBeRepaired };
+export { mocksWithoutParentIdProjects, mocksHiddenWorkspaces, mocksNoProblem, mocksToBeRepaired, mocksToBeRepairedWithValidProjects, mocksToBeRepairedWithNoDupe };
 export { mockRemoteBackgroundCheck, mockRemoteBackgroundCheckMessedUp };

--- a/packages/insomnia/src/sync/vcs/__tests__/migrate-projects-into-organizatino.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/migrate-projects-into-organizatino.test.ts
@@ -238,7 +238,7 @@ describe('_migrateToLocalVault()', () => {
       models.workspace.getById(records.files.get('wrk_4')),
     ]);
 
-    expect(wrk1).toMatchObject({});
+    expect(wrk1!.parentId).toBe('proj_1');
     expect(wrk2).toBeTruthy();
     expect(wrk2!.parentId).not.toBeNull();
 

--- a/packages/insomnia/src/sync/vcs/__tests__/migrate-projects-into-organizatino.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/migrate-projects-into-organizatino.test.ts
@@ -1,73 +1,212 @@
-import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 
 import { globalBeforeEach } from '../../../__jest__/before-each';
 import * as models from '../../../models';
-import MemoryDriver from '../../store/drivers/memory-driver';
-import { pushSnapshotOnInitialize } from '../initialize-backend-project';
-import { VCS } from '../vcs';
+import { _migrateToCloudSync, _migrateToLocalVault, _validateProjectsWithRemote, scanForMigration, shouldMigrate } from '../migrate-projects-into-organization';
+import { fakeDatabase, mockRemoteBackgroundCheck, mockRemoteBackgroundCheckMessedUp, mocksHiddenWorkspaces, mocksNoProblem, mocksToBeRepaired, mocksWithoutParentIdProjects } from './database.mock';
 
-describe('migrate-projects-into-organizatino', () => {
-  beforeEach(globalBeforeEach);
+console.log({
+  _migrateToCloudSync, _migrateToLocalVault, _validateProjectsWithRemote,
+});
+describe('scanForMigration()', () => {
+  beforeEach(async () => {
+    await globalBeforeEach();
+  });
+  it('should scan all the untracked projects and files (both files under projects and un parent project files)', async () => {
+    await fakeDatabase(mocksWithoutParentIdProjects);
 
-  describe('pushSnapshotOnInitialize()', () => {
-    const vcs = new VCS(new MemoryDriver());
+    const result = await scanForMigration();
+    console.log(result.filesByProject.size);
+    expect(result.filesByProject.size).toBe(3);
 
-    const pushSpy = jest.spyOn(vcs, 'push');
+    expect(result.filesByProject.has('wrk_2'));
+    expect(result.filesByProject.has('wrk_3'));
+    expect(result.filesByProject.has('wrk_4'));
+    expect(result.filesNoProject.size).toBe(1);
+    expect(result.filesNoProject.has('wrk_1'));
+    expect(result.projects.size).toBe(3);
+    expect(result.projects.has('proj_1'));
+    expect(result.projects.has('proj_2'));
+    expect(result.projects.has('proj_3'));
+  });
 
-    beforeEach(() => {
-      jest.resetAllMocks();
-    });
+  it('should scan all the untracked files (only files)', async () => {
+    await fakeDatabase(mocksHiddenWorkspaces);
 
-    afterAll(() => {
-      pushSpy.mockClear();
-    });
+    const result = await scanForMigration();
+    expect(result.filesByProject.size).toBe(0);
+    expect(result.filesNoProject.size).toBe(3);
+    expect(result.filesNoProject.has('wrk_2'));
+    expect(result.filesNoProject.has('wrk_3'));
+    expect(result.filesNoProject.has('wrk_4'));
+    expect(result.projects.size).toBe(0);
+  });
 
-    it('should not push if no active project', async () => {
-      const project = await models.project.create({ remoteId: null });
-      const workspace = await models.workspace.create({ parentId: project._id });
-      const workspaceMeta = await models.workspaceMeta.create({ parentId: workspace._id });
-      vcs.clearBackendProject();
+  it('should scan when there are no untracked projects and files', async () => {
+    await fakeDatabase(mocksNoProblem);
 
-      await pushSnapshotOnInitialize({ vcs, project, workspace });
+    const result = await scanForMigration();
+    expect(result.filesByProject.size).toBe(0);
+    expect(result.filesNoProject.size).toBe(0);
+    expect(result.projects.size).toBe(0);
+  });
+});
 
-      expect(pushSpy).not.toHaveBeenCalled();
-      await expect(models.workspaceMeta.getByParentId(workspace._id)).resolves.toStrictEqual(workspaceMeta);
-    });
+describe('shouldMigrate()', () => {
+  beforeEach(async () => {
+    await globalBeforeEach();
+  });
+  it('should return true with untracked projects and files (both files under projects and un parent project files)', async () => {
+    await fakeDatabase(mocksWithoutParentIdProjects);
 
-    it('should not push snapshot if not remote project', async () => {
-      const project = await models.project.create({ remoteId: null });
-      const workspace = await models.workspace.create({ parentId: project._id });
-      const workspaceMeta = await models.workspaceMeta.create({ parentId: workspace._id });
-      vcs.switchAndCreateBackendProjectIfNotExist(workspace._id, workspace.name);
+    const queue = await scanForMigration();
+    const result = await shouldMigrate(queue);
+    expect(result).toBeTruthy();
+  });
 
-      await pushSnapshotOnInitialize({ vcs, project, workspace });
+  it('should return true with untracked files (only files)', async () => {
+    await fakeDatabase(mocksHiddenWorkspaces);
 
-      expect(pushSpy).not.toHaveBeenCalled();
-      await expect(models.workspaceMeta.getByParentId(workspace._id)).resolves.toStrictEqual(workspaceMeta);
-    });
+    const queue = await scanForMigration();
+    const result = await shouldMigrate(queue);
+    expect(result).toBeTruthy();
+  });
 
-    it('should not push snapshot if workspace not in project', async () => {
-      const project = await models.project.create({ remoteId: 'abc' });
-      const anotherProject = await models.project.create({ remoteId: 'def' });
-      const workspace = await models.workspace.create({ parentId: anotherProject._id });
-      vcs.switchAndCreateBackendProjectIfNotExist(workspace._id, workspace.name);
+  it('should return false with no untracked files', async () => {
+    await fakeDatabase(mocksNoProblem);
 
-      await pushSnapshotOnInitialize({ vcs, project, workspace });
+    const queue = await scanForMigration();
+    const result = await shouldMigrate(queue);
+    expect(result).not.toBeTruthy();
+  });
+});
 
-      expect(pushSpy).not.toHaveBeenCalled();
-    });
+describe('_migrateToCloudSync()', () => {
+  beforeEach(async () => {
+    await globalBeforeEach();
+  });
 
-    it('should push snapshot if conditions are met', async () => {
-      const project = await models.project.create({ remoteId: 'abc', parentId: 'team_abc' });
-      const workspace = await models.workspace.create({ parentId: project._id });
-      await models.workspaceMeta.create({ parentId: workspace._id, pushSnapshotOnInitialize: true });
-      vcs.switchAndCreateBackendProjectIfNotExist(workspace._id, workspace.name);
+  it('should fallback to local migration when there are no valid remote projects', async () => {
+    await fakeDatabase(mocksWithoutParentIdProjects);
 
-      await pushSnapshotOnInitialize({ vcs, project, workspace });
+    const queue = await scanForMigration();
+    const records = await _migrateToCloudSync(queue, mockRemoteBackgroundCheckMessedUp);
 
-      expect(pushSpy).toHaveBeenCalledWith({ teamId: 'team_abc', teamProjectId: project.remoteId });
-      const updatedMeta = await models.workspaceMeta.getByParentId(workspace._id);
-      expect(updatedMeta?.pushSnapshotOnInitialize).toBe(false);
-    });
+    expect(records.filesForSync.length).toBe(0);
+    expect(records.projects.size).toBe(3);
+    expect(records.projects.has('proj_1')).toBeTruthy();
+    expect(records.projects.has('proj_2')).toBeTruthy();
+    expect(records.projects.has('proj_3')).toBeTruthy();
+    const [proj1, proj2, proj3] = await Promise.all([
+      models.project.getById(records.projects.get('proj_1')!),
+      models.project.getById(records.projects.get('proj_2')!),
+      models.project.getById(records.projects.get('proj_3')!),
+    ]);
+    expect(proj1).toBeTruthy();
+    expect(proj1!.remoteId).toBeNull();
+    expect(proj2).toBeTruthy();
+    expect(proj2!.remoteId).toBeNull();
+    expect(proj3).toBeTruthy();
+    expect(proj3!.remoteId).toBeNull();
+
+    expect(records.files.size).toBe(4);
+    expect(records.files.has('wrk_1')).toBeTruthy();
+    expect(records.files.has('wrk_2')).toBeTruthy(); // part of proj_3
+    expect(records.files.has('wrk_3')).toBeTruthy(); // part of proj_3
+    expect(records.files.has('wrk_4')).toBeTruthy(); // part of proj_3
+  });
+
+  it('should repair projects with valid remote ids with personal workspace id if not linked correctly', async () => {
+    await fakeDatabase(mocksToBeRepaired);
+
+    const beforeProj1 = await models.project.getById('proj_1');
+    expect(beforeProj1!.parentId).toBeNull();
+
+    const beforeProj2 = await models.project.getById('proj_2');
+    expect(beforeProj2!.parentId).toBeNull();
+
+    const queue = await scanForMigration();
+    const records = await _migrateToCloudSync(queue, mockRemoteBackgroundCheck);
+
+    expect(records.projects.size).toBe(1);
+    expect(records.files.size).toBe(4); // => we've duplicated the files because they are not in correct linking between the local and remote
+
+    const repairedProj1 = await models.project.getById('proj_1');
+    expect(repairedProj1!.parentId).toBe('org_my');
+
+    const repairedProj2 = await models.project.getById('proj_2');
+    expect(repairedProj2!.parentId).toBe('org_my');
+
+    const [wrk1, wrk2, wrk3, wrk4] = await Promise.all([
+      models.workspace.getById(records.files.get('wrk_1')!),
+      models.workspace.getById(records.files.get('wrk_2')!),
+      models.workspace.getById(records.files.get('wrk_3')!),
+      models.workspace.getById(records.files.get('wrk_4')!),
+    ]);
+
+    expect(wrk1!.parentId).not.toBeNull(); // files without parent id (no project linking) => now corrected
+    expect(wrk2!.parentId).not.toBe('proj_3'); // files with the parent id that does not exist in the cloud => duplicated and linked to the existing remote project
+    expect(wrk3!.parentId).not.toBe('proj_3'); // files with the parent id that does not exist in the cloud => duplicated and linked to the existing remote project
+    expect(wrk4!.parentId).not.toBe('proj_3'); // files with the parent id that does not exist in the cloud => duplicated and linked to the existing remote project
+
+    // these duplicated 4 files need to be synced now
+    expect(records.filesForSync.length).toBe(4);
+  });
+});
+
+describe('_migrateToLocalVault()', () => {
+  beforeEach(async () => {
+    await globalBeforeEach();
+  });
+
+  it('should duplicate all files and projects', async () => {
+    await fakeDatabase(mocksWithoutParentIdProjects);
+
+    const queue = await scanForMigration();
+    const records = await _migrateToLocalVault(queue, mockRemoteBackgroundCheck);
+
+    // should never happen
+    expect(records).not.toHaveProperty('filesForSync');
+    expect(records.projects.size).toBe(3);
+    expect(records.projects.has('proj_1')).toBeTruthy();
+    expect(records.projects.has('proj_2')).toBeTruthy();
+    expect(records.projects.has('proj_3')).toBeTruthy();
+    expect(records.files.size).toBe(4);
+    expect(records.files.has('wrk_1')).toBeTruthy();
+    expect(records.files.has('wrk_2')).toBeTruthy(); // part of proj_3
+    expect(records.files.has('wrk_3')).toBeTruthy(); // part of proj_3
+    expect(records.files.has('wrk_4')).toBeTruthy(); // part of proj_3
+  });
+
+  it('should link untracked files to a newly created local vault', async () => {
+    await fakeDatabase(mocksHiddenWorkspaces);
+
+    const queue = await scanForMigration();
+    const records = await _migrateToLocalVault(queue, mockRemoteBackgroundCheck);
+    expect(records).not.toHaveProperty('filesForSync');
+    expect(records.projects.size).toBe(0);
+    expect(records.projects.has('proj_1')).not.toBeTruthy();
+    expect(records.files.size).toBe(3);
+    expect(records.files.has('wrk_1')).not.toBeTruthy(); // part of proj_1
+    expect(records.files.has('wrk_2')).toBeTruthy();
+    expect(records.files.has('wrk_3')).toBeTruthy();
+    expect(records.files.has('wrk_4')).toBeTruthy();
+
+    const [wrk1, wrk2, wrk3, wrk4] = await Promise.all([
+      models.workspace.getById('wrk_1'),
+      models.workspace.getById(records.files.get('wrk_2')),
+      models.workspace.getById(records.files.get('wrk_3')),
+      models.workspace.getById(records.files.get('wrk_4')),
+    ]);
+
+    expect(wrk1).toMatchObject({});
+    expect(wrk2).toBeTruthy();
+    expect(wrk2?.parentId).not.toBeNull();
+
+    const { parentId: newVaultId } = wrk2!;
+    expect(wrk3).toBeTruthy();
+    expect(wrk3?.parentId).toEqual(newVaultId);
+    expect(wrk4).toBeTruthy();
+    expect(wrk4?.parentId).toEqual(newVaultId);
   });
 });

--- a/packages/insomnia/src/sync/vcs/__tests__/migrate-projects-into-organizatino.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/migrate-projects-into-organizatino.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { globalBeforeEach } from '../../../__jest__/before-each';
+import * as models from '../../../models';
+import MemoryDriver from '../../store/drivers/memory-driver';
+import { pushSnapshotOnInitialize } from '../initialize-backend-project';
+import { VCS } from '../vcs';
+
+describe('migrate-projects-into-organizatino', () => {
+  beforeEach(globalBeforeEach);
+
+  describe('pushSnapshotOnInitialize()', () => {
+    const vcs = new VCS(new MemoryDriver());
+
+    const pushSpy = jest.spyOn(vcs, 'push');
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    afterAll(() => {
+      pushSpy.mockClear();
+    });
+
+    it('should not push if no active project', async () => {
+      const project = await models.project.create({ remoteId: null });
+      const workspace = await models.workspace.create({ parentId: project._id });
+      const workspaceMeta = await models.workspaceMeta.create({ parentId: workspace._id });
+      vcs.clearBackendProject();
+
+      await pushSnapshotOnInitialize({ vcs, project, workspace });
+
+      expect(pushSpy).not.toHaveBeenCalled();
+      await expect(models.workspaceMeta.getByParentId(workspace._id)).resolves.toStrictEqual(workspaceMeta);
+    });
+
+    it('should not push snapshot if not remote project', async () => {
+      const project = await models.project.create({ remoteId: null });
+      const workspace = await models.workspace.create({ parentId: project._id });
+      const workspaceMeta = await models.workspaceMeta.create({ parentId: workspace._id });
+      vcs.switchAndCreateBackendProjectIfNotExist(workspace._id, workspace.name);
+
+      await pushSnapshotOnInitialize({ vcs, project, workspace });
+
+      expect(pushSpy).not.toHaveBeenCalled();
+      await expect(models.workspaceMeta.getByParentId(workspace._id)).resolves.toStrictEqual(workspaceMeta);
+    });
+
+    it('should not push snapshot if workspace not in project', async () => {
+      const project = await models.project.create({ remoteId: 'abc' });
+      const anotherProject = await models.project.create({ remoteId: 'def' });
+      const workspace = await models.workspace.create({ parentId: anotherProject._id });
+      vcs.switchAndCreateBackendProjectIfNotExist(workspace._id, workspace.name);
+
+      await pushSnapshotOnInitialize({ vcs, project, workspace });
+
+      expect(pushSpy).not.toHaveBeenCalled();
+    });
+
+    it('should push snapshot if conditions are met', async () => {
+      const project = await models.project.create({ remoteId: 'abc', parentId: 'team_abc' });
+      const workspace = await models.workspace.create({ parentId: project._id });
+      await models.workspaceMeta.create({ parentId: workspace._id, pushSnapshotOnInitialize: true });
+      vcs.switchAndCreateBackendProjectIfNotExist(workspace._id, workspace.name);
+
+      await pushSnapshotOnInitialize({ vcs, project, workspace });
+
+      expect(pushSpy).toHaveBeenCalledWith({ teamId: 'team_abc', teamProjectId: project.remoteId });
+      const updatedMeta = await models.workspaceMeta.getByParentId(workspace._id);
+      expect(updatedMeta?.pushSnapshotOnInitialize).toBe(false);
+    });
+  });
+});

--- a/packages/insomnia/src/sync/vcs/__tests__/migrate-projects-into-organizatino.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/migrate-projects-into-organizatino.test.ts
@@ -201,12 +201,12 @@ describe('_migrateToLocalVault()', () => {
 
     expect(wrk1).toMatchObject({});
     expect(wrk2).toBeTruthy();
-    expect(wrk2?.parentId).not.toBeNull();
+    expect(wrk2!.parentId).not.toBeNull();
 
     const { parentId: newVaultId } = wrk2!;
     expect(wrk3).toBeTruthy();
-    expect(wrk3?.parentId).toEqual(newVaultId);
+    expect(wrk3!.parentId).toEqual(newVaultId);
     expect(wrk4).toBeTruthy();
-    expect(wrk4?.parentId).toEqual(newVaultId);
+    expect(wrk4!.parentId).toEqual(newVaultId);
   });
 });

--- a/packages/insomnia/src/sync/vcs/initialize-backend-project.ts
+++ b/packages/insomnia/src/sync/vcs/initialize-backend-project.ts
@@ -38,10 +38,8 @@ export const pushSnapshotOnInitialize = async ({
   vcs: VCS;
   workspace: Workspace;
   project: Project;
-}) => {
-  console.log('????');
+  }) => {
   const projectIsForWorkspace = projectId === workspace.parentId;
-  console.log({ projectIsForWorkspace });
   // A race condition occurs in App.tsx when updating the active workspace
   // One code path is that a React Key updates, forcing all children to unmount and remount (https://github.com/Kong/insomnia/blob/9a943879060927d6ab1c21d3e12daba39ad05eea/packages/insomnia-app/app/ui/containers/app.tsx#L1514-L1514)
   // At the same time, we set VCS to null, then set it to the correct value, in state in App.tsx, forcing downstream updates (https://github.com/Kong/insomnia/blob/9a943879060927d6ab1c21d3e12daba39ad05eea/packages/insomnia-app/app/ui/containers/app.tsx#L1149-L1149)

--- a/packages/insomnia/src/sync/vcs/initialize-backend-project.ts
+++ b/packages/insomnia/src/sync/vcs/initialize-backend-project.ts
@@ -39,8 +39,9 @@ export const pushSnapshotOnInitialize = async ({
   workspace: Workspace;
   project: Project;
 }) => {
+  console.log('????');
   const projectIsForWorkspace = projectId === workspace.parentId;
-
+  console.log({ projectIsForWorkspace });
   // A race condition occurs in App.tsx when updating the active workspace
   // One code path is that a React Key updates, forcing all children to unmount and remount (https://github.com/Kong/insomnia/blob/9a943879060927d6ab1c21d3e12daba39ad05eea/packages/insomnia-app/app/ui/containers/app.tsx#L1514-L1514)
   // At the same time, we set VCS to null, then set it to the correct value, in state in App.tsx, forcing downstream updates (https://github.com/Kong/insomnia/blob/9a943879060927d6ab1c21d3e12daba39ad05eea/packages/insomnia-app/app/ui/containers/app.tsx#L1149-L1149)

--- a/packages/insomnia/src/sync/vcs/migrate-projects-into-organization.ts
+++ b/packages/insomnia/src/sync/vcs/migrate-projects-into-organization.ts
@@ -479,11 +479,11 @@ export const migrateIfNeeded = async (sessionId: string, local: boolean): Promis
   const records = await _migrateToCloudSync(queue, remoteBackground);
   const total = queue.filesByProject.size + queue.filesNoProject.size;
   if (total > records.files.size) {
-    console.log('[migration] FAILURE: ');
+    console.log(`[migration] INCOMPLETE: ${total - records.files.size} files are not migrated`);
   }
 
   if (queue.projects.size > records.projects.size) {
-    console.log('[migration] FAILURE: ');
+    console.log(`[migration] INCOMPLETE: ${queue.projects.size - records.projects.size} projects are not migrated`);
   }
 
   // clean up the duplicated records now

--- a/packages/insomnia/src/sync/vcs/migrate-projects-into-organization.ts
+++ b/packages/insomnia/src/sync/vcs/migrate-projects-into-organization.ts
@@ -1,7 +1,12 @@
+import format from 'date-fns/format';
+
 import { database } from '../../common/database';
 import * as models from '../../models';
-import { Organization } from '../../models/organization';
 import { Project, RemoteProject } from '../../models/project';
+import { Workspace } from '../../models/workspace';
+import { getOrCreateByParentId } from '../../models/workspace-meta';
+import { initializeLocalBackendProjectAndMarkForSync, pushSnapshotOnInitialize } from './initialize-backend-project';
+import { VCS } from './vcs';
 
 // Migration:
 // Team ~= Project > Workspaces
@@ -16,50 +21,530 @@ import { Project, RemoteProject } from '../../models/project';
 // which was a wrapper for the team_id prefixing proj_to the above id,
 // which is now the remoteId for tracking the projects within an org
 
-export const shouldMigrateProjectUnderOrganization = async () => {
-  const localProjectCount = await database.count<Project>(models.project.type, {
-    remoteId: null,
-    parentId: null,
-    _id: { $ne: models.project.SCRATCHPAD_PROJECT_ID },
-  });
+type RemoteOrganizationId = string;
+type RemoteFileId = string; // project id
+type RemoteProjectId = string; // team project id
+type LocalWorkspaceToLocalProjectMap = Record<RemoteFileId, RemoteProjectId>;
+interface OwernshipSnapshot {
+  ownedByMe: boolean;
+  isPersonal: boolean;
+  fileIdMap: LocalWorkspaceToLocalProjectMap;
+  projectIds: RemoteProjectId[];
+}
 
-  const legacyRemoteProjectCount = await database.count<RemoteProject>(models.project.type, {
-    remoteId: { $ne: null },
-    parentId: null,
-  });
+type RemoteFileSnapshot = Record<RemoteOrganizationId, OwernshipSnapshot>;
+interface QueueForMigration {
+  projects: Set<string>;
+  filesByProject: Set<string>;
+  filesNoProject: Set<string>;
+}
+export const scanForMigration = async (): Promise<QueueForMigration> => {
+  const queueLocalProjects = new Set<string>();
+  const queueLocalFilesByProject = new Set<string>();
+  const queueLocalFilesNoProject = new Set<string>();
 
-  return localProjectCount > 0 || legacyRemoteProjectCount > 0;
-};
-
-export const migrateProjectsIntoOrganization = async ({
-  personalOrganization,
-}: {
-  personalOrganization: Organization;
-  }) => {
-  // Legacy remote projects without organizations
+  console.log('[migration] querying legacy remote projects');
   const legacyRemoteProjects = await database.find<RemoteProject>(models.project.type, {
     remoteId: { $ne: null },
     parentId: null,
   });
-  // Legacy remoteId should be orgId and legacy _id should be remoteId
-  for (const remoteProject of legacyRemoteProjects) {
-    await models.project.update(remoteProject, {
-      parentId: remoteProject.remoteId,
-      remoteId: remoteProject._id,
-    });
+
+  for (const project of legacyRemoteProjects) {
+    console.log('[migration] found legacy remote project', project);
+    queueLocalProjects.add(project._id);
+
+    console.log('[migration] querying files under the legacy remote projects', project._id);
+    const files = await database.find<Workspace>(models.workspace.type, { parentId: project._id });
+    for (const file of files) {
+      console.log('[migration] found the legacy remote project %d - %v', project._id, file._id);
+      queueLocalFilesByProject.add(file._id);
+    }
   }
 
-  // Local projects without organizations except scratchpad
+  console.log('[migration] querying local projects');
   const localProjects = await database.find<Project>(models.project.type, {
     remoteId: null,
     parentId: null,
     _id: { $ne: models.project.SCRATCHPAD_PROJECT_ID },
   });
 
-  // Assign all local projects to personal organization
-  for (const localProject of localProjects) {
-    await models.project.update(localProject, {
-      parentId: personalOrganization.id,
+  for (const project of localProjects) {
+    console.log('[migration] found local project', project._id);
+    queueLocalProjects.add(project._id);
+
+    console.log('[migration] querying files under the local projects', project._id);
+    const files = await database.find<Workspace>(models.workspace.type, { parentId: project._id });
+    for (const file of files) {
+      console.log('[migration] found the legacy remote project %d - %v', project._id, file._id);
+      queueLocalFilesByProject.add(file._id);
+    }
+  }
+
+  console.log('[migration] querying untracked files with no parents');
+  const untrackedFiles = await database.find<Workspace>(models.workspace.type, {
+    parentId: null,
+  });
+
+  for (const file of untrackedFiles) {
+    console.log('[migration] found an untracked file with no parents', file._id);
+    queueLocalFilesNoProject.add(file._id);
+  }
+
+  // queues to iterate for migration
+  return {
+    projects: queueLocalProjects,
+    filesByProject: queueLocalFilesByProject,
+    filesNoProject: queueLocalFilesNoProject,
+  };
+};
+
+interface RemoteBackground {
+  myWorkspaceId: string;
+  remoteFileSnapshot: RemoteFileSnapshot;
+  byRemoteProjectId: Map<RemoteProjectId, RemoteOrganizationId>;
+  byRemoteFileId: Map<RemoteFileId, {
+    remoteOrgId: RemoteOrganizationId;
+    remoteProjectId: RemoteProjectId;
+  }>;
+}
+const remoteBackgroundCheck = async (sessionId: string): Promise<RemoteBackground | null> => {
+  const response = await window.main.insomniaFetch<RemoteFileSnapshot | { error: string; message: string }>({
+    method: 'GET',
+    path: '/v1/user/file-snapshot',
+    sessionId,
+  });
+
+  if (!response) {
+    console.log('[migration] network failed to run remote background check for file snapshot per organizations');
+    return null;
+  }
+
+  if ('error' in response) {
+    console.log('[migration] network error', response.message);
+    return null;
+  }
+
+  const remotePersonalWorkspaceId = Object.keys(response).find(remoteOrgId => response![remoteOrgId].isPersonal && response![remoteOrgId].ownedByMe);
+  if (!remotePersonalWorkspaceId) {
+    return null;
+  }
+
+  const byRemoteProjectId: Map<RemoteProjectId, RemoteOrganizationId> = new Map();
+  const byRemoteFileId: Map<RemoteFileId, {
+    remoteOrgId: RemoteOrganizationId;
+    remoteProjectId: RemoteProjectId;
+  }> = new Map();
+
+  const remoteOrgIds = Object.keys(response);
+  for (const remoteOrgId of remoteOrgIds) {
+    const orgSnapshot = response[remoteOrgId];
+    const orgFileIdMap = Object.entries(orgSnapshot.fileIdMap);
+
+    for (const [remoteFileId, remoteProjectId] of orgFileIdMap) {
+      if (byRemoteFileId.has(remoteFileId)) {
+        // map the conflict into the log if it ever happens
+        console.log('[migration] CONFLICT: file id %a from remote project %b already exists in %c', remoteFileId, remoteProjectId, byRemoteFileId.get(remoteFileId));
+        continue;
+      }
+
+      byRemoteFileId.set(remoteFileId, { remoteProjectId, remoteOrgId });
+
+      if (byRemoteProjectId.has(remoteProjectId)) {
+        // map the conflict into the log if it ever happens
+        console.log('[migration] CONFLICT: remote project id - %a from org - %b already exists in %c', remoteProjectId, remoteOrgId, byRemoteProjectId.get(remoteProjectId));
+        continue;
+      }
+
+      byRemoteProjectId.set(remoteProjectId, remoteOrgId);
+    }
+  }
+
+  return {
+    myWorkspaceId: remotePersonalWorkspaceId,
+    remoteFileSnapshot: response,
+    byRemoteProjectId,
+    byRemoteFileId,
+  };
+};
+
+interface RecordsForMigration {
+  projects: Map<string, string>;
+  files: Map<string, string>;
+};
+const _migrateToLocalVault = async (queue: QueueForMigration, remoteBackground: RemoteBackground): Promise<RecordsForMigration> => {
+  const recordsForProjectMigration = new Map<string, string>();
+  const recordsForFileMigration = new Map<string, string>();
+
+  for (const localProjectId of queue.projects.keys()) {
+    const docs = await database.find<Project>(models.project.type, { _id: localProjectId });
+    if (!docs.length) {
+      console.log('[migration] you are one of the rare lucky user. magic happened your project is gone after queued for migration');
+      continue;
+    }
+
+    const localProject = docs[0];
+    const { _id: oldProjectId, remoteId, parentId, ...props } = localProject;
+
+    const newProject = await database.docCreate<Project>(models.project.type, {
+      ...props,
+      parentId: remoteBackground.myWorkspaceId,
+      remoteId: null,
     });
+
+    recordsForProjectMigration.set(oldProjectId, newProject._id);
+
+    const files = await database.find<Workspace>(models.workspace.type, { parentId: localProjectId });
+    for (const oldFile of files) {
+      const newFile = await database.duplicate<Workspace>(oldFile, { parentId: newProject._id });
+      recordsForFileMigration.set(oldFile._id, newFile._id);
+    }
+  }
+
+  if (!queue.filesNoProject.size) {
+    return {
+      projects: recordsForProjectMigration,
+      files: recordsForFileMigration,
+    };
+  }
+
+  const timestamp = format(Date.now(), 'MM-dd');
+  const vaultName = `Local Vault ${timestamp}`;
+  const newLocalVault = await database.docCreate<Project>(models.project.type, {
+    name: vaultName,
+    parentId: remoteBackground.myWorkspaceId,
+    remoteId: null,
+  });
+
+  console.log('[migration] new local vault is created for untracked files without a project');
+  for (const fileId of queue.filesNoProject.keys()) {
+    const docs = await database.find<Workspace>(models.workspace.type, { _id: fileId });
+    if (!docs.length) {
+      continue;
+    }
+
+    const oldFile = docs[0];
+    const newFile = await database.duplicate<Workspace>(oldFile, { parentId: newLocalVault._id });
+    recordsForFileMigration.set(oldFile._id, newFile._id);
+  }
+  return {
+    projects: recordsForProjectMigration,
+    files: recordsForFileMigration,
+  };
+};
+
+const _validateProjectsWithRemote = async (queue: QueueForMigration, remoteBackground: RemoteBackground) => {
+  console.log('[migration] validating projects against the remote');
+  const { myWorkspaceId } = remoteBackground;
+  const myWorkspace = remoteBackground.remoteFileSnapshot[myWorkspaceId];
+
+  const validProjectIds = new Set<string>();
+  const validProjects = [];
+
+  for (const remoteProjectId of myWorkspace.projectIds) {
+    // scan all the project entities with the remote project id that belongs to my workspace
+    const docs = await database.find<Project>(models.project.type, { remoteId: remoteProjectId });
+    if (!docs.length) {
+      // remote project has not been created in the local yet => create one
+      const newProject = await database.docCreate<Project>(models.project.type, {
+        name: 'Cloud Sync ' + remoteProjectId, // name should matter here?
+        parentId: remoteBackground.myWorkspaceId,
+        remoteId: remoteProjectId,
+      });
+
+      validProjectIds.add(newProject._id);
+      validProjects.push(newProject);
+      continue;
+    }
+
+    if (docs.length > 1) {
+      // this is messed up case for whatever reason.
+      // let's reconcile this.
+      // ideally we should compare the project parent id (organization id) and see if the user belongs to the organization,
+      // but this will be a very rare case. It may be more valuable to prioritize data linking recovery
+
+      const defaultProjectWithSameRemoteId = docs[0];
+      validProjectIds.add(defaultProjectWithSameRemoteId._id);
+      validProjects.push(defaultProjectWithSameRemoteId);
+
+      // two different projects with the same remote id
+      for (const doc of docs) {
+        // let's still iterate through all the sub files
+        // first let's check,
+        // this case should be already filtered by scanning, but let's correct
+        if (doc._id !== defaultProjectWithSameRemoteId._id) {
+          // repair
+          console.log('[migration] repairing file-project linking');
+          const projectFiles = await database.find<Workspace>(models.workspace.type, {
+            parentId: doc._id,
+          });
+
+          // move the file linking to the selected project with the same remote id
+          for (const projectFile of projectFiles) {
+            await database.docUpdate(projectFile, { parentId: defaultProjectWithSameRemoteId._id });
+            queue.filesByProject.delete(projectFile._id);
+          }
+        }
+      }
+
+      continue;
+    }
+
+    const doc = docs[0];
+    validProjectIds.add(doc._id);
+    validProjects.push(doc);
+  }
+
+  return {
+    validProjectIds,
+    validProjects,
+  };
+};
+
+type RecordsForCloudMigration = RecordsForMigration & {
+  filesForSync: Workspace[];
+};
+const _migrateToCloudSync = async (
+  queue: QueueForMigration,
+  remoteBackground: RemoteBackground,
+): Promise<RecordsForCloudMigration> => {
+  const filesForSync: Workspace[] = [];
+  const recordsForProjectMigration = new Map<string, string>();
+  const recordsForFileMigration = new Map<string, string>();
+
+  // first ensure all the remote team project in my workspace exists and only link to them
+  const { myWorkspaceId } = remoteBackground;
+  // const myWorkspace = remoteBackground.remoteFileSnapshot[myWorkspaceId];
+
+  // this is important as the number of team project in the cloud is limited by the plan tier
+  // if we link files to local project entities with parent ids that don't exist in the cloud, then they will see no files => data loss experience
+
+  const { validProjectIds, validProjects } = await _validateProjectsWithRemote(queue, remoteBackground);
+  if (!validProjects.length) {
+    console.log('[migration] there are no valid projects in the cloud. most likely, data issue. fallback to the local valut instead');
+    const fallbackResult = await _migrateToLocalVault(queue, remoteBackground);
+    return { ...fallbackResult, filesForSync };
+  }
+
+  // now we can safely proceed migration
+  // 1. ensure these projects are correctly linked to my workspace (if not ideally we should hault)
+  for (const validProject of validProjects) {
+    if (validProject.parentId !== myWorkspaceId) {
+      console.log('[migration] repairing team-project to organization linking for local database');
+      await database.docUpdate<Project>(validProject, {
+        parentId: myWorkspaceId,
+      });
+    }
+
+    // if the valid project id exists in the queue, delete them.
+    queue.projects.delete(validProject._id);
+  }
+
+  // due to the constraint - free user can have only 1 team project with collaborators
+  const defaultRemoteProject = validProjects[0]; // <=== link all the cloud sync files here, so users can see their files
+  for (const fileId of queue.filesByProject.keys()) {
+    const docs = await database.find<Workspace>(models.workspace.type, { _id: fileId });
+    if (!docs.length) {
+      continue;
+    }
+
+    const file = docs[0];
+    const remoteFileRecord = remoteBackground.byRemoteFileId.get(file._id);
+    if (!remoteFileRecord) {
+      // No file record in the remote => just create new file and move on
+      const newFile = await database.duplicate<Workspace>(file, { parentId: defaultRemoteProject._id });
+      filesForSync.push(newFile);
+      recordsForFileMigration.set(file._id, newFile._id);
+      continue;
+    }
+
+    if (remoteFileRecord.remoteOrgId !== myWorkspaceId) {
+      // There is a conflicting record in the remote but not in my workspace => create new file and continue;
+      // we should revisit this to tighten the ownership
+      const newFile = await database.duplicate<Workspace>(file, { parentId: defaultRemoteProject._id });
+      filesForSync.push(newFile);
+      recordsForFileMigration.set(file._id, newFile._id);
+      continue;
+    }
+
+    if (!validProjectIds.has(file.parentId)) {
+      // remote file record exists under the same workspace but local file record is not in the valid linking
+      // => create new file and continue;
+      const newFile = await database.duplicate<Workspace>(file, { parentId: defaultRemoteProject._id });
+      filesForSync.push(newFile);
+      recordsForFileMigration.set(file._id, newFile._id);
+      continue;
+    }
+
+    // this is correctly linked both locally and remotely
+    // we should remove this from the queue and prevent modification or deletion
+    queue.filesByProject.delete(file._id);
+  }
+
+  // these are simpler cases. Just create new files and move on
+  for (const fileId of queue.filesNoProject.keys()) {
+    const docs = await database.find<Workspace>(models.workspace.type, { _id: fileId });
+    if (!docs.length) {
+      continue;
+    }
+
+    const file = docs[0];
+    const newFile = await database.duplicate<Workspace>(file, { parentId: defaultRemoteProject._id });
+    filesForSync.push(newFile);
+    recordsForFileMigration.set(file._id, newFile._id);
+  }
+
+  for (const projectId of queue.projects.keys()) {
+    // we are updating the existing one wit the default remote project id to run clean up
+    // queue only has applicable projects as others were removed when matched with the remote ids before
+    recordsForProjectMigration.set(projectId, defaultRemoteProject._id);
+  }
+
+  return {
+    projects: recordsForProjectMigration,
+    files: recordsForFileMigration,
+    filesForSync,
+  };
+};
+
+export const shouldMigrate = (queue: QueueForMigration) => {
+  const shouldContinue = queue.projects.size > 0 || queue.filesByProject.size > 0 || queue.filesNoProject.size > 0;
+  return shouldContinue;
+};
+export const migrateIfNeeded = async (sessionId: string, local: boolean): Promise<Workspace[]> => {
+  const queue = await scanForMigration();
+
+  if (!shouldMigrate(queue)) {
+    return [];
+  }
+
+  const remoteBackground = await remoteBackgroundCheck(sessionId);
+  if (!remoteBackground) {
+    throw new Error("Failed to check against user's remote snapshot");
+  }
+
+  if (local) {
+    const records = await _migrateToLocalVault(queue, remoteBackground);
+    const total = queue.filesByProject.size + queue.filesNoProject.size;
+    if (total > records.files.size) {
+      console.error(`[migration] failed as not all the queued files are migrated  - ${total - records.files.size} files`);
+      // don't delete records
+      return [];
+    }
+
+    if (queue.projects.size > records.projects.size) {
+      console.error(`[migration] failed as not all the queued projects are migrated  - ${queue.projects.size - records.projects.size} projects`);
+      // don't delete records
+      return [];
+    }
+
+    // clean up the duplicated records now
+    for (const oldFileId of records.files.keys()) {
+      const docs = await database.find<Workspace>(models.workspace.type, { _id: oldFileId });
+      const oldFile = docs[0];
+      if (!oldFile) {
+        console.error(`[migration] failed to clean up old file - ${oldFileId}`);
+        // TODO: log this
+        // TODO: handle the error communication to the UI
+        continue;
+      }
+
+      await database.removeWhere<Workspace>(models.workspace.type, { _id: oldFileId });
+      if (oldFile.parentId) {
+        queue.filesByProject.delete(oldFileId);
+      } else {
+        queue.filesNoProject.delete(oldFileId);
+      }
+      console.log(`[migration] cleaned up old file - ${oldFileId}`);
+    }
+
+    for (const oldProjectId of records.projects.keys()) {
+      const docs = await database.find<Project>(models.project.type, { _id: oldProjectId });
+      const oldProject = docs[0];
+      if (!oldProject) {
+        console.error(`[migration] failed to clean up old project - ${oldProjectId}`);
+        continue;
+      }
+
+      await database.removeWhere<Project>(models.project.type, { _id: oldProjectId });
+      queue.projects.delete(oldProjectId);
+      console.log(`[migration] cleaned up old project - ${oldProjectId}`);
+    }
+
+    console.log('[migration] incomplete migration project count: %a', queue.projects.size);
+    console.log('[migration] incomplete migration files with project count: %a', queue.filesByProject.size);
+    console.log('[migration] incomplete migration files without project count: %a', queue.filesNoProject.size);
+    return [];
+  }
+
+  const records = await _migrateToCloudSync(queue, remoteBackground);
+  const total = queue.filesByProject.size + queue.filesNoProject.size;
+  if (total > records.files.size) {
+    console.log('[migration] FAILURE: ');
+  }
+
+  if (queue.projects.size > records.projects.size) {
+    console.log('[migration] FAILURE: ');
+  }
+
+  // clean up the duplicated records now
+  for (const oldFileId of records.files.keys()) {
+    const docs = await database.find<Workspace>(models.workspace.type, { _id: oldFileId });
+    const oldFile = docs[0];
+    if (!oldFile) {
+      console.log('[migration] failed to clean up old file - %a', oldFileId);
+      // TODO: log this
+      // TODO: handle the error communication to the UI
+      continue;
+    }
+
+    await database.removeWhere<Workspace>(models.workspace.type, { _id: oldFileId });
+    if (oldFile.parentId) {
+      queue.filesByProject.delete(oldFileId);
+    } else {
+      queue.filesNoProject.delete(oldFileId);
+    }
+    console.log('[migration] cleaned up old file - %a', oldFileId);
+  }
+
+  for (const oldProjectId of records.projects.keys()) {
+    const docs = await database.find<Project>(models.project.type, { _id: oldProjectId });
+    const oldProject = docs[0];
+    if (!oldProject) {
+      console.log('[migration] failed to clean up old project - %a', oldProjectId);
+      continue;
+    }
+
+    await database.removeWhere<Project>(models.project.type, { _id: oldProjectId });
+    queue.projects.delete(oldProjectId);
+    console.log('[migration] cleaned up old project - %a', oldProjectId);
+  }
+
+  console.log('[migration] incomplete migration project count: %a', queue.projects.size);
+  console.log('[migration] incomplete migration files with project count: %a', queue.filesByProject.size);
+  console.log('[migration] incomplete migration files without project count: %a', queue.filesNoProject.size);
+  return records.filesForSync;
+};
+
+export const autoSyncForMigration = async (files: Workspace[], vcs: VCS) => {
+  for (const file of files) {
+    const docs = await database.find<Project>(models.project.type, { _id: file.parentId });
+    if (!docs.length) {
+      // at this point, this shouldn't happen but just in case.
+      console.log('[migration] you are one of the rare lucky user');
+      continue;
+    }
+
+    const project = docs[0];
+    const workspaceMeta = await getOrCreateByParentId(file._id);
+    // Initialize Sync on the workspace if it's not using Git sync
+    try {
+      if (!workspaceMeta.gitRepositoryId) {
+        console.log(`[migration] syncing a file - ${file._id}: ${file.name}`);
+        await initializeLocalBackendProjectAndMarkForSync({ vcs, workspace: file });
+        await pushSnapshotOnInitialize({ vcs, project, workspace: file });
+      }
+    } catch (e) {
+      console.warn('Failed to initialize sync on workspace. This will be retried when the workspace is opened on the app.', e);
+    }
   }
 };

--- a/packages/insomnia/src/sync/vcs/migrate-projects-into-organization.ts
+++ b/packages/insomnia/src/sync/vcs/migrate-projects-into-organization.ts
@@ -49,8 +49,6 @@ export const scanForMigration = async (): Promise<QueueForMigration> => {
     parentId: null,
   });
 
-  console.log({ legacyRemoteProjects });
-
   for (const project of legacyRemoteProjects) {
     console.log('[migration] found legacy remote project', project);
     queueLocalProjects.add(project._id);
@@ -70,7 +68,6 @@ export const scanForMigration = async (): Promise<QueueForMigration> => {
     _id: { $ne: models.project.SCRATCHPAD_PROJECT_ID },
   });
 
-  console.log({ localProjects });
   for (const project of localProjects) {
     console.log('[migration] found local project', project._id);
     queueLocalProjects.add(project._id);
@@ -87,8 +84,6 @@ export const scanForMigration = async (): Promise<QueueForMigration> => {
   const untrackedFiles = await database.find<Workspace>(models.workspace.type, {
     parentId: null,
   });
-
-  console.log({ untrackedFiles });
 
   for (const file of untrackedFiles) {
     console.log('[migration] found an untracked file with no parents', file._id);
@@ -246,7 +241,6 @@ export const _validateProjectsWithRemote = async (queue: QueueForMigration, remo
 
   const validProjectIds = new Set<string>();
   const validProjects = [];
-
   for (const remoteProjectId of myWorkspace.projectIds) {
     // scan all the project entities with the remote project id that belongs to my workspace
     const docs = await database.find<Project>(models.project.type, { remoteId: remoteProjectId });
@@ -338,7 +332,6 @@ export const _migrateToCloudSync = async (
   for (const validProject of validProjects) {
     if (validProject.parentId !== myWorkspaceId) {
       console.log('[migration] repairing team-project to organization linking for local database');
-      // TODO: update the array validProjects here
       await database.docUpdate<Project>(validProject, {
         parentId: myWorkspaceId,
       });

--- a/packages/insomnia/src/ui/routes/onboarding.migrate.tsx
+++ b/packages/insomnia/src/ui/routes/onboarding.migrate.tsx
@@ -9,8 +9,8 @@ import { InsomniaLogo } from '../components/insomnia-icon';
 import { TrailLinesContainer } from '../components/trail-lines-container';
 
 export const loader: LoaderFunction = async () => {
-  const queue = await scanForMigration();
-  if (!shouldMigrate(queue)) {
+  const result = await scanForMigration();
+  if (!shouldMigrate(result)) {
     return redirect('/organization');
   }
   return null;

--- a/packages/insomnia/src/ui/routes/onboarding.migrate.tsx
+++ b/packages/insomnia/src/ui/routes/onboarding.migrate.tsx
@@ -2,17 +2,17 @@ import React from 'react';
 import { Button, Heading, Radio, RadioGroup } from 'react-aria-components';
 import { ActionFunction, LoaderFunction, redirect, useFetcher } from 'react-router-dom';
 
-import { shouldMigrateProjectUnderOrganization } from '../../sync/vcs/migrate-projects-into-organization';
+import { scanForMigration, shouldMigrate } from '../../sync/vcs/migrate-projects-into-organization';
 import { invariant } from '../../utils/invariant';
 import { Icon } from '../components/icon';
 import { InsomniaLogo } from '../components/insomnia-icon';
 import { TrailLinesContainer } from '../components/trail-lines-container';
 
 export const loader: LoaderFunction = async () => {
-  if (!shouldMigrateProjectUnderOrganization()) {
+  const queue = await scanForMigration();
+  if (!shouldMigrate(queue)) {
     return redirect('/organization');
   }
-
   return null;
 };
 


### PR DESCRIPTION
Refactored the [existing PR](https://github.com/Kong/insomnia/pull/6745) to address some of concerns during the migration from version upgrade (upgrading to 8.x from the prior versions) in much smaller scope. There are some design preferences that I gave up (such as running database operations, syncing networking, encryption/decryption outside of the UI process).

Now every account has the concept of "team" that is now called "organization". This was not the case prior to 8.x versions (there was no such concept for free users. Only paid/trial users, but now we offer this to every free user alongside e2ee cloud sync). Therefore, the hierarchy is now imposed in the data structure. This is an extension of what was already designed for paid users.

The following are the changes and considerations made:
```diff
- Prior to this PR,
- the approach was taken to migrate locally first and make subsequent network calls for syncing.

However, still requiring the network requests like fetching organizations and current plan.

+ In this PR, 
+ An additional network call is made to get the snapshot of the user's file ownership per organization,
+ which is crucial information for organization > project > file hierarchy mapping

- Prior to this PR,
- Only entities in Project.db file are queried and considered as "untracked" under some conditions

+ In this PR, 
+ In addition to the project entities, file entities in Workspace.db are also queried
+ and considered "untracked" under some conditions

- Prior to this PR,
- There was no comparison of org/project/file ids to those of the local database entities

+ In this PR, 
+ Such comparison is added to correct linking between the local and the remote for cloud syncing.
+ Unavoidably, this adds more complexity compared to how it was migrated prior to this change

- Prior to this PR,
- No file records are created

+ In this PR,
- files are mapped and duplicated under certain conditions (these get cleaned up eventually)

- Prior to this PR,
- No entities are actually deleted (the data loss that users reported is, in fact, linking issue in the org/project/file hierarchy)

+ In this PR,
+ projects and files are duplicated with new unique identifiers to establish clean records with repaired linking
+ between local and remote and actually DELETE the original records to iron out all kinds of weird issues between
+ local entity hierarchy and remote data entities
+ the exception to this deletion is some cases during cloud migration when files detected as "untracked"
+ actually exist in the cloud => this case, it is just updated

- Prior to this PR,
- local project entities may not validate before linking the files, and these projects are created in the cloud later

+ In this PR,
+ no remote projects are created, but inherit from the cloud into the local project entities with validation
+ for linking to ensure local file hierarchy to be reflected correctly

- Prior to this PR,
- file linking happens first to n number of projects. Then they are be requested to be created remotely,
- which can be more than one remote project. In such case, it will have a rejection from the server for upgrade plan. Then file migration and syncing may halt

+ In this PR,
+ as no remote projects are created, it was made to select one default remote project to be linked with files
+ that have no parent ids. Therefore, it will not halt even on free plan

- Prior to this PR,
- No logging was made during the migration

+ In this PR,
+ Logging is added to enable users and ourselves to trouble-shoot quicker and more accurately


```
NOTE:
This operation can last longer with more files and network requests. The way the data fetching works now withholds the UI to be rendered until the routing loader context execution finishes. I attempted to solve this by moving it to different process, but it increased the scope of this work unreasonably. This is the downside, and we may need to fix that in subsequent work. However, this migration logic will be something that should run only once for specific conditions.

Still TODOs:
- [x] add as many unit tests as possible to find bugs in the cloud sync migration logic. (this is actually super challenging)
- [x] run many smoke tests before merging this