### PR TITLE
Add ability to use Buf Schema Registry as a schema source for gRPC requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23482,6 +23482,11 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "node_modules/unique-filename": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -741,6 +741,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.4.1.tgz",
+      "integrity": "sha512-4dthhwBGD9nlpY35ic8dMQC5R0dsND2b2xyeVO3qf+hBk8m7Y9dUs+SmMh6rqO2pGLUTKHefGXLDW+z19hBPdQ=="
+    },
     "node_modules/@codemirror/language": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.0.0.tgz",
@@ -773,6 +778,29 @@
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.1.3.tgz",
+      "integrity": "sha512-AXkbsLQe2Nm7VuoN5nqp05GEb9mPa/f5oFzDqTbHME4i8TghTrlY03uefbhuAq4wjsnfDnmuxHZvn6ndlgXmbg==",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.3.3"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.1.3.tgz",
+      "integrity": "sha512-oq7Uk8XlLzC2+eHaxZTX189dhujD0/tK9plizxofsFHUnLquMSmzQQ2GzvTv4u6U05eZYc/crySmf86Sqpi1bA==",
+      "dependencies": {
+        "undici": "^5.26.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.3.3",
+        "@connectrpc/connect": "1.1.3"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -1772,6 +1800,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
@@ -23435,10 +23471,16 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    "node_modules/undici": {
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
+      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
@@ -24829,6 +24871,9 @@
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
         "@apidevtools/swagger-parser": "10.1.0",
+        "@bufbuild/protobuf": "^1.4.1",
+        "@connectrpc/connect": "^1.1.3",
+        "@connectrpc/connect-node": "^1.1.3",
         "@getinsomnia/node-libcurl": "^2.4.1-9",
         "@grpc/grpc-js": "^1.8.17",
         "@grpc/proto-loader": "^0.7.7",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -36,6 +36,9 @@
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
     "@apidevtools/swagger-parser": "10.1.0",
+    "@bufbuild/protobuf": "^1.4.1",
+    "@connectrpc/connect": "^1.1.3",
+    "@connectrpc/connect-node": "^1.1.3",
     "@getinsomnia/node-libcurl": "^2.4.1-9",
     "@grpc/grpc-js": "^1.8.17",
     "@grpc/proto-loader": "^0.7.7",

--- a/packages/insomnia/src/__jest__/setup.ts
+++ b/packages/insomnia/src/__jest__/setup.ts
@@ -1,3 +1,7 @@
+import { TextDecoder, TextEncoder } from 'util';
+
+Object.assign(globalThis, { TextDecoder, TextEncoder });
+
 globalThis.__DEV__ = false;
 
 globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {

--- a/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
+++ b/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
@@ -47,9 +47,9 @@ describe('loadMethodsFromReflection', () => {
 
     it('parses methods', async () => {
       const methods = await loadMethodsFromReflection({
-        url: "foo.com",
+        url: 'foo.com',
         metadata: [],
-        reflectionApi: { enabled: false, apiKey: "", url: "", module: "" },
+        reflectionApi: { enabled: false, apiKey: '', url: '', module: '' },
       });
       expect(methods).toStrictEqual([{
         type: 'unary',
@@ -89,9 +89,9 @@ describe('loadMethodsFromReflection', () => {
 
     it('parses methods', async () => {
       const methods = await loadMethodsFromReflection({
-        url: "foo.com",
+        url: 'foo.com',
         metadata: [],
-        reflectionApi: { enabled: false, apiKey: "", url: "", module: "" },
+        reflectionApi: { enabled: false, apiKey: '', url: '', module: '' },
       });
       expect(methods).toStrictEqual([{
         type: 'unary',
@@ -143,9 +143,9 @@ describe('loadMethodsFromReflection', () => {
 
     it('parses methods', async () => {
       const methods = await loadMethodsFromReflection({
-        url: "foo-bar.com",
+        url: 'foo-bar.com',
         metadata: [],
-        reflectionApi: { enabled: false, apiKey: "", url: "", module: "" },
+        reflectionApi: { enabled: false, apiKey: '', url: '', module: '' },
       });
       expect(methods).toStrictEqual([{
         type: 'unary',
@@ -195,13 +195,13 @@ describe('loadMethodsFromReflection', () => {
         }
       );
       const methods = await loadMethodsFromReflection({
-        url: "foo.com",
+        url: 'foo.com',
         metadata: [],
         reflectionApi: {
           enabled: true,
-          apiKey: "TEST_KEY",
-          url: "https://buf.build",
-          module: "buf.build/connectrpc/eliza",
+          apiKey: 'TEST_KEY',
+          url: 'https://buf.build',
+          module: 'buf.build/connectrpc/eliza',
         },
       });
       expect(methods).toStrictEqual(

--- a/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
+++ b/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
@@ -46,7 +46,11 @@ describe('loadMethodsFromReflection', () => {
     });
 
     it('parses methods', async () => {
-      const methods = await loadMethodsFromReflection({ url: 'foo.com', metadata: [], bufReflectionApi: { enabled: false, apiKey: '', url: '', module: '' } });
+      const methods = await loadMethodsFromReflection({
+        url: "foo.com",
+        metadata: [],
+        reflectionApi: { enabled: false, apiKey: "", url: "", module: "" },
+      });
       expect(methods).toStrictEqual([{
         type: 'unary',
         fullPath: '/FooService/Foo',
@@ -84,7 +88,11 @@ describe('loadMethodsFromReflection', () => {
     });
 
     it('parses methods', async () => {
-      const methods = await loadMethodsFromReflection({ url: 'foo.com', metadata: [], bufReflectionApi: { enabled: false, apiKey: '', url: '', module: '' } });
+      const methods = await loadMethodsFromReflection({
+        url: "foo.com",
+        metadata: [],
+        reflectionApi: { enabled: false, apiKey: "", url: "", module: "" },
+      });
       expect(methods).toStrictEqual([{
         type: 'unary',
         fullPath: '/FooService/format',
@@ -134,7 +142,11 @@ describe('loadMethodsFromReflection', () => {
     });
 
     it('parses methods', async () => {
-      const methods = await loadMethodsFromReflection({ url: 'foo-bar.com', metadata: [], bufReflectionApi: { enabled: false, apiKey: '', url: '', module: '' } });
+      const methods = await loadMethodsFromReflection({
+        url: "foo-bar.com",
+        metadata: [],
+        reflectionApi: { enabled: false, apiKey: "", url: "", module: "" },
+      });
       expect(methods).toStrictEqual([{
         type: 'unary',
         fullPath: '/FooService/Foo',
@@ -183,13 +195,13 @@ describe('loadMethodsFromReflection', () => {
         }
       );
       const methods = await loadMethodsFromReflection({
-        url: 'foo.com',
+        url: "foo.com",
         metadata: [],
-        bufReflectionApi: {
+        reflectionApi: {
           enabled: true,
-          apiKey: 'TEST_KEY',
-          url: 'https://buf.build',
-          module: 'buf.build/connectrpc/eliza',
+          apiKey: "TEST_KEY",
+          url: "https://buf.build",
+          module: "buf.build/connectrpc/eliza",
         },
       });
       expect(methods).toStrictEqual(

--- a/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
+++ b/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
@@ -1,3 +1,11 @@
+import {
+  AnyMessage,
+  MethodInfo,
+  PartialMessage,
+  ServiceType,
+} from '@bufbuild/protobuf';
+import { UnaryResponse } from '@connectrpc/connect';
+import { createConnectTransport } from '@connectrpc/connect-node';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import * as grpcReflection from 'grpc-reflection-js';
 import protobuf from 'protobufjs';
@@ -6,6 +14,7 @@ import { globalBeforeEach } from '../../../__jest__/before-each';
 import { loadMethodsFromReflection } from '../grpc';
 
 jest.mock('grpc-reflection-js');
+jest.mock('@connectrpc/connect-node');
 
 describe('loadMethodsFromReflection', () => {
   beforeEach(globalBeforeEach);
@@ -37,7 +46,7 @@ describe('loadMethodsFromReflection', () => {
     });
 
     it('parses methods', async () => {
-      const methods = await loadMethodsFromReflection({ url: 'foo.com', metadata: [] });
+      const methods = await loadMethodsFromReflection({ url: 'foo.com', metadata: [], bufReflectionApi: { enabled: false, apiKey: '', url: '', module: '' } });
       expect(methods).toStrictEqual([{
         type: 'unary',
         fullPath: '/FooService/Foo',
@@ -75,7 +84,7 @@ describe('loadMethodsFromReflection', () => {
     });
 
     it('parses methods', async () => {
-      const methods = await loadMethodsFromReflection({ url: 'foo.com', metadata: [] });
+      const methods = await loadMethodsFromReflection({ url: 'foo.com', metadata: [], bufReflectionApi: { enabled: false, apiKey: '', url: '', module: '' } });
       expect(methods).toStrictEqual([{
         type: 'unary',
         fullPath: '/FooService/format',
@@ -125,7 +134,7 @@ describe('loadMethodsFromReflection', () => {
     });
 
     it('parses methods', async () => {
-      const methods = await loadMethodsFromReflection({ url: 'foo-bar.com', metadata: [] });
+      const methods = await loadMethodsFromReflection({ url: 'foo-bar.com', metadata: [], bufReflectionApi: { enabled: false, apiKey: '', url: '', module: '' } });
       expect(methods).toStrictEqual([{
         type: 'unary',
         fullPath: '/FooService/Foo',
@@ -142,4 +151,66 @@ describe('loadMethodsFromReflection', () => {
     });
   });
 
+  describe('buf reflection api', () => {
+    it('loads module', async () => {
+      (createConnectTransport as unknown as jest.Mock).mockImplementation(
+        options => {
+          expect(options.baseUrl).toStrictEqual('https://buf.build');
+          return {
+            async unary(
+              service: ServiceType,
+              method: MethodInfo,
+              _: AbortSignal | undefined,
+              __: number | undefined,
+              header: HeadersInit | undefined,
+              input: PartialMessage<AnyMessage>
+            ): Promise<UnaryResponse> {
+              expect(new Headers(header).get('Authorization')).toStrictEqual('Bearer TEST_KEY');
+              expect(input).toStrictEqual({ module: 'buf.build/connectrpc/eliza' });
+              return {
+                service: service,
+                method: method,
+                header: new Headers(),
+                trailer: new Headers(),
+                stream: false,
+                // Output of running `buf curl https://buf.build/buf.reflect.v1beta1.FileDescriptorSetService/GetFileDescriptorSet --data '{"module": "buf.build/connectrpc/eliza"}' --schema buf.build/bufbuild/reflect -H 'Authorization: Bearer buf-token'`
+                message: method.O.fromJsonString(
+                  '{"fileDescriptorSet":{"file":[{"name":"connectrpc/eliza/v1/eliza.proto","package":"connectrpc.eliza.v1","messageType":[{"name":"SayRequest","field":[{"name":"sentence","number":1,"label":"LABEL_OPTIONAL","type":"TYPE_STRING","jsonName":"sentence"}]},{"name":"SayResponse","field":[{"name":"sentence","number":1,"label":"LABEL_OPTIONAL","type":"TYPE_STRING","jsonName":"sentence"}]},{"name":"ConverseRequest","field":[{"name":"sentence","number":1,"label":"LABEL_OPTIONAL","type":"TYPE_STRING","jsonName":"sentence"}]},{"name":"ConverseResponse","field":[{"name":"sentence","number":1,"label":"LABEL_OPTIONAL","type":"TYPE_STRING","jsonName":"sentence"}]},{"name":"IntroduceRequest","field":[{"name":"name","number":1,"label":"LABEL_OPTIONAL","type":"TYPE_STRING","jsonName":"name"}]},{"name":"IntroduceResponse","field":[{"name":"sentence","number":1,"label":"LABEL_OPTIONAL","type":"TYPE_STRING","jsonName":"sentence"}]}],"service":[{"name":"ElizaService","method":[{"name":"Say","inputType":".connectrpc.eliza.v1.SayRequest","outputType":".connectrpc.eliza.v1.SayResponse","options":{"idempotencyLevel":"NO_SIDE_EFFECTS"}},{"name":"Converse","inputType":".connectrpc.eliza.v1.ConverseRequest","outputType":".connectrpc.eliza.v1.ConverseResponse","options":{},"clientStreaming":true,"serverStreaming":true},{"name":"Introduce","inputType":".connectrpc.eliza.v1.IntroduceRequest","outputType":".connectrpc.eliza.v1.IntroduceResponse","options":{},"serverStreaming":true}]}],"syntax":"proto3"}]},"version":"233fca715f49425581ec0a1b660be886"}'
+                ),
+              };
+            },
+          };
+        }
+      );
+      const methods = await loadMethodsFromReflection({
+        url: 'foo.com',
+        metadata: [],
+        bufReflectionApi: {
+          enabled: true,
+          apiKey: 'TEST_KEY',
+          url: 'https://buf.build',
+          module: 'buf.build/connectrpc/eliza',
+        },
+      });
+      expect(methods).toStrictEqual(
+        [
+           {
+            example: undefined,
+            fullPath: '/connectrpc.eliza.v1.ElizaService/Say',
+            type: 'unary',
+          },
+           {
+            example: undefined,
+            fullPath: '/connectrpc.eliza.v1.ElizaService/Converse',
+            type: 'bidi',
+          },
+           {
+            example: undefined,
+            fullPath: '/connectrpc.eliza.v1.ElizaService/Introduce',
+            type: 'server',
+          },
+        ]
+      );
+    });
+  });
 });

--- a/packages/insomnia/src/main/ipc/grpc.ts
+++ b/packages/insomnia/src/main/ipc/grpc.ts
@@ -35,6 +35,7 @@ import { parseGrpcUrl } from '../../network/grpc/parse-grpc-url';
 import { writeProtoFile } from '../../network/grpc/write-proto-file';
 import { invariant } from '../../utils/invariant';
 import { mockRequestMethods } from './automock';
+import { version } from '../../../package.json';
 
 const grpcCalls = new Map<string, Call>();
 
@@ -152,8 +153,10 @@ const getMethodsFromReflectionServer = async (
     httpVersion: "1.1",
   });
   const client = createPromiseClient(FileDescriptorSetService, transport);
-  const headers: HeadersInit =
-    apiKey === "" ? {} : { Authorization: `Bearer ${apiKey}` };
+  const headers: HeadersInit = {
+    'User-Agent': `insomnia/${version}`,
+    ...(apiKey === "" ? {} : { Authorization: `Bearer ${apiKey}` }),
+  };
   try {
     const res = await client.getFileDescriptorSet(
       {

--- a/packages/insomnia/src/main/ipc/grpc.ts
+++ b/packages/insomnia/src/main/ipc/grpc.ts
@@ -112,7 +112,6 @@ const getMethodsFromReflectionServer = async (bufReflectionApi: GrpcRequest['buf
       module,
       apiKey,
     } = bufReflectionApi;
-    console.log(bufReflectionApi);
     const GetFileDescriptorSetRequest = proto3.makeMessageType(
       'buf.reflect.v1beta1.GetFileDescriptorSetRequest',
       () => [
@@ -145,13 +144,12 @@ const getMethodsFromReflectionServer = async (bufReflectionApi: GrpcRequest['buf
       httpVersion: '1.1',
     });
     const client = createPromiseClient(FileDescriptorSetService, transport);
+    const headers: HeadersInit = apiKey === '' ? {} : { 'Authorization': `Bearer ${apiKey}` };
     try {
       const res = await client.getFileDescriptorSet({
         module,
       }, {
-        headers: {
-          'Authorization': `Bearer ${apiKey}`,
-        },
+        headers,
       });
       const methodDefs: MethodDefs[] = [];
       if (res.fileDescriptorSet === undefined) {

--- a/packages/insomnia/src/models/__tests__/grpc-request.test.ts
+++ b/packages/insomnia/src/models/__tests__/grpc-request.test.ts
@@ -18,6 +18,12 @@ describe('init()', () => {
       body: {
         text: '{}',
       },
+      bufReflectionApi: {
+        enabled: false,
+        apiKey: '',
+        module: '',
+        url: 'https://buf.build',
+      },
       metaSortKey: -1478795580200,
       isPrivate: false,
     });
@@ -46,6 +52,12 @@ describe('create()', () => {
       metadata: [],
       body: {
         text: '{}',
+      },
+      bufReflectionApi: {
+        enabled: false,
+        apiKey: '',
+        module: '',
+        url: 'https://buf.build',
       },
       metaSortKey: -1478795580200,
       isPrivate: false,

--- a/packages/insomnia/src/models/__tests__/grpc-request.test.ts
+++ b/packages/insomnia/src/models/__tests__/grpc-request.test.ts
@@ -9,20 +9,20 @@ describe('init()', () => {
   it('contains all required fields', async () => {
     Date.now = jest.fn().mockReturnValue(1478795580200);
     expect(models.grpcRequest.init()).toEqual({
-      url: '',
-      name: 'New gRPC Request',
-      description: '',
-      protoFileId: '',
-      protoMethodName: '',
+      url: "",
+      name: "New gRPC Request",
+      description: "",
+      protoFileId: "",
+      protoMethodName: "",
       metadata: [],
       body: {
-        text: '{}',
+        text: "{}",
       },
-      bufReflectionApi: {
+      reflectionApi: {
         enabled: false,
-        apiKey: '',
-        module: 'buf.build/connectrpc/eliza',
-        url: 'https://buf.build',
+        apiKey: "",
+        module: "buf.build/connectrpc/eliza",
+        url: "https://buf.build",
       },
       metaSortKey: -1478795580200,
       isPrivate: false,
@@ -40,28 +40,28 @@ describe('create()', () => {
       parentId: 'fld_124',
     });
     const expected = {
-      _id: 'greq_cc1dd2ca4275747aa88199e8efd42403',
+      _id: "greq_cc1dd2ca4275747aa88199e8efd42403",
       created: 1478795580200,
       modified: 1478795580200,
-      parentId: 'fld_124',
-      name: 'My request',
-      description: '',
-      url: '',
-      protoFileId: '',
-      protoMethodName: '',
+      parentId: "fld_124",
+      name: "My request",
+      description: "",
+      url: "",
+      protoFileId: "",
+      protoMethodName: "",
       metadata: [],
       body: {
-        text: '{}',
+        text: "{}",
       },
-      bufReflectionApi: {
+      reflectionApi: {
         enabled: false,
-        apiKey: '',
-        module: 'buf.build/connectrpc/eliza',
-        url: 'https://buf.build',
+        apiKey: "",
+        module: "buf.build/connectrpc/eliza",
+        url: "https://buf.build",
       },
       metaSortKey: -1478795580200,
       isPrivate: false,
-      type: 'GrpcRequest',
+      type: "GrpcRequest",
     };
     expect(request).toEqual(expected);
     expect(await models.grpcRequest.getById(expected._id)).toEqual(expected);

--- a/packages/insomnia/src/models/__tests__/grpc-request.test.ts
+++ b/packages/insomnia/src/models/__tests__/grpc-request.test.ts
@@ -9,20 +9,20 @@ describe('init()', () => {
   it('contains all required fields', async () => {
     Date.now = jest.fn().mockReturnValue(1478795580200);
     expect(models.grpcRequest.init()).toEqual({
-      url: "",
-      name: "New gRPC Request",
-      description: "",
-      protoFileId: "",
-      protoMethodName: "",
+      url: '',
+      name: 'New gRPC Request',
+      description: '',
+      protoFileId: '',
+      protoMethodName: '',
       metadata: [],
       body: {
-        text: "{}",
+        text: '{}',
       },
       reflectionApi: {
         enabled: false,
-        apiKey: "",
-        module: "buf.build/connectrpc/eliza",
-        url: "https://buf.build",
+        apiKey: '',
+        module: 'buf.build/connectrpc/eliza',
+        url: 'https://buf.build',
       },
       metaSortKey: -1478795580200,
       isPrivate: false,
@@ -40,28 +40,28 @@ describe('create()', () => {
       parentId: 'fld_124',
     });
     const expected = {
-      _id: "greq_cc1dd2ca4275747aa88199e8efd42403",
+      _id: 'greq_cc1dd2ca4275747aa88199e8efd42403',
       created: 1478795580200,
       modified: 1478795580200,
-      parentId: "fld_124",
-      name: "My request",
-      description: "",
-      url: "",
-      protoFileId: "",
-      protoMethodName: "",
+      parentId: 'fld_124',
+      name: 'My request',
+      description: '',
+      url: '',
+      protoFileId: '',
+      protoMethodName: '',
       metadata: [],
       body: {
-        text: "{}",
+        text: '{}',
       },
       reflectionApi: {
         enabled: false,
-        apiKey: "",
-        module: "buf.build/connectrpc/eliza",
-        url: "https://buf.build",
+        apiKey: '',
+        module: 'buf.build/connectrpc/eliza',
+        url: 'https://buf.build',
       },
       metaSortKey: -1478795580200,
       isPrivate: false,
-      type: "GrpcRequest",
+      type: 'GrpcRequest',
     };
     expect(request).toEqual(expected);
     expect(await models.grpcRequest.getById(expected._id)).toEqual(expected);

--- a/packages/insomnia/src/models/__tests__/grpc-request.test.ts
+++ b/packages/insomnia/src/models/__tests__/grpc-request.test.ts
@@ -21,7 +21,7 @@ describe('init()', () => {
       bufReflectionApi: {
         enabled: false,
         apiKey: '',
-        module: '',
+        module: 'buf.build/connectrpc/eliza',
         url: 'https://buf.build',
       },
       metaSortKey: -1478795580200,
@@ -56,7 +56,7 @@ describe('create()', () => {
       bufReflectionApi: {
         enabled: false,
         apiKey: '',
-        module: '',
+        module: 'buf.build/connectrpc/eliza',
         url: 'https://buf.build',
       },
       metaSortKey: -1478795580200,

--- a/packages/insomnia/src/models/grpc-request.ts
+++ b/packages/insomnia/src/models/grpc-request.ts
@@ -48,22 +48,22 @@ export const isGrpcRequestId = (id: string | null) => (
 
 export function init(): BaseGrpcRequest {
   return {
-    url: "",
-    name: "New gRPC Request",
-    description: "",
-    protoFileId: "",
-    protoMethodName: "",
+    url: '',
+    name: 'New gRPC Request',
+    description: '',
+    protoFileId: '',
+    protoMethodName: '',
     metadata: [],
     body: {
-      text: "{}",
+      text: '{}',
     },
     metaSortKey: -1 * Date.now(),
     isPrivate: false,
     reflectionApi: {
       enabled: false,
-      url: "https://buf.build",
-      apiKey: "",
-      module: "buf.build/connectrpc/eliza",
+      url: 'https://buf.build',
+      apiKey: '',
+      module: 'buf.build/connectrpc/eliza',
     },
   };
 }

--- a/packages/insomnia/src/models/grpc-request.ts
+++ b/packages/insomnia/src/models/grpc-request.ts
@@ -63,7 +63,7 @@ export function init(): BaseGrpcRequest {
       enabled: false,
       url: 'https://buf.build',
       apiKey: '',
-      module: '',
+      module: 'buf.build/connectrpc/eliza',
     },
   };
 }

--- a/packages/insomnia/src/models/grpc-request.ts
+++ b/packages/insomnia/src/models/grpc-request.ts
@@ -28,7 +28,7 @@ interface BaseGrpcRequest {
   metadata: GrpcRequestHeader[];
   metaSortKey: number;
   isPrivate: boolean;
-  bufReflectionApi: {
+  reflectionApi: {
     enabled: boolean;
     url: string;
     apiKey: string;
@@ -48,22 +48,22 @@ export const isGrpcRequestId = (id: string | null) => (
 
 export function init(): BaseGrpcRequest {
   return {
-    url: '',
-    name: 'New gRPC Request',
-    description: '',
-    protoFileId: '',
-    protoMethodName: '',
+    url: "",
+    name: "New gRPC Request",
+    description: "",
+    protoFileId: "",
+    protoMethodName: "",
     metadata: [],
     body: {
-      text: '{}',
+      text: "{}",
     },
     metaSortKey: -1 * Date.now(),
     isPrivate: false,
-    bufReflectionApi: {
+    reflectionApi: {
       enabled: false,
-      url: 'https://buf.build',
-      apiKey: '',
-      module: 'buf.build/connectrpc/eliza',
+      url: "https://buf.build",
+      apiKey: "",
+      module: "buf.build/connectrpc/eliza",
     },
   };
 }

--- a/packages/insomnia/src/models/grpc-request.ts
+++ b/packages/insomnia/src/models/grpc-request.ts
@@ -28,6 +28,12 @@ interface BaseGrpcRequest {
   metadata: GrpcRequestHeader[];
   metaSortKey: number;
   isPrivate: boolean;
+  bufReflectionApi: {
+    enabled: boolean;
+    url: string;
+    apiKey: string;
+    module: string;
+  };
 }
 
 export type GrpcRequest = BaseModel & BaseGrpcRequest;
@@ -53,6 +59,12 @@ export function init(): BaseGrpcRequest {
     },
     metaSortKey: -1 * Date.now(),
     isPrivate: false,
+    bufReflectionApi: {
+      enabled: false,
+      url: 'https://buf.build',
+      apiKey: '',
+      module: '',
+    },
   };
 }
 

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -71,6 +71,17 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
   const toggleCheckBox = async (event: any) => {
     patchRequest(request._id, { [event.currentTarget.name]: event.currentTarget.checked ? true : false });
   };
+  const updateReflectonApi = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!isGrpcRequest(request)) {
+      throw new Error('Must be a gRPC request');
+    }
+    patchRequest(request._id, {
+      bufReflectionApi: {
+        ...request.bufReflectionApi,
+        [event.currentTarget.name]: event.currentTarget.value,
+      },
+    });
+  };
   const updateDescription = (description: string) => {
     patchRequest(request._id, { description });
     setState({
@@ -150,7 +161,7 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                     </label>
                   </div>
                 </>
-                <hr />
+                <hr/>
                 <div className="form-row">
                   <div className="form-control form-control--outlined">
                     <label>
@@ -202,10 +213,79 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                 </div>
               </>)}
             {request && isGrpcRequest(request) && (
-              <p className="faint italic">
-                Are there any gRPC settings you expect to see? Create a{' '}
-                <a href={'https://github.com/Kong/insomnia/issues/new/choose'}>feature request</a>!
-              </p>
+              <>
+                <hr className="pad-top"/>
+                <h2>Reflection</h2>
+                <div className="form-control form-control--thin">
+                  <label className="inline-block">
+                    Use Buf reflection Api
+                    <HelpTooltip className="space-left">
+                      Buf Reflection Api uses the Buf Schema Registry to fetch the proto definitions instead of
+                      relying on servers enabling reflection or using raw proto files.
+                    </HelpTooltip>
+                    <input
+                      type="checkbox"
+                      name="bufReflectionApi"
+                      checked={request.bufReflectionApi.enabled}
+                      onChange={event => patchRequest(request._id, {
+                        bufReflectionApi: {
+                          ...request.bufReflectionApi,
+                          enabled: event.currentTarget.checked,
+                        },
+                      })}
+                    />̵
+                  </label>
+                </div>
+                <div className="form-row pad-top-sm">
+                  <div className="form-control form-control--outlined">
+                    <label>
+                      Reflection Server Url
+                      <HelpTooltip className="space-left">The BSR address for example https://buf.build</HelpTooltip>
+                      <input
+                        type="text"
+                        name="url"
+                        placeholder="https://buf.build"
+                        value={request.bufReflectionApi.url}
+                        onChange={updateReflectonApi}
+                        disabled={!request.bufReflectionApi.enabled}
+                      />
+                    </label>
+                  </div>
+                  <div className="form-control form-control--outlined">
+                    <label>
+                      Reflection Server Api Key
+                      <HelpTooltip className="space-left">The BSR Token. See
+                        https://buf.build/docs/bsr/authentication#create-an-api-token to create one</HelpTooltip>
+                      <input
+                        type="password"
+                        name="apiKey"
+                        value={request.bufReflectionApi.apiKey}
+                        onChange={updateReflectonApi}
+                        disabled={!request.bufReflectionApi.enabled}
+                      />
+                    </label>
+                  </div>
+                  <div className="form-control form-control--outlined">
+                    <label>
+                      Reflection Server Module
+                      <HelpTooltip className="space-left">The buf module. For example
+                        buf.build/connectrpc/eliza</HelpTooltip>
+                      <input
+                        type="text"
+                        name="module"
+                        placeholder="buf.build/connectrpc/eliza"
+                        value={request.bufReflectionApi.module}
+                        onChange={updateReflectonApi}
+                        disabled={!request.bufReflectionApi.enabled}
+                      />
+                    </label>
+                  </div>
+                </div>
+                <p className="faint italic">
+                  Are there any gRPC settings you expect to see? Create a{' '}
+                  <a href={'https://github.com/Kong/insomnia/issues/new/choose'}>feature request</a>!
+                </p>
+              </>
             )}
             {request && isRequest(request) && (
               <>

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -219,7 +219,7 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                 <div className="rounded-md border border-solid border-[--hl-md] p-4 flex flex-col gap-2">
                   <Heading className="text-lg font-bold flex items-center gap-2">Reflection </Heading>
                   <div className="form-control form-control--thin">
-                    <label className="inline">
+                    <label>
                       Use the Buf Reflection API
                       <a href="https://buf.build/docs/bsr/reflection/overview" className="pad-left-sm">
                         <Icon icon="external-link" size="sm"/>

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { OverlayContainer } from 'react-aria';
-import { Heading } from 'react-aria-components';
 import { useFetcher, useNavigate, useParams } from 'react-router-dom';
 
 import * as models from '../../../models';
@@ -216,11 +215,9 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
               </>)}
             {request && isGrpcRequest(request) && (
               <>
-                <div className="rounded-md border border-solid border-[--hl-md] p-4 flex flex-col gap-2">
-                  <Heading className="text-lg font-bold flex items-center gap-2">Reflection </Heading>
                   <div className="form-control form-control--thin">
                     <label>
-                      Use the Buf Reflection API
+                      Use the Buf Schema Registry API
                       <a href="https://buf.build/docs/bsr/reflection/overview" className="pad-left-sm">
                         <Icon icon="external-link" size="sm"/>
                       </a>
@@ -238,55 +235,59 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                     </label>
                   </div>
                   <div className="form-row pad-top-sm">
-                    <div className="form-control form-control--outlined">
-                      <label>
-                        Reflection server URL
-                        <a href="https://buf.build/docs/bsr/api-access" className="pad-left-sm">
-                          <Icon icon="external-link" size="sm"/>
-                        </a>
-                        <input
-                          type="text"
-                          name="url"
-                          placeholder="https://buf.build"
-                          value={request.bufReflectionApi.url}
-                          onChange={updateReflectonApi}
-                          disabled={!request.bufReflectionApi.enabled}
-                        />
-                      </label>
-                    </div>
-                    <div className="form-control form-control--outlined">
-                      <label>
-                        Reflection server API key
-                        <a href="https://buf.build/docs/bsr/authentication#manage-tokens" className="pad-left-sm">
-                          <Icon icon="external-link" size="sm"/>
-                        </a>
-                        <input
-                          type="password"
-                          name="apiKey"
-                          value={request.bufReflectionApi.apiKey}
-                          onChange={updateReflectonApi}
-                          disabled={!request.bufReflectionApi.enabled}
-                        />
-                      </label>
-                    </div>
-                    <div className="form-control form-control--outlined">
-                      <label>
-                        BSR module
-                        <a href="https://buf.build/docs/bsr/module/manage" className="pad-left-sm">
-                          <Icon icon="external-link" size="sm"/>
-                        </a>
-                        <input
-                          type="text"
-                          name="module"
-                          placeholder="buf.build/connectrpc/eliza"
-                          value={request.bufReflectionApi.module}
-                          onChange={updateReflectonApi}
-                          disabled={!request.bufReflectionApi.enabled}
-                        />
-                      </label>
-                    </div>
+                    { request.bufReflectionApi.enabled && (
+                        <>
+                          <div className="form-control form-control--outlined">
+                            <label>
+                              Reflection server URL
+                              <a href="https://buf.build/docs/bsr/api-access" className="pad-left-sm">
+                                <Icon icon="external-link" size="sm"/>
+                              </a>
+                              <input
+                                type="text"
+                                name="bsrUrl"
+                                placeholder="https://buf.build"
+                                value={request.bufReflectionApi.url}
+                                onChange={updateReflectonApi}
+                                disabled={!request.bufReflectionApi.enabled}
+                              />
+                            </label>
+                          </div>
+                          <div className="form-control form-control--outlined">
+                            <label>
+                              Reflection server API key
+                              <a href="https://buf.build/docs/bsr/authentication#manage-tokens" className="pad-left-sm">
+                                <Icon icon="external-link" size="sm"/>
+                              </a>
+                            <input
+                              type="password"
+                              name="bsrApiKey"
+                              value={request.bufReflectionApi.apiKey}
+                              onChange={updateReflectonApi}
+                              disabled={!request.bufReflectionApi.enabled}
+                            />
+                            </label>
+                          </div>
+                          <div className="form-control form-control--outlined">
+                            <label>
+                              Module
+                              <a href="https://buf.build/docs/bsr/module/manage" className="pad-left-sm">
+                                <Icon icon="external-link" size="sm"/>
+                              </a>
+                              <input
+                                type="text"
+                                name="bsrModule"
+                                placeholder="buf.build/connectrpc/eliza"
+                                value={request.bufReflectionApi.module}
+                                onChange={updateReflectonApi}
+                                disabled={!request.bufReflectionApi.enabled}
+                              />
+                            </label>
+                          </div>
+                        </>
+                      )
+                    }
                   </div>
-                </div>
                 <p className="faint italic pad-top">
                   Are there any gRPC settings you expect to see? Create a{' '}
                   <a href={'https://github.com/Kong/insomnia/issues/new/choose'}>feature request</a>!

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -73,14 +73,11 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
     patchRequest(request._id, { [event.currentTarget.name]: event.currentTarget.checked ? true : false });
   };
   const updateReflectonApi = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (!isGrpcRequest(request)) {
-      throw new Error('Must be a gRPC request');
-    }
-    const property = event.currentTarget.name.replace("reflectionApi.", "");
+    invariant(isGrpcRequest(request), 'Must be gRPC request');
     patchRequest(request._id, {
       reflectionApi: {
         ...request.reflectionApi,
-        [property]: event.currentTarget.value,
+        [event.currentTarget.name]: event.currentTarget.value,
       },
     });
   };
@@ -163,7 +160,7 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                     </label>
                   </div>
                 </>
-                <hr/>
+                <hr />
                 <div className="form-row">
                   <div className="form-control form-control--outlined">
                     <label>
@@ -216,79 +213,78 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
               </>)}
             {request && isGrpcRequest(request) && (
               <>
-                  <div className="form-control form-control--thin pad-top-sm">
-                    <label>
-                      Use the Buf Schema Registry API
-                      <a href="https://buf.build/docs/bsr/reflection/overview" className="pad-left-sm">
-                        <Icon icon="external-link" size="sm"/>
-                      </a>
-                      <input
-                        type="checkbox"
-                        name="reflectionApi"
-                        checked={request.reflectionApi.enabled}
-                        onChange={event => patchRequest(request._id, {
-                          reflectionApi: {
-                            ...request.reflectionApi,
-                            enabled: event.currentTarget.checked,
-                          },
-                        })}
-                      />̵
-                    </label>
-                  </div>
-                  <div className="form-row pad-top-sm">
-                    { request.reflectionApi.enabled && (
-                        <>
-                          <div className="form-control form-control--outlined">
-                            <label>
-                              Reflection server URL
-                              <a href="https://buf.build/docs/bsr/api-access" className="pad-left-sm">
-                                <Icon icon="external-link" size="sm"/>
-                              </a>
-                              <input
-                                type="text"
-                                name="reflectionApi.url"
-                                placeholder="https://buf.build"
-                                value={request.reflectionApi.url}
-                                onChange={updateReflectonApi}
-                                disabled={!request.reflectionApi.enabled}
-                              />
-                            </label>
-                          </div>
-                          <div className="form-control form-control--outlined">
-                            <label>
-                              Reflection server API key
-                              <a href="https://buf.build/docs/bsr/authentication#manage-tokens" className="pad-left-sm">
-                                <Icon icon="external-link" size="sm"/>
-                              </a>
-                            <input
-                              type="password"
-                              name="reflectionApi.apiKey"
-                              value={request.reflectionApi.apiKey}
-                              onChange={updateReflectonApi}
-                              disabled={!request.reflectionApi.enabled}
-                            />
-                            </label>
-                          </div>
-                          <div className="form-control form-control--outlined">
-                            <label>
-                              Module
-                              <a href="https://buf.build/docs/bsr/module/manage" className="pad-left-sm">
-                                <Icon icon="external-link" size="sm"/>
-                              </a>
-                              <input
-                                type="text"
-                                name="reflectionApi.module"
-                                placeholder="buf.build/connectrpc/eliza"
-                                value={request.reflectionApi.module}
-                                onChange={updateReflectonApi}
-                                disabled={!request.reflectionApi.enabled}
-                              />
-                            </label>
-                          </div>
-                        </>
-                      )
-                    }
-                  </div>
+                <div className="form-control form-control--thin pad-top-sm">
+                  <label>
+                    Use the Buf Schema Registry API
+                    <a href="https://buf.build/docs/bsr/reflection/overview" className="pad-left-sm">
+                      <Icon icon="external-link" size="sm" />
+                    </a>
+                    <input
+                      type="checkbox"
+                      name="reflectionApi"
+                      checked={request.reflectionApi.enabled}
+                      onChange={event => patchRequest(request._id, {
+                        reflectionApi: {
+                          ...request.reflectionApi,
+                          enabled: event.currentTarget.checked,
+                        },
+                      })}
+                    />̵
+                  </label>
+                </div>
+                <div className="form-row pad-top-sm">
+                  {request.reflectionApi.enabled && (
+                    <>
+                      <div className="form-control form-control--outlined">
+                        <label>
+                          Reflection server URL
+                          <a href="https://buf.build/docs/bsr/api-access" className="pad-left-sm">
+                            <Icon icon="external-link" size="sm" />
+                          </a>
+                          <input
+                            type="text"
+                            name="url"
+                            placeholder="https://buf.build"
+                            defaultValue={request.reflectionApi.url}
+                            onBlur={updateReflectonApi}
+                            disabled={!request.reflectionApi.enabled}
+                          />
+                        </label>
+                      </div>
+                      <div className="form-control form-control--outlined">
+                        <label>
+                          Reflection server API key
+                          <a href="https://buf.build/docs/bsr/authentication#manage-tokens" className="pad-left-sm">
+                            <Icon icon="external-link" size="sm" />
+                          </a>
+                          <input
+                            type="password"
+                            name="apiKey"
+                            defaultValue={request.reflectionApi.apiKey}
+                            onBlur={updateReflectonApi}
+                            disabled={!request.reflectionApi.enabled}
+                          />
+                        </label>
+                      </div>
+                      <div className="form-control form-control--outlined">
+                        <label>
+                          Module
+                          <a href="https://buf.build/docs/bsr/module/manage" className="pad-left-sm">
+                            <Icon icon="external-link" size="sm" />
+                          </a>
+                          <input
+                            type="text"
+                            name="module"
+                            placeholder="buf.build/connectrpc/eliza"
+                            defaultValue={request.reflectionApi.module}
+                            onBlur={updateReflectonApi}
+                            disabled={!request.reflectionApi.enabled}
+                          />
+                        </label>
+                      </div>
+                    </>
+                  )}
+                </div>
                 <p className="faint italic pad-top">
                   Are there any gRPC settings you expect to see? Create a{' '}
                   <a href={'https://github.com/Kong/insomnia/issues/new/choose'}>feature request</a>!

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -76,10 +76,11 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
     if (!isGrpcRequest(request)) {
       throw new Error('Must be a gRPC request');
     }
+    const property = event.currentTarget.name.replace("reflectionApi.", "");
     patchRequest(request._id, {
-      bufReflectionApi: {
-        ...request.bufReflectionApi,
-        [event.currentTarget.name]: event.currentTarget.value,
+      reflectionApi: {
+        ...request.reflectionApi,
+        [property]: event.currentTarget.value,
       },
     });
   };
@@ -215,7 +216,7 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
               </>)}
             {request && isGrpcRequest(request) && (
               <>
-                  <div className="form-control form-control--thin">
+                  <div className="form-control form-control--thin pad-top-sm">
                     <label>
                       Use the Buf Schema Registry API
                       <a href="https://buf.build/docs/bsr/reflection/overview" className="pad-left-sm">
@@ -223,11 +224,11 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                       </a>
                       <input
                         type="checkbox"
-                        name="bufReflectionApi"
-                        checked={request.bufReflectionApi.enabled}
+                        name="reflectionApi"
+                        checked={request.reflectionApi.enabled}
                         onChange={event => patchRequest(request._id, {
-                          bufReflectionApi: {
-                            ...request.bufReflectionApi,
+                          reflectionApi: {
+                            ...request.reflectionApi,
                             enabled: event.currentTarget.checked,
                           },
                         })}
@@ -235,7 +236,7 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                     </label>
                   </div>
                   <div className="form-row pad-top-sm">
-                    { request.bufReflectionApi.enabled && (
+                    { request.reflectionApi.enabled && (
                         <>
                           <div className="form-control form-control--outlined">
                             <label>
@@ -245,11 +246,11 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                               </a>
                               <input
                                 type="text"
-                                name="bsrUrl"
+                                name="reflectionApi.url"
                                 placeholder="https://buf.build"
-                                value={request.bufReflectionApi.url}
+                                value={request.reflectionApi.url}
                                 onChange={updateReflectonApi}
-                                disabled={!request.bufReflectionApi.enabled}
+                                disabled={!request.reflectionApi.enabled}
                               />
                             </label>
                           </div>
@@ -261,10 +262,10 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                               </a>
                             <input
                               type="password"
-                              name="bsrApiKey"
-                              value={request.bufReflectionApi.apiKey}
+                              name="reflectionApi.apiKey"
+                              value={request.reflectionApi.apiKey}
                               onChange={updateReflectonApi}
-                              disabled={!request.bufReflectionApi.enabled}
+                              disabled={!request.reflectionApi.enabled}
                             />
                             </label>
                           </div>
@@ -276,11 +277,11 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                               </a>
                               <input
                                 type="text"
-                                name="bsrModule"
+                                name="reflectionApi.module"
                                 placeholder="buf.build/connectrpc/eliza"
-                                value={request.bufReflectionApi.module}
+                                value={request.reflectionApi.module}
                                 onChange={updateReflectonApi}
-                                disabled={!request.bufReflectionApi.enabled}
+                                disabled={!request.reflectionApi.enabled}
                               />
                             </label>
                           </div>

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -287,7 +287,7 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                     </div>
                   </div>
                 </div>
-                <p className="faint italic">
+                <p className="faint italic pad-top">
                   Are there any gRPC settings you expect to see? Create a{' '}
                   <a href={'https://github.com/Kong/insomnia/issues/new/choose'}>feature request</a>!
                 </p>

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { OverlayContainer } from 'react-aria';
+import { Heading } from 'react-aria-components';
 import { useFetcher, useNavigate, useParams } from 'react-router-dom';
 
 import * as models from '../../../models';
@@ -14,6 +15,7 @@ import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { CodeEditorHandle } from '../codemirror/code-editor';
 import { HelpTooltip } from '../help-tooltip';
+import { Icon } from '../icon';
 import { MarkdownEditor } from '../markdown-editor';
 
 export interface RequestSettingsModalOptions {
@@ -214,71 +216,75 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
               </>)}
             {request && isGrpcRequest(request) && (
               <>
-                <hr className="pad-top"/>
-                <h2>Reflection</h2>
-                <div className="form-control form-control--thin">
-                  <label className="inline-block">
-                    Use Buf reflection Api
-                    <HelpTooltip className="space-left">
-                      Buf Reflection Api uses the Buf Schema Registry to fetch the proto definitions instead of
-                      relying on servers enabling reflection or using raw proto files.
-                    </HelpTooltip>
-                    <input
-                      type="checkbox"
-                      name="bufReflectionApi"
-                      checked={request.bufReflectionApi.enabled}
-                      onChange={event => patchRequest(request._id, {
-                        bufReflectionApi: {
-                          ...request.bufReflectionApi,
-                          enabled: event.currentTarget.checked,
-                        },
-                      })}
-                    />̵
-                  </label>
-                </div>
-                <div className="form-row pad-top-sm">
-                  <div className="form-control form-control--outlined">
-                    <label>
-                      Reflection Server Url
-                      <HelpTooltip className="space-left">The BSR address for example https://buf.build</HelpTooltip>
+                <div className="rounded-md border border-solid border-[--hl-md] p-4 flex flex-col gap-2">
+                  <Heading className="text-lg font-bold flex items-center gap-2">Reflection </Heading>
+                  <div className="form-control form-control--thin">
+                    <label className="inline">
+                      Use the Buf Reflection API
+                      <a href="https://buf.build/docs/bsr/reflection/overview" className="pad-left-sm">
+                        <Icon icon="external-link" size="sm"/>
+                      </a>
                       <input
-                        type="text"
-                        name="url"
-                        placeholder="https://buf.build"
-                        value={request.bufReflectionApi.url}
-                        onChange={updateReflectonApi}
-                        disabled={!request.bufReflectionApi.enabled}
-                      />
+                        type="checkbox"
+                        name="bufReflectionApi"
+                        checked={request.bufReflectionApi.enabled}
+                        onChange={event => patchRequest(request._id, {
+                          bufReflectionApi: {
+                            ...request.bufReflectionApi,
+                            enabled: event.currentTarget.checked,
+                          },
+                        })}
+                      />̵
                     </label>
                   </div>
-                  <div className="form-control form-control--outlined">
-                    <label>
-                      Reflection Server Api Key
-                      <HelpTooltip className="space-left">The BSR Token. See
-                        https://buf.build/docs/bsr/authentication#create-an-api-token to create one</HelpTooltip>
-                      <input
-                        type="password"
-                        name="apiKey"
-                        value={request.bufReflectionApi.apiKey}
-                        onChange={updateReflectonApi}
-                        disabled={!request.bufReflectionApi.enabled}
-                      />
-                    </label>
-                  </div>
-                  <div className="form-control form-control--outlined">
-                    <label>
-                      Reflection Server Module
-                      <HelpTooltip className="space-left">The buf module. For example
-                        buf.build/connectrpc/eliza</HelpTooltip>
-                      <input
-                        type="text"
-                        name="module"
-                        placeholder="buf.build/connectrpc/eliza"
-                        value={request.bufReflectionApi.module}
-                        onChange={updateReflectonApi}
-                        disabled={!request.bufReflectionApi.enabled}
-                      />
-                    </label>
+                  <div className="form-row pad-top-sm">
+                    <div className="form-control form-control--outlined">
+                      <label>
+                        Reflection server URL
+                        <a href="https://buf.build/docs/bsr/api-access" className="pad-left-sm">
+                          <Icon icon="external-link" size="sm"/>
+                        </a>
+                        <input
+                          type="text"
+                          name="url"
+                          placeholder="https://buf.build"
+                          value={request.bufReflectionApi.url}
+                          onChange={updateReflectonApi}
+                          disabled={!request.bufReflectionApi.enabled}
+                        />
+                      </label>
+                    </div>
+                    <div className="form-control form-control--outlined">
+                      <label>
+                        Reflection server API key
+                        <a href="https://buf.build/docs/bsr/authentication#manage-tokens" className="pad-left-sm">
+                          <Icon icon="external-link" size="sm"/>
+                        </a>
+                        <input
+                          type="password"
+                          name="apiKey"
+                          value={request.bufReflectionApi.apiKey}
+                          onChange={updateReflectonApi}
+                          disabled={!request.bufReflectionApi.enabled}
+                        />
+                      </label>
+                    </div>
+                    <div className="form-control form-control--outlined">
+                      <label>
+                        BSR module
+                        <a href="https://buf.build/docs/bsr/module/manage" className="pad-left-sm">
+                          <Icon icon="external-link" size="sm"/>
+                        </a>
+                        <input
+                          type="text"
+                          name="module"
+                          placeholder="buf.build/connectrpc/eliza"
+                          value={request.bufReflectionApi.module}
+                          onChange={updateReflectonApi}
+                          disabled={!request.bufReflectionApi.enabled}
+                        />
+                      </label>
+                    </div>
                   </div>
                 </div>
                 <p className="faint italic">

--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
@@ -197,7 +197,7 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                 disabled={!activeRequest.url}
                 onClick={async () => {
                   try {
-                    const rendered = await tryToInterpolateRequestOrShowRenderErrorModal({ request: activeRequest, environmentId, payload: { url: activeRequest.url, metadata: activeRequest.metadata } });
+                    const rendered = await tryToInterpolateRequestOrShowRenderErrorModal({ request: activeRequest, environmentId, payload: { url: activeRequest.url, metadata: activeRequest.metadata, bufReflectionApi: activeRequest.bufReflectionApi } });
                     const methods = await window.main.grpc.loadMethodsFromReflection(rendered);
                     setGrpcState({ ...grpcState, methods });
                     patchRequest(requestId, { protoFileId: '', protoMethodName: '' });

--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
@@ -197,7 +197,16 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                 disabled={!activeRequest.url}
                 onClick={async () => {
                   try {
-                    const rendered = await tryToInterpolateRequestOrShowRenderErrorModal({ request: activeRequest, environmentId, payload: { url: activeRequest.url, metadata: activeRequest.metadata, bufReflectionApi: activeRequest.bufReflectionApi } });
+                    const rendered =
+                      await tryToInterpolateRequestOrShowRenderErrorModal({
+                        request: activeRequest,
+                        environmentId,
+                        payload: {
+                          url: activeRequest.url,
+                          metadata: activeRequest.metadata,
+                          reflectionApi: activeRequest.reflectionApi,
+                        },
+                      });
                     const methods = await window.main.grpc.loadMethodsFromReflection(rendered);
                     setGrpcState({ ...grpcState, methods });
                     patchRequest(requestId, { protoFileId: '', protoMethodName: '' });


### PR DESCRIPTION
As of now, gRPC requests support gRPC Reflection and parsing the protobuf files to get the schema. [Buf Schema Registry (BSR)](https://buf.build/docs/bsr/introduction) is a registry for storing and distributing protobuf sources. It also houses several popular open source protobuf definitions. This PR adds the ability to retrieve the schema from the BSR.

<img width="884" alt="Screenshot 2024-01-23 at 4 22 34 PM" src="https://github.com/Kong/insomnia/assets/93153132/8f7cc418-6fa0-4ce3-bf3b-2e0adc14eaa7">

