### PR TITLE
fix(Error View): fix loading state for logout button in error view

### DIFF
--- a/packages/insomnia/src/ui/routes/error.tsx
+++ b/packages/insomnia/src/ui/routes/error.tsx
@@ -67,7 +67,7 @@ export const ErrorRoute: FC<{ defaultMessage?: string }> = ({ defaultMessage }) 
           )}
         >
           Logout{' '}
-          <span>{navigation.state === 'loading' ? <Icon icon="spinner" className='animate-spin' /> : null}</span>
+          <span>{logoutFetcher.state === 'loading' ? <Icon icon="spinner" className='animate-spin' /> : null}</span>
         </Button>
       </div>
       <div className='text-[--color-font] p-6 overflow-y-auto'>


### PR DESCRIPTION
Highlights:

- [x] Fixes an issue where clicking `try again` in the error view would show a spinner on the logout button