### PR TITLE
fix: url is encoded during execute pre-request script [INS-3681]

### DIFF
--- a/packages/insomnia/src/sdk/objects/request.ts
+++ b/packages/insomnia/src/sdk/objects/request.ts
@@ -560,7 +560,8 @@ export function mergeRequests(
     }
 
     const updatedReqProperties: Partial<InsomniaRequest> = {
-        url: typeof updatedReq.url === 'string' ? updatedReq.url : updatedReq.url.toString(),
+        // url is encoded during parsing phase. Need decode url In order to recognized variables
+        url: decodeURI(typeof updatedReq.url === 'string' ? updatedReq.url : updatedReq.url.toString()),
         method: updatedReq.method,
         body: {
             mimeType: mimeType,


### PR DESCRIPTION
ipt

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

close #7219 

When user use pre-request script, the url in request data will be encoded during execute the script.
In order to recognize variable, we need to decode url
