### PR TITLE
can navigate to folder and inherit auth

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/oauth.yaml
+++ b/packages/insomnia-smoke-test/fixtures/oauth.yaml
@@ -3,6 +3,65 @@ __export_format: 4
 __export_date: 2022-02-24T01:02:16.537Z
 __export_source: insomnia.desktop.app:v2022.1.0-beta.0
 resources:
+  - _id: req_8f029a22e56341748fa92ad14851a7be
+    parentId: fld_9fd59e794fe5455692a3c33af67f7668
+    modified: 1715935264320
+    created: 1715935207910
+    url: "{{ _.oidc_base_path }}/me"
+    name: Request with Inherited Auth
+    description: ""
+    method: GET
+    body: {}
+    preRequestScript: ""
+    parameters: []
+    headers:
+      - name: User-Agent
+        value: insomnia/9.2.0
+    authentication: {}
+    metaSortKey: -1715935264244
+    isPrivate: false
+    pathParameters: []
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: fld_9fd59e794fe5455692a3c33af67f7668
+    parentId: fld_e45987966c224b63b68b09b34687209c
+    modified: 1715935256495
+    created: 1715935256495
+    name: Inherit Auth Folder
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1715935256495
+    preRequestScript: ""
+    postRequestScript: ""
+    authentication: {}
+    _type: request_group
+  - _id: fld_e45987966c224b63b68b09b34687209c
+    parentId: wrk_392055e2aa29457b9d2904396cd7631f
+    modified: 1715935142556
+    created: 1715935030239
+    name: Folder Level Auth Code
+    description: ""
+    environment: {}
+    environmentPropertyOrder: null
+    metaSortKey: -1715935030239
+    preRequestScript: ""
+    postRequestScript: ""
+    authentication:
+      type: oauth2
+      grantType: authorization_code
+      authorizationUrl: "{{ _.oidc_base_path }}/auth"
+      accessTokenUrl: "{{ _.oidc_base_path }}/token"
+      clientId: "{{ _.client_id_authorization_code }}"
+      clientSecret: "{{ _.client_secret }}"
+      redirectUrl: "{{ _.oidc_callback }}"
+      scope: openid offline_access
+    _type: request_group
   - _id: req_54f2824040c847ebaf3ed6d080111b4e
     parentId: fld_0e50ba4426bb4540ade91e0525ea1f29
     modified: 1645664215605

--- a/packages/insomnia-smoke-test/fixtures/oauth.yaml
+++ b/packages/insomnia-smoke-test/fixtures/oauth.yaml
@@ -7,7 +7,7 @@ resources:
     parentId: fld_9fd59e794fe5455692a3c33af67f7668
     modified: 1715935264320
     created: 1715935207910
-    url: "{{ _.oidc_base_path }}/me"
+    url: "http://127.0.0.1:4010/oidc/me"
     name: Request with Inherited Auth
     description: ""
     method: GET
@@ -53,14 +53,20 @@ resources:
     preRequestScript: ""
     postRequestScript: ""
     authentication:
-      type: oauth2
+      accessTokenUrl: "http://127.0.0.1:4010/oidc/token"
+      authorizationUrl: "http://127.0.0.1:4010/oidc/auth"
+      clientId: "authorization_code"
+      clientSecret: "secret"
+      disabled: false
       grantType: authorization_code
-      authorizationUrl: "{{ _.oidc_base_path }}/auth"
-      accessTokenUrl: "{{ _.oidc_base_path }}/token"
-      clientId: "{{ _.client_id_authorization_code }}"
-      clientSecret: "{{ _.client_secret }}"
-      redirectUrl: "{{ _.oidc_callback }}"
+      redirectUrl: "http://127.0.0.1:4010/callback"
+      responseType: id_token
       scope: openid offline_access
+      state: ""
+      type: oauth2
+      usePkce: false
+      credentialsInBody: "false"
+      tokenPrefix: ""
     _type: request_group
   - _id: req_54f2824040c847ebaf3ed6d080111b4e
     parentId: fld_0e50ba4426bb4540ade91e0525ea1f29

--- a/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
@@ -93,6 +93,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
 
   // Inherited Auth from folder
   await page.getByLabel('Request Collection').getByTestId('Request with Inherited Auth').press('Enter');
+  await expect(page.locator('.app')).toContainText('http://127.0.0.1:4010/oidc/me');
   await sendButton.click();
   await expect(statusTag).toContainText('200 OK');
   await expect(responseBody).toContainText('"sub": "admin"');

--- a/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
@@ -91,6 +91,12 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await expect(statusTag).toContainText('200 OK');
   await expect(responseBody).toContainText('"sub": "admin"');
 
+  // Inherited Auth from folder
+  await page.getByLabel('Request Collection').getByTestId('Request with Inherited Auth').press('Enter');
+  await sendButton.click();
+  await expect(statusTag).toContainText('200 OK');
+  await expect(responseBody).toContainText('"sub": "admin"');
+
   // Reset the OAuth 2 session from Preferences
   if (process.platform === 'darwin') {
     await page.keyboard.press('Meta+,');

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -410,7 +410,7 @@ export function getAuthTypeName(authType: string, useLong = false) {
   if (authTypesMap.hasOwnProperty(authType)) {
     return useLong ? authTypesMap[authType][1] : authTypesMap[authType][0];
   } else {
-    return '';
+    return 'Auth';
   }
 }
 

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -304,6 +304,7 @@ const authTypesMap: Record<string, string[]> = {
   [AUTH_AWS_IAM]: ['AWS', 'AWS IAM v4'],
   [AUTH_ASAP]: ['ASAP', 'Atlassian ASAP'],
   [AUTH_NETRC]: ['Netrc', 'Netrc File'],
+  [AUTH_NONE]: ['None', 'No Auth'],
 };
 
 // Sort Orders

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -407,8 +407,8 @@ export function getContentTypeName(contentType?: string | null, useLong = false)
   return useLong ? contentTypesMap[CONTENT_TYPE_OTHER][1] : contentTypesMap[CONTENT_TYPE_OTHER][0];
 }
 
-export function getAuthTypeName(authType: string, useLong = false) {
-  if (authTypesMap.hasOwnProperty(authType)) {
+export function getAuthTypeName(authType?: string, useLong = false) {
+  if (authType && authTypesMap.hasOwnProperty(authType)) {
     return useLong ? authTypesMap[authType][1] : authTypesMap[authType][0];
   } else {
     return 'Auth';

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -565,19 +565,19 @@ export const database = {
     }
   },
 
-  withAncestors: async function<T extends BaseModel>(doc: T | null, types: string[] = allTypes()) {
+  withAncestors: async function (doc: BaseModel | null, types: string[] = allTypes()) {
     if (db._empty) {
-      return _send<T[]>('withAncestors', ...arguments);
+      return _send('withAncestors', ...arguments);
     }
 
     if (!doc) {
       return [];
     }
 
-    let docsToReturn: T[] = doc ? [doc] : [];
+    let docsToReturn = doc ? [doc] : [];
 
-    async function next(docs: T[]): Promise<T[]> {
-      const foundDocs: T[] = [];
+    async function next(docs) {
+      const foundDocs = [];
 
       for (const d of docs) {
         for (const type of types) {

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -565,19 +565,19 @@ export const database = {
     }
   },
 
-  withAncestors: async function (doc: BaseModel | null, types: string[] = allTypes()) {
+  withAncestors: async function <T extends BaseModel>(doc: T | null, types: string[] = allTypes()) {
     if (db._empty) {
-      return _send('withAncestors', ...arguments);
+      return _send<T[]>('withAncestors', ...arguments);
     }
 
     if (!doc) {
       return [];
     }
 
-    let docsToReturn = doc ? [doc] : [];
+    let docsToReturn: T[] = doc ? [doc] : [];
 
-    async function next(docs) {
-      const foundDocs = [];
+    async function next(docs: T[]): Promise<T[]> {
+      const foundDocs: T[] = [];
 
       for (const d of docs) {
         for (const type of types) {

--- a/packages/insomnia/src/common/har.ts
+++ b/packages/insomnia/src/common/har.ts
@@ -5,8 +5,9 @@ import { Cookie as ToughCookie } from 'tough-cookie';
 
 import * as models from '../models';
 import type { Request } from '../models/request';
+import type { RequestGroup } from '../models/request-group';
 import type { Response } from '../models/response';
-import { isWorkspace } from '../models/workspace';
+import { isWorkspace, type Workspace } from '../models/workspace';
 import { getAuthHeader } from '../network/authentication';
 import * as plugins from '../plugins';
 import * as pluginContexts from '../plugins/context/index';
@@ -26,7 +27,7 @@ export interface ExportRequest {
 }
 
 export async function exportHarCurrentRequest(request: Request, response: Response): Promise<Har.Har> {
-  const ancestors = await database.withAncestors(request, [
+  const ancestors = await database.withAncestors<Request | RequestGroup | Workspace>(request, [
     models.workspace.type,
     models.requestGroup.type,
   ]);

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -2,9 +2,11 @@ import path from 'path';
 
 import { BaseModel, types as modelTypes } from '../models';
 import * as models from '../models';
+import type { Request } from '../models/request';
+import type { RequestGroup } from '../models/request-group';
 import { getBodyBuffer } from '../models/response';
 import { Settings } from '../models/settings';
-import { isWorkspace } from '../models/workspace';
+import { isWorkspace, type Workspace } from '../models/workspace';
 import {
   responseTransform,
   sendCurlAndWriteTimeline,
@@ -48,7 +50,7 @@ export async function getSendRequestCallbackMemDb(environmentId: string, memDB: 
   const fetchInsoRequestData = async (requestId: string) => {
     const request = await models.request.getById(requestId);
     invariant(request, 'failed to find request');
-    const ancestors = await database.withAncestors(request, [
+    const ancestors = await database.withAncestors<Request | RequestGroup | Workspace>(request, [
       models.request.type,
       models.requestGroup.type,
       models.workspace.type,

--- a/packages/insomnia/src/models/grpc-request.ts
+++ b/packages/insomnia/src/models/grpc-request.ts
@@ -42,7 +42,7 @@ export const isGrpcRequest = (model: Pick<BaseModel, 'type'>): model is GrpcRequ
   model.type === type
 );
 
-export const isGrpcRequestId = (id: string | null) => (
+export const isGrpcRequestId = (id?: string | null) => (
   id?.startsWith(`${prefix}_`)
 );
 

--- a/packages/insomnia/src/models/request-group.ts
+++ b/packages/insomnia/src/models/request-group.ts
@@ -42,7 +42,6 @@ export function init(): BaseRequestGroup {
 }
 
 export function migrate(doc: RequestGroup) {
-  doc.authentication = doc.authentication || {};
   return doc;
 }
 

--- a/packages/insomnia/src/models/request-group.ts
+++ b/packages/insomnia/src/models/request-group.ts
@@ -96,4 +96,4 @@ export async function duplicate(requestGroup: RequestGroup, patch: Partial<Reque
   });
 }
 
-export const isRequestGroupId = (id: string) => id.startsWith(prefix);
+export const isRequestGroupId = (id?: string | null) => id?.startsWith(prefix);

--- a/packages/insomnia/src/models/request-group.ts
+++ b/packages/insomnia/src/models/request-group.ts
@@ -16,6 +16,8 @@ interface BaseRequestGroup {
   environment: Record<string, any>;
   environmentPropertyOrder: Record<string, any> | null;
   metaSortKey: number;
+  preRequestScript: string;
+  postRequestScript: string;
 }
 
 export type RequestGroup = BaseModel & BaseRequestGroup;
@@ -31,6 +33,8 @@ export function init(): BaseRequestGroup {
     environment: {},
     environmentPropertyOrder: null,
     metaSortKey: -1 * Date.now(),
+    preRequestScript: '',
+    postRequestScript: '',
   };
 }
 

--- a/packages/insomnia/src/models/request-group.ts
+++ b/packages/insomnia/src/models/request-group.ts
@@ -1,5 +1,6 @@
 import { database as db } from '../common/database';
 import type { BaseModel } from './index';
+import { RequestAuthentication } from './request';
 
 export const name = 'Folder';
 
@@ -18,6 +19,7 @@ interface BaseRequestGroup {
   metaSortKey: number;
   preRequestScript: string;
   postRequestScript: string;
+  authentication: RequestAuthentication | {};
 }
 
 export type RequestGroup = BaseModel & BaseRequestGroup;
@@ -35,10 +37,12 @@ export function init(): BaseRequestGroup {
     metaSortKey: -1 * Date.now(),
     preRequestScript: '',
     postRequestScript: '',
+    authentication: {},
   };
 }
 
 export function migrate(doc: RequestGroup) {
+  doc.authentication = doc.authentication || {};
   return doc;
 }
 

--- a/packages/insomnia/src/models/request.ts
+++ b/packages/insomnia/src/models/request.ts
@@ -273,7 +273,7 @@ export const isRequest = (model: Pick<BaseModel, 'type'>): model is Request => (
   model.type === type
 );
 
-export const isRequestId = (id: string | null) => (
+export const isRequestId = (id?: string | null) => (
   id?.startsWith(`${prefix}_`)
 );
 

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -33,7 +33,7 @@ export const isWebSocketRequest = (model: Pick<BaseModel, 'type'>): model is Web
   model.type === type
 );
 
-export const isWebSocketRequestId = (id: string | null) => (
+export const isWebSocketRequestId = (id?: string | null) => (
   id?.startsWith(`${prefix}_`)
 );
 

--- a/packages/insomnia/src/network/authentication.ts
+++ b/packages/insomnia/src/network/authentication.ts
@@ -189,3 +189,6 @@ export const _buildBearerHeader = (accessToken: string, prefix?: string) => {
 
   return header;
 };
+export const isAuthEnabled = (auth?: RequestAuthentication | {}) => (auth && 'disabled' in auth) ? auth.disabled !== true : true;
+export const getAuthObjectOrNull = (auth?: RequestAuthentication | {}): RequestAuthentication | null =>
+  (auth === undefined || Object.keys(auth).length === 0 || !('type' in auth)) ? null : auth;

--- a/packages/insomnia/src/network/grpc/write-proto-file.ts
+++ b/packages/insomnia/src/network/grpc/write-proto-file.ts
@@ -7,7 +7,7 @@ import type { BaseModel } from '../../models';
 import * as models from '../../models';
 import { isProtoDirectory, ProtoDirectory } from '../../models/proto-directory';
 import { isProtoFile, ProtoFile } from '../../models/proto-file';
-import { isWorkspace } from '../../models/workspace';
+import { isWorkspace, type Workspace } from '../../models/workspace';
 
 interface WriteResult {
   filePath: string;
@@ -40,7 +40,7 @@ const recursiveWriteProtoDirectory = async (
 
 export const writeProtoFile = async (protoFile: ProtoFile): Promise<WriteResult> => {
   // Find all ancestors
-  const ancestors = await db.withAncestors(protoFile, [
+  const ancestors = await db.withAncestors<ProtoFile | ProtoDirectory | Workspace>(protoFile, [
     models.protoDirectory.type,
     models.workspace.type,
   ]);

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -260,7 +260,6 @@ export async function sendCurlAndWriteTimeline(
   if (!renderedRequest.settingSendCookies) {
     timelineStrings.push(JSON.stringify({ value: 'Disable cookie sending due to user setting', name: 'Text', timestamp: Date.now() }) + '\n');
   }
-  console.log('send', { authentication });
   const authHeader = await getAuthHeader(renderedRequest, finalUrl);
   const requestOptions = {
     requestId,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -106,7 +106,14 @@ export const tryToExecutePreRequestScript = async (
     const requestGroups = await db.withAncestors(request, [
       models.requestGroup.type,
     ]) as (Request | RequestGroup)[];
-    const folderScripts = requestGroups.reverse().filter(group => group?.preRequestScript).map(group => group.preRequestScript);
+
+    const folderScripts = requestGroups.reverse()
+      .filter(group => group?.preRequestScript)
+      .map((group, i) => `const fn${i} = async ()=>{
+      ${group.preRequestScript}
+    }
+    await fn${i}();
+`);
     const joinedScript = [...folderScripts].join('\n');
     console.log({ requestGroups, folderScripts, joinedScript });
 

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -36,21 +36,18 @@ import {
   joinUrlAndQueryString,
   smartEncodeUrl,
 } from '../utils/url/querystring';
-import { getAuthHeader, getAuthQueryParams } from './authentication';
+import { getAuthHeader, getAuthObjectOrNull, getAuthQueryParams, isAuthEnabled } from './authentication';
 import { cancellableCurlRequest, cancellableRunPreRequestScript } from './cancellation';
 import { filterClientCertificates } from './certificate';
 import { addSetCookiesToToughCookieJar } from './set-cookie-util';
 
-const hasAuthOnRequest = (auth: RequestAuthentication | {}) => 'type' in auth;
-const isAuthEnabled = (auth: RequestAuthentication | {}) => ('disabled' in auth) ? auth.disabled !== true : true;
-
 export const getOrInheritAuthentication = ({ request, requestGroups }: { request: Request; requestGroups: RequestGroup[] }): RequestAuthentication | {} => {
-  const hasValidAuth = hasAuthOnRequest(request.authentication) && isAuthEnabled(request.authentication);
+  const hasValidAuth = getAuthObjectOrNull(request.authentication) && isAuthEnabled(request.authentication);
   if (hasValidAuth) {
     return request.authentication;
   }
   const hasParentFolders = requestGroups.length > 0;
-  const closestParentFolderWithAuth = requestGroups.find(({ authentication }) => hasAuthOnRequest(authentication) && isAuthEnabled(authentication));
+  const closestParentFolderWithAuth = requestGroups.find(({ authentication }) => getAuthObjectOrNull(authentication) && isAuthEnabled(authentication));
   const shouldCheckFolderAuth = hasParentFolders && closestParentFolderWithAuth;
   if (shouldCheckFolderAuth) {
     // override auth with closest parent folder that has one set

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -62,13 +62,13 @@ export const getOrInheritAuthentication = ({ request, requestGroups }: { request
 export const fetchRequestData = async (requestId: string) => {
   const request = await models.request.getById(requestId);
   invariant(request, 'failed to find request');
-  const ancestors = await db.withAncestors(request, [
+  const ancestors = await db.withAncestors<Request | RequestGroup | Workspace | MockRoute | MockServer>(request, [
     models.request.type,
     models.requestGroup.type,
     models.workspace.type,
     models.mockRoute.type,
     models.mockServer.type,
-  ]) as (Request | RequestGroup | Workspace | MockRoute | MockServer)[];
+  ]);
   const workspaceDoc = ancestors.find(isWorkspace);
   invariant(workspaceDoc?._id, 'failed to find workspace');
   const workspaceId = workspaceDoc._id;
@@ -124,7 +124,7 @@ export const tryToExecutePreRequestScript = async (
         // TODO: restart the hidden browser window
       }, timeout + 1000);
     });
-    const requestGroups = await db.withAncestors(request, [
+    const requestGroups = await db.withAncestors<Request | RequestGroup>(request, [
       models.requestGroup.type,
     ]) as (Request | RequestGroup)[];
 

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -124,19 +124,18 @@ export const tryToExecutePreRequestScript = async (
         // TODO: restart the hidden browser window
       }, timeout + 1000);
     });
-    const requestGroups = await db.withAncestors<Request | RequestGroup>(request, [
-      models.requestGroup.type,
-    ]) as (Request | RequestGroup)[];
+    //     const requestGroups = await db.withAncestors<Request | RequestGroup>(request, [
+    //       models.requestGroup.type,
+    //     ]) as (Request | RequestGroup)[];
 
-    const folderScripts = requestGroups.reverse()
-      .filter(group => group?.preRequestScript)
-      .map((group, i) => `const fn${i} = async ()=>{
-      ${group.preRequestScript}
-    }
-    await fn${i}();
-`);
-    const joinedScript = [...folderScripts].join('\n');
-    console.log({ requestGroups, folderScripts, joinedScript });
+    //     const folderScripts = requestGroups.reverse()
+    //       .filter(group => group?.preRequestScript)
+    //       .map((group, i) => `const fn${i} = async ()=>{
+    //       ${group.preRequestScript}
+    //     }
+    //     await fn${i}();
+    // `);
+    const joinedScript = request.preRequestScript;// [...folderScripts].join('\n');
 
     const preRequestPromise = cancellableRunPreRequestScript({
       script: joinedScript,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -121,21 +121,9 @@ export const tryToExecutePreRequestScript = async (
         // TODO: restart the hidden browser window
       }, timeout + 1000);
     });
-    //     const requestGroups = await db.withAncestors<Request | RequestGroup>(request, [
-    //       models.requestGroup.type,
-    //     ]) as (Request | RequestGroup)[];
-
-    //     const folderScripts = requestGroups.reverse()
-    //       .filter(group => group?.preRequestScript)
-    //       .map((group, i) => `const fn${i} = async ()=>{
-    //       ${group.preRequestScript}
-    //     }
-    //     await fn${i}();
-    // `);
-    const joinedScript = request.preRequestScript;// [...folderScripts].join('\n');
 
     const preRequestPromise = cancellableRunPreRequestScript({
-      script: joinedScript,
+      script: request.preRequestScript,
       context: {
         request,
         timelinePath,

--- a/packages/insomnia/src/templating/base-extension.ts
+++ b/packages/insomnia/src/templating/base-extension.ts
@@ -1,5 +1,8 @@
 import { database as db } from '../common/database';
 import * as models from '../models/index';
+import type { Request } from '../models/request';
+import type { RequestGroup } from '../models/request-group';
+import type { Workspace } from '../models/workspace';
 import * as pluginContexts from '../plugins/context';
 import { PluginTemplateTag } from './extensions';
 import * as templating from './index';
@@ -119,7 +122,7 @@ export default class BaseExtension {
           request: {
             getById: models.request.getById,
             getAncestors: async (request: any) => {
-              const ancestors = await db.withAncestors(request, [
+              const ancestors = await db.withAncestors<Request | RequestGroup | Workspace>(request, [
                 models.requestGroup.type,
                 models.workspace.type,
               ]);

--- a/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
@@ -9,7 +9,6 @@ import {
   AUTH_DIGEST,
   AUTH_HAWK,
   AUTH_NETRC,
-  AUTH_NONE,
   AUTH_NTLM,
   AUTH_OAUTH_1,
   AUTH_OAUTH_2,
@@ -29,8 +28,7 @@ import { OAuth2Auth } from './o-auth-2-auth';
 
 export const AuthWrapper: FC<{ authentication?: RequestAuthentication | {}; disabled?: boolean }> = ({ authentication, disabled = false }) => {
   const isInitialised = authentication && 'type' in authentication;
-  const type = isInitialised ? authentication.type : AUTH_NONE;
-
+  const type = isInitialised ? authentication.type : '';
   let authBody: ReactNode = null;
 
   if (type === AUTH_BASIC) {

--- a/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
@@ -1,5 +1,4 @@
 import React, { FC, ReactNode } from 'react';
-import { useRouteLoaderData } from 'react-router-dom';
 
 import {
   AUTH_API_KEY,
@@ -10,12 +9,12 @@ import {
   AUTH_DIGEST,
   AUTH_HAWK,
   AUTH_NETRC,
+  AUTH_NONE,
   AUTH_NTLM,
   AUTH_OAUTH_1,
   AUTH_OAUTH_2,
 } from '../../../../common/constants';
 import { RequestAuthentication } from '../../../../models/request';
-import { RequestLoaderData } from '../../../routes/request';
 import { ApiKeyAuth } from './api-key-auth';
 import { AsapAuth } from './asap-auth';
 import { AWSAuth } from './aws-auth';
@@ -28,11 +27,9 @@ import { NTLMAuth } from './ntlm-auth';
 import { OAuth1Auth } from './o-auth-1-auth';
 import { OAuth2Auth } from './o-auth-2-auth';
 
-export const AuthWrapper: FC<{ disabled?: boolean }> = ({ disabled = false }) => {
-  const { activeRequest } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
-  const authentication = activeRequest.authentication as RequestAuthentication;
-
-  const { type } = authentication;
+export const AuthWrapper: FC<{ authentication?: RequestAuthentication | {}; disabled?: boolean }> = ({ authentication, disabled = false }) => {
+  const isInitialised = authentication && 'type' in authentication;
+  const type = isInitialised ? authentication.type : AUTH_NONE;
 
   let authBody: ReactNode = null;
 

--- a/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/auth-wrapper.tsx
@@ -14,6 +14,7 @@ import {
   AUTH_OAUTH_2,
 } from '../../../../common/constants';
 import { RequestAuthentication } from '../../../../models/request';
+import { getAuthObjectOrNull } from '../../../../network/authentication';
 import { ApiKeyAuth } from './api-key-auth';
 import { AsapAuth } from './asap-auth';
 import { AWSAuth } from './aws-auth';
@@ -27,8 +28,7 @@ import { OAuth1Auth } from './o-auth-1-auth';
 import { OAuth2Auth } from './o-auth-2-auth';
 
 export const AuthWrapper: FC<{ authentication?: RequestAuthentication | {}; disabled?: boolean }> = ({ authentication, disabled = false }) => {
-  const isInitialised = authentication && 'type' in authentication;
-  const type = isInitialised ? authentication.type : '';
+  const type = getAuthObjectOrNull(authentication)?.type || '';
   let authBody: ReactNode = null;
 
   if (type === AUTH_BASIC) {

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-accordion.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-accordion.tsx
@@ -5,6 +5,7 @@ import { useRouteLoaderData } from 'react-router-dom';
 import { RequestAccordionKeys } from '../../../../../models/request-meta';
 import { useRequestMetaPatcher } from '../../../../hooks/use-request';
 import { RequestLoaderData } from '../../../../routes/request';
+import { RequestGroupLoaderData } from '../../../../routes/request-group';
 
 interface Props {
   label: string;
@@ -12,14 +13,14 @@ interface Props {
 }
 
 export const AuthAccordion: FC<PropsWithChildren<Props>> = ({ accordionKey, label, children }) => {
-  const { activeRequest, activeRequestMeta } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
-
-  const expanded = Boolean(activeRequestMeta?.expandedAccordionKeys[accordionKey]);
+  const reqData = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  // const groupData = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
+  const expanded = !reqData || Boolean(reqData.activeRequestMeta?.expandedAccordionKeys[accordionKey]);
   const patchRequestMeta = useRequestMetaPatcher();
-  const toggle = async () => {
-    patchRequestMeta(activeRequest._id, {
+  const toggle = () => {
+    reqData && patchRequestMeta(reqData.activeRequest._id, {
       expandedAccordionKeys: {
-        ...activeRequestMeta?.expandedAccordionKeys,
+        ...reqData.activeRequestMeta?.expandedAccordionKeys,
         [accordionKey]: !expanded,
       },
     });

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-accordion.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-accordion.tsx
@@ -5,7 +5,6 @@ import { useRouteLoaderData } from 'react-router-dom';
 import { RequestAccordionKeys } from '../../../../../models/request-meta';
 import { useRequestMetaPatcher } from '../../../../hooks/use-request';
 import { RequestLoaderData } from '../../../../routes/request';
-import { RequestGroupLoaderData } from '../../../../routes/request-group';
 
 interface Props {
   label: string;

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-accordion.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-accordion.tsx
@@ -13,7 +13,6 @@ interface Props {
 
 export const AuthAccordion: FC<PropsWithChildren<Props>> = ({ accordionKey, label, children }) => {
   const reqData = useRouteLoaderData('request/:requestId') as RequestLoaderData;
-  // const groupData = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
   const expanded = !reqData || Boolean(reqData.activeRequestMeta?.expandedAccordionKeys[accordionKey]);
   const patchRequestMeta = useRequestMetaPatcher();
   const toggle = () => {

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-input-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-input-row.tsx
@@ -3,8 +3,9 @@ import { useRouteLoaderData } from 'react-router-dom';
 import { useToggle } from 'react-use';
 
 import { toKebabCase } from '../../../../../common/misc';
-import { useRequestPatcher } from '../../../../hooks/use-request';
+import { useRequestGroupPatcher, useRequestPatcher } from '../../../../hooks/use-request';
 import { RequestLoaderData } from '../../../../routes/request';
+import { RequestGroupLoaderData } from '../../../../routes/request-group';
 import { useRootLoaderData } from '../../../../routes/root';
 import { OneLineEditor } from '../../../codemirror/one-line-editor';
 import { AuthRow } from './auth-row';
@@ -22,14 +23,18 @@ export const AuthInputRow: FC<Props> = ({ label, getAutocompleteConstants, prope
     settings,
   } = useRootLoaderData();
   const { showPasswords } = settings;
-  const { activeRequest: { authentication, _id: requestId } } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const reqData = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const groupData = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
   const patchRequest = useRequestPatcher();
+  const patchRequestGroup = useRequestGroupPatcher();
+  const { authentication, _id } = reqData?.activeRequest || groupData.activeRequestGroup;
+  const patcher = Boolean(reqData) ? patchRequest : patchRequestGroup;
   const [masked, toggleMask] = useToggle(true);
   const canBeMasked = !showPasswords && mask;
   const isMasked = canBeMasked && masked;
 
-  const onChange = useCallback((value: string) => patchRequest(requestId, { authentication: { ...authentication, [property]: value } }),
-    [authentication, patchRequest, property, requestId]);
+  const onChange = useCallback((value: string) => patcher(_id, { authentication: { ...authentication, [property]: value } }),
+    [patcher, _id, authentication, property]);
 
   const id = toKebabCase(label);
 

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-private-key-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-private-key-row.tsx
@@ -4,8 +4,9 @@ import { useRouteLoaderData } from 'react-router-dom';
 import { toKebabCase } from '../../../../../common/misc';
 import { invariant } from '../../../../../utils/invariant';
 import { useNunjucks } from '../../../../context/nunjucks/use-nunjucks';
-import { useRequestPatcher } from '../../../../hooks/use-request';
+import { useRequestGroupPatcher, useRequestPatcher } from '../../../../hooks/use-request';
 import { RequestLoaderData } from '../../../../routes/request';
+import { RequestGroupLoaderData } from '../../../../routes/request-group';
 import { showModal } from '../../../modals';
 import { CodePromptModal } from '../../../modals/code-prompt-modal';
 import { AuthRow } from './auth-row';
@@ -30,13 +31,20 @@ interface Props {
 }
 
 export const AuthPrivateKeyRow: FC<Props> = ({ label, property, help }) => {
-  const { activeRequest: { authentication, _id: requestId } } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
-  invariant('privateKey' in authentication, 'must have privateKey property in authentication object');
+  const reqData = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const groupData = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
   const patchRequest = useRequestPatcher();
+  const patchRequestGroup = useRequestGroupPatcher();
+  const patcher = Boolean(reqData) ? patchRequest : patchRequestGroup;
+
+  const { authentication, _id } = reqData?.activeRequest || groupData.activeRequestGroup;
+  invariant('privateKey' in authentication, 'must have privateKey property in authentication object');
+
   const { handleGetRenderContext, handleRender } = useNunjucks();
 
   const privateKey = authentication[property];
-  const onChange = useCallback((value: string) => patchRequest(requestId, { authentication: { ...authentication, [property]: value } }), [authentication, patchRequest, property, requestId]);
+  const onChange = useCallback((value: string) => patcher(_id, { authentication: { ...authentication, [property]: value } }),
+    [_id, authentication, patcher, property]);
 
   const editPrivateKey = () => {
     showModal(CodePromptModal, {

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-row.tsx
@@ -2,8 +2,8 @@ import classnames from 'classnames';
 import React, { FC, PropsWithChildren, ReactNode } from 'react';
 import { useRouteLoaderData } from 'react-router-dom';
 
-import { RequestAuthentication } from '../../../../../models/request';
 import { RequestLoaderData } from '../../../../routes/request';
+import { RequestGroupLoaderData } from '../../../../routes/request-group';
 import { HelpTooltip } from '../../../help-tooltip';
 
 interface Props {
@@ -14,9 +14,10 @@ interface Props {
 }
 
 export const AuthRow: FC<PropsWithChildren<Props>> = ({ labelFor, label, help, disabled, children }) => {
-  const { activeRequest } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
-  const authentication = activeRequest.authentication as RequestAuthentication;
-
+  const reqData = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const groupData = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
+  const { authentication } = reqData?.activeRequest || groupData.activeRequestGroup;
+  const isDisabled = (authentication && 'disabled' in authentication && authentication.disabled) || disabled;
   return (
     <tr key={labelFor}>
       <td className="pad-right no-wrap valign-middle">
@@ -28,7 +29,7 @@ export const AuthRow: FC<PropsWithChildren<Props>> = ({ labelFor, label, help, d
       <td className="wide">
         <div
           className={classnames('form-control form-control--underlined no-margin flex wide', {
-            'form-control--inactive': authentication.disabled || disabled,
+            'form-control--inactive': isDisabled,
           })}
         >
           {children}

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-select-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-select-row.tsx
@@ -2,8 +2,9 @@ import React, { ChangeEvent, FC, ReactNode, useCallback } from 'react';
 import { useRouteLoaderData } from 'react-router-dom';
 
 import { toKebabCase } from '../../../../../common/misc';
-import { useRequestPatcher } from '../../../../hooks/use-request';
+import { useRequestGroupPatcher, useRequestPatcher } from '../../../../hooks/use-request';
 import { RequestLoaderData } from '../../../../routes/request';
+import { RequestGroupLoaderData } from '../../../../routes/request-group';
 import { AuthRow } from './auth-row';
 
 interface Props {
@@ -18,9 +19,13 @@ interface Props {
 }
 
 export const AuthSelectRow: FC<Props> = ({ label, property, help, options, disabled }) => {
-  const { activeRequest: { authentication, _id: requestId } } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const reqData = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const groupData = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
   const patchRequest = useRequestPatcher();
+  const patchRequestGroup = useRequestGroupPatcher();
+  const patcher = Boolean(reqData) ? patchRequest : patchRequestGroup;
 
+  const { authentication, _id } = reqData?.activeRequest || groupData.activeRequestGroup;
   // @ts-expect-error -- garbage abstraction
   const selectedValue = authentication.hasOwnProperty(property) ? authentication[property] : options[0].value;
 
@@ -30,14 +35,12 @@ export const AuthSelectRow: FC<Props> = ({ label, property, help, options, disab
     if (updatedValue === 'true' || updatedValue === 'false') {
       updatedValue = JSON.parse(updatedValue);
     }
-    patchRequest(requestId, { authentication: { ...authentication, [property]: updatedValue } });
-  }, [authentication, patchRequest, property, requestId]);
-
-  const id = toKebabCase(label);
+    patcher(_id, { authentication: { ...authentication, [property]: updatedValue } });
+  }, [patcher, _id, authentication, property]);
 
   return (
-    <AuthRow labelFor={id} label={label} help={help} disabled={disabled}>
-      <select id={id} onChange={onChange} value={selectedValue}>
+    <AuthRow labelFor={toKebabCase(label)} label={label} help={help} disabled={disabled}>
+      <select id={toKebabCase(label)} onChange={onChange} value={selectedValue}>
         {options.map(({ name, value }) => (
           <option key={value} value={value}>
             {name}

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-1-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-1-auth.tsx
@@ -10,6 +10,7 @@ import {
   SIGNATURE_METHOD_RSA_SHA1,
 } from '../../../../network/o-auth-1/constants';
 import { RequestLoaderData } from '../../../routes/request';
+import { RequestGroupLoaderData } from '../../../routes/request-group';
 import { AuthInputRow } from './components/auth-input-row';
 import { AuthPrivateKeyRow } from './components/auth-private-key-row';
 import { AuthSelectRow } from './components/auth-select-row';
@@ -35,8 +36,9 @@ export const signatureMethodOptions: { name: OAuth1SignatureMethod; value: OAuth
 }];
 
 export const OAuth1Auth: FC = () => {
-  const { activeRequest } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
-  const authentication = activeRequest.authentication as AuthTypeOAuth1;
+  const reqData = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const groupData = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
+  const authentication = (reqData?.activeRequest || groupData.activeRequestGroup).authentication as AuthTypeOAuth1;
 
   const { signatureMethod } = authentication;
   return (

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -20,6 +20,7 @@ import { getOAuth2Token } from '../../../../network/o-auth-2/get-token';
 import { initNewOAuthSession } from '../../../../network/o-auth-2/get-token';
 import { useNunjucks } from '../../../context/nunjucks/use-nunjucks';
 import { RequestLoaderData } from '../../../routes/request';
+import { RequestGroupLoaderData } from '../../../routes/request-group';
 import { Link } from '../../base/link';
 import { showModal } from '../../modals';
 import { ResponseDebugModal } from '../../modals/response-debug-modal';
@@ -245,9 +246,11 @@ const getFieldsForGrantType = (authentication: Extract<RequestAuthentication, { 
 };
 
 export const OAuth2Auth: FC = () => {
-  const { activeRequest } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
-  const authentication = activeRequest.authentication as AuthTypeOAuth2;
-  const { basic, advanced } = getFieldsForGrantType(authentication);
+  const reqData = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const groupData = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
+  const { authentication } = reqData?.activeRequest || groupData.activeRequestGroup;
+
+  const { basic, advanced } = getFieldsForGrantType(authentication as AuthTypeOAuth2);
 
   return (
     <>
@@ -339,13 +342,14 @@ const renderAccessTokenExpiry = (token?: Pick<OAuth2Token, 'accessToken' | 'expi
 };
 
 const OAuth2TokenInput: FC<{ token: OAuth2Token | null; label: string; property: keyof Pick<OAuth2Token, 'accessToken' | 'refreshToken' | 'identityToken'> }> = ({ token, label, property }) => {
-  const { activeRequest } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
-
+  const reqData = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const groupData = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
+  const { _id } = reqData?.activeRequest || groupData.activeRequestGroup;
   const onChange = async ({ currentTarget: { value } }: ChangeEvent<HTMLInputElement>) => {
     if (token) {
       await models.oAuth2Token.update(token, { [property]: value });
     } else {
-      await models.oAuth2Token.create({ [property]: value, parentId: activeRequest._id });
+      await models.oAuth2Token.create({ [property]: value, parentId: _id });
     }
   };
 
@@ -422,15 +426,17 @@ const OAuth2Error: FC<{ token: OAuth2Token | null }> = ({ token }) => {
 };
 
 const OAuth2Tokens: FC = () => {
-  const { activeRequest: { authentication, _id: requestId } } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const reqData = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const groupData = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
+  const { authentication, _id } = reqData?.activeRequest || groupData.activeRequestGroup;
   const [token, setToken] = useState<OAuth2Token | null>(null);
   useEffect(() => {
     const fn = async () => {
-      const token = await models.oAuth2Token.getByParentId(requestId);
+      const token = await models.oAuth2Token.getByParentId(_id);
       setToken(token);
     };
     fn();
-  }, [requestId]);
+  }, [_id]);
   const { handleRender } = useNunjucks();
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -470,7 +476,7 @@ const OAuth2Tokens: FC = () => {
 
             try {
               const renderedAuthentication = await handleRender(authentication) as AuthTypeOAuth2;
-              const t = await getOAuth2Token(requestId, renderedAuthentication, true);
+              const t = await getOAuth2Token(_id, renderedAuthentication, true);
               setToken(t);
               setLoading(false);
             } catch (err) {

--- a/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-group-settings-modal.tsx
@@ -44,7 +44,7 @@ export const RequestGroupSettingsModal = ({ requestGroup, onHide }: ModalProps &
   const requestFetcher = useFetcher();
 
   const duplicateRequestGroup = (r: Partial<RequestGroup>) => {
-    requestFetcher.submit(r,
+    requestFetcher.submit(JSON.stringify(r),
       {
         action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request-group/duplicate`,
         method: 'post',

--- a/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
@@ -29,7 +29,7 @@ export const RequestGroupPane: FC<{ settings: Settings }> = ({ settings }) => {
             errorClassName="font-error pad text-center"
           >
             <div />
-            {/* <AuthWrapper /> */}
+            <AuthWrapper authentication={activeRequestGroup.authentication} />
           </ErrorBoundary>
         </TabItem>
         <TabItem

--- a/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
@@ -90,7 +90,7 @@ export const RequestGroupPane: FC<{ settings: Settings }> = ({ settings }) => {
             )}
           </PanelContainer>
         </TabItem>
-        <TabItem
+        {/* <TabItem
           key="pre-request-script"
           data-testid="pre-request-script-tab"
           title={
@@ -116,7 +116,7 @@ export const RequestGroupPane: FC<{ settings: Settings }> = ({ settings }) => {
               settings={settings}
             />
           </ErrorBoundary>
-        </TabItem>
+        </TabItem> */}
       </Tabs>
       {isRequestGroupSettingsModalOpen && (
         <RequestGroupSettingsModal

--- a/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
@@ -2,24 +2,26 @@ import React, { FC, useState } from 'react';
 import { useRouteLoaderData } from 'react-router-dom';
 
 import { Settings } from '../../../models/settings';
-import { useRequestGroupPatcher } from '../../hooks/use-request';
+// import { useRequestGroupPatcher } from '../../hooks/use-request';
 import { RequestGroupLoaderData } from '../../routes/request-group';
+import { WorkspaceLoaderData } from '../../routes/workspace';
 import { PanelContainer, TabItem, Tabs } from '../base/tabs';
 import { AuthDropdown } from '../dropdowns/auth-dropdown';
 import { AuthWrapper } from '../editors/auth/auth-wrapper';
-import { PreRequestScriptEditor } from '../editors/pre-request-script-editor';
+// import { PreRequestScriptEditor } from '../editors/pre-request-script-editor';
 import { ErrorBoundary } from '../error-boundary';
 import { MarkdownPreview } from '../markdown-preview';
 import { RequestGroupSettingsModal } from '../modals/request-group-settings-modal';
 
-export const RequestGroupPane: FC<{ settings: Settings }> = ({ settings }) => {
+export const RequestGroupPane: FC<{ settings: Settings }> = ({ }) => {
   const { activeRequestGroup } = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
+  const { activeEnvironment } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
   const [isRequestGroupSettingsModalOpen, setIsRequestGroupSettingsModalOpen] = useState(false);
-  const patchRequestGroup = useRequestGroupPatcher();
+  // const patchRequestGroup = useRequestGroupPatcher();
 
   // const uniqueKey = `${activeEnvironment?.modified}::${activeRequestGroup._id}::${gitVersion}::${activeRequestSyncVersion}::${activeRequestMeta?.activeResponseId}`;
   // TODO
-  const uniqueKey = `${activeRequestGroup._id}`;
+  const uniqueKey = `${activeEnvironment?.modified}::${activeRequestGroup._id}`;
   return (
     <>
       <Tabs aria-label="Request group pane tabs">

--- a/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
@@ -2,6 +2,7 @@ import React, { FC, useState } from 'react';
 import { useRouteLoaderData } from 'react-router-dom';
 
 import { Settings } from '../../../models/settings';
+import { useActiveRequestSyncVCSVersion, useGitVCSVersion } from '../../hooks/use-vcs-version';
 // import { useRequestGroupPatcher } from '../../hooks/use-request';
 import { RequestGroupLoaderData } from '../../routes/request-group';
 import { WorkspaceLoaderData } from '../../routes/workspace';
@@ -18,10 +19,9 @@ export const RequestGroupPane: FC<{ settings: Settings }> = ({ }) => {
   const { activeEnvironment } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
   const [isRequestGroupSettingsModalOpen, setIsRequestGroupSettingsModalOpen] = useState(false);
   // const patchRequestGroup = useRequestGroupPatcher();
-
-  // const uniqueKey = `${activeEnvironment?.modified}::${activeRequestGroup._id}::${gitVersion}::${activeRequestSyncVersion}::${activeRequestMeta?.activeResponseId}`;
-  // TODO
-  const uniqueKey = `${activeEnvironment?.modified}::${activeRequestGroup._id}`;
+  const gitVersion = useGitVCSVersion();
+  const activeRequestSyncVersion = useActiveRequestSyncVCSVersion();
+  const uniqueKey = `${activeEnvironment?.modified}::${activeRequestGroup._id}::${gitVersion}::${activeRequestSyncVersion}`;
   return (
     <>
       <Tabs aria-label="Request group pane tabs">

--- a/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
@@ -3,13 +3,11 @@ import { useRouteLoaderData } from 'react-router-dom';
 
 import { Settings } from '../../../models/settings';
 import { useActiveRequestSyncVCSVersion, useGitVCSVersion } from '../../hooks/use-vcs-version';
-// import { useRequestGroupPatcher } from '../../hooks/use-request';
 import { RequestGroupLoaderData } from '../../routes/request-group';
 import { WorkspaceLoaderData } from '../../routes/workspace';
 import { PanelContainer, TabItem, Tabs } from '../base/tabs';
 import { AuthDropdown } from '../dropdowns/auth-dropdown';
 import { AuthWrapper } from '../editors/auth/auth-wrapper';
-// import { PreRequestScriptEditor } from '../editors/pre-request-script-editor';
 import { ErrorBoundary } from '../error-boundary';
 import { MarkdownPreview } from '../markdown-preview';
 import { RequestGroupSettingsModal } from '../modals/request-group-settings-modal';
@@ -18,7 +16,6 @@ export const RequestGroupPane: FC<{ settings: Settings }> = ({ }) => {
   const { activeRequestGroup } = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
   const { activeEnvironment } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
   const [isRequestGroupSettingsModalOpen, setIsRequestGroupSettingsModalOpen] = useState(false);
-  // const patchRequestGroup = useRequestGroupPatcher();
   const gitVersion = useGitVCSVersion();
   const activeRequestSyncVersion = useActiveRequestSyncVCSVersion();
   const uniqueKey = `${activeEnvironment?.modified}::${activeRequestGroup._id}::${gitVersion}::${activeRequestSyncVersion}`;
@@ -92,33 +89,6 @@ export const RequestGroupPane: FC<{ settings: Settings }> = ({ }) => {
             )}
           </PanelContainer>
         </TabItem>
-        {/* <TabItem
-          key="pre-request-script"
-          data-testid="pre-request-script-tab"
-          title={
-            <div className='flex items-center gap-2'>
-              Pre-request Script{' '}
-              {activeRequestGroup.preRequestScript && (
-                <span className="ml-2 p-2 border-solid border border-[--hl-md] rounded-lg">
-                  <span className="flex w-2 h-2 bg-green-500 rounded-full" />
-                </span>
-              )}
-            </div>
-          }
-          aria-label={'experimental'}
-        >
-          <ErrorBoundary
-            key={uniqueKey}
-            errorClassName="tall wide vertically-align font-error pad text-center"
-          >
-            <PreRequestScriptEditor
-              uniquenessKey={uniqueKey}
-              defaultValue={activeRequestGroup.preRequestScript || ''}
-              onChange={preRequestScript => patchRequestGroup(activeRequestGroup._id, { preRequestScript })}
-              settings={settings}
-            />
-          </ErrorBoundary>
-        </TabItem> */}
       </Tabs>
       {isRequestGroupSettingsModalOpen && (
         <RequestGroupSettingsModal

--- a/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
@@ -1,16 +1,23 @@
 import React, { FC, useState } from 'react';
 import { useRouteLoaderData } from 'react-router-dom';
 
+import { Settings } from '../../../models/settings';
+import { useRequestGroupPatcher } from '../../hooks/use-request';
 import { RequestGroupLoaderData } from '../../routes/request-group';
 import { PanelContainer, TabItem, Tabs } from '../base/tabs';
+import { PreRequestScriptEditor } from '../editors/pre-request-script-editor';
 import { ErrorBoundary } from '../error-boundary';
 import { MarkdownPreview } from '../markdown-preview';
 import { RequestGroupSettingsModal } from '../modals/request-group-settings-modal';
 
-export const RequestGroupPane: FC = () => {
+export const RequestGroupPane: FC<{ settings: Settings }> = ({ settings }) => {
   const { activeRequestGroup } = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
   const [isRequestGroupSettingsModalOpen, setIsRequestGroupSettingsModalOpen] = useState(false);
+  const patchRequestGroup = useRequestGroupPatcher();
 
+  // const uniqueKey = `${activeEnvironment?.modified}::${activeRequestGroup._id}::${gitVersion}::${activeRequestSyncVersion}::${activeRequestMeta?.activeResponseId}`;
+  // TODO
+  const uniqueKey = `${activeRequestGroup._id}`;
   return (
     <>
       <Tabs aria-label="Request group pane tabs">
@@ -71,6 +78,33 @@ export const RequestGroupPane: FC = () => {
               </div>
             )}
           </PanelContainer>
+        </TabItem>
+        <TabItem
+          key="pre-request-script"
+          data-testid="pre-request-script-tab"
+          title={
+            <div className='flex items-center gap-2'>
+              Pre-request Script{' '}
+              {activeRequestGroup.preRequestScript && (
+                <span className="ml-2 p-2 border-solid border border-[--hl-md] rounded-lg">
+                  <span className="flex w-2 h-2 bg-green-500 rounded-full" />
+                </span>
+              )}
+            </div>
+          }
+          aria-label={'experimental'}
+        >
+          <ErrorBoundary
+            key={uniqueKey}
+            errorClassName="tall wide vertically-align font-error pad text-center"
+          >
+            <PreRequestScriptEditor
+              uniquenessKey={uniqueKey}
+              defaultValue={activeRequestGroup.preRequestScript || ''}
+              onChange={preRequestScript => patchRequestGroup(activeRequestGroup._id, { preRequestScript })}
+              settings={settings}
+            />
+          </ErrorBoundary>
         </TabItem>
       </Tabs>
       {isRequestGroupSettingsModalOpen && (

--- a/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
@@ -5,6 +5,8 @@ import { Settings } from '../../../models/settings';
 import { useRequestGroupPatcher } from '../../hooks/use-request';
 import { RequestGroupLoaderData } from '../../routes/request-group';
 import { PanelContainer, TabItem, Tabs } from '../base/tabs';
+import { AuthDropdown } from '../dropdowns/auth-dropdown';
+import { AuthWrapper } from '../editors/auth/auth-wrapper';
 import { PreRequestScriptEditor } from '../editors/pre-request-script-editor';
 import { ErrorBoundary } from '../error-boundary';
 import { MarkdownPreview } from '../markdown-preview';
@@ -21,6 +23,15 @@ export const RequestGroupPane: FC<{ settings: Settings }> = ({ settings }) => {
   return (
     <>
       <Tabs aria-label="Request group pane tabs">
+        <TabItem key="auth" title={<AuthDropdown authentication={activeRequestGroup.authentication} />}>
+          <ErrorBoundary
+            key={uniqueKey}
+            errorClassName="font-error pad text-center"
+          >
+            <div />
+            {/* <AuthWrapper /> */}
+          </ErrorBoundary>
+        </TabItem>
         <TabItem
           key="docs"
           title={

--- a/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
@@ -1,12 +1,83 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { useRouteLoaderData } from 'react-router-dom';
 
 import { RequestGroupLoaderData } from '../../routes/request-group';
+import { PanelContainer, TabItem, Tabs } from '../base/tabs';
+import { ErrorBoundary } from '../error-boundary';
+import { MarkdownPreview } from '../markdown-preview';
+import { RequestGroupSettingsModal } from '../modals/request-group-settings-modal';
 
 export const RequestGroupPane: FC = () => {
   const { activeRequestGroup } = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
+  const [isRequestGroupSettingsModalOpen, setIsRequestGroupSettingsModalOpen] = useState(false);
 
   return (
-    <div>test{activeRequestGroup.name}</div>
+    <>
+      <Tabs aria-label="Request group pane tabs">
+        <TabItem
+          key="docs"
+          title={
+            <>
+              Docs
+              {activeRequestGroup.description && (
+                <span className="ml-2 p-2 border-solid border border-[--hl-md] rounded-lg">
+                  <span className="flex w-2 h-2 bg-green-500 rounded-full" />
+                </span>
+              )}
+            </>
+          }
+        >
+          <PanelContainer className="tall">
+            {activeRequestGroup.description ? (
+              <div>
+                <div className="pull-right pad bg-default">
+                  <button
+                    className="btn btn--clicky"
+                    onClick={() => setIsRequestGroupSettingsModalOpen(true)}
+                  >
+                    Edit
+                  </button>
+                </div>
+                <div className="pad">
+                  <ErrorBoundary errorClassName="font-error pad text-center">
+                    <MarkdownPreview
+                      heading={activeRequestGroup.name}
+                      markdown={activeRequestGroup.description}
+                    />
+                  </ErrorBoundary>
+                </div>
+              </div>
+            ) : (
+              <div className="overflow-hidden editor vertically-center text-center">
+                <p className="pad text-sm text-center">
+                  <span className="super-faint">
+                    <i
+                      className="fa fa-file-text-o"
+                      style={{
+                        fontSize: '8rem',
+                        opacity: 0.3,
+                      }}
+                    />
+                  </span>
+                  <br />
+                  <br />
+                  <button
+                    className="btn btn--clicky faint"
+                    onClick={() => setIsRequestGroupSettingsModalOpen(true)}
+                  >
+                    Add Description
+                  </button>
+                </p>
+              </div>
+            )}
+          </PanelContainer>
+        </TabItem>
+      </Tabs>
+      {isRequestGroupSettingsModalOpen && (
+        <RequestGroupSettingsModal
+          requestGroup={activeRequestGroup}
+          onHide={() => setIsRequestGroupSettingsModalOpen(false)}
+        />
+      )}</>
   );
 };

--- a/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
@@ -1,0 +1,12 @@
+import React, { FC } from 'react';
+import { useRouteLoaderData } from 'react-router-dom';
+
+import { RequestGroupLoaderData } from '../../routes/request-group';
+
+export const RequestGroupPane: FC = () => {
+  const { activeRequestGroup } = useRouteLoaderData('request-group/:requestGroupId') as RequestGroupLoaderData;
+
+  return (
+    <div>test{activeRequestGroup.name}</div>
+  );
+};

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -51,7 +51,6 @@ export const RequestPane: FC<Props> = ({
   const patchRequest = useRequestPatcher();
 
   const [dismissPathParameterTip, setDismissPathParameterTip] = useLocalStorage('dismissPathParameterTip', '');
-  console.log({ activeRequest });
   const handleImportQueryFromUrl = () => {
     let query;
 

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -47,8 +47,7 @@ export const RequestPane: FC<Props> = ({
   const { activeRequest, activeRequestMeta } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
   const { workspaceId, requestId } = useParams() as { organizationId: string; projectId: string; workspaceId: string; requestId: string };
   const patchSettings = useSettingsPatcher();
-  const [isRequestSettingsModalOpen, setIsRequestSettingsModalOpen] =
-    useState(false);
+  const [isRequestSettingsModalOpen, setIsRequestSettingsModalOpen] = useState(false);
   const patchRequest = useRequestPatcher();
 
   const [dismissPathParameterTip, setDismissPathParameterTip] = useLocalStorage('dismissPathParameterTip', '');

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment, useState } from 'react';
+import React, { act, FC, Fragment, useState } from 'react';
 import { Button, Heading, ToggleButton } from 'react-aria-components';
 import { useParams, useRouteLoaderData } from 'react-router-dom';
 import { useLocalStorage } from 'react-use';
@@ -51,7 +51,7 @@ export const RequestPane: FC<Props> = ({
   const patchRequest = useRequestPatcher();
 
   const [dismissPathParameterTip, setDismissPathParameterTip] = useLocalStorage('dismissPathParameterTip', '');
-
+  console.log({ activeRequest });
   const handleImportQueryFromUrl = () => {
     let query;
 
@@ -228,7 +228,7 @@ export const RequestPane: FC<Props> = ({
             environmentId={environmentId}
           />
         </TabItem>
-        <TabItem key="auth" title={<AuthDropdown />}>
+        <TabItem key="auth" title={<AuthDropdown authentication={activeRequest.authentication} />}>
           <ErrorBoundary
             key={uniqueKey}
             errorClassName="font-error pad text-center"

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -233,7 +233,7 @@ export const RequestPane: FC<Props> = ({
             key={uniqueKey}
             errorClassName="font-error pad text-center"
           >
-            <AuthWrapper />
+            <AuthWrapper authentication={activeRequest.authentication} />
           </ErrorBoundary>
         </TabItem>
         <TabItem

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -1,4 +1,4 @@
-import React, { act, FC, Fragment, useState } from 'react';
+import React, { FC, Fragment, useState } from 'react';
 import { Button, Heading, ToggleButton } from 'react-aria-components';
 import { useParams, useRouteLoaderData } from 'react-router-dom';
 import { useLocalStorage } from 'react-use';

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -91,6 +91,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, environmentId,
     }
     // Render any nunjucks tags in the url/headers/authentication settings/cookies
     const workspaceCookieJar = await models.cookieJar.getOrCreateForParentId(workspaceId);
+    // TODO: support websocket auth inheritance, ensuring only the supported types, apikey, basic and bearer are included from the parents
     const rendered = await tryToInterpolateRequestOrShowRenderErrorModal({
       request,
       environmentId,

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -393,7 +393,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
             />
           </div>
         </TabItem>
-        <TabItem key="auth" title={<AuthDropdown authTypes={supportedAuthTypes} disabled={disabled} />}>
+        <TabItem key="auth" title={<AuthDropdown authentication={activeRequest.authentication} authTypes={supportedAuthTypes} disabled={disabled} />}>
           {disabled && <PaneReadOnlyBanner />}
           <AuthWrapper
             key={uniqueKey}

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -397,6 +397,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
           {disabled && <PaneReadOnlyBanner />}
           <AuthWrapper
             key={uniqueKey}
+            authentication={activeRequest.authentication}
             disabled={disabled}
           />
         </TabItem>

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -347,6 +347,15 @@ async function renderApp() {
                                       ).reorderCollectionAction(...args),
                                   },
                                   {
+                                    path: 'request-group/:requestGroupId',
+                                    id: 'request-group/:requestGroupId',
+                                    loader: async (...args) =>
+                                      (await import('./routes/request-group')).loader(
+                                        ...args,
+                                      ),
+                                    element: <Outlet />,
+                                  },
+                                  {
                                     path: 'request/:requestId',
                                     id: 'request/:requestId',
                                     loader: async (...args) =>

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -1256,20 +1256,22 @@ export const Debug: FC = () => {
               </ErrorBoundary>
             ) : null}
           </Panel>
-          <PanelResizeHandle className={direction === 'horizontal' ? 'h-full w-[1px] bg-[--hl-md]' : 'w-full h-[1px] bg-[--hl-md]'} />
-          <Panel id="pane-two" className='pane-two theme--pane'>
-            <ErrorBoundary showAlert>
-              {activeRequest && isGrpcRequest(activeRequest) && grpcState && (
-                <GrpcResponsePane grpcState={grpcState} />
-              )}
-              {isRealtimeRequest && (
-                <RealtimeResponsePane requestId={activeRequest._id} />
-              )}
-              {activeRequest && isRequest(activeRequest) && !isRealtimeRequest && (
-                <ResponsePane runningRequests={runningRequests} />
-              )}
-            </ErrorBoundary>
-          </Panel>
+          {requestGroupId ? null : (<>
+            <PanelResizeHandle className={direction === 'horizontal' ? 'h-full w-[1px] bg-[--hl-md]' : 'w-full h-[1px] bg-[--hl-md]'} />
+            <Panel id="pane-two" className='pane-two theme--pane'>
+              <ErrorBoundary showAlert>
+                {activeRequest && isGrpcRequest(activeRequest) && grpcState && (
+                  <GrpcResponsePane grpcState={grpcState} />
+                )}
+                {isRealtimeRequest && (
+                  <RealtimeResponsePane requestId={activeRequest._id} />
+                )}
+                {activeRequest && isRequest(activeRequest) && !isRealtimeRequest && (
+                  <ResponsePane runningRequests={runningRequests} />
+                )}
+              </ErrorBoundary>
+            </Panel>
+          </>)}
         </PanelGroup>
       </Panel>
     </PanelGroup>

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -1065,7 +1065,7 @@ export const Debug: FC = () => {
                 disallowEmptySelection
                 key={sortOrder}
                 dragAndDropHooks={sortOrder === 'type-manual' ? collectionDragAndDrop.dragAndDropHooks : undefined}
-                selectedKeys={requestId ? [requestId] : []}
+                selectedKeys={requestId && [requestId] || requestGroupId && [requestGroupId]}
                 selectionMode="single"
                 onSelectionChange={keys => {
                   if (keys !== 'all') {
@@ -1145,9 +1145,7 @@ export const Debug: FC = () => {
                           className="px-1 flex-1"
                           onSingleClick={() => {
                             if (item && isRequestGroup(item.doc)) {
-                              // groupMetaPatcher(item.doc._id, { collapsed: !item.collapsed });
                               navigate(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request-group/${item.doc._id}?${searchParams.toString()}`);
-
                             } else {
                               navigate(
                                 `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${item.doc._id}?${searchParams.toString()}`
@@ -1255,7 +1253,7 @@ export const Debug: FC = () => {
               </ErrorBoundary>
             ) : null}
           </Panel>
-          {requestGroupId ? null : (<>
+          {activeRequest ? (<>
             <PanelResizeHandle className={direction === 'horizontal' ? 'h-full w-[1px] bg-[--hl-md]' : 'w-full h-[1px] bg-[--hl-md]'} />
             <Panel id="pane-two" className='pane-two theme--pane'>
               <ErrorBoundary showAlert>
@@ -1270,7 +1268,7 @@ export const Debug: FC = () => {
                 )}
               </ErrorBoundary>
             </Panel>
-          </>)}
+          </>) : null}
         </PanelGroup>
       </Panel>
     </PanelGroup>

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -1224,7 +1224,7 @@ export const Debug: FC = () => {
             {workspaceId ? (
               <ErrorBoundary showAlert>
                 {isRequestGroupId(requestGroupId) && (
-                  <RequestGroupPane />
+                  <RequestGroupPane settings={settings} />
                 )}
                 {isGrpcRequestId(requestId) && grpcState && (
                   <GrpcRequestPane

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -343,7 +343,7 @@ export const Debug: FC = () => {
       }
     },
     request_showDelete: () => {
-      if (activeRequest) {
+      if (activeRequest && requestId) {
         showModal(AskModal, {
           title: 'Delete Request?',
           message: `Really delete ${activeRequest.name}?`,
@@ -961,7 +961,7 @@ export const Debug: FC = () => {
               items={collection.filter(item => item.pinned)}
               aria-label="Pinned Requests"
               disallowEmptySelection
-              selectedKeys={[requestId]}
+              selectedKeys={requestId ? [requestId] : []}
               selectionMode="single"
               onSelectionChange={keys => {
                 if (keys !== 'all') {
@@ -1064,7 +1064,7 @@ export const Debug: FC = () => {
                 disallowEmptySelection
                 key={sortOrder}
                 dragAndDropHooks={sortOrder === 'type-manual' ? collectionDragAndDrop.dragAndDropHooks : undefined}
-                selectedKeys={[requestId]}
+                selectedKeys={requestId ? [requestId] : []}
                 selectionMode="single"
                 onSelectionChange={keys => {
                   if (keys !== 'all') {

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -187,7 +187,6 @@ export const Debug: FC = () => {
     requestId?: string;
     requestGroupId?: string;
   };
-  console.log('debug', { requestId, requestGroupId });
   const [grpcStates, setGrpcStates] = useState<GrpcRequestState[]>(
     grpcRequests.map(r => ({
       requestId: r._id,

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -957,6 +957,7 @@ export const Debug: FC = () => {
             </div>
 
             <GridList
+              id="sidebar-pinned-request-gridlist"
               className="overflow-y-auto border-b border-t data-[empty]:py-0 py-[--padding-sm] data-[empty]:border-none border-solid border-[--hl-sm]"
               items={collection.filter(item => item.pinned)}
               aria-label="Pinned Requests"
@@ -1075,8 +1076,6 @@ export const Debug: FC = () => {
                     );
                     if (item && isRequestGroup(item.doc)) {
                       groupMetaPatcher(value, { collapsed: !item.collapsed });
-                      navigate(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request-group/${item.doc._id}?${searchParams.toString()}`);
-
                     } else {
                       navigate(
                         `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${value}?${searchParams.toString()}`
@@ -1146,7 +1145,7 @@ export const Debug: FC = () => {
                           className="px-1 flex-1"
                           onSingleClick={() => {
                             if (item && isRequestGroup(item.doc)) {
-                              groupMetaPatcher(item.doc._id, { collapsed: !item.collapsed });
+                              // groupMetaPatcher(item.doc._id, { collapsed: !item.collapsed });
                               navigate(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request-group/${item.doc._id}?${searchParams.toString()}`);
 
                             } else {

--- a/packages/insomnia/src/ui/routes/request-group.tsx
+++ b/packages/insomnia/src/ui/routes/request-group.tsx
@@ -1,9 +1,28 @@
-import { ActionFunction } from 'react-router-dom';
+import { ActionFunction, LoaderFunction, redirect } from 'react-router-dom';
 
 import * as models from '../../models';
 import { RequestGroup } from '../../models/request-group';
 import { RequestGroupMeta } from '../../models/request-group-meta';
 import { invariant } from '../../utils/invariant';
+
+export interface RequestGroupLoaderData {
+  activeRequestGroup: RequestGroup;
+}
+export const loader: LoaderFunction = async ({ params }): Promise<RequestGroupLoaderData> => {
+  const { organizationId, projectId, requestGroupId, workspaceId } = params;
+  invariant(requestGroupId, 'Request ID is required');
+  invariant(workspaceId, 'Workspace ID is required');
+  invariant(projectId, 'Project ID is required');
+  const activeRequestGroup = await models.requestGroup.getById(requestGroupId);
+  console.log('req group loader', requestGroupId);
+  if (!activeRequestGroup) {
+    throw redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug`);
+  }
+
+  return {
+    activeRequestGroup,
+  };
+};
 
 export const createRequestGroupAction: ActionFunction = async ({ request, params }) => {
   const { workspaceId } = params;

--- a/packages/insomnia/src/ui/routes/request-group.tsx
+++ b/packages/insomnia/src/ui/routes/request-group.tsx
@@ -14,7 +14,6 @@ export const loader: LoaderFunction = async ({ params }): Promise<RequestGroupLo
   invariant(workspaceId, 'Workspace ID is required');
   invariant(projectId, 'Project ID is required');
   const activeRequestGroup = await models.requestGroup.getById(requestGroupId);
-  console.log('req group loader', requestGroupId);
   if (!activeRequestGroup) {
     throw redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug`);
   }

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -363,10 +363,8 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
   invariant(typeof requestId === 'string', 'Request ID is required');
   invariant(workspaceId, 'Workspace ID is required');
 
-  const req = await requestOperations.getById(requestId) as Request;
-  invariant(req, 'Request not found');
-
   const {
+    request: req,
     environment,
     settings,
     clientCertificates,

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -15,7 +15,7 @@ import { ResponsePatch } from '../../main/network/libcurl-promise';
 import * as models from '../../models';
 import { BaseModel } from '../../models';
 import { CookieJar } from '../../models/cookie-jar';
-import { GrpcRequest, isGrpcRequest, isGrpcRequestId } from '../../models/grpc-request';
+import { GrpcRequest, isGrpcRequestId } from '../../models/grpc-request';
 import { GrpcRequestMeta } from '../../models/grpc-request-meta';
 import * as requestOperations from '../../models/helpers/request-operations';
 import { MockRoute } from '../../models/mock-route';
@@ -292,11 +292,11 @@ export const connectAction: ActionFunction = async ({ request, params }) => {
   invariant(workspaceId, 'Workspace ID is required');
   const rendered = await request.json() as ConnectActionParams;
 
-  const ancestors = await db.withAncestors(req, [
-    models.requestGroup.type,
-  ]) as (Request | RequestGroup)[];
   // TODO: support websocket auth inheritance, ensuring only the supported types, apikey, basic and bearer are included from the parents
   if (isRequest(req) && isEventStreamRequest(req)) {
+    const ancestors = await db.withAncestors<Request | RequestGroup>(req, [
+      models.requestGroup.type,
+    ]);
     // check for authentication overrides in parent folders
     const requestGroups = ancestors.filter(isRequestGroup) as RequestGroup[];
     req.authentication = getOrInheritAuthentication({ request: req, requestGroups });

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -7,6 +7,7 @@ import { ActionFunction, LoaderFunction, redirect } from 'react-router-dom';
 
 import { version } from '../../../package.json';
 import { CONTENT_TYPE_EVENT_STREAM, CONTENT_TYPE_GRAPHQL, CONTENT_TYPE_JSON, METHOD_GET, METHOD_POST } from '../../common/constants';
+import { database as db } from '../../common/database';
 import { ChangeBufferEvent, database } from '../../common/database';
 import { getContentDispositionHeader } from '../../common/misc';
 import { RENDER_PURPOSE_SEND, RenderedRequest } from '../../common/render';
@@ -14,19 +15,20 @@ import { ResponsePatch } from '../../main/network/libcurl-promise';
 import * as models from '../../models';
 import { BaseModel } from '../../models';
 import { CookieJar } from '../../models/cookie-jar';
-import { GrpcRequest, isGrpcRequestId } from '../../models/grpc-request';
+import { GrpcRequest, isGrpcRequest, isGrpcRequestId } from '../../models/grpc-request';
 import { GrpcRequestMeta } from '../../models/grpc-request-meta';
 import * as requestOperations from '../../models/helpers/request-operations';
 import { MockRoute } from '../../models/mock-route';
 import { MockServer } from '../../models/mock-server';
 import { getPathParametersFromUrl, isEventStreamRequest, isRequest, Request, RequestAuthentication, RequestBody, RequestHeader, RequestParameter } from '../../models/request';
+import { isRequestGroup, RequestGroup } from '../../models/request-group';
 import { isRequestMeta, RequestMeta } from '../../models/request-meta';
 import { RequestVersion } from '../../models/request-version';
 import { Response } from '../../models/response';
 import { isWebSocketRequest, isWebSocketRequestId, WebSocketRequest } from '../../models/websocket-request';
 import { WebSocketResponse } from '../../models/websocket-response';
 import { getAuthHeader } from '../../network/authentication';
-import { fetchRequestData, responseTransform, sendCurlAndWriteTimeline, tryToExecutePreRequestScript, tryToInterpolateRequest, tryToTransformRequestWithPlugins } from '../../network/network';
+import { fetchRequestData, getOrInheritAuthentication, responseTransform, sendCurlAndWriteTimeline, tryToExecutePreRequestScript, tryToInterpolateRequest, tryToTransformRequestWithPlugins } from '../../network/network';
 import { RenderErrorSubType } from '../../templating';
 import { invariant } from '../../utils/invariant';
 import { SegmentEvent } from '../analytics';
@@ -289,6 +291,17 @@ export const connectAction: ActionFunction = async ({ request, params }) => {
   invariant(req, 'Request not found');
   invariant(workspaceId, 'Workspace ID is required');
   const rendered = await request.json() as ConnectActionParams;
+
+  const ancestors = await db.withAncestors(req, [
+    models.requestGroup.type,
+  ]) as (Request | RequestGroup)[];
+  // TODO: support websocket auth inheritance, ensuring only the supported types, apikey, basic and bearer are included from the parents
+  if (isRequest(req) && isEventStreamRequest(req)) {
+    // check for authentication overrides in parent folders
+    const requestGroups = ancestors.filter(isRequestGroup) as RequestGroup[];
+    req.authentication = getOrInheritAuthentication({ request: req, requestGroups });
+  }
+
   if (isWebSocketRequestId(requestId)) {
     window.main.webSocket.open({
       requestId,


### PR DESCRIPTION
motivation: shared auth is a 4 year old ask.
goal of this PR: add folder navigation and tabs, ensure all auth methods are supported for http requests


TODO
- [x] can navigate to folder
- [x] can edit docs
- [x] can edit and use auth
- [x] can select inherit as an auth option
- [x] test oauth2 auth window
- [x] test auth inheritance
- [x] test with sync
- [x] only toggle folder open on icon click

split into second pass
- [ ] can edit and use prerequest scripts
- [ ] support websocket only auth inheritance
- [ ] refactor auth components
- [ ] add a separator under new items in request/group context menus

nice to have
- [ ] can edit folder level headers
- [ ] can edit and use env vars (what event to save on)
- [ ] docs editor is inlined

closes INS-3731

aiming to address #3518

challenges
- executing scripts in scopes in order to avoid collision
- testing 
- auth components are hard to extend
- kvp editor is legacy
- env vars are usually edited in a modal

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
