### PR TITLE
maintain folder sort when app is re-opened

### DIFF
--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -337,6 +337,36 @@ export const sortOrderName: Record<SortOrder, string> = {
   [SORT_TYPE_ASC]: 'Requests First',
 };
 
+export type CollectionSortOrder =
+  | 'name-asc'
+  | 'name-desc'
+  | 'created-asc'
+  | 'created-desc'
+  | 'http-method'
+  | 'type-desc'
+  | 'type-asc'
+  | 'type-manual';
+export const COLLECTION_SORT_ORDERS = [
+  SORT_TYPE_MANUAL,
+  SORT_NAME_ASC,
+  SORT_NAME_DESC,
+  SORT_CREATED_ASC,
+  SORT_CREATED_DESC,
+  SORT_HTTP_METHOD,
+  SORT_TYPE_DESC,
+  SORT_TYPE_ASC,
+] as const;
+export const collectionSortOrderName: Record<CollectionSortOrder, string> = {
+  [SORT_TYPE_MANUAL]: 'Manual',
+  [SORT_NAME_ASC]: 'Name Ascending (A-Z)',
+  [SORT_NAME_DESC]: 'Name Descending (Z-A)',
+  [SORT_CREATED_ASC]: 'Oldest First',
+  [SORT_CREATED_DESC]: 'Newest First',
+  [SORT_HTTP_METHOD]: 'HTTP Method',
+  [SORT_TYPE_DESC]: 'Folders First',
+  [SORT_TYPE_ASC]: 'Requests First',
+};
+
 export type DashboardSortOrder =
   | 'name-asc'
   | 'name-desc'


### PR DESCRIPTION
Closes #7130, #5751 

###Background
After I click the sort button the sorting is applied but after restart of the IDE it is reset to "Manual" and the previous sorting is lost. Also drag & drop of folders and requests does not work at all after clicking the sort button.

This was caused by two issues:

- seems code was reading values from search parameters which are always undefiend
- code never saved the most recent/latest sort order so that when ever user re-opens the IDE, the sorting is preserved

###Changes
- New type for Folder/Collection sort orders 
- Leverage local storage to set the most recent sort order user has selected
- default sort order to be alphabatical sort asc

