### PR TITLE
feat: translate pm object handler into insomnia object instead of supporting alias - INS-3702

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -357,13 +357,13 @@ resources:
     settingFollowRedirects: global
     preRequestScript: |-
       // set local
-      pm.variables.set('varStr', 'varStr');
-      pm.variables.set('varNum', 777);
-      pm.variables.set('varBool', true);
+      insomnia.variables.set('varStr', 'varStr');
+      insomnia.variables.set('varNum', 777);
+      insomnia.variables.set('varBool', true);
       // has
-      pm.environment.set('varStr', pm.variables.get('varStr'));
-      pm.environment.set('varNum', pm.variables.get('varNum'));
-      pm.environment.set('varBool', pm.variables.get('varBool'));
+      insomnia.environment.set('varStr', insomnia.variables.get('varStr'));
+      insomnia.environment.set('varNum', insomnia.variables.get('varNum'));
+      insomnia.environment.set('varBool', insomnia.variables.get('varBool'));
     body:
       mimeType: "application/json"
       text: |-
@@ -773,23 +773,23 @@ resources:
     settingFollowRedirects: global
     preRequestScript: |-
       insomnia.test('happy tests', () => {
-        pm.expect(200).to.eql(200);
-        pm.expect('uname').to.be.a('string');
-        pm.expect('a').to.have.lengthOf(1);
-        pm.expect('xxx_customer_id_yyy').to.include("customer_id");
-        pm.expect(201).to.be.oneOf([201,202]);
-        pm.expect(199).to.be.below(200);
+        insomnia.expect(200).to.eql(200);
+        insomnia.expect('uname').to.be.a('string');
+        insomnia.expect('a').to.have.lengthOf(1);
+        insomnia.expect('xxx_customer_id_yyy').to.include("customer_id");
+        insomnia.expect(201).to.be.oneOf([201,202]);
+        insomnia.expect(199).to.be.below(200);
         // test objects
-        pm.expect({a: 1, b: 2}).to.have.all.keys('a', 'b');
-        pm.expect({a: 1, b: 2}).to.have.any.keys('a', 'b');
-        pm.expect({a: 1, b: 2}).to.not.have.any.keys('c', 'd');
-        pm.expect({a: 1}).to.have.property('a');
-        pm.expect({a: 1, b: 2}).to.be.a('object')
+        insomnia.expect({a: 1, b: 2}).to.have.all.keys('a', 'b');
+        insomnia.expect({a: 1, b: 2}).to.have.any.keys('a', 'b');
+        insomnia.expect({a: 1, b: 2}).to.not.have.any.keys('c', 'd');
+        insomnia.expect({a: 1}).to.have.property('a');
+        insomnia.expect({a: 1, b: 2}).to.be.a('object')
           .that.has.all.keys('a', 'b');
       });
       insomnia.test('unhappy tests', () => {
-        pm.expect(199).to.eql(200);
-        pm.expect(199).to.be.oneOf([201,202]);
+        insomnia.expect(199).to.eql(200);
+        insomnia.expect(199).to.be.oneOf([201,202]);
       });
     body:
       mimeType: "application/json"

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -65,7 +65,7 @@ const runPreRequestScript = async (
     'eval',
     '_',
     `
-      const $ = insomnia, pm = insomnia;
+      const $ = insomnia;
        ${script};
       return insomnia;`
   );

--- a/packages/insomnia/src/utils/importers/importers/__tests__/postman.test.ts
+++ b/packages/insomnia/src/utils/importers/importers/__tests__/postman.test.ts
@@ -1,5 +1,3 @@
-// import url from 'node:url';
-
 import { describe, expect, it } from '@jest/globals';
 
 import { translateHandlersInScript } from '../postman';

--- a/packages/insomnia/src/utils/importers/importers/__tests__/postman.test.ts
+++ b/packages/insomnia/src/utils/importers/importers/__tests__/postman.test.ts
@@ -1,0 +1,48 @@
+// import url from 'node:url';
+
+import { describe, expect, it } from '@jest/globals';
+
+import { translateHandlersInScript } from '../postman';
+
+describe('test translateHandlersInScript', () => {
+    [
+        {
+            script: "pm.environment.set('', '')",
+            expected: "insomnia.environment.set('', '')",
+        },
+        {
+            script: 'ipm.fn()',
+            expected: 'ipm.fn()',
+        },
+        {
+            script: 'h5pm.fn()',
+            expected: 'h5pm.fn()',
+        },
+        {
+            script: '$pm.fn()',
+            expected: '$pm.fn()',
+        },
+        {
+            script: '_pm.fn()',
+            expected: '_pm.fn()',
+        },
+        {
+            script: 'call(pm.environment.get("hehe"))',
+            expected: 'call(insomnia.environment.get("hehe"))',
+        },
+        {
+            script: `
+                console.log(pm.variables.get('score'), pm.variables.get('score2'));
+                console.log(pm.collectionVariables.get('score'));
+                console.log(pm.environment.get('score'));`,
+            expected: `
+                console.log(insomnia.variables.get('score'), insomnia.variables.get('score2'));
+                console.log(insomnia.collectionVariables.get('score'));
+                console.log(insomnia.environment.get('score'));`,
+        },
+    ].forEach(testCase => {
+        it(`translate: ${testCase.script}`, () => {
+            expect(translateHandlersInScript(testCase.script)).toBe(testCase.expected);
+        });
+    });
+});

--- a/packages/insomnia/src/utils/importers/importers/postman.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.ts
@@ -69,6 +69,26 @@ const mapGrantTypeToInsomniaGrantType = (grantType: string) => {
   return grantType;
 };
 
+export function translateHandlersInScript(scriptContent: string): string {
+  let translated = scriptContent;
+
+  let offset = 0;
+  for (let i = 0; i < scriptContent.length - 2; i++) {
+    if (scriptContent.slice(i, i + 3) !== 'pm.') {
+      continue;
+    }
+
+    if (i - 1 >= 0 && /[0-9a-zA-Z\_\$]/.test(scriptContent[i - 1])) {
+      continue;
+    } else {
+      translated = translated.slice(0, i + offset) + 'insomnia.' + translated.slice(i + 3 + offset);
+      offset += 6;
+    }
+  }
+
+  return translated;
+}
+
 export class ImportPostman {
   collection;
 
@@ -132,7 +152,7 @@ export class ImportPostman {
       (Array.isArray(scriptOrRows.exec) ? scriptOrRows.exec.join('\n') : scriptOrRows.exec) :
       '';
 
-    return scriptContent;
+    return translateHandlersInScript(scriptContent);
   };
 
   importRequestItem = (

--- a/packages/insomnia/src/utils/importers/importers/postman.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.ts
@@ -72,15 +72,13 @@ const mapGrantTypeToInsomniaGrantType = (grantType: string) => {
 export function translateHandlersInScript(scriptContent: string): string {
   let translated = scriptContent;
 
+  // Replace pm.* with insomnia.*
+  // This is a simple implementation that only replaces the first instance of pm.* in the script
   let offset = 0;
   for (let i = 0; i < scriptContent.length - 2; i++) {
-    if (scriptContent.slice(i, i + 3) !== 'pm.') {
-      continue;
-    }
-
-    if (i - 1 >= 0 && /[0-9a-zA-Z\_\$]/.test(scriptContent[i - 1])) {
-      continue;
-    } else {
+    const isPM = scriptContent.slice(i, i + 3) === 'pm.';
+    const isPrevCharacterAlphaNumeric = i - 1 >= 0 && /[0-9a-zA-Z\_\$]/.test(scriptContent[i - 1]);
+    if (isPM && !isPrevCharacterAlphaNumeric) {
       translated = translated.slice(0, i + offset) + 'insomnia.' + translated.slice(i + 3 + offset);
       offset += 6;
     }


### PR DESCRIPTION
…

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

This change enables translating `pm` objects into `insomnia` objects in scripts, and disable the original alias.

Changes:
- [x] Apply translation in importing
- [x] Add tests

