### PR TITLE
Recover untracked workspaces when checking for local VCS projects

### DIFF
--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -1,3 +1,6 @@
+// @TODOs
+// - [ ] Rename things that run a fetch to fetchSomething...
+// - [ ] Make sure that pull handles updating the parentId to the current project._id
 import clone from 'clone';
 import crypto from 'crypto';
 import path from 'path';

--- a/packages/insomnia/src/ui/components/dropdowns/remote-workspaces-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/remote-workspaces-dropdown.tsx
@@ -30,7 +30,7 @@ export const RemoteWorkspacesDropdown: FC<Props> = ({ project: { remoteId } }) =
     }
   }, [data, load, organizationId, projectId, state]);
 
-  const remoteBackendProjects = data?.remoteBackendProjects ?? [];
+  const backendProjectsToPull = data?.backendProjectsToPull ?? [];
 
   // Show a disabled button if remote project but not logged in
   if (!isLoggedIn()) {
@@ -62,7 +62,7 @@ export const RemoteWorkspacesDropdown: FC<Props> = ({ project: { remoteId } }) =
     >
       <DropdownSection
         aria-label='Remote Workspaces Section'
-        items={remoteBackendProjects.length === 0 ? [{
+        items={backendProjectsToPull.length === 0 ? [{
           id: 1,
           isDisabled: true,
           label: 'Nothing to pull',
@@ -87,7 +87,7 @@ export const RemoteWorkspacesDropdown: FC<Props> = ({ project: { remoteId } }) =
 
       <DropdownSection
         aria-label='Remote Workspaces Section'
-        items={remoteBackendProjects.length ? remoteBackendProjects : []}
+        items={backendProjectsToPull.length ? backendProjectsToPull : []}
         title={
           <>
             Remote {strings.collection.plural}

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -341,10 +341,8 @@ export const deleteWorkspaceAction: ActionFunction = async ({
 
   try {
     const vcs = VCSInstance();
-      const backendProject = await vcs._getBackendProjectByRootDocument(workspace._id);
-      await vcs._removeProject(backendProject);
-
-    console.log({ projectsLOCAL: await vcs.localBackendProjects() });
+    const backendProject = await vcs._getBackendProjectByRootDocument(workspace._id);
+    await vcs._removeProject(backendProject);
   } catch (err) {
     console.warn('Failed to remove project from VCS', err);
   }


### PR DESCRIPTION
When checking for local VCS files, check for missing parentId's and recover those workspaces.

How to test:
- Set a workspace's parentId to null (before opening the app or restart to make it dissapear)
- Go to that workspace's project and open the Pull dropdown
Before this PR
- The workspace shouldn't be on the list of files on the project or in the Pull dropdown list
After this PR
- The workspace should appear back into the list of files to pull