### PR TITLE
fix(ssl): verify host on macos [INS-3424]

### DIFF
--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -332,7 +332,9 @@ export const createConfiguredCurlInstance = ({
   }
   const { validateSSL } = settings;
   if (!validateSSL) {
-    curl.setOpt(Curl.option.SSL_VERIFYHOST, 0);
+    if (process.platform !== 'darwin') {
+      curl.setOpt(Curl.option.SSL_VERIFYHOST, 0);
+    }
     curl.setOpt(Curl.option.SSL_VERIFYPEER, 0);
   }
   debugTimeline.push({ value: `${validateSSL ? 'Enable' : 'Disable'} SSL validation`, name: 'Text', timestamp: Date.now() });

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -332,6 +332,7 @@ export const createConfiguredCurlInstance = ({
   }
   const { validateSSL } = settings;
   if (!validateSSL) {
+    // node-libcurl 2.4.1-4 macOS is build with `--with-secure-transport` TLS backend (in order to read the keychain) which interferes with disabling VERIFY_HOST curl option
     if (process.platform !== 'darwin') {
       curl.setOpt(Curl.option.SSL_VERIFYHOST, 0);
     }


### PR DESCRIPTION
Always verify hostname on macOS even when `Validate certificates` is disabled.

1. Can't reproduce this issue on Windows with `validate certificates` disabled, but not verify it on Linux, so I think OpenSSL always verifies the hostname.
2. To make the smallest change, it only enables the hostname verification on macOS.

Have verified locally, that the regression issue has been fixed on macOS.