### PR TITLE
fix: use collection name when importing from postman

### DIFF
--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -8,6 +8,7 @@ import { BaseModel, getModel } from '../models/index';
 import * as models from '../models/index';
 import { isMockRoute, MockRoute } from '../models/mock-route';
 import { isRequest, Request } from '../models/request';
+import { isRequestGroup } from '../models/request-group';
 import { isUnitTest, UnitTest } from '../models/unit-test';
 import { isUnitTestSuite, UnitTestSuite } from '../models/unit-test-suite';
 import {
@@ -151,10 +152,19 @@ export async function importResourcesToProject({ projectId }: { projectId: strin
   invariant(ResourceCache, 'No resources to import');
   const resources = ResourceCache.resources;
   const bufferId = await db.bufferChanges();
+  const postmanTopLevelFolder = resources.find(
+    resource => isRequestGroup(resource) && resource.parentId === '__WORKSPACE_ID__'
+  ) as Workspace | undefined;
+  if (postmanTopLevelFolder) {
+    await importResourcesToNewWorkspace(projectId, postmanTopLevelFolder);
+    return { resources };
+  }
+  // No workspace, so create one
   if (!resources.find(isWorkspace)) {
     await importResourcesToNewWorkspace(projectId);
     return { resources };
   }
+  // One or more workspaces
   const r = await Promise.all(resources.filter(isWorkspace)
     .map(resource => importResourcesToNewWorkspace(projectId, resource)));
 

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -155,7 +155,7 @@ export async function importResourcesToProject({ projectId }: { projectId: strin
   const postmanTopLevelFolder = resources.find(
     resource => isRequestGroup(resource) && resource.parentId === '__WORKSPACE_ID__'
   ) as Workspace | undefined;
-  if (postmanTopLevelFolder) {
+  if (ResourceCache.type.id === 'postman' && postmanTopLevelFolder) {
     await importResourcesToNewWorkspace(projectId, postmanTopLevelFolder);
     return { resources };
   }


### PR DESCRIPTION
- [x] workspace name carries over to imported workspace

closes INS-3597

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
