### PR TITLE
feat: show deprecation warnings on graphql arguments

### DIFF
--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -86,7 +86,7 @@ const fetchGraphQLSchemaForRequest = async ({
   try {
 
     const bodyJson = JSON.stringify({
-      query: getIntrospectionQuery(),
+      query: getIntrospectionQuery({ inputValueDeprecation: true }),
       operationName: 'IntrospectionQuery',
     });
     const introspectionRequest = await db.upsert(

--- a/packages/insomnia/src/ui/components/graph-ql-explorer/graph-ql-explorer-arg-links.tsx
+++ b/packages/insomnia/src/ui/components/graph-ql-explorer/graph-ql-explorer-arg-links.tsx
@@ -1,6 +1,8 @@
 import { GraphQLArgument, GraphQLType } from 'graphql';
 import React, { FC } from 'react';
 
+import { SvgIcon } from '../svg-icon';
+import { Tooltip } from '../tooltip';
 import { GraphQLExplorerTypeLink } from './graph-ql-explorer-type-link';
 
 interface Props {
@@ -16,6 +18,15 @@ export const GraphQLExplorerArgLinks: FC<Props> = ({
     <div key={a.name} className="graphql-explorer__defs__arg">
       <span className="info">{a.name}</span>:{' '}
       <GraphQLExplorerTypeLink onNavigate={onNavigate} type={a.type} />
+      {a.deprecationReason && (
+        <Tooltip
+          message={`The argument "${a.name}" is deprecated. ${a.deprecationReason}`}
+          position="bottom"
+          delay={1000}
+        >
+          <SvgIcon icon="warning" />
+        </Tooltip>
+      )}
     </div>
   )) : null}
 </>;

--- a/packages/insomnia/src/ui/css/main.css
+++ b/packages/insomnia/src/ui/css/main.css
@@ -2087,6 +2087,9 @@ html {
 .graphql-explorer__defs li {
   margin-bottom: var(--padding-md);
 }
+.graphql-explorer__defs .tooltip {
+  margin-left: var(--padding-sm);
+}
 .graphql-explorer a {
   font-weight: normal !important;
 }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

GraphQL supports deprecating arguments! I noticed Insomnia isn't actually fetching deprecated arguments in its introspection query, so I added that in and updated the UI to render the deprecation warning.

<details>
<summary>Before my change</summary>
<img width="2672" alt="Screenshot 2024-05-02 at 4 13 35 PM" src="https://github.com/Kong/insomnia/assets/305254/b5280672-9877-4271-acc4-41744a53d0b4">
</details>

<details>
<summary>After my change</summary>
<img width="2672" alt="Screenshot 2024-05-02 at 4 13 13 PM" src="https://github.com/Kong/insomnia/assets/305254/8bcff4e4-1d17-490c-8dbe-d8d78f3bdfc3">
<img width="2672" alt="Screenshot 2024-05-02 at 4 13 05 PM" src="https://github.com/Kong/insomnia/assets/305254/8c0b6915-fe62-43ea-98ca-a00d412661ff">
</details>