### PR TITLE
fix: move changelog step to release-publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -222,6 +222,16 @@ jobs:
         with:
           username: ${{ (github.event_name == 'workflow_dispatch' && github.actor) || 'insomnia-infra' }}
 
+      - name: Update CHANGELOG
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ secrets.RELEASE_GH_TOKEN }}
+          tag: ${{ env.RELEASE_CORE_TAG }}
+
+      - name: Git Commit Changelog
+        run: git commit -am "update CHANGELOG.md for ${{ env.RELEASE_VERSION }} [skip ci]"
+
       - name: Merge git branch into develop
         run: |
           remote_repo="https://${GITHUB_ACTOR}:${RELEASE_GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -102,16 +102,6 @@ jobs:
       - name: Git Commit
         run: git commit -am "Bump app version to ${{ env.RELEASE_VERSION }}"
 
-      # - name: Update CHANGELOG
-      #   id: changelog
-      #   uses: requarks/changelog-action@v1
-      #   with:
-      #     token: ${{ secrets.RELEASE_GH_TOKEN }}
-      #     tag: ${{ github.ref_name }}
-
-      # - name: Git Commit Changelog
-      #   run: git commit -am "update CHANGELOG.md for ${{ env.RELEASE_VERSION }} [skip ci]"
-
       - name: Git Push changes
         run: |
           remote_repo="https://${GITHUB_ACTOR}:${RELEASE_GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: develop
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'
@@ -71,7 +71,7 @@ jobs:
           branch: ${{ env.RELEASE_BRANCH }}
 
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.RELEASE_BRANCH }}
           persist-credentials: false
@@ -102,15 +102,15 @@ jobs:
       - name: Git Commit
         run: git commit -am "Bump app version to ${{ env.RELEASE_VERSION }}"
 
-      - name: Update CHANGELOG
-        id: changelog
-        uses: requarks/changelog-action@v1
-        with:
-          token: ${{ secrets.RELEASE_GH_TOKEN }}
-          tag: ${{ github.sha }}
+      # - name: Update CHANGELOG
+      #   id: changelog
+      #   uses: requarks/changelog-action@v1
+      #   with:
+      #     token: ${{ secrets.RELEASE_GH_TOKEN }}
+      #     tag: ${{ github.ref_name }}
 
-      - name: Git Commit Changelog
-        run: git commit -am "update CHANGELOG.md for ${{ env.RELEASE_VERSION }} [skip ci]"
+      # - name: Git Commit Changelog
+      #   run: git commit -am "update CHANGELOG.md for ${{ env.RELEASE_VERSION }} [skip ci]"
 
       - name: Git Push changes
         run: |

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: develop
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'
@@ -71,7 +71,7 @@ jobs:
           branch: ${{ env.RELEASE_BRANCH }}
 
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_BRANCH }}
           persist-credentials: false


### PR DESCRIPTION
the way the GH action works we need a git tag to be pushed to remote beforehand, we can handle this in release-publish instead, right before we merge the commit.