### PR TITLE
fix(sync): Handle removals from db entities leading to stuck loading state

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -205,9 +205,9 @@ export const SyncDropdown: FC<Props> = ({ gitSyncEnabled }) => {
       },
       {
         id: 'revert',
-        name: 'Revert to latest commit',
+        name: 'Discard all changes',
         icon: 'undo',
-        isDisabled: historyCount === 0 || rollbackFetcher.state !== 'idle',
+        isDisabled: historyCount === 0 || rollbackFetcher.state !== 'idle' || !canCreateSnapshot,
         action: () => {
           rollbackFetcher.submit({}, {
             method: 'POST',

--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -339,7 +339,7 @@ export const createBranchAction: ActionFunction = async ({ request, params }) =>
 };
 
 export const deleteBranchAction: ActionFunction = async ({ params, request }) => {
-  const { workspaceId } = params;
+  const { organizationId, projectId, workspaceId } = params;
   invariant(typeof workspaceId === 'string', 'Workspace Id is required');
   const formData = await request.formData();
   const branch = formData.get('branch');
@@ -362,11 +362,11 @@ export const deleteBranchAction: ActionFunction = async ({ params, request }) =>
     };
   }
 
-  return null;
+  return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug`);
 };
 
 export const pullFromRemoteAction: ActionFunction = async ({ params }) => {
-  const { projectId, workspaceId } = params;
+  const { organizationId, projectId, workspaceId } = params;
   invariant(typeof projectId === 'string', 'Project Id is required');
   invariant(typeof workspaceId === 'string', 'Workspace Id is required');
   const project = await models.project.getById(projectId);
@@ -386,7 +386,7 @@ export const pullFromRemoteAction: ActionFunction = async ({ params }) => {
     };
   }
 
-  return null;
+  return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug`);
 };
 
 export const fetchRemoteBranchAction: ActionFunction = async ({ request, params }) => {
@@ -449,7 +449,7 @@ export const pushToRemoteAction: ActionFunction = async ({ params }) => {
 };
 
 export const rollbackChangesAction: ActionFunction = async ({ params }) => {
-  const { workspaceId } = params;
+  const { organizationId, projectId, workspaceId } = params;
   invariant(typeof workspaceId === 'string', 'Workspace Id is required');
   try {
     const vcs = VCSInstance();
@@ -457,17 +457,18 @@ export const rollbackChangesAction: ActionFunction = async ({ params }) => {
     const delta = await vcs.rollbackToLatest(syncItems);
     await database.batchModifyDocs(delta as unknown as Operation);
     delete remoteCompareCache[workspaceId];
-    return {};
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Unknown error while rolling back changes.';
     return {
       error: errorMessage,
     };
   }
+
+  return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug`);
 };
 
 export const restoreChangesAction: ActionFunction = async ({ request, params }) => {
-  const { workspaceId } = params;
+  const { organizationId, projectId, workspaceId } = params;
   invariant(typeof workspaceId === 'string', 'Workspace Id is required');
   const formData = await request.formData();
   const id = formData.get('id');
@@ -485,7 +486,7 @@ export const restoreChangesAction: ActionFunction = async ({ request, params }) 
     };
   }
 
-  return null;
+  return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug`);
 };
 
 export const createSnapshotAction: ActionFunction = async ({ request, params }) => {


### PR DESCRIPTION
Highlights:
- [x] Update sync actions to fix an issue where removing entities can lead to the fetcher state getting stuck in 'loading'
- [x] Rename `Revert to latest commit` to `Undo all changes` so that it's clear what the dropdown option does.

Future work:
- This is an issue with the fetcher state in react-router. We'd need to update our approach when this is fixed by undoing the changes of this PR.