### PR TITLE
fix: startsWith not a function error [INS-3640]

### DIFF
--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -373,6 +373,8 @@ async function getAllLocalFiles({
         modifiedLocally > workspaceMeta?.cachedGitLastCommitTime
     );
 
+    const specVersion = spec?.info?.version ? String(spec?.info?.version) : '';
+
     return {
       id: workspace._id,
       name: workspace.name,
@@ -382,7 +384,7 @@ async function getAllLocalFiles({
       lastModifiedTimestamp: (hasUnsavedChanges && modifiedLocally) || workspaceMeta?.cachedGitLastCommitTime || lastModifiedTimestamp,
       branch: lastActiveBranch || '',
       lastCommit: hasUnsavedChanges && workspaceMeta?.cachedGitLastCommitTime && lastCommitAuthor ? `by ${lastCommitAuthor}` : '',
-      version: spec?.info?.version ? `${spec?.info?.version?.startsWith('v') ? '' : 'v'}${spec?.info?.version}` : '',
+      version: specVersion ? `${specVersion?.startsWith('v') ? '' : 'v'}${specVersion}` : '',
       oasFormat: specFormat ? `${specFormat === 'openapi' ? 'OpenAPI' : 'Swagger'} ${specFormatVersion || ''}` : '',
       mockServer,
       apiSpec,


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Close #7164 

## ErrorMessage
![image](https://github.com/Kong/insomnia/assets/163384738/3410bab4-f2e6-4715-9af0-c656de97372b)

## Reason
<img width="838" alt="image" src="https://github.com/Kong/insomnia/assets/163384738/e7e154df-6562-434e-b7a5-2b2176c1beab">
The version field in yaml should be string type, but even if you enter numbers, you can save them, although an error will be reported.
The  `spec.info.version`  may be string type or number, so we need to covert to string type when it has value.