### PR TITLE
feat(unit-tests): Unit test reordering

### DIFF
--- a/packages/insomnia-inso/src/commands/run-tests.ts
+++ b/packages/insomnia-inso/src/commands/run-tests.ts
@@ -88,7 +88,7 @@ export async function runInsomniaTests(
     suites.map(suite =>
       createTestSuite(
         suite,
-        db.UnitTest.filter(test => test.parentId === suite._id),
+        db.UnitTest.filter(test => test.parentId === suite._id).sort((a, b) => a.metaSortKey - b.metaSortKey),
       ),
     ),
   );

--- a/packages/insomnia-inso/src/db/models/types.ts
+++ b/packages/insomnia-inso/src/db/models/types.ts
@@ -17,6 +17,7 @@ export type ApiSpec = BaseModel & BaseApiSpec;
 
 interface BaseUnitTestSuite {
     name: string;
+    metaSortKey: number;
 }
 
 export type UnitTestSuite = BaseModel & BaseUnitTestSuite;
@@ -25,6 +26,7 @@ interface BaseUnitTest {
     name: string;
     code: string;
     requestId: string | null;
+    metaSortKey: number;
 }
 
 export type UnitTest = BaseModel & BaseUnitTest;

--- a/packages/insomnia-inso/src/db/models/unit-test-suite.ts
+++ b/packages/insomnia-inso/src/db/models/unit-test-suite.ts
@@ -36,7 +36,7 @@ export const loadTestSuites = (
   const workspace = loadWorkspace(db, apiSpec?.parentId || identifier); // if identifier is for an apiSpec or a workspace, return all suites for that workspace
 
   if (workspace) {
-    return db.UnitTestSuite.filter(s => s.parentId === workspace._id);
+    return db.UnitTestSuite.filter(s => s.parentId === workspace._id).sort((a, b) => a.metaSortKey - b.metaSortKey);
   } // load particular suite
 
   const result = loadUnitTestSuite(db, identifier);

--- a/packages/insomnia/src/models/unit-test-suite.ts
+++ b/packages/insomnia/src/models/unit-test-suite.ts
@@ -12,6 +12,7 @@ export const canDuplicate = true;
 export const canSync = true;
 export interface BaseUnitTestSuite {
   name: string;
+  metaSortKey: number;
 }
 
 export type UnitTestSuite = BaseModel & BaseUnitTestSuite;
@@ -23,6 +24,7 @@ export const isUnitTestSuite = (model: Pick<BaseModel, 'type'>): model is UnitTe
 export function init() {
   return {
     name: 'My Test',
+    metaSortKey: -1 * Date.now(),
   };
 }
 

--- a/packages/insomnia/src/models/unit-test.ts
+++ b/packages/insomnia/src/models/unit-test.ts
@@ -14,6 +14,7 @@ interface BaseUnitTest {
   name: string;
   code: string;
   requestId: string | null;
+  metaSortKey: number;
 }
 
 export type UnitTest = BaseModel & BaseUnitTest;
@@ -27,6 +28,7 @@ export function init() {
     requestId: null,
     name: 'My Test',
     code: '',
+    metaSortKey: -1 * Date.now(),
   };
 }
 

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -605,11 +605,11 @@ const router = createMemoryRouter(
                                             ).deleteTestSuiteAction(...args),
                                         },
                                         {
-                                          path: 'rename',
+                                          path: 'update',
                                           action: async (...args) =>
                                             (
                                               await import('./routes/actions')
-                                            ).renameTestSuiteAction(...args),
+                                            ).updateTestSuiteAction(...args),
                                         },
                                         {
                                           path: 'run-all-tests',

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -16,6 +16,7 @@ import { isRemoteProject } from '../../models/project';
 import { isRequest, Request } from '../../models/request';
 import { isRequestGroup, isRequestGroupId } from '../../models/request-group';
 import { UnitTest } from '../../models/unit-test';
+import { UnitTestSuite } from '../../models/unit-test-suite';
 import { isCollection, Workspace } from '../../models/workspace';
 import { WorkspaceMeta } from '../../models/workspace-meta';
 import { getSendRequestCallback } from '../../network/unit-test-feature';
@@ -545,23 +546,21 @@ export const runAllTestsAction: ActionFunction = async ({
   return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/test/test-suite/${testSuiteId}/test-result/${testResult._id}`);
 };
 
-export const renameTestSuiteAction: ActionFunction = async ({ request, params }) => {
+export const updateTestSuiteAction: ActionFunction = async ({ request, params }) => {
   const { workspaceId, projectId, testSuiteId } = params;
   invariant(typeof testSuiteId === 'string', 'Test Suite ID is required');
   invariant(typeof workspaceId === 'string', 'Workspace ID is required');
   invariant(typeof projectId === 'string', 'Project ID is required');
 
-  const formData = await request.formData();
-  const name = formData.get('name');
-  invariant(typeof name === 'string', 'Name is required');
+  const data = await request.json() as Partial<UnitTestSuite>;
 
-  const unitTestSuite = await database.getWhere(models.unitTestSuite.type, {
+  const unitTestSuite = await database.getWhere<UnitTestSuite>(models.unitTestSuite.type, {
     _id: testSuiteId,
   });
 
   invariant(unitTestSuite, 'Test Suite not found');
 
-  await models.unitTestSuite.update(unitTestSuite, { name });
+  await models.unitTestSuite.update(unitTestSuite, data);
 
   return null;
 };

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -604,24 +604,14 @@ export const deleteTestAction: ActionFunction = async ({ params }) => {
 
 export const updateTestAction: ActionFunction = async ({ request, params }) => {
   const { testId } = params;
-  const formData = await request.formData();
-  invariant(typeof testId === 'string', 'Test ID is required');
-  const code = formData.get('code');
-  invariant(typeof code === 'string', 'Code is required');
-  const name = formData.get('name');
-  invariant(typeof name === 'string', 'Name is required');
-  const requestId = formData.get('requestId');
-
-  if (requestId) {
-    invariant(typeof requestId === 'string', 'Request ID is required');
-  }
+  const data = await request.json() as Partial<UnitTest>;
 
   const unitTest = await database.getWhere<UnitTest>(models.unitTest.type, {
     _id: testId,
   });
   invariant(unitTest, 'Test not found');
 
-  await models.unitTest.update(unitTest, { name, code, requestId: requestId || null });
+  await models.unitTest.update(unitTest, data);
 
   return null;
 };

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -517,9 +517,11 @@ export const runAllTestsAction: ActionFunction = async ({
   invariant(typeof workspaceId === 'string', 'Workspace ID is required');
   invariant(typeof testSuiteId === 'string', 'Test Suite ID is required');
 
-  const unitTests = await database.find<UnitTest>(models.unitTest.type, {
-    parentId: testSuiteId,
-  });
+  const unitTests = await database.find<UnitTest>(
+    models.unitTest.type,
+    { parentId: testSuiteId },
+    { metaSortKey: 1 }
+  );
   invariant(unitTests, 'No unit tests found');
 
   const tests: Test[] = unitTests

--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -54,7 +54,7 @@ async function getSyncItems({
   const wsReqs = await database.find(models.webSocketRequest.type, { parentId: { $in: listOfParentIds } });
   const allRequests = [...reqs, ...reqGroups, ...grpcReqs, ...wsReqs] as (Request | RequestGroup | GrpcRequest | WebSocketRequest)[];
   const testSuites = await models.unitTestSuite.findByParentId(workspaceId);
-  const tests = await database.find(models.unitTest.type, { parentId: { $in: testSuites.map(t => t._id) } });
+  const tests = await database.find<UnitTest>(models.unitTest.type, { parentId: { $in: testSuites.map(t => t._id) } });
 
   const baseEnvironment = await models.environment.getByParentId(workspaceId);
   invariant(baseEnvironment, 'Base environment not found');

--- a/packages/insomnia/src/ui/routes/test-suite.tsx
+++ b/packages/insomnia/src/ui/routes/test-suite.tsx
@@ -1,12 +1,14 @@
 import React, { Fragment, useRef, useState } from 'react';
 import {
   Button,
+  DropIndicator,
   Heading,
   ListBox,
   ListBoxItem,
   Popover,
   Select,
   SelectValue,
+  useDragAndDrop,
 } from 'react-aria-components';
 import {
   LoaderFunction,
@@ -90,13 +92,12 @@ const UnitTestItemView = ({
               if (name) {
                 updateUnitTestFetcher.submit(
                   {
-                    code: unitTest.code,
                     name,
-                    requestId: unitTest.requestId || '',
                   },
                   {
                     action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/test/test-suite/${unitTestSuite._id}/test/${unitTest._id}/update`,
                     method: 'POST',
+                    encType: 'application/json',
                   }
                 );
               }
@@ -110,13 +111,12 @@ const UnitTestItemView = ({
           onSelectionChange={requestId => {
             updateUnitTestFetcher.submit(
               {
-                code: unitTest.code,
-                name: unitTest.name,
                 requestId,
               },
               {
                 action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/test/test-suite/${unitTestSuite._id}/test/${unitTest._id}/update`,
                 method: 'post',
+                encType: 'application/json',
               }
             );
           }}
@@ -306,12 +306,11 @@ const UnitTestItemView = ({
             updateUnitTestFetcher.submit(
               {
                 code,
-                name: unitTest.name,
-                requestId: unitTest.requestId || '',
               },
               {
                 action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/test/test-suite/${unitTestSuite._id}/test/${unitTest._id}/update`,
                 method: 'post',
+                encType: 'application/json',
               }
             )
           }
@@ -369,7 +368,7 @@ export const loader: LoaderFunction = async ({
   const workspaceEntities = await database.withDescendants(workspace);
   const requests: Request[] = workspaceEntities.filter(isRequest);
 
-  const unitTestSuite = await database.getWhere(models.unitTestSuite.type, {
+  const unitTestSuite = await database.getWhere<UnitTestSuite>(models.unitTestSuite.type, {
     _id: testSuiteId,
   });
 
@@ -385,7 +384,7 @@ export const loader: LoaderFunction = async ({
 
   const unitTests = (await database.withDescendants(unitTestSuite)).filter(
     isUnitTest
-  );
+  ).sort((a, b) => a.metaSortKey - b.metaSortKey);
 
   return {
     unitTests,
@@ -408,12 +407,63 @@ const TestSuiteRoute = () => {
   const createUnitTestFetcher = useFetcher();
   const runAllTestsFetcher = useFetcher();
   const renameTestSuiteFetcher = useFetcher();
+  const updateUnitTestFetcher = useFetcher();
 
   const testsRunning = runAllTestsFetcher.state === 'submitting';
 
   const testSuiteName =
     renameTestSuiteFetcher.formData?.get('name')?.toString() ??
     unitTestSuite.name;
+
+  const unitTestsDragAndDrop = useDragAndDrop({
+    getItems: keys => [...keys].map(key => ({ 'text/plain': key.toString() })),
+    onReorder(e) {
+      const source = [...e.keys][0];
+      const sourceTest = unitTests.find(test => test._id === source);
+      const targetTest = unitTests.find(test => test._id === e.target.key);
+
+      if (!sourceTest || !targetTest) {
+        return;
+      }
+      const dropPosition = e.target.dropPosition;
+      if (dropPosition === 'before') {
+        const currentTestIndex = unitTests.findIndex(test => test._id === targetTest._id);
+        const previousTest = unitTests[currentTestIndex - 1];
+        if (!previousTest) {
+          sourceTest.metaSortKey = targetTest.metaSortKey - 1;
+        } else {
+          sourceTest.metaSortKey = (previousTest.metaSortKey + targetTest.metaSortKey) / 2;
+        }
+      }
+      if (dropPosition === 'after') {
+        const currentTestIndex = unitTests.findIndex(test => test._id === targetTest._id);
+        const nextEnv = unitTests[currentTestIndex + 1];
+        if (!nextEnv) {
+          sourceTest.metaSortKey = targetTest.metaSortKey + 1;
+        } else {
+          sourceTest.metaSortKey = (nextEnv.metaSortKey + targetTest.metaSortKey) / 2;
+        }
+      }
+
+      updateUnitTestFetcher.submit(
+        { metaSortKey: sourceTest.metaSortKey },
+        {
+          action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/test/test-suite/${unitTestSuite._id}/test/${sourceTest._id}/update`,
+          method: 'POST',
+          encType: 'application/json',
+        }
+      );
+    },
+    renderDropIndicator(target) {
+      return (
+        <DropIndicator
+          target={target}
+          className="outline-[--color-surprise] outline-1 outline"
+        />
+      );
+    },
+  });
+
   return (
     <div className="flex flex-col h-full w-full overflow-hidden divide-solid divide-y divide-[--hl-md]">
       <div className="flex flex-shrink-0 gap-2 p-[--padding-md]">
@@ -505,15 +555,25 @@ const TestSuiteRoute = () => {
         </div>
       )}
       {unitTests.length > 0 && (
-        <ul className="flex-1 flex flex-col divide-y divide-solid divide-[--hl-md] overflow-y-auto">
-          {unitTests.map(unitTest => (
-            <UnitTestItemView
-              key={unitTest._id}
-              unitTest={unitTest}
-              testsRunning={testsRunning}
-            />
-          ))}
-        </ul>
+        <ListBox
+          dragAndDropHooks={unitTestsDragAndDrop.dragAndDropHooks}
+          items={unitTests.map(unitTest => ({
+            ...unitTest,
+            id: unitTest._id,
+            key: unitTest._id,
+          }))}
+          className="flex-1 flex flex-col divide-y divide-solid divide-[--hl-md] overflow-y-auto"
+        >
+          {unitTest => (
+            <ListBoxItem>
+              <Button slot="drag" className="hidden" />
+              <UnitTestItemView
+                unitTest={unitTest}
+                testsRunning={testsRunning}
+              />
+            </ListBoxItem>
+          )}
+        </ListBox>
       )}
     </div>
   );

--- a/packages/insomnia/src/ui/routes/test-suite.tsx
+++ b/packages/insomnia/src/ui/routes/test-suite.tsx
@@ -23,7 +23,7 @@ import { documentationLinks } from '../../common/documentation';
 import * as models from '../../models';
 import { isGrpcRequest } from '../../models/grpc-request';
 import { isRequest, Request } from '../../models/request';
-import { isUnitTest, UnitTest } from '../../models/unit-test';
+import { UnitTest } from '../../models/unit-test';
 import { UnitTestSuite } from '../../models/unit-test-suite';
 import { isWebSocketRequest } from '../../models/websocket-request';
 import { invariant } from '../../utils/invariant';
@@ -382,9 +382,15 @@ export const loader: LoaderFunction = async ({
 
   invariant(unitTestSuite, 'Test Suite not found');
 
-  const unitTests = (await database.withDescendants(unitTestSuite)).filter(
-    isUnitTest
-  ).sort((a, b) => a.metaSortKey - b.metaSortKey);
+  const unitTests = await database.find<UnitTest>(
+    models.unitTest.type,
+    {
+      parentId: testSuiteId,
+    },
+    {
+      metaSortKey: 1,
+    }
+  );
 
   return {
     unitTests,

--- a/packages/insomnia/src/ui/routes/test-suite.tsx
+++ b/packages/insomnia/src/ui/routes/test-suite.tsx
@@ -412,13 +412,16 @@ const TestSuiteRoute = () => {
 
   const createUnitTestFetcher = useFetcher();
   const runAllTestsFetcher = useFetcher();
-  const renameTestSuiteFetcher = useFetcher();
+  const updateTestSuiteFetcher = useFetcher();
   const updateUnitTestFetcher = useFetcher();
 
   const testsRunning = runAllTestsFetcher.state === 'submitting';
 
+  const optimisticUpdateTestSuiteName = updateTestSuiteFetcher.json && typeof updateTestSuiteFetcher.json === 'object' &&
+    'name' in updateTestSuiteFetcher.json && updateTestSuiteFetcher.json?.name?.toString();
+
   const testSuiteName =
-    renameTestSuiteFetcher.formData?.get('name')?.toString() ??
+    optimisticUpdateTestSuiteName ||
     unitTestSuite.name;
 
   const unitTestsDragAndDrop = useDragAndDrop({
@@ -464,7 +467,7 @@ const TestSuiteRoute = () => {
       return (
         <DropIndicator
           target={target}
-          className="outline-[--color-surprise] outline-1 outline"
+          className="outline-[--color-surprise] outline-1 outline !border-none"
         />
       );
     },
@@ -478,11 +481,12 @@ const TestSuiteRoute = () => {
             className='w-full px-1'
             onSubmit={name =>
               name &&
-              renameTestSuiteFetcher.submit(
+              updateTestSuiteFetcher.submit(
                 { name },
                 {
-                  action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/test/test-suite/${unitTestSuite._id}/rename`,
+                  action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/test/test-suite/${unitTestSuite._id}/update`,
                   method: 'POST',
+                  encType: 'application/json',
                 }
               )
             }
@@ -571,7 +575,7 @@ const TestSuiteRoute = () => {
           className="flex-1 flex flex-col divide-y divide-solid divide-[--hl-md] overflow-y-auto"
         >
           {unitTest => (
-            <ListBoxItem>
+            <ListBoxItem className="outline-none">
               <Button slot="drag" className="hidden" />
               <UnitTestItemView
                 unitTest={unitTest}

--- a/packages/insomnia/src/ui/routes/unit-test.tsx
+++ b/packages/insomnia/src/ui/routes/unit-test.tsx
@@ -112,7 +112,6 @@ const TestRoute: FC = () => {
 
   const createUnitTestSuiteFetcher = useFetcher();
   const deleteUnitTestSuiteFetcher = useFetcher();
-  const renameTestSuiteFetcher = useFetcher();
   const updateTestSuiteFetcher = useFetcher();
   const runAllTestsFetcher = useFetcher();
   const runningTests = useFetchers()
@@ -155,7 +154,7 @@ const TestRoute: FC = () => {
             defaultValue: unitTestSuites.find(s => s._id === suiteId)?.name,
             submitName: 'Rename',
             onComplete: name => {
-              name && renameTestSuiteFetcher.submit(
+              name && updateTestSuiteFetcher.submit(
                 { name },
                 {
                   action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/test/test-suite/${suiteId}/update`,
@@ -459,11 +458,12 @@ const TestRoute: FC = () => {
                           });
                         }}
                         onSubmit={name => {
-                          name && renameTestSuiteFetcher.submit(
+                          name && updateTestSuiteFetcher.submit(
                             { name },
                             {
-                              action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/test/test-suite/${item._id}/rename`,
+                              action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/test/test-suite/${item._id}/update`,
                               method: 'POST',
+                              encType: 'application/json',
                             }
                           );
                         }}

--- a/packages/insomnia/src/ui/routes/unit-test.tsx
+++ b/packages/insomnia/src/ui/routes/unit-test.tsx
@@ -30,6 +30,7 @@ import {
   useRouteLoaderData,
 } from 'react-router-dom';
 
+import { database } from '../../common/database';
 import * as models from '../../models';
 import { Environment } from '../../models/environment';
 import type { UnitTestSuite } from '../../models/unit-test-suite';
@@ -61,7 +62,16 @@ export const loader: LoaderFunction = async ({
 
   invariant(workspaceId, 'Workspace ID is required');
 
-  const unitTestSuites = (await models.unitTestSuite.findByParentId(workspaceId)).sort((a, b) => a.metaSortKey - b.metaSortKey);
+  const unitTestSuites = await database.find<UnitTestSuite>(
+    models.unitTestSuite.type,
+    {
+      parentId: workspaceId,
+    },
+    {
+      metaSortKey: 1,
+    }
+  );
+
   invariant(unitTestSuites, 'Unit test suites not found');
 
   return {

--- a/packages/insomnia/src/ui/routes/unit-test.tsx
+++ b/packages/insomnia/src/ui/routes/unit-test.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   DropIndicator,
   GridList,
+  GridListItem,
   Heading,
   ListBox,
   ListBoxItem,
@@ -219,23 +220,12 @@ const TestRoute: FC = () => {
       });
     },
     renderDropIndicator(target) {
-      if (target.type === 'item') {
-        if (target.dropPosition === 'before' && target.key === baseEnvironment._id) {
-          return <DropIndicator
-            target={target}
-            className="hidden"
-          />;
-        }
-        return <DropIndicator
+      return (
+        <DropIndicator
           target={target}
           className="outline-[--color-surprise] outline-1 outline"
-        />;
-      }
-
-      return <DropIndicator
-        target={target}
-        className="outline-[--color-surprise] outline-1 outline"
-      />;
+        />
+      );
     },
   });
 
@@ -439,7 +429,7 @@ const TestRoute: FC = () => {
             >
               {item => {
                 return (
-                  <ListBoxItem
+                  <GridListItem
                     key={item._id}
                     id={item._id}
                     textValue={item.name}
@@ -502,7 +492,7 @@ const TestRoute: FC = () => {
                         </Popover>
                       </MenuTrigger>
                     </div>
-                  </ListBoxItem>
+                  </GridListItem>
                 );
               }}
             </GridList>


### PR DESCRIPTION
Update unit-tests and test-suites to be reorderable.

Highlights:
- [x] Add metaSortKey to the unit-test and unit-test-suite models
- [x] Update the UI so that test-suites and unit-tests can be reordered
- [x] Use the metaSortKey property to sort unit-tests/test-suites on the UI
- [x] Use the metaSortKey property to sort unit-tests/test-suites on Inso

Closes INS-3493
Closes #2592