### PR TITLE
fix(workspace-cards): Truncate the name after 2 lines

### DIFF
--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1270,7 +1270,7 @@ const ProjectRoute: FC = () => {
                               />
                             )}
                           </div>
-                          <Heading className="pt-4 text-lg font-bold truncate" title={item.name}>
+                          <Heading className="pt-4 text-lg font-bold line-clamp-2" title={item.name}>
                             {item.name}
                           </Heading>
                           <div className="flex-1 flex flex-col gap-2 justify-end text-sm text-[--hl]">


### PR DESCRIPTION
Currently we truncate the workspace name in the first line but this doesn't work that well for some workspace names and creates confusion to users.
This PR changes the truncation to happen in the 2nd line of the text.

<img width="535" alt="image" src="https://github.com/Kong/insomnia/assets/12115431/30fd3a8f-c36c-48ef-882f-47577b195e72">
