### PR TITLE
feat(organizations): Cache organizations to support offline first UX

### DIFF
--- a/packages/insomnia/src/ui/routes/commands.tsx
+++ b/packages/insomnia/src/ui/routes/commands.tsx
@@ -2,16 +2,15 @@ import { LoaderFunctionArgs } from 'react-router-dom';
 
 import { database } from '../../common/database';
 import { fuzzyMatch } from '../../common/misc';
-import { environment, grpcRequest, project, request, requestGroup, webSocketRequest, workspace } from '../../models';
+import { environment, grpcRequest, project, request, requestGroup, userSession, webSocketRequest, workspace } from '../../models';
 import { Environment } from '../../models/environment';
 import { GrpcRequest } from '../../models/grpc-request';
-import { isScratchpadOrganizationId } from '../../models/organization';
+import { isScratchpadOrganizationId, Organization } from '../../models/organization';
 import { Request } from '../../models/request';
 import { RequestGroup } from '../../models/request-group';
 import { WebSocketRequest } from '../../models/websocket-request';
 import { scopeToActivity, Workspace } from '../../models/workspace';
 import { invariant } from '../../utils/invariant';
-import { organizationsData } from './organization';
 
 export interface CommandItem<TItem> {
   id: string;
@@ -54,7 +53,9 @@ export async function loader(args: LoaderFunctionArgs): Promise<LoaderResult> {
     )?.indexes);
   };
 
-  const allOrganizations = organizationsData.organizations;
+  const { accountId } = await userSession.getOrCreate();
+
+  const allOrganizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
 
   const allOrganizationsIds = isScratchpadOrganizationId(organizationId) ? [organizationId] : allOrganizations.map(org => org.id);
 

--- a/packages/insomnia/src/ui/routes/untracked-projects.tsx
+++ b/packages/insomnia/src/ui/routes/untracked-projects.tsx
@@ -1,10 +1,10 @@
 import { LoaderFunction } from 'react-router-dom';
 
 import { database } from '../../common/database';
-import { SCRATCHPAD_ORGANIZATION_ID } from '../../models/organization';
+import { userSession } from '../../models';
+import { Organization, SCRATCHPAD_ORGANIZATION_ID } from '../../models/organization';
 import { Project } from '../../models/project';
 import { Workspace } from '../../models/workspace';
-import { organizationsData } from './organization';
 
 export interface UntrackedProjectsLoaderData {
   untrackedProjects: (Project & { workspacesCount: number })[];
@@ -12,7 +12,8 @@ export interface UntrackedProjectsLoaderData {
 }
 
 export const loader: LoaderFunction = async () => {
-  const { organizations } = organizationsData;
+  const { accountId } = await userSession.getOrCreate();
+  const organizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
   const listOfOrganizationIds = [...organizations.map(o => o.id), SCRATCHPAD_ORGANIZATION_ID];
 
   const projects = await database.find<Project>('Project', {


### PR DESCRIPTION
Highlights:

- [x] Caches the results of fetching organizations and user data to allow the app to keep working while offline
- [x] The data are cached in localStorage instead of in-memory using the accountId as a cache key

Next steps:
- [ ] Evaluate better caching strategies and ttl set from the server
- [ ] Features and Rules for organisations are a bottleneck for performance atm when switching between organisations and could use a better solution
- [ ] Move all localStorage to a file accessible from main context, to avoid localStorage corruption caused by app crashes.
- [ ] Rather than using the localStorage to get data in other loaders, we could first render from the cache with a defer to fetch, or an alternative initial load strategy

notes
- we cache org, user, plan at app-start, and sync triggered by SSE
- we read from the cache in three places
- cache mechanism is different to projects because projects are a intersection of remote and local and orgs, user, and plan is just a copy of whatever it the latest state on the remote.
- could cache feature rules responses, but would mean first visits would always have delays, could prefetch or could add to org response?