### PR TITLE
fix: Export popup has small z-index [INS-3640]

### DIFF
--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -41,7 +41,7 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
   }), []);
 
   return (
-    <Modal ref={modalRef} tall {...props}>
+    <Modal className='!z-10' ref={modalRef} tall {...props}>
       <ModalHeader>
         {getProductName()} Preferences
         <span className="faint txt-sm">


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Close #7176 

Changes

- remove the global variable(globalZIndex) in base modal component
- add a new hook to admin every modal z-index(Even without using the base modal component)
- change the export request modal z-index, use globalModalZIndex instead

How to test

- Click Preferences → Data -> Export the collection, and you can see the export modal
