### PR TITLE
fix: URL PREVIEW cut off first few lines for very long URL [INS-3640]

### DIFF
--- a/packages/insomnia/src/ui/components/rendered-query-string.tsx
+++ b/packages/insomnia/src/ui/components/rendered-query-string.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, { FC, useState } from 'react';
 import { useAsync } from 'react-use';
 import styled from 'styled-components';
@@ -81,7 +82,7 @@ export const RenderedQueryString: FC<Props> = ({ request }) => {
 
   return (
     <Wrapper>
-      <span className={className}>{previewString}</span>
+      <span className={classNames('my-auto', className)}>{previewString}</span>
 
       <CopyButton
         size="small"

--- a/packages/insomnia/src/ui/components/rendered-query-string.tsx
+++ b/packages/insomnia/src/ui/components/rendered-query-string.tsx
@@ -11,7 +11,6 @@ import { CopyButton as _CopyButton } from './base/copy-button';
 const Wrapper = styled.div({
   display: 'flex',
   justifyContent: 'space-between',
-  alignItems: 'center',
   overflow: 'auto',
   position: 'relative',
   height: '100%',


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Closes #7178 

Change

- delete the wrapper alignItems style
- use margin auto to keep vertical center

How to test
- Enter a long URL. When it exceeds the maximum height of the URL preview box, it can slide normally to top.
