### PR TITLE
feat(session): Store session data in the db instead of LocalStorage

### DIFF
--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -40,8 +40,8 @@ export interface SessionData {
   encPrivateKey: crypt.AESMessage;
 }
 export function onLoginLogout(loginCallback: LoginCallback) {
-  window.main.on('loggedIn', () => {
-    loginCallback(isLoggedIn());
+  window.main.on('loggedIn', async () => {
+    loginCallback(await isLoggedIn());
   });
 }
 
@@ -182,8 +182,8 @@ export async function getFullName() {
 }
 
 /** Check if we (think) we have a session */
-export function isLoggedIn() {
-  return !!getCurrentSessionId();
+export async function isLoggedIn() {
+  return Boolean(await getCurrentSessionId());
 }
 
 /** Log out and delete session data */

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -1,6 +1,6 @@
 import * as srp from 'srp-js';
 
-import { user } from '../models';
+import { userSession } from '../models';
 import * as crypt from './crypt';
 
 type LoginCallback = (isLoggedIn: boolean) => void;
@@ -150,7 +150,7 @@ export async function getPrivateKey() {
 }
 
 export async function getCurrentSessionId() {
-  const { id, sessionExpiry } = await user.getOrCreate();
+  const { id, sessionExpiry } = await userSession.getOrCreate();
   try {
     if (typeof sessionExpiry !== 'string' || !sessionExpiry) {
       return '';
@@ -231,8 +231,8 @@ export async function setSessionData(
     lastName,
   };
 
-  const userData = await user.getOrCreate();
-  await user.update(userData, sessionData);
+  const userData = await userSession.getOrCreate();
+  await userSession.update(userData, sessionData);
 
   return sessionData;
 }
@@ -271,14 +271,14 @@ async function _getAuthSalts(email: string) {
 }
 
 export async function getUserSession(): Promise<SessionData> {
-  const userData = await user.getOrCreate();
+  const userData = await userSession.getOrCreate();
 
   return userData;
 };
 
 async function _unsetSessionData() {
-  await user.getOrCreate();
-  await user.update(await user.getOrCreate(), {
+  await userSession.getOrCreate();
+  await userSession.update(await userSession.getOrCreate(), {
     id: '',
     sessionExpiry: null,
     accountId: '',

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -1,5 +1,6 @@
 import * as srp from 'srp-js';
 
+import { user } from '../models';
 import * as crypt from './crypt';
 
 type LoginCallback = (isLoggedIn: boolean) => void;
@@ -30,7 +31,7 @@ export interface WhoamiResponse {
 export interface SessionData {
   accountId: string;
   id: string;
-  sessionExpiry: Date;
+  sessionExpiry: Date | null;
   email: string;
   firstName: string;
   lastName: string;
@@ -62,7 +63,7 @@ export async function absorbKey(sessionId: string, key: string) {
   const sessionExpiryDate = new Date(Date.now() + (sessionExpiry * 1000));
 
   // Store the information for later
-  setSessionData(
+  await setSessionData(
     sessionId,
     sessionExpiryDate,
     accountId,
@@ -81,7 +82,7 @@ export async function changePasswordWithToken(rawNewPassphrase: string, confirma
   // Sanitize inputs
   const newPassphrase = _sanitizePassphrase(rawNewPassphrase);
 
-  const newEmail = getEmail(); // Use the same one
+  const newEmail = await getEmail(); // Use the same one
 
   if (!newEmail) {
     throw new Error('Session e-mail unexpectedly not set');
@@ -115,24 +116,24 @@ export async function changePasswordWithToken(rawNewPassphrase: string, confirma
       newVerifier,
       newEncSymmetricKey,
     },
-    sessionId: getCurrentSessionId(),
+    sessionId: await getCurrentSessionId(),
   });
 }
 
-export function sendPasswordChangeCode() {
+export async function sendPasswordChangeCode() {
   window.main.insomniaFetch({
     method: 'POST',
     path: '/auth/send-password-code',
-    sessionId: getCurrentSessionId(),
+    sessionId: await getCurrentSessionId(),
   });
 }
 
-export function getPublicKey() {
-  return _getSessionData()?.publicKey;
+export async function getPublicKey() {
+  return (await _getSessionData())?.publicKey;
 }
 
-export function getPrivateKey() {
-  const sessionData = _getSessionData();
+export async function getPrivateKey() {
+  const sessionData = await _getSessionData();
 
   if (!sessionData) {
     throw new Error("Can't get private key: session is blank.");
@@ -148,48 +149,36 @@ export function getPrivateKey() {
   return JSON.parse(privateKeyStr);
 }
 
-export function getCurrentSessionId() {
-  if (window) {
-    const sessionId = window.localStorage.getItem('currentSessionId');
-    try {
-      const { sessionExpiry } = JSON.parse(window.localStorage.getItem(_getSessionKey(sessionId)) || '{}');
-      if (typeof sessionExpiry !== 'string' || !sessionExpiry) {
-        return '';
-      }
-
-      const isExpired = new Date(sessionExpiry).getTime() < Date.now();
-      if (isExpired) {
-        console.log('Session has expired', sessionExpiry);
-        return '';
-      }
-      return sessionId;
-    } catch (e) {
-      console.log('Error in expiry logic', e);
+export async function getCurrentSessionId() {
+  const { id, sessionExpiry } = await user.getOrCreate();
+  try {
+    if (typeof sessionExpiry !== 'string' || !sessionExpiry) {
       return '';
     }
-  } else {
+
+    const isExpired = new Date(sessionExpiry).getTime() < Date.now();
+    if (isExpired) {
+      console.log('Session has expired', sessionExpiry);
+      return '';
+    }
+    return id;
+  } catch (e) {
+    console.log('Error in expiry logic', e);
     return '';
   }
 }
 
-export function getAccountId() {
-  return _getSessionData()?.accountId;
+export async function getAccountId() {
+  return (await _getSessionData())?.accountId;
 }
 
-export function getEmail() {
-  return _getSessionData()?.email;
+export async function getEmail() {
+  return (await _getSessionData())?.email;
 }
 
-export function getFirstName() {
-  return _getSessionData()?.firstName;
-}
-
-export function getLastName() {
-  return _getSessionData()?.lastName;
-}
-
-export function getFullName() {
-  return `${getFirstName()} ${getLastName()}`.trim();
+export async function getFullName() {
+  const { firstName, lastName } = await _getSessionData() || {};
+  return `${firstName} ${lastName}`.trim();
 }
 
 /** Check if we (think) we have a session */
@@ -199,7 +188,7 @@ export function isLoggedIn() {
 
 /** Log out and delete session data */
 export async function logout() {
-  const sessionId = getCurrentSessionId();
+  const sessionId = await getCurrentSessionId();
   if (sessionId) {
     try {
       window.main.insomniaFetch({
@@ -219,7 +208,7 @@ export async function logout() {
 }
 
 /** Set data for the new session and store it encrypted with the sessionId */
-export function setSessionData(
+export async function setSessionData(
   id: string,
   sessionExpiry: Date,
   accountId: string,
@@ -241,25 +230,25 @@ export function setSessionData(
     firstName,
     lastName,
   };
-  const dataStr = JSON.stringify(sessionData);
-  window.localStorage.setItem(_getSessionKey(id), dataStr);
-  // NOTE: We're setting this last because the stuff above might fail
-  window.localStorage.setItem('currentSessionId', id);
+
+  const userData = await user.getOrCreate();
+  await user.update(userData, sessionData);
+
   return sessionData;
 }
 
 // ~~~~~~~~~~~~~~~~ //
 // Helper Functions //
 // ~~~~~~~~~~~~~~~~ //
-function _getSymmetricKey() {
-  return _getSessionData()?.symmetricKey;
+async function _getSymmetricKey() {
+  return (await _getSessionData())?.symmetricKey;
 }
 
 async function _whoami(sessionId: string | null = null): Promise<WhoamiResponse> {
   const response = await window.main.insomniaFetch<WhoamiResponse | string>({
     method: 'GET',
     path: '/auth/whoami',
-    sessionId: sessionId || getCurrentSessionId(),
+    sessionId: sessionId || await getCurrentSessionId(),
   });
   if (typeof response === 'string') {
     throw new Error('Unexpected plaintext response: ' + response);
@@ -270,37 +259,36 @@ async function _whoami(sessionId: string | null = null): Promise<WhoamiResponse>
   return response;
 }
 
-function _getAuthSalts(email: string) {
-  return window.main.insomniaFetch<{ saltKey: string; saltAuth: string }>({
+async function _getAuthSalts(email: string) {
+  const response = await window.main.insomniaFetch<{ saltKey: string; saltAuth: string }>({
     method: 'POST',
     path: '/auth/login-s',
     data: { email },
-    sessionId: getCurrentSessionId(),
+    sessionId: await getCurrentSessionId(),
   });
+
+  return response;
 }
 
-const _getSessionData = (): Partial<SessionData> | null => {
-  const sessionId = getCurrentSessionId();
+const _getSessionData = async (): Promise<SessionData | null> => {
+  const userData = await user.getOrCreate();
 
-  if (!sessionId || !window) {
-    return {};
-  }
-
-  const dataStr = window.localStorage.getItem(_getSessionKey(sessionId));
-  if (dataStr === null) {
-    return null;
-  }
-  return JSON.parse(dataStr) as SessionData;
+  return userData;
 };
 
-function _unsetSessionData() {
-  const sessionId = getCurrentSessionId();
-  window.localStorage.removeItem(_getSessionKey(sessionId));
-  window.localStorage.removeItem('currentSessionId');
-}
-
-function _getSessionKey(sessionId: string | null) {
-  return `session__${(sessionId || '').slice(0, 10)}`;
+async function _unsetSessionData() {
+  await user.getOrCreate();
+  await user.update(await user.getOrCreate(), {
+    id: '',
+    sessionExpiry: null,
+    accountId: '',
+    email: '',
+    firstName: '',
+    lastName: '',
+    symmetricKey: {} as JsonWebKey,
+    publicKey: {} as JsonWebKey,
+    encPrivateKey: {} as crypt.AESMessage,
+  });
 }
 
 function _getSrpParams() {

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -129,11 +129,11 @@ export async function sendPasswordChangeCode() {
 }
 
 export async function getPublicKey() {
-  return (await _getSessionData())?.publicKey;
+  return (await getUserSession())?.publicKey;
 }
 
 export async function getPrivateKey() {
-  const sessionData = await _getSessionData();
+  const sessionData = await getUserSession();
 
   if (!sessionData) {
     throw new Error("Can't get private key: session is blank.");
@@ -169,15 +169,15 @@ export async function getCurrentSessionId() {
 }
 
 export async function getAccountId() {
-  return (await _getSessionData())?.accountId;
+  return (await getUserSession())?.accountId;
 }
 
 export async function getEmail() {
-  return (await _getSessionData())?.email;
+  return (await getUserSession())?.email;
 }
 
 export async function getFullName() {
-  const { firstName, lastName } = await _getSessionData() || {};
+  const { firstName, lastName } = await getUserSession() || {};
   return `${firstName} ${lastName}`.trim();
 }
 
@@ -241,7 +241,7 @@ export async function setSessionData(
 // Helper Functions //
 // ~~~~~~~~~~~~~~~~ //
 async function _getSymmetricKey() {
-  return (await _getSessionData())?.symmetricKey;
+  return (await getUserSession())?.symmetricKey;
 }
 
 async function _whoami(sessionId: string | null = null): Promise<WhoamiResponse> {
@@ -270,7 +270,7 @@ async function _getAuthSalts(email: string) {
   return response;
 }
 
-const _getSessionData = async (): Promise<SessionData | null> => {
+export async function getUserSession(): Promise<SessionData> {
   const userData = await user.getOrCreate();
 
   return userData;

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -146,7 +146,7 @@ export async function getPrivateKey() {
   }
 
   const privateKeyStr = crypt.decryptAES(symmetricKey, encPrivateKey);
-  return JSON.parse(privateKeyStr);
+  return JSON.parse(privateKeyStr) as JsonWebKey;
 }
 
 export async function getCurrentSessionId() {

--- a/packages/insomnia/src/main/sentry.ts
+++ b/packages/insomnia/src/main/sentry.ts
@@ -13,15 +13,15 @@ let enabled = false;
  * Watch setting for changes. This must be called after the DB is initialized.
  */
 export function sentryWatchAnalyticsEnabled() {
-  models.settings.get().then(settings => {
-    enabled = settings.enableAnalytics || session.isLoggedIn();
+  models.settings.get().then(async settings => {
+    enabled = settings.enableAnalytics || await session.isLoggedIn();
   });
 
   db.onChange(async (changes: ChangeBufferEvent[]) => {
     for (const change of changes) {
       const [event, doc] = change;
       if (isSettings(doc) && event === 'update') {
-        enabled = doc.enableAnalytics || session.isLoggedIn();
+        enabled = doc.enableAnalytics || await session.isLoggedIn();
       }
 
       if (event === 'insert' || event === 'update') {

--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -42,6 +42,7 @@ import * as _stats from './stats';
 import * as _unitTest from './unit-test';
 import * as _unitTestResult from './unit-test-result';
 import * as _unitTestSuite from './unit-test-suite';
+import * as _user from './user';
 import * as _webSocketPayload from './websocket-payload';
 import * as _webSocketRequest from './websocket-request';
 import * as _webSocketResponse from './websocket-response';
@@ -94,6 +95,7 @@ export const webSocketResponse = _webSocketResponse;
 export const workspace = _workspace;
 export const workspaceMeta = _workspaceMeta;
 export * as organization from './organization';
+export const user = _user;
 
 export function all() {
   // NOTE: This list should be from most to least specific (ie. parents above children)
@@ -131,6 +133,7 @@ export function all() {
     webSocketPayload,
     webSocketRequest,
     webSocketResponse,
+    user,
   ] as const;
 }
 

--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -42,7 +42,7 @@ import * as _stats from './stats';
 import * as _unitTest from './unit-test';
 import * as _unitTestResult from './unit-test-result';
 import * as _unitTestSuite from './unit-test-suite';
-import * as _user from './user';
+import * as _userSession from './user-session';
 import * as _webSocketPayload from './websocket-payload';
 import * as _webSocketRequest from './websocket-request';
 import * as _webSocketResponse from './websocket-response';
@@ -95,7 +95,7 @@ export const webSocketResponse = _webSocketResponse;
 export const workspace = _workspace;
 export const workspaceMeta = _workspaceMeta;
 export * as organization from './organization';
-export const user = _user;
+export const userSession = _userSession;
 
 export function all() {
   // NOTE: This list should be from most to least specific (ie. parents above children)
@@ -133,7 +133,7 @@ export function all() {
     webSocketPayload,
     webSocketRequest,
     webSocketResponse,
-    user,
+    userSession,
   ] as const;
 }
 

--- a/packages/insomnia/src/models/user-session.ts
+++ b/packages/insomnia/src/models/user-session.ts
@@ -2,7 +2,7 @@ import type { AESMessage } from '../account/crypt';
 import { database as db } from '../common/database';
 import type { BaseModel } from './index';
 
-export interface BaseUser {
+export interface BaseUserSession {
   accountId: string;
   id: string;
   sessionExpiry: Date | null;
@@ -14,14 +14,14 @@ export interface BaseUser {
   encPrivateKey: AESMessage;
 };
 
-export type User = BaseModel & BaseUser;
-export const name = 'User';
-export const type = 'User';
+export type UserSession = BaseModel & BaseUserSession;
+export const name = 'UserSession';
+export const type = 'UserSession';
 export const prefix = 'usr';
 export const canDuplicate = false;
 export const canSync = false;
 
-export function init(): BaseUser {
+export function init(): BaseUserSession {
   return {
     accountId: '',
     id: '',
@@ -35,12 +35,12 @@ export function init(): BaseUser {
   };
 }
 
-export function migrate(doc: User) {
+export function migrate(doc: UserSession) {
   return doc;
 }
 
 export async function all() {
-  let userList = await db.all<User>(type);
+  let userList = await db.all<UserSession>(type);
 
   if (userList?.length === 0) {
     userList = [await getOrCreate()];
@@ -50,23 +50,23 @@ export async function all() {
 }
 
 async function create() {
-  const user = await db.docCreate<User>(type);
+  const user = await db.docCreate<UserSession>(type);
   return user;
 }
 
-export async function update(user: User, patch: Partial<User>) {
-  const updatedUser = await db.docUpdate<User>(user, patch);
+export async function update(user: UserSession, patch: Partial<UserSession>) {
+  const updatedUser = await db.docUpdate<UserSession>(user, patch);
   return updatedUser;
 }
 
-export async function patch(patch: Partial<User>) {
+export async function patch(patch: Partial<UserSession>) {
   const user = await getOrCreate();
-  const updatedUser = await db.docUpdate<User>(user, patch);
+  const updatedUser = await db.docUpdate<UserSession>(user, patch);
   return updatedUser;
 }
 
 export async function getOrCreate() {
-  const results = await db.all<User>(type) || [];
+  const results = await db.all<UserSession>(type) || [];
 
   if (results.length === 0) {
     return await create();
@@ -75,7 +75,7 @@ export async function getOrCreate() {
 }
 
 export async function get() {
-  const results = await db.all<User>(type) || [];
+  const results = await db.all<UserSession>(type) || [];
 
   return results[0];
 }

--- a/packages/insomnia/src/models/user.ts
+++ b/packages/insomnia/src/models/user.ts
@@ -1,0 +1,81 @@
+import type { AESMessage } from '../account/crypt';
+import { database as db } from '../common/database';
+import type { BaseModel } from './index';
+
+export interface BaseUser {
+  accountId: string;
+  id: string;
+  sessionExpiry: Date | null;
+  email: string;
+  firstName: string;
+  lastName: string;
+  symmetricKey: JsonWebKey;
+  publicKey: JsonWebKey;
+  encPrivateKey: AESMessage;
+};
+
+export type User = BaseModel & BaseUser;
+export const name = 'User';
+export const type = 'User';
+export const prefix = 'usr';
+export const canDuplicate = false;
+export const canSync = false;
+
+export function init(): BaseUser {
+  return {
+    accountId: '',
+    id: '',
+    sessionExpiry: null,
+    email: '',
+    firstName: '',
+    lastName: '',
+    symmetricKey: {} as JsonWebKey,
+    publicKey: {} as JsonWebKey,
+    encPrivateKey: {} as AESMessage,
+  };
+}
+
+export function migrate(doc: User) {
+  return doc;
+}
+
+export async function all() {
+  let userList = await db.all<User>(type);
+
+  if (userList?.length === 0) {
+    userList = [await getOrCreate()];
+  }
+
+  return userList;
+}
+
+async function create() {
+  const user = await db.docCreate<User>(type);
+  return user;
+}
+
+export async function update(user: User, patch: Partial<User>) {
+  const updatedUser = await db.docUpdate<User>(user, patch);
+  return updatedUser;
+}
+
+export async function patch(patch: Partial<User>) {
+  const user = await getOrCreate();
+  const updatedUser = await db.docUpdate<User>(user, patch);
+  return updatedUser;
+}
+
+export async function getOrCreate() {
+  const results = await db.all<User>(type) || [];
+
+  if (results.length === 0) {
+    return await create();
+  }
+  return results[0];
+}
+
+export async function get() {
+  const results = await db.all<User>(type) || [];
+
+  return results[0];
+}

--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -1328,16 +1328,17 @@ export class VCS {
   }
 
   async _assertSession() {
-    const { accountId, id, encPrivateKey, publicKey } = await session.getUserSession();
-
+    const { accountId, id, publicKey } = await session.getUserSession();
+    const privateKey = await session.getPrivateKey();
     if (!id) {
       throw new Error('Not logged in');
     }
 
+    console.log({ privateKey });
     return {
       accountId,
       sessionId: id,
-      privateKey: encPrivateKey,
+      privateKey,
       publicKey,
     };
   }

--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -1334,7 +1334,6 @@ export class VCS {
       throw new Error('Not logged in');
     }
 
-    console.log({ privateKey });
     return {
       accountId,
       sessionId: id,

--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -1328,11 +1328,11 @@ export class VCS {
   }
 
   async _assertSession() {
-    if (!session.isLoggedIn()) {
+    const { accountId, id, encPrivateKey, publicKey } = await session.getUserSession();
+
+    if (!id) {
       throw new Error('Not logged in');
     }
-
-    const { accountId, id, encPrivateKey, publicKey } = await session.getUserSession();
 
     return {
       accountId,

--- a/packages/insomnia/src/ui/components/command-palette.tsx
+++ b/packages/insomnia/src/ui/components/command-palette.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { Button, Collection, ComboBox, Dialog, DialogTrigger, Header, Input, Keyboard, Label, ListBox, ListBoxItem, Modal, ModalOverlay, Section, Text } from 'react-aria-components';
 import { useFetcher, useNavigate, useParams, useRouteLoaderData } from 'react-router-dom';
 
-import { getAccountId } from '../../account/session';
 import { constructKeyCombinationDisplay, getPlatformKeyCombinations } from '../../common/hotkeys';
 import { fuzzyMatch } from '../../common/misc';
 import { isGrpcRequest } from '../../models/grpc-request';
@@ -36,14 +35,14 @@ export const CommandPalette = () => {
     };
 
   const projectRouteData = useRouteLoaderData('/project/:projectId') as ProjectLoaderData | undefined;
-  const { settings } = useRouteLoaderData('root') as RootLoaderData;
+  const { settings, user } = useRouteLoaderData('root') as RootLoaderData;
   const { presence } = useInsomniaEventStreamContext();
   const pullFileFetcher = useFetcher();
   const setActiveEnvironmentFetcher = useFetcher();
   const navigate = useNavigate();
 
   const projectDataLoader = useFetcher<ProjectLoaderData>();
-  const accountId = getAccountId();
+  const accountId = user.accountId;
 
   useEffect(() => {
     if (!projectRouteData && !projectDataLoader.data && projectDataLoader.state === 'idle' && !isScratchpadOrganizationId(organizationId)) {

--- a/packages/insomnia/src/ui/components/command-palette.tsx
+++ b/packages/insomnia/src/ui/components/command-palette.tsx
@@ -35,14 +35,14 @@ export const CommandPalette = () => {
     };
 
   const projectRouteData = useRouteLoaderData('/project/:projectId') as ProjectLoaderData | undefined;
-  const { settings, user } = useRouteLoaderData('root') as RootLoaderData;
+  const { settings, userSession } = useRouteLoaderData('root') as RootLoaderData;
   const { presence } = useInsomniaEventStreamContext();
   const pullFileFetcher = useFetcher();
   const setActiveEnvironmentFetcher = useFetcher();
   const navigate = useNavigate();
 
   const projectDataLoader = useFetcher<ProjectLoaderData>();
-  const accountId = user.accountId;
+  const accountId = userSession.accountId;
 
   useEffect(() => {
     if (!projectRouteData && !projectDataLoader.data && projectDataLoader.state === 'idle' && !isScratchpadOrganizationId(organizationId)) {

--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -32,7 +32,7 @@ const ONE_MINUTE_IN_MS = 1000 * 60;
 export const SyncDropdown: FC<Props> = ({ gitSyncEnabled }) => {
   const { organizationId, projectId, workspaceId } = useParams<{ organizationId: string; projectId: string; workspaceId: string }>();
   const { organizations } = useOrganizationLoaderData();
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
   const currentOrg = organizations.find(organization => (organization.id === organizationId));
   const [isGitRepoSettingsModalOpen, setIsGitRepoSettingsModalOpen] = useState(false);
   const [isSyncHistoryModalOpen, setIsSyncHistoryModalOpen] = useState(false);
@@ -150,7 +150,7 @@ export const SyncDropdown: FC<Props> = ({ gitSyncEnabled }) => {
     }
     const isOwner = isOwnerOfOrganization({
       organization: currentOrg,
-      accountId: user.accountId,
+      accountId: userSession.accountId,
     });
 
     isOwner ?

--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -11,6 +11,7 @@ import { Project } from '../../../models/project';
 import type { Workspace } from '../../../models/workspace';
 import { useOrganizationLoaderData } from '../../routes/organization';
 import { SyncDataLoaderData } from '../../routes/remote-collections';
+import { useRootLoaderData } from '../../routes/root';
 import { Icon } from '../icon';
 import { showError, showModal } from '../modals';
 import { AlertModal } from '../modals/alert-modal';
@@ -31,6 +32,7 @@ const ONE_MINUTE_IN_MS = 1000 * 60;
 export const SyncDropdown: FC<Props> = ({ gitSyncEnabled }) => {
   const { organizationId, projectId, workspaceId } = useParams<{ organizationId: string; projectId: string; workspaceId: string }>();
   const { organizations } = useOrganizationLoaderData();
+  const { user } = useRootLoaderData();
   const currentOrg = organizations.find(organization => (organization.id === organizationId));
   const [isGitRepoSettingsModalOpen, setIsGitRepoSettingsModalOpen] = useState(false);
   const [isSyncHistoryModalOpen, setIsSyncHistoryModalOpen] = useState(false);
@@ -148,7 +150,7 @@ export const SyncDropdown: FC<Props> = ({ gitSyncEnabled }) => {
     }
     const isOwner = isOwnerOfOrganization({
       organization: currentOrg,
-      accountId,
+      accountId: user.accountId,
     });
 
     isOwner ?

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
@@ -39,7 +39,7 @@ interface WorkspaceActionItem {
 export const WorkspaceDropdown: FC = () => {
   const { organizationId, projectId, workspaceId } = useParams<{ organizationId: string; projectId: string; workspaceId: string }>();
   invariant(organizationId, 'Expected organizationId');
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
   const {
     activeWorkspace,
     activeProject,
@@ -187,7 +187,7 @@ export const WorkspaceDropdown: FC = () => {
         icon: <Icon icon='code' />,
         action: () => handleGenerateConfig(generator.label),
       } satisfies WorkspaceActionItem)) : [],
-    ...user.id && access.enabled && activeWorkspace.scope === 'design' ? [{
+    ...userSession.id && access.enabled && activeWorkspace.scope === 'design' ? [{
         id: 'insomnia-ai/generate-test-suite',
         name: 'Auto-generate Tests For Collection',
         action: generateTests,

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
@@ -3,7 +3,6 @@ import React, { FC, ReactNode, useCallback, useState } from 'react';
 import { Button, Dialog, Heading, Menu, MenuItem, MenuTrigger, Modal, ModalOverlay, Popover } from 'react-aria-components';
 import { useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
-import { isLoggedIn } from '../../../account/session';
 import { getProductName } from '../../../common/constants';
 import { database as db } from '../../../common/database';
 import { exportMockServerToFile } from '../../../common/export';
@@ -18,6 +17,7 @@ import { getWorkspaceActions } from '../../../plugins';
 import * as pluginContexts from '../../../plugins/context';
 import { invariant } from '../../../utils/invariant';
 import { useAIContext } from '../../context/app/ai-context';
+import { useRootLoaderData } from '../../routes/root';
 import { WorkspaceLoaderData } from '../../routes/workspace';
 import { Icon } from '../icon';
 import { InsomniaAI } from '../insomnia-ai-icon';
@@ -39,6 +39,7 @@ interface WorkspaceActionItem {
 export const WorkspaceDropdown: FC = () => {
   const { organizationId, projectId, workspaceId } = useParams<{ organizationId: string; projectId: string; workspaceId: string }>();
   invariant(organizationId, 'Expected organizationId');
+  const { user } = useRootLoaderData();
   const {
     activeWorkspace,
     activeProject,
@@ -186,7 +187,7 @@ export const WorkspaceDropdown: FC = () => {
         icon: <Icon icon='code' />,
         action: () => handleGenerateConfig(generator.label),
       } satisfies WorkspaceActionItem)) : [],
-      ...isLoggedIn() && access.enabled && activeWorkspace.scope === 'design' ? [{
+    ...user.id && access.enabled && activeWorkspace.scope === 'design' ? [{
         id: 'insomnia-ai/generate-test-suite',
         name: 'Auto-generate Tests For Collection',
         action: generateTests,

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
@@ -2,9 +2,9 @@ import { FC } from 'react';
 import React from 'react';
 import { useRouteLoaderData } from 'react-router-dom';
 
-import { isLoggedIn } from '../../../account/session';
 import { isRemoteProject } from '../../../models/project';
 import { FeatureList } from '../../routes/organization';
+import { useRootLoaderData } from '../../routes/root';
 import { WorkspaceLoaderData } from '../../routes/workspace';
 import { GitSyncDropdown } from './git-sync-dropdown';
 import { SyncDropdown } from './sync-dropdown';
@@ -19,9 +19,10 @@ export const WorkspaceSyncDropdown: FC = () => {
     ':workspaceId'
   ) as WorkspaceLoaderData;
 
+  const { user } = useRootLoaderData();
   const { features } = useRouteLoaderData(':organizationId') as { features: FeatureList };
 
-  if (!isLoggedIn()) {
+  if (!user.id) {
     return null;
   }
 

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
@@ -19,10 +19,10 @@ export const WorkspaceSyncDropdown: FC = () => {
     ':workspaceId'
   ) as WorkspaceLoaderData;
 
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
   const { features } = useRouteLoaderData(':organizationId') as { features: FeatureList };
 
-  if (!user.id) {
+  if (!userSession.id) {
     return null;
   }
 

--- a/packages/insomnia/src/ui/components/mocks/mock-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/mocks/mock-response-pane.tsx
@@ -5,7 +5,6 @@ import { useRouteLoaderData } from 'react-router-dom';
 import { useFetcher } from 'react-router-dom';
 import { useInterval } from 'react-use';
 
-import { getCurrentSessionId } from '../../../account/session';
 import { getMockServiceURL, getPreviewModeName, PREVIEW_MODE_FRIENDLY, PREVIEW_MODES, PreviewMode } from '../../../common/constants';
 import { exportHarCurrentRequest } from '../../../common/har';
 import { ResponseTimelineEntry } from '../../../main/network/libcurl-promise';
@@ -119,6 +118,7 @@ export const MockResponsePane = () => {
 const HistoryViewWrapperComponentFactory = ({ mockServer, mockRoute }: { mockServer: MockServer; mockRoute: MockRoute }) => {
   const [logs, setLogs] = useState<MockbinLogOutput | null>(null);
   const [logEntryId, setLogEntryId] = useState<number | null>(null);
+  const { user } = useRootLoaderData();
 
   const fetchLogs = useCallback(async () => {
     const compoundId = mockRoute.parentId + mockRoute.name;
@@ -128,7 +128,7 @@ const HistoryViewWrapperComponentFactory = ({ mockServer, mockRoute }: { mockSer
         origin: mockbinUrl,
         path: `/bin/log/${compoundId}`,
         method: 'GET',
-        sessionId: getCurrentSessionId(),
+        sessionId: user.id,
       });
       if (res?.log) {
         setLogs(res);
@@ -139,7 +139,7 @@ const HistoryViewWrapperComponentFactory = ({ mockServer, mockRoute }: { mockSer
       // network erros will be managed by the upsert trigger, so we can ignore them here
       console.log({ mockbinUrl, e });
     }
-  }, [mockRoute.name, mockRoute.parentId, mockServer.url, mockServer.useInsomniaCloud]);
+  }, [mockRoute.name, mockRoute.parentId, mockServer.url, mockServer.useInsomniaCloud, user.id]);
   // refetches logs whenever the path changes, or a response is recieved, or tenseconds elapses or history tab is click
   // chatgpt: answer my called
   useInterval(() => {

--- a/packages/insomnia/src/ui/components/mocks/mock-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/mocks/mock-response-pane.tsx
@@ -118,7 +118,7 @@ export const MockResponsePane = () => {
 const HistoryViewWrapperComponentFactory = ({ mockServer, mockRoute }: { mockServer: MockServer; mockRoute: MockRoute }) => {
   const [logs, setLogs] = useState<MockbinLogOutput | null>(null);
   const [logEntryId, setLogEntryId] = useState<number | null>(null);
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
 
   const fetchLogs = useCallback(async () => {
     const compoundId = mockRoute.parentId + mockRoute.name;
@@ -128,7 +128,7 @@ const HistoryViewWrapperComponentFactory = ({ mockServer, mockRoute }: { mockSer
         origin: mockbinUrl,
         path: `/bin/log/${compoundId}`,
         method: 'GET',
-        sessionId: user.id,
+        sessionId: userSession.id,
       });
       if (res?.log) {
         setLogs(res);
@@ -139,7 +139,7 @@ const HistoryViewWrapperComponentFactory = ({ mockServer, mockRoute }: { mockSer
       // network erros will be managed by the upsert trigger, so we can ignore them here
       console.log({ mockbinUrl, e });
     }
-  }, [mockRoute.name, mockRoute.parentId, mockServer.url, mockServer.useInsomniaCloud, user.id]);
+  }, [mockRoute.name, mockRoute.parentId, mockServer.url, mockServer.useInsomniaCloud, userSession.id]);
   // refetches logs whenever the path changes, or a response is recieved, or tenseconds elapses or history tab is click
   // chatgpt: answer my called
   useInterval(() => {

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -27,7 +27,7 @@ export const TAB_INDEX_AI = 'ai';
 
 export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props, ref) => {
   const [defaultTabKey, setDefaultTabKey] = useState('general');
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
   const modalRef = useRef<ModalHandle>(null);
 
   useImperativeHandle(ref, () => ({
@@ -46,7 +46,7 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
         {getProductName()} Preferences
         <span className="faint txt-sm">
           &nbsp;&nbsp;–&nbsp; v{getAppVersion()}
-          {(user.id && user.email) ? ` – ${user.email}` : null}
+          {(userSession.id && userSession.email) ? ` – ${userSession.email}` : null}
         </span>
       </ModalHeader>
       <ModalBody noScroll>

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 
-import { getEmail, isLoggedIn } from '../../../account/session';
 import { getAppVersion, getProductName } from '../../../common/constants';
+import { useRootLoaderData } from '../../routes/root';
 import { Modal, type ModalHandle, ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
@@ -27,9 +27,9 @@ export const TAB_INDEX_AI = 'ai';
 
 export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props, ref) => {
   const [defaultTabKey, setDefaultTabKey] = useState('general');
+  const { user } = useRootLoaderData();
   const modalRef = useRef<ModalHandle>(null);
-  const email = getEmail();
-  const showEmail = isLoggedIn();
+
   useImperativeHandle(ref, () => ({
     hide: () => {
       modalRef.current?.hide();
@@ -46,7 +46,7 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
         {getProductName()} Preferences
         <span className="faint txt-sm">
           &nbsp;&nbsp;–&nbsp; v{getAppVersion()}
-          {(showEmail && email) ? ` – ${email}` : null}
+          {(user.id && user.email) ? ` – ${user.email}` : null}
         </span>
       </ModalHeader>
       <ModalBody noScroll>

--- a/packages/insomnia/src/ui/components/modals/sync-history-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-history-modal.tsx
@@ -42,14 +42,14 @@ const RestoreButton = ({ snapshot }: { snapshot: Snapshot }) => {
 };
 
 export const SyncHistoryModal = ({ history, onClose }: Props) => {
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
   const authorName = (snapshot: Snapshot) => {
     let fullName = '';
     if (snapshot.authorAccount) {
       const { firstName, lastName } = snapshot.authorAccount;
       fullName += `${firstName} ${lastName}`;
     }
-    if (snapshot.author === user.accountId) {
+    if (snapshot.author === userSession.accountId) {
       fullName += ' (you)';
     }
 

--- a/packages/insomnia/src/ui/components/modals/sync-history-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-history-modal.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Button, Cell, Column, Dialog, Heading, Modal, ModalOverlay, Row, Table, TableBody, TableHeader } from 'react-aria-components';
 import { useFetcher, useParams } from 'react-router-dom';
 
-import * as session from '../../../account/session';
 import type { Snapshot } from '../../../sync/types';
+import { useRootLoaderData } from '../../routes/root';
 import { PromptButton } from '../base/prompt-button';
 import { HelpTooltip } from '../help-tooltip';
 import { Icon } from '../icon';
@@ -42,14 +42,14 @@ const RestoreButton = ({ snapshot }: { snapshot: Snapshot }) => {
 };
 
 export const SyncHistoryModal = ({ history, onClose }: Props) => {
-
+  const { user } = useRootLoaderData();
   const authorName = (snapshot: Snapshot) => {
     let fullName = '';
     if (snapshot.authorAccount) {
       const { firstName, lastName } = snapshot.authorAccount;
       fullName += `${firstName} ${lastName}`;
     }
-    if (snapshot.author === session.getAccountId()) {
+    if (snapshot.author === user.accountId) {
       fullName += ' (you)';
     }
 

--- a/packages/insomnia/src/ui/components/panes/project-empty-state-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/project-empty-state-pane.tsx
@@ -6,6 +6,7 @@ import { getAccountId } from '../../../account/session';
 import { getAppWebsiteBaseURL } from '../../../common/constants';
 import { isOwnerOfOrganization } from '../../../models/organization';
 import { type FeatureList, useOrganizationLoaderData } from '../../../ui/routes/organization';
+import { useRootLoaderData } from '../../routes/root';
 import { showModal } from '../modals';
 import { AlertModal } from '../modals/alert-modal';
 import { AskModal } from '../modals/ask-modal';
@@ -81,6 +82,7 @@ interface Props {
 export const EmptyStatePane: FC<Props> = ({ createRequestCollection, createDesignDocument, createMockServer, importFrom, cloneFromGit }) => {
   const { organizationId } = useParams<{ organizationId: string }>();
   const { organizations } = useOrganizationLoaderData();
+  const { user } = useRootLoaderData();
   const currentOrg = organizations.find(organization => (organization.id === organizationId));
   const { features } = useRouteLoaderData(':organizationId') as { features: FeatureList };
 
@@ -93,7 +95,7 @@ export const EmptyStatePane: FC<Props> = ({ createRequestCollection, createDesig
     }
     const isOwner = isOwnerOfOrganization({
       organization: currentOrg,
-      accountId,
+      accountId: user.accountId,
     });
 
     isOwner ?

--- a/packages/insomnia/src/ui/components/panes/project-empty-state-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/project-empty-state-pane.tsx
@@ -82,7 +82,7 @@ interface Props {
 export const EmptyStatePane: FC<Props> = ({ createRequestCollection, createDesignDocument, createMockServer, importFrom, cloneFromGit }) => {
   const { organizationId } = useParams<{ organizationId: string }>();
   const { organizations } = useOrganizationLoaderData();
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
   const currentOrg = organizations.find(organization => (organization.id === organizationId));
   const { features } = useRouteLoaderData(':organizationId') as { features: FeatureList };
 
@@ -95,7 +95,7 @@ export const EmptyStatePane: FC<Props> = ({ createRequestCollection, createDesig
     }
     const isOwner = isOwnerOfOrganization({
       organization: currentOrg,
-      accountId: user.accountId,
+      accountId: userSession.accountId,
     });
 
     isOwner ?

--- a/packages/insomnia/src/ui/components/present-users.tsx
+++ b/packages/insomnia/src/ui/components/present-users.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { useParams, useRouteLoaderData } from 'react-router-dom';
 
-import { getAccountId } from '../../account/session';
 import { useInsomniaEventStreamContext } from '../context/app/insomnia-event-stream-context';
 import { ProjectLoaderData } from '../routes/project';
+import { useRootLoaderData } from '../routes/root';
 import { WorkspaceLoaderData } from '../routes/workspace';
 import { AvatarGroup } from './avatar';
 
 export const PresentUsers = () => {
   const { presence } = useInsomniaEventStreamContext();
   const { workspaceId } = useParams() as { workspaceId: string };
+  const { user } = useRootLoaderData();
   const projectData = useRouteLoaderData('/project/:projectId') as ProjectLoaderData | null;
   const workspaceData = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData | null;
   const remoteId = projectData?.activeProject.remoteId || workspaceData?.activeProject.remoteId;
@@ -18,13 +19,11 @@ export const PresentUsers = () => {
     return null;
   }
 
-  const accountId = getAccountId();
-
   const activeUsers = presence
     .filter(p => {
       return p.project === remoteId && p.file === workspaceId;
     })
-    .filter(p => p.acct !== accountId)
+    .filter(p => p.acct !== user.accountId)
     .map(user => {
       return {
         key: user.acct,

--- a/packages/insomnia/src/ui/components/present-users.tsx
+++ b/packages/insomnia/src/ui/components/present-users.tsx
@@ -10,7 +10,7 @@ import { AvatarGroup } from './avatar';
 export const PresentUsers = () => {
   const { presence } = useInsomniaEventStreamContext();
   const { workspaceId } = useParams() as { workspaceId: string };
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
   const projectData = useRouteLoaderData('/project/:projectId') as ProjectLoaderData | null;
   const workspaceData = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData | null;
   const remoteId = projectData?.activeProject.remoteId || workspaceData?.activeProject.remoteId;
@@ -23,7 +23,7 @@ export const PresentUsers = () => {
     .filter(p => {
       return p.project === remoteId && p.file === workspaceId;
     })
-    .filter(p => p.acct !== user.accountId)
+    .filter(p => p.acct !== userSession.accountId)
     .map(user => {
       return {
         key: user.acct,

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -1,6 +1,5 @@
 import React, { FC, Fragment } from 'react';
 
-import * as session from '../../../account/session';
 import {
   EditorKeyMap,
   isMac,
@@ -40,8 +39,9 @@ const RestartTooltip: FC<{ message: string }> = ({ message }) => (
 export const General: FC = () => {
   const {
     settings,
+    user,
   } = useRootLoaderData();
-  const isLoggedIn = session.isLoggedIn();
+  const isLoggedIn = Boolean(user.id);
 
   return (
     <div className="pad-bottom">

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -39,9 +39,9 @@ const RestartTooltip: FC<{ message: string }> = ({ message }) => (
 export const General: FC = () => {
   const {
     settings,
-    user,
+    userSession,
   } = useRootLoaderData();
-  const isLoggedIn = Boolean(user.id);
+  const isLoggedIn = Boolean(userSession.id);
 
   return (
     <div className="pad-bottom">

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -250,7 +250,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
 
   const workspaceData = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData | undefined;
   const activeWorkspaceName = workspaceData?.activeWorkspace.name;
-  const { workspaceCount, user } = useRootLoaderData();
+  const { workspaceCount, userSession } = useRootLoaderData();
   const workspacesFetcher = useFetcher();
   useEffect(() => {
     const isIdleAndUninitialized = workspacesFetcher.state === 'idle' && !workspacesFetcher.data;
@@ -366,7 +366,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
 
             <Button
               className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
-              isDisabled={!user.id}
+              isDisabled={!userSession.id}
               onPress={() => window.main.openInBrowser('https://insomnia.rest/create-run-button')}
             >
               <i className="fa fa-file-import" />

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -3,7 +3,6 @@ import { Button, Heading, ListBox, ListBoxItem, Popover, Select, SelectValue } f
 import { useFetcher, useParams } from 'react-router-dom';
 import { useRouteLoaderData } from 'react-router-dom';
 
-import { isLoggedIn } from '../../../account/session';
 import { getProductName } from '../../../common/constants';
 import { exportProjectToFile } from '../../../common/export';
 import { exportAllData } from '../../../common/export-all-data';
@@ -251,7 +250,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
 
   const workspaceData = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData | undefined;
   const activeWorkspaceName = workspaceData?.activeWorkspace.name;
-  const { workspaceCount } = useRootLoaderData();
+  const { workspaceCount, user } = useRootLoaderData();
   const workspacesFetcher = useFetcher();
   useEffect(() => {
     const isIdleAndUninitialized = workspacesFetcher.state === 'idle' && !workspacesFetcher.data;
@@ -367,7 +366,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal }) => {
 
             <Button
               className="px-4 py-1 font-semibold border border-solid border-[--hl-md] flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
-              isDisabled={!isLoggedIn()}
+              isDisabled={!user.id}
               onPress={() => window.main.openInBrowser('https://insomnia.rest/create-run-button')}
             >
               <i className="fa fa-file-import" />

--- a/packages/insomnia/src/ui/components/toast.tsx
+++ b/packages/insomnia/src/ui/components/toast.tsx
@@ -3,7 +3,6 @@ import type { IpcRendererEvent } from 'electron';
 import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import * as session from '../../account/session';
 import {
   getAppId,
   getAppPlatform,
@@ -13,6 +12,7 @@ import {
 } from '../../common/constants';
 import * as models from '../../models/index';
 import imgSrcCore from '../images/insomnia-logo.svg';
+import { useRootLoaderData } from '../routes/root';
 import { Link } from './base/link';
 
 const INSOMNIA_NOTIFICATIONS_SEEN = 'insomnia::notifications::seen';
@@ -52,6 +52,7 @@ const StyledFooter = styled.footer`
 type SeenNotifications = Record<string, boolean>;
 
 export const Toast: FC = () => {
+  const { user } = useRootLoaderData();
   const [notification, setNotification] = useState<ToastNotification | null>(null);
   const [visible, setVisible] = useState(false);
   const handleNotification = (notification: ToastNotification | null | undefined) => {
@@ -108,7 +109,7 @@ export const Toast: FC = () => {
         method: 'POST',
         path: '/notification',
         data,
-        sessionId: session.getCurrentSessionId(),
+        sessionId: user.id,
       });
       if (notificationOrEmpty && typeof notificationOrEmpty !== 'string') {
         updatedNotification = notificationOrEmpty;

--- a/packages/insomnia/src/ui/components/toast.tsx
+++ b/packages/insomnia/src/ui/components/toast.tsx
@@ -52,7 +52,7 @@ const StyledFooter = styled.footer`
 type SeenNotifications = Record<string, boolean>;
 
 export const Toast: FC = () => {
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
   const [notification, setNotification] = useState<ToastNotification | null>(null);
   const [visible, setVisible] = useState(false);
   const handleNotification = (notification: ToastNotification | null | undefined) => {
@@ -109,7 +109,7 @@ export const Toast: FC = () => {
         method: 'POST',
         path: '/notification',
         data,
-        sessionId: user.id,
+        sessionId: userSession.id,
       });
       if (notificationOrEmpty && typeof notificationOrEmpty !== 'string') {
         updatedNotification = notificationOrEmpty;

--- a/packages/insomnia/src/ui/context/app/ai-context.tsx
+++ b/packages/insomnia/src/ui/context/app/ai-context.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, FC, PropsWithChildren, useContext, useEffect, useRef } from 'react';
 import { useFetcher, useFetchers, useParams } from 'react-router-dom';
 
-import { isLoggedIn } from '../../../account/session';
+import { useRootLoaderData } from '../../routes/root';
 
 const AIContext = createContext({
   generating: false,
@@ -28,6 +28,7 @@ export const AIProvider: FC<PropsWithChildren> = ({ children }) => {
     workspaceId: string;
   };
 
+  const { user } = useRootLoaderData();
   const [progress, setProgress] = React.useState({
     total: 0,
     progress: 0,
@@ -37,11 +38,10 @@ export const AIProvider: FC<PropsWithChildren> = ({ children }) => {
   const aiGenerateTestsFromSpecFetcher = useFetcher();
   const loading = useFetchers().filter(loader => loader.formAction?.includes('/ai/generate/')).some(loader => loader.state !== 'idle');
 
-  const loggedIn = isLoggedIn();
   const previousOrganizationIdRef = useRef(organizationId);
 
   useEffect(() => {
-    if (!loggedIn) {
+    if (!user.id) {
       return;
     }
 
@@ -55,7 +55,7 @@ export const AIProvider: FC<PropsWithChildren> = ({ children }) => {
         action: `/organization/${organizationId}/ai/access`,
       });
     }
-  }, [aiAccessFetcher, organizationId, loggedIn]);
+  }, [aiAccessFetcher, organizationId, user.id]);
 
   const isAIEnabled = Boolean(aiAccessFetcher.data?.enabled);
 

--- a/packages/insomnia/src/ui/context/app/ai-context.tsx
+++ b/packages/insomnia/src/ui/context/app/ai-context.tsx
@@ -28,7 +28,7 @@ export const AIProvider: FC<PropsWithChildren> = ({ children }) => {
     workspaceId: string;
   };
 
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
   const [progress, setProgress] = React.useState({
     total: 0,
     progress: 0,
@@ -41,7 +41,7 @@ export const AIProvider: FC<PropsWithChildren> = ({ children }) => {
   const previousOrganizationIdRef = useRef(organizationId);
 
   useEffect(() => {
-    if (!user.id) {
+    if (!userSession.id) {
       return;
     }
 
@@ -55,7 +55,7 @@ export const AIProvider: FC<PropsWithChildren> = ({ children }) => {
         action: `/organization/${organizationId}/ai/access`,
       });
     }
-  }, [aiAccessFetcher, organizationId, user.id]);
+  }, [aiAccessFetcher, organizationId, userSession.id]);
 
   const isAIEnabled = Boolean(aiAccessFetcher.data?.enabled);
 

--- a/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
@@ -76,7 +76,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
       workspaceId: string;
   };
 
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
   const projectData = useRouteLoaderData('/project/:projectId') as ProjectLoaderData | null;
   const workspaceData = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData | null;
   const remoteId = projectData?.activeProject.remoteId || workspaceData?.activeProject.remoteId;
@@ -90,7 +90,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
   // Update presence when the user switches org, projects, workspaces
   useEffect(() => {
     async function updatePresence() {
-      const sessionId = user.id;
+      const sessionId = userSession.id;
       if (sessionId && remoteId) {
         try {
           const response = await window.main.insomniaFetch<{
@@ -116,7 +116,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
     }
 
     updatePresence();
-  }, [organizationId, remoteId, user.id, workspaceId]);
+  }, [organizationId, remoteId, userSession.id, workspaceId]);
 
   useEffect(() => {
     const sessionId = getCurrentSessionId();

--- a/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
@@ -3,6 +3,7 @@ import { useFetcher, useParams, useRevalidator, useRouteLoaderData } from 'react
 
 import { getCurrentSessionId } from '../../../account/session';
 import { ProjectLoaderData } from '../../routes/project';
+import { useRootLoaderData } from '../../routes/root';
 import { WorkspaceLoaderData } from '../../routes/workspace';
 
 const InsomniaEventStreamContext = createContext<{
@@ -75,6 +76,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
       workspaceId: string;
   };
 
+  const { user } = useRootLoaderData();
   const projectData = useRouteLoaderData('/project/:projectId') as ProjectLoaderData | null;
   const workspaceData = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData | null;
   const remoteId = projectData?.activeProject.remoteId || workspaceData?.activeProject.remoteId;
@@ -88,7 +90,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
   // Update presence when the user switches org, projects, workspaces
   useEffect(() => {
     async function updatePresence() {
-      const sessionId = getCurrentSessionId();
+      const sessionId = user.id;
       if (sessionId && remoteId) {
         try {
           const response = await window.main.insomniaFetch<{
@@ -114,7 +116,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
     }
 
     updatePresence();
-  }, [organizationId, remoteId, workspaceId]);
+  }, [organizationId, remoteId, user.id, workspaceId]);
 
   useEffect(() => {
     const sessionId = getCurrentSessionId();

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -62,7 +62,7 @@ try {
 
   if (insomniaSession) {
     const session = JSON.parse(insomniaSession) as SessionData;
-    await setSessionData(
+    setSessionData(
       session.id,
       session.sessionExpiry || new Date(),
       session.accountId,

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -75,7 +75,7 @@ async function getInitialEntry() {
 
     const hasUserLoggedInBefore = window.localStorage.getItem('hasUserLoggedInBefore');
 
-    const user = await models.user.getOrCreate();
+    const user = await models.userSession.getOrCreate();
     if (user.id) {
       return '/organization';
     }

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -9,7 +9,7 @@ import {
   RouterProvider,
 } from 'react-router-dom';
 
-import { SessionData, setSessionData } from '../account/session';
+import { migrateFromLocalStorage, SessionData, setSessionData } from '../account/session';
 import {
   ACTIVITY_DEBUG,
   ACTIVITY_SPEC,
@@ -93,6 +93,8 @@ async function getInitialEntry() {
 async function renderApp() {
   await database.initClient();
   await initPlugins();
+
+  await migrateFromLocalStorage();
   const insomniaSession = getInsomniaSession();
   if (insomniaSession) {
     try {

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -62,9 +62,9 @@ try {
 
   if (insomniaSession) {
     const session = JSON.parse(insomniaSession) as SessionData;
-    setSessionData(
+    await setSessionData(
       session.id,
-      session.sessionExpiry,
+      session.sessionExpiry || new Date(),
       session.accountId,
       session.firstName,
       session.lastName,

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -54,25 +54,9 @@ try {
   // In order to run playwight tests that simulate a logged in user
   // we need to inject state into localStorage
   const skipOnboarding = getSkipOnboarding();
-  const insomniaSession = getInsomniaSession();
   if (skipOnboarding) {
     window.localStorage.setItem('hasSeenOnboarding', skipOnboarding.toString());
     window.localStorage.setItem('hasUserLoggedInBefore', skipOnboarding.toString());
-  }
-
-  if (insomniaSession) {
-    const session = JSON.parse(insomniaSession) as SessionData;
-    setSessionData(
-      session.id,
-      session.sessionExpiry || new Date(),
-      session.accountId,
-      session.firstName,
-      session.lastName,
-      session.email,
-      session.symmetricKey,
-      session.publicKey,
-      session.encPrivateKey
-    );
   }
 } catch (e) {
   console.log('Failed to parse session data', e);
@@ -1066,6 +1050,26 @@ router.subscribe(({ location, navigation }) => {
 async function renderApp() {
   await database.initClient();
   await initPlugins();
+
+  const insomniaSession = getInsomniaSession();
+  if (insomniaSession) {
+    try {
+      const session = JSON.parse(insomniaSession) as SessionData;
+      await setSessionData(
+        session.id,
+        session.sessionExpiry || new Date(),
+        session.accountId,
+        session.firstName,
+        session.lastName,
+        session.email,
+        session.symmetricKey,
+        session.publicKey,
+        session.encPrivateKey
+      );
+    } catch (e) {
+      console.log('Failed to parse session data', e);
+    }
+  }
 
   const settings = await models.settings.getOrCreate();
 

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -9,7 +9,7 @@ import {
   RouterProvider,
 } from 'react-router-dom';
 
-import { isLoggedIn, SessionData, setSessionData } from '../account/session';
+import { SessionData, setSessionData } from '../account/session';
 import {
   ACTIVITY_DEBUG,
   ACTIVITY_SPEC,
@@ -62,7 +62,7 @@ try {
   console.log('Failed to parse session data', e);
 }
 
-function getInitialEntry() {
+async function getInitialEntry() {
   // If the user has not seen the onboarding, then show it
   // Otherwise if the user is not logged in and has not logged in before, then show the login
   // Otherwise if the user is logged in, then show the organization
@@ -75,7 +75,8 @@ function getInitialEntry() {
 
     const hasUserLoggedInBefore = window.localStorage.getItem('hasUserLoggedInBefore');
 
-    if (isLoggedIn()) {
+    const user = await models.user.getOrCreate();
+    if (user.id) {
       return '/organization';
     }
 
@@ -89,968 +90,9 @@ function getInitialEntry() {
   }
 }
 
-const initialEntry = getInitialEntry();
-
-const router = createMemoryRouter(
-  // @TODO - Investigate file based routing to generate these routes:
-  [
-    {
-      path: '/',
-      id: 'root',
-      element: <Root />,
-      loader: async (...args) => (await import('./routes/root')).loader(...args),
-      errorElement: <ErrorRoute />,
-      children: [
-        {
-          path: 'onboarding/*',
-          element: <Onboarding />,
-          errorElement: <ErrorRoute />,
-        },
-        {
-          path: 'onboarding/migrate',
-          loader: async (...args) => (await import('./routes/onboarding.migrate')).loader(...args),
-          action: async (...args) => (await import('./routes/onboarding.migrate')).action(...args),
-          element: <Migrate />,
-        },
-        {
-          path: 'commands',
-          loader: async (...args) => (await import('./routes/commands')).loader(...args),
-        },
-        {
-          path: 'import',
-          children: [
-            {
-              path: 'scan',
-              action: async (...args) =>
-                (await import('./routes/import')).scanForResourcesAction(
-                  ...args,
-                ),
-            },
-            {
-              path: 'resources',
-              action: async (...args) =>
-                (await import('./routes/import')).importResourcesAction(
-                  ...args,
-                ),
-            },
-          ],
-        },
-        {
-          path: 'settings/update',
-          action: async (...args) =>
-            (await import('./routes/actions')).updateSettingsAction(...args),
-        },
-        {
-          path: 'untracked-projects',
-          loader: async (...args) => (await import('./routes/untracked-projects')).loader(...args),
-        },
-        {
-          path: 'organization',
-          id: '/organization',
-          loader: async (...args) => (await import('./routes/organization')).loader(...args),
-          element: <Suspense fallback={<AppLoadingIndicator />}><Organization /></Suspense>,
-          errorElement: <ErrorRoute defaultMessage='A temporarily unexpected error occurred, please reload to try again' />,
-          children: [
-            {
-              index: true,
-              loader: async (...args) => (await import('./routes/organization')).indexLoader(...args),
-            },
-            {
-              path: 'sync',
-              action: async (...args) => (await import('./routes/organization')).syncOrganizationsAction(...args),
-            },
-            {
-              path: ':organizationId',
-              id: ':organizationId',
-              shouldRevalidate: shouldOrganizationsRevalidate,
-              loader: async (...args) =>
-                (
-                  await import('./routes/organization')
-                ).singleOrgLoader(...args),
-              children: [
-                {
-                  index: true,
-                  loader: async (...args) =>
-                    (await import('./routes/project')).indexLoader(...args),
-                },
-                {
-                  path: 'sync-projects',
-                  action: async (...args) =>
-                    (
-                      await import('./routes/project')
-                    ).syncProjectsAction(...args),
-                },
-                {
-                  path: 'ai/access',
-                  action: async (...args) =>
-                    (
-                      await import('./routes/actions')
-                    ).accessAIApiAction(...args),
-                },
-                {
-                  path: 'project',
-                  id: '/project',
-                  children: [
-                    {
-                      path: ':projectId',
-                      id: '/project/:projectId',
-                      loader: async (...args) =>
-                        (await import('./routes/project')).loader(...args),
-                      element: (
-                        <Suspense fallback={<AppLoadingIndicator />}>
-                          <Project />
-                        </Suspense>
-                      ),
-                      children: [
-                        {
-                          path: 'delete',
-                          action: async (...args) =>
-                            (
-                              await import('./routes/actions')
-                            ).deleteProjectAction(...args),
-                        },
-                        {
-                          path: 'move',
-                          action: async (...args) =>
-                            (
-                              await import('./routes/actions')
-                            ).moveProjectAction(...args),
-                        },
-                        {
-                          path: 'move-workspace',
-                          action: async (...args) =>
-                            (
-                              await import('./routes/actions')
-                            ).moveWorkspaceIntoProjectAction(...args),
-                        },
-                        {
-                          path: 'update',
-                          action: async (...args) =>
-                            (
-                              await import('./routes/actions')
-                            ).updateProjectAction(...args),
-                        },
-                        {
-                          path: 'git',
-                          children: [
-                            {
-                              path: 'clone',
-                              action: async (...args) =>
-                                (
-                                  await import('./routes/git-actions')
-                                ).cloneGitRepoAction(...args),
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                    {
-                      path: ':projectId/workspace',
-                      children: [
-                        {
-                          path: ':workspaceId',
-                          id: ':workspaceId',
-                          loader: async (...args) =>
-                            (
-                              await import('./routes/workspace')
-                            ).workspaceLoader(...args),
-                          element: (
-                            <Suspense fallback={<AppLoadingIndicator />}>
-                              <Workspace />
-                            </Suspense>
-                          ),
-                          children: [
-                            {
-                              path: `${ACTIVITY_DEBUG}`,
-                              loader: async (...args) =>
-                                (await import('./routes/debug')).loader(
-                                  ...args,
-                                ),
-                              element: (
-                                <Suspense fallback={<AppLoadingIndicator />}>
-                                  <Debug />
-                                </Suspense>
-                              ),
-                              children: [
-                                {
-                                  path: 'reorder',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).reorderCollectionAction(...args),
-                                },
-                                {
-                                  path: 'request/:requestId',
-                                  id: 'request/:requestId',
-                                  loader: async (...args) =>
-                                    (await import('./routes/request')).loader(
-                                      ...args,
-                                    ),
-                                  element: <Outlet />,
-                                  children: [
-                                    {
-                                      path: 'send',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/request')
-                                        ).sendAction(...args),
-                                    },
-                                    {
-                                      path: 'connect',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/request')
-                                        ).connectAction(...args),
-                                    },
-                                    {
-                                      path: 'duplicate',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/request')
-                                        ).duplicateRequestAction(...args),
-                                    },
-                                    {
-                                      path: 'update',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/request')
-                                        ).updateRequestAction(...args),
-                                    },
-                                    {
-                                      path: 'update-meta',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/request')
-                                        ).updateRequestMetaAction(...args),
-                                    },
-                                    {
-                                      path: 'response/delete-all',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/request')
-                                        ).deleteAllResponsesAction(...args),
-                                    },
-                                    {
-                                      path: 'response/delete',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/request')
-                                        ).deleteResponseAction(...args),
-                                    },
-                                  ],
-                                },
-                                {
-                                  path: 'request/new',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/request')
-                                    ).createRequestAction(...args),
-                                },
-                                {
-                                  path: 'request/new-mock-send',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/request')
-                                    ).createAndSendToMockbinAction(...args),
-                                },
-                                {
-                                  path: 'request/delete',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/request')
-                                    ).deleteRequestAction(...args),
-                                },
-                                {
-                                  path: 'request-group/new',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/request-group')
-                                    ).createRequestGroupAction(...args),
-                                },
-                                {
-                                  path: 'request-group/delete',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/request-group')
-                                    ).deleteRequestGroupAction(...args),
-                                },
-                                {
-                                  path: 'request-group/:requestGroupId/update',
-                                  action: async (...args) => (await import('./routes/request-group')).updateRequestGroupAction(...args),
-                                },
-                                {
-                                  path: 'request-group/duplicate',
-                                  action: async (...args) => (await import('./routes/request-group')).duplicateRequestGroupAction(...args),
-                                },
-                                {
-                                  path: 'request-group/:requestGroupId/update-meta',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/request-group')
-                                    ).updateRequestGroupMetaAction(...args),
-                                },
-                              ],
-                            },
-                            {
-                              path: `${ACTIVITY_SPEC}`,
-                              loader: async (...args) =>
-                                (await import('./routes/design')).loader(
-                                  ...args,
-                                ),
-                              element: (
-                                <Suspense fallback={<AppLoadingIndicator />}>
-                                  <Design />
-                                </Suspense>
-                              ),
-                              children: [
-                                {
-                                  path: 'update',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).updateApiSpecAction(...args),
-                                },
-                                {
-                                  path: 'generate-request-collection',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).generateCollectionFromApiSpecAction(
-                                      ...args,
-                                    ),
-                                },
-                              ],
-                            },
-                            {
-                              path: 'mock-server/*',
-                              id: 'mock-server',
-                              loader: async (...args) =>
-                                (await import('./routes/mock-server')).loader(
-                                  ...args,
-                                ),
-                              element: (
-                                <Suspense fallback={<AppLoadingIndicator />}>
-                                  <MockServer />
-                                </Suspense>
-                              ),
-                              children: [
-                                {
-                                  path: 'update',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).updateMockServerAction(...args),
-                                },
-                                {
-                                  path: 'mock-route',
-                                  id: 'mock-route',
-                                  children: [
-                                    {
-                                      path: ':mockRouteId',
-                                      id: ':mockRouteId',
-                                      loader: async (...args) =>
-                                        (
-                                          await import('./routes/mock-route')
-                                        ).loader(...args),
-                                      element: <Outlet />,
-                                    },
-                                    {
-                                      path: 'new',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/actions')
-                                        ).createMockRouteAction(...args),
-                                    },
-                                    {
-                                      path: ':mockRouteId/update',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/actions')
-                                        ).updateMockRouteAction(...args),
-                                    },
-                                    {
-                                      path: ':mockRouteId/delete',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/actions')
-                                        ).deleteMockRouteAction(...args),
-                                    },
-                                  ],
-                                },
-                              ],
-                            },
-                            {
-                              path: 'cacert',
-                              children: [
-                                {
-                                  path: 'new',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).createNewCaCertificateAction(...args),
-                                },
-                                {
-                                  path: 'update',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).updateCaCertificateAction(...args),
-                                },
-                                {
-                                  path: 'delete',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).deleteCaCertificateAction(...args),
-                                },
-                              ],
-                            },
-                            {
-                              path: 'clientcert',
-                              children: [
-                                {
-                                  path: 'new',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).createNewClientCertificateAction(...args),
-                                },
-                                {
-                                  path: 'update',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).updateClientCertificateAction(...args),
-                                },
-                                {
-                                  path: 'delete',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).deleteClientCertificateAction(...args),
-                                },
-                              ],
-                            },
-                            {
-                              path: 'environment',
-                              children: [
-                                {
-                                  path: 'update',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).updateEnvironment(...args),
-                                },
-                                {
-                                  path: 'delete',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).deleteEnvironmentAction(...args),
-                                },
-                                {
-                                  path: 'create',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).createEnvironmentAction(...args),
-                                },
-                                {
-                                  path: 'duplicate',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).duplicateEnvironmentAction(...args),
-                                },
-                                {
-                                  path: 'set-active',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).setActiveEnvironmentAction(...args),
-                                },
-                              ],
-                            },
-                            {
-                              path: 'cookieJar',
-                              children: [
-                                {
-                                  path: 'update',
-                                  action: async (...args) =>
-                                    (
-                                      await import('./routes/actions')
-                                    ).updateCookieJarAction(...args),
-                                },
-                              ],
-                            },
-                            {
-                              path: 'test/*',
-                              loader: async (...args) =>
-                                (await import('./routes/unit-test')).loader(
-                                  ...args,
-                                ),
-                              element: (
-                                <Suspense fallback={<AppLoadingIndicator />}>
-                                  <UnitTest />
-                                </Suspense>
-                              ),
-                              children: [
-                                {
-                                  index: true,
-                                  loader: async (...args) =>
-                                    (
-                                      await import('./routes/test-suite')
-                                    ).indexLoader(...args),
-                                },
-                                {
-                                  path: 'test-suite',
-                                  children: [
-                                    {
-                                      index: true,
-                                      loader: async (...args) =>
-                                        (
-                                          await import('./routes/test-suite')
-                                        ).indexLoader(...args),
-                                    },
-                                    {
-                                      path: 'new',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/actions')
-                                        ).createNewTestSuiteAction(...args),
-                                    },
-                                    {
-                                      path: ':testSuiteId',
-                                      id: ':testSuiteId',
-                                      loader: async (...args) =>
-                                        (
-                                          await import('./routes/test-suite')
-                                        ).loader(...args),
-                                      children: [
-                                        {
-                                          index: true,
-                                          loader: async (...args) =>
-                                            (
-                                              await import(
-                                                './routes/test-results'
-                                              )
-                                            ).indexLoader(...args),
-                                        },
-                                        {
-                                          path: 'test-result',
-                                          children: [
-                                            {
-                                              path: ':testResultId',
-                                              id: ':testResultId',
-                                              loader: async (...args) =>
-                                                (
-                                                  await import(
-                                                    './routes/test-results'
-                                                  )
-                                                ).loader(...args),
-                                            },
-                                          ],
-                                        },
-                                        {
-                                          path: 'delete',
-                                          action: async (...args) =>
-                                            (
-                                              await import('./routes/actions')
-                                            ).deleteTestSuiteAction(...args),
-                                        },
-                                        {
-                                          path: 'update',
-                                          action: async (...args) =>
-                                            (
-                                              await import('./routes/actions')
-                                            ).updateTestSuiteAction(...args),
-                                        },
-                                        {
-                                          path: 'run-all-tests',
-                                          action: async (...args) =>
-                                            (
-                                              await import('./routes/actions')
-                                            ).runAllTestsAction(...args),
-                                        },
-                                        {
-                                          path: 'test',
-                                          children: [
-                                            {
-                                              path: 'new',
-                                              action: async (...args) =>
-                                                (
-                                                  await import(
-                                                    './routes/actions'
-                                                  )
-                                                ).createNewTestAction(...args),
-                                            },
-                                            {
-                                              path: ':testId',
-                                              children: [
-                                                {
-                                                  path: 'delete',
-                                                  action: async (...args) =>
-                                                    (
-                                                      await import(
-                                                        './routes/actions'
-                                                      )
-                                                    ).deleteTestAction(...args),
-                                                },
-                                                {
-                                                  path: 'update',
-                                                  action: async (...args) =>
-                                                    (
-                                                      await import(
-                                                        './routes/actions'
-                                                      )
-                                                    ).updateTestAction(...args),
-                                                },
-                                                {
-                                                  path: 'run',
-                                                  action: async (...args) =>
-                                                    (
-                                                      await import(
-                                                        './routes/actions'
-                                                      )
-                                                    ).runTestAction(...args),
-                                                },
-                                              ],
-                                            },
-                                          ],
-                                        },
-                                      ],
-                                    },
-                                  ],
-                                },
-                              ],
-                            },
-                            {
-                              path: 'ai',
-                              children: [
-                                {
-                                  path: 'generate',
-                                  children: [
-                                    {
-                                      path: 'collection-and-tests',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/actions')
-                                        ).generateCollectionAndTestsAction(
-                                          ...args,
-                                        ),
-                                    },
-                                    {
-                                      path: 'tests',
-                                      action: async (...args) =>
-                                        (
-                                          await import('./routes/actions')
-                                        ).generateTestsAction(...args),
-                                    },
-                                  ],
-                                },
-                              ],
-                            },
-                            {
-                              path: 'duplicate',
-                              action: async (...args) =>
-                                (
-                                  await import('./routes/actions')
-                                ).duplicateWorkspaceAction(...args),
-                            },
-                            {
-                              path: 'git',
-                              children: [
-                                {
-                                  path: 'repo',
-                                  loader: async (...args) =>
-                                    (await import('./routes/git-actions')).gitRepoLoader(...args),
-                                },
-                                {
-                                  path: 'changes',
-                                  loader: async (...args) =>
-                                    (await import('./routes/git-actions')).gitChangesLoader(...args),
-                                },
-                                {
-                                  path: 'log',
-                                  loader: async (...args) =>
-                                    (await import('./routes/git-actions')).gitLogLoader(...args),
-                                },
-                                {
-                                  path: 'branches',
-                                  loader: async (...args) =>
-                                    (await import('./routes/git-actions')).gitBranchesLoader(...args),
-                                },
-                                {
-                                  path: 'status',
-                                  action: async (...args) =>
-                                    (await import('./routes/git-actions')).gitStatusAction(...args),
-                                },
-                                {
-                                  path: 'commit',
-                                  action: async (...args) =>
-                                    (await import('./routes/git-actions')).commitToGitRepoAction(...args),
-                                },
-                                {
-                                  path: 'fetch',
-                                  action: async (...args) =>
-                                    (await import('./routes/git-actions')).gitFetchAction(...args),
-                                },
-                                {
-                                  path: 'rollback',
-                                  action: async (...args) =>
-                                    (await import('./routes/git-actions')).gitRollbackChangesAction(...args),
-                                },
-                                {
-                                  path: 'update',
-                                  action: async (...args) =>
-                                    (await import('./routes/git-actions')).updateGitRepoAction(...args),
-                                },
-                                {
-                                  path: 'reset',
-                                  action: async (...args) =>
-                                    (await import('./routes/git-actions')).resetGitRepoAction(...args),
-                                },
-                                {
-                                  path: 'pull',
-                                  action: async (...args) =>
-                                    (await import('./routes/git-actions')).pullFromGitRemoteAction(...args),
-                                },
-                                {
-                                  path: 'push',
-                                  action: async (...args) =>
-                                    (await import('./routes/git-actions')).pushToGitRemoteAction(...args),
-                                },
-                                {
-                                  path: 'branch',
-                                  children: [
-                                    {
-                                      path: 'new',
-                                      action: async (...args) =>
-                                        (await import('./routes/git-actions')).createNewGitBranchAction(...args),
-                                    },
-                                    {
-                                      path: 'delete',
-                                      action: async (...args) =>
-                                        (await import('./routes/git-actions')).deleteGitBranchAction(...args),
-                                    },
-                                    {
-                                      path: 'checkout',
-                                      action: async (...args) =>
-                                        (await import('./routes/git-actions')).checkoutGitBranchAction(...args),
-                                    },
-                                    {
-                                      path: 'merge',
-                                      action: async (...args) =>
-                                        (await import('./routes/git-actions')).mergeGitBranchAction(...args),
-                                    },
-                                  ],
-                                },
-                              ],
-                            },
-                            {
-                              path: 'insomnia-sync',
-                              children: [
-                                {
-                                  path: 'sync-data',
-                                  action: async (...args) =>
-                                    (await import('./routes/remote-collections')).syncDataAction(...args),
-                                  loader: async (...args) =>
-                                    (await import('./routes/remote-collections')).syncDataLoader(...args),
-                                },
-                                {
-                                  path: 'stage',
-                                  action: async (...args) => (await import('./routes/remote-collections')).stageChangesAction(...args),
-                                },
-                                {
-                                  path: 'unstage',
-                                  action: async (...args) => (await import('./routes/remote-collections')).unstageChangesAction(...args),
-                                },
-                                {
-                                  path: 'pull',
-                                  action: async (...args) =>
-                                    (await import('./routes/remote-collections')).pullFromRemoteAction(...args),
-                                },
-                                {
-                                  path: 'push',
-                                  action: async (...args) =>
-                                    (await import('./routes/remote-collections')).pushToRemoteAction(...args),
-                                },
-                                {
-                                  path: 'rollback',
-                                  action: async (...args) =>
-                                    (await import('./routes/remote-collections')).rollbackChangesAction(...args),
-                                },
-                                {
-                                  path: 'restore',
-                                  action: async (...args) =>
-                                    (await import('./routes/remote-collections')).restoreChangesAction(...args),
-                                },
-                                {
-                                  path: 'branch',
-                                  children: [
-                                    {
-                                      path: 'checkout',
-                                      action: async (...args) =>
-                                        (await import('./routes/remote-collections')).checkoutBranchAction(...args),
-                                    },
-                                    {
-                                      path: 'create',
-                                      action: async (...args) =>
-                                        (await import('./routes/remote-collections')).createBranchAction(...args),
-                                    },
-                                    {
-                                      path: 'fetch',
-                                      action: async (...args) =>
-                                        (await import('./routes/remote-collections')).fetchRemoteBranchAction(...args),
-                                    },
-                                    {
-                                      path: 'delete',
-                                      action: async (...args) =>
-                                        (await import('./routes/remote-collections')).deleteBranchAction(...args),
-                                    },
-                                    {
-                                      path: 'merge',
-                                      action: async (...args) =>
-                                        (await import('./routes/remote-collections')).mergeBranchAction(...args),
-                                    },
-                                    {
-                                      path: 'create-snapshot',
-                                      action: async (...args) =>
-                                        (await import('./routes/remote-collections')).createSnapshotAction(...args),
-                                    },
-                                    {
-                                      path: 'create-snapshot-and-push',
-                                      action: async (...args) =>
-                                        (await import('./routes/remote-collections')).createSnapshotAndPushAction(...args),
-                                    },
-                                    {
-                                      path: 'rollback',
-                                      action: async (...args) =>
-                                        (await import('./routes/remote-collections')).rollbackChangesAction(...args),
-                                    },
-                                  ],
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                        {
-                          path: 'new',
-                          action: async (...args) =>
-                            (
-                              await import('./routes/actions')
-                            ).createNewWorkspaceAction(...args),
-                        },
-                        {
-                          path: 'delete',
-                          action: async (...args) =>
-                            (
-                              await import('./routes/actions')
-                            ).deleteWorkspaceAction(...args),
-                        },
-                        {
-                          path: 'update',
-                          action: async (...args) =>
-                            (
-                              await import('./routes/actions')
-                            ).updateWorkspaceAction(...args),
-                        },
-                        {
-                          path: ':workspaceId/update-meta',
-                          action: async (...args) =>
-                            (await import('./routes/actions')).updateWorkspaceMetaAction(
-                              ...args
-                            ),
-                        },
-                      ],
-                    },
-                    {
-                      path: 'new',
-                      action: async (...args) =>
-                        (
-                          await import('./routes/actions')
-                        ).createNewProjectAction(...args),
-                    },
-                    {
-                      path: ':projectId/remote-collections',
-                      loader: async (...args) =>
-                        (
-                          await import('./routes/remote-collections')
-                        ).remoteLoader(...args),
-                      children: [
-                        {
-                          path: 'pull',
-                          action: async (...args) =>
-                            (
-                              await import('./routes/remote-collections')
-                            ).pullRemoteCollectionAction(...args),
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          path: 'auth',
-          element: <Suspense fallback={<AppLoadingIndicator />}>
-            <Auth />
-          </Suspense>,
-          errorElement: <ErrorRoute defaultMessage='A temporarily unexpected error occurred, please reload to try again' />,
-          children: [
-            {
-              path: 'login',
-              action: async (...args) => (await import('./routes/auth.login')).action(...args),
-              element: <Login />,
-            },
-            {
-              path: 'logout',
-              action: async (...args) => (await import('./routes/auth.logout')).action(...args),
-            },
-            {
-              path: 'authorize',
-              action: async (...args) => (await import('./routes/auth.authorize')).action(...args),
-              element: <Authorize />,
-            },
-          ],
-        },
-      ],
-    },
-  ],
-  {
-    initialEntries: [initialEntry],
-  }
-);
-
-// Store the last location in local storage
-router.subscribe(({ location, navigation }) => {
-  const match = matchPath(
-    {
-      path: '/organization/:organizationId',
-      end: false,
-    },
-    location.pathname
-  );
-  const nextRoute = navigation.location?.pathname;
-  const currentRoute = location.pathname;
-  // Use navigation send tracking events on page change
-  const bothHaveValueButNotEqual = nextRoute && currentRoute && nextRoute !== currentRoute;
-  if (bothHaveValueButNotEqual) {
-    // transforms /organization/:org_* to /organization/:org_id
-    const routeWithoutUUID = nextRoute.replace(/_[a-f0-9]{32}/g, '_id');
-    // console.log('Tracking page view', { name: routeWithoutUUID });
-    window.main.trackPageView({ name: routeWithoutUUID });
-  }
-
-  match?.params.organizationId && localStorage.setItem(`locationHistoryEntry:${match?.params.organizationId}`, currentRoute);
-});
-
 async function renderApp() {
   await database.initClient();
   await initPlugins();
-
   const insomniaSession = getInsomniaSession();
   if (insomniaSession) {
     try {
@@ -1082,6 +124,964 @@ async function renderApp() {
   const root = document.getElementById('root');
 
   invariant(root, 'Could not find root element');
+
+  const initialEntry = await getInitialEntry();
+
+  const router = createMemoryRouter(
+    // @TODO - Investigate file based routing to generate these routes:
+    [
+      {
+        path: '/',
+        id: 'root',
+        element: <Root />,
+        loader: async (...args) => (await import('./routes/root')).loader(...args),
+        errorElement: <ErrorRoute />,
+        children: [
+          {
+            path: 'onboarding/*',
+            element: <Onboarding />,
+            errorElement: <ErrorRoute />,
+          },
+          {
+            path: 'onboarding/migrate',
+            loader: async (...args) => (await import('./routes/onboarding.migrate')).loader(...args),
+            action: async (...args) => (await import('./routes/onboarding.migrate')).action(...args),
+            element: <Migrate />,
+          },
+          {
+            path: 'commands',
+            loader: async (...args) => (await import('./routes/commands')).loader(...args),
+          },
+          {
+            path: 'import',
+            children: [
+              {
+                path: 'scan',
+                action: async (...args) =>
+                  (await import('./routes/import')).scanForResourcesAction(
+                    ...args,
+                  ),
+              },
+              {
+                path: 'resources',
+                action: async (...args) =>
+                  (await import('./routes/import')).importResourcesAction(
+                    ...args,
+                  ),
+              },
+            ],
+          },
+          {
+            path: 'settings/update',
+            action: async (...args) =>
+              (await import('./routes/actions')).updateSettingsAction(...args),
+          },
+          {
+            path: 'untracked-projects',
+            loader: async (...args) => (await import('./routes/untracked-projects')).loader(...args),
+          },
+          {
+            path: 'organization',
+            id: '/organization',
+            loader: async (...args) => (await import('./routes/organization')).loader(...args),
+            element: <Suspense fallback={<AppLoadingIndicator />}><Organization /></Suspense>,
+            errorElement: <ErrorRoute defaultMessage='A temporarily unexpected error occurred, please reload to try again' />,
+            children: [
+              {
+                index: true,
+                loader: async (...args) => (await import('./routes/organization')).indexLoader(...args),
+              },
+              {
+                path: 'sync',
+                action: async (...args) => (await import('./routes/organization')).syncOrganizationsAction(...args),
+              },
+              {
+                path: ':organizationId',
+                id: ':organizationId',
+                shouldRevalidate: shouldOrganizationsRevalidate,
+                loader: async (...args) =>
+                  (
+                    await import('./routes/organization')
+                  ).singleOrgLoader(...args),
+                children: [
+                  {
+                    index: true,
+                    loader: async (...args) =>
+                      (await import('./routes/project')).indexLoader(...args),
+                  },
+                  {
+                    path: 'sync-projects',
+                    action: async (...args) =>
+                      (
+                        await import('./routes/project')
+                      ).syncProjectsAction(...args),
+                  },
+                  {
+                    path: 'ai/access',
+                    action: async (...args) =>
+                      (
+                        await import('./routes/actions')
+                      ).accessAIApiAction(...args),
+                  },
+                  {
+                    path: 'project',
+                    id: '/project',
+                    children: [
+                      {
+                        path: ':projectId',
+                        id: '/project/:projectId',
+                        loader: async (...args) =>
+                          (await import('./routes/project')).loader(...args),
+                        element: (
+                          <Suspense fallback={<AppLoadingIndicator />}>
+                            <Project />
+                          </Suspense>
+                        ),
+                        children: [
+                          {
+                            path: 'delete',
+                            action: async (...args) =>
+                              (
+                                await import('./routes/actions')
+                              ).deleteProjectAction(...args),
+                          },
+                          {
+                            path: 'move',
+                            action: async (...args) =>
+                              (
+                                await import('./routes/actions')
+                              ).moveProjectAction(...args),
+                          },
+                          {
+                            path: 'move-workspace',
+                            action: async (...args) =>
+                              (
+                                await import('./routes/actions')
+                              ).moveWorkspaceIntoProjectAction(...args),
+                          },
+                          {
+                            path: 'update',
+                            action: async (...args) =>
+                              (
+                                await import('./routes/actions')
+                              ).updateProjectAction(...args),
+                          },
+                          {
+                            path: 'git',
+                            children: [
+                              {
+                                path: 'clone',
+                                action: async (...args) =>
+                                  (
+                                    await import('./routes/git-actions')
+                                  ).cloneGitRepoAction(...args),
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        path: ':projectId/workspace',
+                        children: [
+                          {
+                            path: ':workspaceId',
+                            id: ':workspaceId',
+                            loader: async (...args) =>
+                              (
+                                await import('./routes/workspace')
+                              ).workspaceLoader(...args),
+                            element: (
+                              <Suspense fallback={<AppLoadingIndicator />}>
+                                <Workspace />
+                              </Suspense>
+                            ),
+                            children: [
+                              {
+                                path: `${ACTIVITY_DEBUG}`,
+                                loader: async (...args) =>
+                                  (await import('./routes/debug')).loader(
+                                    ...args,
+                                  ),
+                                element: (
+                                  <Suspense fallback={<AppLoadingIndicator />}>
+                                    <Debug />
+                                  </Suspense>
+                                ),
+                                children: [
+                                  {
+                                    path: 'reorder',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).reorderCollectionAction(...args),
+                                  },
+                                  {
+                                    path: 'request/:requestId',
+                                    id: 'request/:requestId',
+                                    loader: async (...args) =>
+                                      (await import('./routes/request')).loader(
+                                        ...args,
+                                      ),
+                                    element: <Outlet />,
+                                    children: [
+                                      {
+                                        path: 'send',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/request')
+                                          ).sendAction(...args),
+                                      },
+                                      {
+                                        path: 'connect',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/request')
+                                          ).connectAction(...args),
+                                      },
+                                      {
+                                        path: 'duplicate',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/request')
+                                          ).duplicateRequestAction(...args),
+                                      },
+                                      {
+                                        path: 'update',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/request')
+                                          ).updateRequestAction(...args),
+                                      },
+                                      {
+                                        path: 'update-meta',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/request')
+                                          ).updateRequestMetaAction(...args),
+                                      },
+                                      {
+                                        path: 'response/delete-all',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/request')
+                                          ).deleteAllResponsesAction(...args),
+                                      },
+                                      {
+                                        path: 'response/delete',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/request')
+                                          ).deleteResponseAction(...args),
+                                      },
+                                    ],
+                                  },
+                                  {
+                                    path: 'request/new',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/request')
+                                      ).createRequestAction(...args),
+                                  },
+                                  {
+                                    path: 'request/new-mock-send',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/request')
+                                      ).createAndSendToMockbinAction(...args),
+                                  },
+                                  {
+                                    path: 'request/delete',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/request')
+                                      ).deleteRequestAction(...args),
+                                  },
+                                  {
+                                    path: 'request-group/new',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/request-group')
+                                      ).createRequestGroupAction(...args),
+                                  },
+                                  {
+                                    path: 'request-group/delete',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/request-group')
+                                      ).deleteRequestGroupAction(...args),
+                                  },
+                                  {
+                                    path: 'request-group/:requestGroupId/update',
+                                    action: async (...args) => (await import('./routes/request-group')).updateRequestGroupAction(...args),
+                                  },
+                                  {
+                                    path: 'request-group/duplicate',
+                                    action: async (...args) => (await import('./routes/request-group')).duplicateRequestGroupAction(...args),
+                                  },
+                                  {
+                                    path: 'request-group/:requestGroupId/update-meta',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/request-group')
+                                      ).updateRequestGroupMetaAction(...args),
+                                  },
+                                ],
+                              },
+                              {
+                                path: `${ACTIVITY_SPEC}`,
+                                loader: async (...args) =>
+                                  (await import('./routes/design')).loader(
+                                    ...args,
+                                  ),
+                                element: (
+                                  <Suspense fallback={<AppLoadingIndicator />}>
+                                    <Design />
+                                  </Suspense>
+                                ),
+                                children: [
+                                  {
+                                    path: 'update',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).updateApiSpecAction(...args),
+                                  },
+                                  {
+                                    path: 'generate-request-collection',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).generateCollectionFromApiSpecAction(
+                                        ...args,
+                                      ),
+                                  },
+                                ],
+                              },
+                              {
+                                path: 'mock-server/*',
+                                id: 'mock-server',
+                                loader: async (...args) =>
+                                  (await import('./routes/mock-server')).loader(
+                                    ...args,
+                                  ),
+                                element: (
+                                  <Suspense fallback={<AppLoadingIndicator />}>
+                                    <MockServer />
+                                  </Suspense>
+                                ),
+                                children: [
+                                  {
+                                    path: 'update',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).updateMockServerAction(...args),
+                                  },
+                                  {
+                                    path: 'mock-route',
+                                    id: 'mock-route',
+                                    children: [
+                                      {
+                                        path: ':mockRouteId',
+                                        id: ':mockRouteId',
+                                        loader: async (...args) =>
+                                          (
+                                            await import('./routes/mock-route')
+                                          ).loader(...args),
+                                        element: <Outlet />,
+                                      },
+                                      {
+                                        path: 'new',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/actions')
+                                          ).createMockRouteAction(...args),
+                                      },
+                                      {
+                                        path: ':mockRouteId/update',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/actions')
+                                          ).updateMockRouteAction(...args),
+                                      },
+                                      {
+                                        path: ':mockRouteId/delete',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/actions')
+                                          ).deleteMockRouteAction(...args),
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                              {
+                                path: 'cacert',
+                                children: [
+                                  {
+                                    path: 'new',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).createNewCaCertificateAction(...args),
+                                  },
+                                  {
+                                    path: 'update',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).updateCaCertificateAction(...args),
+                                  },
+                                  {
+                                    path: 'delete',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).deleteCaCertificateAction(...args),
+                                  },
+                                ],
+                              },
+                              {
+                                path: 'clientcert',
+                                children: [
+                                  {
+                                    path: 'new',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).createNewClientCertificateAction(...args),
+                                  },
+                                  {
+                                    path: 'update',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).updateClientCertificateAction(...args),
+                                  },
+                                  {
+                                    path: 'delete',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).deleteClientCertificateAction(...args),
+                                  },
+                                ],
+                              },
+                              {
+                                path: 'environment',
+                                children: [
+                                  {
+                                    path: 'update',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).updateEnvironment(...args),
+                                  },
+                                  {
+                                    path: 'delete',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).deleteEnvironmentAction(...args),
+                                  },
+                                  {
+                                    path: 'create',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).createEnvironmentAction(...args),
+                                  },
+                                  {
+                                    path: 'duplicate',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).duplicateEnvironmentAction(...args),
+                                  },
+                                  {
+                                    path: 'set-active',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).setActiveEnvironmentAction(...args),
+                                  },
+                                ],
+                              },
+                              {
+                                path: 'cookieJar',
+                                children: [
+                                  {
+                                    path: 'update',
+                                    action: async (...args) =>
+                                      (
+                                        await import('./routes/actions')
+                                      ).updateCookieJarAction(...args),
+                                  },
+                                ],
+                              },
+                              {
+                                path: 'test/*',
+                                loader: async (...args) =>
+                                  (await import('./routes/unit-test')).loader(
+                                    ...args,
+                                  ),
+                                element: (
+                                  <Suspense fallback={<AppLoadingIndicator />}>
+                                    <UnitTest />
+                                  </Suspense>
+                                ),
+                                children: [
+                                  {
+                                    index: true,
+                                    loader: async (...args) =>
+                                      (
+                                        await import('./routes/test-suite')
+                                      ).indexLoader(...args),
+                                  },
+                                  {
+                                    path: 'test-suite',
+                                    children: [
+                                      {
+                                        index: true,
+                                        loader: async (...args) =>
+                                          (
+                                            await import('./routes/test-suite')
+                                          ).indexLoader(...args),
+                                      },
+                                      {
+                                        path: 'new',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/actions')
+                                          ).createNewTestSuiteAction(...args),
+                                      },
+                                      {
+                                        path: ':testSuiteId',
+                                        id: ':testSuiteId',
+                                        loader: async (...args) =>
+                                          (
+                                            await import('./routes/test-suite')
+                                          ).loader(...args),
+                                        children: [
+                                          {
+                                            index: true,
+                                            loader: async (...args) =>
+                                              (
+                                                await import(
+                                                  './routes/test-results'
+                                                )
+                                              ).indexLoader(...args),
+                                          },
+                                          {
+                                            path: 'test-result',
+                                            children: [
+                                              {
+                                                path: ':testResultId',
+                                                id: ':testResultId',
+                                                loader: async (...args) =>
+                                                  (
+                                                    await import(
+                                                      './routes/test-results'
+                                                    )
+                                                  ).loader(...args),
+                                              },
+                                            ],
+                                          },
+                                          {
+                                            path: 'delete',
+                                            action: async (...args) =>
+                                              (
+                                                await import('./routes/actions')
+                                              ).deleteTestSuiteAction(...args),
+                                          },
+                                          {
+                                            path: 'update',
+                                            action: async (...args) =>
+                                              (
+                                                await import('./routes/actions')
+                                              ).updateTestSuiteAction(...args),
+                                          },
+                                          {
+                                            path: 'run-all-tests',
+                                            action: async (...args) =>
+                                              (
+                                                await import('./routes/actions')
+                                              ).runAllTestsAction(...args),
+                                          },
+                                          {
+                                            path: 'test',
+                                            children: [
+                                              {
+                                                path: 'new',
+                                                action: async (...args) =>
+                                                  (
+                                                    await import(
+                                                      './routes/actions'
+                                                    )
+                                                  ).createNewTestAction(...args),
+                                              },
+                                              {
+                                                path: ':testId',
+                                                children: [
+                                                  {
+                                                    path: 'delete',
+                                                    action: async (...args) =>
+                                                      (
+                                                        await import(
+                                                          './routes/actions'
+                                                        )
+                                                      ).deleteTestAction(...args),
+                                                  },
+                                                  {
+                                                    path: 'update',
+                                                    action: async (...args) =>
+                                                      (
+                                                        await import(
+                                                          './routes/actions'
+                                                        )
+                                                      ).updateTestAction(...args),
+                                                  },
+                                                  {
+                                                    path: 'run',
+                                                    action: async (...args) =>
+                                                      (
+                                                        await import(
+                                                          './routes/actions'
+                                                        )
+                                                      ).runTestAction(...args),
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                              {
+                                path: 'ai',
+                                children: [
+                                  {
+                                    path: 'generate',
+                                    children: [
+                                      {
+                                        path: 'collection-and-tests',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/actions')
+                                          ).generateCollectionAndTestsAction(
+                                            ...args,
+                                          ),
+                                      },
+                                      {
+                                        path: 'tests',
+                                        action: async (...args) =>
+                                          (
+                                            await import('./routes/actions')
+                                          ).generateTestsAction(...args),
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                              {
+                                path: 'duplicate',
+                                action: async (...args) =>
+                                  (
+                                    await import('./routes/actions')
+                                  ).duplicateWorkspaceAction(...args),
+                              },
+                              {
+                                path: 'git',
+                                children: [
+                                  {
+                                    path: 'repo',
+                                    loader: async (...args) =>
+                                      (await import('./routes/git-actions')).gitRepoLoader(...args),
+                                  },
+                                  {
+                                    path: 'changes',
+                                    loader: async (...args) =>
+                                      (await import('./routes/git-actions')).gitChangesLoader(...args),
+                                  },
+                                  {
+                                    path: 'log',
+                                    loader: async (...args) =>
+                                      (await import('./routes/git-actions')).gitLogLoader(...args),
+                                  },
+                                  {
+                                    path: 'branches',
+                                    loader: async (...args) =>
+                                      (await import('./routes/git-actions')).gitBranchesLoader(...args),
+                                  },
+                                  {
+                                    path: 'status',
+                                    action: async (...args) =>
+                                      (await import('./routes/git-actions')).gitStatusAction(...args),
+                                  },
+                                  {
+                                    path: 'commit',
+                                    action: async (...args) =>
+                                      (await import('./routes/git-actions')).commitToGitRepoAction(...args),
+                                  },
+                                  {
+                                    path: 'fetch',
+                                    action: async (...args) =>
+                                      (await import('./routes/git-actions')).gitFetchAction(...args),
+                                  },
+                                  {
+                                    path: 'rollback',
+                                    action: async (...args) =>
+                                      (await import('./routes/git-actions')).gitRollbackChangesAction(...args),
+                                  },
+                                  {
+                                    path: 'update',
+                                    action: async (...args) =>
+                                      (await import('./routes/git-actions')).updateGitRepoAction(...args),
+                                  },
+                                  {
+                                    path: 'reset',
+                                    action: async (...args) =>
+                                      (await import('./routes/git-actions')).resetGitRepoAction(...args),
+                                  },
+                                  {
+                                    path: 'pull',
+                                    action: async (...args) =>
+                                      (await import('./routes/git-actions')).pullFromGitRemoteAction(...args),
+                                  },
+                                  {
+                                    path: 'push',
+                                    action: async (...args) =>
+                                      (await import('./routes/git-actions')).pushToGitRemoteAction(...args),
+                                  },
+                                  {
+                                    path: 'branch',
+                                    children: [
+                                      {
+                                        path: 'new',
+                                        action: async (...args) =>
+                                          (await import('./routes/git-actions')).createNewGitBranchAction(...args),
+                                      },
+                                      {
+                                        path: 'delete',
+                                        action: async (...args) =>
+                                          (await import('./routes/git-actions')).deleteGitBranchAction(...args),
+                                      },
+                                      {
+                                        path: 'checkout',
+                                        action: async (...args) =>
+                                          (await import('./routes/git-actions')).checkoutGitBranchAction(...args),
+                                      },
+                                      {
+                                        path: 'merge',
+                                        action: async (...args) =>
+                                          (await import('./routes/git-actions')).mergeGitBranchAction(...args),
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                              {
+                                path: 'insomnia-sync',
+                                children: [
+                                  {
+                                    path: 'sync-data',
+                                    action: async (...args) =>
+                                      (await import('./routes/remote-collections')).syncDataAction(...args),
+                                    loader: async (...args) =>
+                                      (await import('./routes/remote-collections')).syncDataLoader(...args),
+                                  },
+                                  {
+                                    path: 'stage',
+                                    action: async (...args) => (await import('./routes/remote-collections')).stageChangesAction(...args),
+                                  },
+                                  {
+                                    path: 'unstage',
+                                    action: async (...args) => (await import('./routes/remote-collections')).unstageChangesAction(...args),
+                                  },
+                                  {
+                                    path: 'pull',
+                                    action: async (...args) =>
+                                      (await import('./routes/remote-collections')).pullFromRemoteAction(...args),
+                                  },
+                                  {
+                                    path: 'push',
+                                    action: async (...args) =>
+                                      (await import('./routes/remote-collections')).pushToRemoteAction(...args),
+                                  },
+                                  {
+                                    path: 'rollback',
+                                    action: async (...args) =>
+                                      (await import('./routes/remote-collections')).rollbackChangesAction(...args),
+                                  },
+                                  {
+                                    path: 'restore',
+                                    action: async (...args) =>
+                                      (await import('./routes/remote-collections')).restoreChangesAction(...args),
+                                  },
+                                  {
+                                    path: 'branch',
+                                    children: [
+                                      {
+                                        path: 'checkout',
+                                        action: async (...args) =>
+                                          (await import('./routes/remote-collections')).checkoutBranchAction(...args),
+                                      },
+                                      {
+                                        path: 'create',
+                                        action: async (...args) =>
+                                          (await import('./routes/remote-collections')).createBranchAction(...args),
+                                      },
+                                      {
+                                        path: 'fetch',
+                                        action: async (...args) =>
+                                          (await import('./routes/remote-collections')).fetchRemoteBranchAction(...args),
+                                      },
+                                      {
+                                        path: 'delete',
+                                        action: async (...args) =>
+                                          (await import('./routes/remote-collections')).deleteBranchAction(...args),
+                                      },
+                                      {
+                                        path: 'merge',
+                                        action: async (...args) =>
+                                          (await import('./routes/remote-collections')).mergeBranchAction(...args),
+                                      },
+                                      {
+                                        path: 'create-snapshot',
+                                        action: async (...args) =>
+                                          (await import('./routes/remote-collections')).createSnapshotAction(...args),
+                                      },
+                                      {
+                                        path: 'create-snapshot-and-push',
+                                        action: async (...args) =>
+                                          (await import('./routes/remote-collections')).createSnapshotAndPushAction(...args),
+                                      },
+                                      {
+                                        path: 'rollback',
+                                        action: async (...args) =>
+                                          (await import('./routes/remote-collections')).rollbackChangesAction(...args),
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                          {
+                            path: 'new',
+                            action: async (...args) =>
+                              (
+                                await import('./routes/actions')
+                              ).createNewWorkspaceAction(...args),
+                          },
+                          {
+                            path: 'delete',
+                            action: async (...args) =>
+                              (
+                                await import('./routes/actions')
+                              ).deleteWorkspaceAction(...args),
+                          },
+                          {
+                            path: 'update',
+                            action: async (...args) =>
+                              (
+                                await import('./routes/actions')
+                              ).updateWorkspaceAction(...args),
+                          },
+                          {
+                            path: ':workspaceId/update-meta',
+                            action: async (...args) =>
+                              (await import('./routes/actions')).updateWorkspaceMetaAction(
+                                ...args
+                              ),
+                          },
+                        ],
+                      },
+                      {
+                        path: 'new',
+                        action: async (...args) =>
+                          (
+                            await import('./routes/actions')
+                          ).createNewProjectAction(...args),
+                      },
+                      {
+                        path: ':projectId/remote-collections',
+                        loader: async (...args) =>
+                          (
+                            await import('./routes/remote-collections')
+                          ).remoteLoader(...args),
+                        children: [
+                          {
+                            path: 'pull',
+                            action: async (...args) =>
+                              (
+                                await import('./routes/remote-collections')
+                              ).pullRemoteCollectionAction(...args),
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            path: 'auth',
+            element: <Suspense fallback={<AppLoadingIndicator />}>
+              <Auth />
+            </Suspense>,
+            errorElement: <ErrorRoute defaultMessage='A temporarily unexpected error occurred, please reload to try again' />,
+            children: [
+              {
+                path: 'login',
+                action: async (...args) => (await import('./routes/auth.login')).action(...args),
+                element: <Login />,
+              },
+              {
+                path: 'logout',
+                action: async (...args) => (await import('./routes/auth.logout')).action(...args),
+              },
+              {
+                path: 'authorize',
+                action: async (...args) => (await import('./routes/auth.authorize')).action(...args),
+                element: <Authorize />,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    {
+      initialEntries: [initialEntry],
+    }
+  );
+
+  // Store the last location in local storage
+  router.subscribe(({ location, navigation }) => {
+    const match = matchPath(
+      {
+        path: '/organization/:organizationId',
+        end: false,
+      },
+      location.pathname
+    );
+    const nextRoute = navigation.location?.pathname;
+    const currentRoute = location.pathname;
+    // Use navigation send tracking events on page change
+    const bothHaveValueButNotEqual = nextRoute && currentRoute && nextRoute !== currentRoute;
+    if (bothHaveValueButNotEqual) {
+      // transforms /organization/:org_* to /organization/:org_id
+      const routeWithoutUUID = nextRoute.replace(/_[a-f0-9]{32}/g, '_id');
+      // console.log('Tracking page view', { name: routeWithoutUUID });
+      window.main.trackPageView({ name: routeWithoutUUID });
+    }
+
+    match?.params.organizationId && localStorage.setItem(`locationHistoryEntry:${match?.params.organizationId}`, currentRoute);
+  });
 
   ReactDOM.createRoot(root).render(
     <RouterProvider router={router} />

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -95,6 +95,8 @@ async function renderApp() {
   await initPlugins();
 
   await migrateFromLocalStorage();
+
+  // Check if there is a Session provided by an env variable and use this
   const insomniaSession = getInsomniaSession();
   if (insomniaSession) {
     try {

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -3,7 +3,6 @@ import { generate, runTests, type Test } from 'insomnia-testing';
 import path from 'path';
 import { ActionFunction, redirect } from 'react-router-dom';
 
-import * as session from '../../account/session';
 import { parseApiSpec, resolveComponentSchemaRefs } from '../../common/api-specs';
 import { ACTIVITY_DEBUG, getAIServiceURL } from '../../common/constants';
 import { database } from '../../common/database';
@@ -311,7 +310,9 @@ export const createNewWorkspaceAction: ActionFunction = async ({
   const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(workspace._id);
 
   await database.flushChanges(flushId);
-  if (session.isLoggedIn() && !workspaceMeta.gitRepositoryId) {
+
+  const { id } = await models.user.getOrCreate();
+  if (id && !workspaceMeta.gitRepositoryId) {
     const vcs = VCSInstance();
     await initializeLocalBackendProjectAndMarkForSync({
       vcs,
@@ -407,8 +408,9 @@ export const duplicateWorkspaceAction: ActionFunction = async ({ request, params
   await models.workspaceMeta.getOrCreateByParentId(newWorkspace._id);
 
   try {
+    const { id } = await models.user.getOrCreate();
     // Mark for sync if logged in and in the expected project
-    if (session.isLoggedIn()) {
+    if (id) {
       const vcs = VCSInstance();
       await initializeLocalBackendProjectAndMarkForSync({
         vcs: vcs.newInstance(),

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -34,7 +34,7 @@ export const createNewProjectAction: ActionFunction = async ({ request, params }
   const projectType = formData.get('type');
   invariant(projectType === 'local' || projectType === 'remote', 'Project type is required');
 
-  const user = await models.user.getOrCreate();
+  const user = await models.userSession.getOrCreate();
   const sessionId = user.id;
   invariant(sessionId, 'User must be logged in to create a project');
 
@@ -109,7 +109,7 @@ export const updateProjectAction: ActionFunction = async ({
 
   invariant(project, 'Project not found');
 
-  const user = await models.user.getOrCreate();
+  const user = await models.userSession.getOrCreate();
   const sessionId = user.id;
 
   try {
@@ -208,7 +208,7 @@ export const deleteProjectAction: ActionFunction = async ({ params }) => {
   const project = await models.project.getById(projectId);
   invariant(project, 'Project not found');
 
-  const user = await models.user.getOrCreate();
+  const user = await models.userSession.getOrCreate();
   const sessionId = user.id;
   invariant(sessionId, 'User must be logged in to delete a project');
 
@@ -311,7 +311,7 @@ export const createNewWorkspaceAction: ActionFunction = async ({
 
   await database.flushChanges(flushId);
 
-  const { id } = await models.user.getOrCreate();
+  const { id } = await models.userSession.getOrCreate();
   if (id && !workspaceMeta.gitRepositoryId) {
     const vcs = VCSInstance();
     await initializeLocalBackendProjectAndMarkForSync({
@@ -408,7 +408,7 @@ export const duplicateWorkspaceAction: ActionFunction = async ({ request, params
   await models.workspaceMeta.getOrCreateByParentId(newWorkspace._id);
 
   try {
-    const { id } = await models.user.getOrCreate();
+    const { id } = await models.userSession.getOrCreate();
     // Mark for sync if logged in and in the expected project
     if (id) {
       const vcs = VCSInstance();
@@ -837,7 +837,7 @@ export const generateCollectionAndTestsAction: ActionFunction = async ({ params 
           throw new Error('Request not found');
         }
 
-        const user = await models.user.getOrCreate();
+        const user = await models.userSession.getOrCreate();
         const sessionId = user.id;
 
         const methodInfo = resolveComponentSchemaRefs(spec, getMethodInfo(request));
@@ -921,7 +921,7 @@ export const generateTestsAction: ActionFunction = async ({ params }) => {
 
   async function generateTests() {
     async function generateTest(test: Partial<UnitTest>) {
-      const user = await models.user.getOrCreate();
+      const user = await models.userSession.getOrCreate();
       const sessionId = user.id;
       try {
         const response = await window.main.insomniaFetch<{ test: { requestId: string } }>({
@@ -968,7 +968,7 @@ export const accessAIApiAction: ActionFunction = async ({ params }) => {
   invariant(typeof organizationId === 'string', 'Organization ID is required');
 
   try {
-    const user = await models.user.getOrCreate();
+    const user = await models.userSession.getOrCreate();
     const sessionId = user.id;
     const response = await window.main.insomniaFetch<{ enabled: boolean }>({
       method: 'POST',

--- a/packages/insomnia/src/ui/routes/mock-route.tsx
+++ b/packages/insomnia/src/ui/routes/mock-route.tsx
@@ -91,7 +91,7 @@ export const useMockRoutePatcher = () => {
 
 export const MockRouteRoute = () => {
   const { mockServer, mockRoute } = useRouteLoaderData(':mockRouteId') as MockRouteLoaderData;
-  const { user } = useRootLoaderData();
+  const { userSession } = useRootLoaderData();
   const patchMockRoute = useMockRoutePatcher();
   const mockbinUrl = mockServer.useInsomniaCloud ? getMockServiceURL() : mockServer.url;
 
@@ -108,7 +108,7 @@ export const MockRouteRoute = () => {
         path: `/bin/upsert/${compoundId}`,
         method: 'PUT',
         organizationId,
-        sessionId: user.id,
+        sessionId: userSession.id,
         data: mockRouteToHar({
           statusCode: mockRoute.statusCode,
           statusText: mockRoute.statusText,

--- a/packages/insomnia/src/ui/routes/mock-route.tsx
+++ b/packages/insomnia/src/ui/routes/mock-route.tsx
@@ -2,7 +2,6 @@ import * as Har from 'har-format';
 import React from 'react';
 import { LoaderFunction, useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
-import { getCurrentSessionId } from '../../account/session';
 import { CONTENT_TYPE_JSON, CONTENT_TYPE_PLAINTEXT, CONTENT_TYPE_XML, CONTENT_TYPE_YAML, contentTypesMap, getMockServiceURL, RESPONSE_CODE_REASONS } from '../../common/constants';
 import { database as db } from '../../common/database';
 import { getResponseCookiesFromHeaders } from '../../common/har';
@@ -22,6 +21,7 @@ import { showAlert } from '../components/modals';
 import { EmptyStatePane } from '../components/panes/empty-state-pane';
 import { Pane, PaneBody, PaneHeader } from '../components/panes/pane';
 import { SvgIcon } from '../components/svg-icon';
+import { useRootLoaderData } from './root';
 
 export interface MockRouteLoaderData {
   mockServer: MockServer;
@@ -91,6 +91,7 @@ export const useMockRoutePatcher = () => {
 
 export const MockRouteRoute = () => {
   const { mockServer, mockRoute } = useRouteLoaderData(':mockRouteId') as MockRouteLoaderData;
+  const { user } = useRootLoaderData();
   const patchMockRoute = useMockRoutePatcher();
   const mockbinUrl = mockServer.useInsomniaCloud ? getMockServiceURL() : mockServer.url;
 
@@ -107,7 +108,7 @@ export const MockRouteRoute = () => {
         path: `/bin/upsert/${compoundId}`,
         method: 'PUT',
         organizationId,
-        sessionId: getCurrentSessionId(),
+        sessionId: user.id,
         data: mockRouteToHar({
           statusCode: mockRoute.statusCode,
           statusText: mockRoute.statusText,

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -28,7 +28,7 @@ import { useLocalStorage } from 'react-use';
 import * as session from '../../account/session';
 import { getAppWebsiteBaseURL } from '../../common/constants';
 import { database } from '../../common/database';
-import { user } from '../../models';
+import { userSession } from '../../models';
 import { updateLocalProjectToRemote } from '../../models/helpers/project';
 import { isOwnerOfOrganization, isPersonalOrganization, isScratchpadOrganizationId, Organization } from '../../models/organization';
 import { Project } from '../../models/project';
@@ -133,7 +133,7 @@ function sortOrganizations(accountId: string, organizations: Organization[]): Or
 }
 
 export const indexLoader: LoaderFunction = async () => {
-  const { id: sessionId, accountId } = await user.getOrCreate();
+  const { id: sessionId, accountId } = await userSession.getOrCreate();
   if (sessionId) {
     try {
       const organizationsResult = await window.main.insomniaFetch<OrganizationsResponse | void>({
@@ -214,7 +214,7 @@ export const indexLoader: LoaderFunction = async () => {
 };
 
 export const syncOrganizationsAction: ActionFunction = async () => {
-  const { id: sessionId, accountId } = await user.getOrCreate();
+  const { id: sessionId, accountId } = await userSession.getOrCreate();
 
   if (sessionId) {
     try {
@@ -259,7 +259,7 @@ export interface OrganizationLoaderData {
 }
 
 export const loader: LoaderFunction = async () => {
-  const { id } = await user.getOrCreate();
+  const { id } = await userSession.getOrCreate();
   if (id) {
     return organizationsData;
   } else {
@@ -288,7 +288,7 @@ export interface Billing {
 
 export const singleOrgLoader: LoaderFunction = async ({ params }) => {
   const { organizationId } = params as { organizationId: string };
-  const { id: sessionId } = await user.getOrCreate();
+  const { id: sessionId } = await userSession.getOrCreate();
   const fallbackFeatures = {
     gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
     orgBasicRbac: { enabled: false, reason: 'Insomnia API unreachable' },
@@ -384,7 +384,7 @@ const UpgradeButton = ({
 };
 
 const OrganizationRoute = () => {
-  const { user: userSession, settings } = useRootLoaderData();
+  const { userSession, settings } = useRootLoaderData();
 
   const { organizations, user, currentPlan } =
     useLoaderData() as OrganizationLoaderData;

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -259,7 +259,8 @@ export interface OrganizationLoaderData {
 }
 
 export const loader: LoaderFunction = async () => {
-  if (session.isLoggedIn()) {
+  const { id } = await user.getOrCreate();
+  if (id) {
     return organizationsData;
   } else {
     return {

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -26,12 +26,9 @@ import {
 import { useLocalStorage } from 'react-use';
 
 import * as session from '../../account/session';
-import {
-  getAccountId,
-  getCurrentSessionId,
-} from '../../account/session';
 import { getAppWebsiteBaseURL } from '../../common/constants';
 import { database } from '../../common/database';
+import { user } from '../../models';
 import { updateLocalProjectToRemote } from '../../models/helpers/project';
 import { isOwnerOfOrganization, isPersonalOrganization, isScratchpadOrganizationId, Organization } from '../../models/organization';
 import { Project } from '../../models/project';
@@ -136,7 +133,7 @@ function sortOrganizations(accountId: string, organizations: Organization[]): Or
 }
 
 export const indexLoader: LoaderFunction = async () => {
-  const sessionId = getCurrentSessionId();
+  const { id: sessionId, accountId } = await user.getOrCreate();
   if (sessionId) {
     try {
       const organizationsResult = await window.main.insomniaFetch<OrganizationsResponse | void>({
@@ -163,7 +160,6 @@ export const indexLoader: LoaderFunction = async () => {
 
       const { organizations } = organizationsResult;
 
-      const accountId = getAccountId();
       invariant(accountId, 'Account ID is not defined');
       organizationsData.organizations = sortOrganizations(accountId, organizations);
       organizationsData.user = user;
@@ -218,7 +214,8 @@ export const indexLoader: LoaderFunction = async () => {
 };
 
 export const syncOrganizationsAction: ActionFunction = async () => {
-  const sessionId = getCurrentSessionId();
+  const { id: sessionId, accountId } = await user.getOrCreate();
+
   if (sessionId) {
     try {
 
@@ -243,7 +240,6 @@ export const syncOrganizationsAction: ActionFunction = async () => {
       invariant(organizationsResult, 'Failed to load organizations');
       invariant(user, 'Failed to load user');
       invariant(currentPlan, 'Failed to load current plan');
-      const accountId = getAccountId();
       invariant(accountId, 'Account ID is not defined');
       organizationsData.organizations = sortOrganizations(accountId, organizationsResult.organizations);
       organizationsData.user = user;
@@ -291,7 +287,7 @@ export interface Billing {
 
 export const singleOrgLoader: LoaderFunction = async ({ params }) => {
   const { organizationId } = params as { organizationId: string };
-
+  const { id: sessionId } = await user.getOrCreate();
   const fallbackFeatures = {
     gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
     orgBasicRbac: { enabled: false, reason: 'Insomnia API unreachable' },
@@ -319,7 +315,7 @@ export const singleOrgLoader: LoaderFunction = async ({ params }) => {
     const response = await window.main.insomniaFetch<{ features: FeatureList; billing: Billing } | undefined>({
       method: 'GET',
       path: `/v1/organizations/${organizationId}/features`,
-      sessionId: session.getCurrentSessionId(),
+      sessionId,
     });
 
     return {
@@ -387,7 +383,7 @@ const UpgradeButton = ({
 };
 
 const OrganizationRoute = () => {
-  const { settings } = useRootLoaderData();
+  const { user: userSession, settings } = useRootLoaderData();
 
   const { organizations, user, currentPlan } =
     useLoaderData() as OrganizationLoaderData;
@@ -626,7 +622,7 @@ const OrganizationRoute = () => {
                     >
                       {isPersonalOrganization(organization) && isOwnerOfOrganization({
                         organization,
-                        accountId: getAccountId() || '',
+                        accountId: userSession.accountId || '',
                       }) ? (
                         <Icon icon="home" />
                       ) : (

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -39,7 +39,7 @@ import {
 } from 'react-router-dom';
 import { useLocalStorage } from 'react-use';
 
-import { isLoggedIn, logout } from '../../account/session';
+import { logout } from '../../account/session';
 import { parseApiSpec, ParsedApiSpec } from '../../common/api-specs';
 import {
   DASHBOARD_SORT_ORDERS,
@@ -222,9 +222,10 @@ export const indexLoader: LoaderFunction = async ({ params }) => {
   let teamProjects: TeamProject[] = [];
 
   try {
+    const user = await models.user.getOrCreate();
     teamProjects = await getAllTeamProjects(organizationId);
     // ensure we don't sync projects in the wrong place
-    if (teamProjects.length > 0 && isLoggedIn() && !isScratchpadOrganizationId(organizationId)) {
+    if (teamProjects.length > 0 && user.id && !isScratchpadOrganizationId(organizationId)) {
       await syncTeamProjects({
         organizationId,
         teamProjects,

--- a/packages/insomnia/src/ui/routes/root.tsx
+++ b/packages/insomnia/src/ui/routes/root.tsx
@@ -7,6 +7,7 @@ import { LoaderFunction, Outlet, useFetcher, useNavigate, useParams, useRouteLoa
 import { isDevelopment } from '../../common/constants';
 import * as models from '../../models';
 import { Settings } from '../../models/settings';
+import { User } from '../../models/user';
 import { reloadPlugins } from '../../plugins';
 import { createPlugin } from '../../plugins/create';
 import { setTheme } from '../../plugins/misc';
@@ -30,6 +31,7 @@ import Modals from './modals';
 export interface RootLoaderData {
   settings: Settings;
   workspaceCount: number;
+  user: User;
 }
 
 export const useRootLoaderData = () => {
@@ -39,9 +41,12 @@ export const useRootLoaderData = () => {
 export const loader: LoaderFunction = async (): Promise<RootLoaderData> => {
   const settings = await models.settings.get();
   const workspaceCount = await models.workspace.count();
+  const user = await models.user.getOrCreate();
+
   return {
     settings,
     workspaceCount,
+    user,
   };
 };
 

--- a/packages/insomnia/src/ui/routes/root.tsx
+++ b/packages/insomnia/src/ui/routes/root.tsx
@@ -7,7 +7,7 @@ import { LoaderFunction, Outlet, useFetcher, useNavigate, useParams, useRouteLoa
 import { isDevelopment } from '../../common/constants';
 import * as models from '../../models';
 import { Settings } from '../../models/settings';
-import { User } from '../../models/user';
+import { UserSession } from '../../models/user-session';
 import { reloadPlugins } from '../../plugins';
 import { createPlugin } from '../../plugins/create';
 import { setTheme } from '../../plugins/misc';
@@ -31,7 +31,7 @@ import Modals from './modals';
 export interface RootLoaderData {
   settings: Settings;
   workspaceCount: number;
-  user: User;
+  userSession: UserSession;
 }
 
 export const useRootLoaderData = () => {
@@ -41,12 +41,12 @@ export const useRootLoaderData = () => {
 export const loader: LoaderFunction = async (): Promise<RootLoaderData> => {
   const settings = await models.settings.get();
   const workspaceCount = await models.workspace.count();
-  const user = await models.user.getOrCreate();
+  const userSession = await models.userSession.getOrCreate();
 
   return {
     settings,
     workspaceCount,
-    user,
+    userSession,
   };
 };
 

--- a/packages/insomnia/src/ui/routes/workspace.tsx
+++ b/packages/insomnia/src/ui/routes/workspace.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { LoaderFunction, Outlet } from 'react-router-dom';
 
-import { isLoggedIn } from '../../account/session';
 import { SortOrder } from '../../common/constants';
 import { database } from '../../common/database';
 import { fuzzyMatchAll } from '../../common/misc';
@@ -232,7 +231,8 @@ export const workspaceLoader: LoaderFunction = async ({
     return collection;
   }
 
-  if (isLoggedIn() && !gitRepository) {
+  const user = await models.user.getOrCreate();
+  if (user.id && !gitRepository) {
     try {
       const vcs = VCSInstance();
       await vcs.switchAndCreateBackendProjectIfNotExist(workspaceId, activeWorkspace.name);

--- a/packages/insomnia/src/ui/routes/workspace.tsx
+++ b/packages/insomnia/src/ui/routes/workspace.tsx
@@ -231,8 +231,8 @@ export const workspaceLoader: LoaderFunction = async ({
     return collection;
   }
 
-  const user = await models.user.getOrCreate();
-  if (user.id && !gitRepository) {
+  const userSession = await models.userSession.getOrCreate();
+  if (userSession.id && !gitRepository) {
     try {
       const vcs = VCSInstance();
       await vcs.switchAndCreateBackendProjectIfNotExist(workspaceId, activeWorkspace.name);

--- a/packages/insomnia/src/ui/sentry.ts
+++ b/packages/insomnia/src/ui/sentry.ts
@@ -5,8 +5,8 @@ import { SENTRY_OPTIONS } from '../common/sentry';
 
 /** Configures user info in Sentry scope. */
 function sentryConfigureUserInfo() {
-  Sentry.configureScope(scope => {
-    const id = getAccountId();
+  Sentry.configureScope(async scope => {
+    const id = await getAccountId();
     if (id) {
       scope.setUser({ id });
     } else {


### PR DESCRIPTION
Local Storage is not reliable to persist data across app restarts.

Highlights:
- [x] Creates a new model in the database to persist the user session
- [x] Uses the new database model in the app instead of Local Storage to read/write the session
- [x] Migrate existing sessions stored in local storage to the db?

Closes INS-3633

Next steps:
- [ ] Cleanup the session module and simplify the logic
- [ ] On later versions remove the migration from localStorage
- [ ] On unauthorised response from our API we should log out the user
- [ ] Explore multi-database per account or similar approach