### PR TITLE
Fix: VCS pull results in untracked workspace

### DIFF
--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -356,6 +356,7 @@ export const fetchRemoteBranchAction: ActionFunction = async ({ request, params 
     invariant(project.remoteId, 'Project is not remote');
     await vcs.checkout([], branch);
     const delta = await vcs.pull({ candidates: [], teamId: project.parentId, teamProjectId: project.remoteId }) as unknown as Operation;
+    // vcs.pull sometimes results in a delta with parentId: null, causing workspaces to be orphaned, this is a hack to restore those parentIds until we have a chance to redesign vcs
     await database.batchModifyDocs({
       remove: delta.remove,
       upsert: delta.upsert?.map(doc => ({

--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -355,9 +355,14 @@ export const fetchRemoteBranchAction: ActionFunction = async ({ request, params 
   try {
     invariant(project.remoteId, 'Project is not remote');
     await vcs.checkout([], branch);
-    const delta = await vcs.pull({ candidates: [], teamId: project.parentId, teamProjectId: project.remoteId });
-
-    await database.batchModifyDocs(delta as unknown as Operation);
+    const delta = await vcs.pull({ candidates: [], teamId: project.parentId, teamProjectId: project.remoteId }) as unknown as Operation;
+    await database.batchModifyDocs({
+      remove: delta.remove,
+      upsert: delta.upsert?.map(doc => ({
+        ...doc,
+        ...!doc.parentId && doc.type === models.workspace.type ? { parentId: projectId } : {},
+      })),
+    });
   } catch (err) {
     await vcs.checkout([], currentBranch);
     const errorMessage = err instanceof Error ? err.message : 'Unknown error while fetching remote branch.';


### PR DESCRIPTION
changelog(Fixes): Added a fix for an edge-case where pulling from sync would sometimes result in a locally untracked workspace.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
