### PR TITLE
fix: Maximum update depth exceeded error in key-value editor

### DIFF
--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -1,5 +1,5 @@
 import { useResizeObserver } from '@react-aria/utils';
-import React, { FC, Fragment, useCallback, useRef, useState } from 'react';
+import React, { FC, Fragment, useCallback, useMemo, useRef, useState } from 'react';
 import { FocusScope } from 'react-aria';
 import { Button, Dialog, DialogTrigger, DropIndicator, GridList, GridListItem, Menu, MenuItem, MenuTrigger, Popover, ToggleButton, Toolbar, useDragAndDrop } from 'react-aria-components';
 import { useListData } from 'react-stately';
@@ -170,7 +170,9 @@ export const KeyValueEditor: FC<Props> = ({
     getKey: item => item.id,
   });
 
-  const items = pairsList.items.length > 0 ? pairsList.items : [{ id: generateId('pair'), name: '', value: '', description: '', disabled: false }];
+  const items = useMemo(() => {
+    return pairsList.items.length > 0 ? pairsList.items : [{ id: generateId('pair'), name: '', value: '', description: '', disabled: false }];
+  }, [pairsList.items]);
 
   const readOnlyPairsList = useListData({
     initialItems: readOnlyPairs?.map(pair => {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

The generateId cause the component Infinite loop render