### PR TITLE
fix: re-initialize the parameter editor state when switching between requests

### DIFF
--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -210,7 +210,7 @@ export const RequestPane: FC<Props> = ({
                               key={activeRequest._id}
                               id={'key-value-editor__name' + pathParameter.name}
                               key={activeRequest._id}
-                              placeholder={'Parameter value'}
+                              placeholder="Parameter value"
                               defaultValue={pathParameter.value || ''}
                               onChange={name => {
                                 onPathParameterChange(pathParameters.map(p => p.name === pathParameter.name ? { ...p, value: name } : p));

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -209,6 +209,7 @@ export const RequestPane: FC<Props> = ({
                             <OneLineEditor
                               key={activeRequest._id}
                               id={'key-value-editor__name' + pathParameter.name}
+                              key={activeRequest._id}
                               placeholder={'Parameter value'}
                               defaultValue={pathParameter.value || ''}
                               onChange={name => {

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -209,7 +209,6 @@ export const RequestPane: FC<Props> = ({
                             <OneLineEditor
                               key={activeRequest._id}
                               id={'key-value-editor__name' + pathParameter.name}
-                              key={activeRequest._id}
                               placeholder="Parameter value"
                               defaultValue={pathParameter.value || ''}
                               onChange={name => {

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -321,6 +321,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
                               <OneLineEditor
                                 readOnly={disabled}
                                 id={'key-value-editor__name' + pathParameter.name}
+                                key={activeRequest._id}
                                 placeholder={'Parameter value'}
                                 defaultValue={pathParameter.value || ''}
                                 onChange={name => {


### PR DESCRIPTION
The issue:
- When switching between requests that have the same parameter names the one-line editor keeps the same state and doesn't update.

Fix:
- Re-initialize the one-line editor state when the request changes.

Closes #7000