### PR TITLE
fix(tls): Use the system CA certificates to verify https servers by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2027,9 +2027,9 @@
       }
     },
     "node_modules/@getinsomnia/node-libcurl": {
-      "version": "2.3.6-21",
-      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.3.6-21.tgz",
-      "integrity": "sha512-qCyWIc3VmX9p5524Afnd3T3pgWcCBNnHUkqM01HXZAYqSCLIeQTabuLuVfKhZkxuNPlUttzQFY1ncc6YlfZdtQ==",
+      "version": "2.4.1-4",
+      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.4.1-4.tgz",
+      "integrity": "sha512-/BlqdyR2ghz3wDNrCm3YPfAFCiycQDPe44OgMBmNsvqIdvF7LquogU5U1wGgbmepmkyswd9nfhFF00HojqEN1Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "1.0.5",
@@ -24589,7 +24589,7 @@
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
         "@apidevtools/swagger-parser": "10.1.0",
-        "@getinsomnia/node-libcurl": "^2.3.6-21",
+        "@getinsomnia/node-libcurl": "^2.4.1-4",
         "@grpc/grpc-js": "^1.8.17",
         "@grpc/proto-loader": "^0.7.7",
         "@jest/globals": "^28.1.0",
@@ -24925,7 +24925,7 @@
       "version": "8.4.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@getinsomnia/node-libcurl": "2.3.6-21",
+        "@getinsomnia/node-libcurl": "^2.4.1-4",
         "@segment/analytics-node": "1.0.0",
         "@stoplight/spectral-core": "^1.18.2",
         "@stoplight/spectral-formats": "^1.5.0",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -7,7 +7,7 @@
   "main": "dist/index.js",
   "types": "dist/send-request/index.d.ts",
   "dependencies": {
-    "@getinsomnia/node-libcurl": "2.3.6-21",
+    "@getinsomnia/node-libcurl": "^2.4.1-4",
     "@segment/analytics-node": "1.0.0",
     "@stoplight/spectral-core": "^1.18.2",
     "@stoplight/spectral-formats": "^1.5.0",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
     "@apidevtools/swagger-parser": "10.1.0",
-    "@getinsomnia/node-libcurl": "^2.3.6-21",
+    "@getinsomnia/node-libcurl": "^2.4.1-4",
     "@grpc/grpc-js": "^1.8.17",
     "@grpc/proto-loader": "^0.7.7",
     "@jest/globals": "^28.1.0",

--- a/packages/insomnia/src/__mocks__/@getinsomnia/node-libcurl.ts
+++ b/packages/insomnia/src/__mocks__/@getinsomnia/node-libcurl.ts
@@ -6,6 +6,7 @@ import { CurlFeature } from '@getinsomnia/node-libcurl/dist/enum/CurlFeature';
 import { CurlHttpVersion } from '@getinsomnia/node-libcurl/dist/enum/CurlHttpVersion';
 import { CurlInfoDebug } from '@getinsomnia/node-libcurl/dist/enum/CurlInfoDebug';
 import { CurlNetrc } from '@getinsomnia/node-libcurl/dist/enum/CurlNetrc';
+import { CurlSslOpt } from '@getinsomnia/node-libcurl/dist/enum/CurlSslOpt';
 import { EventEmitter } from 'events';
 import fs from 'fs';
 
@@ -63,6 +64,7 @@ class Curl extends EventEmitter {
     VERBOSE: 'VERBOSE',
     WRITEFUNCTION: 'WRITEFUNCTION',
     XFERINFOFUNCTION: 'XFERINFOFUNCTION',
+    SSL_OPTIONS: 'SSL_OPTIONS',
   };
 
   static getVersion() {
@@ -200,4 +202,5 @@ module.exports = {
   CurlFeature: getTsEnumOnlyWithNamedMembers(CurlFeature),
   CurlNetrc: getTsEnumOnlyWithNamedMembers(CurlNetrc),
   CurlHttpVersion: getTsEnumOnlyWithNamedMembers(CurlHttpVersion),
+  CurlSslOpt: getTsEnumOnlyWithNamedMembers(CurlSslOpt),
 };

--- a/packages/insomnia/src/main/network/curl.ts
+++ b/packages/insomnia/src/main/network/curl.ts
@@ -4,7 +4,6 @@ import { Curl, CurlFeature, CurlInfoDebug, HeaderInfo } from '@getinsomnia/node-
 import electron, { BrowserWindow, ipcMain } from 'electron';
 import fs from 'fs';
 import path from 'path';
-import tls from 'tls';
 import { v4 as uuidV4 } from 'uuid';
 
 import { describeByteSize, generateId, getSetCookieHeaders } from '../../common/misc';
@@ -123,9 +122,8 @@ const openCurlConnection = async (
   const responseEnvironmentId = environment ? environment._id : null;
 
   const caCert = await models.caCertificate.findByParentId(options.workspaceId);
-  const caCertficatePath = caCert?.path;
-  // attempt to read CA Certificate PEM from disk, fallback to root certificates
-  const caCertificate = (caCertficatePath && (await fs.promises.readFile(caCertficatePath)).toString()) || tls.rootCertificates.join('\n');
+  const caCertficatePath = caCert?.path || null;
+  const caCertificate = (caCertficatePath && (await fs.promises.readFile(caCertficatePath)).toString());
 
   try {
     if (!options.url) {

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -3,12 +3,11 @@
 import { invariant } from '../../utils/invariant';
 invariant(process.type !== 'renderer', 'Native abstractions for Nodejs module unavailable in renderer');
 
-import { Curl, CurlAuth, CurlCode, CurlFeature, CurlHttpVersion, CurlInfoDebug, CurlNetrc } from '@getinsomnia/node-libcurl';
+import { Curl, CurlAuth, CurlCode, CurlFeature, CurlHttpVersion, CurlInfoDebug, CurlNetrc, CurlSslOpt } from '@getinsomnia/node-libcurl';
 import electron from 'electron';
 import fs from 'fs';
 import path from 'path';
 import { Readable, Writable } from 'stream';
-import tls from 'tls';
 import { parse as urlParse } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -102,7 +101,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
     const responseBodyPath = path.join(responsesDir, uuidv4() + '.response');
 
     const { requestId, req, finalUrl, settings, certificates, caCertficatePath, socketPath, authHeader } = options;
-    const caCert = (caCertficatePath && (await fs.promises.readFile(caCertficatePath)).toString()) || tls.rootCertificates.join('\n');
+    const caCert = (caCertficatePath && (await fs.promises.readFile(caCertficatePath)).toString());
 
     const { curl, debugTimeline } = createConfiguredCurlInstance({
       req,
@@ -259,7 +258,7 @@ export const createConfiguredCurlInstance = ({
   finalUrl: string;
   settings: SettingsUsedHere;
   certificates: ClientCertificate[];
-  caCert: string;
+  caCert: string | null;
   socketPath?: string;
 }) => {
   const debugTimeline: ResponseTimelineEntry[] = [];
@@ -270,8 +269,11 @@ export const createConfiguredCurlInstance = ({
   curl.setOpt(Curl.option.VERBOSE, true); // Set all the basic options
   curl.setOpt(Curl.option.NOPROGRESS, true); // True so debug function works
   curl.setOpt(Curl.option.ACCEPT_ENCODING, ''); // True so curl doesn't print progress
-  // attempt to read CA Certificate PEM from disk, fallback to root certificates
-  curl.setOpt(Curl.option.CAINFO_BLOB, caCert);
+  // fallback to root certificates or leave unset to use keychain on macOS
+  if (caCert) {
+    curl.setOpt(Curl.option.CAINFO_BLOB, caCert);
+  }
+  curl.setOpt(Curl.option.SSL_OPTIONS, CurlSslOpt.NativeCa);
   certificates.forEach(validCert => {
     const { passphrase, cert, key, pfx } = validCert;
     if (cert) {

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -3,7 +3,7 @@
 import { invariant } from '../../utils/invariant';
 invariant(process.type !== 'renderer', 'Native abstractions for Nodejs module unavailable in renderer');
 
-import { Curl, CurlAuth, CurlCode, CurlFeature, CurlHttpVersion, CurlInfoDebug, CurlNetrc } from '@getinsomnia/node-libcurl';
+import { Curl, CurlAuth, CurlCode, CurlFeature, CurlHttpVersion, CurlInfoDebug, CurlNetrc, CurlSslOpt } from '@getinsomnia/node-libcurl';
 import electron from 'electron';
 import fs from 'fs';
 import path from 'path';
@@ -273,6 +273,7 @@ export const createConfiguredCurlInstance = ({
   if (caCert) {
     curl.setOpt(Curl.option.CAINFO_BLOB, caCert);
   }
+  curl.setOpt(Curl.option.SSL_OPTIONS, CurlSslOpt.NativeCa);
   certificates.forEach(validCert => {
     const { passphrase, cert, key, pfx } = validCert;
     if (cert) {

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -3,7 +3,7 @@
 import { invariant } from '../../utils/invariant';
 invariant(process.type !== 'renderer', 'Native abstractions for Nodejs module unavailable in renderer');
 
-import { Curl, CurlAuth, CurlCode, CurlFeature, CurlHttpVersion, CurlInfoDebug, CurlNetrc, CurlSslOpt } from '@getinsomnia/node-libcurl';
+import { Curl, CurlAuth, CurlCode, CurlFeature, CurlHttpVersion, CurlInfoDebug, CurlNetrc } from '@getinsomnia/node-libcurl';
 import electron from 'electron';
 import fs from 'fs';
 import path from 'path';
@@ -273,7 +273,6 @@ export const createConfiguredCurlInstance = ({
   if (caCert) {
     curl.setOpt(Curl.option.CAINFO_BLOB, caCert);
   }
-  curl.setOpt(Curl.option.SSL_OPTIONS, CurlSslOpt.NativeCa);
   certificates.forEach(validCert => {
     const { passphrase, cert, key, pfx } = validCert;
     if (cert) {

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -140,6 +140,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         URL: 'http://localhost/?foo%20bar=hello%26world',
         USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
+        SSL_OPTIONS: 'NativeCa',
       },
     });
   });
@@ -210,7 +211,8 @@ describe('sendCurlAndWriteTimeline()', () => {
         URL: 'http://localhost/',
         USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
-      },
+        SSL_OPTIONS: 'NativeCa',
+     },
     });
   });
 
@@ -311,6 +313,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         URL: 'http://localhost/?foo%20bar=hello%26world',
         USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
+        SSL_OPTIONS: 'NativeCa',
       },
     });
   });
@@ -375,6 +378,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         URL: 'http://localhost/',
         USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
+        SSL_OPTIONS: 'NativeCa',
       },
     });
   });
@@ -468,6 +472,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         UPLOAD: 1,
         USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
+        SSL_OPTIONS: 'NativeCa',
       },
     });
   });
@@ -509,6 +514,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         UNIX_SOCKET_PATH: '/my/socket',
         USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
+        SSL_OPTIONS: 'NativeCa',
       },
     });
   });
@@ -549,6 +555,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         URL: 'http://localhost:3000/foo/bar',
         USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
+        SSL_OPTIONS: 'NativeCa',
       },
     });
   });
@@ -589,6 +596,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         URL: 'http://unix:3000/my/path',
         USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
+        SSL_OPTIONS: 'NativeCa',
       },
     });
   });
@@ -631,6 +639,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         URL: '',
         USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
+        SSL_OPTIONS: 'NativeCa',
       },
     });
   });
@@ -743,6 +752,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         URL: 'http://localhost/?foo%20bar=hello%26world',
         USERAGENT: `insomnia/${version}`,
         VERBOSE: true,
+        SSL_OPTIONS: 'NativeCa',
       },
     });
   });

--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -314,7 +314,7 @@ export const WorkspaceSettingsModal = ({ workspace, clientCertificates, caCertif
                       <label>
                         CA Certificate
                         <HelpTooltip position="right" className="space-left">
-                          One or more PEM format certificates in a single file to pass to curl. Overrides the root CA certificate.
+                          One or more PEM format certificates in a single file to pass to curl. Overrides the root CA certificate and macOS keychain.
                         </HelpTooltip>
                       </label>
                       <div className="row-spaced">


### PR DESCRIPTION
depends on https://github.com/Kong/node-libcurl/pull/23 to be merged

by setting `tls.rootCertificate` on CAINFO_BLOB we were blocking macos and window from accessing the system CA store(keychain)

this PR will remove the setting of CAINFO_BLOB in the default case, unless a user adds a CA certificate manually in which case the system store will be ignored.

we will no longer use the nodejs provided `tls.rootCertificate`.

changelog(Improvements): Add support for system CA certificates