### PR TITLE
feat(command-palette): Add global search for unsynced files

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/command-palette.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/command-palette.test.ts
@@ -41,7 +41,6 @@ test('Command palette - can switch between requests and workspaces', async ({ ap
   await page.locator('body').press(requestSwitchKeyboardShortcut);
   await page.getByPlaceholder('Search and switch between').press('ArrowUp');
   await page.getByPlaceholder('Search and switch between').press('ArrowUp');
-  await page.getByPlaceholder('Search and switch between').press('ArrowUp');
   await page.getByPlaceholder('Search and switch between').press('Enter');
   await expect(page.getByTestId('workspace-context-dropdown').locator('span')).toContainText('E2E testing specification - swagger 2 1.0.0');
 });

--- a/packages/insomnia/src/ui/components/command-palette.tsx
+++ b/packages/insomnia/src/ui/components/command-palette.tsx
@@ -124,7 +124,7 @@ const CommandPaletteCombobox = ({ close }: { close: () => void }) => {
   const remoteFiles = remoteFilesLoader.data?.files || [];
 
   const currentFilesData = commandsLoader.data?.current.files || [];
-  const currentRemoteFilesData = remoteFiles.filter(file => file.item.teamProjectRemoteId === projectId).filter(file => !currentFilesData.some(f => f.id === file.item.id));
+  const currentRemoteFilesData = remoteFiles.filter(file => file.item.teamProjectLocalId === projectId).filter(file => !currentFilesData.some(f => f.id === file.item.id));
 
   console.log({ currentFilesData });
 
@@ -171,7 +171,7 @@ const CommandPaletteCombobox = ({ close }: { close: () => void }) => {
   })) || [];
 
   const otherFilesData = commandsLoader.data?.other.files || [];
-  const otherRemoteFilesData = remoteFiles.filter(file => file.item.teamProjectRemoteId !== projectId).filter(file => !otherFilesData.some(f => f.id === file.item.id));
+  const otherRemoteFilesData = remoteFiles.filter(file => file.item.teamProjectLocalId !== projectId).filter(file => !otherFilesData.some(f => f.id === file.item.id));
 
   const otherFiles = [...otherFilesData, ...otherRemoteFilesData].map(file => ({
     ...file,

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -155,6 +155,10 @@ async function renderApp() {
             loader: async (...args) => (await import('./routes/commands')).loader(...args),
           },
           {
+            path: 'remote-files',
+            loader: async (...args) => (await import('./routes/commands')).remoteFilesLoader(...args),
+          },
+          {
             path: 'import',
             children: [
               {

--- a/packages/insomnia/src/ui/routes/commands.tsx
+++ b/packages/insomnia/src/ui/routes/commands.tsx
@@ -292,7 +292,7 @@ interface RemoteFile {
 }
 
 export interface RemoteFilesLoaderResult {
-  files: CommandRemoteItem<RemoteFile & { teamProjectRemoteId: string; scope: 'unsynced' }>[];
+  files: CommandRemoteItem<RemoteFile & { teamProjectLocalId: string; scope: 'unsynced' }>[];
 }
 
 export const remoteFilesLoader: LoaderFunction = async (): Promise<RemoteFilesLoaderResult> => {
@@ -332,7 +332,7 @@ export const remoteFilesLoader: LoaderFunction = async (): Promise<RemoteFilesLo
       url: `/organization/${file.organizationId}/project`,
       pullUrl: parentProject ? `/organization/${file.organizationId}/project/${file.teamProjectId}/remote-collections/pull` : '',
       name: file.name,
-      item: { ...file, teamProjectRemoteId: parentProject?._id || '', scope: 'unsynced' as const },
+      item: { ...file, teamProjectLocalId: parentProject?._id || '', scope: 'unsynced' as const },
       organizationName: organizations.find(org => org.id === file.organizationId)?.display_name || '',
       projectName: parentProject?.name || '',
     };

--- a/packages/insomnia/src/ui/routes/commands.tsx
+++ b/packages/insomnia/src/ui/routes/commands.tsx
@@ -6,11 +6,13 @@ import { environment, grpcRequest, project, request, requestGroup, userSession, 
 import { Environment } from '../../models/environment';
 import { GrpcRequest } from '../../models/grpc-request';
 import { isScratchpadOrganizationId, Organization } from '../../models/organization';
+import { isRemoteProject, Project } from '../../models/project';
 import { Request } from '../../models/request';
 import { RequestGroup } from '../../models/request-group';
 import { WebSocketRequest } from '../../models/websocket-request';
 import { scopeToActivity, Workspace } from '../../models/workspace';
 import { invariant } from '../../utils/invariant';
+import { insomniaFetch } from '../insomniaFetch';
 
 export interface CommandItem<TItem> {
   id: string;
@@ -25,12 +27,12 @@ export interface CommandItem<TItem> {
 export interface LoaderResult {
   current: {
     requests: CommandItem<(Request | GrpcRequest | WebSocketRequest)>[];
-    files: CommandItem<Workspace>[];
+    files: CommandItem<Workspace & { teamProjectId: string }>[];
     environments: Environment[];
   };
   other: {
     requests: CommandItem<(Request | GrpcRequest | WebSocketRequest)>[];
-    files: CommandItem<Workspace>[];
+    files: CommandItem<Workspace & { teamProjectId: string }>[];
   };
 }
 
@@ -59,7 +61,7 @@ export const loader: LoaderFunction = async args => {
 
   const allOrganizationsIds = isScratchpadOrganizationId(organizationId) ? [organizationId] : allOrganizations.map(org => org.id);
 
-  const allProjects = await database.find(project.type, {
+  const allProjects = await database.find<Project>(project.type, {
     parentId: { $in: allOrganizationsIds },
   });
 
@@ -232,14 +234,17 @@ export const loader: LoaderFunction = async args => {
         projectName: allProjects.find(project => project._id === parentReferences.get(item.parentId)?.projectId)?.name || '',
         workspaceName: allOrganizationWorkspaces.find(workspace => workspace._id === parentReferences.get(item.parentId)?.workspaceId)?.name || '',
       })),
-      files: currentFiles.map(workspace => ({
-        id: workspace._id,
-        url: `/organization/${parentReferences.get(workspace.parentId)?.organizationId}/project/${parentReferences.get(workspace.parentId)?.projectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
-        name: workspace.name,
-        item: workspace,
-        organizationName: allOrganizations.find(org => org.id === parentReferences.get(workspace.parentId)?.organizationId)?.display_name || '',
-        projectName: allProjects.find(project => project._id === parentReferences.get(workspace.parentId)?.projectId)?.name || '',
-      })),
+      files: currentFiles.map(workspace => {
+        const parentProject = allProjects.find(project => project._id === workspace.parentId);
+        return ({
+          id: workspace._id,
+          url: `/organization/${parentReferences.get(workspace.parentId)?.organizationId}/project/${parentReferences.get(workspace.parentId)?.projectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
+          name: workspace.name,
+          item: { ...workspace, teamProjectId: parentProject && isRemoteProject(parentProject) ? parentProject.remoteId : '' },
+          organizationName: allOrganizations.find(org => org.id === parentReferences.get(workspace.parentId)?.organizationId)?.display_name || '',
+          projectName: allProjects.find(project => project._id === parentReferences.get(workspace.parentId)?.projectId)?.name || '',
+        });
+      }),
       environments,
     },
     other: {
@@ -252,14 +257,88 @@ export const loader: LoaderFunction = async args => {
         projectName: allProjects.find(project => project._id === parentReferences.get(item.parentId)?.projectId)?.name || '',
         workspaceName: allOrganizationWorkspaces.find(workspace => workspace._id === parentReferences.get(item.parentId)?.workspaceId)?.name || '',
       })),
-      files: otherFiles.map(workspace => ({
-        id: workspace._id,
-        url: `/organization/${parentReferences.get(workspace.parentId)?.organizationId}/project/${parentReferences.get(workspace.parentId)?.projectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
-        name: workspace.name,
-        item: workspace,
-        organizationName: allOrganizations.find(org => org.id === parentReferences.get(workspace.parentId)?.organizationId)?.display_name || '',
-        projectName: allProjects.find(project => project._id === parentReferences.get(workspace.parentId)?.projectId)?.name || '',
-      })),
+      files: otherFiles.map(workspace => {
+        const parentProject = allProjects.find(project => project._id === workspace.parentId);
+        return ({
+          id: workspace._id,
+          url: `/organization/${parentReferences.get(workspace.parentId)?.organizationId}/project/${parentReferences.get(workspace.parentId)?.projectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
+          name: workspace.name,
+          item: { ...workspace, teamProjectId: parentProject && isRemoteProject(parentProject) ? parentProject.remoteId : '' },
+          organizationName: allOrganizations.find(org => org.id === parentReferences.get(workspace.parentId)?.organizationId)?.display_name || '',
+          projectName: allProjects.find(project => project._id === parentReferences.get(workspace.parentId)?.projectId)?.name || '',
+        });
+      }),
     },
+  };
+};
+
+export interface CommandRemoteItem<TItem> {
+  id: string;
+  url: string;
+  pullUrl: string;
+  name: string;
+  organizationName: string;
+  projectName: string;
+  workspaceName?: string;
+  item: TItem;
+}
+
+interface RemoteFile {
+  id: string;
+  name: string;
+  projectId: string;
+  teamProjectId: string;
+  organizationId: string;
+}
+
+export interface RemoteFilesLoaderResult {
+  files: CommandRemoteItem<RemoteFile & { teamProjectRemoteId: string; scope: 'unsynced' }>[];
+}
+
+export const remoteFilesLoader: LoaderFunction = async (): Promise<RemoteFilesLoaderResult> => {
+  const { id: sessionId, accountId } = await userSession.get();
+
+  if (!sessionId) {
+    return {
+      files: [],
+    };
+  }
+
+  const remoteFiles = await insomniaFetch<RemoteFile[]>({
+    method: 'GET',
+    path: '/v1/user/files',
+    sessionId,
+  });
+
+  const allOrganizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
+
+  const allRemoteFilesOrganizationIds = remoteFiles.map(file => file.organizationId);
+  const allRemoteFilesProjectIds = remoteFiles.map(file => file.teamProjectId);
+
+  const organizations = allOrganizations.filter(org => allRemoteFilesOrganizationIds.includes(org.id));
+
+  const projects = await database.find<Project>(project.type, {
+    remoteId: {
+      $in: allRemoteFilesProjectIds,
+    },
+  });
+
+  console.log({ projects, allRemoteFilesProjectIds });
+
+  const files = remoteFiles.map(file => {
+    const parentProject = projects.find(project => project.remoteId === file.teamProjectId);
+    return {
+      id: file.id,
+      url: `/organization/${file.organizationId}/project`,
+      pullUrl: parentProject ? `/organization/${file.organizationId}/project/${file.teamProjectId}/remote-collections/pull` : '',
+      name: file.name,
+      item: { ...file, teamProjectRemoteId: parentProject?._id || '', scope: 'unsynced' as const },
+      organizationName: organizations.find(org => org.id === file.organizationId)?.display_name || '',
+      projectName: parentProject?.name || '',
+    };
+  });
+
+  return {
+    files,
   };
 };

--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -124,8 +124,7 @@ export const pullRemoteCollectionAction: ActionFunction = async ({
   request,
   params,
 }) => {
-  const { organizationId, projectId } = params;
-  invariant(typeof projectId === 'string', 'Project Id is required');
+  const { organizationId } = params;
   invariant(typeof organizationId === 'string', 'Organization Id is required');
   const formData = await request.formData();
 
@@ -135,6 +134,7 @@ export const pullRemoteCollectionAction: ActionFunction = async ({
   invariant(typeof remoteId === 'string', 'Remote Id is required');
 
   const vcs = VCSInstance();
+
   const remoteBackendProjects = await vcs.remoteBackendProjects({
     teamId: organizationId,
     teamProjectId: remoteId,
@@ -146,7 +146,7 @@ export const pullRemoteCollectionAction: ActionFunction = async ({
 
   invariant(backendProject, 'Backend project not found');
 
-  const project = await models.project.getById(projectId);
+  const project = await models.project.getByRemoteId(remoteId);
 
   invariant(project?.remoteId, 'Project is not a remote project');
 
@@ -167,7 +167,7 @@ export const pullRemoteCollectionAction: ActionFunction = async ({
   const activity = scopeToActivity(workspace?.scope);
 
   return redirect(
-    `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/${activity}`
+    `/organization/${organizationId}/project/${project._id}/workspace/${workspaceId}/${activity}`
   );
 };
 


### PR DESCRIPTION
Highlights:

- [x] Use the new `v1/user/files` api to fetch remote files
- [x] Update the command palette to merge remote/local files
- [x] When selecting a remote file if we already have the TeamProject we pull that file, otherwise redirect to the TeamProject to sync team projects

Conisderations:
- [ ] Project, TeamProject, BackendProject, remoteId, backendProjectId, teamProjectId, project and so on is **really hard** to reason about. We need to standarize on a common language in the app and api for those things.
- [x] Test with remote files that exist on projects the user hasn't loaded yet

Closes INS-3666