### PR TITLE
feat: enable cookieJar manipulation in pre-request script - INS-3379

### DIFF
--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as _ from 'lodash';
 
 import { invariant } from '../src/utils/invariant';
+import { mergeCookieJar } from './sdk/objects/cookies';
 import { initInsomniaObject, InsomniaObject } from './sdk/objects/insomnia';
 import { RequestContext } from './sdk/objects/interfaces';
 import { mergeClientCertificates, mergeRequests, mergeSettings } from './sdk/objects/request';
@@ -83,6 +84,7 @@ const runPreRequestScript = async (
   const updatedRequest = mergeRequests(context.request, mutatedContextObject.request);
   const updatedSettings = mergeSettings(context.settings, mutatedContextObject.request);
   const updatedCertificates = mergeClientCertificates(context.clientCertificates, mutatedContextObject.request);
+  const updatedCookieJar = mergeCookieJar(context.cookieJar, mutatedContextObject.cookieJar);
 
   await fs.promises.writeFile(context.timelinePath, log.join('\n'));
 
@@ -96,5 +98,6 @@ const runPreRequestScript = async (
     request: updatedRequest,
     settings: updatedSettings,
     clientCertificates: updatedCertificates,
+    cookieJar: updatedCookieJar,
   };
 };

--- a/packages/insomnia/src/network/cancellation.ts
+++ b/packages/insomnia/src/network/cancellation.ts
@@ -1,4 +1,5 @@
 import type { CurlRequestOptions, CurlRequestOutput } from '../main/network/libcurl-promise';
+import { CookieJar } from '../models/cookie-jar';
 import { Request } from '../models/request';
 import { RequestContext } from '../sdk/objects/interfaces';
 
@@ -33,6 +34,7 @@ export const cancellableRunPreRequestScript = async (options: { script: string; 
       request: Request;
       environment: object;
       baseEnvironment: object;
+      cookieJar: CookieJar;
     };
   } catch (err) {
     if (err.name === 'AbortError') {

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -20,6 +20,7 @@ import type { HeaderResult, ResponsePatch } from '../main/network/libcurl-promis
 import * as models from '../models';
 import { CaCertificate } from '../models/ca-certificate';
 import { ClientCertificate } from '../models/client-certificate';
+import { CookieJar } from '../models/cookie-jar';
 import { Environment } from '../models/environment';
 import type { Request, RequestAuthentication, RequestParameter } from '../models/request';
 import type { Settings } from '../models/settings';
@@ -80,6 +81,7 @@ export const tryToExecutePreRequestScript = async (
   responseId: string,
   baseEnvironment: Environment,
   clientCertificates: ClientCertificate[],
+  cookieJar: CookieJar,
 ) => {
   if (!request.preRequestScript) {
     return {
@@ -111,6 +113,7 @@ export const tryToExecutePreRequestScript = async (
         baseEnvironment: baseEnvironment?.data || {},
         clientCertificates,
         settings,
+        cookieJar,
       },
     });
     const output = await Promise.race([timeoutPromise, preRequestPromise]) as {
@@ -119,6 +122,7 @@ export const tryToExecutePreRequestScript = async (
       baseEnvironment: Record<string, any>;
       settings: Settings;
       clientCertificates: ClientCertificate[];
+      cookieJar: CookieJar;
     };
     console.log('[network] Pre-request script succeeded', output);
 
@@ -144,6 +148,7 @@ export const tryToExecutePreRequestScript = async (
       baseEnvironment,
       settings: output.settings,
       clientCertificates: output.clientCertificates,
+      cookieJar: output.cookieJar,
     };
   } catch (err) {
     await fs.promises.appendFile(timelinePath, JSON.stringify({ value: err.message, name: 'Text', timestamp: Date.now() }) + '\n');

--- a/packages/insomnia/src/sdk/objects/__tests__/cookies.test.ts
+++ b/packages/insomnia/src/sdk/objects/__tests__/cookies.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { Cookie } from '../cookies';
+import { Cookie, CookieJar } from '../cookies';
 
 describe('test Cookie object', () => {
     it('test basic operations', () => {
@@ -64,5 +64,82 @@ describe('test Cookie object', () => {
         expect(
             Cookie.unparseSingle(cookie1Opt)
         ).toEqual(expectedCookieString);
+    });
+
+});
+
+describe('test CookieJar', () => {
+    it('basic operations', () => {
+        const cookieOptBase = {
+            key: 'myCookie',
+            value: 'myCookie',
+            expires: '01 Jan 1970 00:00:01 GMT',
+            maxAge: '7',
+            domain: 'domain.com',
+            path: '/',
+            secure: true,
+            httpOnly: true,
+            hostOnly: true,
+            session: true,
+            extensions: [{ key: 'Ext', value: 'ExtValue' }],
+        };
+
+        const jar = new CookieJar(
+            'my jar',
+            [
+                new Cookie({ ...cookieOptBase, key: 'c1', value: 'c1' }),
+                new Cookie({ ...cookieOptBase, key: 'c2', value: 'c2' }),
+            ],
+        );
+
+        jar.set('domain.com', 'c1', { ...cookieOptBase, key: 'c1', value: 'c1Updated' }, (error, cookie) => {
+            expect(error).toBeUndefined();
+            expect(cookie?.toJSON()).toEqual(
+                new Cookie({ ...cookieOptBase, key: 'c1', value: 'c1Updated' }).toJSON()
+            );
+        });
+
+        jar.set('domain2.com', 'c2', { ...cookieOptBase, key: 'c2', value: 'c2' }, (error, cookie) => {
+            expect(error).toBeUndefined();
+            expect(cookie?.toJSON()).toEqual(
+                new Cookie({ ...cookieOptBase, key: 'c2', value: 'c2' }).toJSON()
+            );
+        });
+
+        jar.get('domain.com', 'c1', (err, cookie) => {
+            expect(err).toBeUndefined();
+            expect(
+                cookie?.toJSON(),
+            ).toEqual(
+                new Cookie({ ...cookieOptBase, key: 'c1', value: 'c1Updated' }).toJSON(),
+            );
+        });
+
+        jar.get('domain2.com', 'c2', (err, cookie) => {
+            expect(err).toBeUndefined();
+            expect(
+                cookie?.toJSON(),
+            ).toEqual(
+                new Cookie({ ...cookieOptBase, key: 'c2', value: 'c2' }).toJSON(),
+            );
+        });
+
+        jar.unset('domain.com', 'c1', err => {
+            expect(err).toBeUndefined();
+        });
+
+        jar.get('domain.com', 'c1', (err, cookie) => {
+            expect(err).toBeUndefined();
+            expect(cookie).toBeUndefined();
+        });
+
+        jar.clear('domain2.com', err => {
+            expect(err).toBeUndefined();
+        });
+
+        jar.get('domain2.com', 'c2', (err, cookie) => {
+            expect(err).toBeUndefined();
+            expect(cookie).toBeUndefined();
+        });
     });
 });

--- a/packages/insomnia/src/sdk/objects/cookies.ts
+++ b/packages/insomnia/src/sdk/objects/cookies.ts
@@ -331,14 +331,14 @@ export class CookieJar {
 
 export function mergeCookieJar(
     originalCookieJar: InsomniaCookieJar,
-    updatedCookieJar: InsomniaCookieJar
+    updatedCookieJar: { name: string; cookies: Partial<InsomniaCookie>[] },
 ): InsomniaCookieJar {
-    const cookiesWithId = updatedCookieJar.cookies.map(cookie => {
+    const cookiesWithId = updatedCookieJar.cookies.map((cookie): InsomniaCookie => {
         if (!cookie.id) {
             // this follows the genration apporach in the `cookie-list.tsx`
             cookie.id = uuidv4();
         }
-        return cookie;
+        return cookie as InsomniaCookie;
     });
 
     return {

--- a/packages/insomnia/src/sdk/objects/cookies.ts
+++ b/packages/insomnia/src/sdk/objects/cookies.ts
@@ -1,4 +1,5 @@
 import { Cookie as ToughCookie } from 'tough-cookie';
+import { v4 as uuidv4 } from 'uuid';
 
 import { Cookie as InsomniaCookie, CookieJar as InsomniaCookieJar } from '../../../src/models/cookie-jar';
 import { Property, PropertyList } from './properties';
@@ -42,6 +43,8 @@ export class Cookie extends Property {
         if (!cookie) {
             throw Error('failed to parse cookie, the cookie string seems invalid');
         }
+
+        this.id = cookieDef.id || '';
         this.cookie = cookie;
     }
 
@@ -137,6 +140,7 @@ export class Cookie extends Property {
 
     toJSON = () => {
         return {
+            id: this.id,
             key: this.cookie.key,
             value: this.cookie.value,
             expires: this.cookie.expires === 'Infinity' ? undefined : this.cookie.expires,
@@ -152,26 +156,15 @@ export class Cookie extends Property {
     };
 }
 
-class CookieWrapper extends Cookie {
-    constructor(options: CookieOptions) {
-        super(options);
-    }
-
-    originalCookie = () => {
-        return this.cookie;
-    };
-}
-
 export class CookieList extends PropertyList<Cookie> {
     _kind: string = 'CookieList';
 
-    constructor(parent: CookieList | undefined, cookies: Cookie[]) {
+    constructor(cookies: Cookie[]) {
         super(
             Cookie,
             undefined,
-            cookies
+            cookies,
         );
-        this.parent = parent;
     }
 
     static isCookieList(obj: object) {
@@ -182,7 +175,7 @@ export class CookieList extends PropertyList<Cookie> {
 export class CookieObject extends CookieList {
     private cookieJar: CookieJar;
 
-    constructor(parent: CookieList | undefined, cookieJar: InsomniaCookieJar | null) {
+    constructor(cookieJar: InsomniaCookieJar | null) {
         const cookies = cookieJar
             ? cookieJar.cookies.map((cookie: InsomniaCookie): Cookie => {
                 let expires: string | Date = '';
@@ -210,9 +203,9 @@ export class CookieObject extends CookieList {
                 });
             })
             : [];
-        const scriptCookieJar = cookieJar ? new CookieJar(cookieJar.name, cookies) : new CookieJar('', []);
 
-        super(parent, cookies);
+        super(cookies);
+        const scriptCookieJar = cookieJar ? new CookieJar(cookieJar.name, cookies) : new CookieJar('', []);
         this.cookieJar = scriptCookieJar;
     }
 
@@ -221,39 +214,10 @@ export class CookieObject extends CookieList {
     }
 }
 
-function fromToughCookie(toughCookie: ToughCookie): Cookie {
-    let expires: string | Date = '';
-    if (toughCookie.expires) {
-        if (typeof toughCookie.expires === 'number') {
-            expires = new Date(toughCookie.expires);
-        } else {
-            expires = toughCookie.expires;
-        }
-    }
-    let maxAge: string | undefined = undefined;
-    if (typeof toughCookie.maxAge === 'number') {
-        maxAge = `${toughCookie.maxAge}`;
-    }
-
-    return new Cookie({
-        key: toughCookie.key,
-        value: toughCookie.value,
-        expires: expires,
-        maxAge: maxAge,
-        domain: toughCookie.domain || undefined,
-        path: toughCookie.path || undefined,
-        secure: toughCookie.secure,
-        httpOnly: toughCookie.httpOnly,
-        hostOnly: toughCookie.hostOnly || undefined,
-        session: undefined, // not supported in Insomnia
-        extensions: undefined, // TODO
-    });
-}
-
 export class CookieJar {
     // CookieJar from tough-cookie can not be used, as it will failed in comparing context location and cookies' domain
     // as it reads location from the browser window, it is "localhost"
-    private jar: Map<string, Map<string, ToughCookie>>; // domain -> <key -> cookie>
+    private jar: Map<string, Map<string, Cookie>>; // Map<domain, Map<cookieKey, cookieObject>>
     private jarName: string;
 
     constructor(jarName: string, cookies?: Cookie[]) {
@@ -268,22 +232,7 @@ export class CookieJar {
                 }
 
                 const domainCookies = this.jar.get(properties.domain) || new Map();
-                const domainCookie = new ToughCookie({
-                    key: properties.key,
-                    value: properties.value,
-                    expires: properties.expires,
-                    maxAge: properties.maxAge,
-                    domain: properties.domain,
-                    path: properties.path || undefined,
-                    secure: properties.secure,
-                    httpOnly: properties.httpOnly,
-                    extensions: properties.extensions ?
-                        properties.extensions.map(ext => `${encodeURIComponent(ext.key)}=${encodeURIComponent(ext.key)}`) :
-                        [],
-                    creation: undefined, // it is not supported in Cookie
-                });
-
-                this.jar.set(properties.domain, domainCookies.set(properties.key, domainCookie));
+                this.jar.set(properties.domain, domainCookies.set(properties.key, cookie));
             });
         }
     }
@@ -291,23 +240,17 @@ export class CookieJar {
     set(url: string, key: string, value: string | CookieOptions, cb: (error?: Error, cookie?: Cookie) => void) {
         const domainCookies = this.jar.get(url) || new Map();
         if (typeof value === 'string') {
-            const domainCookie = new ToughCookie({
+            const domainCookie = new Cookie({
                 key: key,
                 value: value,
                 domain: url,
-                creation: new Date(),
-                expires: new Date(Date.now() + 1000 * 3600 * 24 * 30),
             });
             this.jar.set(url, domainCookies.set(key, domainCookie));
-            cb(undefined, new Cookie({
-                key: key,
-                value: value,
-                domain: url,
-            }));
+            cb(undefined, domainCookie);
         } else {
-            const domainCookie = new CookieWrapper(value);
-            this.jar.set(url, domainCookies.set(key, domainCookie.originalCookie()));
-            cb(undefined, domainCookie); // TODO:
+            const domainCookie = new Cookie(value);
+            this.jar.set(url, domainCookies.set(key, domainCookie));
+            cb(undefined, domainCookie);
         }
     }
 
@@ -328,16 +271,14 @@ export class CookieJar {
 
     get(url: string, name: string, cb: (error?: Error, cookie?: Cookie) => void) {
         const domainCookies = this.jar.get(url) || new Map();
-        const toughCookie = domainCookies.get(name);
-        cb(undefined, toughCookie ? fromToughCookie(toughCookie) : undefined);
+        cb(undefined, domainCookies.get(name));
     }
 
     getAll(url: string, cb: (error?: Error, cookies?: Cookie[]) => void) {
         const domainCookies = this.jar.get(url) || new Map();
         cb(
             undefined,
-            Array.from(domainCookies.values())
-                .map((cookie: ToughCookie) => fromToughCookie(cookie)),
+            Array.from(domainCookies.values()),
         );
     }
 
@@ -359,22 +300,24 @@ export class CookieJar {
     toInsomniaCookieJar() {
         const cookies = new Array<Partial<InsomniaCookie>>();
         Array.from(this.jar.values())
-            .forEach((domainCookies: Map<string, ToughCookie>) => {
+            .forEach((domainCookies: Map<string, Cookie>) => {
                 Array.from(domainCookies.values()).forEach(cookie => {
+                    const cookieObj = cookie.toJSON();
                     cookies.push({
-                        key: cookie.key,
-                        value: cookie.value,
-                        expires: cookie.expires,
-                        domain: cookie.domain || undefined,
-                        path: cookie.path || undefined,
-                        secure: cookie.secure,
-                        httpOnly: cookie.httpOnly,
-                        extensions: cookie.extensions || undefined,
-                        creation: cookie.creation || undefined,
-                        creationIndex: cookie.creationIndex,
-                        hostOnly: cookie.hostOnly || undefined,
-                        pathIsDefault: cookie.pathIsDefault || undefined,
-                        lastAccessed: cookie.lastAccessed || undefined,
+                        id: cookieObj.id,
+                        key: cookieObj.key,
+                        value: cookieObj.value,
+                        expires: cookieObj.expires,
+                        domain: cookieObj.domain || undefined,
+                        path: cookieObj.path || undefined,
+                        secure: cookieObj.secure,
+                        httpOnly: cookieObj.httpOnly,
+                        extensions: cookieObj.extensions || undefined,
+                        creation: undefined,
+                        creationIndex: undefined,
+                        hostOnly: cookieObj.hostOnly || undefined,
+                        pathIsDefault: undefined,
+                        lastAccessed: undefined,
                     });
                 });
             });
@@ -384,4 +327,22 @@ export class CookieJar {
             cookies,
         };
     }
+}
+
+export function mergeCookieJar(
+    originalCookieJar: InsomniaCookieJar,
+    updatedCookieJar: InsomniaCookieJar
+): InsomniaCookieJar {
+    const cookiesWithId = updatedCookieJar.cookies.map(cookie => {
+        if (!cookie.id) {
+            // this follows the genration apporach in the `cookie-list.tsx`
+            cookie.id = uuidv4();
+        }
+        return cookie;
+    });
+
+    return {
+        ...originalCookieJar,
+        cookies: cookiesWithId,
+    };
 }

--- a/packages/insomnia/src/sdk/objects/insomnia.ts
+++ b/packages/insomnia/src/sdk/objects/insomnia.ts
@@ -4,6 +4,7 @@ import { ClientCertificate } from '../../models/client-certificate';
 import { RequestBodyParameter, RequestHeader } from '../../models/request';
 import { Settings } from '../../models/settings';
 import { toPreRequestAuth } from './auth';
+import { CookieObject } from './cookies';
 import { Environment, Variables } from './environments';
 import { RequestContext } from './interfaces';
 import { unsupportedError } from './properties';
@@ -18,6 +19,8 @@ export class InsomniaObject {
     public baseEnvironment: Environment;
     public variables: Variables;
     public request: ScriptRequest;
+    public cookies: CookieObject;
+
     private clientCertificates: ClientCertificate[];
     private _expect = expect;
     private _test = test;
@@ -39,6 +42,7 @@ export class InsomniaObject {
             request: ScriptRequest;
             settings: Settings;
             clientCertificates: ClientCertificate[];
+            cookies: CookieObject;
         },
         log: (...msgs: any[]) => void,
     ) {
@@ -48,6 +52,7 @@ export class InsomniaObject {
         this.collectionVariables = this.baseEnvironment; // collectionVariables is mapped to baseEnvironment
         this._iterationData = rawObj.iterationData;
         this.variables = rawObj.variables;
+        this.cookies = rawObj.cookies;
 
         this.request = rawObj.request;
         this._settings = rawObj.settings;
@@ -96,6 +101,7 @@ export class InsomniaObject {
             request: this.request,
             settings: this.settings,
             clientCertificates: this.clientCertificates,
+            cookieJar: this.cookies.jar().toInsomniaCookieJar(),
         };
     };
 }
@@ -109,6 +115,7 @@ export function initInsomniaObject(
     const baseEnvironment = new Environment(rawObj.baseEnvironment);
     const iterationData = new Environment(rawObj.iterationData);
     const collectionVariables = new Environment(rawObj.collectionVariables);
+    const cookies = new CookieObject(rawObj.cookieJar);
 
     const variables = new Variables({
         globals,
@@ -206,6 +213,7 @@ export function initInsomniaObject(
             request,
             settings: rawObj.settings,
             clientCertificates: rawObj.clientCertificates,
+            cookies,
         },
         log,
     );

--- a/packages/insomnia/src/sdk/objects/interfaces.ts
+++ b/packages/insomnia/src/sdk/objects/interfaces.ts
@@ -1,4 +1,5 @@
 import { ClientCertificate } from '../../models/client-certificate';
+import { CookieJar as InsomniaCookieJar } from '../../models/cookie-jar';
 import type { Request } from '../../models/request';
 import { Settings } from '../../models/settings';
 
@@ -13,4 +14,5 @@ export interface RequestContext {
     timeout: number;
     settings: Settings;
     clientCertificates: ClientCertificate[];
+    cookieJar: InsomniaCookieJar;
 }

--- a/packages/insomnia/src/sdk/objects/response.ts
+++ b/packages/insomnia/src/sdk/objects/response.ts
@@ -48,7 +48,6 @@ export class Response extends Property {
         this.body = options.body || '';
         this.code = options.code;
         this.cookies = new CookieList(
-            undefined,
             options.cookie?.map(cookie => new Cookie(cookie)) || [],
         );
         this.headers = new HeaderList(

--- a/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
@@ -2,6 +2,7 @@ import { Snippet } from 'codemirror';
 import React, { FC, Fragment, useRef } from 'react';
 
 import { Settings } from '../../../models/settings';
+import { CookieObject } from '../../../sdk/objects/cookies';
 import { Environment, Variables } from '../../../sdk/objects/environments';
 import { InsomniaObject } from '../../../sdk/objects/insomnia';
 import { Request as ScriptRequest } from '../../../sdk/objects/request';
@@ -172,6 +173,16 @@ export const PreRequestScriptEditor: FC<Props> = ({
       }),
       settings,
       clientCertificates: [],
+      cookies: new CookieObject({
+        _id: '',
+        type: '',
+        parentId: '',
+        modified: 0,
+        created: 0,
+        isPrivate: false,
+        name: '',
+        cookies: [],
+      }),
     },
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       (_msg: string, _fn: () => void) => { }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
`insomnia.cookie` is the missing part of current implementation so this PR enables it.

Changes:
- [x] enable cookieJar manipulation in pre-request script
- [x] add tests
