### PR TITLE
feat(untracked-data): Display a warning when there are untracked data in the app

### DIFF
--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -16,7 +16,7 @@ import { SegmentEvent } from '../../analytics';
 import { useOrganizationLoaderData } from '../../routes/organization';
 import { ProjectLoaderData } from '../../routes/project';
 import { useRootLoaderData } from '../../routes/root';
-import { LoaderData } from '../../routes/untracked-projects';
+import { UntrackedProjectsLoaderData } from '../../routes/untracked-projects';
 import { WorkspaceLoaderData } from '../../routes/workspace';
 import { Dropdown, DropdownItem, DropdownSection, ItemContent } from '../base/dropdown';
 import { Icon } from '../icon';
@@ -236,7 +236,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
   const organizationData = useOrganizationLoaderData();
   const organizations = organizationData?.organizations || [];
 
-  const untrackedProjectsFetcher = useFetcher<LoaderData>();
+  const untrackedProjectsFetcher = useFetcher<UntrackedProjectsLoaderData>();
 
   useEffect(() => {
     const isIdleAndUninitialized = untrackedProjectsFetcher.state === 'idle' && !untrackedProjectsFetcher.data;

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -44,13 +44,14 @@ import { GitHubStarsButton } from '../components/github-stars-button';
 import { Hotkey } from '../components/hotkey';
 import { Icon } from '../components/icon';
 import { InsomniaAILogo } from '../components/insomnia-icon';
-import { showAlert } from '../components/modals';
-import { showSettingsModal } from '../components/modals/settings-modal';
+import { showAlert, showModal } from '../components/modals';
+import { SettingsModal, showSettingsModal } from '../components/modals/settings-modal';
 import { OrganizationAvatar } from '../components/organization-avatar';
 import { PresentUsers } from '../components/present-users';
 import { Toast } from '../components/toast';
 import { InsomniaEventStreamProvider } from '../context/app/insomnia-event-stream-context';
 import { useRootLoaderData } from './root';
+import { UntrackedProjectsLoaderData } from './untracked-projects';
 import { WorkspaceLoaderData } from './workspace';
 
 export interface OrganizationsResponse {
@@ -383,13 +384,24 @@ const OrganizationRoute = () => {
     workspaceData?.activeWorkspace &&
     isScratchpad(workspaceData.activeWorkspace);
   const isScratchPadBannerVisible = !isScratchPadBannerDismissed && isScratchpadWorkspace;
-
+  const untrackedProjectsFetcher = useFetcher<UntrackedProjectsLoaderData>();
   const { organizationId, projectId, workspaceId } = useParams() as {
     organizationId: string;
     projectId?: string;
     workspaceId?: string;
   };
   const [status, setStatus] = useState<'online' | 'offline'>('online');
+
+  useEffect(() => {
+    const isIdleAndUninitialized = untrackedProjectsFetcher.state === 'idle' && !untrackedProjectsFetcher.data;
+    if (isIdleAndUninitialized) {
+      untrackedProjectsFetcher.load('/untracked-projects');
+    }
+  }, [untrackedProjectsFetcher, organizationId]);
+
+  const untrackedProjects = untrackedProjectsFetcher.data?.untrackedProjects || [];
+  const untrackedWorkspaces = untrackedProjectsFetcher.data?.untrackedWorkspaces || [];
+  const hasUntrackedData = untrackedProjects.length > 0 || untrackedWorkspaces.length > 0;
 
   useEffect(() => {
     const handleOnline = () => setStatus('online');
@@ -684,6 +696,14 @@ const OrganizationRoute = () => {
                   />
                 </Tooltip>
               </TooltipTrigger>
+              {hasUntrackedData ? <div>
+                <Button
+                  className="px-4 py-1 h-full flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] text-[--color-warning] text-xs hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all"
+                  onPress={() => showModal(SettingsModal, { tab: 'data' })}
+                >
+                  <Icon icon="exclamation-circle" /> You have untracked data in your local storage
+                </Button>
+              </div> : null}
             </div>
             <div className='flex items-center gap-2 divide divide-y-[--hl-sm]'>
               <TooltipTrigger>

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -701,7 +701,7 @@ const OrganizationRoute = () => {
                   className="px-4 py-1 h-full flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] text-[--color-warning] text-xs hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all"
                   onPress={() => showModal(SettingsModal, { tab: 'data' })}
                 >
-                  <Icon icon="exclamation-circle" /> You have untracked data in your local storage
+                  <Icon icon="exclamation-circle" /> You have untracked data in your computer
                 </Button>
               </div> : null}
             </div>

--- a/packages/insomnia/src/ui/routes/untracked-projects.tsx
+++ b/packages/insomnia/src/ui/routes/untracked-projects.tsx
@@ -6,7 +6,7 @@ import { Project } from '../../models/project';
 import { Workspace } from '../../models/workspace';
 import { organizationsData } from './organization';
 
-export interface LoaderData {
+export interface UntrackedProjectsLoaderData {
   untrackedProjects: (Project & { workspacesCount: number })[];
   untrackedWorkspaces: Workspace[];
 }


### PR DESCRIPTION
- Shows a warning in the status bar when there are untracked data in the app.
- Clicking the warning opens `Preferences > Data` so that users can view them

<img width="1156" alt="image" src="https://github.com/Kong/insomnia/assets/12115431/8a1c6fe0-ece3-4e11-9f5a-5e5bb2858e56">

changelog(Improvements): Show a warning in the status bar when there are untracked data in the app