### PR TITLE
chore: bump electron 27.0.3 [no-ticket]

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,5 @@
 runtime = electron
-target = 27.0.2
+target = 27.0.3
 disturl = https://electronjs.org/headers
 playwright_skip_browser_download=true
 engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11168,9 +11168,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-27.0.2.tgz",
-      "integrity": "sha512-4fbcHQ40ZDlqhr5Pamm+M5BF7ry2lGqjFTWTJ/mrBwuiPWu6xhV/RWgUhKBaLqKNfAaNl3eMxV3Jc82gv6JauQ==",
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.0.3.tgz",
+      "integrity": "sha512-VaB9cI1se+mUtz366NP+zxFVnkHLbCBNO4wwouw3FuGyX/m7/Bv1I89JhWOBv78tC+n11ZYMrVD23Jf6EZgVcg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -24654,7 +24654,7 @@
         "cross-env": "^7.0.3",
         "date-fns": "^2.28.0",
         "deep-equal": "^1.0.1",
-        "electron": "27.0.2",
+        "electron": "27.0.3",
         "electron-builder": "24.4.0",
         "electron-builder-squirrel-windows": "24.4.0",
         "electron-devtools-installer": "^3.2.0",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -142,7 +142,7 @@
     "cross-env": "^7.0.3",
     "date-fns": "^2.28.0",
     "deep-equal": "^1.0.1",
-    "electron": "27.0.2",
+    "electron": "27.0.3",
     "electron-builder": "24.4.0",
     "electron-builder-squirrel-windows": "24.4.0",
     "electron-devtools-installer": "^3.2.0",


### PR DESCRIPTION
Bumps to electron 27.0.3 ([release notes](https://releases.electronjs.org/release/v27.0.3))

changelog(Improvements): Bump electron to 27.0.3