### PR TITLE
feat: enable headers in pre-request scripting [INS-3379] 

### DIFF
--- a/packages/insomnia/src/sdk/objects/__tests__/headers.test.ts
+++ b/packages/insomnia/src/sdk/objects/__tests__/headers.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 
 import { Header } from '../headers';
-// import { QueryParam, setUrlParser, Url, UrlMatchPattern } from '../urls';
 
 describe('test Header object', () => {
     it('test basic operations', () => {
-        // const header = new Header('Content-Type: application/json\nUser-Agent: MyClientLibrary/2.0\n');
         const headerStr = 'Content-Type: application/json\nUser-Agent: MyClientLibrary/2.0\n';
         const headerObjs = [
             { key: 'Content-Type', value: 'application/json' },

--- a/packages/insomnia/src/sdk/objects/__tests__/headers.test.ts
+++ b/packages/insomnia/src/sdk/objects/__tests__/headers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { Header } from '../headers';
+// import { QueryParam, setUrlParser, Url, UrlMatchPattern } from '../urls';
+
+describe('test Header object', () => {
+    it('test basic operations', () => {
+        // const header = new Header('Content-Type: application/json\nUser-Agent: MyClientLibrary/2.0\n');
+        const headerStr = 'Content-Type: application/json\nUser-Agent: MyClientLibrary/2.0\n';
+        const headerObjs = [
+            { key: 'Content-Type', value: 'application/json' },
+            { key: 'User-Agent', value: 'MyClientLibrary/2.0' },
+        ];
+
+        expect(Header.parse(headerStr)).toEqual(headerObjs);
+        expect(
+            Header.parse(Header.unparse(headerObjs))
+        ).toEqual(headerObjs);
+    });
+});

--- a/packages/insomnia/src/sdk/objects/headers.ts
+++ b/packages/insomnia/src/sdk/objects/headers.ts
@@ -1,0 +1,128 @@
+import { unsupportedError } from './insomnia';
+import { Property, PropertyList } from './properties';
+
+export interface HeaderDefinition {
+    key: string;
+    value: string;
+    id?: string;
+    name?: string;
+    type?: string;
+    disabled?: boolean;
+}
+
+export class Header extends Property {
+    _kind: string = 'Header';
+    type: string = '';
+    key: string;
+    value: string;
+
+    constructor(
+        opts: HeaderDefinition | string,
+        name?: string, // if it is defined, it overrides 'key' (not 'name')
+    ) {
+        super();
+
+        if (typeof opts === 'string') {
+            const obj = Header.parseSingle(opts);
+            this.key = obj.key;
+            this.value = obj.value;
+        } else {
+            this.id = opts.id ? opts.id : '';
+            this.key = opts.key ? opts.key : '';
+            this.name = name ? name : (opts.name ? opts.name : '');
+            this.value = opts.value ? opts.value : '';
+            this.type = opts.type ? opts.type : '';
+            this.disabled = opts ? opts.disabled : false;
+        }
+    }
+
+    static create(input?: { key: string; value: string } | string, name?: string): Header {
+        return new Header(input || { key: '', value: '' }, name);
+    }
+
+    static isHeader(obj: object) {
+        return '_kind' in obj && obj._kind === 'Header';
+    }
+
+    // example: 'Content-Type: application/json\nUser-Agent: MyClientLibrary/2.0\n'
+    static parse(headerString: string): { key: string; value: string }[] {
+        return headerString
+            .split('\n')
+            .filter(kvPart => kvPart.trim() !== '')
+            .map(kvPart => Header.parseSingle(kvPart));
+    }
+
+    static parseSingle(headerStr: string): { key: string; value: string } {
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
+        // the first colon is the separator
+        const separatorPos = headerStr.indexOf(':');
+
+        if (separatorPos <= 0) {
+            throw Error('Header.parseSingle: the header string seems invalid');
+        }
+
+        const key = headerStr.slice(0, separatorPos);
+        const value = headerStr.slice(separatorPos + 1);
+
+        return { key: key.trim(), value: value.trim() };
+    }
+
+    static unparse(headers: { key: string; value: string }[] | PropertyList<Header>, separator?: string): string {
+        const headerArray: { key: string; value: string }[] = [
+            ...headers.map(
+                header => this.unparseSingle(header), {}
+            ),
+        ];
+
+        return headerArray.join(separator || '\n');
+    }
+
+    static unparseSingle(header: { key: string; value: string } | Header): string {
+        // both PropertyList and object contains 'key' and 'value'
+        return `${header.key}: ${header.value}`;
+    }
+
+    update(newHeader: { key: string; value: string }) {
+        this.key = newHeader.key;
+        this.value = newHeader.value;
+    }
+
+    valueOf() {
+        return this.value;
+    }
+}
+
+export class HeaderList<T extends Header> extends PropertyList<T> {
+    constructor(
+        parent: PropertyList<T> | undefined,
+        populate: T[]
+    ) {
+        super(
+            Header,
+            undefined,
+            populate
+        );
+        this.parent = parent;
+    }
+
+    static isHeaderList(obj: any) {
+        return '_kind' in obj && obj._kind === 'HeaderList';
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    eachParent(_iterator: any, _context?: object | undefined) {
+        throw unsupportedError('eachParent');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    toObject(_excludeDisabled?: boolean, _caseSensitive?: boolean, _multiValue?: boolean, _sanitizeKeys?: boolean) {
+        throw unsupportedError('toObject');
+    }
+
+    contentSize(): number {
+        return this.list
+            .map(header => header.toString())
+            .map(headerStr => headerStr.length) // TODO: handle special characters
+            .reduce((totalSize, headerSize) => totalSize + headerSize, 0);
+    }
+}

--- a/packages/insomnia/src/sdk/objects/index.ts
+++ b/packages/insomnia/src/sdk/objects/index.ts
@@ -1,1 +1,2 @@
 export { PropertyBase, Property, PropertyList } from './properties';
+export { Header, HeaderList } from './headers';

--- a/packages/insomnia/src/sdk/objects/properties.ts
+++ b/packages/insomnia/src/sdk/objects/properties.ts
@@ -184,8 +184,8 @@ export class PropertyList<T extends Property> {
     protected list: T[] = [];
 
     constructor(
-        protected readonly _typeClass: {}, // TODO: it is not used before collection is introduced
-        protected readonly parent: Property | PropertyList<any> | undefined,
+        protected _typeClass: {}, // TODO: it is not used before collection is introduced
+        protected parent: Property | PropertyList<any> | undefined,
         populate: T[],
     ) {
         this.parent = parent;


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Changes:
- [x] enabled headers in pre-request scripting
- [x] added unit tests and smoke test


### How to test:

Please run this script and check its output.
```
const { Header, HeaderList } = require('insomnia-collection');

const h1 = new Header({key: "X-Header-1", value: "1"});
const h2 = new Header({key: "X-Header-2", value: "2"});

const headerList = new HeaderList(Header, [h1]);
headerList.add(h2)

console.log(h1.toString());
console.log(headerList.all());

```