### PR TITLE
fix: insomnia.environment.name is missing - INS-3765

### DIFF
--- a/packages/insomnia-sdk/src/objects/environments.ts
+++ b/packages/insomnia-sdk/src/objects/environments.ts
@@ -1,9 +1,15 @@
 import { getIntepolator } from './interpolator';
 export class Environment {
+    private _name: string;
     private kvs = new Map<string, boolean | number | string>();
 
-    constructor(jsonObject: object | undefined) {
+    constructor(name: string, jsonObject: object | undefined) {
+        this._name = name;
         this.kvs = new Map(Object.entries(jsonObject || {}));
+    }
+
+    get name() {
+        return this._name;
     }
 
     has = (variableName: string) => {
@@ -55,7 +61,7 @@ export class Variables {
         this.collection = args.collection;
         this.environment = args.environment;
         this.data = args.data;
-        this.local = new Environment({});
+        this.local = new Environment('__local', {});
     }
 
     has = (variableName: string) => {

--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -116,11 +116,12 @@ export function initInsomniaObject(
     rawObj: RequestContext,
     log: (...args: any[]) => void,
 ) {
-    const globals = new Environment(rawObj.globals);
-    const environment = new Environment(rawObj.environment);
-    const baseEnvironment = new Environment(rawObj.baseEnvironment);
-    const iterationData = new Environment(rawObj.iterationData);
-    const collectionVariables = new Environment(rawObj.collectionVariables);
+    const globals = new Environment('globals', rawObj.globals);
+    const environment = new Environment(rawObj.environmentName || '', rawObj.environment);
+    const baseEnvironment = new Environment(rawObj.baseEnvironmentName || '', rawObj.baseEnvironment);
+    // TODO: update "iterationData" name when it is supported
+    const iterationData = new Environment('iterationData', rawObj.iterationData);
+    const collectionVariables = new Environment(rawObj.baseEnvironmentName || '', rawObj.collectionVariables);
     const cookies = new CookieObject(rawObj.cookieJar);
     // TODO: update follows when post-request script and iterating are introduced
     const requestInfo = new RequestInfo({

--- a/packages/insomnia-sdk/src/objects/interfaces.ts
+++ b/packages/insomnia-sdk/src/objects/interfaces.ts
@@ -7,7 +7,9 @@ export interface RequestContext {
     request: Request;
     timelinePath: string;
     environment?: object;
+    environmentName?: string;
     baseEnvironment?: object;
+    baseEnvironmentName?: string;
     collectionVariables?: object;
     globals?: object;
     iterationData?: object;

--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -315,6 +315,10 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     preRequestScript: |-
+      insomnia.environment.set("environmentName", insomnia.environment.name);
+      insomnia.environment.set("baseEnvironmentName", insomnia.baseEnvironment.name);
+      insomnia.environment.set("collectionVariablesName", insomnia.collectionVariables.name);
+      // manipulation
       insomnia.baseEnvironment.set('fromBaseEnv', 'baseEnv');
       insomnia.baseEnvironment.set('scriptValue', 'fromBase');
       insomnia.environment.set('scriptValue', 'fromEnv');
@@ -328,6 +332,9 @@ resources:
       mimeType: "application/json"
       text: |-
         {
+          "environmentName": "{{ _.environmentName }}",
+          "baseEnvironmentName": "{{ _.baseEnvironmentName }}",
+          "collectionVariablesName": "{{ _.collectionVariablesName }}",
           "fromBaseEnv": "{{ _.fromBaseEnv }}",
           "scriptValue": "{{ _.scriptValue }}",
           "preDefinedValue": "{{ _.preDefinedValue }}",

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -26,6 +26,9 @@ test.describe('pre-request features tests', async () => {
         {
             name: 'environments setting and overriding',
             expectedBody: {
+                environmentName: '',
+                baseEnvironmentName: 'Base Environment',
+                collectionVariablesName: 'Base Environment',
                 fromBaseEnv: 'baseEnv',
                 scriptValue: 'fromEnv',
                 preDefinedValue: 'fromScript',

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -109,7 +109,9 @@ export const tryToExecutePreRequestScript = async (
         // it inputs empty environment data when active environment is the base environment
         // this is more deterministic and avoids that script accidently manipulates baseEnvironment instead of environment
         environment: environment._id === baseEnvironment._id ? {} : (environment?.data || {}),
+        environmentName: environment._id === baseEnvironment._id ? '' : (environment?.name || ''),
         baseEnvironment: baseEnvironment?.data || {},
+        baseEnvironmentName: baseEnvironment?.name || '',
         clientCertificates,
         settings,
         cookieJar,

--- a/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/pre-request-script-editor.tsx
@@ -156,15 +156,15 @@ export const PreRequestScriptEditor: FC<Props> = ({
   // TODO(george): Add more to this object to provide improved autocomplete
   const preRequestScriptSnippets = getPreRequestScriptSnippets(
     new InsomniaObject({
-      globals: new Environment({}),
-      iterationData: new Environment({}),
-      environment: new Environment({}),
-      baseEnvironment: new Environment({}),
+      globals: new Environment('globals', {}),
+      iterationData: new Environment('iterationData', {}),
+      environment: new Environment('environment', {}),
+      baseEnvironment: new Environment('baseEnvironment', {}),
       variables: new Variables({
-        globals: new Environment({}),
-        environment: new Environment({}),
-        collection: new Environment({}),
-        data: new Environment({}),
+        globals: new Environment('globals', {}),
+        environment: new Environment('environment', {}),
+        collection: new Environment('collection', {}),
+        data: new Environment('data', {}),
       }),
       request: new ScriptRequest({
         url: new Url('http://placeholder.com'),


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Background:
User should be able to access `insomnia.environment.name`, `insomnia.baseEnvironment.name` and `insomnia.collectionVariables.name` to get environment names. CollectionVariables is also mapped to base environment.

Change:
- [x] add `insomnia.environment.name`, `insomnia.baseEnvironment.name` and `insomnia.collectionVariables.name`
- [x] add a test