### PR TITLE
fix: persist script's changes on environment and baseEnvironment

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -1047,3 +1047,33 @@ resources:
           "asyncTaskDone": {{ _.asyncTaskDone}}
         }
     _type: request
+  - _id: req_89dade2ee9ee42fbb22d588783a9df15
+    parentId: fld_01de564274824ecaad272330339ea6b2
+    modified: 1636707449231
+    created: 1636141014552
+    url: http://127.0.0.1:4010/echo
+    name: persist environment
+    description: ""
+    method: POST
+    parameters: []
+    headers:
+      - name: 'Content-Type'
+        value: 'application/json'
+    authentication: {}
+    metaSortKey: -1636141014553
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    preRequestScript: |-
+      insomnia.environment.set('__fromScript', 'environment');
+      insomnia.baseEnvironment.set('__fromScript1', 'baseEnvironment');
+      insomnia.collectionVariables.set('__fromScript2', 'collection');
+    body:
+      mimeType: "application/json"
+      text: |-
+        {}
+    _type: request

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -408,6 +408,30 @@ test.describe('pre-request features tests', async () => {
         await expect(responsePane).toContainText('✓ happy tests'); // original proxy
         await expect(responsePane).toContainText('✕ unhappy tests: AssertionError: expected 199 to deeply equal 200'); // updated proxy
     });
+
+    test('environment and baseEnvironment can be persisted', async ({ page }) => {
+        const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+        await page.getByLabel('Request Collection').getByTestId('persist environment').press('Enter');
+
+        // send
+        await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+
+        // verify response
+        await page.waitForSelector('[data-testid="response-status-tag"]:visible');
+        await expect(statusTag).toContainText('200 OK');
+
+        // verify persisted environment
+        await page.getByLabel('Manage Environments').click();
+        const responseBody = page.getByRole('dialog').getByTestId('CodeEditor').locator('.CodeMirror-line');
+        const rows = await responseBody.allInnerTexts();
+        const bodyJson = JSON.parse(rows.join(' '));
+
+        expect(bodyJson).toEqual({
+            // no environment is selected so the environment value is not persisted
+            '__fromScript1': 'baseEnvironment',
+            '__fromScript2': 'collection',
+        });
+    });
 });
 
 test.describe('unhappy paths', async () => {

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -402,7 +402,7 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
         );
       }
       // when base environment is activated, `mutatedContext.environment` points to it
-      const isActiveEnvironmentBase = mutatedContext.environment._id === baseEnvironment._id;
+      const isActiveEnvironmentBase = mutatedContext.environment?._id === baseEnvironment._id;
       const hasEnvironmentAndIsNotBase = mutatedContext.environment && !isActiveEnvironmentBase;
       if (hasEnvironmentAndIsNotBase) {
         await models.environment.update(

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -401,11 +401,10 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
           { cookies: mutatedContext.cookieJar.cookies },
         );
       }
-      if (mutatedContext.environment &&
-        // when no environment is activated, `mutatedContext.environment` points to the base environment
-        // so if no environment is activated, it will not persist effects
-        // or it requires to create a new environment on the fly and activate it, which seems not reasonable
-        mutatedContext.environment._id !== baseEnvironment._id) {
+      // when base environment is activated, `mutatedContext.environment` points to it
+      const isActiveEnvironmentBase = mutatedContext.environment._id === baseEnvironment._id;
+      const hasEnvironmentAndIsNotBase = mutatedContext.environment && !isActiveEnvironmentBase;
+      if (hasEnvAndIsUserCreated) {
         await models.environment.update(
           environment,
           {

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -404,7 +404,7 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
       // when base environment is activated, `mutatedContext.environment` points to it
       const isActiveEnvironmentBase = mutatedContext.environment._id === baseEnvironment._id;
       const hasEnvironmentAndIsNotBase = mutatedContext.environment && !isActiveEnvironmentBase;
-      if (hasEnvAndIsUserCreated) {
+      if (hasEnvironmentAndIsNotBase) {
         await models.environment.update(
           environment,
           {

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -405,7 +405,7 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
         // when no environment is activated, `mutatedContext.environment` points to the base environment
         // so if no environment is activated, it will not persist effects
         // or it requires to create a new environment on the fly and activate it, which seems not reasonable
-        mutatedContext.environment._id !== environment._id) {
+        mutatedContext.environment._id !== baseEnvironment._id) {
         await models.environment.update(
           environment,
           {

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -401,7 +401,11 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
           { cookies: mutatedContext.cookieJar.cookies },
         );
       }
-      if (mutatedContext.environment) {
+      if (mutatedContext.environment &&
+        // when no environment is activated, `mutatedContext.environment` points to the base environment
+        // so if no environment is activated, it will not persist effects
+        // or it requires to create a new environment on the fly and activate it, which seems not reasonable
+        mutatedContext.environment._id !== environment._id) {
         await models.environment.update(
           environment,
           {

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -401,6 +401,24 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
           { cookies: mutatedContext.cookieJar.cookies },
         );
       }
+      if (mutatedContext.environment) {
+        await models.environment.update(
+          environment,
+          {
+            data: mutatedContext.environment.data,
+            dataPropertyOrder: mutatedContext.environment.dataPropertyOrder,
+          }
+        );
+      }
+      if (mutatedContext.baseEnvironment) {
+        await models.environment.update(
+          baseEnvironment,
+          {
+            data: mutatedContext.baseEnvironment.data,
+            dataPropertyOrder: mutatedContext.baseEnvironment.dataPropertyOrder,
+          }
+        );
+      }
     }
 
     const renderedResult = await tryToInterpolateRequest(


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Background
For variable modifications from script, the currently behavior will not persist those effects, which is inconsistent with the expected behavior.

### Changes
- [x] persist `environment` and `baseEnvironment` after script execution
- [x] added a smoke test