### PR TITLE
fix: deleting Scratch Pad causes fatal error and application does not recover

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
@@ -141,16 +141,16 @@ export const WorkspaceDropdown: FC = () => {
               ),
           });
         },
+      },
+      {
+        id: 'delete',
+        name: 'Delete',
+        icon: <Icon icon='trash' />,
+        action: () => {
+          setIsDeleteRemoteWorkspaceModalOpen(true);
+        },
       }] : [],
       {
-      id: 'delete',
-      name: 'Delete',
-      icon: <Icon icon='trash' />,
-      action: () => {
-        setIsDeleteRemoteWorkspaceModalOpen(true);
-      },
-    },
-    {
         id: 'import',
         name: 'Import',
         icon: <Icon icon='file-import' />,


### PR DESCRIPTION
Closes #6910 

changelog(Fixes): Fix an issue where the Scratch Pad could be deleted an required restarting the app.