### PR TITLE
Fix/filter out content length

### DIFF
--- a/packages/insomnia/src/ui/components/editors/mock-response-extractor.tsx
+++ b/packages/insomnia/src/ui/components/editors/mock-response-extractor.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-router-dom';
 
 import { getContentTypeName, getMimeTypeFromContentType } from '../../../common/constants';
+import { ResponseHeader } from '../../../models/response';
 import { invariant } from '../../../utils/invariant';
 import { isInMockContentTypeList, useMockRoutePatcher } from '../../routes/mock-route';
 import { RequestLoaderData } from '../../routes/request';
@@ -74,10 +75,8 @@ export const MockResponseExtractor = () => {
               onComplete: async name => {
                 invariant(activeResponse, 'Active response must be defined');
                 const body = await fs.readFile(activeResponse.bodyPath);
-                // TODO: consider setting selected mock server here rather than redirecting
-                const headersWithoutContentLength = Object.fromEntries(
-                  Object.entries(activeResponse.headers).filter(([key]) => key.toLowerCase() !== 'content-length')
-                );
+                // auth mechanism is too sensitive to allow content length checks
+                const headersWithoutContentLength: ResponseHeader[] = activeResponse.headers.filter(h => h.name.toLowerCase() !== 'content-length');
                 fetcher.submit(
                   JSON.stringify({
                     name: name,
@@ -114,9 +113,8 @@ export const MockResponseExtractor = () => {
                   });
                   return;
                 };
-                const headersWithoutContentLength = Object.fromEntries(
-                  Object.entries(activeResponse.headers).filter(([key]) => key.toLowerCase() !== 'content-length')
-                );
+                // auth mechanism is too sensitive to allow content length checks
+                const headersWithoutContentLength: ResponseHeader[] = activeResponse.headers.filter(h => h.name.toLowerCase() !== 'content-length');
                 fetcher.submit(
                   JSON.stringify({
                     name: name,

--- a/packages/insomnia/src/ui/components/editors/mock-response-extractor.tsx
+++ b/packages/insomnia/src/ui/components/editors/mock-response-extractor.tsx
@@ -75,13 +75,16 @@ export const MockResponseExtractor = () => {
                 invariant(activeResponse, 'Active response must be defined');
                 const body = await fs.readFile(activeResponse.bodyPath);
                 // TODO: consider setting selected mock server here rather than redirecting
+                const headersWithoutContentLength = Object.fromEntries(
+                  Object.entries(activeResponse.headers).filter(([key]) => key.toLowerCase() !== 'content-length')
+                );
                 fetcher.submit(
                   JSON.stringify({
                     name: name,
                     body: body.toString(),
                     mimeType,
                     statusCode: activeResponse.statusCode,
-                    headers: activeResponse.headers,
+                    headers: headersWithoutContentLength,
                     mockServerName: activeWorkspace.name,
                   }),
                   {
@@ -111,6 +114,9 @@ export const MockResponseExtractor = () => {
                   });
                   return;
                 };
+                const headersWithoutContentLength = Object.fromEntries(
+                  Object.entries(activeResponse.headers).filter(([key]) => key.toLowerCase() !== 'content-length')
+                );
                 fetcher.submit(
                   JSON.stringify({
                     name: name,
@@ -118,7 +124,7 @@ export const MockResponseExtractor = () => {
                     body: body.toString(),
                     mimeType,
                     statusCode: activeResponse.statusCode,
-                    headers: activeResponse.headers,
+                    headers: headersWithoutContentLength,
                   }),
                   {
                     encType: 'application/json',


### PR DESCRIPTION
 auth mechanism is too sensitive to allow content length checks
 so we filter out until the api can be less restrictive

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
