### PR TITLE
(feat/SEC-1010): Add SAST scanning using semgrep

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -1,0 +1,27 @@
+name: SAST
+
+on:
+  pull_request: {}
+  push:
+    branches:
+    - develop
+    - release/*
+  workflow_dispatch: {}
+
+
+jobs:
+  semgrep:
+    name: Semgrep SAST
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      security-events: write
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    if: (github.actor != 'dependabot[bot]')
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Kong/public-shared-actions/security-actions/semgrep@bd3d75259607dd015bea3b3313123f53b80e9d7f


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Perform SAST scanning in a non-blocking fashion (configurable) by default using shared kong action maintained by sec team.

The Shared Action Doc can be found [here](https://github.com/Kong/public-shared-actions/tree/main/security-actions/semgrep). 

Event triggers:
- PR without `dependabot[bot]` as an actor only on **diff / changed** files that match default semgrep config
- Push to `develop` / `release/*` branches
- Any workflow dispatch

Additional overrides: 

Output:
- Uploads findings to the Security tab (uses GH CodeQL and Advanced security tab) for a public repo
- Generates a workflow artifact/console log output of the results 


Other notes:

Closes INS-3504 (linear)