### PR TITLE
Cache VCS related queries

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -41,16 +41,19 @@ export const SyncDropdown: FC<Props> = ({ gitSyncEnabled }) => {
   const pullFetcher = useFetcher();
   const rollbackFetcher = useFetcher();
   const checkoutFetcher = useFetcher();
-  const syncDataFetcher = useFetcher<SyncDataLoaderData>();
+  const syncDataLoaderFetcher = useFetcher<SyncDataLoaderData>();
+  const syncDataActionFetcher = useFetcher();
 
   useEffect(() => {
-    if (syncDataFetcher.state === 'idle' && !syncDataFetcher.data) {
-      syncDataFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/sync-data`);
+    if (syncDataLoaderFetcher.state === 'idle' && !syncDataLoaderFetcher.data) {
+      syncDataLoaderFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/sync-data`);
     }
-  }, [organizationId, projectId, syncDataFetcher, workspaceId]);
+  }, [organizationId, projectId, syncDataLoaderFetcher, workspaceId]);
 
   useInterval(() => {
-    syncDataFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/sync-data`);
+    syncDataActionFetcher.submit({}, {
+      action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/sync-data`,
+    });
   }, ONE_MINUTE_IN_MS);
 
   const error = checkoutFetcher.data?.error || pullFetcher.data?.error || pushFetcher.data?.error || rollbackFetcher.data?.error;
@@ -64,7 +67,7 @@ export const SyncDropdown: FC<Props> = ({ gitSyncEnabled }) => {
     }
   }, [error]);
 
-  if (syncDataFetcher.state !== 'idle' && !syncDataFetcher.data) {
+  if (syncDataLoaderFetcher.state !== 'idle' && !syncDataLoaderFetcher.data) {
     return (
       <Button className="flex items-center h-9 gap-4 px-[--padding-md] w-full aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm">
         <Icon icon="refresh" className="animate-spin" /> Initializing
@@ -88,8 +91,8 @@ export const SyncDropdown: FC<Props> = ({ gitSyncEnabled }) => {
     compare: { ahead: 0, behind: 0 },
   };
 
-  if (syncDataFetcher.data && !('error' in syncDataFetcher.data)) {
-    syncData = syncDataFetcher.data;
+  if (syncDataLoaderFetcher.data && !('error' in syncDataLoaderFetcher.data)) {
+    syncData = syncDataLoaderFetcher.data;
   }
 
   const {

--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -52,6 +52,7 @@ export const SyncDropdown: FC<Props> = ({ gitSyncEnabled }) => {
 
   useInterval(() => {
     syncDataActionFetcher.submit({}, {
+      method: 'POST',
       action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/sync-data`,
     });
   }, ONE_MINUTE_IN_MS);

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -842,6 +842,10 @@ const router = createMemoryRouter(
                                 },
                                 {
                                   path: 'sync-data',
+                                  action: async (...args) =>
+                                    (
+                                      await import('./routes/remote-collections')
+                                    ).syncDataAction(...args),
                                   loader: async (...args) =>
                                     (
                                       await import('./routes/remote-collections')

--- a/packages/insomnia/src/ui/routes/modals.tsx
+++ b/packages/insomnia/src/ui/routes/modals.tsx
@@ -18,7 +18,6 @@ import { RequestRenderErrorModal } from '../components/modals/request-render-err
 import { ResponseDebugModal } from '../components/modals/response-debug-modal';
 import { SelectModal } from '../components/modals/select-modal';
 import { SettingsModal } from '../components/modals/settings-modal';
-import { SyncMergeModal } from '../components/modals/sync-merge-modal';
 import { WrapperModal } from '../components/modals/wrapper-modal';
 import { WorkspaceLoaderData } from './workspace';
 
@@ -79,12 +78,6 @@ const Modals: FC = () => {
         <EnvironmentEditModal
           ref={instance => registerModal(instance, 'EnvironmentEditModal')}
         />
-
-        {activeWorkspace ? (
-          <SyncMergeModal
-            ref={instance => registerModal(instance, 'SyncMergeModal')}
-          />
-        ) : null}
 
         <AddKeyCombinationModal
           ref={instance => registerModal(instance, 'AddKeyCombinationModal')}

--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -177,6 +177,45 @@ interface SyncData {
   remoteBackendProjects: BackendProject[];
 }
 
+const remoteBranchesCache: Record<string, string[]> = {};
+const remoteCompareCache: Record<string, { ahead: number; behind: number }> = {};
+const remoteBackendProjectsCache: Record<string, BackendProject[]> = {};
+
+export const syncDataAction: ActionFunction = async ({ params }) => {
+  try {
+    const { projectId, workspaceId } = params;
+    invariant(typeof projectId === 'string', 'Project Id is required');
+    invariant(typeof workspaceId === 'string', 'Workspace Id is required');
+
+    const project = await models.project.getById(projectId);
+    invariant(project, 'Project not found');
+    invariant(project.remoteId, 'Project is not remote');
+    const vcs = VCSInstance();
+    const remoteBranches = (await vcs.getRemoteBranches()).sort();
+    const compare = await vcs.compareRemoteBranch();
+    const remoteBackendProjects = await vcs.remoteBackendProjects({
+      teamId: project.parentId,
+      teamProjectId: project.remoteId,
+    });
+
+    // Cache remote branches
+    remoteBranchesCache[workspaceId] = remoteBranches;
+    remoteCompareCache[workspaceId] = compare;
+    remoteBackendProjectsCache[workspaceId] = remoteBackendProjects;
+
+    return {
+      remoteBranches,
+      compare,
+      remoteBackendProjects,
+    };
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : 'Unknown error while syncing data.';
+    return {
+      error: errorMessage,
+    };
+  }
+};
+
 export type SyncDataLoaderData = SyncData | {
   error: string;
 };
@@ -193,16 +232,20 @@ export const syncDataLoader: LoaderFunction = async ({ params }): Promise<SyncDa
     const vcs = VCSInstance();
     const { syncItems } = await getSyncItems({ workspaceId });
     const localBranches = (await vcs.getBranches()).sort();
-    const remoteBranches = (await vcs.getRemoteBranches()).sort();
+    const remoteBranches = (remoteBranchesCache[workspaceId] || await vcs.getRemoteBranches()).sort();
     const currentBranch = await vcs.getBranch();
     const history = (await vcs.getHistory()).sort((a, b) => b.created > a.created ? 1 : -1);
     const historyCount = await vcs.getHistoryCount();
     const status = await vcs.status(syncItems, {});
-    const compare = await vcs.compareRemoteBranch();
-    const remoteBackendProjects = await vcs.remoteBackendProjects({
+    const compare = remoteCompareCache[workspaceId] || await vcs.compareRemoteBranch();
+    const remoteBackendProjects = remoteBackendProjectsCache[workspaceId] || await vcs.remoteBackendProjects({
       teamId: project.parentId,
       teamProjectId: project.remoteId,
     });
+
+    remoteBranchesCache[workspaceId] = remoteBranches;
+    remoteCompareCache[workspaceId] = compare;
+    remoteBackendProjectsCache[workspaceId] = remoteBackendProjects;
 
     return {
       syncItems,


### PR DESCRIPTION
Uses a simple cache to store VCS query results:
- Loader tries to fetch data if the cache is empty
- If there are cached data the loader uses only those.
- The cache gets refreshed explicitly by the new action.

Note:
This is a temp solution to avoid refetching the VCS related queries on the loader path.
It will to be replaced by a proper global network cache in the app.