### PR TITLE
fix: wildcard pattern matching

### DIFF
--- a/packages/insomnia/src/network/url-matches-cert-host.ts
+++ b/packages/insomnia/src/network/url-matches-cert-host.ts
@@ -1,4 +1,4 @@
-import { parse as urlParse } from 'url';
+import { parse as urlParse, URL } from 'url';
 
 import { escapeRegex } from '../common/misc';
 import { setDefaultProtocol } from '../utils/url/protocol';


### PR DESCRIPTION
Closes #7181
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
## Rationale

The `new URL` keyword was previously instantiating an unknown class which does encode the hostname characters so that `https://*.myhost.com/` was turned into `https://%2A.myhost.com` and the latter would not match with the actual url being requested and thus the certificate would not be attached to the request itself.

This fix forces the use of the [node:url module](https://github.com/nodejs/node/blob/v20.11.0/lib/url.js) which does return a more predictable output (and not encoding the star symbol).

It's not clear why this bug is not caught by the test suite since this exact test case [is already validated](https://github.com/Kong/insomnia/blob/2d9e2da52ee6c4e403cb378e36ef4568caf113b6/packages/insomnia/src/network/__tests__/url-matches-cert-host.test.ts#L117). If you have any suggestion we could explore other test scenarios.