### PR TITLE
feat: enable RequestAuth in pre-request scripting [INS-3379] 

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
@@ -72,12 +72,17 @@ test.describe('pre-request UI tests', async () => {
         {
             name: 'require / require classes from insomnia-collection module',
             preReqScript: `
-            const { Property } = require('insomnia-collection');
+            const { Property, Header, Variable } = require('insomnia-collection');
             const prop = new Property('pid', 'pname');
+            const header = new Header({ key: 'headerKey', value: 'headerValue' });
+            const variable = new Variable({ key: 'headerKey', value: 'headerValue' });
+            // set part of values
             insomnia.environment.set('propJson', JSON.stringify(prop.toJSON()));
+            insomnia.environment.set('headerJson', JSON.stringify(header.toJSON()));
             `,
             body: `{
-                "propJson": {{ _.propJson }}
+                "propJson": {{ _.propJson }},
+                "headerJson": {{ _.headerJson }}
             }`,
             expectedBody: {
                 propJson: {
@@ -85,6 +90,14 @@ test.describe('pre-request UI tests', async () => {
                     'disabled': false,
                     'id': 'pid',
                     'name': 'pname',
+                },
+                headerJson: {
+                    '_kind': 'Header',
+                    'key': 'headerKey',
+                    'value': 'headerValue',
+                    'id': '',
+                    'name': '',
+                    'type': '',
                 },
             },
         },

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
@@ -72,10 +72,16 @@ test.describe('pre-request UI tests', async () => {
         {
             name: 'require / require classes from insomnia-collection module',
             preReqScript: `
-            const { Property, Header, Variable } = require('insomnia-collection');
+            const { Property, Header, Variable, QueryParam, Url } = require('insomnia-collection');
             const prop = new Property('pid', 'pname');
             const header = new Header({ key: 'headerKey', value: 'headerValue' });
             const variable = new Variable({ key: 'headerKey', value: 'headerValue' });
+            const qParam = new QueryParam({ key: 'queryKey', value: 'queryValue' });
+            const url = new Url({
+                host: ['insomnia', 'rest'],
+                path: ['path1', 'path2'],
+                protocol: 'https',
+            });
             // set part of values
             insomnia.environment.set('propJson', JSON.stringify(prop.toJSON()));
             insomnia.environment.set('headerJson', JSON.stringify(header.toJSON()));

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
@@ -72,7 +72,7 @@ test.describe('pre-request UI tests', async () => {
         {
             name: 'require / require classes from insomnia-collection module',
             preReqScript: `
-            const { Property, Header, Variable, QueryParam, Url } = require('insomnia-collection');
+            const { Property, Header, Variable, QueryParam, Url, ProxyConfig } = require('insomnia-collection');
             const prop = new Property('pid', 'pname');
             const header = new Header({ key: 'headerKey', value: 'headerValue' });
             const variable = new Variable({ key: 'headerKey', value: 'headerValue' });
@@ -81,6 +81,16 @@ test.describe('pre-request UI tests', async () => {
                 host: ['insomnia', 'rest'],
                 path: ['path1', 'path2'],
                 protocol: 'https',
+            });
+            const proxyConfig = new ProxyConfig({
+                match: 'http+https://*.example.com:80/*',
+                host: 'proxy.com',
+                port: 8080,
+                tunnel: true,
+                disabled: false,
+                authenticate: true,
+                username: 'proxy_username',
+                password: 'proxy_password',
             });
             // set part of values
             insomnia.environment.set('propJson', JSON.stringify(prop.toJSON()));

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-ui.test.ts
@@ -72,7 +72,7 @@ test.describe('pre-request UI tests', async () => {
         {
             name: 'require / require classes from insomnia-collection module',
             preReqScript: `
-            const { Property, Header, Variable, QueryParam, Url, ProxyConfig } = require('insomnia-collection');
+            const { Property, Header, Variable, QueryParam, Url, RequestAuth, ProxyConfig } = require('insomnia-collection');
             const prop = new Property('pid', 'pname');
             const header = new Header({ key: 'headerKey', value: 'headerValue' });
             const variable = new Variable({ key: 'headerKey', value: 'headerValue' });
@@ -91,6 +91,13 @@ test.describe('pre-request UI tests', async () => {
                 authenticate: true,
                 username: 'proxy_username',
                 password: 'proxy_password',
+            });
+            const reqAuth = new RequestAuth({
+                type: 'basic',
+                basic: [
+                    { key: 'username', value: 'user1' },
+                    { key: 'password', value: 'pwd1' },
+                ],
             });
             // set part of values
             insomnia.environment.set('propJson', JSON.stringify(prop.toJSON()));

--- a/packages/insomnia/src/sdk/objects/__tests__/auth.test.ts
+++ b/packages/insomnia/src/sdk/objects/__tests__/auth.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { RequestAuth } from '../auth';
+import { Variable, VariableList } from '../variables';
+
+const varListToObject = (obj: VariableList<Variable> | undefined) => {
+    if (!obj) {
+        return undefined;
+    }
+
+    return obj.map(
+        (optVar: Variable) => ({
+            // type: 'any', // TODO: fix type
+            key: optVar.key,
+            value: optVar.value,
+        }),
+        {}
+    );
+};
+
+describe('test sdk objects', () => {
+    it('test RequestAuth methods', () => {
+        expect(RequestAuth.isValidType('noauth')).toBeTruthy();
+
+        const basicAuthOptions = {
+            type: 'basic',
+            basic: [
+                { key: 'username', value: 'user1' },
+                { key: 'password', value: 'pwd1' },
+            ],
+        };
+
+        const authObj = new RequestAuth(basicAuthOptions);
+
+        const basicAuthOptsFromAuth = varListToObject(authObj.parameters());
+        expect(basicAuthOptsFromAuth).toEqual(basicAuthOptions.basic);
+
+        const basicAuthOptions2 = {
+            type: 'basic',
+            basic: [
+                { key: 'username', value: 'user2' },
+                { key: 'password', value: 'pwd2' },
+            ],
+        };
+        const bearerAuthOptions = {
+            type: 'bearer',
+            bearer: [
+                { key: 'token', value: 'mytoken' },
+            ],
+        };
+
+        authObj.update(basicAuthOptions2);
+        const basicAuthOpt2FromAuth = varListToObject(authObj.parameters());
+        expect(basicAuthOpt2FromAuth).toEqual(basicAuthOptions2.basic);
+
+        authObj.use('bearer', bearerAuthOptions);
+        const beareerAuthOptFromAuth = varListToObject(authObj.parameters());
+        expect(beareerAuthOptFromAuth).toEqual(bearerAuthOptions.bearer);
+
+        authObj.clear('bearer');
+        expect(authObj.parameters()).toBeUndefined();
+    });
+});

--- a/packages/insomnia/src/sdk/objects/__tests__/headers.test.ts
+++ b/packages/insomnia/src/sdk/objects/__tests__/headers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { Header } from '../headers';
+// import { QueryParam, setUrlParser, Url, UrlMatchPattern } from '../urls';
+
+describe('test Header object', () => {
+    it('test basic operations', () => {
+        // const header = new Header('Content-Type: application/json\nUser-Agent: MyClientLibrary/2.0\n');
+        const headerStr = 'Content-Type: application/json\nUser-Agent: MyClientLibrary/2.0\n';
+        const headerObjs = [
+            { key: 'Content-Type', value: 'application/json' },
+            { key: 'User-Agent', value: 'MyClientLibrary/2.0' },
+        ];
+
+        expect(Header.parse(headerStr)).toEqual(headerObjs);
+        expect(
+            Header.parse(Header.unparse(headerObjs))
+        ).toEqual(headerObjs);
+    });
+});

--- a/packages/insomnia/src/sdk/objects/__tests__/proxy-configs.test.ts
+++ b/packages/insomnia/src/sdk/objects/__tests__/proxy-configs.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { ProxyConfig, ProxyConfigList } from '../proxy-configs';
+import { Url } from '../urls';
+
+describe('test ProxyConfig object', () => {
+    it('test basic operations', () => {
+
+        const proxyConfig = new ProxyConfig({
+            match: 'http+https://*.example.com:80/*',
+            host: 'proxy.com',
+            port: 8080,
+            tunnel: true,
+            disabled: false,
+            authenticate: true,
+            username: 'proxy_username',
+            password: 'proxy_password',
+        });
+
+        expect(
+            proxyConfig.getProtocols()
+        ).toEqual(
+            ['http', 'https']
+        );
+
+        proxyConfig.updateProtocols(['http']);
+        expect(
+            proxyConfig.getProtocols()
+        ).toEqual(
+            ['http']
+        );
+
+        expect(proxyConfig.getProxyUrl()).toEqual(
+            'http://proxy_username:proxy_password@proxy.com:8080'
+        );
+
+        expect(
+            proxyConfig.test('http://a.example.com:80/a')
+        ).toBeTruthy();
+
+        const configList = new ProxyConfigList<ProxyConfig>(undefined, []);
+        configList.add(proxyConfig);
+        configList.add(new ProxyConfig({
+            match: 'https://*.example.com:80/*',
+            host: 'proxy.com',
+            port: 8080,
+            tunnel: true,
+            disabled: false,
+            authenticate: true,
+            username: 'proxy_username',
+            password: 'proxy_password',
+        }));
+
+        const matchedProxyConfigDef = configList.resolve(new Url('http://sub.example.com:80/path'));
+        expect(matchedProxyConfigDef?.host).toEqual('proxy.com');
+    });
+});

--- a/packages/insomnia/src/sdk/objects/__tests__/urls.test.ts
+++ b/packages/insomnia/src/sdk/objects/__tests__/urls.test.ts
@@ -1,0 +1,171 @@
+import url from 'node:url';
+
+import { describe, expect, it } from '@jest/globals';
+
+import { QueryParam, setUrlParser, Url, UrlMatchPattern } from '../urls';
+import { Variable } from '../variables';
+
+describe('test Url object', () => {
+    setUrlParser(url.URL);
+
+    it('test QueryParam', () => {
+        const queryParam = new QueryParam({
+            key: 'uname',
+            value: 'patrick star',
+        });
+
+        expect(queryParam.toString()).toEqual('uname=patrick+star');
+
+        queryParam.update('uname=peter+parker');
+        expect(queryParam.toString()).toEqual('uname=peter+parker');
+
+        expect(
+            QueryParam.unparseSingle({ key: 'uname', value: 'patrick star' })
+        ).toEqual('uname=patrick+star');
+
+        expect(
+            QueryParam.unparse({ uname: 'patrick star', password: '123' })
+        ).toEqual('uname=patrick+star&password=123');
+
+        expect(
+            QueryParam.parseSingle('uname=patrick+star')
+        ).toEqual({ key: 'uname', value: 'patrick star' });
+
+        expect(
+            QueryParam.parse('uname=patrick+star&password=123')
+        ).toEqual([{ 'key': 'uname', 'value': 'patrick star' }, { 'key': 'password', 'value': '123' }]);
+    });
+
+    it('test Url methods', () => {
+        const url = new Url({
+            auth: {
+                username: 'usernameValue',
+                password: 'passwordValue',
+            },
+            hash: 'hashValue',
+            host: ['hostValue', 'com'],
+            path: ['pathLevel1', 'pathLevel2'],
+            port: '777',
+            protocol: 'https:',
+            query: [
+                new QueryParam({ key: 'key1', value: 'value1' }),
+                new QueryParam({ key: 'key2', value: 'value2' }),
+            ],
+            variables: [
+                new Variable({ key: 'varKey', value: 'varValue' }),
+            ],
+        });
+
+        expect(url.getHost()).toEqual('hostvalue.com');
+        expect(url.getPath()).toEqual('/pathLevel1/pathLevel2');
+        expect(url.getQueryString()).toEqual('key1=value1&key2=value2');
+        expect(url.getPathWithQuery()).toEqual('/pathLevel1/pathLevel2?key1=value1&key2=value2');
+        expect(url.getRemote(true)).toEqual('hostvalue.com:777');
+        expect(url.getRemote(false)).toEqual('hostvalue.com:777'); // TODO: add more cases
+
+        url.removeQueryParams([
+            new QueryParam({ key: 'key1', value: 'value1' }),
+        ]);
+        expect(url.getQueryString()).toEqual('key2=value2');
+        expect(url.toString()).toEqual('https://usernameValue:passwordValue@hostvalue.com:777/pathLevel1/pathLevel2?key2=value2#hashValue');
+    });
+
+    it('test Url static methods', () => {
+        // static methods
+        const urlStr = 'https://myhost.com/path1/path2';
+        const urlOptions = Url.parse(urlStr);
+        const urlObj = new Url(urlOptions || '');
+
+        expect(urlObj.toString()).toEqual(urlStr);
+    });
+});
+
+describe('test Url Match Pattern', () => {
+    it('test UrlMatchPattern', () => {
+        const pattern = 'http+https+custom://*.insomnia.com:80/p1/*';
+        const matchPattern = new UrlMatchPattern(pattern);
+
+        expect(matchPattern.getProtocols()).toEqual(['http', 'https', 'custom']);
+        expect(matchPattern.testProtocol('http')).toBeTruthy();
+        expect(matchPattern.testProtocol('https')).toBeTruthy();
+        expect(matchPattern.testProtocol('custom')).toBeTruthy();
+        expect(matchPattern.testProtocol('unmatched')).toBeFalsy();
+
+        expect(matchPattern.testHost('download.insomnia.com')).toBeTruthy();
+        expect(matchPattern.testHost('bin.download.insomnia.com')).toBeFalsy();
+        expect(matchPattern.testHost('insomnia.com')).toBeFalsy();
+        expect(matchPattern.testHost('com')).toBeFalsy();
+
+        expect(matchPattern.testPath('/p1/abc')).toBeTruthy();
+        expect(matchPattern.testPath('/p1/')).toBeTruthy();
+        expect(matchPattern.testPath('/p1')).toBeFalsy();
+        expect(matchPattern.testPath('/')).toBeFalsy();
+        expect(matchPattern.testPath('')).toBeFalsy();
+
+        expect(matchPattern.testPort('80', 'https')).toBeTruthy();
+        expect(matchPattern.testPort('443', 'https')).toBeFalsy();
+        expect(matchPattern.testPort('80', 'http')).toBeTruthy();
+        expect(matchPattern.testPort('80', 'unmatched')).toBeFalsy();
+    });
+
+    it('test UrlMatchPattern with no protocol', () => {
+        const pattern = '*.insomnia.com/p1/*';
+        try {
+            const matchPattern = new UrlMatchPattern(pattern);
+            matchPattern.testProtocol('http');
+        } catch (e) {
+            expect(e.message).toContain('UrlMatchPattern: protocol is not specified');
+        }
+    });
+
+    it('test UrlMatchPattern with no port', () => {
+        const pattern = 'http+https+custom://*.insomnia.com/p1/*';
+        const matchPattern = new UrlMatchPattern(pattern);
+
+        expect(matchPattern.getProtocols()).toEqual(['http', 'https', 'custom']);
+        expect(matchPattern.testProtocol('http')).toBeTruthy();
+        expect(matchPattern.testProtocol('https')).toBeTruthy();
+        expect(matchPattern.testProtocol('custom')).toBeTruthy();
+        expect(matchPattern.testProtocol('unmatched')).toBeFalsy();
+
+        expect(matchPattern.testHost('download.insomnia.com')).toBeTruthy();
+        expect(matchPattern.testHost('bin.download.insomnia.com')).toBeFalsy();
+        expect(matchPattern.testHost('insomnia.com')).toBeFalsy();
+        expect(matchPattern.testHost('com')).toBeFalsy();
+
+        expect(matchPattern.testPath('/p1/abc')).toBeTruthy();
+        expect(matchPattern.testPath('/p1/')).toBeTruthy();
+        expect(matchPattern.testPath('/p1')).toBeFalsy();
+        expect(matchPattern.testPath('/')).toBeFalsy();
+        expect(matchPattern.testPath('')).toBeFalsy();
+
+        expect(matchPattern.testPort('443', 'https')).toBeTruthy();
+        expect(matchPattern.testPort('80', 'http')).toBeTruthy();
+        expect(matchPattern.testPort('443', 'http')).toBeFalsy();
+        expect(matchPattern.testPort('80', 'https')).toBeFalsy();
+    });
+
+    it('test UrlMatchPattern with no path', () => {
+        const pattern = 'http+https+custom://*.insomnia.com';
+        const matchPattern = new UrlMatchPattern(pattern);
+
+        expect(matchPattern.getProtocols()).toEqual(['http', 'https', 'custom']);
+        expect(matchPattern.testProtocol('http')).toBeTruthy();
+        expect(matchPattern.testProtocol('https')).toBeTruthy();
+        expect(matchPattern.testProtocol('custom')).toBeTruthy();
+        expect(matchPattern.testProtocol('unmatched')).toBeFalsy();
+
+        expect(matchPattern.testHost('download.insomnia.com')).toBeTruthy();
+        expect(matchPattern.testHost('bin.download.insomnia.com')).toBeFalsy();
+        expect(matchPattern.testHost('insomnia.com')).toBeFalsy();
+        expect(matchPattern.testHost('com')).toBeFalsy();
+
+        expect(matchPattern.testPath('')).toBeTruthy();
+        expect(matchPattern.testPath('/')).toBeFalsy(); // it is not handled temporarily
+
+        expect(matchPattern.testPort('443', 'https')).toBeTruthy();
+        expect(matchPattern.testPort('80', 'http')).toBeTruthy();
+        expect(matchPattern.testPort('443', 'http')).toBeFalsy();
+        expect(matchPattern.testPort('80', 'https')).toBeFalsy();
+    });
+});

--- a/packages/insomnia/src/sdk/objects/__tests__/urls.test.ts
+++ b/packages/insomnia/src/sdk/objects/__tests__/urls.test.ts
@@ -68,6 +68,20 @@ describe('test Url object', () => {
         ]);
         expect(url.getQueryString()).toEqual('key2=value2');
         expect(url.toString()).toEqual('https://usernameValue:passwordValue@hostvalue.com:777/pathLevel1/pathLevel2?key2=value2#hashValue');
+
+        const url2 = new Url('https://usernameValue:passwordValue@hostvalue.com:777/pathLevel1/pathLevel2?key1=value1&key2=value2#hashValue');
+        expect(url2.getHost()).toEqual('hostvalue.com');
+        expect(url2.getPath()).toEqual('/pathLevel1/pathLevel2');
+        expect(url2.getQueryString()).toEqual('key1=value1&key2=value2');
+        expect(url2.getPathWithQuery()).toEqual('/pathLevel1/pathLevel2?key1=value1&key2=value2');
+        expect(url2.getRemote(true)).toEqual('hostvalue.com:777');
+        expect(url2.getRemote(false)).toEqual('hostvalue.com:777'); // TODO: add more cases
+
+        url2.removeQueryParams([
+            new QueryParam({ key: 'key1', value: 'value1' }),
+        ]);
+        expect(url2.getQueryString()).toEqual('key2=value2');
+        expect(url2.toString()).toEqual('https://usernameValue:passwordValue@hostvalue.com:777/pathLevel1/pathLevel2?key2=value2#hashValue');
     });
 
     it('test Url static methods', () => {

--- a/packages/insomnia/src/sdk/objects/__tests__/variables.test.ts
+++ b/packages/insomnia/src/sdk/objects/__tests__/variables.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { Variable } from '../variables';
+
+describe('test Variables object', () => {
+    it('test basic operations', () => {
+
+        const variable = new Variable({
+            id: 'id',
+            key: 'key',
+            name: 'name',
+            value: 'value',
+            type: 'type',
+            disabled: false,
+        });
+
+        expect(variable.get()).toBe('value');
+        variable.set('value2');
+        expect(variable.get()).toBe('value2');
+
+    });
+});

--- a/packages/insomnia/src/sdk/objects/auth.ts
+++ b/packages/insomnia/src/sdk/objects/auth.ts
@@ -1,0 +1,345 @@
+import { Property } from './properties';
+import { Variable, VariableList } from './variables';
+
+export const AuthTypes = new Set([
+    'noauth',
+    'basic',
+    'bearer',
+    'jwt',
+    'digest',
+    'oauth1',
+    'oauth2',
+    'hawk',
+    'awsv4',
+    'ntlm',
+    'apikey',
+    'edgegrid',
+    'asap',
+]);
+
+export interface AuthOption {
+    key: string;
+    value: string;
+    type?: string;
+}
+
+export interface BasicOptions {
+    password: string;
+    username: string;
+    id: string;
+}
+
+export interface BearerOptions {
+    token: string;
+    id: string;
+}
+
+export interface JWTOptions {
+    secret: string;
+    algorithm: string;
+    isSecretBase64Encoded: boolean;
+    payload: string; // e.g. "{}"
+    addTokenTo: string;
+    headerPrefix: string;
+    queryParamKey: string;
+    header: string; // e.g. "{}"
+    id: string;
+}
+
+export interface DigestOptions {
+    opaque: string;
+    clientNonce: string;
+    nonceCount: string;
+    qop: string;
+    nonce: string;
+    realm: string;
+    password: string;
+    username: string;
+    algorithm: string;
+    id: string;
+}
+
+export interface OAuth1Options {
+    addEmptyParamsToSign: boolean;
+    includeBodyHash: boolean;
+    realm: string;
+    nonce: string;
+    timestamp: string;
+    verifier: string;
+    callback: string;
+    tokenSecret: string;
+    token: string;
+    consumerSecret: string;
+    consumerKey: string;
+    signatureMethod: string; // "HMAC-SHA1"
+    version: string;
+    addParamsToHeader: string;
+    id: string;
+}
+
+export interface OAuth2Param {
+    key: string;
+    value: string;
+    enabled: boolean;
+    send_as: string; // it follows exising naming
+}
+
+export interface OAuth2Options {
+    accessToken: string;
+    refreshRequestParams: OAuth2Param[];
+    tokenRequestParams: OAuth2Param[];
+    authRequestParams: OAuth2Param[];
+    refreshTokenUrl: string;
+    state: string;
+    scope: string;
+    clientSecret: string;
+    clientId: string;
+    tokenName: string;
+    addTokenTo: string;
+    id: string;
+}
+
+export interface HAWKOptions {
+    includePayloadHash: boolean;
+    timestamp: string;
+    delegation: string;
+    app: string;
+    extraData: string;
+    nonce: string;
+    user: string;
+    authKey: string;
+    authId: string;
+    algorithm: string;
+    id: string;
+}
+
+export interface AWSV4Options {
+    sessionToken: string;
+    service: string;
+    region: string;
+    secretKey: string;
+    accessKey: string;
+    id: string;
+}
+
+export interface NTLMOptions {
+    workstation: string;
+    domain: string;
+    password: string;
+    username: string;
+    id: string;
+}
+
+export interface APIKeyOptions {
+    key: string;
+    value: string;
+    id: string;
+}
+
+export interface EdgegridOptions {
+    headersToSign: string;
+    baseURL: string;
+    timestamp: string;
+    nonce: string;
+    clientSecret: string;
+    clientToken: string;
+    accessToken: string;
+    id: string;
+}
+
+export interface ASAPOptions {
+    exp: string; // expiry
+    claims: string; // e.g., { "additional claim": "claim value" }
+    sub: string; // subject
+    privateKey: string; // private key
+    kid: string; // key id
+    aud: string; // audience
+    iss: string; // issuer
+    alg: string; // e.g., RS256
+    id: string;
+}
+
+export function authOptionsToParams(
+    authMethod: BasicOptions | BearerOptions | JWTOptions | DigestOptions | OAuth1Options | OAuth2Options | HAWKOptions | AWSV4Options | NTLMOptions | APIKeyOptions | EdgegridOptions | ASAPOptions
+) {
+    return Object.entries(authMethod).
+        map(entry => ({
+            type: 'any',
+            key: entry[0],
+            value: entry[1],
+        }));
+}
+
+export interface AuthOptions {
+    type: string;
+    basic?: AuthOption[];
+    bearer?: AuthOption[];
+    jwt?: AuthOption[];
+    digest?: AuthOption[];
+    oauth1?: AuthOption[];
+    oauth2?: AuthOption[];
+    hawk?: AuthOption[];
+    awsv4?: AuthOption[];
+    ntlm?: AuthOption[];
+    apikey?: AuthOption[];
+    edgegrid?: AuthOption[];
+    asap?: AuthOption[];
+}
+
+function rawOptionsToVariables(options: VariableList<Variable> | Variable[] | AuthOptions, targetType?: string): VariableList<Variable>[] {
+    if (VariableList.isVariableList(options)) {
+        return [options as VariableList<Variable>];
+    } else if ('type' in options) {
+        // options is AuthOptions
+        const optsObj = options as AuthOptions;
+        const optsVarLists = Object.entries(optsObj)
+            .filter(optsObjEntry => {
+                return optsObjEntry[0] === targetType;
+            })
+            .map(optsEntry => {
+                const optVars = optsEntry[1].map((opt: AuthOption) => {
+                    return new Variable({
+                        key: opt.key,
+                        value: opt.value,
+                    });
+                });
+                return new VariableList(undefined, optVars);
+            });
+
+        return optsVarLists;
+    } else if ('length' in options) { // array
+        return [new VariableList(undefined, options)];
+    }
+
+    throw Error('options is not valid: it must be VariableList<Variable> | Variable[] | object');
+}
+
+export class RequestAuth extends Property {
+    private type: string;
+    private authOptions: Map<string, VariableList<Variable>> = new Map();
+
+    constructor(options: AuthOptions, parent?: Property) {
+        super();
+
+        if (!RequestAuth.isValidType(options.type)) {
+            throw Error(`invalid auth type ${options.type}`);
+        }
+
+        this.type = options.type;
+        const optsObj = options as AuthOptions;
+        const optsEntries = Object.entries(optsObj)
+            .filter(optsObjEntry => optsObjEntry[0] !== 'type');
+
+        optsEntries.map((optsEntry: [string, AuthOption[]]) => {
+            const optVars = optsEntry[1]
+                .map(opt => {
+                    return new Variable({
+                        key: opt.key,
+                        value: opt.value,
+                        type: opt.type,
+                    });
+                });
+
+            return {
+                type: optsEntry[0],
+                options: new VariableList(undefined, optVars),
+            };
+        })
+            .forEach(authOpts => {
+                this.authOptions.set(authOpts.type, authOpts.options);
+            });
+
+        this._parent = parent;
+    }
+
+    static isValidType(authType: string) {
+        return AuthTypes.has(authType);
+    }
+
+    clear(type: string) {
+        if (RequestAuth.isValidType(type)) {
+            this.authOptions.delete(type);
+        }
+    }
+
+    parameters(): VariableList<Variable> | undefined {
+        return this.authOptions.get(this.type);
+    }
+
+    toJSON() {
+        const obj: AuthOptions = { type: this.type };
+        const authOption = this.authOptions.get(this.type);
+        if (!authOption) {
+            return obj;
+        }
+
+        const authOptionJSON = authOption.map(optValue => optValue.toJSON(), {});
+
+        switch (this.type) {
+            case 'basic':
+                obj.basic = authOptionJSON;
+                break;
+            case 'bearer':
+                obj.bearer = authOptionJSON;
+                break;
+            case 'jwt':
+                obj.jwt = authOptionJSON;
+                break;
+            case 'digest':
+                obj.digest = authOptionJSON;
+                break;
+            case 'oauth1':
+                obj.oauth1 = authOptionJSON;
+                break;
+            case 'oauth2':
+                obj.oauth2 = authOptionJSON;
+                break;
+            case 'hawk':
+                obj.hawk = authOptionJSON;
+                break;
+            case 'awsv4':
+                obj.awsv4 = authOptionJSON;
+                break;
+            case 'ntlm':
+                obj.ntlm = authOptionJSON;
+                break;
+            case 'apikey':
+                obj.apikey = authOptionJSON;
+                break;
+            case 'edgegrid':
+                obj.edgegrid = authOptionJSON;
+                break;
+            case 'asap':
+                obj.asap = authOptionJSON;
+                break;
+            default: // noauth, no op
+        }
+
+        return obj;
+    }
+
+    update(options: VariableList<Variable> | Variable[] | AuthOptions, type?: string) {
+        const currentType = type ? type : this.type;
+        const authOpts = rawOptionsToVariables(options, currentType);
+
+        if (authOpts.length > 0) {
+            this.authOptions.set(currentType, authOpts[0]);
+        } else {
+            throw Error('no valid RequestAuth options is found');
+        }
+    }
+
+    use(type: string, options: VariableList<Variable> | Variable[] | AuthOptions) {
+        if (!RequestAuth.isValidType(type)) {
+            throw Error(`invalid type (${type}), it must be noauth | basic | bearer | jwt | digest | oauth1 | oauth2 | hawk | awsv4 | ntlm | apikey | edgegrid | asap.`);
+        }
+
+        const authOpts = rawOptionsToVariables(options, type);
+        if (authOpts.length > 0) {
+            this.type = type;
+            this.authOptions.set(type, authOpts[0]);
+        } else {
+            throw Error('no valid RequestAuth options is found');
+        }
+    }
+}

--- a/packages/insomnia/src/sdk/objects/headers.ts
+++ b/packages/insomnia/src/sdk/objects/headers.ts
@@ -1,0 +1,128 @@
+import { unsupportedError } from './insomnia';
+import { Property, PropertyList } from './properties';
+
+export interface HeaderDefinition {
+    key: string;
+    value: string;
+    id?: string;
+    name?: string;
+    type?: string;
+    disabled?: boolean;
+}
+
+export class Header extends Property {
+    _kind: string = 'Header';
+    type: string = '';
+    key: string;
+    value: string;
+
+    constructor(
+        opts: HeaderDefinition | string,
+        name?: string, // if it is defined, it overrides 'key' (not 'name')
+    ) {
+        super();
+
+        if (typeof opts === 'string') {
+            const obj = Header.parseSingle(opts);
+            this.key = obj.key;
+            this.value = obj.value;
+        } else {
+            this.id = opts.id ? opts.id : '';
+            this.key = opts.key ? opts.key : '';
+            this.name = name ? name : (opts.name ? opts.name : '');
+            this.value = opts.value ? opts.value : '';
+            this.type = opts.type ? opts.type : '';
+            this.disabled = opts ? opts.disabled : false;
+        }
+    }
+
+    static create(input?: { key: string; value: string } | string, name?: string): Header {
+        return new Header(input || { key: '', value: '' }, name);
+    }
+
+    static isHeader(obj: object) {
+        return '_kind' in obj && obj._kind === 'Header';
+    }
+
+    // example: 'Content-Type: application/json\nUser-Agent: MyClientLibrary/2.0\n'
+    static parse(headerString: string): { key: string; value: string }[] {
+        return headerString
+            .split('\n')
+            .filter(kvPart => kvPart.trim() !== '')
+            .map(kvPart => Header.parseSingle(kvPart));
+    }
+
+    static parseSingle(headerStr: string): { key: string; value: string } {
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
+        // the first colon is the separator
+        const separatorPos = headerStr.indexOf(':');
+
+        if (separatorPos <= 0) {
+            throw Error('Header.parseSingle: the header string seems invalid');
+        }
+
+        const key = headerStr.slice(0, separatorPos);
+        const value = headerStr.slice(separatorPos + 1);
+
+        return { key: key.trim(), value: value.trim() };
+    }
+
+    static unparse(headers: { key: string; value: string }[] | PropertyList<Header>, separator?: string): string {
+        const headerArray: { key: string; value: string }[] = [
+            ...headers.map(
+                header => this.unparseSingle(header), {}
+            ),
+        ];
+
+        return headerArray.join(separator || '\n');
+    }
+
+    static unparseSingle(header: { key: string; value: string } | Header): string {
+        // both PropertyList and object contains 'key' and 'value'
+        return `${header.key}: ${header.value}`;
+    }
+
+    update(newHeader: { key: string; value: string }) {
+        this.key = newHeader.key;
+        this.value = newHeader.value;
+    }
+
+    valueOf() {
+        return this.value;
+    }
+}
+
+export class HeaderList<T extends Header> extends PropertyList<T> {
+    constructor(
+        parent: PropertyList<T> | undefined,
+        populate: T[]
+    ) {
+        super(
+            Header,
+            undefined,
+            populate
+        );
+        this.parent = parent;
+    }
+
+    static isHeaderList(obj: any) {
+        return '_kind' in obj && obj._kind === 'HeaderList';
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    eachParent(_iterator: any, _context?: object | undefined) {
+        throw unsupportedError('eachParent');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    toObject(_excludeDisabled?: boolean, _caseSensitive?: boolean, _multiValue?: boolean, _sanitizeKeys?: boolean) {
+        throw unsupportedError('toObject');
+    }
+
+    contentSize(): number {
+        return this.list
+            .map(header => header.toString())
+            .map(headerStr => headerStr.length) // TODO: handle special characters
+            .reduce((totalSize, headerSize) => totalSize + headerSize, 0);
+    }
+}

--- a/packages/insomnia/src/sdk/objects/index.ts
+++ b/packages/insomnia/src/sdk/objects/index.ts
@@ -1,1 +1,2 @@
 export { PropertyBase, Property, PropertyList } from './properties';
+export { Header, HeaderList } from './headers';

--- a/packages/insomnia/src/sdk/objects/index.ts
+++ b/packages/insomnia/src/sdk/objects/index.ts
@@ -2,3 +2,4 @@ export { PropertyBase, Property, PropertyList } from './properties';
 export { Header, HeaderList } from './headers';
 export { Variable, VariableList } from './variables';
 export { QueryParam, Url, UrlMatchPattern, UrlMatchPatternList } from './urls';
+export { ProxyConfig, ProxyConfigList } from './proxy-configs';

--- a/packages/insomnia/src/sdk/objects/index.ts
+++ b/packages/insomnia/src/sdk/objects/index.ts
@@ -1,3 +1,4 @@
 export { PropertyBase, Property, PropertyList } from './properties';
 export { Header, HeaderList } from './headers';
 export { Variable, VariableList } from './variables';
+export { QueryParam, Url, UrlMatchPattern, UrlMatchPatternList } from './urls';

--- a/packages/insomnia/src/sdk/objects/index.ts
+++ b/packages/insomnia/src/sdk/objects/index.ts
@@ -1,2 +1,3 @@
 export { PropertyBase, Property, PropertyList } from './properties';
 export { Header, HeaderList } from './headers';
+export { Variable, VariableList } from './variables';

--- a/packages/insomnia/src/sdk/objects/index.ts
+++ b/packages/insomnia/src/sdk/objects/index.ts
@@ -3,3 +3,4 @@ export { Header, HeaderList } from './headers';
 export { Variable, VariableList } from './variables';
 export { QueryParam, Url, UrlMatchPattern, UrlMatchPatternList } from './urls';
 export { ProxyConfig, ProxyConfigList } from './proxy-configs';
+export { RequestAuth } from './auth';

--- a/packages/insomnia/src/sdk/objects/properties.ts
+++ b/packages/insomnia/src/sdk/objects/properties.ts
@@ -184,8 +184,8 @@ export class PropertyList<T extends Property> {
     protected list: T[] = [];
 
     constructor(
-        protected readonly _typeClass: {}, // TODO: it is not used before collection is introduced
-        protected readonly parent: Property | PropertyList<any> | undefined,
+        protected _typeClass: {}, // TODO: it is not used before collection is introduced
+        protected parent: Property | PropertyList<any> | undefined,
         populate: T[],
     ) {
         this.parent = parent;

--- a/packages/insomnia/src/sdk/objects/proxy-configs.ts
+++ b/packages/insomnia/src/sdk/objects/proxy-configs.ts
@@ -1,0 +1,168 @@
+import { Property, PropertyList } from './properties';
+import { Url, UrlMatchPattern, UrlMatchPatternList } from './urls';
+
+export interface ProxyConfigOptions {
+    match: string;
+    host: string;
+    port: number;
+    tunnel: boolean;
+    disabled?: boolean;
+    authenticate: boolean;
+    username: string;
+    password: string;
+}
+
+export class ProxyConfig extends Property {
+    _kind: string = 'ProxyConfig';
+    type: string;
+
+    host: string;
+    match: string;
+    port: number;
+    tunnel: boolean;
+    authenticate: boolean;
+    username: string;
+    password: string;
+
+    static authenticate: boolean = false;
+    static bypass: UrlMatchPatternList<UrlMatchPattern> = new UrlMatchPatternList<UrlMatchPattern>(undefined, []);
+    static host: string = '';
+    static match: string = '';
+    static password: string = '';
+    static port: number = 0;
+    static tunnel: boolean = false; // unsupported
+    static username: string = '';
+
+    constructor(def: {
+        id?: string;
+        name?: string;
+        type?: string;
+
+        match: string;
+        host: string;
+        port: number;
+        tunnel: boolean;
+        disabled?: boolean;
+        authenticate: boolean;
+        username: string;
+        password: string;
+
+    }) {
+        super();
+
+        this.id = def.id ? def.id : '';
+        this.name = def.name ? def.name : '';
+        this.type = def.type ? def.type : '';
+        this.disabled = def.disabled ? def.disabled : false;
+
+        this.host = def.host;
+        this.match = def.match;
+        this.port = def.port;
+        this.tunnel = def.tunnel;
+        this.authenticate = def.authenticate;
+        this.username = def.username;
+        this.password = def.password;
+    }
+
+    static isProxyConfig(obj: object) {
+        return '_kind' in obj && obj._kind === 'ProxyConfig';
+    }
+
+    getProtocols(): string[] {
+        // match field example: 'http+https://example.com/*'
+        const urlMatch = new UrlMatchPattern(this.match);
+        return urlMatch.getProtocols();
+    }
+
+    getProxyUrl(): string {
+        const protos = this.getProtocols();
+        // TODO: how to pick up a protocol?
+        if (protos.length === 0) {
+            return '';
+        }
+
+        // http://proxy_username:proxy_password@proxy.com:8080
+        // TODO: check if port is not given
+        if (this.authenticate) {
+            return `${protos[0]}://${this.username}:${this.password}@${this.host}:${this.port}`;
+        }
+        return `${protos[0]}://${this.host}:${this.port}`;
+    }
+
+    test(url?: string) {
+        if (!url) {
+            // TODO: it is confusing in which case url arg is optional
+            return false;
+        }
+
+        const urlMatch = new UrlMatchPattern(this.match);
+        return urlMatch.test(url);
+    }
+
+    update(options: {
+        host: string;
+        match: string;
+        port: number;
+        tunnel: boolean;
+        authenticate: boolean;
+        username: string;
+        password: string;
+    }) {
+        this.host = options.host;
+        this.match = options.match;
+        this.port = options.port;
+        this.tunnel = options.tunnel;
+        this.authenticate = options.authenticate;
+        this.username = options.username;
+        this.password = options.password;
+    }
+
+    updateProtocols(protocols: string[]) {
+        const protoSeparator = this.match.indexOf('://');
+        if (protoSeparator <= 0 || protoSeparator >= this.match.length) {
+            throw Error('updateProtocols: invalid protocols, no protocol is detected');
+        }
+
+        this.match = protocols.join('+') + this.match.slice(protoSeparator);
+    }
+}
+
+// myProxyConfig = new ProxyConfigList({}, [
+//     {match: 'https://example.com/*', host: 'proxy.com', port: 8080, tunnel: true},
+//     {match: 'http+https://example2.com/*', host: 'proxy2.com'},
+// ]);
+
+export class ProxyConfigList<T extends ProxyConfig> extends PropertyList<T> {
+    constructor(parent: PropertyList<T> | undefined, populate: T[]) {
+        super(
+            ProxyConfig,
+            undefined,
+            populate
+        );
+        this.parent = parent;
+    }
+
+    static isProxyConfigList(obj: any) {
+        return '_kind' in obj && obj._kind === 'ProxyConfigList';
+    }
+
+    resolve(url?: Url) {
+        if (!url) {
+            return null;
+        }
+
+        const urlStr = url.toString();
+        const matches = this.list
+            .filter((proxyConfig: ProxyConfig) => {
+                return proxyConfig.test(urlStr);
+            })
+            .map(proxyConfig => proxyConfig.toJSON());
+
+        if (matches.length > 0) {
+            return matches[0];
+        }
+        return null;
+    }
+
+    // toObject(excludeDisabledopt, nullable, caseSensitiveopt, nullable, multiValueopt, nullable, sanitizeKeysopt) → {Object}
+}

--- a/packages/insomnia/src/sdk/objects/urls.ts
+++ b/packages/insomnia/src/sdk/objects/urls.ts
@@ -408,7 +408,6 @@ export class UrlMatchPattern extends Property {
 
     testHost(hostStr: string) {
         const patternSegments = this.getHost(this.pattern).split('.');
-        console.log(patternSegments);
 
         const inputHostSegments = hostStr.split('.');
 
@@ -468,12 +467,13 @@ export class UrlMatchPattern extends Property {
         const protocolEndPos = urlStr.indexOf('/') + 2;
         const hostBegPos = protocolEndPos;
 
-        const portBegPos = this.pattern.indexOf(':', protocolEndPos) + 1;
+        let portBegPos = urlStr.indexOf(':', protocolEndPos);
         if (portBegPos <= 0) {
             return '';
         }
+        portBegPos += 1; // the port is after ':'
 
-        let portEndPos = this.pattern.length;
+        let portEndPos = urlStr.length;
         const pathBegPos = urlStr.indexOf('/', hostBegPos);
         const queryBegPos = urlStr.indexOf('?');
         const hashBegPos = urlStr.indexOf('#');
@@ -497,13 +497,21 @@ export class UrlMatchPattern extends Property {
         const portPattern = this.getPort(this.pattern);
         if (portPattern === '*') {
             return true;
-        } else if (portPattern === '') {
+        } else if (portPattern === '' || port === '') {
             const protos = this.getProtocols();
 
-            if (protos.includes('https') && port === '443' && protocol === 'https') {
-                return true;
-            } else if (protos.includes('http') && port === '80' && protocol === 'http') {
-                return true;
+            if (protocol === 'https') {
+                return protos.includes('https') && (
+                    (port === '443' && portPattern === '') ||
+                    (port === '' && portPattern === '443') ||
+                    (port === '' && portPattern === '')
+                );
+            } else if (protocol === 'http') {
+                return protos.includes('http') && (
+                    (port === '80' && portPattern === '') ||
+                    (port === '' && portPattern === '80') ||
+                    (port === '' && portPattern === '')
+                );
             }
         }
 

--- a/packages/insomnia/src/sdk/objects/urls.ts
+++ b/packages/insomnia/src/sdk/objects/urls.ts
@@ -1,0 +1,555 @@
+import { Property, PropertyBase, PropertyList } from './properties';
+import { Variable, VariableList } from './variables';
+
+// TODO: make it also work with node.js
+let UrlParser = URL;
+let UrlSearchParams = URLSearchParams;
+export function setUrlParser(provider: any) {
+    UrlParser = provider;
+}
+export function setUrlSearchParams(provider: any) {
+    UrlSearchParams = provider;
+}
+
+export interface QueryParamOptions {
+    key: string;
+    value: string;
+}
+
+export class QueryParam extends Property {
+    _kind: string = 'QueryParam';
+
+    key: string;
+    value: string;
+
+    constructor(options: { key: string; value: string } | string) {
+        super();
+
+        if (typeof options === 'string') {
+            try {
+                const optionsObj = JSON.parse(options);
+                this.key = optionsObj.key;
+                this.value = optionsObj.value;
+            } catch (e) {
+                throw Error(`invalid QueryParam options ${e}`);
+            }
+        } else if (typeof options === 'object' && ('key' in options) && ('value' in options)) {
+            this.key = options.key;
+            this.value = options.value;
+        } else {
+            throw Error('unknown options for new QueryParam');
+        }
+    }
+
+    // TODO:
+    // (static) _postman_propertyAllowsMultipleValues :Boolean
+    // (static) _postman_propertyIndexKey :String
+
+    static parse(queryStr: string) {
+        const params = new UrlSearchParams(queryStr);
+        return Array.from(params.entries())
+            .map(entry => ({ key: entry[0], value: entry[1] }));
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    static parseSingle(paramStr: string, _idx?: number, _all?: string[]) {
+        const pairs = QueryParam.parse(paramStr);
+        if (pairs.length === 0) {
+            throw Error('invalid search query string');
+        }
+
+        return pairs[0];
+    }
+
+    static unparse(params: QueryParamOptions[] | Record<string, string>) {
+        const searchParams = new UrlSearchParams();
+
+        if (Array.isArray(params)) {
+            params.forEach((entry: QueryParamOptions) => searchParams.append(entry.key, entry.value));
+        } else {
+            Object.entries(params)
+                .forEach(entry => searchParams.append(entry[0], entry[1]));
+        }
+
+        return searchParams.toString();
+    }
+
+    static unparseSingle(obj: { key: string; value: string }) {
+        if ('key' in obj && 'value' in obj) {
+            const params = new UrlSearchParams();
+            params.append(obj.key, obj.value);
+
+            return params.toString();
+        }
+        return {};
+    }
+
+    toString() {
+        const params = new UrlSearchParams();
+        params.append(this.key, this.value);
+
+        return params.toString();
+    }
+
+    update(param: string | { key: string; value: string }) {
+        if (typeof param === 'string') {
+            const paramObj = QueryParam.parseSingle(param);
+            this.key = typeof paramObj.key === 'string' ? paramObj.key : '';
+            this.value = typeof paramObj.value === 'string' ? paramObj.value : '';
+        } else if ('key' in param && 'value' in param) {
+            this.key = param.key;
+            this.value = param.value;
+        } else {
+            throw Error('the param for update must be: string | { key: string; value: string }');
+        }
+    }
+}
+
+export interface UrlOptions {
+    auth?: {
+        username: string;
+        password: string;
+    };
+    hash?: string;
+    host: string[];
+    path?: string[];
+    port?: string;
+    protocol: string;
+    query: { key: string; value: string }[];
+    variables: { key: string; value: string }[];
+}
+
+export class Url extends PropertyBase {
+    _kind: string = 'Url';
+
+    // TODO: should be related to RequestAuth
+    // but the implementation seems only supports username + password
+    auth?: { username: string; password: string };
+    hash?: string;
+    host: string[] = [];
+    path?: string[] = [];
+    port?: string;
+    protocol?: string;
+    query: PropertyList<QueryParam> = new PropertyList<QueryParam>(QueryParam, undefined, []);
+    variables: VariableList<Variable> = new VariableList<Variable>(undefined, []);
+
+    constructor(
+        def: UrlOptions | string
+    ) {
+        super();
+        this.setFields(def);
+    }
+
+    private setFields(def: UrlOptions | string) {
+        const urlObj = typeof def === 'string' ? Url.parse(def) : def;
+
+        if (urlObj) {
+            this.auth = urlObj.auth;
+            this.hash = urlObj.hash;
+            this.host = urlObj.host;
+            this.path = urlObj.path;
+            this.port = urlObj.port;
+            this.protocol = urlObj.protocol;
+
+            const queryList = urlObj.query ?
+                urlObj.query.map(kvObj => new QueryParam(kvObj), {}) :
+                [];
+            this.query = new PropertyList<QueryParam>(
+                QueryParam,
+                undefined,
+                queryList
+            );
+
+            // TODO: variable is always empty in this way
+            const varList = urlObj.variables ?
+                urlObj.variables
+                    .map(
+                        (kvObj: { key: string; value: string }) => new Variable(kvObj),
+                        {},
+                    ) :
+                [];
+
+            this.variables = new VariableList(undefined, varList);
+
+        } else {
+            throw Error(`url is invalid: ${def}`); // TODO:
+        }
+    }
+
+    static isUrl(obj: object) {
+        return '_kind' in obj && obj._kind === 'Url';
+    }
+
+    static parse(urlStr: string): UrlOptions | undefined {
+        // TODO: enable validation
+        // if (!UrlParser.canParse(urlStr)) {
+        //     console.error(`invalid URL string ${urlStr}`);
+        //     return undefined;
+        // }
+
+        const url = new UrlParser(urlStr);
+        const query = Array.from(url.searchParams.entries())
+            .map(kv => {
+                const kvArray = kv as [string, string];
+                return { key: kvArray[0], value: kvArray[1] };
+            });
+
+        return {
+            auth: url.username !== '' ? { // TODO: make it compatible with RequestAuth
+                username: url.username,
+                password: url.password,
+            } : undefined,
+            hash: url.hash,
+            host: url.hostname.split('/'),
+            path: url.pathname.split('/'),
+            port: url.port,
+            protocol: url.protocol, // e.g. https:
+            query,
+            variables: [],
+        };
+    }
+
+    addQueryParams(params: { key: string; value: string }[] | string) {
+        let queryParams: { key: string; value: string }[];
+
+        if (typeof params === 'string') {
+            queryParams = QueryParam.parse(params);
+        } else {
+            queryParams = params;
+        }
+
+        queryParams.forEach((param: { key: string; value: string }) => {
+            this.query.append(new QueryParam({ key: param.key, value: param.value }));
+        });
+    }
+
+    getHost() {
+        return this.host.join('.').toLowerCase();
+    }
+
+    getPath(unresolved?: boolean) {
+        const pathStr = this.path ? this.path.join('/') : '/';
+        const finalPath = pathStr.startsWith('/') ? pathStr : '/' + pathStr;
+
+        if (unresolved) {
+            return finalPath;
+        }
+
+        // TODO: should it support rendering variables here?
+        return finalPath;
+    }
+
+    getPathWithQuery() {
+        return `${this.getPath(true)}?${this.getQueryString()}`;
+    }
+
+    getQueryString() {
+        const params = new UrlSearchParams();
+        this.query.each(param => params.append(param.key, param.value), {});
+
+        return params.toString();
+    }
+
+    getRemote(forcePort?: boolean) {
+        const host = this.getHost();
+
+        if (forcePort) {
+            // TODO: it does not support GQL, gRPC and so on
+            const port = this.port ? this.port :
+                this.protocol && (this.protocol === 'https:') ? 443 : 80;
+            return `${host}:${port}`;
+        }
+
+        // TODO: it does not support GQL, gRPC and so on
+        const portWithColon = this.port ? `:${this.port}` : '';
+        return `${host}${portWithColon}`;
+    }
+
+    removeQueryParams(params: QueryParam[] | string[] | string) {
+        if (typeof params === 'string') {
+            // it is a string
+            this.query = new PropertyList(
+                QueryParam,
+                undefined,
+                this.query.filter(queryParam => queryParam.key === params, {})
+            );
+        } else if (params.length > 0) {
+            let toBeRemoved: Set<string>;
+
+            if (typeof params[0] === 'string') {
+                // it is a string[]
+                toBeRemoved = new Set(params as string[]);
+            } else {
+                // it is a QueryParam[]
+                toBeRemoved = new Set(
+                    (params as QueryParam[])
+                        .map(param => param.key)
+                );
+            }
+
+            this.query = new PropertyList(
+                QueryParam,
+                undefined,
+                this.query.filter(queryParam => !toBeRemoved.has(queryParam.key), {})
+            );
+        } else {
+            console.error('failed to remove query params: unknown params type, only supports QueryParam[], string[] or string');
+        }
+    }
+
+    toString(forceProtocol?: boolean) {
+        const protocol = forceProtocol ?
+            (this.protocol ? this.protocol : 'https:') :
+            (this.protocol ? this.protocol : '');
+
+        const parser = new UrlParser(`${protocol}//` + this.getHost());
+        parser.username = this.auth?.username || '';
+        parser.password = this.auth?.password || '';
+        parser.port = this.port || '';
+        parser.pathname = this.getPath();
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        parser.search = this.getQueryString();
+        parser.hash = this.hash || '';
+
+        return parser.toString();
+    }
+
+    update(url: UrlOptions | string) {
+        this.setFields(url);
+    }
+}
+
+// interface Matcher {
+//     match(pattern: string): boolean;
+// }
+
+// UrlMatchPattern implements chrome extension match patterns:
+// https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns
+export class UrlMatchPattern extends Property {
+    // scheme
+    // scheme: 'http:' | 'https:' | '*' | 'file:';
+
+    // host
+    // About wildcard:
+    // If you use a wildcard in the host pattern
+    // it must be the first or only character, and it must be followed by a period (.) or forward slash (/).
+
+    // path
+    // Must contain at least a forward slash
+    // The slash by itself matches any path.
+
+    // Special cases: https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns#special
+    // "<all_urls>"
+    // "file:///"
+    // "http://localhost/*"
+    // It doesn't support match patterns for top Level domains (TLD).
+
+    private pattern: string;
+
+    constructor(pattern: string) {
+        super();
+
+        this.pattern = pattern;
+    }
+
+    static readonly MATCH_ALL_URLS: string = '<all_urls>';
+    static pattern: string | undefined = undefined; // TODO: its usage is unknown
+    static readonly PROTOCOL_DELIMITER: string = '+';
+
+    // TODO: the url can not start with -
+
+    getProtocols(): string[] {
+        const protocolEndPos = this.pattern.indexOf('://');
+        if (protocolEndPos < 0) {
+            throw Error('UrlMatchPattern: protocol is not specified');
+        }
+
+        const protocolPattern = this.pattern.slice(0, protocolEndPos);
+        const protocols = protocolPattern.split(UrlMatchPattern.PROTOCOL_DELIMITER);
+
+        return protocols.map(protocol => protocol.replace(':', ''));
+    }
+
+    test(urlStr: string) {
+        const protoEndPos = urlStr.indexOf(':');
+        const protoStr = urlStr.slice(0, protoEndPos);
+        const hostStr = this.getHost(urlStr);
+        const pathStr = this.getPath(this.pattern);
+        const portStr = this.getPort(urlStr);
+
+        return this.testProtocol(protoStr) &&
+            this.testHost(hostStr) &&
+            this.testPath(pathStr) &&
+            this.testPort(portStr, protoStr);
+    }
+
+    private getHost(urlStr: string) {
+        const protocolEndPos = urlStr.indexOf('://') + 3;
+        const hostBegPos = protocolEndPos;
+
+        const portBegPos = urlStr.indexOf(':', protocolEndPos);
+        const pathBegPos = urlStr.indexOf('/', protocolEndPos);
+        const queryBegPos = urlStr.indexOf('?', protocolEndPos);
+        const hashBegPos = urlStr.indexOf('?', protocolEndPos);
+
+        let hostEndPos = urlStr.length;
+        if (portBegPos >= 0) {
+            hostEndPos = portBegPos;
+        } else if (pathBegPos >= 0) {
+            hostEndPos = pathBegPos;
+        } else if (queryBegPos >= 0) {
+            hostEndPos = queryBegPos;
+        } else if (hashBegPos >= 0) {
+            hostEndPos = hashBegPos;
+        }
+
+        return urlStr.slice(hostBegPos, hostEndPos);
+    }
+
+    testHost(hostStr: string) {
+        const patternSegments = this.getHost(this.pattern).split('.');
+        console.log(patternSegments);
+
+        const inputHostSegments = hostStr.split('.');
+
+        if (patternSegments.length !== inputHostSegments.length) {
+            return false;
+        }
+
+        for (let i = 0; i < patternSegments.length; i++) {
+            if (patternSegments[i] === '*') {
+                continue;
+            } else if (patternSegments[i] !== inputHostSegments[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private getPath(urlStr: string) {
+        const protocolEndPos = urlStr.indexOf('://') + 3;
+        const hostBegPos = protocolEndPos;
+        const pathBegPos = urlStr.indexOf('/', hostBegPos);
+        if (pathBegPos < 0) {
+            return '';
+        }
+
+        const queryBegPos = urlStr.indexOf('?');
+        const hashBegPos = urlStr.indexOf('#');
+        let pathEndPos = urlStr.length;
+        if (queryBegPos >= 0) {
+            pathEndPos = queryBegPos;
+        } else if (hashBegPos >= 0) {
+            pathEndPos = hashBegPos;
+        }
+
+        return urlStr.slice(pathBegPos, pathEndPos);
+    }
+
+    testPath(pathStr: string) {
+        const patternSegments = this.getPath(this.pattern).split('/');
+        const inputSegments = pathStr.split('/');
+
+        if (patternSegments.length !== inputSegments.length) {
+            return false;
+        }
+
+        for (let i = 0; i < patternSegments.length; i++) {
+            if (patternSegments[i] === '*') {
+                continue;
+            } else if (patternSegments[i] !== inputSegments[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private getPort(urlStr: string) {
+        const protocolEndPos = urlStr.indexOf('/') + 2;
+        const hostBegPos = protocolEndPos;
+
+        const portBegPos = this.pattern.indexOf(':', protocolEndPos) + 1;
+        if (portBegPos <= 0) {
+            return '';
+        }
+
+        let portEndPos = this.pattern.length;
+        const pathBegPos = urlStr.indexOf('/', hostBegPos);
+        const queryBegPos = urlStr.indexOf('?');
+        const hashBegPos = urlStr.indexOf('#');
+
+        if (pathBegPos >= 0) {
+            portEndPos = pathBegPos;
+        } else if (queryBegPos >= 0) {
+            portEndPos = queryBegPos;
+        } else if (hashBegPos >= 0) {
+            portEndPos = hashBegPos;
+        }
+
+        return urlStr.slice(portBegPos, portEndPos);
+    }
+
+    testPort(port: string, protocol: string) {
+        if (!this.testProtocol(protocol)) {
+            return false;
+        }
+
+        const portPattern = this.getPort(this.pattern);
+        if (portPattern === '*') {
+            return true;
+        } else if (portPattern === '') {
+            const protos = this.getProtocols();
+
+            if (protos.includes('https') && port === '443' && protocol === 'https') {
+                return true;
+            } else if (protos.includes('http') && port === '80' && protocol === 'http') {
+                return true;
+            }
+        }
+
+        return portPattern === port;
+    }
+
+    testProtocol(protocol: string) {
+        const protoPatterns = this.getProtocols();
+
+        for (let i = 0; i < protoPatterns.length; i++) {
+            if (protoPatterns[i] === '*') {
+                return true;
+            } else if (protoPatterns[i] === protocol) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    toString() {
+        return this.pattern;
+    }
+
+    update(pattern: string) {
+        this.pattern = pattern;
+    }
+}
+
+export class UrlMatchPatternList<T extends UrlMatchPattern> extends PropertyList<T> {
+    _kind: string = 'UrlMatchPatternList';
+
+    constructor(parent: PropertyList<T> | undefined, populate: T[]) {
+        super(UrlMatchPattern, undefined, populate);
+        this.parent = parent;
+    }
+
+    static isUrlMatchPatternList(obj: any) {
+        return '_kind' in obj && obj._kind === 'UrlMatchPatternList';
+    }
+
+    // TODO: unsupported yet
+    // toObject(excludeDisabledopt, nullable, caseSensitiveopt, nullable, multiValueopt, nullable, sanitizeKeysopt) → {Object}
+
+    test(urlStr: string) {
+        return this
+            .filter(matchPattern => matchPattern.test(urlStr), {})
+            .length > 0;
+    }
+}

--- a/packages/insomnia/src/sdk/objects/variables.ts
+++ b/packages/insomnia/src/sdk/objects/variables.ts
@@ -1,0 +1,67 @@
+import { unsupportedError } from './insomnia';
+import { Property, PropertyList } from './properties';
+
+export interface VariableDefinition {
+    id?: string;
+    key: string;
+    name?: string;
+    value: string;
+    type?: string;
+    disabled?: boolean;
+}
+
+export class Variable extends Property {
+    key: string;
+    value: any;
+    type: string;
+    _kind: string = 'Variable';
+
+    constructor(def?: VariableDefinition) {
+        super();
+
+        this.id = def ? def.id || '' : '';
+        this.key = def ? def.key : '';
+        this.name = def ? def.name : '';
+        this.value = def ? def.value : '';
+        this.type = def && def.type ? def.type : 'Variable';
+        this.disabled = def ? def.disabled : false;
+    }
+
+    // unknown usage and unsupported
+    static types() {
+        throw unsupportedError('types');
+    }
+
+    // cast typecasts a value to the Variable.types of this Variable.
+    cast(value: any) {
+        if ('_kind' in value && value._kind === 'Variable') {
+            return value.value;
+        }
+        return undefined;
+    }
+
+    get() {
+        return this.value;
+    }
+
+    set(value: any) {
+        this.value = value;
+    }
+}
+
+export class VariableList<T extends Variable> extends PropertyList<T> {
+    _kind: string = 'VariableList';
+
+    constructor(parent: PropertyList<T> | undefined, populate: T[]) {
+        super(
+            Variable,
+            undefined,
+            populate
+        );
+        this.parent = parent;
+    }
+
+    static isVariableList(obj: any) {
+        return '_kind' in obj && obj._kind === 'VariableList';
+    }
+}


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Changes:
- [x] enabled RequestAuth in pre-request scripting
- [x] added unit tests and smoke test


### How to test:

Please run this script and check its output.
```
const { RequestAuth } = require('insomnia-collection');

const reqAuth = new RequestAuth({
		type: 'basic',
		basic: [
				{ key: 'username', value: 'user1' },
				{ key: 'password', value: 'pwd1' },
		],
});

const result = reqAuth.toJSON();
console.log(result);
```