### PR TITLE
include read only in headers count

### DIFF
--- a/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-headers-editor.tsx
@@ -15,14 +15,14 @@ interface Props {
   isDisabled?: boolean;
   requestType: 'Request' | 'RequestGroup' | 'WebSocketRequest';
 }
-const readOnlyWebsocketPairs = [
+export const readOnlyWebsocketPairs = [
   { name: 'Connection', value: 'Upgrade' },
   { name: 'Upgrade', value: 'websocket' },
   { name: 'Sec-WebSocket-Key', value: '<calculated at runtime>' },
   { name: 'Sec-WebSocket-Version', value: '13' },
   { name: 'Sec-WebSocket-Extensions', value: 'permessage-deflate; client_max_window_bits' },
 ].map(pair => ({ ...pair, id: generateId('pair') }));
-const readOnlyHttpPairs = [
+export const readOnlyHttpPairs = [
   { name: 'Accept', value: '*/*' },
   { name: 'Host', value: '<calculated at runtime>' },
 ].map(pair => ({ ...pair, id: generateId('pair') }));

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -16,7 +16,7 @@ import { WorkspaceLoaderData } from '../../routes/workspace';
 import { OneLineEditor } from '../codemirror/one-line-editor';
 import { AuthWrapper } from '../editors/auth/auth-wrapper';
 import { BodyEditor } from '../editors/body/body-editor';
-import { RequestHeadersEditor } from '../editors/request-headers-editor';
+import { readOnlyHttpPairs, RequestHeadersEditor } from '../editors/request-headers-editor';
 import { RequestParametersEditor } from '../editors/request-parameters-editor';
 import { RequestScriptEditor } from '../editors/request-script-editor';
 import { ErrorBoundary } from '../error-boundary';
@@ -89,7 +89,7 @@ export const RequestPane: FC<Props> = ({
   };
 
   const parametersCount = pathParameters.length + activeRequest.parameters.filter(p => !p.disabled).length;
-  const headersCount = activeRequest.headers.filter(h => !h.disabled).length;
+  const headersCount = activeRequest.headers.filter(h => !h.disabled).length + readOnlyHttpPairs.length;
   const urlHasQueryParameters = activeRequest.url.indexOf('?') >= 0;
   const contentType =
     getContentTypeFromHeaders(activeRequest.headers) ||

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -20,7 +20,7 @@ import { CodeEditor, CodeEditorHandle } from '../codemirror/code-editor';
 import { OneLineEditor } from '../codemirror/one-line-editor';
 import { WebSocketPreviewMode } from '../dropdowns/websocket-preview-mode';
 import { AuthWrapper } from '../editors/auth/auth-wrapper';
-import { RequestHeadersEditor } from '../editors/request-headers-editor';
+import { readOnlyWebsocketPairs, RequestHeadersEditor } from '../editors/request-headers-editor';
 import { RequestParametersEditor } from '../editors/request-parameters-editor';
 import { ErrorBoundary } from '../error-boundary';
 import { Icon } from '../icon';
@@ -234,7 +234,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
   };
 
   const parametersCount = pathParameters.length + activeRequest.parameters.filter(p => !p.disabled).length;
-  const headersCount = activeRequest.headers.filter(h => !h.disabled).length;
+  const headersCount = activeRequest.headers.filter(h => !h.disabled).length + readOnlyWebsocketPairs.length;
   const patchSettings = useSettingsPatcher();
   const upsertPayloadWithMode = async (mode: string) => {
     // @TODO: multiple payloads


### PR DESCRIPTION
not needed for folders because there are no read onlys

however we could count parent folders headers to requests but would need some way to indicate where they were coming from. (future work)
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
