### PR TITLE
Fix: non blocking fetch on navigate

### DIFF
--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -118,7 +118,8 @@ async function _traversePluginPath(
     if (!fs.existsSync(p)) {
       continue;
     }
-
+    const folders = (await fs.promises.readdir(p)).filter(f => f.startsWith('insomnia-plugin-'));
+    console.log('[plugin] Loading', folders.map(f => f.replace('insomnia-plugin-', '')).join(', '));
     for (const filename of fs.readdirSync(p)) {
       try {
         const modulePath = path.join(p, filename);
@@ -166,7 +167,6 @@ async function _traversePluginPath(
             : { disabled: false },
           module: module,
         };
-        console.log(`[plugin] Loaded ${modulePath}`);
       } catch (err) {
         showError({
           title: 'Plugin Error',

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
@@ -1,6 +1,6 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import React from 'react';
-import { useRouteLoaderData } from 'react-router-dom';
+import { useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
 import { isRemoteProject } from '../../../models/project';
 import { OrganizationFeatureLoaderData } from '../../routes/organization';
@@ -20,8 +20,21 @@ export const WorkspaceSyncDropdown: FC = () => {
   ) as WorkspaceLoaderData;
 
   const { userSession } = useRootLoaderData();
-  const { features } = useRouteLoaderData(':organizationId') as OrganizationFeatureLoaderData;
+  const { organizationId } = useParams() as { organizationId: string };
+  const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>();
 
+  useEffect(() => {
+    const isIdleAndUninitialized = permissionsFetcher.state === 'idle' && !permissionsFetcher.data;
+    if (isIdleAndUninitialized) {
+      permissionsFetcher.load(`/organization/${organizationId}/permissions`);
+    }
+  }, [organizationId, permissionsFetcher]);
+
+  const { features } = permissionsFetcher.data || {
+    features: {
+      gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
+    },
+  };
   if (!userSession.id) {
     return null;
   }

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
@@ -21,7 +21,7 @@ export const WorkspaceSyncDropdown: FC = () => {
 
   const { userSession } = useRootLoaderData();
   const { organizationId } = useParams() as { organizationId: string };
-  const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>();
+  const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>({ key: `permissions:${organizationId}` });
 
   useEffect(() => {
     const isIdleAndUninitialized = permissionsFetcher.state === 'idle' && !permissionsFetcher.data;

--- a/packages/insomnia/src/ui/components/panes/project-empty-state-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/project-empty-state-pane.tsx
@@ -1,11 +1,11 @@
-import React, { FC } from 'react';
-import { useParams, useRouteLoaderData } from 'react-router-dom';
+import React, { FC, useEffect } from 'react';
+import { useFetcher, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { getAccountId } from '../../../account/session';
 import { getAppWebsiteBaseURL } from '../../../common/constants';
 import { isOwnerOfOrganization } from '../../../models/organization';
-import { type FeatureList, useOrganizationLoaderData } from '../../../ui/routes/organization';
+import { OrganizationFeatureLoaderData, useOrganizationLoaderData } from '../../../ui/routes/organization';
 import { useRootLoaderData } from '../../routes/root';
 import { showModal } from '../modals';
 import { AlertModal } from '../modals/alert-modal';
@@ -84,8 +84,20 @@ export const EmptyStatePane: FC<Props> = ({ createRequestCollection, createDesig
   const { organizations } = useOrganizationLoaderData();
   const { userSession } = useRootLoaderData();
   const currentOrg = organizations.find(organization => (organization.id === organizationId));
-  const { features } = useRouteLoaderData(':organizationId') as { features: FeatureList };
+  const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>();
 
+  useEffect(() => {
+    const isIdleAndUninitialized = permissionsFetcher.state === 'idle' && !permissionsFetcher.data;
+    if (isIdleAndUninitialized) {
+      permissionsFetcher.load(`/organization/${organizationId}/permissions`);
+    }
+  }, [organizationId, permissionsFetcher]);
+
+  const { features } = permissionsFetcher.data || {
+    features: {
+      gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
+    },
+  };
   const isGitSyncEnabled = features.gitSync.enabled;
   const accountId = getAccountId();
 

--- a/packages/insomnia/src/ui/components/panes/project-empty-state-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/project-empty-state-pane.tsx
@@ -89,7 +89,6 @@ export const EmptyStatePane: FC<Props> = ({ createRequestCollection, createDesig
   useEffect(() => {
     const isIdleAndUninitialized = permissionsFetcher.state === 'idle' && !permissionsFetcher.data;
     if (isIdleAndUninitialized) {
-      console.log('refetching1');
       permissionsFetcher.load(`/organization/${organizationId}/permissions`);
     }
   }, [organizationId, permissionsFetcher]);

--- a/packages/insomnia/src/ui/components/panes/project-empty-state-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/project-empty-state-pane.tsx
@@ -84,11 +84,12 @@ export const EmptyStatePane: FC<Props> = ({ createRequestCollection, createDesig
   const { organizations } = useOrganizationLoaderData();
   const { userSession } = useRootLoaderData();
   const currentOrg = organizations.find(organization => (organization.id === organizationId));
-  const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>();
+  const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>({ key: `permissions:${organizationId}` });
 
   useEffect(() => {
     const isIdleAndUninitialized = permissionsFetcher.state === 'idle' && !permissionsFetcher.data;
     if (isIdleAndUninitialized) {
+      console.log('refetching1');
       permissionsFetcher.load(`/organization/${organizationId}/permissions`);
     }
   }, [organizationId, permissionsFetcher]);

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -32,7 +32,6 @@ import Login from './routes/auth.login';
 import { ErrorRoute } from './routes/error';
 import Onboarding from './routes/onboarding';
 import { Migrate } from './routes/onboarding.migrate';
-import { shouldOrganizationsRevalidate } from './routes/organization';
 import Root from './routes/root';
 import { initializeSentry } from './sentry';
 

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -202,16 +202,18 @@ async function renderApp() {
               {
                 path: ':organizationId',
                 id: ':organizationId',
-                shouldRevalidate: shouldOrganizationsRevalidate,
-                loader: async (...args) =>
-                  (
-                    await import('./routes/organization')
-                  ).singleOrgLoader(...args),
                 children: [
                   {
                     index: true,
                     loader: async (...args) =>
                       (await import('./routes/project')).indexLoader(...args),
+                  },
+                  {
+                    path: 'permissions',
+                    loader: async (...args) =>
+                      (
+                        await import('./routes/organization')
+                      ).organizationPermissionsLoader(...args),
                   },
                   {
                     path: 'sync-projects',

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -17,7 +17,6 @@ import {
   NavLink,
   Outlet,
   redirect,
-  ShouldRevalidateFunction,
   useFetcher,
   useLoaderData,
   useNavigate,

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -302,7 +302,7 @@ export interface OrganizationFeatureLoaderData {
   storage: 'cloud_plus_local' | 'cloud_only' | 'local_only';
 }
 
-export const singleOrgLoader: LoaderFunction = async ({ params }): Promise<OrganizationFeatureLoaderData> => {
+export const organizationPermissionsLoader: LoaderFunction = async ({ params }): Promise<OrganizationFeatureLoaderData> => {
   const { organizationId } = params as { organizationId: string };
   const { id: sessionId, accountId } = await userSession.getOrCreate();
   const fallbackFeatures = {
@@ -361,15 +361,6 @@ export const singleOrgLoader: LoaderFunction = async ({ params }): Promise<Organ
 
 export const useOrganizationLoaderData = () => {
   return useRouteLoaderData('/organization') as OrganizationLoaderData;
-};
-
-export const shouldOrganizationsRevalidate: ShouldRevalidateFunction = ({
-  currentParams,
-  nextParams,
-}) => {
-  const isSwitchingBetweenOrganizations = currentParams.organizationId !== nextParams.organizationId;
-
-  return isSwitchingBetweenOrganizations;
 };
 
 const UpgradeButton = ({

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -34,7 +34,6 @@ import {
   useLoaderData,
   useNavigate,
   useParams,
-  useRouteLoaderData,
   useSearchParams,
 } from 'react-router-dom';
 import { useLocalStorage } from 'react-use';
@@ -570,7 +569,25 @@ const ProjectRoute: FC = () => {
 
   const { organizations } = useOrganizationLoaderData();
   const { presence } = useInsomniaEventStreamContext();
-  const { features, billing, storage } = useRouteLoaderData(':organizationId') as OrganizationFeatureLoaderData;
+  const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>();
+
+  useEffect(() => {
+    const isIdleAndUninitialized = permissionsFetcher.state === 'idle' && !permissionsFetcher.data;
+    if (isIdleAndUninitialized) {
+      permissionsFetcher.load(`/organization/${organizationId}/permissions`);
+    }
+  }, [organizationId, permissionsFetcher]);
+
+  const { features, billing, storage } = permissionsFetcher.data || {
+    features: {
+      gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
+      orgBasicRbac: { enabled: false, reason: 'Insomnia API unreachable' },
+    },
+    billing: {
+      isActive: true,
+    },
+    storage: 'cloud_plus_local',
+  };
   const [scope, setScope] = useLocalStorage(`${projectId}:project-dashboard-scope`, 'all');
   const [sortOrder, setSortOrder] = useLocalStorage(`${projectId}:project-dashboard-sort-order`, 'modified-desc');
   const [filter, setFilter] = useLocalStorage(`${projectId}:project-dashboard-filter`, '');

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -569,10 +569,10 @@ const ProjectRoute: FC = () => {
 
   const { organizations } = useOrganizationLoaderData();
   const { presence } = useInsomniaEventStreamContext();
-  const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>();
+  const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>({ key: `permissions:${organizationId}` });
 
   useEffect(() => {
-    const isIdleAndUninitialized = permissionsFetcher.state === 'idle' && !permissionsFetcher.data;
+    const isIdleAndUninitialized = permissionsFetcher.state === 'idle' && !permissionsFetcher.data && !isScratchpadOrganizationId(organizationId);
     if (isIdleAndUninitialized) {
       permissionsFetcher.load(`/organization/${organizationId}/permissions`);
     }


### PR DESCRIPTION
Removes the blocking fetch on organisation navigate

Instead makes a non-blocking request whenever one of three components is loaded, including project which might be a wasteful call but can be cached out of scope.


- [x] test that it refetches on org change

note: from #7318

future work
- [ ] use SSE to control re-fetching and use cache for initial state if available
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
