### PR TITLE
fix: graphql render issue caused by illegal Object.includes()

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/graphql.yaml
+++ b/packages/insomnia-smoke-test/fixtures/graphql.yaml
@@ -29,6 +29,58 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
+  - _id: req_63e5c8a8d1674bb39ba6df1d0eb452a1
+    parentId: wrk_d8bfe72fd18b42daa55d2ccc08c9eecb
+    modified: 1655289849596
+    created: 1655289826760
+    url: localhost:4010/graphql
+    name: GraphQL request with number
+    description: ""
+    method: POST
+    body:
+      mimeType: application/graphql
+      text: '{"query": "query($inputVar: Int) { echoNum(intVar: $inputVar)}", "variables": "{ \"inputVar\": {{ _.intVar }} }"}'
+    parameters: []
+    headers:
+      - name: Content-Type
+        value: application/json
+        id: pair_91da32f74847489ab06da669db0b425f
+    authentication: {}
+    metaSortKey: -1655289826761
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_63e5c8a8d1674bb39ba6df1d0eb452a2
+    parentId: wrk_d8bfe72fd18b42daa55d2ccc08c9eecb
+    modified: 1655289849596
+    created: 1655289826760
+    url: localhost:4010/graphql
+    name: GraphQL request with variables
+    description: ""
+    method: POST
+    body:
+      mimeType: application/graphql
+      text: '{"query":"query($vars: VarsInput) {\n\techoVars(vars: $vars) {\n\t\tstringVar \n\t\tintVar\n\t}\n}", "variables":{"vars":{"stringVar":"3","intVar": 3}} }'
+    parameters: []
+    headers:
+      - name: Content-Type
+        value: application/json
+        id: pair_91da32f74847489ab06da669db0b425f
+    authentication: {}
+    metaSortKey: -1655289826761
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
   - _id: wrk_d8bfe72fd18b42daa55d2ccc08c9eecb
     parentId: null
     modified: 1655289816535
@@ -42,7 +94,8 @@ resources:
     modified: 1655289816558
     created: 1655289816558
     name: Base Environment
-    data: {}
+    data:
+      intVar: 3
     dataPropertyOrder: null
     color: null
     isPrivate: false

--- a/packages/insomnia-smoke-test/server/graphql.ts
+++ b/packages/insomnia-smoke-test/server/graphql.ts
@@ -1,4 +1,20 @@
-import { GraphQLEnumType, GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
+import { GraphQLEnumType, GraphQLInputObjectType, GraphQLInt, GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
+
+const TypeVars = new GraphQLObjectType({
+  name: 'Vars',
+  fields: () => ({
+    stringVar: { type: GraphQLString },
+    intVar: { type: GraphQLInt },
+  }),
+});
+
+const InputVars = new GraphQLInputObjectType({
+  name: 'VarsInput',
+  fields: () => ({
+    stringVar: { type: GraphQLString },
+    intVar: { type: GraphQLInt },
+  }),
+});
 
 export const schema = new GraphQLSchema({
   query: new GraphQLObjectType({
@@ -27,6 +43,20 @@ export const schema = new GraphQLSchema({
           },
         }),
         resolve: () => 3,
+      },
+      echoNum: {
+        type: GraphQLInt,
+        args: {
+          'intVar': { type: GraphQLInt },
+        },
+        resolve: () => 777,
+      },
+      echoVars: {
+        type: TypeVars,
+        args: {
+          'vars': { type: InputVars },
+        },
+        resolve: vars => vars,
       },
     },
   }),

--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -18,6 +18,7 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByText('CollectionSmoke GraphQLjust now').click();
+
   // Open the graphql request
   await page.getByLabel('Request Collection').getByTestId('GraphQL request').press('Enter');
   // Assert the schema is fetched after switching to GraphQL request
@@ -42,6 +43,88 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
   });
   await expect(responseBody).toContainText('"bearer": "Gandalf"');
 });
+
+test('can render schema and send GraphQL requests with object variables', async ({ app, page }) => {
+  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+
+  await page.getByRole('button', { name: 'Create in project' }).click();
+
+  // Copy the collection with the graphql query to clipboard
+  const text = await loadFixture('graphql.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+  // Import from clipboard
+  await page.getByRole('menuitemradio', { name: 'Import' }).click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await page.getByText('CollectionSmoke GraphQLjust now').click();
+
+  // Open the graphql request
+  await page.getByLabel('Request Collection').getByTestId('GraphQL request with variables').press('Enter');
+  // Assert the schema is fetched after switching to GraphQL request
+  await expect(page.locator('.graphql-editor__meta')).toContainText('schema fetched just now');
+
+  // Assert schema documentation stuff
+  await page.getByRole('button', { name: 'schema' }).click();
+  await page.getByRole('menuitem', { name: 'Show Documentation' }).click();
+  await page.click('a:has-text("Query")');
+  await page.locator('a:has-text("RingBearer")').click();
+  const graphqlExplorer2 = page.locator('.graphql-explorer');
+  await expect(graphqlExplorer2).toContainText('Characters who at any time bore a Ring of Power.');
+  await page.click('text=QueryRingBearer >> button');
+
+  // Send and assert GraphQL request
+  await page.click('[data-testid="request-pane"] >> text=Send');
+  const statusTag2 = page.locator('[data-testid="response-status-tag"]:visible');
+  await expect(statusTag2).toContainText('200 OK');
+
+  const responseBody2 = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
+    has: page.locator('.CodeMirror-activeline'),
+  });
+  await expect(responseBody2).toContainText('"echoVars": null');
+});
+
+// test('can render numeric environment', async ({ app, page }) => {
+//   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+
+//   await page.getByRole('button', { name: 'Create in project' }).click();
+
+//   // Copy the collection with the graphql query to clipboard
+//   const text = await loadFixture('graphql.yaml');
+//   await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+//   // Import from clipboard
+//   await page.getByRole('menuitemradio', { name: 'Import' }).click();
+//   await page.locator('[data-test-id="import-from-clipboard"]').click();
+//   await page.getByRole('button', { name: 'Scan' }).click();
+//   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+//   await page.getByText('CollectionSmoke GraphQLjust now').click();
+
+//   // Open the graphql request
+//   await page.getByLabel('Request Collection').getByTestId('GraphQL request with number').press('Enter');
+//   // Assert the schema is fetched after switching to GraphQL request
+//   await expect(page.locator('.graphql-editor__meta')).toContainText('schema fetched just now');
+
+//   // Assert schema documentation stuff
+//   await page.getByRole('button', { name: 'schema' }).click();
+//   await page.getByRole('menuitem', { name: 'Show Documentation' }).click();
+//   await page.click('a:has-text("Query")');
+//   await page.locator('a:has-text("RingBearer")').click();
+//   const graphqlExplorer2 = page.locator('.graphql-explorer');
+//   await expect(graphqlExplorer2).toContainText('Characters who at any time bore a Ring of Power.');
+//   await page.click('text=QueryRingBearer >> button');
+
+//   // Send and assert GraphQL request
+//   await page.click('[data-testid="request-pane"] >> text=Send');
+//   const statusTag2 = page.locator('[data-testid="response-status-tag"]:visible');
+//   await expect(statusTag2).toContainText('200 OK');
+
+//   const responseBody2 = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
+//     has: page.locator('.CodeMirror-activeline'),
+//   });
+//   await expect(responseBody2).toContainText('"echoVars": null');
+// });
 
 test('can send GraphQL requests after editing and prettifying query', async ({ app, page }) => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');

--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -85,46 +85,46 @@ test('can render schema and send GraphQL requests with object variables', async 
   await expect(responseBody2).toContainText('"echoVars": null');
 });
 
-// test('can render numeric environment', async ({ app, page }) => {
-//   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+test('can render numeric environment', async ({ app, page }) => {
+  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
 
-//   await page.getByRole('button', { name: 'Create in project' }).click();
+  await page.getByRole('button', { name: 'Create in project' }).click();
 
-//   // Copy the collection with the graphql query to clipboard
-//   const text = await loadFixture('graphql.yaml');
-//   await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+  // Copy the collection with the graphql query to clipboard
+  const text = await loadFixture('graphql.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
 
-//   // Import from clipboard
-//   await page.getByRole('menuitemradio', { name: 'Import' }).click();
-//   await page.locator('[data-test-id="import-from-clipboard"]').click();
-//   await page.getByRole('button', { name: 'Scan' }).click();
-//   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-//   await page.getByText('CollectionSmoke GraphQLjust now').click();
+  // Import from clipboard
+  await page.getByRole('menuitemradio', { name: 'Import' }).click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await page.getByText('CollectionSmoke GraphQLjust now').click();
 
-//   // Open the graphql request
-//   await page.getByLabel('Request Collection').getByTestId('GraphQL request with number').press('Enter');
-//   // Assert the schema is fetched after switching to GraphQL request
-//   await expect(page.locator('.graphql-editor__meta')).toContainText('schema fetched just now');
+  // Open the graphql request
+  await page.getByLabel('Request Collection').getByTestId('GraphQL request with number').press('Enter');
+  // Assert the schema is fetched after switching to GraphQL request
+  await expect(page.locator('.graphql-editor__meta')).toContainText('schema fetched just now');
 
-//   // Assert schema documentation stuff
-//   await page.getByRole('button', { name: 'schema' }).click();
-//   await page.getByRole('menuitem', { name: 'Show Documentation' }).click();
-//   await page.click('a:has-text("Query")');
-//   await page.locator('a:has-text("RingBearer")').click();
-//   const graphqlExplorer2 = page.locator('.graphql-explorer');
-//   await expect(graphqlExplorer2).toContainText('Characters who at any time bore a Ring of Power.');
-//   await page.click('text=QueryRingBearer >> button');
+  // Assert schema documentation stuff
+  await page.getByRole('button', { name: 'schema' }).click();
+  await page.getByRole('menuitem', { name: 'Show Documentation' }).click();
+  await page.click('a:has-text("Query")');
+  await page.locator('a:has-text("RingBearer")').click();
+  const graphqlExplorer2 = page.locator('.graphql-explorer');
+  await expect(graphqlExplorer2).toContainText('Characters who at any time bore a Ring of Power.');
+  await page.click('text=QueryRingBearer >> button');
 
-//   // Send and assert GraphQL request
-//   await page.click('[data-testid="request-pane"] >> text=Send');
-//   const statusTag2 = page.locator('[data-testid="response-status-tag"]:visible');
-//   await expect(statusTag2).toContainText('200 OK');
+  // Send and assert GraphQL request
+  await page.click('[data-testid="request-pane"] >> text=Send');
+  const statusTag2 = page.locator('[data-testid="response-status-tag"]:visible');
+  await expect(statusTag2).toContainText('200 OK');
 
-//   const responseBody2 = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
-//     has: page.locator('.CodeMirror-activeline'),
-//   });
-//   await expect(responseBody2).toContainText('"echoVars": null');
-// });
+  const responseBody2 = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
+    has: page.locator('.CodeMirror-activeline'),
+  });
+  await expect(responseBody2).toContainText('"echoNum": 777');
+});
 
 test('can send GraphQL requests after editing and prettifying query', async ({ app, page }) => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');

--- a/packages/insomnia/src/network/unit-test-feature.ts
+++ b/packages/insomnia/src/network/unit-test-feature.ts
@@ -16,6 +16,20 @@ export function getSendRequestCallback() {
 
     const renderResult = await tryToInterpolateRequest(request, environment._id, RENDER_PURPOSE_SEND);
     const renderedRequest = await tryToTransformRequestWithPlugins(renderResult);
+
+    // TODO: remove this temporary hack to support GraphQL variables in the request body properly
+    if (renderedRequest && renderedRequest.body?.text && renderedRequest.body?.mimeType === 'application/graphql') {
+      try {
+        const parsedBody = JSON.parse(renderedRequest.body.text);
+        if (typeof parsedBody.variables === 'string') {
+          parsedBody.variables = JSON.parse(parsedBody.variables);
+          renderedRequest.body.text = JSON.stringify(parsedBody, null, 2);
+        }
+      } catch (e) {
+        console.error('Failed to parse GraphQL variables', e);
+      }
+    }
+
     const response = await sendCurlAndWriteTimeline(
       renderedRequest,
       clientCertificates,

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -190,6 +190,9 @@ export const GraphQLEditor: FC<Props> = ({
   }
 
   requestBody.variables = requestBody.variables || '';
+  if (typeof requestBody.variables !== 'string') {
+    requestBody.variables = JSON.stringify(requestBody.variables);
+  }
 
   let documentAST;
   try {

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -190,10 +190,6 @@ export const GraphQLEditor: FC<Props> = ({
   }
 
   requestBody.variables = requestBody.variables || '';
-  // TODO: it should be always string, need to do this in the persistent layer
-  if (typeof requestBody.variables !== 'string') {
-    requestBody.variables = JSON.stringify(requestBody.variables);
-  }
 
   let documentAST;
   try {

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -190,6 +190,7 @@ export const GraphQLEditor: FC<Props> = ({
   }
 
   requestBody.variables = requestBody.variables || '';
+  // TODO: it should be always string, need to do this in the persistent layer
   if (typeof requestBody.variables !== 'string') {
     requestBody.variables = JSON.stringify(requestBody.variables);
   }


### PR DESCRIPTION
changelog(Fixes): Fixed issue #6857 related to GraphQL render issue caused by illegal Object.includes() method call. Also fixed an issue where GraphQL variables were not properly sent as an object when sending requests (both from Debug and Test view).

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

It seems we've tried to fix one issue and caused another issue. I took a very conservative approach here to fix the issue on top of the previous fix.

## Root Cause
Basically variables are passed as Object. Object does not contain 'includes()' method, and, therefore,  it throws an error.

## Solution
The fix here is in jsonPrettify method, we should give a default value as an empty string and stringify the object if passed instead of string in trycatch block. If it fails, we should return the default value, so it does not break the app. Ideally, I would prefer to show a toast when it happens, so the user can be aware. Currently it silently fails but the app still runs.


## TODO
- [x] solved issue with graphql variables field being sent as a string when it should be sent as an objectg
- [x] added reproduction smoke tests to check cases where we send Integer variables, Object variables, ... in Graphql requests

The codebase has very low test coverage, and in general, we should try increasing the coverage (despite little time we have)

Huge thanks to [camiloclc](https://github.com/camiloclc) who didn't mind jumping on the call and helped us reproduce it. 


Closes #6857 and all the other duplicate issues