### PR TITLE
mock-extraction feedback

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/mock.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/mock.test.ts
@@ -1,22 +1,15 @@
-import { loadFixture } from '../../playwright/paths';
 import { test } from '../../playwright/test';
 
-test('can make a mock route', async ({ app, page }) => {
+test('can make a mock route', async ({ page }) => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
-  const text = await loadFixture('smoke-test-collection.yaml');
-  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
-
-  await page.getByRole('button', { name: 'Create in project' }).click();
-  await page.getByRole('menuitemradio', { name: 'Import' }).click();
-  await page.locator('[data-test-id="import-from-clipboard"]').click();
-  await page.getByRole('button', { name: 'Scan' }).click();
-  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
 
   await page.getByLabel('New Mock Server').click();
   await page.getByRole('button', { name: 'Create', exact: true }).click();
   await page.getByRole('button', { name: 'New Mock Route' }).click();
-  await page.getByText('GET/').click();
-  await page.getByTestId('CodeEditor').getByRole('textbox').fill('123');
+  await page.getByLabel('Project Actions').click();
+  await page.getByText('Rename').click();
+  await page.locator('#prompt-input').fill('/123');
+  await page.getByRole('button', { name: 'Rename' }).click();
 
   await page.getByRole('button', { name: 'Test' }).click();
   await page.getByText('No body returned for response').click();

--- a/packages/insomnia/src/ui/routes/mock-route.tsx
+++ b/packages/insomnia/src/ui/routes/mock-route.tsx
@@ -1,6 +1,6 @@
 import * as Har from 'har-format';
 import React from 'react';
-import { LoaderFunction, useFetcher, useLoaderData, useParams, useRouteLoaderData } from 'react-router-dom';
+import { LoaderFunction, useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
 import { CONTENT_TYPE_JSON, CONTENT_TYPE_PLAINTEXT, CONTENT_TYPE_XML, CONTENT_TYPE_YAML, contentTypesMap, getMockServiceURL, RESPONSE_CODE_REASONS } from '../../common/constants';
 import { database as db } from '../../common/database';

--- a/packages/insomnia/src/ui/routes/mock-route.tsx
+++ b/packages/insomnia/src/ui/routes/mock-route.tsx
@@ -1,6 +1,6 @@
 import * as Har from 'har-format';
 import React from 'react';
-import { LoaderFunction, useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
+import { LoaderFunction, useFetcher, useLoaderData, useParams, useRouteLoaderData } from 'react-router-dom';
 
 import { CONTENT_TYPE_JSON, CONTENT_TYPE_PLAINTEXT, CONTENT_TYPE_XML, CONTENT_TYPE_YAML, contentTypesMap, getMockServiceURL, RESPONSE_CODE_REASONS } from '../../common/constants';
 import { database as db } from '../../common/database';
@@ -17,10 +17,12 @@ import { CodeEditor } from '../components/codemirror/code-editor';
 import { MockResponseHeadersEditor } from '../components/editors/mock-response-headers-editor';
 import { MockResponsePane } from '../components/mocks/mock-response-pane';
 import { MockUrlBar } from '../components/mocks/mock-url-bar';
-import { showAlert } from '../components/modals';
+import { showAlert, showModal } from '../components/modals';
+import { AlertModal } from '../components/modals/alert-modal';
 import { EmptyStatePane } from '../components/panes/empty-state-pane';
 import { Pane, PaneBody, PaneHeader } from '../components/panes/pane';
 import { SvgIcon } from '../components/svg-icon';
+import { MockServerLoaderData } from './mock-server';
 import { useRootLoaderData } from './root';
 
 export interface MockRouteLoaderData {
@@ -91,6 +93,8 @@ export const useMockRoutePatcher = () => {
 
 export const MockRouteRoute = () => {
   const { mockServer, mockRoute } = useRouteLoaderData(':mockRouteId') as MockRouteLoaderData;
+  const { mockRoutes } = useRouteLoaderData('mock-server') as MockServerLoaderData;
+
   const { userSession } = useRootLoaderData();
   const patchMockRoute = useMockRoutePatcher();
   const mockbinUrl = mockServer.useInsomniaCloud ? getMockServiceURL() : mockServer.url;
@@ -142,6 +146,15 @@ export const MockRouteRoute = () => {
       });
 
   const upsertMockbinHar = async (pathInput?: string) => {
+    const hasRouteInServer = mockRoutes.find(m => m.name === pathInput);
+    if (hasRouteInServer) {
+      showModal(AlertModal, {
+        title: 'Error',
+        message: 'Route name must be unique. Please enter a different name.',
+      });
+
+      return;
+    };
     const compoundId = mockRoute.parentId + pathInput;
     const error = await upsertBinOnRemoteFromResponse(compoundId);
     if (error) {
@@ -163,6 +176,15 @@ export const MockRouteRoute = () => {
     });
   };
   const onSend = async (pathInput: string) => {
+    const hasRouteInServer = mockRoutes.find(m => m.name === pathInput);
+    if (hasRouteInServer) {
+      showModal(AlertModal, {
+        title: 'Error',
+        message: 'Route name must be unique. Please enter a different name.',
+      });
+
+      return;
+    };
     await upsertMockbinHar(pathInput);
     const compoundId = mockRoute.parentId + pathInput;
     createandSendPrivateRequest({

--- a/packages/insomnia/src/ui/routes/mock-route.tsx
+++ b/packages/insomnia/src/ui/routes/mock-route.tsx
@@ -146,11 +146,11 @@ export const MockRouteRoute = () => {
       });
 
   const upsertMockbinHar = async (pathInput?: string) => {
-    const hasRouteInServer = mockRoutes.find(m => m.name === pathInput);
+    const hasRouteInServer = mockRoutes.filter(m => m._id !== mockRoute._id).find(m => m.name === pathInput);
     if (hasRouteInServer) {
       showModal(AlertModal, {
         title: 'Error',
-        message: 'Route name must be unique. Please enter a different name.',
+        message: `Path "${pathInput}" must be unique. Please enter a different name.`,
       });
 
       return;
@@ -176,11 +176,11 @@ export const MockRouteRoute = () => {
     });
   };
   const onSend = async (pathInput: string) => {
-    const hasRouteInServer = mockRoutes.find(m => m.name === pathInput);
+    const hasRouteInServer = mockRoutes.filter(m => m._id !== mockRoute._id).find(m => m.name === pathInput);
     if (hasRouteInServer) {
       showModal(AlertModal, {
         title: 'Error',
-        message: 'Route name must be unique. Please enter a different name.',
+        message: `Path "${pathInput}" must be unique. Please enter a different name.`,
       });
 
       return;

--- a/packages/insomnia/src/ui/routes/mock-server.tsx
+++ b/packages/insomnia/src/ui/routes/mock-server.tsx
@@ -67,11 +67,11 @@ const MockServerRoute = () => {
             defaultValue: mockRoutes.find(s => s._id === id)?.name,
             submitName: 'Rename',
             onComplete: name => {
-              const hasRouteInServer = mockRoutes.find(s => s.name === name);
+              const hasRouteInServer = mockRoutes.filter(m => m._id !== id).find(m => m.name === name);
               if (hasRouteInServer) {
                 showModal(AlertModal, {
                   title: 'Error',
-                  message: 'Route name must be unique. Please enter a different name.',
+                  message: `Path "${name}" must be unique. Please enter a different name.`,
                 });
                 return;
               };
@@ -204,11 +204,11 @@ const MockServerRoute = () => {
                       });
                     }}
                     onSubmit={name => {
-                      const hasRouteInServer = mockRoutes.find(s => s.name === name);
+                      const hasRouteInServer = mockRoutes.filter(m => m._id !== item._id).find(m => m.name === name);
                       if (hasRouteInServer) {
                         showModal(AlertModal, {
                           title: 'Error',
-                          message: 'Route name must be unique. Please enter a different name.',
+                          message: `Path "${name}" must be unique. Please enter a different name.`,
                         });
                         return;
                       };

--- a/packages/insomnia/src/ui/routes/mock-server.tsx
+++ b/packages/insomnia/src/ui/routes/mock-server.tsx
@@ -11,17 +11,18 @@ import { WorkspaceSyncDropdown } from '../components/dropdowns/workspace-sync-dr
 import { EditableInput } from '../components/editable-input';
 import { Icon } from '../components/icon';
 import { showModal, showPrompt } from '../components/modals';
+import { AlertModal } from '../components/modals/alert-modal';
 import { AskModal } from '../components/modals/ask-modal';
 import { EmptyStatePane } from '../components/panes/empty-state-pane';
 import { SidebarLayout } from '../components/sidebar-layout';
 import { SvgIcon } from '../components/svg-icon';
 import { formatMethodName } from '../components/tags/method-tag';
 import { MockRouteResponse, MockRouteRoute, useMockRoutePatcher } from './mock-route';
-interface LoaderData {
+export interface MockServerLoaderData {
   mockServerId: string;
   mockRoutes: MockRoute[];
 }
-export const loader: LoaderFunction = async ({ params }): Promise<LoaderData> => {
+export const loader: LoaderFunction = async ({ params }): Promise<MockServerLoaderData> => {
   const { organizationId, projectId, workspaceId } = params;
   invariant(organizationId, 'Organization ID is required');
   invariant(projectId, 'Project ID is required');
@@ -46,7 +47,7 @@ const MockServerRoute = () => {
     workspaceId: string;
     mockRouteId: string;
   };
-  const { mockServerId, mockRoutes } = useLoaderData() as LoaderData;
+  const { mockServerId, mockRoutes } = useLoaderData() as MockServerLoaderData;
   const fetcher = useFetcher();
   const navigate = useNavigate();
   const patchMockRoute = useMockRoutePatcher();
@@ -66,6 +67,14 @@ const MockServerRoute = () => {
             defaultValue: mockRoutes.find(s => s._id === id)?.name,
             submitName: 'Rename',
             onComplete: name => {
+              const hasRouteInServer = mockRoutes.find(s => s.name === name);
+              if (hasRouteInServer) {
+                showModal(AlertModal, {
+                  title: 'Error',
+                  message: 'Route name must be unique. Please enter a different name.',
+                });
+                return;
+              };
               name && patchMockRoute(id, { name });
             },
           });
@@ -195,6 +204,14 @@ const MockServerRoute = () => {
                       });
                     }}
                     onSubmit={name => {
+                      const hasRouteInServer = mockRoutes.find(s => s.name === name);
+                      if (hasRouteInServer) {
+                        showModal(AlertModal, {
+                          title: 'Error',
+                          message: 'Route name must be unique. Please enter a different name.',
+                        });
+                        return;
+                      };
                       name && fetcher.submit(
                         { name },
                         {


### PR DESCRIPTION
- [x] can create new server and route
- [x] force paths to be unique in the ux

future work
- eliminate the mockServerName newRoute hack
- perhaps figure out how to get ids back from the actions to change selected values in the dropdown

<img width="381" alt="image" src="https://github.com/Kong/insomnia/assets/3679927/944dcb13-7e5c-4a2b-9e54-3285bb215adb">

closes INS-3644
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
