### PR TITLE
fix: enhance all kinds xpath queries and clean code

### DIFF
--- a/packages/insomnia/src/utils/xpath/query.test.ts
+++ b/packages/insomnia/src/utils/xpath/query.test.ts
@@ -28,6 +28,18 @@ describe('queryXPath()', () => {
     ]);
   });
 
+  it('handles number query', () => {
+    expect(queryXPath('<x><y>1</y>/x>', 'number(//y[1])')).toEqual([
+      { inner: 1, outer: 1 },
+    ]);
+  });
+
+  it('handles boolean query', () => {
+    expect(queryXPath('<x><y>1</y></x>', '//y[1]/text() = "1"')).toEqual([
+      { inner: true, outer: true },
+    ]);
+  });
+
   it('handles text() query', () => {
     expect(queryXPath('<book><title>Harry</title><title>Potter</title></book>', 'local-name(/book)'))
       .toEqual([{ 'inner': 'book', 'outer': 'book' }]);

--- a/packages/insomnia/src/utils/xpath/query.ts
+++ b/packages/insomnia/src/utils/xpath/query.ts
@@ -1,41 +1,45 @@
 import { DOMParser } from 'xmldom';
-import xpath, { SelectedValue } from 'xpath';
+import xpath from 'xpath';
+
+/**
+ * A revised type for the return value of `xpath.select(expression, node)`
+ */
+type SelectedValue = string | number | boolean | Node[];
 
 /**
  * Query an XML blob with XPath
  */
 export const queryXPath = (xml: string, query?: string) => {
-  const dom = new DOMParser().parseFromString(xml);
-  let selectedValues: SelectedValue[] = [];
   if (query === undefined) {
     throw new Error('Must pass an XPath query.');
   }
+  const dom = new DOMParser().parseFromString(xml);
+  let selectedValues: SelectedValue = [];
   try {
-    selectedValues = xpath.select(query, dom);
+    selectedValues = xpath.select(query, dom) as SelectedValue;
   } catch (err) {
     throw new Error(`Invalid XPath query: ${query}`);
   }
-  // Functions return plain strings
-  if (typeof selectedValues === 'string') {
-    return [{ outer: selectedValues, inner: selectedValues }];
+
+  if (Array.isArray(selectedValues)) {
+    return selectedValues
+      .filter(sv => sv.nodeType === Node.ATTRIBUTE_NODE
+        || sv.nodeType === Node.ELEMENT_NODE
+        || sv.nodeType === Node.TEXT_NODE)
+      .map(selectedValue => {
+        const outer = selectedValue.toString().trim();
+        if (selectedValue.nodeType === Node.ATTRIBUTE_NODE) {
+          return { outer, inner: selectedValue.nodeValue };
+        }
+        if (selectedValue.nodeType === Node.ELEMENT_NODE) {
+          return { outer, inner: selectedValue.childNodes.toString() };
+        }
+        if (selectedValue.nodeType === Node.TEXT_NODE) {
+          return { outer, inner: selectedValue.toString().trim() };
+        }
+        return { outer, inner: null };
+      });
   }
 
-  return (selectedValues as Node[])
-    .filter(sv => sv.nodeType === Node.ATTRIBUTE_NODE
-      || sv.nodeType === Node.ELEMENT_NODE
-      || sv.nodeType === Node.TEXT_NODE)
-    .map(selectedValue => {
-      const outer = selectedValue.toString().trim();
-      if (selectedValue.nodeType === Node.ATTRIBUTE_NODE) {
-        return { outer, inner: selectedValue.nodeValue };
-      }
-      if (selectedValue.nodeType === Node.ELEMENT_NODE) {
-        return { outer, inner: selectedValue.childNodes.toString() };
-      }
-      if (selectedValue.nodeType === Node.TEXT_NODE) {
-        return { outer, inner: selectedValue.toString().trim() };
-      }
-      return { outer, inner: null };
-    });
-
+  return [{ outer: selectedValues, inner: selectedValues }];
 };


### PR DESCRIPTION
Closes #6898.

The root is the following condition statements miss `else` clause, so that it will cause error when `selectedValues ` is a string.

https://github.com/Kong/insomnia/blob/1d9768909b3c4a9177270fa847681f74be88e18c/packages/insomnia/src/ui/components/templating/local-template-tags.ts#L724-L732

I found similar code in `queryXPath` util function, so I refactored the code with it, and adjust `queryXPath` to deal with all kinds xpath queries.