### PR TITLE
chore: INS-3449 check run as node option

### DIFF
--- a/packages/insomnia/esbuild.main.ts
+++ b/packages/insomnia/esbuild.main.ts
@@ -30,6 +30,7 @@ export default async function build(options: Options) {
       'process.env.NODE_ENV': JSON.stringify('production'),
       'process.env.INSOMNIA_ENV': JSON.stringify('production'),
       'process.env.BUILD_DATE': JSON.stringify(new Date()),
+      'process.env.ELECTRON_RUN_AS_NODE': JSON.stringify(0),
     };
   const preload = esbuild.build({
     entryPoints: ['./src/preload.ts'],

--- a/packages/insomnia/src/main/install-plugin.ts
+++ b/packages/insomnia/src/main/install-plugin.ts
@@ -107,7 +107,7 @@ async function _isInsomniaPlugin(lookupName: string) {
         shell: true,
         env: {
           NODE_ENV: 'production',
-          ELECTRON_RUN_AS_NODE: 'true',
+          ELECTRON_RUN_AS_NODE: 'false',
         },
       },
       (err, stdout, stderr) => {
@@ -185,7 +185,7 @@ async function _installPluginToTmpDir(lookupName: string) {
         // Some package installs require a shell
         env: {
           NODE_ENV: 'production',
-          ELECTRON_RUN_AS_NODE: 'true',
+          ELECTRON_RUN_AS_NODE: 'false',
         },
       },
       (err, stdout, stderr) => {


### PR DESCRIPTION
Closes INS-3449

Still investigating - disabling it potentially affects plugin installation.