### PR TITLE
fix: bulk editor styles

### DIFF
--- a/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
@@ -65,6 +65,7 @@ export const RequestParametersEditor: FC<Props> = ({
     return (
       <CodeEditor
         id="request-parameters-editor"
+        className='min-h-[8rem]'
         onChange={handleBulkUpdate}
         defaultValue={paramsString}
         enableNunjucks


### PR DESCRIPTION
Adds a min-height to the bulk editor to avoid shrinking completely when the parent elements use flex/grid