### PR TITLE
Use event listener on gridlist to capture send meta+enter

### DIFF
--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -986,6 +986,7 @@ export const Debug: FC = () => {
 
             <div className='flex-1 overflow-y-auto' ref={parentRef} >
               <GridList
+                id="sidebar-request-gridlist"
                 style={{ height: virtualizer.getTotalSize() }}
                 items={virtualizer.getVirtualItems()}
                 className="relative"


### PR DESCRIPTION
Use event listeners to capture hotkeys which would otherwise be captured by react-aria.

Replaces #6741

closes INS-3251

changelog(Fixes): Meta + Enter should now be sending the request when focused on the debug sidebar