### PR TITLE
Spike/util-proc

### DIFF
--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -17,6 +17,7 @@ import { axiosRequest } from '../network/axios-request';
 import { CurlBridgeAPI } from '../network/curl';
 import { cancelCurlRequest, curlRequest } from '../network/libcurl-promise';
 import { WebSocketBridgeAPI } from '../network/websocket';
+import { runCalculation } from '../run-calc';
 import { gRPCBridgeAPI } from './grpc';
 
 export interface MainBridgeAPI {
@@ -42,6 +43,7 @@ export interface MainBridgeAPI {
   trackPageView: (options: { name: string }) => void;
   axiosRequest: typeof axiosRequest;
   insomniaFetch: typeof insomniaFetch;
+  runCalculation: typeof runCalculation;
   showContextMenu: (options: { key: string }) => void;
   database: {
     caCertificate: {
@@ -50,6 +52,9 @@ export interface MainBridgeAPI {
   };
 }
 export function registerMainHandlers() {
+  ipcMain.handle('runCalculation', async (_, options: Parameters<typeof runCalculation>[0]) => {
+    return await runCalculation(options);
+  });
   ipcMain.handle('insomniaFetch', async (_, options: Parameters<typeof insomniaFetch>[0]) => {
     return insomniaFetch(options);
   });

--- a/packages/insomnia/src/main/run-calc.ts
+++ b/packages/insomnia/src/main/run-calc.ts
@@ -16,6 +16,86 @@ interface ChildMessage {
 //   console.log('Hashed value:', hashedValue);
 //   hashedValue
 // `
+
+// await main.runCalculation`
+// insomnia.environment.set('test', 'test');
+// `
+
+// class BaseKV {
+//   private kvs = new Map<string, boolean | number | string>();
+
+//   constructor(jsonObject: object | undefined) {
+//     // TODO: currently it doesn't support getting nested field directly
+//     this.kvs = new Map(Object.entries(jsonObject || {}));
+//   }
+
+//   has = (variableName: string) => {
+//     return this.kvs.has(variableName);
+//   };
+
+//   get = (variableName: string) => {
+//     return this.kvs.get(variableName);
+//   };
+
+//   set = (variableName: string, variableValue: boolean | number | string) => {
+//     this.kvs.set(variableName, variableValue);
+//   };
+
+//   unset = (variableName: string) => {
+//     this.kvs.delete(variableName);
+//   };
+
+//   clear = () => {
+//     this.kvs.clear();
+//   };
+
+//   // replaceIn = (template: string) => {
+//   // return getIntepolator().render(template, this.toObject());
+//   // };
+
+//   toObject = () => {
+//     return Object.fromEntries(this.kvs.entries());
+//   };
+// }
+
+// class Environment extends BaseKV {
+//   constructor(jsonObject: object | undefined) {
+//     super(jsonObject);
+//   }
+// }
+
+// export class InsomniaObject {
+//   public environment: Environment;
+
+//   constructor(input: {
+//     environment: Environment;
+//   }) {
+//     this.environment = input.environment;
+//   }
+
+//   toObject = () => {
+//     return {
+//       environment: this.environment.toObject(),
+//     };
+//   };
+// }
+
+// export interface RawObject {
+//   globals?: object;
+//   environment?: object;
+//   collectionVariables?: object;
+//   iterationData?: object;
+//   requestInfo?: object;
+// }
+
+// export function initGlobalObject(rawObj: RawObject) {
+//   const environment = new Environment(rawObj.environment);
+
+//   return new InsomniaObject({
+//     environment,
+//   });
+// };
+
 export const runCalculation = async (code: string): Promise<string> => {
   // First, we need to wrap the code in the sandbox environment
   const wrappedCode = wrapCode(code);
@@ -63,6 +143,7 @@ const wrapCode = (code: string): string => {
     const sendMessageData = (obj) => {
       process.parentPort.postMessage(JSON.stringify(obj));
     }
+    const kvs = new Map();
 
     try {
       const context = {
@@ -70,6 +151,12 @@ const wrapCode = (code: string): string => {
           createHash: crypto.createHash,
         },
         console,  // You may include other necessary objects from the global context
+        insomnia:{
+          environment:{
+            set:(...args)=>kvs.set(...args),
+            get:(...args)=>kvs.get(...args)
+          }
+        },
       };
       result = vm.runInNewContext(code,context);
       sendMessageData({ result });

--- a/packages/insomnia/src/main/run-calc.ts
+++ b/packages/insomnia/src/main/run-calc.ts
@@ -14,6 +14,7 @@ interface ChildMessage {
 //   hash.update('Hello, world!');
 //   const hashedValue = hash.digest('hex');
 //   console.log('Hashed value:', hashedValue);
+//   hashedValue
 // `
 export const runCalculation = async (code: string): Promise<string> => {
   // First, we need to wrap the code in the sandbox environment

--- a/packages/insomnia/src/main/run-calc.ts
+++ b/packages/insomnia/src/main/run-calc.ts
@@ -1,0 +1,85 @@
+import { utilityProcess } from 'electron';
+import { unlink, writeFile } from 'fs/promises';
+import os from 'os';
+// import { dedent } from 'ts-dedent';
+
+// Handling for forking code written by ChatGPT for the smart calculator function
+
+interface ChildMessage {
+  result?: string;
+  error?: string;
+}
+
+export const runCalculation = async (code: string): Promise<string> => {
+  // First, we need to wrap the code in the sandbox environment
+  const wrappedCode = wrapCode(code);
+  const tempFile = await createTempFile(wrappedCode);
+  const child = utilityProcess.fork(tempFile, [], {
+    env: {},
+    stdio: 'ignore',
+    serviceName: 'tomato-calculator',
+  });
+
+  try {
+    return await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        child.kill();
+        reject(new Error('Timeout'));
+      }, calculatorTimeout());
+
+      child.on('message', (message: string) => {
+        const parsedMessage: ChildMessage = JSON.parse(message);
+        if (parsedMessage.result) {
+          clearTimeout(timer);
+          resolve(parsedMessage.result.toString());
+        } else {
+          clearTimeout(timer);
+          reject(new Error(parsedMessage.error));
+        }
+      });
+    });
+  } finally {
+    await cleanupTempFile(tempFile);
+  }
+};
+
+const wrapCode = (code: string): string => {
+  console.log('Running code');
+  console.log(code);
+  // We'll JSON encode the code so that we can safely embed it in the sandbox
+  const encodedCode = JSON.stringify(code);
+  // return dedent`
+  return `
+    const vm = require("vm");
+    const code = ${encodedCode};
+
+    const sendMessageData = (obj) => {
+      process.parentPort.postMessage(JSON.stringify(obj));
+    }
+
+    try {
+      result = vm.runInNewContext(code);
+      sendMessageData({ result });
+    } catch (e) {
+      sendMessageData({ error: e.message });
+    }
+  `;
+};
+
+const calculatorTimeout = (): number | undefined => {
+  // TODO: Make this configurable
+  return 5000;
+};
+
+const createTempFile = async (code: string): Promise<string> => {
+  // Create a temporary file using the os temp directory
+  const tmp = os.tmpdir();
+  const tempFile = `${tmp}/tomato-calculator-${Date.now()}.js`;
+  await writeFile(tempFile, code);
+  return tempFile;
+};
+
+const cleanupTempFile = async (tempFile: string): Promise<void> => {
+  // Delete the temporary file
+  await unlink(tempFile);
+};

--- a/packages/insomnia/src/main/run-calc.ts
+++ b/packages/insomnia/src/main/run-calc.ts
@@ -87,13 +87,14 @@ const wrapCode = (code: string): string => {
           sendRequest: async (url) => {
             const response = await fetch(url);
             const movies = await response.json();
-            console.log(movies);
             return movies
           }
         },
       };
-      result = vm.runInNewContext(code,context);
-      sendMessageData({ result });
+      vm.runInNewContext(code,context).then((result)=>{
+        sendMessageData({ result });
+      })
+
     } catch (e) {
       sendMessageData({ error: e.message });
     }

--- a/packages/insomnia/src/main/run-calc.ts
+++ b/packages/insomnia/src/main/run-calc.ts
@@ -21,81 +21,9 @@ interface ChildMessage {
 // insomnia.environment.set('test', 'test');
 // `
 
-// class BaseKV {
-//   private kvs = new Map<string, boolean | number | string>();
-
-//   constructor(jsonObject: object | undefined) {
-//     // TODO: currently it doesn't support getting nested field directly
-//     this.kvs = new Map(Object.entries(jsonObject || {}));
-//   }
-
-//   has = (variableName: string) => {
-//     return this.kvs.has(variableName);
-//   };
-
-//   get = (variableName: string) => {
-//     return this.kvs.get(variableName);
-//   };
-
-//   set = (variableName: string, variableValue: boolean | number | string) => {
-//     this.kvs.set(variableName, variableValue);
-//   };
-
-//   unset = (variableName: string) => {
-//     this.kvs.delete(variableName);
-//   };
-
-//   clear = () => {
-//     this.kvs.clear();
-//   };
-
-//   // replaceIn = (template: string) => {
-//   // return getIntepolator().render(template, this.toObject());
-//   // };
-
-//   toObject = () => {
-//     return Object.fromEntries(this.kvs.entries());
-//   };
-// }
-
-// class Environment extends BaseKV {
-//   constructor(jsonObject: object | undefined) {
-//     super(jsonObject);
-//   }
-// }
-
-// export class InsomniaObject {
-//   public environment: Environment;
-
-//   constructor(input: {
-//     environment: Environment;
-//   }) {
-//     this.environment = input.environment;
-//   }
-
-//   toObject = () => {
-//     return {
-//       environment: this.environment.toObject(),
-//     };
-//   };
-// }
-
-// export interface RawObject {
-//   globals?: object;
-//   environment?: object;
-//   collectionVariables?: object;
-//   iterationData?: object;
-//   requestInfo?: object;
-// }
-
-// export function initGlobalObject(rawObj: RawObject) {
-//   const environment = new Environment(rawObj.environment);
-
-//   return new InsomniaObject({
-//     environment,
-//   });
-// };
-
+// await main.runCalculation`
+// insomnia.sendRequest('https://api.insomnia.rest').then(res=>console.log({a:1,res}));
+// `
 export const runCalculation = async (code: string): Promise<string> => {
   // First, we need to wrap the code in the sandbox environment
   const wrappedCode = wrapCode(code);
@@ -117,7 +45,7 @@ export const runCalculation = async (code: string): Promise<string> => {
         const parsedMessage: ChildMessage = JSON.parse(message);
         if (parsedMessage.result) {
           clearTimeout(timer);
-          resolve(parsedMessage.result.toString());
+          resolve(parsedMessage.result);
         } else {
           clearTimeout(timer);
           reject(new Error(parsedMessage.error));
@@ -155,6 +83,12 @@ const wrapCode = (code: string): string => {
           environment:{
             set:(...args)=>kvs.set(...args),
             get:(...args)=>kvs.get(...args)
+          },
+          sendRequest: async (url) => {
+            const response = await fetch(url);
+            const movies = await response.json();
+            console.log(movies);
+            return movies
           }
         },
       };

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -63,6 +63,7 @@ const main: Window['main'] = {
   trackPageView: options => ipcRenderer.send('trackPageView', options),
   axiosRequest: options => ipcRenderer.invoke('axiosRequest', options),
   insomniaFetch: options => ipcRenderer.invoke('insomniaFetch', options),
+  runCalculation: options => ipcRenderer.invoke('runCalculation', options),
   showContextMenu: options => ipcRenderer.send('show-context-menu', options),
   database: {
     caCertificate: {

--- a/packages/insomnia/src/ui/components/templating/local-template-tags.ts
+++ b/packages/insomnia/src/ui/components/templating/local-template-tags.ts
@@ -232,7 +232,11 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
           throw new Error(`Cannot hash value of type "${valueType}"`);
         }
 
-        return await window.main.runCalculation(`crypto.createHash('${algorithm}').update('${value}','utf8').digest('${encoding}');`);
+        return await window.main.runCalculation(`
+        crypto.createHash('${algorithm}')
+        .update('${value}','utf8')
+        .digest('${encoding}');
+        `);
       },
     },
   },

--- a/packages/insomnia/src/ui/components/templating/local-template-tags.ts
+++ b/packages/insomnia/src/ui/components/templating/local-template-tags.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import { format } from 'date-fns';
 import fs from 'fs';
 import iconv from 'iconv-lite';
@@ -223,7 +222,7 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
           placeholder: 'Value to hash',
         },
       ],
-      run(_context, algorithm, encoding, value = '') {
+      async run(_context, algorithm, encoding, value = '') {
         if (encoding !== 'hex' && encoding !== 'latin1' && encoding !== 'base64') {
           throw new Error(`Invalid encoding ${encoding}. Choices are hex, latin1, base64`);
         }
@@ -233,9 +232,7 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
           throw new Error(`Cannot hash value of type "${valueType}"`);
         }
 
-        const hash = crypto.createHash(algorithm);
-        hash.update(value || '', 'utf8');
-        return hash.digest(encoding);
+        return await window.main.runCalculation(`crypto.createHash('${algorithm}').update('${value}','utf8').digest('${encoding}');`);
       },
     },
   },
@@ -434,10 +431,8 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
         // We do this because we may render the prompt multiple times per request.
         // We cache it under the requestId so it only prompts once. We then clear
         // the cache in a response hook when the request is sent.
-        const titleHash = crypto
-          .createHash('md5')
-          .update(title)
-          .digest('hex');
+        const titleHash = await window.main.runCalculation(`crypto.createHash('md5').update('${title}').digest('hex');`);
+
         const storageKey = explicitStorageKey || `${context.meta.requestId}.${titleHash}`;
         const cachedValue = await context.store.getItem(storageKey);
 


### PR DESCRIPTION
runs crypto module in electron utilityProcess, inspired by https://github.com/osuushi/TOMaTo

- uses a promise api to wrap all new concepts in a single file.
- uses context to make modules available to code
- returns values stated on the last line

###new concepts
- utilityProcess.fork
- child message promise resolver and 5 second timeout
- context wrapper to control execution
- temp file generation and cleanup

###pros
- matches our simple preloaded promise api making calls in renderer or main trivial
- it can mutate context
- single file
- easy to move execution over the ipc bridge, unlocking contextisolation!

###cons
- need to iterate on context
- passing strings isn't ideal for static code, but there should be a way to avoid that
- it can return strings needs iteration to return objects, perhaps avoidable
- debugging is a bit unclear
- need to make context very explicit

### requirements
- [x] environment
- [ ] return mutated context object eg. request to send
- [ ] linting the wrapper
- [ ] top level await in pre request script
- [ ] set request params transient
- [x] send request
- [ ] insomnia-collection
- [ ] expose a context item to the nunjucks renderer?
- [ ] expose some node modules, uuid?
- [ ] read and write to nedb
- [ ] which order, pre-request script, interpolation with nunjucks, plugins

