### PR TITLE
fix: project with null remoteId don't need to be updated

### DIFF
--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -186,7 +186,9 @@ async function syncTeamProjects({
   const removedRemoteProjects = await database.find<Project>(models.project.type, {
     // filter by this organization so no legacy data can be accidentally removed, because legacy had null parentId
     parentId: organizationId,
-    // Remote ID is not in the list of remote projects
+    // Remote ID is not in the list of remote projects.
+    // add `$ne: null` condition because if remoteId is already null, we dont need to remove it again.
+    // nedb use append-only format, all updates and deletes actually result in lines added
     remoteId: {
       $nin: teamProjects.map(p => p.id),
       $ne: null,

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -187,7 +187,10 @@ async function syncTeamProjects({
     // filter by this organization so no legacy data can be accidentally removed, because legacy had null parentId
     parentId: organizationId,
     // Remote ID is not in the list of remote projects
-    remoteId: { $nin: teamProjects.map(p => p.id) },
+    remoteId: {
+      $nin: teamProjects.map(p => p.id),
+      $ne: null,
+    },
   });
 
   await Promise.all(removedRemoteProjects.map(async prj => {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Add `$ne null` condition when removeRemoteProjects.So if remoteId is already null, we will not remove it again.
