### PR TITLE
fix: release-start [no-ticket]

### DIFF
--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -47,12 +47,12 @@ jobs:
 
     # handle new "major" beta releases, e.g. 10.0, 11.0, 12.0 ...
       - name: App version (alpha/beta, with new general version)
-        if: github.event.inputs.channel != 'stable' && github.event.inputs.version
+        if: github.event.inputs.channel != 'stable' && github.event.inputs.version && !contains(github.event.inputs.version, "-${{ github.event.inputs.channel }}")
         run: npm --workspaces version "${{ github.event.inputs.version }}-${{ github.event.inputs.channel }}.0"
 
     # handle botched alpha/beta releases, e.g. for iterations that were merged before running release-publish
       - name: App version (alpha/beta, with a specific version)
-        if: github.event.inputs.channel != 'stable' && github.event.inputs.version && !contains(github.event.inputs.version, "-${{ github.event.inputs.channel }}")
+        if: github.event.inputs.channel != 'stable' && github.event.inputs.version && contains(github.event.inputs.version, "-${{ github.event.inputs.channel }}")
         run: npm --workspaces version "${{ github.event.inputs.version }}"
 
       - name: App version (alpha/beta, patch latest)

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -37,20 +37,25 @@ jobs:
       - name: Install packages
         run: npm ci
 
-      - name: App version (stable, no version doing patch)
+      - name: App version (stable, patch latest stable)
         if: github.event.inputs.channel == 'stable' && !github.event.inputs.version
         run: npm --workspaces version patch
 
-      - name: App version (stable)
+      - name: App version (stable, with a specific version)
         if: github.event.inputs.channel == 'stable' && github.event.inputs.version
         run: npm --workspaces version "${{ github.event.inputs.version }}"
 
-      # required for 8.0.0 beta
-      - name: App version (initial alpha/beta where we specify a new general version)
+    # handle new "major" beta releases, e.g. 10.0, 11.0, 12.0 ...
+      - name: App version (alpha/beta, with new general version)
         if: github.event.inputs.channel != 'stable' && github.event.inputs.version
         run: npm --workspaces version "${{ github.event.inputs.version }}-${{ github.event.inputs.channel }}.0"
 
-      - name: App version (alpha/beta)
+    # handle botched alpha/beta releases, e.g. for iterations that were merged before running release-publish
+      - name: App version (alpha/beta, with a specific version)
+        if: github.event.inputs.channel != 'stable' && github.event.inputs.version && !contains(github.event.inputs.version, "-${{ github.event.inputs.channel }}")
+        run: npm --workspaces version "${{ github.event.inputs.version }}"
+
+      - name: App version (alpha/beta, patch latest)
         if: github.event.inputs.channel != 'stable' && !github.event.inputs.version
         run: npm --workspaces version --preid "${{ github.event.inputs.channel }}" prerelease
 


### PR DESCRIPTION
adds a workaround to handle weird botched releases (e.g. when we merge a beta release without running publish, which causes iterations to get a bit messy, due to that info not being added by npm workspaces version to the package lock, I think)


Example, currently if we just try to run beta release, it will default to `beta.0` due to a previous mistake:
![image](https://github.com/Kong/insomnia/assets/11976836/2af754bd-82b5-44cd-a093-f7600aad2d3c)



With this workaround we can force `beta.2`:
![image](https://github.com/Kong/insomnia/assets/11976836/c3776727-4ef8-4d1d-bfaa-e5aecf65e49c)


and then commit that version. Later if we would trigger, `beta.3`, we could go back to running `npm --workspaces version --preid "beta" prerelease` and it would get picked up correctly:
![image](https://github.com/Kong/insomnia/assets/11976836/bbb938c8-30d8-40a5-8bad-b14eac551f11)

