### PR TITLE
chore: clean up pre-request script sdk objects

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -165,13 +165,11 @@ test.describe('pre-request features tests', async () => {
             }`,
             expectedBody: {
                 propJson: {
-                    '_kind': 'Property',
                     'disabled': false,
                     'id': 'pid',
                     'name': 'pname',
                 },
                 headerJson: {
-                    '_kind': 'Header',
                     'key': 'headerKey',
                     'value': 'headerValue',
                     'id': '',

--- a/packages/insomnia/src/sdk/objects/__tests__/properties.test.ts
+++ b/packages/insomnia/src/sdk/objects/__tests__/properties.test.ts
@@ -8,11 +8,9 @@ describe('test Property objects', () => {
         const pbase = new PropertyBase('my property');
 
         expect(pbase.toJSON()).toEqual({
-            _kind: 'PropertyBase',
             description: 'my property',
         });
         expect(pbase.toObject()).toEqual({
-            _kind: 'PropertyBase',
             description: 'my property',
         });
     });
@@ -26,7 +24,6 @@ describe('test Property objects', () => {
         );
 
         expect(prop.toJSON()).toEqual({
-            _kind: 'Property',
             disabled: false,
             id: 'real_id',
             name: 'real_name',
@@ -47,19 +44,16 @@ describe('test Property objects', () => {
         expect(propList.count()).toBe(3);
         expect(propList.all()).toEqual([
             {
-                _kind: 'Property',
                 disabled: false,
                 id: 'id1',
                 name: 'p1',
             },
             {
-                _kind: 'Property',
                 disabled: false,
                 id: 'id2',
                 name: 'p2',
             },
             {
-                _kind: 'Property',
                 disabled: false,
                 id: 'id3',
                 name: 'p3',
@@ -141,7 +135,11 @@ describe('test Property objects', () => {
         ]);
 
         expect(propList.toString()).toEqual(
-            '[{"_kind":"Property","id":"id1","name":"p1","disabled":false}; {"_kind":"Property","id":"id2","name":"p2","disabled":false}]',
+            '[{"id":"id1","name":"p1","disabled":false}; {"id":"id2","name":"p2","disabled":false}]',
+        );
+
+        expect(propList.toObject()).toEqual(
+            [{ 'disabled': false, 'id': 'id1', 'name': 'p1' }, { 'disabled': false, 'id': 'id2', 'name': 'p2' }]
         );
     });
 });

--- a/packages/insomnia/src/sdk/objects/cookies.ts
+++ b/packages/insomnia/src/sdk/objects/cookies.ts
@@ -45,6 +45,8 @@ export class Cookie extends Property {
         this.cookie = cookie;
     }
 
+    static _index = 'key';
+
     static isCookie(obj: Property) {
         return '_kind' in obj && obj._kind === 'Cookie';
     }

--- a/packages/insomnia/src/sdk/objects/environments.ts
+++ b/packages/insomnia/src/sdk/objects/environments.ts
@@ -1,3 +1,4 @@
+import { getIntepolator } from './interpolator';
 export class Environment {
     private kvs = new Map<string, boolean | number | string>();
 
@@ -25,10 +26,9 @@ export class Environment {
         this.kvs.clear();
     };
 
-    // TODO: enable this after intepolator is introduced
-    // replaceIn = (template: string) => {
-    //     return getIntepolator().render(template, this.toObject());
-    // };
+    replaceIn = (template: string) => {
+        return getIntepolator().render(template, this.toObject());
+    };
 
     toObject = () => {
         return Object.fromEntries(this.kvs.entries());
@@ -90,10 +90,10 @@ export class Variables {
         this.local.set(variableName, variableValue);
     };
 
-    // replaceIn = (template: string) => {
-    //     const context = this.toObject();
-    //     return getIntepolator().render(template, context);
-    // };
+    replaceIn = (template: string) => {
+        const context = this.toObject();
+        return getIntepolator().render(template, context);
+    };
 
     toObject = () => {
         return [

--- a/packages/insomnia/src/sdk/objects/headers.ts
+++ b/packages/insomnia/src/sdk/objects/headers.ts
@@ -35,6 +35,8 @@ export class Header extends Property {
         }
     }
 
+    static _index: string = 'key';
+
     static create(input?: { key: string; value: string } | string, name?: string): Header {
         return new Header(input || { key: '', value: '' }, name);
     }
@@ -111,11 +113,6 @@ export class HeaderList<T extends Header> extends PropertyList<T> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     eachParent(_iterator: any, _context?: object | undefined) {
         throw unsupportedError('eachParent');
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    toObject(_excludeDisabled?: boolean, _caseSensitive?: boolean, _multiValue?: boolean, _sanitizeKeys?: boolean) {
-        throw unsupportedError('toObject');
     }
 
     contentSize(): number {

--- a/packages/insomnia/src/sdk/objects/interpolator.ts
+++ b/packages/insomnia/src/sdk/objects/interpolator.ts
@@ -1,0 +1,34 @@
+import { configure, type ConfigureOptions, type Environment as NunjuncksEnv } from 'nunjucks';
+
+class Intepolator {
+    private engine: NunjuncksEnv;
+
+    constructor(config: ConfigureOptions) {
+        this.engine = configure(config);
+    }
+
+    render = (template: string, context: object) => {
+        // TODO: handle timeout
+        // TODO: support plugin?
+        return this.engine.renderString(template, context);
+    };
+}
+
+const intepolator = new Intepolator({
+    autoescape: false,
+    // Don't escape HTML
+    throwOnUndefined: true,
+    // Strict mode
+    tags: {
+        blockStart: '{%',
+        blockEnd: '%}',
+        variableStart: '{{',
+        variableEnd: '}}',
+        commentStart: '{#',
+        commentEnd: '#}',
+    },
+});
+
+export function getIntepolator() {
+    return intepolator;
+}

--- a/packages/insomnia/src/sdk/objects/proxy-configs.ts
+++ b/packages/insomnia/src/sdk/objects/proxy-configs.ts
@@ -64,6 +64,8 @@ export class ProxyConfig extends Property {
         this.password = def.password;
     }
 
+    static _index: string = 'key';
+
     static isProxyConfig(obj: object) {
         return '_kind' in obj && obj._kind === 'ProxyConfig';
     }

--- a/packages/insomnia/src/sdk/objects/request.ts
+++ b/packages/insomnia/src/sdk/objects/request.ts
@@ -31,6 +31,8 @@ export class FormParam extends Property {
         this.value = options.value;
     }
 
+    static _index = 'key';
+
     static _postman_propertyAllowsMultipleValues() {
         throw Error('unsupported');
     }

--- a/packages/insomnia/src/sdk/objects/urls.ts
+++ b/packages/insomnia/src/sdk/objects/urls.ts
@@ -45,6 +45,8 @@ export class QueryParam extends Property {
     // (static) _postman_propertyAllowsMultipleValues :Boolean
     // (static) _postman_propertyIndexKey :String
 
+    static _index: string = 'key';
+
     static parse(queryStr: string) {
         const params = new UrlSearchParams(queryStr);
         return Array.from(params.entries())
@@ -106,6 +108,7 @@ export class QueryParam extends Property {
 }
 
 export interface UrlOptions {
+    id?: string;
     auth?: {
         username: string;
         password: string;
@@ -122,6 +125,7 @@ export interface UrlOptions {
 export class Url extends PropertyBase {
     _kind: string = 'Url';
 
+    id?: string;
     // TODO: should be related to RequestAuth
     // but the implementation seems only supports username + password
     auth?: { username: string; password: string };
@@ -144,6 +148,9 @@ export class Url extends PropertyBase {
         const urlObj = typeof def === 'string' ? Url.parse(def) : def;
 
         if (urlObj) {
+            // `id` could be undefined, it is mainly for methods such as `indexOf`.
+            this.id = urlObj.id;
+
             this.auth = urlObj.auth;
             this.hash = urlObj.hash;
             this.host = urlObj.host;
@@ -175,6 +182,8 @@ export class Url extends PropertyBase {
             throw Error(`url is invalid: ${def}`); // TODO:
         }
     }
+
+    static _index: string = 'key';
 
     static isUrl(obj: object) {
         return '_kind' in obj && obj._kind === 'Url';
@@ -344,6 +353,7 @@ export class UrlMatchPattern extends Property {
     // "http://localhost/*"
     // It doesn't support match patterns for top Level domains (TLD).
 
+    id: string = '';
     private pattern: string;
 
     constructor(pattern: string) {
@@ -351,6 +361,8 @@ export class UrlMatchPattern extends Property {
 
         this.pattern = pattern;
     }
+
+    static _index = 'id';
 
     static readonly MATCH_ALL_URLS: string = '<all_urls>';
     static pattern: string | undefined = undefined; // TODO: its usage is unknown

--- a/packages/insomnia/src/sdk/objects/variables.ts
+++ b/packages/insomnia/src/sdk/objects/variables.ts
@@ -27,6 +27,8 @@ export class Variable extends Property {
         this.disabled = def ? def.disabled : false;
     }
 
+    static _index = 'key';
+
     // unknown usage and unsupported
     static types() {
         throw unsupportedError('types');


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
### Please review this PR (https://github.com/Kong/insomnia/pull/7147) firstly as current one is based on it

Changes:
- [x] add simple interpolator for enabling replaceIn methods and cleanups
- [x] add private _index field to follow existing method behavior such as `one`

### How to test
Run this script and check if it runs well:

```javascript
insomnia.environment.set('name', 'jack');
const welcome = pm.environment.replaceIn("Hello {{name}}.");
console.log(welcome);
```