### PR TITLE
fix: add viewport meta tag

### DIFF
--- a/packages/insomnia/src/index.html
+++ b/packages/insomnia/src/index.html
@@ -6,6 +6,7 @@
       http-equiv="Content-Security-Policy"
       content="font-src 'self' data:; connect-src * data: api: insomnia-event-source:; default-src * insomnia://*; img-src blob: data: * insomnia://*; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src blob: data: mediastream: * insomnia://*;"
     />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="./ui/css/styles.css" />
   </head>
 

--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -175,6 +175,8 @@ const _launchApp = async () => {
       app.on('second-instance', (_1, args) => {
         console.log('Second instance listener received:', args.join('||'));
         window = windowUtils.getOrCreateWindow();
+        window.webContents.setZoomFactor(1);
+
         if (window) {
           if (window.isMinimized()) {
             window.restore();
@@ -186,10 +188,13 @@ const _launchApp = async () => {
         window.webContents.send('shell:open', lastArg);
       });
       window = windowUtils.getOrCreateWindow();
+      window.webContents.setZoomFactor(1);
 
       app.on('open-url', (_event, url) => {
         console.log('[main] Open Deep Link URL', url);
         window = windowUtils.getOrCreateWindow();
+        window.webContents.setZoomFactor(1);
+
         if (window) {
           if (window.isMinimized()) {
             window.restore();
@@ -203,6 +208,7 @@ const _launchApp = async () => {
     }
   } else {
     window = windowUtils.getOrCreateWindow();
+    window.webContents.setZoomFactor(1);
   }
 
   // Don't send origin header from Insomnia because we're not technically using CORS

--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -160,6 +160,7 @@ const _launchApp = async () => {
       window = windowUtils.getOrCreateWindow();
       windowUtils.createHiddenBrowserWindow();
       window.webContents.send('shell:open', args.join());
+      window.webContents.setZoomFactor(1);
     }
   });
   // Disable deep linking in playwright e2e tests in order to run multiple tests in parallel


### PR DESCRIPTION
Attempting to resolve a strange behavior where the Electron app on a fresh installation appears zoomed out, and CMD+0 is needed to reset the zoom level.