### PR TITLE
Fix: deleting a key combination

### DIFF
--- a/packages/insomnia/src/ui/components/settings/shortcuts.tsx
+++ b/packages/insomnia/src/ui/components/settings/shortcuts.tsx
@@ -112,13 +112,15 @@ export const Shortcuts: FC = () => {
                                 withPrompt
                                 onClick={() => {
                                   let toBeRemovedIndex = -1;
-                                  keyCombosForThisPlatform.forEach((existingKeyComb, index) => {
+                                  const keyCombs = getPlatformKeyCombinations(hotKeyRegistry[keyboardShortcut]);
+                                  keyCombs.forEach((existingKeyComb, index) => {
                                     if (areSameKeyCombinations(existingKeyComb, keyComb)) {
                                       toBeRemovedIndex = index;
                                     }
                                   });
                                   if (toBeRemovedIndex >= 0) {
-                                    keyCombosForThisPlatform.splice(toBeRemovedIndex, 1);
+                                    keyCombs.splice(toBeRemovedIndex, 1);
+
                                     patchSettings({ hotKeyRegistry });
                                   }
                                 }}


### PR DESCRIPTION
Deleting a key combination doesn't work.

This PR mutates the appropriate list of combinations that we pass to update the settings.

Next steps:
- Mutating a list like we do is error prone and can lead to other issues like this one.
- We should improve the api for adding/removing/updating a key combination in the hotkey registry 

changelog(Fixes): Fixed an issue where removing an existing keyboard shortcut would not work as expected