### PR TITLE
fix changelog

### DIFF
--- a/changelog.js
+++ b/changelog.js
@@ -1,0 +1,73 @@
+const { Octokit } = require('@octokit/rest');
+
+const owner = 'kong';
+const repo = 'insomnia';
+const sinceTag = process.env.SINCE;// 'v8.5.0';
+const prNumber = process.env.PR;// 7262;
+const token = process.env.GITHUB_TOKEN;
+if (!sinceTag) {
+  console.error('Please provide SINCE env variable');
+  process.exit(1);
+}
+if (!prNumber) {
+  console.error('Please provide PR env variable');
+  process.exit(1);
+}
+if (!token) {
+  console.error('Please provide GITHUB_TOKEN env variable');
+  process.exit(1);
+}
+
+const octokit = new Octokit({
+  auth: token,
+});
+
+async function getPrTitles(owner, repo, sinceTag) {
+  try {
+    // Get the commits since the specified tag
+    const commitsResponse = await octokit.repos.listCommits({
+      owner,
+      repo,
+      since: sinceTag,
+    });
+
+    const prTitles = commitsResponse.data
+      .map(commit => {
+        const newLinePosition = commit.commit.message.indexOf('\n');
+        if (newLinePosition !== -1) {
+          return commit.commit.message.slice(0, newLinePosition + 1);
+        }
+        return commit.commit.message;
+      })
+      .map(title => '- ' + title.trim());
+
+    return prTitles;
+  } catch (error) {
+    console.error('Error fetching PR titles:', error.message);
+    return [];
+  }
+}
+async function postCommentOnPR(owner, repo, prNumber, comment) {
+  try {
+    const response = await octokit.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body: comment,
+    });
+
+    console.log('Comment posted successfully:', response.data.html_url);
+  } catch (error) {
+    console.error('Error posting comment:', error.message);
+  }
+}
+
+getPrTitles(owner, repo, sinceTag)
+  .then(prTitles => {
+    console.log('PR Titles since', sinceTag, ':');
+    prTitles.forEach(title => console.log(title));
+    // postCommentOnPR(owner, repo, prNumber, prTitles.join('\n'));
+  })
+  .catch(err => {
+    console.error('Error:', err);
+  });


### PR DESCRIPTION
- [ ] remove broken automation
- [ ] replace with documentation
- [ ] simplify?

focus of this change is that the changelog should be updated in the release PR and release notes should take the latest section of the changelog


also tempted to discuss the process in general in order to ensure we are doing the release notes in the simplest way

current release process
- press release start
- select release channel eg beta
- if major release input force version eg 10.0.0
- a PR will be created with version bumps in all the packages
- pre-release tests will run in addition to usual tests
- if the tests fail you can push fixes to this PR
- push changelog to this PR
- when ready to release run the release publish
- this action will merge the PR, tag and sign artifacts


potential release process (flattened)
- press release start
- select release channel eg beta
- if major release input force version eg 10.0.0
- pre-release tests will run in addition to usual tests
- this action will merge the PR, tag and sign artifacts


<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
