### PR TITLE
Fix parsing urlencoded pairs with empty values.

### DIFF
--- a/packages/insomnia/src/utils/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/utils/importers/importers/curl.test.ts
@@ -123,7 +123,7 @@ describe('curl', () => {
       { flag: '--data-urlencode', inputs: ['=value'], expected: [{ name: '', value: 'value' }] },
 
       // --data-urlencode URI encoding
-      { flag: '--data-urlencode', inputs: ['a='], expected: [{ name: '', value: 'a=' }] },
+      { flag: '--data-urlencode', inputs: ['a='], expected: [{ name: 'a', value: '' }] },
       { flag: '--data-urlencode', inputs: [' '], expected: [{ name: '', value: ' ' }] },
       { flag: '--data-urlencode', inputs: ['<'], expected: [{ name: '', value: '<' }] },
       { flag: '--data-urlencode', inputs: ['>'], expected: [{ name: '', value: '>' }] },
@@ -133,7 +133,7 @@ describe('curl', () => {
       { flag: '--data-urlencode', inputs: ['|'], expected: [{ name: '', value: '|' }] },
       { flag: '--data-urlencode', inputs: ['^'], expected: [{ name: '', value: '^' }] },
       { flag: '--data-urlencode', inputs: ['"'], expected: [{ name: '', value: '"' }] },
-      { flag: '--data-urlencode', inputs: ['='], expected: [{ name: '', value: '=' }] },
+      { flag: '--data-urlencode', inputs: ['='], expected: [{ name: '', value: '' }] },
       { flag: '--data-urlencode', inputs: ['%3D'], expected: [{ name: '', value: '%3D' }] },
     ])('handles %p correctly', async ({
       flag,

--- a/packages/insomnia/src/utils/importers/importers/curl.ts
+++ b/packages/insomnia/src/utils/importers/importers/curl.ts
@@ -348,7 +348,7 @@ const pairToParameters = (pair: Pair, allowFiles = false): Parameter[] => {
     }
 
     const [name, value] = pair.split('=');
-    if (!value || !pair.includes('=')) {
+    if (!value && !pair.includes('=')) {
       return { name: '', value: pair };
     }
 


### PR DESCRIPTION
There is a bug with parsing curl statements with empty values. This fixes the bug and adjusts the tests to expected behavior.