### PR TITLE
fix: migrate loader redirect

### DIFF
--- a/packages/insomnia/src/ui/routes/onboarding.migrate.tsx
+++ b/packages/insomnia/src/ui/routes/onboarding.migrate.tsx
@@ -9,7 +9,7 @@ import { InsomniaLogo } from '../components/insomnia-icon';
 import { TrailLinesContainer } from '../components/trail-lines-container';
 
 export const loader: LoaderFunction = async () => {
-  if (!shouldMigrateProjectUnderOrganization()) {
+  if (!await shouldMigrateProjectUnderOrganization()) {
     return redirect('/organization');
   }
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

The `shouldMigrateProjectUnderOrganization` is an async function, so we need to add `await`