### PR TITLE
fix: avoid rendering script by temporarily disable it

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/after-response-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/after-response-collection.yaml
@@ -70,6 +70,7 @@ resources:
       insomnia.environment.set('__fromAfterScript', 'environment');
       insomnia.baseEnvironment.set('__fromAfterScript1', 'baseEnvironment');
       insomnia.collectionVariables.set('__fromAfterScript2', 'collection');
+      insomnia.environment.replaceIn('{{ $timestamp }}');
     body:
       mimeType: "application/json"
       text: |-


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Ref: INS-3913

### Changes:
- fix: avoid rendering after-response script content (Changing `blacklistPathRegex` would introduce much more changes as `render` function is called many places)
- test: added tests