### PR TITLE
feat(pre-req-script-editor): translate handlers in pasting script

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -2,7 +2,7 @@ import './base-imports';
 
 import classnames from 'classnames';
 import clone from 'clone';
-import CodeMirror, { CodeMirrorLinkClickCallback, EditorChangeCancellable, EditorConfiguration, ShowHintOptions } from 'codemirror';
+import CodeMirror, { CodeMirrorLinkClickCallback, EditorConfiguration, ShowHintOptions } from 'codemirror';
 import { GraphQLInfoOptions } from 'codemirror-graphql/info';
 import { ModifiedGraphQLJumpOptions } from 'codemirror-graphql/jump';
 import deepEqual from 'deep-equal';
@@ -27,7 +27,6 @@ import { FilterHelpModal } from '../modals/filter-help-modal';
 import { showModal } from '../modals/index';
 import { isKeyCombinationInRegistry } from '../settings/shortcuts';
 import { normalizeIrregularWhitespace } from './normalizeIrregularWhitespace';
-import { translateHandlersInScript } from '../../../utils/importers/importers/postman';
 const TAB_SIZE = 4;
 const MAX_SIZE_FOR_LINTING = 1000000; // Around 1MB
 

--- a/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
@@ -188,11 +188,6 @@ export const PreRequestScriptEditor: FC<Props> = ({
     'insomnia',
   );
 
-  const translateHandlersInEditor = () => {
-    const translated = translateHandlersInScript(editorRef.current?.getValue() || '');
-    editorRef.current?.setValue(translated);
-  };
-
   return (
     <Fragment>
       <div className="h-[calc(100%-var(--line-height-xs))]">
@@ -409,13 +404,6 @@ export const PreRequestScriptEditor: FC<Props> = ({
               icon="circle-plus"
               label='Require a module'
               onClick={() => addSnippet(requireAModule)}
-            />
-          </DropdownItem>
-          <DropdownItem textValue='Migrate the script' arial-label={'Migrate the script'}>
-            <ItemContent
-              icon="file-import"
-              label='Migrate the script'
-              onClick={translateHandlersInEditor}
             />
           </DropdownItem>
         </Dropdown>

--- a/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
@@ -1,7 +1,8 @@
 import { Snippet } from 'codemirror';
 import { CookieObject, Environment, InsomniaObject, Request as ScriptRequest, Url, Variables } from 'insomnia-sdk';
-import React, { FC, Fragment, useRef } from 'react';
+import React, { FC, Fragment, useCallback, useRef } from 'react';
 
+import { translateHandlersInScript } from '../../../../src/utils/importers/importers/postman';
 import { Settings } from '../../../models/settings';
 import { Dropdown, DropdownButton, DropdownItem, DropdownSection, ItemContent } from '../base/dropdown';
 import { CodeEditor, CodeEditorHandle } from '../codemirror/code-editor';
@@ -187,6 +188,11 @@ export const PreRequestScriptEditor: FC<Props> = ({
     'insomnia',
   );
 
+  const translateHandlersInEditor = () => {
+    const translated = translateHandlersInScript(editorRef.current?.getValue() || '');
+    editorRef.current?.setValue(translated);
+  };
+
   return (
     <Fragment>
       <div className="h-[calc(100%-var(--line-height-xs))]">
@@ -204,6 +210,7 @@ export const PreRequestScriptEditor: FC<Props> = ({
           lintOptions={lintOptions}
           ref={editorRef}
           getAutocompleteSnippets={() => preRequestScriptSnippets}
+          onPaste={translateHandlersInScript}
         />
       </div>
       <div className="h-[calc(var(--line-height-xs))] border-solid border-t border-[var(--hl-md)] text-[var(--font-size-sm)] p-[var(--padding-xs)]">
@@ -402,6 +409,13 @@ export const PreRequestScriptEditor: FC<Props> = ({
               icon="circle-plus"
               label='Require a module'
               onClick={() => addSnippet(requireAModule)}
+            />
+          </DropdownItem>
+          <DropdownItem textValue='Migrate the script' arial-label={'Migrate the script'}>
+            <ItemContent
+              icon="file-import"
+              label='Migrate the script'
+              onClick={translateHandlersInEditor}
             />
           </DropdownItem>
         </Dropdown>

--- a/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
@@ -1,6 +1,6 @@
 import { Snippet } from 'codemirror';
 import { CookieObject, Environment, InsomniaObject, Request as ScriptRequest, Url, Variables } from 'insomnia-sdk';
-import React, { FC, Fragment, useCallback, useRef } from 'react';
+import React, { FC, Fragment, useRef } from 'react';
 
 import { translateHandlersInScript } from '../../../../src/utils/importers/importers/postman';
 import { Settings } from '../../../models/settings';


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Changes:
- Add `onPaste` callback for the code editor
- Enable auto migration for the pre-request script editor