### PR TITLE
feat: Import/folder-auth

### DIFF
--- a/packages/insomnia-sdk/src/objects/auth.ts
+++ b/packages/insomnia-sdk/src/objects/auth.ts
@@ -468,10 +468,11 @@ export function fromPreRequestAuth(auth: RequestAuth): RequestAuthentication {
 
             const responseType = ((): OAuth2ResponseType => {
                 const inputResponseType = findValueInOauth2Options('response_type', authObj.oauth2);
-                if (['code', 'id_token', 'id_token token', 'none', 'token'].includes(inputResponseType)) {
+                // responseType is currently always set to '' in our request auth model, this should be investigated what is correct to be set
+                if (['code', 'id_token', 'id_token token', 'none', 'token', ''].includes(inputResponseType)) {
                     return inputResponseType as OAuth2ResponseType;
                 };
-                throw Error(`unknown response type for oauth2: "${inputResponseType}", it could be: 'code' | 'id_token' | 'id_token token' | 'none' | 'token'`);
+                throw Error(`unknown response type for oauth2: "${inputResponseType}", it could be: 'code' | 'id_token' | 'id_token token' | 'none' | 'token' | ''`);
             })();
 
             return {

--- a/packages/insomnia/src/main/analytics.ts
+++ b/packages/insomnia/src/main/analytics.ts
@@ -16,7 +16,6 @@ const analytics = new Analytics({
   writeKey: getSegmentWriteKey(),
   httpClient: {
     makeRequest(_options) {
-      console.log('makeRequest', _options);
       return net.fetch(_options.url, {
         method: _options.method,
         headers: _options.headers,
@@ -65,7 +64,6 @@ export async function trackSegmentEvent(
   const settings = await models.settings.getOrCreate();
   const userSession = await models.userSession.getOrCreate();
   const allowAnalytics = settings.enableAnalytics || userSession?.accountId;
-  console.log('allowAnalytics', allowAnalytics, settings.enableAnalytics, userSession?.accountId);
   if (allowAnalytics) {
     try {
       const anonymousId = await getDeviceId() ?? '';
@@ -96,7 +94,6 @@ export async function trackPageView(name: string) {
   const userSession = await models.userSession.getOrCreate();
 
   const allowAnalytics = settings.enableAnalytics || userSession?.accountId;
-  console.log('allowAnalytics', allowAnalytics, settings.enableAnalytics, userSession?.accountId);
   if (allowAnalytics) {
     try {
       const anonymousId = await getDeviceId() ?? '';

--- a/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
@@ -139,17 +139,18 @@ export const AuthDropdown: FC<Props> = ({ authentication, authTypes = defaultTyp
   const { requestId, requestGroupId } = useParams() as { organizationId: string; projectId: string; workspaceId: string; requestId?: string; requestGroupId?: string };
   const patchRequest = useRequestPatcher();
   const patchRequestGroup = useRequestGroupPatcher();
-  const onClick = useCallback(async (type?: AuthTypes) => {
-    const clickedSameSetting = type === getAuthObjectOrNull(authentication)?.type;
+  const onClick = useCallback(async (type: AuthTypes | 'inherit') => {
+    const clickedSameSetting = type === getAuthObjectOrNull(authentication)?.type || '';
     if (clickedSameSetting) {
       return;
     }
-    const newAuthentication = type ? castOneAuthTypeToAnother(type, authentication || {}) : {};
+    const selectedInherit = type === 'inherit';
+    const newAuthentication = selectedInherit ? {} : castOneAuthTypeToAnother(type, authentication || {});
     requestId && patchRequest(requestId, { authentication: newAuthentication });
     requestGroupId && patchRequestGroup(requestGroupId, { authentication: newAuthentication });
   }, [authentication, patchRequest, patchRequestGroup, requestGroupId, requestId]);
 
-  const selectedAuthType = getAuthObjectOrNull(authentication)?.type || 'none';
+  const selectedAuthType = getAuthObjectOrNull(authentication)?.type || 'inherit';
 
   const authTypesItems: {
     id: AuthTypes;
@@ -206,7 +207,7 @@ export const AuthDropdown: FC<Props> = ({ authentication, authTypes = defaultTyp
     icon: IconName;
     name: string;
     items: {
-      id: AuthTypes;
+      id: AuthTypes | 'inherit';
       name: string;
     }[];
   }[] = [
@@ -224,6 +225,10 @@ export const AuthDropdown: FC<Props> = ({ authentication, authTypes = defaultTyp
           {
             id: 'none',
             name: 'None',
+          },
+          {
+            id: 'inherit',
+            name: 'Inherit from parent',
           },
         ],
       },

--- a/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
+++ b/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
@@ -3833,6 +3833,7 @@ exports[`Fixtures Import postman api-key-default-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -3875,6 +3876,7 @@ exports[`Fixtures Import postman api-key-header-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -3917,6 +3919,7 @@ exports[`Fixtures Import postman api-key-queryParams-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -3959,6 +3962,7 @@ exports[`Fixtures Import postman aws-signature-auth-v2_0-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4003,6 +4007,7 @@ exports[`Fixtures Import postman aws-signature-auth-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4047,6 +4052,7 @@ exports[`Fixtures Import postman basic-auth-v2_0-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4088,6 +4094,7 @@ exports[`Fixtures Import postman basic-auth-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4129,6 +4136,7 @@ exports[`Fixtures Import postman bearer-token-v2_0-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4170,6 +4178,7 @@ exports[`Fixtures Import postman bearer-token-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4211,6 +4220,7 @@ exports[`Fixtures Import postman complex-url-v2_0-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4253,6 +4263,7 @@ exports[`Fixtures Import postman complex-url-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4295,6 +4306,7 @@ exports[`Fixtures Import postman complex-v2_0_fromHeaders-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4305,6 +4317,7 @@ exports[`Fixtures Import postman complex-v2_0_fromHeaders-input.json 1`] = `
       "_id": "__GRP_2__",
       "_type": "request_group",
       "afterResponseScript": "",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117983999,
@@ -4557,6 +4570,7 @@ exports[`Fixtures Import postman complex-v2_0-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4567,6 +4581,7 @@ exports[`Fixtures Import postman complex-v2_0-input.json 1`] = `
       "_id": "__GRP_2__",
       "_type": "request_group",
       "afterResponseScript": "",
+      "authentication": {},
       "description": "The first folder",
       "environment": {},
       "metaSortKey": -1622117983999,
@@ -4725,6 +4740,7 @@ exports[`Fixtures Import postman complex-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4735,6 +4751,7 @@ exports[`Fixtures Import postman complex-v2_1-input.json 1`] = `
       "_id": "__GRP_2__",
       "_type": "request_group",
       "afterResponseScript": "",
+      "authentication": {},
       "description": "The first folder",
       "environment": {},
       "metaSortKey": -1622117983999,
@@ -4899,6 +4916,7 @@ exports[`Fixtures Import postman digest-auth-v2_0-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4940,6 +4958,7 @@ exports[`Fixtures Import postman digest-auth-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -4981,6 +5000,7 @@ exports[`Fixtures Import postman faker-vars-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -5037,6 +5057,7 @@ exports[`Fixtures Import postman minimal-v2_0-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -5073,6 +5094,7 @@ exports[`Fixtures Import postman minimal-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -5109,6 +5131,7 @@ exports[`Fixtures Import postman oauth1_0-auth-v2_0-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -5284,6 +5307,7 @@ exports[`Fixtures Import postman oauth1_0-auth-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -5459,6 +5483,7 @@ exports[`Fixtures Import postman oauth2_0-auth-v2_0-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "A collection for testing",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -5527,6 +5552,7 @@ exports[`Fixtures Import postman oauth2_0-auth-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -5712,6 +5738,7 @@ exports[`Fixtures Import postman postman-export-oauth2-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -5765,6 +5792,7 @@ exports[`Fixtures Import postman scripts-import-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -8139,6 +8167,7 @@ exports[`Fixtures Import wsdl addition-input.wsdl 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -8149,6 +8178,7 @@ exports[`Fixtures Import wsdl addition-input.wsdl 1`] = `
       "_id": "__GRP_2__",
       "_type": "request_group",
       "afterResponseScript": "",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117983999,
@@ -8225,6 +8255,7 @@ exports[`Fixtures Import wsdl calculator-input.wsdl 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117984000,
@@ -8235,6 +8266,7 @@ exports[`Fixtures Import wsdl calculator-input.wsdl 1`] = `
       "_id": "__GRP_2__",
       "_type": "request_group",
       "afterResponseScript": "",
+      "authentication": {},
       "description": "",
       "environment": {},
       "metaSortKey": -1622117983999,

--- a/packages/insomnia/src/utils/importers/importers/postman.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.ts
@@ -264,15 +264,19 @@ export class ImportPostman {
       item,
       info: { name, description },
       variable,
+      auth,
     } = this.collection;
 
     const postmanVariable = this.importVariable(variable || []);
+    const { authentication } = this.importAuthentication(auth);
+
     const collectionFolder: ImportRequest = {
       parentId: '__WORKSPACE_ID__',
       _id: `__GRP_${requestGroupCount++}__`,
       _type: 'request_group',
       name,
       description: typeof description === 'string' ? description : '',
+      authentication,
     };
 
     if (postmanVariable) {

--- a/packages/insomnia/src/utils/importers/importers/postman.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.ts
@@ -1,3 +1,4 @@
+import { AuthTypeOAuth2 } from '../../../models/request';
 import { fakerFunctions } from '../../../ui/components/templating/faker-functions';
 import { Converter, ImportRequest, Parameter } from '../entities';
 import {
@@ -802,7 +803,7 @@ export class ImportPostman {
       disabled: false,
     };
   };
-  importOauth2Authentication = (auth: Authetication) => {
+  importOauth2Authentication = (auth: Authetication): AuthTypeOAuth2 | {} => {
     if (!auth.oauth2) {
       return {};
     }

--- a/packages/insomnia/src/utils/importers/importers/postman.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.ts
@@ -83,7 +83,7 @@ const mapGrantTypeToInsomniaGrantType = (grantType: string) => {
     return 'password';
   }
 
-  return grantType;
+  return grantType || 'authorization_code';
 };
 
 export function translateHandlersInScript(scriptContent: string): string {
@@ -243,10 +243,10 @@ export class ImportPostman {
     }) as Parameter);
   };
 
-  importFolderItem = ({ name, description, event }: Folder, parentId: string) => {
+  importFolderItem = ({ name, description, event, auth }: Folder, parentId: string) => {
+    const { authentication } = this.importAuthentication(auth);
     const preRequestScript = this.importPreRequestScript(event);
     const afterResponseScript = this.importAfterResponseScript(event);
-
     return {
       parentId,
       _id: `__GRP_${requestGroupCount++}__`,
@@ -255,6 +255,7 @@ export class ImportPostman {
       description: description || '',
       preRequestScript,
       afterResponseScript,
+      authentication,
     };
   };
 


### PR DESCRIPTION
removes console logs
adds import functionality for postman auth in folders
also adds for auth in collections although postman doesn't appear to actually export auth values.
restores auth inheritance behaviour lost in accessibility PR

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
