### PR TITLE
fix(curl): revert to use openssl on macos [INS-3445]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2028,9 +2028,9 @@
       }
     },
     "node_modules/@getinsomnia/node-libcurl": {
-      "version": "2.4.1-5",
-      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.4.1-5.tgz",
-      "integrity": "sha512-QI9cufADALZtoAPPj9G4X1hzZLCdcP1wxQbL4niY86cNhFpennhiE+WL1qqD5DSBuXa+0xWeOG+LBn36PfE0CA==",
+      "version": "2.4.1-9",
+      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.4.1-9.tgz",
+      "integrity": "sha512-8UBi9HQXQXeCzv+SyWQTO/bwEQLBSOrdcmDNftLtOsdCBvRy9ftKopOAx+DliDWAaBk2kWdeuCOZ9gsMns08/g==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "1.0.5",
@@ -25350,7 +25350,7 @@
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
         "@apidevtools/swagger-parser": "10.1.0",
-        "@getinsomnia/node-libcurl": "^2.4.1-5",
+        "@getinsomnia/node-libcurl": "^2.4.1-9",
         "@grpc/grpc-js": "^1.8.17",
         "@grpc/proto-loader": "^0.7.7",
         "@jest/globals": "^28.1.0",
@@ -25686,7 +25686,7 @@
       "version": "8.5.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@getinsomnia/node-libcurl": "^2.4.1-5",
+        "@getinsomnia/node-libcurl": "^2.4.1-9",
         "@seald-io/nedb": "^4.0.3",
         "@segment/analytics-node": "1.0.0",
         "@stoplight/spectral-core": "^1.18.2",

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -7,7 +7,7 @@
   "main": "dist/index.js",
   "types": "dist/send-request/index.d.ts",
   "dependencies": {
-    "@getinsomnia/node-libcurl": "^2.4.1-5",
+    "@getinsomnia/node-libcurl": "^2.4.1-9",
     "@segment/analytics-node": "1.0.0",
     "@stoplight/spectral-core": "^1.18.2",
     "@stoplight/spectral-formats": "^1.5.0",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
     "@apidevtools/swagger-parser": "10.1.0",
-    "@getinsomnia/node-libcurl": "^2.4.1-5",
+    "@getinsomnia/node-libcurl": "^2.4.1-9",
     "@grpc/grpc-js": "^1.8.17",
     "@grpc/proto-loader": "^0.7.7",
     "@jest/globals": "^28.1.0",

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -332,10 +332,7 @@ export const createConfiguredCurlInstance = ({
   }
   const { validateSSL } = settings;
   if (!validateSSL) {
-    // node-libcurl 2.4.1-4 macOS is build with `--with-secure-transport` TLS backend (in order to read the keychain) which interferes with disabling VERIFY_HOST curl option
-    if (process.platform !== 'darwin') {
-      curl.setOpt(Curl.option.SSL_VERIFYHOST, 0);
-    }
+    curl.setOpt(Curl.option.SSL_VERIFYHOST, 0);
     curl.setOpt(Curl.option.SSL_VERIFYPEER, 0);
   }
   debugTimeline.push({ value: `${validateSSL ? 'Enable' : 'Disable'} SSL validation`, name: 'Text', timestamp: Date.now() });


### PR DESCRIPTION
Revert to use OpenSSL on macOS, since some limitations of SecureTransport backend.

- [x] Upgrade node-libcurl version to 2.4.1-9
- [x] Remove the special code for macOS in the last release

changelog(Fixes): Fixes an issue with SSL Certificates on macOS that was related to the usage of the SecureTransport backend for libcurl.