### PR TITLE
fix(vcs-sync): clean cache on api error

### DIFF
--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -182,11 +182,10 @@ const remoteCompareCache: Record<string, { ahead: number; behind: number }> = {}
 const remoteBackendProjectsCache: Record<string, BackendProject[]> = {};
 
 export const syncDataAction: ActionFunction = async ({ params }) => {
+  const { projectId, workspaceId } = params;
+  invariant(typeof projectId === 'string', 'Project Id is required');
+  invariant(typeof workspaceId === 'string', 'Workspace Id is required');
   try {
-    const { projectId, workspaceId } = params;
-    invariant(typeof projectId === 'string', 'Project Id is required');
-    invariant(typeof workspaceId === 'string', 'Workspace Id is required');
-
     const project = await models.project.getById(projectId);
     invariant(project, 'Project not found');
     invariant(project.remoteId, 'Project is not remote');
@@ -210,6 +209,9 @@ export const syncDataAction: ActionFunction = async ({ params }) => {
     };
   } catch (e) {
     const errorMessage = e instanceof Error ? e.message : 'Unknown error while syncing data.';
+    delete remoteBranchesCache[workspaceId];
+    delete remoteCompareCache[workspaceId];
+    delete remoteBackendProjectsCache[workspaceId];
     return {
       error: errorMessage,
     };


### PR DESCRIPTION
Clean the vcs cache when there are errors refreshing the state