### PR TITLE
fix: prevent yarn directory traversal on plugin installation

### DIFF
--- a/packages/insomnia/src/main/install-plugin.ts
+++ b/packages/insomnia/src/main/install-plugin.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, readdir, stat } from 'node:fs/promises';
+import { cp, mkdir, readdir, stat, writeFile } from 'node:fs/promises';
 
 import childProcess from 'child_process';
 import * as electron from 'electron';
@@ -162,6 +162,8 @@ async function _installPluginToTmpDir(lookupName: string) {
   return new Promise<{ tmpDir: string }>(async (resolve, reject) => {
     const tmpDir = path.join(electron.app.getPath('temp'), `${lookupName}-${Date.now()}`);
     await mkdir(tmpDir, { recursive: true });
+    // Write a dummy package.json so that yarn doesn't traverse up the directory tree
+    await writeFile(path.join(tmpDir, 'package.json'), JSON.stringify({license: 'ISC', workspaces: []}), 'utf-8');
 
     console.log(`[plugins] Installing plugin to ${tmpDir}`);
     childProcess.execFile(
@@ -178,6 +180,7 @@ async function _installPluginToTmpDir(lookupName: string) {
         '--no-lockfile',
         '--production',
         '--no-progress',
+        '--ignore-workspace-root-check',
       ],
       {
         timeout: 5 * 60 * 1000,

--- a/packages/insomnia/src/main/install-plugin.ts
+++ b/packages/insomnia/src/main/install-plugin.ts
@@ -163,7 +163,7 @@ async function _installPluginToTmpDir(lookupName: string) {
     const tmpDir = path.join(electron.app.getPath('temp'), `${lookupName}-${Date.now()}`);
     await mkdir(tmpDir, { recursive: true });
     // Write a dummy package.json so that yarn doesn't traverse up the directory tree
-    await writeFile(path.join(tmpDir, 'package.json'), JSON.stringify({license: 'ISC', workspaces: []}), 'utf-8');
+    await writeFile(path.join(tmpDir, 'package.json'), JSON.stringify({ license: 'ISC', workspaces: [] }), 'utf-8');
 
     console.log(`[plugins] Installing plugin to ${tmpDir}`);
     childProcess.execFile(


### PR DESCRIPTION
fixes #4041 (and possibly others)

Yarn would previously traverse up the directory tree looking for a workspace `package.json`.
This PR prevents this behavior by writing a dummy `package.json` so yarn stops looking.

Solves errors that occur when a `package.json` exists in a parent directory (such as the user home directory or the root directory). Even when those errors don't occur, this may speed up execution very slightly by making fewer disk calls.