### PR TITLE
feat: hook pre-request script UI and sandbox to the sending request workflow [INS-3380]

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/smoke-test-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/smoke-test-collection.yaml
@@ -176,12 +176,34 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
+  - _id: req_89dade2ee9ee42fbb22d588783a9df3c
+    parentId: wrk_5b5ab67830944ffcbec47528366ef403
+    modified: 1636707449231
+    created: 1636141014552
+    url: http://127.0.0.1:4010/echo
+    name: echo pre-request script result
+    description: ""
+    method: GET
+    body: {}
+    parameters: []
+    headers: []
+    authentication: {}
+    metaSortKey: -1636141014553
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request    
   - _id: env_afc214be117853a024cce22f194c500e68dac13f
     parentId: wrk_5b5ab67830944ffcbec47528366ef403
     modified: 1636140994432
     created: 1636140994432
     name: Base Environment
-    data: {}
+    data:
+      predefined: base
     dataPropertyOrder: null
     color: null
     isPrivate: false

--- a/packages/insomnia-smoke-test/server/index.ts
+++ b/packages/insomnia-smoke-test/server/index.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
 
+import * as bodyParser from 'body-parser';
 import express from 'express';
 import { readFileSync } from 'fs';
 import { createHandler } from 'graphql-http/lib/use/http';
@@ -19,9 +20,14 @@ const app = express();
 const port = 4010;
 const httpsPort = 4011;
 const grpcPort = 50051;
+const jsonParser = bodyParser.json();
 
 app.get('/pets/:id', (req, res) => {
   res.status(200).send({ id: req.params.id });
+});
+
+app.get('/echo', jsonParser, async (req, res) => {
+  res.status(200).send({ data: req.body });
 });
 
 app.get('/builds/check/*', (_req, res) => {

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
@@ -1,0 +1,116 @@
+import { expect } from '@playwright/test';
+
+import { loadFixture } from '../../playwright/paths';
+import { test } from '../../playwright/test';;
+
+test.describe('pre-request UI tests', async () => {
+    test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+
+    test.beforeEach(async ({ app, page }) => {
+        const text = await loadFixture('smoke-test-collection.yaml');
+        await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+        await page.getByRole('button', { name: 'Create in project' }).click();
+        await page.getByRole('menuitemradio', { name: 'Import' }).click();
+        await page.locator('[data-test-id="import-from-clipboard"]').click();
+        await page.getByRole('button', { name: 'Scan' }).click();
+        await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+
+        await page.getByText('CollectionSmoke testsjust now').click();
+
+        // Set filter responses by environment
+        await page.locator('[data-testid="settings-button"]').click();
+        await page.locator('text=Insomnia Preferences').first().click();
+        await page.getByRole('tab', { name: 'Experiments' }).click();
+        await page.getByText('Pre-request Script', { exact: true }).click();
+        await page.locator('.app').press('Escape');
+    });
+
+    const testCases = [
+        {
+            name: 'send collectionVariables-populated request',
+            preReqScript: `
+                insomnia.collectionVariables.set('baseFromScript', 'baseFromScriptValue');
+            `,
+            body: `{
+                "base": "{{ _.baseFromScript }}"
+            }`,
+            expectedBody: {
+                base: 'baseFromScriptValue',
+            },
+        },
+        {
+            name: 'send environment-populated request',
+            preReqScript: `
+                insomnia.collectionVariables.set('fromBase', 'base');
+                insomnia.environment.set('fromEnv1', 'env1');
+            `,
+            body: `{
+                "fromBase": "{{ _.fromBase }}",
+                "fromEnv1": "{{ _.fromEnv1 }}"
+            }`,
+            expectedBody: {
+                fromBase: 'base',
+                fromEnv1: 'env1',
+            },
+        },
+        {
+            name: 'send environment-overridden request',
+            preReqScript: `
+                // 'predefined' is already defined in the base environment, its original value is 'base'
+                insomnia.environment.set('predefined', 'updatedByScript');
+            `,
+            body: `{
+                "predefined": "{{ _.predefined }}"
+            }`,
+            expectedBody: {
+                predefined: 'updatedByScript',
+            },
+        },
+    ];
+
+    for (let i = 0; i < testCases.length; i++) {
+        const tc = testCases[i];
+
+        test(tc.name, async ({ page }) => {
+            const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+            const responseBody = page.getByTestId('response-pane').getByTestId('CodeEditor').locator('.CodeMirror-line');
+            // const responseBody = page.getByTestId('response-pane').locator('[data-testid="CodeEditor"]:visible', {
+            //     has: page.locator('.CodeMirror-activeline'),
+            // });
+
+            await page.getByLabel('Request Collection').getByTestId('echo pre-request script result').press('Enter');
+
+            // set request body
+            await page.getByRole('button', { name: 'Body' }).click();
+            await page.getByRole('menuitem', { name: 'JSON' }).click();
+
+            const bodyEditor = page.getByTestId('CodeEditor').getByRole('textbox');
+            await bodyEditor.fill(tc.body);
+
+            // enter script
+            const preRequestScriptTab = page.getByRole('tab', { name: 'Pre-request Script' });
+            await preRequestScriptTab.click();
+            const preRequestScriptEditor = page.getByTestId('CodeEditor').getByRole('textbox');
+            await preRequestScriptEditor.fill(tc.preReqScript);
+
+            // TODO: wait for body and pre-request script are persisted to the disk
+            // should improve this part
+            await page.waitForTimeout(500);
+
+            // send
+            await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+
+            // verify
+            await page.waitForSelector('[data-testid="response-status-tag"]:visible');
+
+            await expect(statusTag).toContainText('200 OK');
+
+            const rows = await responseBody.allInnerTexts();
+            expect(rows.length).toBeGreaterThan(0);
+
+            const bodyJson = JSON.parse(rows.join('\n'));
+            expect(bodyJson.data).toEqual(tc.expectedBody);
+        });
+    }
+});

--- a/packages/insomnia/src/common/__tests__/database.test.ts
+++ b/packages/insomnia/src/common/__tests__/database.test.ts
@@ -200,7 +200,7 @@ describe('requestCreate()', () => {
       parentId: 'wrk_123',
     };
     const r = await models.request.create(patch);
-    expect(Object.keys(r).length).toBe(21);
+    expect(Object.keys(r).length).toBe(22);
     expect(r._id).toMatch(/^req_[a-zA-Z0-9]{32}$/);
     expect(r.created).toBeGreaterThanOrEqual(now);
     expect(r.modified).toBeGreaterThanOrEqual(now);
@@ -210,6 +210,7 @@ describe('requestCreate()', () => {
     expect(r.method).toBe('GET');
     expect(r.body).toEqual({});
     expect(r.parameters).toEqual([]);
+    expect(r.preRequestScript).toEqual('');
     expect(r.headers).toEqual([]);
     expect(r.authentication).toEqual({});
     expect(r.metaSortKey).toBeLessThanOrEqual(-1 * now);

--- a/packages/insomnia/src/common/har.ts
+++ b/packages/insomnia/src/common/har.ts
@@ -316,11 +316,11 @@ export async function exportHarRequest(
 
 export async function exportHarWithRequest(
   request: Request,
-  environmentId?: string,
+  environment?: string,
   addContentLength = false,
 ) {
   try {
-    const renderResult = await getRenderedRequestAndContext({ request, environmentId });
+    const renderResult = await getRenderedRequestAndContext({ request, environment });
     const renderedRequest = await _applyRequestPluginHooks(
       renderResult.request,
       renderResult.context,

--- a/packages/insomnia/src/common/settings.ts
+++ b/packages/insomnia/src/common/settings.ts
@@ -145,4 +145,6 @@ export interface Settings {
   useBulkParametersEditor: boolean;
   validateAuthSSL: boolean;
   validateSSL: boolean;
+
+  experimentalFlagPreRequestScript: boolean;
 }

--- a/packages/insomnia/src/models/__tests__/request.test.ts
+++ b/packages/insomnia/src/models/__tests__/request.test.ts
@@ -20,6 +20,7 @@ describe('init()', () => {
       name: 'New Request',
       description: '',
       parameters: [],
+      preRequestScript: '',
       url: '',
       settingStoreCookies: true,
       settingSendCookies: true,
@@ -56,6 +57,7 @@ describe('create()', () => {
       method: 'GET',
       name: 'Test Request',
       parameters: [],
+      preRequestScript: '',
       url: '',
       settingStoreCookies: true,
       settingSendCookies: true,
@@ -388,6 +390,7 @@ describe('migrate()', () => {
       headers: [],
       authentication: {},
       parameters: [],
+      preRequestScript: '',
       parentId: null,
       body: {
         mimeType: '',

--- a/packages/insomnia/src/models/request.ts
+++ b/packages/insomnia/src/models/request.ts
@@ -100,6 +100,7 @@ export interface BaseRequest {
   authentication: RequestAuthentication;
   metaSortKey: number;
   isPrivate: boolean;
+  preRequestScript?: string;
   // Settings
   settingStoreCookies: boolean;
   settingSendCookies: boolean;
@@ -135,6 +136,7 @@ export function init(): BaseRequest {
     authentication: {},
     metaSortKey: -1 * Date.now(),
     isPrivate: false,
+    preRequestScript: '',
     // Settings
     settingStoreCookies: true,
     settingSendCookies: true,

--- a/packages/insomnia/src/models/settings.ts
+++ b/packages/insomnia/src/models/settings.ts
@@ -69,6 +69,7 @@ export function init(): BaseSettings {
     useBulkParametersEditor: false,
     validateAuthSSL: true,
     validateSSL: true,
+    experimentalFlagPreRequestScript: false,
   };
 }
 

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -19,6 +19,7 @@ import type { HeaderResult, ResponsePatch, ResponseTimelineEntry } from '../main
 import * as models from '../models';
 import { CaCertificate } from '../models/ca-certificate';
 import { ClientCertificate } from '../models/client-certificate';
+import { Environment } from '../models/environment';
 import type { Request, RequestAuthentication, RequestParameter } from '../models/request';
 import type { Settings } from '../models/settings';
 import { isWorkspace } from '../models/workspace';
@@ -61,14 +62,21 @@ export const fetchRequestData = async (requestId: string) => {
   const clientCertificates = await models.clientCertificate.findByParentId(workspaceId);
   const caCert = await models.caCertificate.findByParentId(workspaceId);
 
-  return { request, environment, settings, clientCertificates, caCert, activeEnvironmentId };
+  return { request, environment, settings, clientCertificates, caCert, activeEnvironmentId, workspace };
 };
 
-export const tryToInterpolateRequest = async (request: Request, environmentId: string, purpose?: RenderPurpose, extraInfo?: ExtraRenderInfo) => {
+export const tryToInterpolateRequest = async (
+  request: Request,
+  environment: string | Environment,
+  purpose?: RenderPurpose,
+  extraInfo?: ExtraRenderInfo,
+  baseEnvironment?: Environment,
+) => {
   try {
     return await getRenderedRequestAndContext({
       request: request,
-      environmentId,
+      environment,
+      baseEnvironment,
       purpose,
       extraInfo,
     });
@@ -92,9 +100,10 @@ export async function sendCurlAndWriteTimeline(
   clientCertificates: ClientCertificate[],
   caCert: CaCertificate | null,
   settings: Settings,
+  inputTimeline?: ResponseTimelineEntry[],
 ) {
   const requestId = renderedRequest._id;
-  const timeline: ResponseTimelineEntry[] = [];
+  const timeline: ResponseTimelineEntry[] = inputTimeline ? [...inputTimeline] : [];
 
   const { finalUrl, socketPath } = transformUrl(renderedRequest.url, renderedRequest.parameters, renderedRequest.authentication, renderedRequest.settingEncodeUrl);
 

--- a/packages/insomnia/src/network/request-sender.ts
+++ b/packages/insomnia/src/network/request-sender.ts
@@ -1,0 +1,229 @@
+import path from 'node:path';
+
+import * as contentDisposition from 'content-disposition';
+import orderedJSON from 'json-order';
+import { extension as mimeExtension } from 'mime-types';
+import { v4 as uuidv4 } from 'uuid';
+
+import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from '../common/constants';
+import { getContentDispositionHeader } from '../common/misc';
+import { RENDER_PURPOSE_SEND } from '../common/render';
+import { RenderedRequest } from '../common/render';
+import type { ResponseTimelineEntry } from '../main/network/libcurl-promise';
+import { ResponsePatch } from '../main/network/libcurl-promise';
+import * as models from '../models';
+import { CaCertificate } from '../models/ca-certificate';
+import { ClientCertificate } from '../models/client-certificate';
+import { Environment } from '../models/environment';
+import type { Request } from '../models/request';
+import { Settings } from '../models/settings';
+import { RawObject } from '../renderers/hidden-browser-window/inso-object';
+import { writeToDownloadPath } from '../ui/routes/request';
+import { getWindowMessageHandler } from '../ui/window-message-handlers';
+import { invariant } from '../utils/invariant';
+import { storeTimeline } from './network';
+import { responseTransform, sendCurlAndWriteTimeline } from './network';
+import { tryToInterpolateRequest, tryToTransformRequestWithPlugins } from './network';
+
+interface PreRequestScriptMessage {
+    insomnia: RawObject;
+}
+
+export class RequestSender {
+    private request: Request;
+    private shouldPromptForPathAfterResponse: boolean | undefined;
+    private baseEnvironment: Environment;
+    private environment: Environment;
+    private settings: Settings;
+    private clientCertificates: ClientCertificate[];
+    private caCert: CaCertificate | null;
+    private preRequestScript: string;
+
+    private timeline: ResponseTimelineEntry[];
+
+    constructor(
+        req: Request,
+        shouldPromptForPathAfterResponse: boolean | undefined,
+        baseEnvironment: Environment,
+        environment: Environment,
+        settings: Settings,
+        clientCertificates: ClientCertificate[],
+        caCert: CaCertificate | null,
+        preRequestScript: string,
+    ) {
+        this.request = req;
+        this.shouldPromptForPathAfterResponse = shouldPromptForPathAfterResponse;
+        this.baseEnvironment = baseEnvironment;
+        this.environment = environment;
+        this.settings = settings;
+        this.clientCertificates = clientCertificates;
+        this.caCert = caCert;
+        this.preRequestScript = preRequestScript;
+
+        this.timeline = [];
+    }
+
+    start = async () => {
+        const insomniaObject: PreRequestScriptMessage = {
+            insomnia: {
+                globals: {}, // TODO:
+                environment: this.environment.data,
+                collectionVariables: this.baseEnvironment.data,
+                iterationData: {}, // TODO:
+                requestInfo: {}, // TODO:
+            },
+        };
+
+        try {
+            if (this.preRequestScript !== '') {
+                const populatedObj = await this.runPreRequestScript(insomniaObject, this.preRequestScript);
+                if (!populatedObj) {
+                    console.error('no response returned');
+                    return;
+                }
+
+                const rawObj = populatedObj as Record<string, any>;
+                const envJsonMap = orderedJSON.parse(
+                    JSON.stringify(rawObj.environment),
+                    JSON_ORDER_PREFIX,
+                    JSON_ORDER_SEPARATOR,
+                );
+                const baseEnvJsonMap = orderedJSON.parse(
+                    JSON.stringify(rawObj.collectionVariables),
+                    JSON_ORDER_PREFIX,
+                    JSON_ORDER_SEPARATOR,
+                );
+
+                // map raw object to insomnia's environment hierarchy
+                this.environment.data = rawObj.environment;
+                this.environment.dataPropertyOrder = envJsonMap.map;
+                this.baseEnvironment.data = rawObj.collectionVariables;
+                this.baseEnvironment.dataPropertyOrder = baseEnvJsonMap.map;
+
+                this.timeline.push({
+                    value: 'Pre-request script execution done',
+                    name: 'Text',
+                    timestamp: Date.now(),
+                });
+            }
+
+            const { renderedRequest, renderedResult } = await this.renderRequest(this.request);
+            const responsePatch = await this.sendRequest(renderedRequest);
+            await this.persistRequestAndResponse(renderedRequest, responsePatch, renderedResult);
+        } catch (e) {
+            if (!e.message) {
+                console.error(`no message found in error: ${JSON.stringify(e)}`);
+                e.message = 'unknown error';
+            }
+
+            this.timeline.push({
+                value: `Pre-request script execution failed: ${e.message}`,
+                name: 'Text',
+                timestamp: Date.now(),
+            });
+
+            const timelinePath = await storeTimeline(this.timeline);
+
+            const nonRespPatch = {
+                parentId: this.request._id,
+                timelinePath,
+                statusCode: 0,
+                statusMessage: 'Error',
+            };
+
+            const requestMeta = await models.requestMeta.getByParentId(this.request._id);
+            if (!requestMeta) {
+                console.error(`no request meta found for request: ${this.request._id}`);
+                return;
+            }
+            const response = await models.response.create(nonRespPatch, this.settings.maxHistoryResponses);
+            await models.requestMeta.update(requestMeta, { activeResponseId: response._id });
+        }
+    };
+
+    runPreRequestScript = async (context: object, code: string) => {
+        const scriptRunId = uuidv4();
+        const winMsgHandler = getWindowMessageHandler();
+        return await winMsgHandler.runPreRequestScript(
+            scriptRunId,
+            code,
+            context,
+        );
+    };
+
+    renderRequest = async (req: Request) => {
+        const renderedResult = await tryToInterpolateRequest(req, this.environment, RENDER_PURPOSE_SEND, undefined, this.baseEnvironment);
+        const renderedRequest = await tryToTransformRequestWithPlugins(renderedResult);
+
+        // TODO: remove this temporary hack to support GraphQL variables in the request body properly
+        if (renderedRequest && renderedRequest.body?.text && renderedRequest.body?.mimeType === 'application/graphql') {
+            try {
+                const parsedBody = JSON.parse(renderedRequest.body.text);
+                if (typeof parsedBody.variables === 'string') {
+                    parsedBody.variables = JSON.parse(parsedBody.variables);
+                    renderedRequest.body.text = JSON.stringify(parsedBody, null, 2);
+                }
+            } catch (e) {
+                console.error('Failed to parse GraphQL variables', e);
+            }
+        }
+
+        return { renderedRequest, renderedResult };
+    };
+
+    sendRequest = async (req: RenderedRequest) => {
+        return await sendCurlAndWriteTimeline(
+            req,
+            this.clientCertificates,
+            this.caCert,
+            this.settings,
+            this.timeline,
+        );
+    };
+
+    persistRequestAndResponse = async (
+        req: RenderedRequest,
+        rawRespPatch: ResponsePatch,
+        renderedResult: Record<string, any>,
+    ) => {
+        const requestMeta = await models.requestMeta.getByParentId(this.request._id);
+        invariant(requestMeta, 'RequestMeta not found');
+
+        const responsePatch = await responseTransform(rawRespPatch, this.environment._id, req, renderedResult.context);
+        const is2XXWithBodyPath = responsePatch.statusCode &&
+            responsePatch.statusCode >= 200 &&
+            responsePatch.statusCode < 300 &&
+            responsePatch.bodyPath;
+
+        const shouldWriteToFile = this.shouldPromptForPathAfterResponse && is2XXWithBodyPath;
+        if (!shouldWriteToFile) {
+            const response = await models.response.create(responsePatch, this.settings.maxHistoryResponses);
+            await models.requestMeta.update(requestMeta, { activeResponseId: response._id });
+            // setLoading(false);
+            return null;
+        }
+
+        if (requestMeta.downloadPath) {
+            const header = getContentDispositionHeader(responsePatch.headers || []);
+            const name = header
+                ? contentDisposition.parse(header.value).parameters.filename
+                : `${req.name.replace(/\s/g, '-').toLowerCase()}.${responsePatch.contentType && mimeExtension(responsePatch.contentType) || 'unknown'}`;
+            return writeToDownloadPath(path.join(requestMeta.downloadPath, name), responsePatch, requestMeta, this.settings.maxHistoryResponses);
+        } else {
+            const defaultPath = window.localStorage.getItem('insomnia.sendAndDownloadLocation');
+            const { filePath } = await window.dialog.showSaveDialog({
+                title: 'Select Download Location',
+                buttonLabel: 'Save',
+                // NOTE: An error will be thrown if defaultPath is supplied but not a String
+                ...(defaultPath ? { defaultPath } : {}),
+            });
+            if (!filePath) {
+                // setLoading(false);
+                return null;
+            }
+
+            window.localStorage.setItem('insomnia.sendAndDownloadLocation', filePath);
+            return writeToDownloadPath(filePath, responsePatch, requestMeta, this.settings.maxHistoryResponses);
+        }
+    };
+}

--- a/packages/insomnia/src/plugins/context/__tests__/data.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/data.test.ts
@@ -195,6 +195,7 @@ describe('app.export.*', () => {
           modified: 222,
           name: 'New Request',
           parameters: [],
+          preRequestScript: '',
           parentId: 'wrk_1',
           settingDisableRenderRequestBody: false,
           settingEncodeUrl: true,

--- a/packages/insomnia/src/renderers/hidden-browser-window/index.html
+++ b/packages/insomnia/src/renderers/hidden-browser-window/index.html
@@ -10,7 +10,7 @@
   </head>
 
   <body>
-    <h1>>Hidden Browser Window</h1>
+    <h1>Hidden Browser Window</h1>
     <script src="./index.js" type="module"></script>
   </body>
 </html>

--- a/packages/insomnia/src/renderers/hidden-browser-window/index.ts
+++ b/packages/insomnia/src/renderers/hidden-browser-window/index.ts
@@ -1,4 +1,4 @@
-import { initGlobalObject, InsomniaObject } from './inso-object';
+import { initGlobalObject, InsomniaObject, require } from './inso-object';
 
 const ErrorTimeout = 'executing script timeout';
 const ErrorInvalidResult = 'result is invalid, null or custom value may be returned';
@@ -21,6 +21,7 @@ async function init() {
                 const AsyncFunction = (async () => { }).constructor;
                 const executeScript = AsyncFunction(
                     'insomnia',
+                    'require',
                     // if possible, avoid adding code to the following part
                     `
                         const $ = insomnia, pm = insomnia;
@@ -35,7 +36,10 @@ async function init() {
                     const timeoutChecker = setTimeout(alertTimeout, timeout);
 
                     try {
-                        const insoObject = await executeScript(insomniaObject);
+                        const insoObject = await executeScript(
+                            insomniaObject,
+                            require,
+                        );
                         clearTimeout(timeoutChecker);
                         if (insoObject instanceof InsomniaObject) {
                             resolve(insoObject.toObject());

--- a/packages/insomnia/src/renderers/hidden-browser-window/inso-object.ts
+++ b/packages/insomnia/src/renderers/hidden-browser-window/inso-object.ts
@@ -1,3 +1,5 @@
+import * as uuid from 'uuid';
+
 import { getIntepolator } from './intepolator';
 
 export type EventName = 'prerequest' | 'test';
@@ -223,3 +225,21 @@ export function initGlobalObject(rawObj: RawObject) {
         requestInfo,
     });
 };
+
+const builtinModules = new Map<string, any>([
+    ['uuid', uuid],
+]);
+
+const nodeModules = new Map<string, any>([]);
+
+export function require(moduleName: string) {
+    if (builtinModules.has(moduleName)) {
+        return builtinModules.get(moduleName);
+    }
+
+    if (nodeModules.has(moduleName)) {
+        // invoke main.js
+    }
+
+    throw Error(`no module is found for "${moduleName}"`);
+}

--- a/packages/insomnia/src/ui/components/base/tabs.tsx
+++ b/packages/insomnia/src/ui/components/base/tabs.tsx
@@ -186,7 +186,11 @@ const Tabs: FC<TabsProps> = props => {
   return (
     <StyledTabsContainer>
       <StyledTabList {...tabListProps} ref={ref} isNested={props.isNested}>
-        {[...state.collection].map((item: Node<TabItemProps>) => (
+        {[...state.collection]
+          .filter(item => (
+            item['aria-label'] !== 'experimental'
+          ))
+          .map((item: Node<TabItemProps>) => (
           <Tab
             key={item.key}
             item={item}

--- a/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
@@ -1,0 +1,33 @@
+import React, { FC, Fragment } from 'react';
+
+import { CodeEditor } from '../codemirror/code-editor';
+
+interface Props {
+    onChange: (value: string) => void;
+    content: string;
+    contentType: string;
+    uniquenessKey: string;
+    className?: string;
+}
+
+export const PreRequestScriptEditor: FC<Props> = ({
+    className,
+    content,
+    contentType,
+    onChange,
+    uniquenessKey,
+}) => (
+    <Fragment>
+        <CodeEditor
+          id="pre-request-script-editor"
+          showPrettifyButton
+          uniquenessKey={uniquenessKey}
+          defaultValue={content}
+          className={className}
+        //   enableNunjucks
+          onChange={onChange}
+          mode={contentType}
+          placeholder="..."
+        />
+    </Fragment>
+);

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -7,6 +7,7 @@ import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { PanelContainer, TabItem, Tabs } from '../base/tabs';
 import { AI } from '../settings/ai';
+import { Experiments } from '../settings/experiments';
 import { General } from '../settings/general';
 import { ImportExport } from '../settings/import-export';
 import { Plugins } from '../settings/plugins';
@@ -79,6 +80,11 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
           <TabItem key="ai" title="AI">
             <PanelContainer className="pad">
               <AI />
+            </PanelContainer>
+          </TabItem>
+          <TabItem key="experiments" title="Experiments">
+            <PanelContainer className="pad">
+              <Experiments />
             </PanelContainer>
           </TabItem>
         </Tabs>

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -312,7 +312,7 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: {
                             <MenuTrigger>
                               <Button
                                 aria-label="Create Environment"
-                                data-testId="CreateEnvironmentDropdown"
+                                data-testid="CreateEnvironmentDropdown"
                                 className="items-center flex justify-center h-6 aspect-square data-[pressed]:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
                               >
                                 <Icon icon="plus-circle" />

--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
@@ -104,7 +104,7 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
       try {
         const request = await getRenderedGrpcRequest({
           request: activeRequest,
-          environmentId,
+          environment: environmentId,
           purpose: RENDER_PURPOSE_SEND,
           skipBody: canClientStream(methodType),
         });
@@ -242,7 +242,7 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                         onClick={async () => {
                           const requestBody = await getRenderedGrpcRequestMessage({
                             request: activeRequest,
-                            environmentId,
+                            environment: environmentId,
                             purpose: RENDER_PURPOSE_SEND,
                           });
                           const preparedMessage = {

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -16,6 +16,7 @@ import { AuthDropdown } from '../dropdowns/auth-dropdown';
 import { ContentTypeDropdown } from '../dropdowns/content-type-dropdown';
 import { AuthWrapper } from '../editors/auth/auth-wrapper';
 import { BodyEditor } from '../editors/body/body-editor';
+import { PreRequestScriptEditor } from '../editors/pre-request-script-editor';
 import {
   QueryEditor,
   QueryEditorContainer,
@@ -100,6 +101,11 @@ export const RequestPane: FC<Props> = ({
       patchRequest(requestId, { url, parameters });
     }
   };
+
+  const handlePreRequestScriptChange = (content: string) => {
+    patchRequest(requestId, { preRequestScript: content });
+  };
+
   const gitVersion = useGitVCSVersion();
   const activeRequestSyncVersion = useActiveRequestSyncVCSVersion();
 
@@ -121,6 +127,7 @@ export const RequestPane: FC<Props> = ({
   const contentType =
     getContentTypeFromHeaders(activeRequest.headers) ||
     activeRequest.body.mimeType;
+
   return (
     <Pane type="request">
       <PaneHeader>
@@ -150,6 +157,19 @@ export const RequestPane: FC<Props> = ({
           >
             <AuthWrapper />
           </ErrorBoundary>
+        </TabItem>
+        <TabItem
+          key="pre-request-script"
+          title={'Pre-request Script'}
+          aria-label={settings.experimentalFlagPreRequestScript ? '' : 'experimental'}
+        >
+          <PreRequestScriptEditor
+            uniquenessKey={uniqueKey}
+            contentType='text/javascript'
+            content={activeRequest.preRequestScript || ''}
+            onChange={handlePreRequestScriptChange}
+          />
+          )
         </TabItem>
         <TabItem
           key="query"

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -68,6 +68,13 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     searchParams.delete('error');
     setSearchParams({});
   }
+  if (searchParams.has('callback')) {
+    // clean up params
+    searchParams.delete('callback');
+    setSearchParams({});
+
+    // setLoading(false);
+  }
 
   const {
     activeWorkspace,
@@ -113,13 +120,17 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
       });
   }, [fetcher, organizationId, projectId, requestId, workspaceId]);
   const send = useCallback((sendParams: SendActionParams) => {
+    const url = settings.experimentalFlagPreRequestScript ?
+      `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${requestId}/send2` :
+      `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${requestId}/send`;
+
     fetcher.submit(JSON.stringify(sendParams),
       {
-        action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${requestId}/send`,
+        action: url,
         method: 'post',
         encType: 'application/json',
       });
-  }, [fetcher, organizationId, projectId, requestId, workspaceId]);
+  }, [fetcher, organizationId, projectId, requestId, workspaceId, settings]);
 
   const sendOrConnect = useCallback(async (shouldPromptForPathAfterResponse?: boolean) => {
     models.stats.incrementExecutedRequests();

--- a/packages/insomnia/src/ui/components/settings/experiments.tsx
+++ b/packages/insomnia/src/ui/components/settings/experiments.tsx
@@ -1,0 +1,19 @@
+import React, { FC } from 'react';
+
+import { BooleanSetting } from './boolean-setting';
+
+export const Experiments: FC = () => {
+  return (
+    <div className="pad-bottom">
+      <div className="row-fill row-fill--top">
+        <div>
+          <BooleanSetting
+            label="Pre-request Script"
+            setting="experimentalFlagPreRequestScript"
+            help="Enable pre-request script feature."
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
+++ b/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
@@ -25,7 +25,7 @@ export const useNunjucks = () => {
     const ancestors = await getRenderContextAncestors(requestData?.activeRequest || workspaceData?.activeWorkspace);
     return getRenderContext({
       request: requestData?.activeRequest || undefined,
-      environmentId: workspaceData?.activeEnvironment._id,
+      environment: workspaceData?.activeEnvironment._id,
       ancestors,
     });
   }, [requestData?.activeRequest, workspaceData?.activeWorkspace, workspaceData?.activeEnvironment._id]);

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -310,6 +310,13 @@ const router = createMemoryRouter(
                                         ).sendAction(...args),
                                     },
                                     {
+                                      path: 'send2',
+                                      action: async (...args) =>
+                                        (
+                                          await import('./routes/request')
+                                        ).sendAction2(...args),
+                                    },
+                                    {
                                       path: 'connect',
                                       action: async (...args) =>
                                         (

--- a/packages/insomnia/src/ui/window-message-handlers.ts
+++ b/packages/insomnia/src/ui/window-message-handlers.ts
@@ -96,6 +96,23 @@ class WindowMessageHandler {
         console.error(logPrefix, 'the hidden window is still not ready');
     };
 
+    waitUntilHiddenBrowserWindowReady = async () => {
+        window.hiddenBrowserWindow.start();
+
+        // TODO: find a better way to wait for hidden browser window ready
+        // the hiddenBrowserWindow may be still in starting
+        // this is relatively simpler than receiving a 'ready' message from hidden browser window
+        for (let i = 0; i < 100; i++) {
+            if (this.hiddenBrowserWindowPort) {
+                break;
+            } else {
+                await new Promise<void>(resolve => setTimeout(resolve, 100));
+            }
+        }
+
+        console.error('the hidden window is still not ready');
+    };
+
     debugEventHandler = async (ev: MessageEvent) => {
         if (!this.hiddenBrowserWindowPort) {
             console.error(logPrefix, 'hidden browser window port is not inited, restarting');
@@ -118,6 +135,8 @@ class WindowMessageHandler {
     };
 
     start = () => {
+        window.hiddenBrowserWindow.start();
+
         this.register('message-event://renderers/publish-port', this.publishPortHandler);
         this.register('message-event://hidden.browser-window/debug', this.debugEventHandler);
 

--- a/packages/insomnia/src/ui/window-message-handlers.ts
+++ b/packages/insomnia/src/ui/window-message-handlers.ts
@@ -96,23 +96,6 @@ class WindowMessageHandler {
         console.error(logPrefix, 'the hidden window is still not ready');
     };
 
-    waitUntilHiddenBrowserWindowReady = async () => {
-        window.hiddenBrowserWindow.start();
-
-        // TODO: find a better way to wait for hidden browser window ready
-        // the hiddenBrowserWindow may be still in starting
-        // this is relatively simpler than receiving a 'ready' message from hidden browser window
-        for (let i = 0; i < 100; i++) {
-            if (this.hiddenBrowserWindowPort) {
-                break;
-            } else {
-                await new Promise<void>(resolve => setTimeout(resolve, 100));
-            }
-        }
-
-        console.error('the hidden window is still not ready');
-    };
-
     debugEventHandler = async (ev: MessageEvent) => {
         if (!this.hiddenBrowserWindowPort) {
             console.error(logPrefix, 'hidden browser window port is not inited, restarting');

--- a/packages/insomnia/src/utils/try-interpolate.ts
+++ b/packages/insomnia/src/utils/try-interpolate.ts
@@ -8,7 +8,7 @@ import { RequestRenderErrorModal } from '../ui/components/modals/request-render-
 // NOTE: template interpolation is tightly coupled with modal implementation
 export const tryToInterpolateRequestOrShowRenderErrorModal = async ({ request, environmentId, payload }: { request: Request | WebSocketRequest | GrpcRequest; environmentId: string; payload: any }): Promise<any> => {
   try {
-    const renderContext = await getRenderContext({ request, environmentId, purpose: RENDER_PURPOSE_SEND });
+    const renderContext = await getRenderContext({ request, environment: environmentId, purpose: RENDER_PURPOSE_SEND });
     return await render(payload, renderContext);
   } catch (error) {
     if (error.type === 'render') {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Changes:
- [x] Added basic UI for editing pre-request scripts for REST requests
- [x] Refactored sending request workflow
- [x] Added pre-request script execution into the workflow
  - [x] Make timeline be accessible by each step in the workflow
- [x] Added tests which populates `environment` and `collectionVariables` before sending request
- [x] Add a static feature flag and turn off this by default

How to test with it:
- Enable `Pre-request Script` in `Preference`->`Experiments`.
- Write some scripts in the `Pre-request Script` tab and send the request.