### PR TITLE
fix: subEnvironment's id should be real id instead of n/a - INS-3802

### DIFF
--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -330,7 +330,7 @@ export async function getRenderContext(
     workspace ? workspace._id : 'n/a',
   );
   const subEnvironmentId = environment ?
-    typeof environment === 'string' ? environment : 'n/a' :
+    typeof environment === 'string' ? environment : environment._id :
     'n/a';
   const subEnvironment = environment ?
     typeof environment === 'string' ? await models.environment.getById(environment) : environment :


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Background
The `render` function accepts environment as string (env id) or as Environment for making it work for modified environment (by pre-request script). But its id is not correctly set here.
The `environment` is transient but it still would affect some of downstream plugin, which consume it. [ref](https://getinsomnia.slack.com/archives/C3BBF236C/p1714379861949559)
This tiny change fixes it.

### Change
- [x] subEnvironment's id should be real id instead of n/a