### PR TITLE
fix(git): Sync repo data on collection/repo updates

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -72,10 +72,7 @@ export const GitSyncDropdown: FC<Props> = ({ className, gitRepository, isInsomni
       !gitRepoDataFetcher.data
     ) {
       console.log('[git:fetcher] Fetching git repo data');
-      gitRepoDataFetcher.submit({}, {
-        action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/git/repo`,
-        method: 'post',
-      });
+      gitRepoDataFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/git/repo`);
     }
   }, [
     gitRepoDataFetcher,

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -790,10 +790,10 @@ const router = createMemoryRouter(
                                 },
                                 {
                                   path: 'repo',
-                                  action: async (...args) =>
+                                  loader: async (...args) =>
                                     (
                                       await import('./routes/git-actions')
-                                    ).gitRepoAction(...args),
+                                    ).gitRepoLoader(...args),
                                 },
                                 {
                                   path: 'update',

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -707,46 +707,64 @@ const router = createMemoryRouter(
                               path: 'git',
                               children: [
                                 {
-                                  path: 'status',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).gitStatusAction(...args),
+                                  path: 'repo',
+                                  loader: async (...args) =>
+                                    (await import('./routes/git-actions')).gitRepoLoader(...args),
                                 },
                                 {
                                   path: 'changes',
                                   loader: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).gitChangesLoader(...args),
-                                },
-                                {
-                                  path: 'commit',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).commitToGitRepoAction(...args),
-                                },
-                                {
-                                  path: 'branches',
-                                  loader: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).gitBranchesLoader(...args),
+                                    (await import('./routes/git-actions')).gitChangesLoader(...args),
                                 },
                                 {
                                   path: 'log',
                                   loader: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).gitLogLoader(...args),
+                                    (await import('./routes/git-actions')).gitLogLoader(...args),
+                                },
+                                {
+                                  path: 'branches',
+                                  loader: async (...args) =>
+                                    (await import('./routes/git-actions')).gitBranchesLoader(...args),
+                                },
+                                {
+                                  path: 'status',
+                                  action: async (...args) =>
+                                    (await import('./routes/git-actions')).gitStatusAction(...args),
+                                },
+                                {
+                                  path: 'commit',
+                                  action: async (...args) =>
+                                    (await import('./routes/git-actions')).commitToGitRepoAction(...args),
                                 },
                                 {
                                   path: 'fetch',
                                   action: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).gitFetchAction(...args),
+                                    (await import('./routes/git-actions')).gitFetchAction(...args),
+                                },
+                                {
+                                  path: 'rollback',
+                                  action: async (...args) =>
+                                    (await import('./routes/git-actions')).gitRollbackChangesAction(...args),
+                                },
+                                {
+                                  path: 'update',
+                                  action: async (...args) =>
+                                    (await import('./routes/git-actions')).updateGitRepoAction(...args),
+                                },
+                                {
+                                  path: 'reset',
+                                  action: async (...args) =>
+                                    (await import('./routes/git-actions')).resetGitRepoAction(...args),
+                                },
+                                {
+                                  path: 'pull',
+                                  action: async (...args) =>
+                                    (await import('./routes/git-actions')).pullFromGitRemoteAction(...args),
+                                },
+                                {
+                                  path: 'push',
+                                  action: async (...args) =>
+                                    (await import('./routes/git-actions')).pushToGitRemoteAction(...args),
                                 },
                                 {
                                   path: 'branch',
@@ -754,74 +772,24 @@ const router = createMemoryRouter(
                                     {
                                       path: 'new',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/git-actions')
-                                        ).createNewGitBranchAction(...args),
+                                        (await import('./routes/git-actions')).createNewGitBranchAction(...args),
                                     },
                                     {
                                       path: 'delete',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/git-actions')
-                                        ).deleteGitBranchAction(...args),
+                                        (await import('./routes/git-actions')).deleteGitBranchAction(...args),
                                     },
                                     {
                                       path: 'checkout',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/git-actions')
-                                        ).checkoutGitBranchAction(...args),
+                                        (await import('./routes/git-actions')).checkoutGitBranchAction(...args),
                                     },
                                     {
                                       path: 'merge',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/git-actions')
-                                        ).mergeGitBranchAction(...args),
+                                        (await import('./routes/git-actions')).mergeGitBranchAction(...args),
                                     },
                                   ],
-                                },
-                                {
-                                  path: 'rollback',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).gitRollbackChangesAction(...args),
-                                },
-                                {
-                                  path: 'repo',
-                                  loader: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).gitRepoLoader(...args),
-                                },
-                                {
-                                  path: 'update',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).updateGitRepoAction(...args),
-                                },
-                                {
-                                  path: 'reset',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).resetGitRepoAction(...args),
-                                },
-                                {
-                                  path: 'pull',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).pullFromGitRemoteAction(...args),
-                                },
-                                {
-                                  path: 'push',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/git-actions')
-                                    ).pushToGitRemoteAction(...args),
                                 },
                               ],
                             },
@@ -829,43 +797,31 @@ const router = createMemoryRouter(
                               path: 'insomnia-sync',
                               children: [
                                 {
+                                  path: 'sync-data',
+                                  action: async (...args) =>
+                                    (await import('./routes/remote-collections')).syncDataAction(...args),
+                                  loader: async (...args) =>
+                                    (await import('./routes/remote-collections')).syncDataLoader(...args),
+                                },
+                                {
                                   path: 'pull',
                                   action: async (...args) =>
-                                    (
-                                      await import('./routes/remote-collections')
-                                    ).pullFromRemoteAction(...args),
+                                    (await import('./routes/remote-collections')).pullFromRemoteAction(...args),
                                 },
                                 {
                                   path: 'push',
                                   action: async (...args) =>
-                                    (
-                                      await import('./routes/remote-collections')
-                                    ).pushToRemoteAction(...args),
+                                    (await import('./routes/remote-collections')).pushToRemoteAction(...args),
                                 },
                                 {
                                   path: 'rollback',
                                   action: async (...args) =>
-                                    (
-                                      await import('./routes/remote-collections')
-                                    ).rollbackChangesAction(...args),
+                                    (await import('./routes/remote-collections')).rollbackChangesAction(...args),
                                 },
                                 {
                                   path: 'restore',
                                   action: async (...args) =>
-                                    (
-                                      await import('./routes/remote-collections')
-                                    ).restoreChangesAction(...args),
-                                },
-                                {
-                                  path: 'sync-data',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/remote-collections')
-                                    ).syncDataAction(...args),
-                                  loader: async (...args) =>
-                                    (
-                                      await import('./routes/remote-collections')
-                                    ).syncDataLoader(...args),
+                                    (await import('./routes/remote-collections')).restoreChangesAction(...args),
                                 },
                                 {
                                   path: 'branch',
@@ -873,58 +829,42 @@ const router = createMemoryRouter(
                                     {
                                       path: 'checkout',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/remote-collections')
-                                        ).checkoutBranchAction(...args),
+                                        (await import('./routes/remote-collections')).checkoutBranchAction(...args),
                                     },
                                     {
                                       path: 'create',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/remote-collections')
-                                        ).createBranchAction(...args),
+                                        (await import('./routes/remote-collections')).createBranchAction(...args),
                                     },
                                     {
                                       path: 'fetch',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/remote-collections')
-                                        ).fetchRemoteBranchAction(...args),
+                                        (await import('./routes/remote-collections')).fetchRemoteBranchAction(...args),
                                     },
                                     {
                                       path: 'delete',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/remote-collections')
-                                        ).deleteBranchAction(...args),
+                                        (await import('./routes/remote-collections')).deleteBranchAction(...args),
                                     },
                                     {
                                       path: 'merge',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/remote-collections')
-                                        ).mergeBranchAction(...args),
+                                        (await import('./routes/remote-collections')).mergeBranchAction(...args),
                                     },
                                     {
                                       path: 'create-snapshot',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/remote-collections')
-                                        ).createSnapshotAction(...args),
+                                        (await import('./routes/remote-collections')).createSnapshotAction(...args),
                                     },
                                     {
                                       path: 'create-snapshot-and-push',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/remote-collections')
-                                        ).createSnapshotAndPushAction(...args),
+                                        (await import('./routes/remote-collections')).createSnapshotAndPushAction(...args),
                                     },
                                     {
                                       path: 'rollback',
                                       action: async (...args) =>
-                                        (
-                                          await import('./routes/remote-collections')
-                                        ).rollbackChangesAction(...args),
+                                        (await import('./routes/remote-collections')).rollbackChangesAction(...args),
                                     },
                                   ],
                                 },

--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -49,7 +49,7 @@ export type GitRepoLoaderData =
       errors: string[];
     };
 
-export const gitRepoAction: ActionFunction = async ({
+export const gitRepoLoader: ActionFunction = async ({
   params,
 }): Promise<GitRepoLoaderData> => {
   try {

--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -92,10 +92,10 @@ export const gitRepoLoader: ActionFunction = async ({
     const gitDataClient = fsClient(baseDir);
 
     // All data outside the directories listed below will be stored in an 'other' directory. This is so we can support files that exist outside the ones the app is specifically in charge of.
-    const otherDatClient = fsClient(path.join(baseDir, 'other'));
+    const otherDataClient = fsClient(path.join(baseDir, 'other'));
 
     // The routable FS client directs isomorphic-git to read/write from the database or from the correct directory on the file system while performing git operations.
-    const routableFS = routableFSClient(otherDatClient, {
+    const routableFS = routableFSClient(otherDataClient, {
       [GIT_INSOMNIA_DIR]: neDbClient,
       [GIT_INTERNAL_DIR]: gitDataClient,
     });


### PR DESCRIPTION
Using an action to sync doesn't update the sync dropdown on collection/repo changes.

This PR moves the logic to a loader instead to make sure the data get updated when the repo gets updated or when there are updates in the repo (new branches etc.)

TODO:
- Make sure performance is not affected by this change

Closes INS-3336
Closes #6896

changelog(Fixes): Fixed issues when using Git and switching between branches or making changes to the repo were not reflected properly in the dropdown