### PR TITLE
fix: use base64 output file for provenance for large assets

### DIFF
--- a/.github/scripts/generate-binary-digest.sh
+++ b/.github/scripts/generate-binary-digest.sh
@@ -8,21 +8,19 @@ echo "${cli_files}"
 echo "CLI FILES WITH PATH STRIPPED"
 echo "${cli_files}" | sed "s/\(.* \)\(.*\(inso\)\)/\1\\3/" | sort > "${CLI_ARTIFACT_SHAFILE}"
 cat "${CLI_ARTIFACT_SHAFILE}"
-cli_digest=$(base64 -w0 "${CLI_ARTIFACT_SHAFILE}")
 echo "ELECTRON APP FILES FOUND"
 app_files=$(find "${ARTIFACT_PATH}" -type f \( -name "Insomnia.Core-*" \)  -exec sha256sum {} \;)
 echo "${app_files}"
 echo "ELECTRON APP FILES WITH PATH STRIPPED"
 echo "${app_files}" | sed "s/\(.* \)\(.*\(Insomnia.Core\)\)/\1\\3/" | sort > "${ELECTRON_ARTIFACT_SHAFILE}"
 cat "${ELECTRON_ARTIFACT_SHAFILE}"
-app_digest=$(base64 -w0 "${ELECTRON_ARTIFACT_SHAFILE}")
 
 if [[ -z "$(cat ${CLI_ARTIFACT_SHAFILE})" ]]; then
     echo "CLI Artifacts SHA256 Digest file generation failed"
     exit 1
 else
-    echo "CLI FILE DIGEST"
-    echo "${cli_digest}"
+    echo "CLI ARTIFACT BASE64 DIGEST"
+    base64 -w0 "${CLI_ARTIFACT_SHAFILE}" > "${CLI_ARTIFACT_BASE64_FILE}"
 fi
 
 if [[ -z "$(cat ${ELECTRON_ARTIFACT_SHAFILE})" ]]; then
@@ -30,8 +28,9 @@ if [[ -z "$(cat ${ELECTRON_ARTIFACT_SHAFILE})" ]]; then
     exit 1
 else
     echo "ELECTRON APP FILE DIGEST"
-    echo "${app_digest}"
+    base64 -w0 "${ELECTRON_ARTIFACT_SHAFILE}" > "${ELECTRON_ARTIFACT_BASE64_FILE}"
 fi
 
-echo "inso_binary_artifact_digest_base64=${cli_digest}" >> "$GITHUB_OUTPUT"
-echo "electron_binary_artifact_digest_base64=${app_digest}" >> "$GITHUB_OUTPUT"
+# Due to limitation here: https://github.com/orgs/community/discussions/37942
+echo "inso_binary_artifact_base64_file=${CLI_ARTIFACT_BASE64_FILE}" >> "$GITHUB_OUTPUT"
+echo "electron_binary_artifact_base64_file=${ELECTRON_ARTIFACT_BASE64_FILE}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       NOTARY_REPOSITORY: ${{ env.NOTARY_REPOSITORY }}
-      INSO_BINARY_ARTIFACTS_DIGEST_BASE64: ${{ steps.metadata.outputs.inso_binary_artifact_digest_base64 }}
+      INSO_BINARY_ARTIFACTS_SUBJECTS_AS_FILE: ${{ steps.cli_binary_hashes.outputs.handle }}
       INSO_DOCKER_IMAGE: ${{ env.INSO_DOCKER_IMAGE }}
       INSO_DOCKER_IMAGE_DIGEST: ${{ steps.image_manifest_metadata.outputs.inso_image_sha }}
       INSOMNIA_RELEASE_TAG: ${{ env.RELEASE_CORE_TAG }}
-      ELECTRON_BINARY_ARTIFACTS_DIGEST_BASE64: ${{ steps.metadata.outputs.electron_binary_artifact_digest_base64 }}
+      ELECTRON_BINARY_ARTIFACTS_SUBJECTS_AS_FILE: ${{ steps.electron_binary_hashes.outputs.handle }}
     permissions:
       id-token: write # needed for signing the images
       actions: read # For getting workflow run info for keyless signing of docker image
@@ -69,7 +69,19 @@ jobs:
           ARTIFACT_PATH: "${{ env.ARTIFACTS_DOWNLOAD_PATH }}"
           CLI_ARTIFACT_SHAFILE: ${{runner.temp}}/cli.sha256
           ELECTRON_ARTIFACT_SHAFILE: ${{runner.temp}}/electron.sha256
-          
+          CLI_ARTIFACT_HASHES_FILE: ${{runner.temp}}/cli_digests_file.text
+          ELECTRON_ARTIFACT_HASHES_FILE: ${{runner.temp}}/electron_digests_file.text
+
+      - uses: slsa-framework/slsa-github-generator/actions/generator/generic/create-base64-subjects-from-file@v2.0.0
+        id: cli_binary_hashes
+        with:
+          path: ${{ steps.metadata.outputs.inso_binary_artifact_base64_file }}
+      
+      - uses: slsa-framework/slsa-github-generator/actions/generator/generic/create-base64-subjects-from-file@v2.0.0
+        id: electron_binary_hashes
+        with:
+          path: ${{ steps.metadata.outputs.electron_binary_artifact_base64_file }}
+      
       - name: Temporarily move artifacts
         shell: bash
         run: |
@@ -287,13 +299,13 @@ jobs:
       matrix:
         include:
           - product: insomnia
-            binary_artifacts_digest_base64: ${{ needs.publish.outputs.ELECTRON_BINARY_ARTIFACTS_DIGEST_BASE64 }}  
+            binary_artifacts_subject_as_file: ${{ needs.publish.outputs.ELECTRON_BINARY_ARTIFACTS_SUBJECTS_AS_FILE }}  
           - product: inso
-            binary_artifacts_digest_base64: ${{ needs.publish.outputs.INSO_BINARY_ARTIFACTS_DIGEST_BASE64 }}
+            binary_artifacts_subject_as_file: ${{ needs.publish.outputs.INSO_BINARY_ARTIFACTS_SUBJECTS_AS_FILE }}
     # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
-      base64-subjects: ${{matrix.binary_artifacts_digest_base64 }}
+      base64-subjects-as-file: "${{ matrix.binary_artifacts_subject_as_file }}"
       upload-assets: true
       upload-tag-name: ${{ needs.publish.outputs.INSOMNIA_RELEASE_TAG }}
       provenance-name: ${{ matrix.product }}-provenance.intoto.jsonl


### PR DESCRIPTION
## Summary
GH jobs redacts base64 encoded string of large assets and might contain secrets. There is no way to pass the encoded digest as job outputs for provenance.  

**Failed workflow**: https://github.com/Kong/insomnia/actions/runs/9383289942/job/25836570705#step:8:49 with digest redacted leading to send failed [job output considered sensitive](https://github.com/Kong/insomnia/actions/runs/9383289942/job/25836570705#step:53:7)

**Issue**: https://github.com/orgs/community/discussions/37942

## Solution: 
Refer https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#getting-started 




<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
