### PR TITLE
chore: add a log on the parentId set null

### DIFF
--- a/packages/insomnia/src/main/sentry.ts
+++ b/packages/insomnia/src/main/sentry.ts
@@ -4,6 +4,7 @@ import type { SentryRequestType } from '@sentry/types';
 import * as session from '../account/session';
 import { ChangeBufferEvent, database as db } from '../common/database';
 import { SENTRY_OPTIONS } from '../common/sentry';
+import { ExceptionCallback, loadCaptureException } from '../models/capture-exception.util';
 import * as models from '../models/index';
 import { isSettings } from '../models/settings';
 
@@ -44,4 +45,6 @@ export function initializeSentry() {
     ...SENTRY_OPTIONS,
     transport: ElectronSwitchableTransport,
   });
+
+  loadCaptureException(Sentry.captureException as ExceptionCallback);
 }

--- a/packages/insomnia/src/main/sentry.ts
+++ b/packages/insomnia/src/main/sentry.ts
@@ -46,5 +46,7 @@ export function initializeSentry() {
     transport: ElectronSwitchableTransport,
   });
 
+  // this is a hack for logging the sentry error synthetically made for database parent id null issue
+  // currently the database modules are used in the inso-cli as well as it uses NeDB (why?)
   loadCaptureException(Sentry.captureException as ExceptionCallback);
 }

--- a/packages/insomnia/src/main/sentry.ts
+++ b/packages/insomnia/src/main/sentry.ts
@@ -4,7 +4,7 @@ import type { SentryRequestType } from '@sentry/types';
 import * as session from '../account/session';
 import { ChangeBufferEvent, database as db } from '../common/database';
 import { SENTRY_OPTIONS } from '../common/sentry';
-import { ExceptionCallback, loadCaptureException } from '../models/capture-exception.util';
+import { ExceptionCallback, registerCaptureException } from '../models/capture-exception.util';
 import * as models from '../models/index';
 import { isSettings } from '../models/settings';
 
@@ -48,5 +48,5 @@ export function initializeSentry() {
 
   // this is a hack for logging the sentry error synthetically made for database parent id null issue
   // currently the database modules are used in the inso-cli as well as it uses NeDB (why?)
-  loadCaptureException(Sentry.captureException as ExceptionCallback);
+  registerCaptureException(Sentry.captureException as ExceptionCallback);
 }

--- a/packages/insomnia/src/models/capture-exception.util.ts
+++ b/packages/insomnia/src/models/capture-exception.util.ts
@@ -10,8 +10,10 @@ let captureException: ExceptionCallback = (exception: unknown) => {
     return '';
 };
 
-export function loadCaptureException(fn: ExceptionCallback) {
-    captureException = fn;
+export function loadCaptureException() {
+    return captureException;
 }
 
-export default captureException;
+export function registerCaptureException(fn: ExceptionCallback) {
+    captureException = fn;
+}

--- a/packages/insomnia/src/models/capture-exception.util.ts
+++ b/packages/insomnia/src/models/capture-exception.util.ts
@@ -1,0 +1,15 @@
+export type ExceptionCallback = (exception: unknown, captureContext?: unknown) => string;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+let captureException = (exception: unknown, _captureContext?: unknown) => {
+    console.error(exception);
+    return '';
+};
+
+if (process.versions.electron) {
+    import('@sentry/electron').then(Sentry => {
+        captureException = Sentry.captureException as ExceptionCallback;
+    });
+}
+
+export default captureException;

--- a/packages/insomnia/src/models/capture-exception.util.ts
+++ b/packages/insomnia/src/models/capture-exception.util.ts
@@ -1,3 +1,8 @@
+/**
+ * This is a HACK to work around inso cli using the database module used for Insomnia desktop client.
+ * Now this is getting coupled with Electron side, and CLI should not be really related to the electron at all.
+ * That is another tech debt.
+ */
 export type ExceptionCallback = (exception: unknown, captureContext?: unknown) => string;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/insomnia/src/models/capture-exception.util.ts
+++ b/packages/insomnia/src/models/capture-exception.util.ts
@@ -5,14 +5,13 @@
  */
 export type ExceptionCallback = (exception: unknown, captureContext?: unknown) => string;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-let captureException = (exception: unknown, _captureContext?: unknown) => {
+let captureException: ExceptionCallback = (exception: unknown) => {
     console.error(exception);
     return '';
 };
 
-export function loadCaptureException(capture: ExceptionCallback) {
-    captureException = capture;
+export function loadCaptureException(fn: ExceptionCallback) {
+    captureException = fn;
 }
 
 export default captureException;

--- a/packages/insomnia/src/models/capture-exception.util.ts
+++ b/packages/insomnia/src/models/capture-exception.util.ts
@@ -11,10 +11,8 @@ let captureException = (exception: unknown, _captureContext?: unknown) => {
     return '';
 };
 
-if (process.versions.electron) {
-    import('@sentry/electron').then(Sentry => {
-        captureException = Sentry.captureException as ExceptionCallback;
-    });
+export function loadCaptureException(capture: ExceptionCallback) {
+    captureException = capture;
 }
 
 export default captureException;

--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -1,4 +1,4 @@
-import { SentryError } from '@sentry/utils';
+import * as Sentry from '@sentry/electron';
 
 import {
   EXPORT_TYPE_API_SPEC,
@@ -171,7 +171,7 @@ const assertModelWithParentId = (model: BaseModel, info: string) => {
     console.warn(msg);
 
     const err = new Error(msg);
-    SentryError.captureStackTrace(err);
+    Sentry.captureException(err);
   }
 };
 

--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/electron';
-
 import {
   EXPORT_TYPE_API_SPEC,
   EXPORT_TYPE_COOKIE_JAR,
@@ -18,6 +16,7 @@ import {
 import { generateId } from '../common/misc';
 import * as _apiSpec from './api-spec';
 import * as _caCertificate from './ca-certificate';
+import captureException from './capture-exception.util';
 import * as _clientCertificate from './client-certificate';
 import * as _cookieJar from './cookie-jar';
 import * as _environment from './environment';
@@ -171,7 +170,7 @@ const assertModelWithParentId = (model: BaseModel, info: string) => {
     console.warn(msg);
 
     const err = new Error(msg);
-    Sentry.captureException(err);
+    captureException(err);
   }
 };
 

--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -16,7 +16,7 @@ import {
 import { generateId } from '../common/misc';
 import * as _apiSpec from './api-spec';
 import * as _caCertificate from './ca-certificate';
-import captureException from './capture-exception.util';
+import { loadCaptureException } from './capture-exception.util';
 import * as _clientCertificate from './client-certificate';
 import * as _cookieJar from './cookie-jar';
 import * as _environment from './environment';
@@ -170,7 +170,8 @@ const assertModelWithParentId = (model: BaseModel, info: string) => {
     console.warn(msg);
 
     const err = new Error(msg);
-    captureException(err);
+    const capture = loadCaptureException();
+    capture(err);
   }
 };
 

--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -1,3 +1,5 @@
+import { SentryError } from '@sentry/utils';
+
 import {
   EXPORT_TYPE_API_SPEC,
   EXPORT_TYPE_COOKIE_JAR,
@@ -186,6 +188,13 @@ export async function initModel<T extends BaseModel>(type: string, ...sources: R
     model.init(),
   );
   const fullObject = Object.assign({}, objectDefaults, ...sources);
+  if (!fullObject.parentId && (type === 'Project' || type === 'Workspace')) {
+    const msg = `[bug] parent id is set null unexpectedly ${type} - ${fullObject._id}`;
+    console.warn(msg);
+
+    const err = new Error(msg);
+    SentryError.captureStackTrace(err);
+  }
 
   // Generate an _id if there isn't one yet
   if (!fullObject._id) {

--- a/packages/insomnia/src/models/websocket-response.ts
+++ b/packages/insomnia/src/models/websocket-response.ts
@@ -60,7 +60,7 @@ export function init(): BaseWebSocketResponse {
   };
 }
 
-export function migrate(doc: Response) {
+export function migrate(doc: WebSocketResponse) {
   return doc;
 }
 


### PR DESCRIPTION
Let's measure how many users are impacted by this bug and experiencing the data linking issue.
- adding a error creation upon parentId set null (this should not happen now)
- adding error stack capturing by Sentry

Closes INS-3301