### PR TITLE
fix(UI): add titles to some elements in Test view [no-ticket]

### DIFF
--- a/packages/insomnia/src/ui/routes/test-results.tsx
+++ b/packages/insomnia/src/ui/routes/test-results.tsx
@@ -89,7 +89,7 @@ export const TestRunStatus: FC = () => {
                     {errorMessage ? 'Failed' : 'Passed'}
                   </span>
                 </div>
-                <div className="flex-1 truncate">{test.title}</div>
+                <div className="flex-1 truncate" title={test.title}>{test.title}</div>
                 <div className="flex flex-shrink-0">{test.duration} ms</div>
               </div>
               {errorMessage && (

--- a/packages/insomnia/src/ui/routes/test-suite.tsx
+++ b/packages/insomnia/src/ui/routes/test-suite.tsx
@@ -78,7 +78,7 @@ const UnitTestItemView = ({
 
   return (
     <div className="p-[--padding-sm] flex-shrink-0 overflow-hidden">
-      <div className="flex items-center gap-2 w-full">
+      <div className="flex items-center gap-2 w-full" title={unitTest.name}>
         <Button
           className="flex flex-shrink-0 flex-nowrap items-center justify-center aspect-square h-8 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
           onPress={() => setIsOpen(!isOpen)}
@@ -474,7 +474,7 @@ const TestSuiteRoute = () => {
   });
 
   return (
-    <div className="flex flex-col h-full w-full overflow-hidden divide-solid divide-y divide-[--hl-md]">
+    <div className="flex flex-col h-full w-full overflow-hidden divide-solid divide-y divide-[--hl-md]" title={testSuiteName}>
       <div className="flex h-[--line-height-sm] flex-shrink-0 gap-2 items-center px-[--padding-md]">
         <Heading className="text-lg flex-shrink-0 flex items-center gap-2 w-full truncate flex-1">
           <EditableInput

--- a/packages/insomnia/src/ui/routes/unit-test.tsx
+++ b/packages/insomnia/src/ui/routes/unit-test.tsx
@@ -502,7 +502,7 @@ const TestRoute: FC = () => {
                     textValue={item.name}
                     className="group outline-none select-none w-full"
                   >
-                    <div className="flex select-none outline-none group-aria-selected:text-[--color-font] relative group-hover:bg-[--hl-xs] group-focus:bg-[--hl-sm] transition-colors gap-2 px-4 items-center h-[--line-height-xs] w-full overflow-hidden text-[--hl]">
+                    <div className="flex select-none outline-none group-aria-selected:text-[--color-font] relative group-hover:bg-[--hl-xs] group-focus:bg-[--hl-sm] transition-colors gap-2 px-4 items-center h-[--line-height-xs] w-full overflow-hidden text-[--hl]" title={item.name}>
                       <span className="group-aria-selected:bg-[--color-surprise] transition-colors top-0 left-0 absolute h-full w-[2px] bg-transparent" />
                       <Button slot="drag" className="hidden" />
                       <EditableInput


### PR DESCRIPTION
Adding titles for cases where tests and test suites have too much text.

![image](https://github.com/Kong/insomnia/assets/11976836/d989e6f8-d992-422e-8a78-cf6b4e05e344)
![image](https://github.com/Kong/insomnia/assets/11976836/0731a85a-1be2-4984-a93c-048a54b2982f)
![image](https://github.com/Kong/insomnia/assets/11976836/f4ba6f1c-7151-4dc8-8ef6-283f59be08cb)
![image](https://github.com/Kong/insomnia/assets/11976836/2c6aa2e0-b49f-4e67-9046-770db5da238c)
