### PR TITLE
fix: unify after-response script property name for folders

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/oauth.yaml
+++ b/packages/insomnia-smoke-test/fixtures/oauth.yaml
@@ -38,7 +38,7 @@ resources:
     environmentPropertyOrder: null
     metaSortKey: -1715935256495
     preRequestScript: ""
-    postRequestScript: ""
+    afterResponseScript: ""
     authentication: {}
     _type: request_group
   - _id: fld_e45987966c224b63b68b09b34687209c
@@ -51,7 +51,7 @@ resources:
     environmentPropertyOrder: null
     metaSortKey: -1715935030239
     preRequestScript: ""
-    postRequestScript: ""
+    afterResponseScript: ""
     authentication:
       accessTokenUrl: "http://127.0.0.1:4010/oidc/token"
       authorizationUrl: "http://127.0.0.1:4010/oidc/auth"

--- a/packages/insomnia/src/models/request-group.ts
+++ b/packages/insomnia/src/models/request-group.ts
@@ -18,7 +18,7 @@ interface BaseRequestGroup {
   environmentPropertyOrder: Record<string, any> | null;
   metaSortKey: number;
   preRequestScript: string;
-  postRequestScript: string;
+  afterResponseScript: string;
   authentication?: RequestAuthentication | {};
   headers?: RequestHeader[];
 }
@@ -37,7 +37,7 @@ export function init(): BaseRequestGroup {
     environmentPropertyOrder: null,
     metaSortKey: -1 * Date.now(),
     preRequestScript: '',
-    postRequestScript: '',
+    afterResponseScript: '',
     authentication: {},
     headers: [],
   };


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes
- [x] replace `postResponseScript` with `afterResponseScript`.

Ref: INS-3920
