### PR TITLE
feat(prereq): add simple timeout

### DIFF
--- a/packages/insomnia-smoke-test/tests/critical/bundling.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/bundling.test.ts
@@ -16,7 +16,7 @@ test('can use node-libcurl, httpsnippet, hidden browser window', async ({ app, p
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke testsjust now').click();
+  await page.getByLabel('Smoke tests').click();
 
   await page.getByLabel('Request Collection').getByTestId('send JSON request').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();

--- a/packages/insomnia-smoke-test/tests/critical/certificates.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/certificates.test.ts
@@ -12,7 +12,7 @@ test('can send request with custom ca root certificate', async ({ app, page }) =
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke testsjust now').click();
+  await page.getByLabel('Smoke tests').click();
 
   await page.getByLabel('Request Collection').getByTestId('sends request with certs').press('Enter');
 

--- a/packages/insomnia-smoke-test/tests/prerelease/grpc-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/grpc-interactions.test.ts
@@ -20,7 +20,8 @@ test.describe('gRPC interactions', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByText('CollectionPreRelease gRPCjust now').click();
+    await page.getByLabel('PreRelease gRPC').click();
+
     statusTag = page.locator('[data-testid="response-status-tag"]:visible');
     responseBody = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
       has: page.locator('.CodeMirror-activeline'),

--- a/packages/insomnia-smoke-test/tests/prerelease/preferences-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/preferences-interactions.test.ts
@@ -24,7 +24,7 @@ test('Check filter responses by environment preference', async ({ app, page }) =
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByText('Collectionsimplejust now').click();
+  await page.getByLabel('simple').click();
 
   // Send a request
   await page.getByLabel('Request Collection').getByTestId('example http').press('Enter');

--- a/packages/insomnia-smoke-test/tests/smoke/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/app.test.ts
@@ -23,7 +23,7 @@ test('can send requests', async ({ app, page }) => {
   await page.getByText('Which format would you like to export as?').click();
   await page.locator('.app').press('Escape');
 
-  await page.getByText('CollectionSmoke testsjust now').click();
+  await page.getByLabel('Smoke tests').click();
 
   await page.getByLabel('Create in collection').click();
   await page.getByRole('menuitemradio', { name: 'From Curl' }).click();
@@ -93,7 +93,7 @@ test('can cancel requests', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke testsjust now').click();
+  await page.getByLabel('Smoke tests').click();
 
   await page.getByLabel('Request Collection').getByTestId('delayed request').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/cookie-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cookie-editor-interactions.test.ts
@@ -11,7 +11,7 @@ test.describe('Cookie editor', async () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByText('Collectionsimplejust now').click();
+    await page.getByLabel('simple').click();
   });
 
   test('create and send a cookie', async ({ page }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/dashboard-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/dashboard-interactions.test.ts
@@ -59,7 +59,7 @@ test.describe('Dashboard', async () => {
       await page.locator('[data-test-id="import-from-clipboard"]').click();
       await page.getByRole('button', { name: 'Scan' }).click();
       await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-      await page.getByText('CollectionSmoke testsjust now').click();
+      await page.getByLabel('Smoke tests').click();
       // Check that 10 new workspaces are imported besides the default one
       const workspaceCards = page.getByLabel('Workspaces').getByRole('gridcell');
       await expect(workspaceCards).toHaveCount(11);

--- a/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
@@ -13,7 +13,7 @@ test.describe('Debug-Sidebar', async () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByText('Collectionsimplejust now').click();
+    await page.getByLabel('simple').click();
   });
 
   test.describe('Interact with sidebar', async () => {

--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -17,7 +17,7 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke GraphQLjust now').click();
+  await page.getByLabel('Smoke GraphQL').click();
 
   // Open the graphql request
   await page.getByLabel('Request Collection').getByTestId('GraphQL request').press('Enter');
@@ -59,7 +59,7 @@ test('can render schema and send GraphQL requests with object variables', async 
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke GraphQLjust now').click();
+  await page.getByLabel('Smoke GraphQL').click();
 
   // Open the graphql request
   await page.getByLabel('Request Collection').getByTestId('GraphQL request with variables').press('Enter');
@@ -101,7 +101,7 @@ test('can render numeric environment', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke GraphQLjust now').click();
+  await page.getByLabel('Smoke GraphQL').click();
 
   // Open the graphql request
   await page.getByLabel('Request Collection').getByTestId('GraphQL request with number').press('Enter');
@@ -140,7 +140,7 @@ test('can send GraphQL requests after editing and prettifying query', async ({ a
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionSmoke GraphQLjust now').click();
+  await page.getByLabel('Smoke GraphQL').click();
   await page.getByLabel('Request Collection').getByTestId('GraphQL request').press('Enter');
 
   // Edit and prettify query

--- a/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
@@ -19,7 +19,7 @@ test('can send gRPC requests with reflection', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionPreRelease gRPCjust now').click();
+  await page.getByLabel('PreRelease gRPC').click();
 
   await page.getByLabel('Request Collection').getByTestId('UnaryWithOutProtoFile').press('Enter');
   await expect(page.getByRole('button', { name: 'Select Method' })).toBeDisabled();

--- a/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
@@ -26,7 +26,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionOAuth Testingjust now').click();
+  await page.getByLabel('OAuth Testing').click();
 
   // No PKCE
   await projectView.getByLabel('Request Collection').getByTestId('No PKCE').press('Enter');

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
@@ -16,7 +16,7 @@ test.describe('pre-request UI tests', async () => {
         await page.getByRole('button', { name: 'Scan' }).click();
         await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
 
-        await page.getByText('CollectionSmoke testsjust now').click();
+        await page.getByLabel('Smoke tests').click();
     });
 
     const testCases = [

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script.test.ts
@@ -27,3 +27,35 @@ test('can cancel pre-request script', async ({ app, page }) => {
   await page.getByRole('button', { name: 'Cancel Request' }).click();
   await page.click('text=Request was cancelled');
 });
+
+test('handle hidden browser window getting closed', async ({ app, page }) => {
+  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+
+  const text = await loadFixture('pre-request-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+  await page.getByRole('button', { name: 'Create in project' }).click();
+  await page.getByRole('menuitemradio', { name: 'Import' }).click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+
+  await page.getByText('Pre-request Scripts').click();
+
+  await page.getByLabel('Request Collection').getByTestId('Long running task').press('Enter');
+  await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+
+  await page.getByTestId('settings-button').click();
+  await page.getByLabel('Request timeout (ms)').fill('1');
+  await page.getByRole('button', { name: '' }).click();
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await page.getByText('Timeout: Pre-request script took too long').click();
+  await page.getByRole('tab', { name: 'Timeline' }).click();
+  await page.getByRole('tab', { name: 'Preview ' }).click();
+  const windows = await app.windows();
+  const hiddenWindow = windows[1];
+  hiddenWindow.close();
+  await page.getByRole('button', { name: 'Send' }).click();
+  await page.getByText('Timeout: Hidden browser window is not responding').click();
+});

--- a/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
@@ -19,7 +19,7 @@ test('can make websocket connection', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByText('CollectionWebSocketsjust now').click();
+  await page.getByLabel('WebSockets').click();
 
   await page.getByLabel('Request Collection').getByTestId('localhost:4010').press('Enter');
   await expect(page.locator('.app')).toContainText('ws://localhost:4010');

--- a/packages/insomnia/.eslintignore
+++ b/packages/insomnia/.eslintignore
@@ -2,7 +2,7 @@ build
 bin
 send-request
 coverage
-src/main.min.js
-src/preload.js
+src/*.js
+src/*.js.map
 **/svgr
 svgr.config.js

--- a/packages/insomnia/.gitignore
+++ b/packages/insomnia/.gitignore
@@ -2,9 +2,6 @@ dist
 build
 
 # Generated
-src/main.min.js
-src/main.min.js.map
-src/preload.js
-src/preload.js.map
-src/hidden-window-preload.js
-src/hidden-window-preload.js.map
+src/*.js
+src/*.js.map
+

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -10,7 +10,7 @@ window.bridge.onmessage(async (data, callback) => {
     const timeout = data.context.timeout || 5000;
     const timeoutPromise = new Promise(resolve => {
       setTimeout(() => {
-        resolve({ error: 'Timeout: Operation took too long' });
+        resolve({ error: 'Timeout: Pre-request script took too long' });
       }, timeout);
     });
     const result = await Promise.race([timeoutPromise, runPreRequestScript(data)]);

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -7,7 +7,12 @@ export interface HiddenBrowserWindowBridgeAPI {
 window.bridge.onmessage(async (data, callback) => {
   console.log('[hidden-browser-window] recieved message', data);
   try {
-    const result = await runPreRequestScript(data);
+    const timeoutPromise = new Promise(resolve => {
+      setTimeout(() => {
+        resolve({ error: 'Timeout: Operation took too long' });
+      }, 5000);
+    });
+    const result = await Promise.race([timeoutPromise, runPreRequestScript(data)]);
     callback(result);
   } catch (err) {
     console.error('error', err);

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -7,10 +7,11 @@ export interface HiddenBrowserWindowBridgeAPI {
 window.bridge.onmessage(async (data, callback) => {
   console.log('[hidden-browser-window] recieved message', data);
   try {
+    const timeout = data.context.timeout || 5000;
     const timeoutPromise = new Promise(resolve => {
       setTimeout(() => {
         resolve({ error: 'Timeout: Operation took too long' });
-      }, 5000);
+      }, timeout);
     });
     const result = await Promise.race([timeoutPromise, runPreRequestScript(data)]);
     callback(result);

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -584,6 +584,13 @@ export function createWindow(): ElectronBrowserWindow {
           hiddenBrowserWindow.isVisible() ? hiddenBrowserWindow.hide() : hiddenBrowserWindow.show();
         },
       },
+      {
+        label: 'Stop/start hidden browser window ',
+        click: () => {
+          const hiddenBrowserWindow = browserWindows.get('HiddenBrowserWindow');
+          hiddenBrowserWindow ? stopHiddenBrowserWindow() : createHiddenBrowserWindow();
+        },
+      },
     ],
   };
   const toolsMenu: MenuItemConstructorOptions = {

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -576,6 +576,14 @@ export function createWindow(): ElectronBrowserWindow {
           setZoom(() => 4)();
         },
       },
+      {
+        label: 'Show/hide hidden browser window ',
+        click: () => {
+          const hiddenBrowserWindow = browserWindows.get('HiddenBrowserWindow');
+          invariant(hiddenBrowserWindow, 'hiddenBrowserWindow is not defined');
+          hiddenBrowserWindow.isVisible() ? hiddenBrowserWindow.hide() : hiddenBrowserWindow.show();
+        },
+      },
     ],
   };
   const toolsMenu: MenuItemConstructorOptions = {

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -26,7 +26,6 @@ import type { Settings } from '../models/settings';
 import { isWorkspace } from '../models/workspace';
 import * as pluginContexts from '../plugins/context/index';
 import * as plugins from '../plugins/index';
-import { RequestContext } from '../sdk/objects/insomnia';
 import { invariant } from '../utils/invariant';
 import { setDefaultProtocol } from '../utils/url/protocol';
 import {
@@ -111,7 +110,7 @@ export const tryToExecutePreRequestScript = async (
         baseEnvironment: baseEnvironment?.data || {},
       },
     });
-    const output = await Promise.race([timeoutPromise, preRequestPromise]) as RequestContext;
+    const output = await Promise.race([timeoutPromise, preRequestPromise]) as { request: Request; environment: Record<string, any>; baseEnvironment: Record<string, any> };
     console.log('[network] Pre-request script succeeded', output);
 
     const envPropertyOrder = orderedJSON.parse(
@@ -119,6 +118,7 @@ export const tryToExecutePreRequestScript = async (
       JSON_ORDER_PREFIX,
       JSON_ORDER_SEPARATOR,
     );
+
     environment.data = output.environment;
     environment.dataPropertyOrder = envPropertyOrder.map;
     const baseEnvPropertyOrder = orderedJSON.parse(
@@ -126,6 +126,7 @@ export const tryToExecutePreRequestScript = async (
       JSON_ORDER_PREFIX,
       JSON_ORDER_SEPARATOR,
     );
+
     baseEnvironment.data = output.baseEnvironment;
     baseEnvironment.dataPropertyOrder = baseEnvPropertyOrder.map;
 

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -35,7 +35,7 @@ import {
   smartEncodeUrl,
 } from '../utils/url/querystring';
 import { getAuthHeader, getAuthQueryParams } from './authentication';
-import { cancellableCurlRequest, cancellableRunPreRequestScript, cancelRequestById } from './cancellation';
+import { cancellableCurlRequest, cancellableRunPreRequestScript } from './cancellation';
 import { addSetCookiesToToughCookieJar } from './set-cookie-util';
 import { urlMatchesCertHost } from './url-matches-cert-host';
 

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -87,6 +87,7 @@ export const tryToExecutePreRequestScript = async (
       baseEnvironment: undefined,
     };
   }
+  const settings = await models.settings.get();
 
   try {
     const output = await cancellableRunPreRequestScript({
@@ -94,6 +95,7 @@ export const tryToExecutePreRequestScript = async (
       context: {
         request,
         timelinePath,
+        timeout: settings.timeout,
         // it inputs empty environment data when active environment is the base environment
         // this is more deterministic and avoids that script accidently manipulates baseEnvironment instead of environment
         environment: environment._id === baseEnvironment._id ? {} : (environment?.data || {}),
@@ -126,7 +128,6 @@ export const tryToExecutePreRequestScript = async (
     await fs.promises.appendFile(timelinePath, JSON.stringify({ value: err.message, name: 'Text', timestamp: Date.now() }) + '\n');
 
     const requestId = request._id;
-    const settings = await models.settings.get();
     const responsePatch = {
       _id: responseId,
       parentId: requestId,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -94,7 +94,6 @@ export const tryToExecutePreRequestScript = async (
     const timeout = settings.timeout || 5000;
     const timeoutPromise = new Promise((_, reject) => {
       setTimeout(() => {
-        cancelRequestById(request._id);
         reject(new Error('Timeout: Hidden browser window is not responding'));
         // Add one extra second to ensure the hidden browser window has had a chance to return its timeout
         // TODO: restart the hidden browser window

--- a/packages/insomnia/src/sdk/objects/insomnia.ts
+++ b/packages/insomnia/src/sdk/objects/insomnia.ts
@@ -11,11 +11,11 @@ export interface RequestContext {
     request: Request;
     timelinePath: string;
     timeout: number;
-    environment?: object;
-    baseEnvironment?: object;
-    collectionVariables?: object;
-    globals?: object;
-    iterationData?: object;
+    environment?: Record<string, any>;
+    baseEnvironment?: Record<string, any>;
+    collectionVariables?: Record<string, any>;
+    globals?: Record<string, any>;
+    iterationData?: Record<string, any>;
 }
 
 export class InsomniaObject {

--- a/packages/insomnia/src/sdk/objects/insomnia.ts
+++ b/packages/insomnia/src/sdk/objects/insomnia.ts
@@ -10,6 +10,7 @@ export const unsupportedError = (featureName: string, alternative?: string) => {
 export interface RequestContext {
     request: Request;
     timelinePath: string;
+    timeout: number;
     environment?: object;
     baseEnvironment?: object;
     collectionVariables?: object;


### PR DESCRIPTION
todo

- [x] add a timeout on the hidden browser side
- [x] decide on a configuration ux, global and/or per request? we could use request timeout 30s from global settings as a stop gap
- [x] show/hide hidden browser window
- [x] create a second timeout which is intended to catch communication issues with the hidden browser window
maybe:
- [ ] use an abort controller to stop executing the script after timeout
- [x] an e2e test case

closes INS-3562

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
