### PR TITLE
Double click rename requests/unit-test/test-suite

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
@@ -132,7 +132,7 @@ test.describe('Debug-Sidebar', async () => {
     test('Rename a request by clicking', async ({ page }) => {
       await page.getByTestId('example http').getByLabel('request name').click();
       await page.getByRole('textbox', { name: 'request name' }).fill('new name');
-      await page.getByLabel('Request Collection').click();
+      await page.getByLabel('Request Collection').dblclick();
       await expect(page.getByTestId('new name').getByLabel('request name')).toContainText('new name');
     });
 

--- a/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
@@ -130,9 +130,9 @@ test.describe('Debug-Sidebar', async () => {
     });
 
     test('Rename a request by clicking', async ({ page }) => {
-      await page.getByTestId('example http').getByLabel('request name').click();
+      await page.getByTestId('example http').getByLabel('request name').dblclick();
       await page.getByRole('textbox', { name: 'request name' }).fill('new name');
-      await page.getByLabel('Request Collection').dblclick();
+      await page.getByLabel('Request Collection').click();
       await expect(page.getByTestId('new name').getByLabel('request name')).toContainText('new name');
     });
 

--- a/packages/insomnia/src/ui/components/editable-input.tsx
+++ b/packages/insomnia/src/ui/components/editable-input.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { FocusScope } from 'react-aria';
 import { Button, Input } from 'react-aria-components';
 
@@ -6,17 +6,19 @@ export const EditableInput = ({
   value = 'Untitled',
   ariaLabel,
   name,
-  paddingClass,
+  className,
   onChange,
+  onSingleClick,
 }: {
   value: string;
   ariaLabel?: string;
   name?: string;
-  paddingClass?: string;
+    className?: string;
   onChange: (value: string) => void;
+    onSingleClick?: () => void;
 }) => {
   const [isEditable, setIsEditable] = useState(false);
-
+  const buttonRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
     if (!isEditable) {
       return;
@@ -46,20 +48,60 @@ export const EditableInput = ({
     };
   }, [isEditable]);
 
-  const defaultPaddingClass = paddingClass != null && paddingClass.startsWith('px-') ? paddingClass : 'px-2';
+  useEffect(() => {
+    const button = buttonRef.current;
+    if (button) {
+      let clickTimeout: ReturnType<typeof setTimeout> | null = null;
+      function onClick(e: MouseEvent) {
+        e.stopPropagation();
+        e.preventDefault();
+        if (clickTimeout !== null) {
+          console.log('click: timeout exists');
+          clearTimeout(clickTimeout);
+        }
+        // If timeout passes fire the single click
+        // else prevent the single click and fire the double click
+        clickTimeout = setTimeout(() => {
+          onSingleClick?.();
+        }, 200);
+      }
+      button.addEventListener('click', onClick);
+
+      function onDoubleClick(e: MouseEvent) {
+        e.stopPropagation();
+        e.preventDefault();
+        if (clickTimeout !== null) {
+          clearTimeout(clickTimeout);
+          clickTimeout = null;
+        }
+        setIsEditable(true);
+      }
+
+      button.addEventListener('dblclick', onDoubleClick);
+
+      return () => {
+        button.removeEventListener('click', onClick);
+        button.removeEventListener('dblclick', onDoubleClick);
+      };
+    }
+
+    return () => { };
+  }, [onSingleClick]);
 
   return (
     <>
-
       <Button
+        ref={buttonRef}
         className={
-          `items-center truncate justify-center px-2 data-[pressed]:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all
+          `items-center truncate justify-center data-[pressed]:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all
             ${isEditable ? 'hidden' : ''}
-            ${defaultPaddingClass}
+            ${className || 'px-2'}
           `
         }
-        onPress={() => {
-          setIsEditable(true);
+        onPress={e => {
+          if (e.pointerType !== 'mouse') {
+            setIsEditable(true);
+          }
         }}
         name={name}
         aria-label={ariaLabel}
@@ -70,7 +112,7 @@ export const EditableInput = ({
       {isEditable && (
         <FocusScope contain restoreFocus autoFocus>
           <Input
-            className="px-2 truncate"
+            className={`truncate ${className || 'px-2'}`}
             name={name}
             aria-label={ariaLabel}
             defaultValue={value}

--- a/packages/insomnia/src/ui/components/editable-input.tsx
+++ b/packages/insomnia/src/ui/components/editable-input.tsx
@@ -88,10 +88,6 @@ export const EditableInput = ({
     return () => { };
   }, [onSingleClick]);
 
-  console.log({
-    className,
-  });
-
   return (
     <>
       <Button

--- a/packages/insomnia/src/ui/components/editable-input.tsx
+++ b/packages/insomnia/src/ui/components/editable-input.tsx
@@ -7,14 +7,14 @@ export const EditableInput = ({
   ariaLabel,
   name,
   className,
-  onChange,
+  onSubmit,
   onSingleClick,
 }: {
   value: string;
   ariaLabel?: string;
   name?: string;
     className?: string;
-  onChange: (value: string) => void;
+    onSubmit: (value: string) => void;
     onSingleClick?: () => void;
 }) => {
   const [isEditable, setIsEditable] = useState(false);
@@ -88,6 +88,10 @@ export const EditableInput = ({
     return () => { };
   }, [onSingleClick]);
 
+  console.log({
+    className,
+  });
+
   return (
     <>
       <Button
@@ -120,7 +124,7 @@ export const EditableInput = ({
               const value = e.currentTarget.value;
               if (e.key === 'Enter') {
                 e.stopPropagation();
-                onChange(value);
+                onSubmit(value);
                 setIsEditable(false);
               }
 
@@ -131,7 +135,7 @@ export const EditableInput = ({
             }}
             onBlur={e => {
               const value = e.currentTarget.value;
-              onChange(value);
+              onSubmit(value);
               setIsEditable(false);
             }}
           />

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -949,7 +949,16 @@ export const Debug: FC = () => {
                         value={getRequestNameOrFallback(item.doc)}
                         name="request name"
                         ariaLabel="request name"
-                        paddingClass="px-0"
+                        className="px-1 flex-1"
+                        onSingleClick={() => {
+                          if (item && isRequestGroup(item.doc)) {
+                            groupMetaPatcher(item.doc._id, { collapsed: !item.collapsed });
+                          } else {
+                            navigate(
+                              `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${item.doc._id}?${searchParams.toString()}`
+                            );
+                          }
+                        }}
                         onChange={name => {
                           if (isRequestGroup(item.doc)) {
                             patchGroup(item.doc._id, { name });
@@ -958,7 +967,6 @@ export const Debug: FC = () => {
                           }
                         }}
                       />
-                      <span className="flex-1" />
                       {item.pinned && (
                         <Icon className='text-[--font-size-sm]' icon="thumb-tack" />
                       )}
@@ -1062,7 +1070,16 @@ export const Debug: FC = () => {
                           value={getRequestNameOrFallback(item.doc)}
                           name="request name"
                           ariaLabel="request name"
-                          paddingClass="px-0"
+                          className="px-1 flex-1"
+                          onSingleClick={() => {
+                            if (item && isRequestGroup(item.doc)) {
+                              groupMetaPatcher(item.doc._id, { collapsed: !item.collapsed });
+                            } else {
+                              navigate(
+                                `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${item.doc._id}?${searchParams.toString()}`
+                              );
+                            }
+                          }}
                           onChange={name => {
                             if (isRequestGroup(item.doc)) {
                               patchGroup(item.doc._id, { name });
@@ -1071,7 +1088,6 @@ export const Debug: FC = () => {
                             }
                           }}
                         />
-                        <span className="flex-1" />
                         {isWebSocketRequest(item.doc) && <WebSocketSpinner requestId={item.doc._id} />}
                         {isEventStreamRequest(item.doc) && <EventStreamSpinner requestId={item.doc._id} />}
                         {item.pinned && (

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -959,7 +959,7 @@ export const Debug: FC = () => {
                             );
                           }
                         }}
-                        onChange={name => {
+                        onSubmit={name => {
                           if (isRequestGroup(item.doc)) {
                             patchGroup(item.doc._id, { name });
                           } else {
@@ -1080,7 +1080,7 @@ export const Debug: FC = () => {
                               );
                             }
                           }}
-                          onChange={name => {
+                          onSubmit={name => {
                             if (isRequestGroup(item.doc)) {
                               patchGroup(item.doc._id, { name });
                             } else {

--- a/packages/insomnia/src/ui/routes/test-suite.tsx
+++ b/packages/insomnia/src/ui/routes/test-suite.tsx
@@ -83,7 +83,8 @@ const UnitTestItemView = ({
         </Button>
         <Heading className="flex-1 truncate">
           <EditableInput
-            onChange={name => {
+            className='w-full px-1'
+            onSubmit={name => {
               if (name) {
                 updateUnitTestFetcher.submit(
                   {
@@ -404,7 +405,8 @@ const TestSuiteRoute = () => {
       <div className="flex flex-shrink-0 gap-2 p-[--padding-md]">
         <Heading className="text-lg flex-shrink-0 flex items-center gap-2 w-full truncate flex-1">
           <EditableInput
-            onChange={name =>
+            className='w-full px-1'
+            onSubmit={name =>
               name &&
               renameTestSuiteFetcher.submit(
                 { name },

--- a/packages/insomnia/src/ui/routes/unit-test.tsx
+++ b/packages/insomnia/src/ui/routes/unit-test.tsx
@@ -375,7 +375,8 @@ const TestRoute: FC = () => {
                         value={item.name}
                         name="name"
                         ariaLabel="Test suite name"
-                        onChange={name => {
+                        className='flex-1 px-1'
+                        onSubmit={name => {
                           name && renameTestSuiteFetcher.submit(
                             { name },
                             {
@@ -385,7 +386,6 @@ const TestRoute: FC = () => {
                           );
                         }}
                       />
-                      <span className="flex-1" />
                       <MenuTrigger>
                         <Button
                           aria-label="Project Actions"

--- a/packages/insomnia/src/ui/routes/unit-test.tsx
+++ b/packages/insomnia/src/ui/routes/unit-test.tsx
@@ -376,6 +376,11 @@ const TestRoute: FC = () => {
                         name="name"
                         ariaLabel="Test suite name"
                         className='flex-1 px-1'
+                        onSingleClick={() => {
+                          navigate({
+                            pathname: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/test/test-suite/${item._id}`,
+                          });
+                        }}
                         onSubmit={name => {
                           name && renameTestSuiteFetcher.submit(
                             { name },


### PR DESCRIPTION
- Change the behaviour of the editable input to trigger on double click instead of click.
- Allow onClick behaviour to be passed as a prop

changelog(Fixes): Renaming a request/folder/test-suite now happens with double click and allows single click to navigate instead