### PR TITLE
Request URL bar fix and collection name truncation improvement

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -109,7 +109,9 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     codeMirror.current.on('beforeChange', (_: CodeMirror.Editor, change: CodeMirror.EditorChangeCancellable) => {
       const isPaste = change.text && change.text.length > 1;
       if (isPaste) {
-        if (change.text[0].startsWith('curl') || !change.text.join('').trim()) {
+        const startsWithCurl = change.text[0].startsWith('curl');
+        const isWhitespace = change.text.join('').trim();
+        if (startsWithCurl || !isWhitespace) {
           change.cancel();
           return;
         }

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -109,7 +109,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     codeMirror.current.on('beforeChange', (_: CodeMirror.Editor, change: CodeMirror.EditorChangeCancellable) => {
       const isPaste = change.text && change.text.length > 1;
       if (isPaste) {
-        if (change.text[0].startsWith('curl')) {
+        if (change.text[0].startsWith('curl') || !change.text.join('').trim()) {
           change.cancel();
           return;
         }

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
@@ -205,7 +205,7 @@ export const WorkspaceDropdown: FC = () => {
           data-testid="workspace-context-dropdown"
           className="px-3 py-1 h-7 flex flex-1 items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm truncate"
         >
-          <span className="truncate">{activeWorkspaceName}</span>
+          <span className="truncate" title={activeWorkspaceName}>{activeWorkspaceName}</span>
           <Icon icon="caret-down" />
         </Button>
         <Popover className="min-w-max">

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1360,7 +1360,7 @@ const ProjectRoute: FC = () => {
                             />
                           )}
                         </div>
-                        <Heading className="pt-4 text-lg font-bold truncate">
+                        <Heading className="pt-4 text-lg font-bold truncate" title={item.name}>
                           {item.name}
                         </Heading>
                         <div className="flex-1 flex flex-col gap-2 justify-end text-sm text-[--hl]">


### PR DESCRIPTION
Closes #7221: Pressing enter/return while text is selected in the request URL bar causes the selected text to be deleted
- Fixed 'paste' handling code which was causing text replacement logic to run when text had merely been selected but not actually changed

Closes #7029: Unable to see full collection names
- Added title (hover tooltip) for name label on collection card