### PR TITLE
Make websocket immutable headers read-only in the UI

### DIFF
--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -128,12 +128,14 @@ export const KeyValueEditor: FC<Props> = ({
                 <input
                   style={{ width: '100%' }}
                   defaultValue={pair.name}
+                  readOnly
                 />
               </div>
               <div className="form-control form-control--underlined form-control--wide">
                 <input
                   style={{ width: '100%' }}
                   defaultValue={pair.value}
+                  readOnly
                 />
               </div>
               <button><i className="fa fa-empty" /></button>


### PR DESCRIPTION
The immutable headers of a WebSocket request were read-only in the logic but editable in the UI.

changelog(Fixes): WebSocket default headers are now shown as read-only in the UI