### PR TITLE
fix: some UI improvements of the pre-request script tab - INS-3711

### DIFF
--- a/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
@@ -7,7 +7,7 @@ import { Environment, Variables } from '../../../sdk/objects/environments';
 import { InsomniaObject } from '../../../sdk/objects/insomnia';
 import { Request as ScriptRequest } from '../../../sdk/objects/request';
 import { Url } from '../../../sdk/objects/urls';
-import { Dropdown, DropdownButton, DropdownItem, ItemContent } from '../base/dropdown';
+import { Dropdown, DropdownButton, DropdownItem, DropdownSection, ItemContent } from '../base/dropdown';
 import { CodeEditor, CodeEditorHandle } from '../codemirror/code-editor';
 
 interface Props {
@@ -59,6 +59,7 @@ const updateRequestAuth =
   },
   'bearer'
 );`;
+const requireAModule = "const atob = require('atob');";
 
 const lintOptions = {
   globals: {
@@ -222,83 +223,101 @@ export const PreRequestScriptEditor: FC<Props> = ({
             </DropdownButton>
           }
         >
-          <DropdownItem textValue='Get an environment variable' arial-label={'Get an environment variable'}>
-            <ItemContent
-              icon="sliders"
-              label='Get an environment variable'
-              onClick={() => addSnippet(getEnvVar)}
-            />
-          </DropdownItem>
-          {/* <DropdownItem textValue='Get a global variable' arial-label={'Get a global variable'}>
+          <DropdownSection
+            aria-label="Get values"
+            title="Get values"
+          >
+
+            <DropdownItem textValue='Get an environment variable' arial-label={'Get an environment variable'}>
+              <ItemContent
+                icon="sliders"
+                label='Get an environment variable'
+                onClick={() => addSnippet(getEnvVar)}
+              />
+            </DropdownItem>
+            {/* <DropdownItem textValue='Get a global variable' arial-label={'Get a global variable'}>
             <ItemContent
               icon="sliders"
               label='Get a global variable'
               onClick={() => addSnippet(getGlbVar)}
             />
           </DropdownItem> */}
-          <DropdownItem textValue='Get a variable' arial-label={'Get a variable'}>
+            <DropdownItem textValue='Get a variable' arial-label={'Get a variable'}>
+              <ItemContent
+                icon="sliders"
+                label='Get a variable'
+                onClick={() => addSnippet(getVar)}
+              />
+            </DropdownItem>
+            <DropdownItem textValue='Get a collection variable' arial-label={'Get a collection variable'}>
+              <ItemContent
+                icon="sliders"
+                label='Get a collection variable'
+                onClick={() => addSnippet(getCollectionVar)}
+              />
+            </DropdownItem>
+          </DropdownSection>
+
+          <DropdownSection
+            aria-label="Set values"
+            title="Set values"
+          >
+            <DropdownItem textValue='Set an environment variable' arial-label={'Set an environment variable'}>
+              <ItemContent
+                icon="circle-plus"
+                label='Set an environment variable'
+                onClick={() => addSnippet(setEnvVar)}
+              />
+            </DropdownItem>
+            {/* <DropdownItem textValue='Set a global variable' arial-label={'Set a global variable'}>
             <ItemContent
-              icon="sliders"
-              label='Get a variable'
-              onClick={() => addSnippet(getVar)}
-            />
-          </DropdownItem>
-          <DropdownItem textValue='Get a collection variable' arial-label={'Get a collection variable'}>
-            <ItemContent
-              icon="sliders"
-              label='Get a collection variable'
-              onClick={() => addSnippet(getCollectionVar)}
-            />
-          </DropdownItem>
-          <DropdownItem textValue='Set an environment variable' arial-label={'Set an environment variable'}>
-            <ItemContent
-              icon="plus"
-              label='Set an environment variable'
-              onClick={() => addSnippet(setEnvVar)}
-            />
-          </DropdownItem>
-          {/* <DropdownItem textValue='Set a global variable' arial-label={'Set a global variable'}>
-            <ItemContent
-              icon="plus"
+              icon="circle-plus"
               label='Set a global variable'
               onClick={() => addSnippet(setGlbVar)}
             />
           </DropdownItem> */}
-          <DropdownItem textValue='Set a variable' arial-label={'Set a variable'}>
+            <DropdownItem textValue='Set a variable' arial-label={'Set a variable'}>
+              <ItemContent
+                icon="circle-plus"
+                label='Set a variable'
+                onClick={() => addSnippet(setVar)}
+              />
+            </DropdownItem>
+            <DropdownItem textValue='Set a collection variable' arial-label={'Set a collection variable'}>
+              <ItemContent
+                icon="circle-plus"
+                label='Set a collection variable'
+                onClick={() => addSnippet(setCollectionVar)}
+              />
+            </DropdownItem>
+          </DropdownSection>
+
+          <DropdownSection
+            aria-label="Clear values"
+            title="Clear values"
+          >
+            <DropdownItem textValue='Clear an environment variable' arial-label={'Clear an environment variable'}>
+              <ItemContent
+                icon="circle-minus"
+                label='Clear an environment variable'
+                onClick={() => addSnippet(unsetEnvVar)}
+              />
+            </DropdownItem>
+            {/* <DropdownItem textValue='Clear a global variable' arial-label={'Clear a global variable'}>
             <ItemContent
-              icon="plus"
-              label='Set a variable'
-              onClick={() => addSnippet(setVar)}
-            />
-          </DropdownItem>
-          <DropdownItem textValue='Set a collection variable' arial-label={'Set a collection variable'}>
-            <ItemContent
-              icon="plus"
-              label='Set a collection variable'
-              onClick={() => addSnippet(setCollectionVar)}
-            />
-          </DropdownItem>
-          <DropdownItem textValue='Clear an environment variable' arial-label={'Clear an environment variable'}>
-            <ItemContent
-              icon="minus"
-              label='Clear an environment variable'
-              onClick={() => addSnippet(unsetEnvVar)}
-            />
-          </DropdownItem>
-          {/* <DropdownItem textValue='Clear a global variable' arial-label={'Clear a global variable'}>
-            <ItemContent
-              icon="minus"
+              icon="circle-minus"
               label='Clear a global variable'
               onClick={() => addSnippet(unsetGlbVar)}
             />
           </DropdownItem> */}
-          <DropdownItem textValue='Clear a collection variable' arial-label={'Clear a collection variable'}>
-            <ItemContent
-              icon="minus"
-              label='Clear a collection variable'
-              onClick={() => addSnippet(unsetCollectionVar)}
-            />
-          </DropdownItem>
+            <DropdownItem textValue='Clear a collection variable' arial-label={'Clear a collection variable'}>
+              <ItemContent
+                icon="circle-minus"
+                label='Clear a collection variable'
+                onClick={() => addSnippet(unsetCollectionVar)}
+              />
+            </DropdownItem>
+          </DropdownSection>
         </Dropdown>
 
         <Dropdown
@@ -315,35 +334,35 @@ export const PreRequestScriptEditor: FC<Props> = ({
         >
           <DropdownItem textValue='Add query param' arial-label={'Add query param'}>
             <ItemContent
-              icon="p"
+              icon="circle-plus"
               label='Add a query param'
               onClick={() => addSnippet(addQueryParams)}
             />
           </DropdownItem>
           <DropdownItem textValue='Set method' arial-label={'Set method'}>
             <ItemContent
-              icon="m"
+              icon="circle-info"
               label='Set method'
               onClick={() => addSnippet(setMethod)}
             />
           </DropdownItem>
           <DropdownItem textValue='Add a header' arial-label={'Add a header'}>
             <ItemContent
-              icon="h"
+              icon="circle-plus"
               label='Add a header'
               onClick={() => addSnippet(addHeader)}
             />
           </DropdownItem>
           <DropdownItem textValue='Remove header' arial-label={'Remove header'}>
             <ItemContent
-              icon="h"
+              icon="circle-minus"
               label='Remove a header'
               onClick={() => addSnippet(removeHeader)}
             />
           </DropdownItem>
           <DropdownItem textValue='Update body as raw' arial-label={'Update body as raw'}>
             <ItemContent
-              icon="b"
+              icon="circle-info"
               label='Update body as raw'
               onClick={() => addSnippet(updateRequestBody)}
             />
@@ -382,8 +401,15 @@ export const PreRequestScriptEditor: FC<Props> = ({
               onClick={() => addSnippet(logValue)}
             />
           </DropdownItem>
+          <DropdownItem textValue='Require a module' arial-label={'Require a module'}>
+            <ItemContent
+              icon="circle-plus"
+              label='Require a module'
+              onClick={() => addSnippet(requireAModule)}
+            />
+          </DropdownItem>
         </Dropdown>
-      </div>
-    </Fragment>
+      </div >
+    </Fragment >
   );
 };

--- a/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
@@ -409,7 +409,7 @@ export const PreRequestScriptEditor: FC<Props> = ({
             />
           </DropdownItem>
         </Dropdown>
-      </div >
-    </Fragment >
+      </div>
+    </Fragment>
   );
 };

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -296,8 +296,10 @@ export const RequestPane: FC<Props> = ({
           title={
             <div className='flex items-center gap-2'>
               Pre-request Script{' '}
-              {headersCount > 0 && (
-                <span className="p-1 flex items-center color-inherit justify-between border-solid border border-[--hl-md] overflow-hidden rounded-lg text-xs shadow-small">Beta</span>
+              {activeRequest.preRequestScript && (
+                <span className="bubble space-left">
+                  <i className="fa fa--skinny fa-check txt-xxs" />
+                </span>
               )}
             </div>
           }

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -297,7 +297,7 @@ export const RequestPane: FC<Props> = ({
             <div className='flex items-center gap-2'>
               Pre-request Script{' '}
               {activeRequest.preRequestScript && (
-                <span className="bubble space-left">
+                <span className="ml-2 p-2 border-solid border border-[--hl-md] rounded-lg">
                   <span className="flex w-2 h-2 bg-green-500 rounded-full" />
                 </span>
               )}
@@ -323,7 +323,7 @@ export const RequestPane: FC<Props> = ({
             <>
               Docs
               {activeRequest.description && (
-                <span className="bubble space-left">
+                <span className="ml-2 p-2 border-solid border border-[--hl-md] rounded-lg">
                   <span className="flex w-2 h-2 bg-green-500 rounded-full" />
                 </span>
               )}

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -298,7 +298,7 @@ export const RequestPane: FC<Props> = ({
               Pre-request Script{' '}
               {activeRequest.preRequestScript && (
                 <span className="bubble space-left">
-                  <i className="fa fa--skinny fa-check txt-xxs" />
+                  <span className="flex w-2 h-2 bg-green-500 rounded-full" />
                 </span>
               )}
             </div>
@@ -324,7 +324,7 @@ export const RequestPane: FC<Props> = ({
               Docs
               {activeRequest.description && (
                 <span className="bubble space-left">
-                  <i className="fa fa--skinny fa-check txt-xxs" />
+                  <span className="flex w-2 h-2 bg-green-500 rounded-full" />
                 </span>
               )}
             </>


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Changes:
- [x] add green dot to pre-request script and doc tab when they are active
- [x] re-org and add script snippet menu items

### Snapshots:

#### Menu Items:
<img width="411" alt="Screenshot 2024-04-11 at 11 28 05" src="https://github.com/Kong/insomnia/assets/24986718/7f8ccd7f-d849-48ec-ba83-30a1a0ce2b43">

#### Tab title:
<img width="369" alt="Screenshot 2024-04-11 at 14 57 08" src="https://github.com/Kong/insomnia/assets/24986718/7f7889da-97ec-497f-94eb-792243682c40">
