### PR TITLE
fix: extract correct position through err message

### DIFF
--- a/packages/insomnia/src/templating/index.ts
+++ b/packages/insomnia/src/templating/index.ts
@@ -83,7 +83,7 @@ export function render(
           .replace(/\[Line \d+, Column \d*]/, '')
           .replace(/^\s*Error:\s*/, '')
           .trim();
-        const location = err.message.match(/\[Line (\d)+, Column (\d)*]/);
+        const location = err.message.match(/\[Line (\d+), Column (\d+)*]/);
         const line = location ? parseInt(location[1]) : 1;
         const column = location ? parseInt(location[2]) : 1;
         const reason = err.message.includes('attempted to output null or undefined value')


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

The previous regexp can not extract correct position when the number is multidigit