### PR TITLE
fix: add a missing assertion chain for the response entity - INS-3917

### DIFF
--- a/packages/insomnia-sdk/src/objects/__tests__/response.test.ts
+++ b/packages/insomnia-sdk/src/objects/__tests__/response.test.ts
@@ -44,7 +44,6 @@ describe('test request and response objects', () => {
             body: '{"key": 888}',
             stream: undefined,
             responseTime: 100,
-            status: 'OK',
             originalRequest: req,
         });
 
@@ -69,5 +68,11 @@ describe('test request and response objects', () => {
         resp.to.have.header('header1');
         resp.to.have.jsonBody({ 'key': 888 });
         resp.to.have.body('{"key": 888}');
+
+        resp.to.not.have.status(201);
+        resp.to.not.have.status('NOT FOUND');
+        resp.to.not.have.header('header_nonexist');
+        resp.to.not.have.jsonBody({ 'key': 777 });
+        resp.to.not.have.body('{"key": 777}');
     });
 });

--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -126,7 +126,6 @@ export async function initInsomniaObject(
     const baseEnvironment = new Environment(rawObj.baseEnvironmentName || '', rawObj.baseEnvironment);
     // TODO: update "iterationData" name when it is supported
     const iterationData = new Environment('iterationData', rawObj.iterationData);
-    const collectionVariables = new Environment(rawObj.baseEnvironmentName || '', rawObj.baseEnvironment);
     const cookies = new CookieObject(rawObj.cookieJar);
     // TODO: update follows when post-request script and iterating are introduced
     const requestInfo = new RequestInfo({
@@ -140,7 +139,7 @@ export async function initInsomniaObject(
     const variables = new Variables({
         globals,
         environment,
-        collection: collectionVariables,
+        collection: baseEnvironment,
         data: iterationData,
     });
 

--- a/packages/insomnia-sdk/src/objects/response.ts
+++ b/packages/insomnia-sdk/src/objects/response.ts
@@ -186,34 +186,52 @@ export class Response extends Property {
 
     // Besides chai.expect, "to" is extended to support cases like:
     // insomnia.response.to.have.status(200);
+    // insomnia.response.to.not.have.status(200);
     get to() {
         type valueType = boolean | number | string | object | undefined;
-        const verify = (got: valueType, expected: valueType) => {
-            if (['boolean', 'number', 'string', 'undefined'].includes(typeof got) && expected === got) {
-                return;
-            } else if (deepEqual(got, expected, { strict: true })) {
+
+        const verify = (got: valueType, expected: valueType, checkEquality: boolean = true) => {
+            if (['boolean', 'number', 'string', 'undefined'].includes(typeof got)) {
+                if ((checkEquality && expected === got) || (!checkEquality && expected !== got)) {
+                    return;
+                }
+            } else if (
+                (checkEquality && deepEqual(got, expected, { strict: true })) ||
+                (!checkEquality && !deepEqual(got, expected, { strict: true }))
+            ) {
                 return;
             }
             throw Error(`"${got}" is not equal to the expected value: "${expected}"`);
         };
+        const haveStatus = (expected: number | string, checkEquality: boolean) => {
+            if (typeof expected === 'string') {
+                verify(this.status, expected, checkEquality);
+            } else {
+                verify(this.code, expected, checkEquality);
+            }
+        };
+        const haveHeader = (expected: string, checkEquality: boolean) => verify(
+            this.headers.toObject().find(header => header.key === expected) !== undefined,
+            checkEquality,
+        );
+        const haveBody = (expected: string, checkEquality: boolean) => verify(this.text(), expected, checkEquality);
+        const haveJsonBody = (expected: object, checkEquality: boolean) => verify(this.json(), expected, checkEquality);
 
         return {
             // follows extend chai's chains for compatibility
             have: {
-                status: (expected: number | string) => {
-                    if (typeof expected === 'string') {
-                        verify(this.status, expected);
-                    } else {
-                        verify(this.code, expected);
-                    }
+                status: (expected: number | string) => haveStatus(expected, true),
+                header: (expected: string) => haveHeader(expected, true),
+                body: (expected: string) => haveBody(expected, true),
+                jsonBody: (expected: object) => haveJsonBody(expected, true),
+            },
+            not: {
+                have: {
+                    status: (expected: number | string) => haveStatus(expected, false),
+                    header: (expected: string) => haveHeader(expected, false),
+                    body: (expected: string) => haveBody(expected, false),
+                    jsonBody: (expected: object) => haveJsonBody(expected, false),
                 },
-                header: (expected: string) => verify(
-                    this.headers.toObject().find(header => header.key === expected) !== undefined,
-                    true,
-                ),
-
-                body: (expected: string) => verify(this.text(), expected),
-                jsonBody: (expected: object) => verify(this.json(), expected),
             },
         };
     }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes
- Supported negative assertion chain such as `insomnia.response.to.not.have.status(200);`
- Added utests
- Only keep one instance for `collectionVariables` and `baseEnvironment` so that operations triggered from different entities will take effect.

Ref: - INS-3917