### PR TITLE
Fix: [Performance] - Transform sync to action instead of loader

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -45,12 +45,18 @@ export const SyncDropdown: FC<Props> = ({ gitSyncEnabled }) => {
 
   useEffect(() => {
     if (syncDataFetcher.state === 'idle' && !syncDataFetcher.data) {
-      syncDataFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/sync-data`);
+      syncDataFetcher.submit({}, {
+        action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/sync-data`,
+        method: 'POST',
+      });
     }
   }, [organizationId, projectId, syncDataFetcher, workspaceId]);
 
   useInterval(() => {
-    syncDataFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/sync-data`);
+    syncDataFetcher.submit({}, {
+      action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/sync-data`,
+      method: 'POST',
+    });
   }, ONE_MINUTE_IN_MS);
 
   const error = checkoutFetcher.data?.error || pullFetcher.data?.error || pushFetcher.data?.error || rollbackFetcher.data?.error;

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -842,10 +842,10 @@ const router = createMemoryRouter(
                                 },
                                 {
                                   path: 'sync-data',
-                                  loader: async (...args) =>
+                                  action: async (...args) =>
                                     (
                                       await import('./routes/remote-collections')
-                                    ).syncDataLoader(...args),
+                                    ).syncDataAction(...args),
                                 },
                                 {
                                   path: 'branch',

--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -181,7 +181,7 @@ export type SyncDataLoaderData = SyncData | {
   error: string;
 };
 
-export const syncDataLoader: LoaderFunction = async ({ params }): Promise<SyncDataLoaderData> => {
+export const syncDataAction: ActionFunction = async ({ params }): Promise<SyncDataLoaderData> => {
   try {
     const { projectId, workspaceId } = params;
     invariant(typeof projectId === 'string', 'Project Id is required');


### PR DESCRIPTION
Use an action for sync to avoid refetching vcs data.