### PR TITLE
fix: add certificateSubjectName [INS-3983]

### DIFF
--- a/packages/insomnia-smoke-test/tests/prerelease/plugins-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/prerelease/plugins-interactions.test.ts
@@ -16,27 +16,4 @@ test.describe('Plugins', async () => {
     // check if the plugin shows up on the plugin list
     await page.getByRole('cell', { name: 'insomnia-plugin-demo-example' }).click();
   });
-
-  test('Check Declarative Config and Kong Kubernetes config', async ({ page }) => {
-    await page.getByRole('button', { name: 'New Document' }).click();
-    await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click();
-
-    // Set example OpenAPI spec
-    await page.click('text=start from an example');
-    await expect(page.locator('.app')).toContainText('This is a sample server Petstore server');
-
-    // Open declarative config
-    await page.getByLabel('Workspace actions').click();
-    await page.getByRole('menuitemradio', { name: 'Declarative Config (Legacy)' }).click();
-    // Check for declarative config contents
-    await page.getByText('_format_version').click();
-
-    // Switch to Kong for Kubernetes tab
-    await page.click('div[role="tab"]:has-text("Kong for Kubernetes")');
-
-    // Check for Kong for Kubernetes contents
-    await page.getByText('apiVersion: networking.k8s.io/v1').click();
-  });
-
-  // TODO: more scenarios will be added in follow-up iterations of increasing test coverage
 });

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -88,6 +88,7 @@ const config = {
     ],
   },
   win: {
+    certificateSubjectName: 'Kong Inc.',
     target: [
       {
         target: 'squirrel',
@@ -98,9 +99,6 @@ const config = {
     artifactName: `${BINARY_PREFIX}-\${version}.\${ext}`,
     iconUrl:
       'https://github.com/kong/insomnia/blob/develop/packages/insomnia/src/icons/icon.ico?raw=true',
-  },
-  portable: {
-    artifactName: `${BINARY_PREFIX}-\${version}-portable.\${ext}`,
   },
   linux: {
     artifactName: `${BINARY_PREFIX}-\${version}.\${ext}`,

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -89,6 +89,7 @@ const config = {
   },
   win: {
     certificateSubjectName: 'Kong Inc.',
+    signAndEditExecutable: false,
     target: [
       {
         target: 'squirrel',


### PR DESCRIPTION
Closes INS-3983

Based on https://stackoverflow.com/a/72267165 and https://www.electron.build/configuration/win#WindowsConfiguration-certificateSubjectName this change could do the trick to make it so it's not just the installer that is code signed?


Update: converting back to draft, this doesn't work the way we think it does, and release-recurring fails trying to find a certificate locally.