### PR TITLE
fix: repeat on interval may lead to stay requesting

### DIFF
--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -190,7 +190,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     };
   }, [sendOrConnect]);
 
-  useInterval(sendOrConnect, currentInterval ? currentInterval : null);
+  useInterval(sendOrConnect, currentInterval && fetcher.state === 'idle' ? currentInterval : null);
   useTimeoutWhen(sendOrConnect, currentTimeout, !!currentTimeout);
   const patchRequest = useRequestPatcher();
 
@@ -327,6 +327,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
                           defaultValue: '3',
                           submitName: 'Start',
                           onComplete: seconds => {
+                            sendOrConnect();
                             setCurrentInterval(+seconds * 1000);
                           },
                         })}


### PR DESCRIPTION
Closes #6891 

Two adjustments:
1. The time interval starts from the end of the previous request.
2. Send the request immediately upon button click.

