### PR TITLE
Fix: Delete project should only archive locally after the API call

### DIFF
--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -341,8 +341,6 @@ export const deleteWorkspaceAction: ActionFunction = async ({
     try {
       const vcs = VCSInstance();
       await vcs.switchAndCreateBackendProjectIfNotExist(workspaceId, workspace.name);
-      const backendProject = await vcs._getBackendProjectByRootDocument(workspace._id);
-      await vcs._removeProject(backendProject);
       await vcs.archiveProject();
     } catch (err) {
       return {


### PR DESCRIPTION
changelog(Fixes): Fixed an issue where deleting a project would archive it locally if the user didn't have permission to delete it in the cloud