### PR TITLE
Guard against null parentId's on db updates/inserts

### DIFF
--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -709,6 +709,11 @@ type Patch<T> = Partial<T>;
 // Helpers //
 // ~~~~~~~ //
 async function _send<T>(fnName: string, ...args: any[]) {
+  if (['update', 'insert'].includes(fnName) && args[0] && !['Stats', 'Settings', 'PluginData', 'GitRepository'].includes(args[0].type) && !args[0].parentId) {
+    console.error(`[db] Attempted to ${fnName} a doc without a parentId`, args[0]);
+    throw new Error(`Attempted to ${fnName} a doc without a parentId`);
+  }
+
   return new Promise<T>((resolve, reject) => {
     const replyChannel = `db.fn.reply:${uuidv4()}`;
     electron.ipcRenderer.send('db.fn', fnName, replyChannel, ...args);

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -709,7 +709,7 @@ type Patch<T> = Partial<T>;
 // Helpers //
 // ~~~~~~~ //
 async function _send<T>(fnName: string, ...args: any[]) {
-  if (['update', 'insert'].includes(fnName) && args[0] && args[0].type==='Workspace' && !args[0].parentId) {
+  if (['update', 'insert'].includes(fnName) && args[0] && args[0].type === 'Workspace' && !args[0].parentId) {
     console.error(`[db] Attempted to ${fnName} a doc without a parentId`, args[0]);
     throw new Error(`Attempted to ${fnName} a doc without a parentId`);
   }

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -709,7 +709,7 @@ type Patch<T> = Partial<T>;
 // Helpers //
 // ~~~~~~~ //
 async function _send<T>(fnName: string, ...args: any[]) {
-  if (['update', 'insert'].includes(fnName) && args[0] && !['Stats', 'Settings', 'PluginData', 'GitRepository'].includes(args[0].type) && !args[0].parentId) {
+  if (['update', 'insert'].includes(fnName) && args[0] && args[0].type==='Workspace' && !args[0].parentId) {
     console.error(`[db] Attempted to ${fnName} a doc without a parentId`, args[0]);
     throw new Error(`Attempted to ${fnName} a doc without a parentId`);
   }


### PR DESCRIPTION
changelog(Improvements): Added data loss guard rails related to preventing null parentIds on database inserts/updates.

There might be use cases where we pass a patch that doesn't contain the parentId as expected.
We need to revisit this and make sure we've tested appropriately 