### PR TITLE
Fix: Register sync-merge modal

### DIFF
--- a/packages/insomnia/src/ui/routes/modals.tsx
+++ b/packages/insomnia/src/ui/routes/modals.tsx
@@ -18,6 +18,7 @@ import { RequestRenderErrorModal } from '../components/modals/request-render-err
 import { ResponseDebugModal } from '../components/modals/response-debug-modal';
 import { SelectModal } from '../components/modals/select-modal';
 import { SettingsModal } from '../components/modals/settings-modal';
+import { SyncMergeModal } from '../components/modals/sync-merge-modal';
 import { WrapperModal } from '../components/modals/wrapper-modal';
 import { WorkspaceLoaderData } from './workspace';
 
@@ -81,6 +82,10 @@ const Modals: FC = () => {
 
         <AddKeyCombinationModal
           ref={instance => registerModal(instance, 'AddKeyCombinationModal')}
+        />
+
+        <SyncMergeModal
+          ref={instance => registerModal(instance, 'SyncMergeModal')}
         />
 
       </ErrorBoundary>


### PR DESCRIPTION
The sync-merge modal was not registered leading to an error whenever we tried to show it

changelog(Fixes): Fixed an issue where sync conflicts would not show the conflict resolution modal