### PR TITLE
Added Proxy Support for OAuth 2 Authorization Code Flow Popup

### DIFF
--- a/packages/insomnia/src/main/authorizeUserInWindow.ts
+++ b/packages/insomnia/src/main/authorizeUserInWindow.ts
@@ -37,7 +37,7 @@ export function authorizeUserInWindow({
       proxyEnabled,
       httpProxy,
       httpsProxy,
-      noProxy
+      noProxy,
     } = await models.settings.get();
 
     // Create a child window
@@ -147,9 +147,9 @@ export function authorizeUserInWindow({
         proxyRules:
           (httpProxy ? `http=${httpProxy};` : '') +
           (httpsProxy ? `https=${httpsProxy}` : ''),
-        proxyBypassRules: noProxy
+        proxyBypassRules: noProxy,
       });
-      console.log(`[oauth2] Proxy loaded`);
+      console.log('[oauth2] Proxy loaded');
     }
 
     try {

--- a/packages/insomnia/src/main/authorizeUserInWindow.ts
+++ b/packages/insomnia/src/main/authorizeUserInWindow.ts
@@ -34,6 +34,10 @@ export function authorizeUserInWindow({
     // Fetch user setting to determine whether to validate SSL certificates during auth
     const {
       validateAuthSSL,
+      proxyEnabled,
+      httpProxy,
+      httpsProxy,
+      noProxy
     } = await models.settings.get();
 
     // Create a child window
@@ -136,6 +140,17 @@ export function authorizeUserInWindow({
     });
     // Show the window to the user after it loads
     child.on('ready-to-show', child.show.bind(child));
+
+    // Set proxy for browser window
+    if (proxyEnabled) {
+      await child.webContents.session.setProxy({
+        proxyRules:
+          (httpProxy ? `http=${httpProxy};` : '') +
+          (httpsProxy ? `https=${httpsProxy}` : ''),
+        proxyBypassRules: noProxy
+      });
+      console.log(`[oauth2] Proxy loaded`);
+    }
 
     try {
       await child.loadURL(url);


### PR DESCRIPTION
In this pull request, I've implemented proxy support for the popup used in the OAuth 2 Authorization Code flow window. Previously, this feature was missing from the current implementation, which meant that configured proxies were not utilized within the window.

With this change, the configured proxies will now be appropriately utilized in the popup window. This enhancement was crucial for me, as I encountered difficulties connecting to the authorization URL without a proxy in my environment.

Best regards,

Moritz
