### PR TITLE
harden lint rule about array indexes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,6 @@ const {
   TYPESCRIPT_CONVERSION,
   TYPESCRIPT_EXTENSION,
   UNKNOWN,
-  WARN,
 } = require('eslint-config-helpers');
 
 /** @type { import('eslint').Linter.Config } */
@@ -119,7 +118,7 @@ module.exports = {
     'react/jsx-closing-bracket-location': [ERROR, 'line-aligned'],
     'react/prefer-stateless-function': ERROR,
     'react/jsx-key': [ERROR, { 'checkFragmentShorthand': true }],
-    'react/no-array-index-key': WARN(UNKNOWN),
+    'react/no-array-index-key': ERROR,
     'react/self-closing-comp': ERROR,
 
     'react-hooks/exhaustive-deps': [ERROR, {

--- a/packages/insomnia/src/ui/components/modals/error-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/error-modal.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, ReactNode, useImperativeHandle, useRef, useState } from 'react';
 
 import { Modal, type ModalHandle, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
@@ -9,7 +9,7 @@ export interface ErrorModalOptions {
   title?: string;
   error?: Error | null;
   addCancel?: boolean;
-  message?: string;
+  message?: string | ReactNode;
 }
 export interface ErrorModalHandle {
   show: (options: ErrorModalOptions) => void;


### PR DESCRIPTION
future work
perhaps use `react-error-boundary` package as suggested by react.dev docs
eliminate most of the fine grained error boundaries. We probably only need them on layout components.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
