### PR TITLE
fix: prevent app restart when editor setting change [INS-3668]

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -7,7 +7,7 @@ import { GraphQLInfoOptions } from 'codemirror-graphql/info';
 import { ModifiedGraphQLJumpOptions } from 'codemirror-graphql/jump';
 import deepEqual from 'deep-equal';
 import { JSONPath } from 'jsonpath-plus';
-import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { Button, Menu, MenuItem, MenuTrigger, Popover } from 'react-aria-components';
 import { useMount, useUnmount } from 'react-use';
 import vkBeautify from 'vkbeautify';
@@ -20,6 +20,7 @@ import { NunjucksParsedTag } from '../../../templating/utils';
 import { jsonPrettify } from '../../../utils/prettify/json';
 import { queryXPath } from '../../../utils/xpath/query';
 import { useGatedNunjucks } from '../../context/nunjucks/use-gated-nunjucks';
+import { useEditorRefresh } from '../../hooks/use-editor-refresh';
 import { useRootLoaderData } from '../../routes/root';
 import { Icon } from '../icon';
 import { createKeybindingsHandler, useDocBodyKeyboardShortcuts } from '../keydown-binder';
@@ -180,7 +181,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
   const indentSize = settings.editorIndentSize;
   const indentWithTabs = shouldIndentWithTabs({ mode, indentWithTabs: settings.editorIndentWithTabs });
   const indentChars = indentWithTabs ? '\t' : new Array((indentSize || TAB_SIZE) + 1).join(' ');
-  const extraKeys = {
+  const extraKeys = useMemo(() => ({
     'Ctrl-Q': (cm: CodeMirror.Editor) => cm.foldCode(cm.getCursor()),
     [isMac() ? 'Cmd-/' : 'Ctrl-/']: 'toggleComment',
     // Autocomplete
@@ -194,45 +195,46 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
     // Indent with tabs or spaces
     // From https://github.com/codemirror/CodeMirror/issues/988#issuecomment-14921785
     Tab: (cm: CodeMirror.Editor) => cm.somethingSelected() ? cm.indentSelection('add') : cm.replaceSelection(indentChars, 'end'),
-  };
+  }), [indentChars]);
   const { handleRender, handleGetRenderContext } = useGatedNunjucks({ disabled: !enableNunjucks });
-  const prettifyXML = (code: string, filter?: string) => {
-    if (updateFilter && filter) {
-      try {
-        const results = queryXPath(code, filter);
-        code = `<result>${results.map(r => r.outer).join('\n')}</result>`;
-      } catch (err) {
-        // Failed to parse filter (that's ok)
-        code = `<error>${err.message}</error>`;
-      }
-    }
-    try {
-      return vkBeautify.xml(code, indentChars);
-    } catch (error) {
-      // Failed to parse so just return original
-      return code;
-    }
-  };
-  const prettifyJSON = (code: string, filter?: string) => {
-    try {
-      let jsonString = code;
+
+  const maybePrettifyAndSetValue = useCallback((code?: string, forcePrettify?: boolean, filter?: string) => {
+    const prettifyXML = (code: string, filter?: string) => {
       if (updateFilter && filter) {
         try {
-          const codeObj = JSON.parse(code);
-          const results = JSONPath({ json: codeObj, path: filter.trim() });
-          jsonString = JSON.stringify(results);
+          const results = queryXPath(code, filter);
+          code = `<result>${results.map(r => r.outer).join('\n')}</result>`;
         } catch (err) {
-          console.log('[jsonpath] Error: ', err);
-          jsonString = '[]';
+          // Failed to parse filter (that's ok)
+          code = `<error>${err.message}</error>`;
         }
       }
-      return jsonPrettify(jsonString, indentChars, autoPrettify);
-    } catch (error) {
-      // That's Ok, just leave it
-      return code;
-    }
-  };
-  const maybePrettifyAndSetValue = (code?: string, forcePrettify?: boolean, filter?: string) => {
+      try {
+        return vkBeautify.xml(code, indentChars);
+      } catch (error) {
+        // Failed to parse so just return original
+        return code;
+      }
+    };
+    const prettifyJSON = (code: string, filter?: string) => {
+      try {
+        let jsonString = code;
+        if (updateFilter && filter) {
+          try {
+            const codeObj = JSON.parse(code);
+            const results = JSONPath({ json: codeObj, path: filter.trim() });
+            jsonString = JSON.stringify(results);
+          } catch (err) {
+            console.log('[jsonpath] Error: ', err);
+            jsonString = '[]';
+          }
+        }
+        return jsonPrettify(jsonString, indentChars, autoPrettify);
+      } catch (error) {
+        // That's Ok, just leave it
+        return code;
+      }
+    };
     if (typeof code !== 'string') {
       console.warn('Code editor was passed non-string value', code);
       return;
@@ -252,7 +254,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
       return;
     }
     codeMirror.current?.setValue(code || '');
-  };
+  }, [autoPrettify, mode, indentChars, updateFilter]);
 
   useDocBodyKeyboardShortcuts({
     beautifyRequestBody: () => {
@@ -262,7 +264,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
     },
   });
 
-  useMount(() => {
+  const initEditor = useCallback(() => {
     if (!textAreaRef.current) {
       return;
     }
@@ -453,12 +455,27 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
         codeMirror.current.foldCode(from, to);
       }
     }
-  });
-  useUnmount(() => {
+  }, [defaultValue, dynamicHeight, extraKeys, filter, getAutocompleteConstants, getAutocompleteSnippets, handleGetRenderContext, handleRender, hideGutters, hideLineNumbers, hintOptions, indentSize, indentWithTabs, infoOptions, jumpOptions, maybePrettifyAndSetValue, mode, noLint, noMatchBrackets, noStyleActiveLine, onClickLink, pinToBottom, placeholder, readOnly, settings.autocompleteDelay, settings.editorKeyMap, settings.editorLineWrapping, settings.hotKeyRegistry, settings.nunjucksPowerUserMode, settings.showVariableSourceAndValue, uniquenessKey]);
+
+  const cleanUpEditor = useCallback(() => {
     codeMirror.current?.toTextArea();
     codeMirror.current?.closeHintDropdown();
     codeMirror.current = null;
+  }, []);
+
+  useMount(() => {
+    initEditor();
   });
+  useUnmount(() => {
+    cleanUpEditor();
+  });
+
+  const reinitialize = useCallback(() => {
+    cleanUpEditor();
+    initEditor();
+  }, [cleanUpEditor, initEditor]);
+
+  useEditorRefresh(reinitialize);
 
   useEffect(() => {
     const fn = misc.debounce((doc: CodeMirror.Editor) => {

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -455,7 +455,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(({
         codeMirror.current.foldCode(from, to);
       }
     }
-  }, [defaultValue, dynamicHeight, extraKeys, filter, getAutocompleteConstants, getAutocompleteSnippets, handleGetRenderContext, handleRender, hideGutters, hideLineNumbers, hintOptions, indentSize, indentWithTabs, infoOptions, jumpOptions, maybePrettifyAndSetValue, mode, noLint, noMatchBrackets, noStyleActiveLine, onClickLink, pinToBottom, placeholder, readOnly, settings.autocompleteDelay, settings.editorKeyMap, settings.editorLineWrapping, settings.hotKeyRegistry, settings.nunjucksPowerUserMode, settings.showVariableSourceAndValue, uniquenessKey]);
+  }, [defaultValue, dynamicHeight, extraKeys, filter, getAutocompleteConstants, getAutocompleteSnippets, handleGetRenderContext, handleRender, hideGutters, hideLineNumbers, hintOptions, indentSize, indentWithTabs, infoOptions, jumpOptions, maybePrettifyAndSetValue, mode, noLint, noMatchBrackets, noStyleActiveLine, onClickLink, pinToBottom, placeholder, readOnly, settings.autocompleteDelay, settings.editorKeyMap, settings.editorLineWrapping, settings.hotKeyRegistry, settings.nunjucksPowerUserMode, settings.showVariableSourceAndValue, uniquenessKey, onPaste]);
 
   const cleanUpEditor = useCallback(() => {
     codeMirror.current?.toTextArea();

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -3,7 +3,7 @@ import './base-imports';
 import classnames from 'classnames';
 import clone from 'clone';
 import CodeMirror, { EditorConfiguration } from 'codemirror';
-import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from 'react';
 import { useMount, useUnmount } from 'react-use';
 
 import { DEBOUNCE_MILLIS } from '../../../common/constants';
@@ -12,6 +12,7 @@ import { KeyCombination } from '../../../common/settings';
 import { getTagDefinitions } from '../../../templating/index';
 import { NunjucksParsedTag } from '../../../templating/utils';
 import { useNunjucks } from '../../context/nunjucks/use-nunjucks';
+import { useEditorRefresh } from '../../hooks/use-editor-refresh';
 import { useRootLoaderData } from '../../routes/root';
 import { isKeyCombinationInRegistry } from '../settings/shortcuts';
 export interface OneLineEditorProps {
@@ -50,7 +51,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
   } = useRootLoaderData();
   const { handleRender, handleGetRenderContext } = useNunjucks();
 
-  useMount(() => {
+  const initEditor = useCallback(() => {
     if (!textAreaRef.current) {
       return;
     }
@@ -191,12 +192,26 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
         settings.showVariableSourceAndValue,
       );
     }
-  });
-  useUnmount(() => {
+  }, [defaultValue, getAutocompleteConstants, handleGetRenderContext, handleRender, onBlur, onKeyDown, onPaste, placeholder, readOnly, settings.autocompleteDelay, settings.editorKeyMap, settings.hotKeyRegistry, settings.nunjucksPowerUserMode, settings.showVariableSourceAndValue, type]);
+
+  const cleanUpEditor = useCallback(() => {
     codeMirror.current?.toTextArea();
     codeMirror.current?.closeHintDropdown();
     codeMirror.current = null;
+  }, []);
+  useMount(() => {
+    initEditor();
   });
+  useUnmount(() => {
+    cleanUpEditor();
+  });
+
+  const reinitialize = useCallback(() => {
+    cleanUpEditor();
+    initEditor();
+  }, [cleanUpEditor, initEditor]);
+
+  useEditorRefresh(reinitialize);
 
   useEffect(() => {
     const fn = misc.debounce((doc: CodeMirror.Editor) => {

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -23,9 +23,6 @@ import { NumberSetting } from './number-setting';
 import { TextSetting } from './text-setting';
 
 /**
- * We are attempting to move the app away from needing settings changes to restart the app.
- * For now, this component is a holdover until such a time as we are able to fix the underlying cases. (INS-1245)
- */
 
 export const General: FC = () => {
   const {

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -26,14 +26,6 @@ import { TextSetting } from './text-setting';
  * We are attempting to move the app away from needing settings changes to restart the app.
  * For now, this component is a holdover until such a time as we are able to fix the underlying cases. (INS-1245)
  */
-// const RestartTooltip: FC<{ message: string }> = ({ message }) => (
-//   <Fragment>
-//     {message}{' '}
-//     <Tooltip message="Will restart the app" className="space-left">
-//       <i className="fa fa-refresh super-duper-faint" />
-//     </Tooltip>
-//   </Fragment>
-// );
 
 export const General: FC = () => {
   const {

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -16,7 +16,6 @@ import { initNewOAuthSession } from '../../../network/o-auth-2/get-token';
 import { useRootLoaderData } from '../../routes/root';
 import { Link } from '../base/link';
 import { CheckForUpdatesButton } from '../check-for-updates-button';
-import { Tooltip } from '../tooltip';
 import { BooleanSetting } from './boolean-setting';
 import { EnumSetting } from './enum-setting';
 import { MaskedSetting } from './masked-setting';
@@ -27,14 +26,14 @@ import { TextSetting } from './text-setting';
  * We are attempting to move the app away from needing settings changes to restart the app.
  * For now, this component is a holdover until such a time as we are able to fix the underlying cases. (INS-1245)
  */
-const RestartTooltip: FC<{ message: string }> = ({ message }) => (
-  <Fragment>
-    {message}{' '}
-    <Tooltip message="Will restart the app" className="space-left">
-      <i className="fa fa-refresh super-duper-faint" />
-    </Tooltip>
-  </Fragment>
-);
+// const RestartTooltip: FC<{ message: string }> = ({ message }) => (
+//   <Fragment>
+//     {message}{' '}
+//     <Tooltip message="Will restart the app" className="space-left">
+//       <i className="fa fa-refresh super-duper-faint" />
+//     </Tooltip>
+//   </Fragment>
+// );
 
 export const General: FC = () => {
   const {
@@ -57,7 +56,7 @@ export const General: FC = () => {
             help="If checked, stack request and response panels vertically. Otherwise they will be side-by-side above 880px."
           />
           <BooleanSetting
-            label={<RestartTooltip message="Show variable source and value" />}
+            label="Show variable source and value"
             help="If checked, reveals the environment variable source and value in the template tag. Otherwise, hover over the template tag to see the source and value."
             setting="showVariableSourceAndValue"
           />
@@ -74,7 +73,7 @@ export const General: FC = () => {
             />
           )}
           <BooleanSetting
-            label={<RestartTooltip message="Raw template syntax" />}
+            label="Raw template syntax"
             setting="nunjucksPowerUserMode"
           />
         </div>

--- a/packages/insomnia/src/ui/hooks/use-editor-refresh.ts
+++ b/packages/insomnia/src/ui/hooks/use-editor-refresh.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { usePrevious } from 'react-use';
+
+import { useRootLoaderData } from '../routes/root';
+
+export const useEditorRefresh = (callback: () => void) => {
+  const { settings } = useRootLoaderData();
+  const { showVariableSourceAndValue, nunjucksPowerUserMode } = settings;
+  const previousShowVariableSourceAndValue = usePrevious(showVariableSourceAndValue);
+  const previousNunjucksPowerUserMode = usePrevious(nunjucksPowerUserMode);
+
+  useEffect(() => {
+    if (previousShowVariableSourceAndValue === undefined || previousNunjucksPowerUserMode === undefined) {
+      return;
+    }
+
+    if (previousShowVariableSourceAndValue === showVariableSourceAndValue && previousNunjucksPowerUserMode === nunjucksPowerUserMode) {
+      return;
+    }
+
+    callback?.();
+  }, [showVariableSourceAndValue, nunjucksPowerUserMode, previousShowVariableSourceAndValue, previousNunjucksPowerUserMode, callback]);
+
+};

--- a/packages/insomnia/src/ui/hooks/use-settings-side-effects.ts
+++ b/packages/insomnia/src/ui/hooks/use-settings-side-effects.ts
@@ -1,30 +1,6 @@
 import { useEffect, useLayoutEffect } from 'react';
-import { usePrevious } from 'react-use';
 
-import { Settings } from '../../models/settings';
 import { useRootLoaderData } from '../routes/root';
-
-const useRestartSetting = (setting: keyof Settings) => {
-  const {
-    settings,
-  } = useRootLoaderData();
-
-  const nextValue = settings[setting];
-  const previousValue = usePrevious(nextValue);
-  useEffect(() => {
-    // for the first value only, the return of `usePrevious` is `undefined` since there's no "previous" value at the time of the first value.
-    if (previousValue === undefined) {
-      return;
-    }
-
-    // there's not been a change, so no need to take any action
-    if (nextValue === previousValue) {
-      return;
-    }
-
-    window.main.restart();
-  }, [nextValue, previousValue]);
-};
 
 const updateFontStyle = (key: string, value: string | null) => document?.querySelector('html')?.style.setProperty(key, value);
 
@@ -54,6 +30,4 @@ export const useSettingsSideEffects = () => {
     window.main.setMenuBarVisibility(!settings.autoHideMenuBar);
   }, [settings.autoHideMenuBar]);
 
-  useRestartSetting('nunjucksPowerUserMode');
-  useRestartSetting('showVariableSourceAndValue');
 };


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Close #6389 

There is a historical logic when `nunjucksPowerUserMode` and `showVariableSourceAndValue` change the app will restart，in order to modify how variables are displayed
https://github.com/Kong/insomnia/blob/6c63b0d8d3a8b37c813a8c2fc0584e2d20f7e166/packages/insomnia/src/ui/hooks/use-settings-side-effects.ts#L58

The purpose of this PR is to use other way to refresh editor

Changes:

- [x] add a hook to listen showVariableSourceAndValue and nunjucksPowerUserMode variable change 
    - [x] one-line editor
    - [x] code editor
- [x] extract the init and clean up logic to external  function 
- [x] run cleanup and init to reinitialize codeMirror editor
- [x] delete old app restart logic