### PR TITLE
spike: proxy error on login [INS-4009]

### DIFF
--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -6,6 +6,7 @@ import { invariant } from '../../utils/invariant';
 import { SegmentEvent } from '../analytics';
 import { getLoginUrl, submitAuthCode } from '../auth-session-provider';
 import { Icon } from '../components/icon';
+import { showSettingsModal } from '../components/modals/settings-modal';
 import { Button } from '../components/themed-button';
 
 export const action: ActionFunction = async ({
@@ -16,7 +17,7 @@ export const action: ActionFunction = async ({
   invariant(typeof data?.code === 'string', 'Expected code to be a string');
   const error = await submitAuthCode(data.code);
   if (error) {
-    const humanReadableError = error?.message === 'Failed to fetch' ? 'Network failed, please try again. Note: if this happens many times, check if you have any Proxy configuration enabled on Insomnia settings and disable it.' : error?.message;
+    const humanReadableError = error?.message === 'Failed to fetch' ? 'Network failed, please try again. If this happens repeatedly, check if you have any Proxy enabled on Insomnia Preferences or on your device and try to disable it.' : error?.message;
     return {
       errors: {
         message: humanReadableError,
@@ -151,6 +152,13 @@ const Authorize = () => {
         >
           <Icon icon="arrow-left" />
           <span>Go Back</span>
+        </Button>
+        <Button
+          data-testid="settings-button"
+          className="px-4 py-1 h-full flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] text-[--color-font] text-xs hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all"
+          onClick={showSettingsModal}
+        >
+          <Icon icon="gear" /> Preferences
         </Button>
       </div>
     </div>

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -17,7 +17,7 @@ export const action: ActionFunction = async ({
   invariant(typeof data?.code === 'string', 'Expected code to be a string');
   const error = await submitAuthCode(data.code);
   if (error) {
-    const humanReadableError = error?.message === 'Failed to fetch' ? 'Network failed, please try again. If this happens repeatedly, check if you have any Proxy enabled on Insomnia Preferences or on your device and try to disable it.' : error?.message;
+    const humanReadableError = error?.message === 'Failed to fetch' ? 'Network failed, please try again. If the problem persists, check you rnetwork and proxy settings.' : error?.message;
     return {
       errors: {
         message: humanReadableError,

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -17,7 +17,7 @@ export const action: ActionFunction = async ({
   invariant(typeof data?.code === 'string', 'Expected code to be a string');
   const error = await submitAuthCode(data.code);
   if (error) {
-    const humanReadableError = error?.message === 'Failed to fetch' ? 'Network failed, please try again. If the problem persists, check you rnetwork and proxy settings.' : error?.message;
+    const humanReadableError = error?.message === 'Failed to fetch' ? 'Network failed, please try again. If the problem persists, check you network and proxy settings.' : error?.message;
     return {
       errors: {
         message: humanReadableError,

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -154,7 +154,7 @@ const Authorize = () => {
           <span>Go Back</span>
         </Button>
         <Button
-          data-testid="settings-button"
+          data-testid="settings-button-auth-authorize"
           className="px-4 py-1 h-full flex items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] text-[--color-font] text-xs hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all"
           onClick={showSettingsModal}
         >

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -17,7 +17,7 @@ export const action: ActionFunction = async ({
   invariant(typeof data?.code === 'string', 'Expected code to be a string');
   const error = await submitAuthCode(data.code);
   if (error) {
-    const humanReadableError = error?.message === 'Failed to fetch' ? 'Network failed, please try again. If the problem persists, check you network and proxy settings.' : error?.message;
+    const humanReadableError = error?.message === 'Failed to fetch' ? 'Network failed, please try again. If the problem persists, check your network and proxy settings.' : error?.message;
     return {
       errors: {
         message: humanReadableError,

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -16,7 +16,7 @@ export const action: ActionFunction = async ({
   invariant(typeof data?.code === 'string', 'Expected code to be a string');
   const error = await submitAuthCode(data.code);
   if (error) {
-    const humanReadableError = error?.message === 'TypeError: Failed to fetch' ? 'Network failed, try again.' : error?.message;
+    const humanReadableError = error?.message === 'Failed to fetch' ? 'Network failed, please try again. Note: if this happens many times, check if you have any Proxy configuration enabled on Insomnia settings and disable it.' : error?.message;
     return {
       errors: {
         message: humanReadableError,


### PR DESCRIPTION
Closes, barely, INS-4009. _hic sunt dracones_

Some users will see the "Failed to Fetch" due to having a Proxy configured, either on their machines or on Insomnia Settings, which doesn't seem to work well with InsomniaFetch during login or the whoami call. One extra hypothesis, untested, is that some users might be facing problems due to CORS, not sure yet

I've tried capturing exception similar to `ERR_PROXY_CONNECTION_FAILED` but it gets swallowed by sentry instrumentation on `fetch()` function, regardless of what failure happens of fetch, it's swallowed with a `TypeError: Failed to fetch`.

By the time we try to capture a http status code, we always get the above exception.

![image](https://github.com/Kong/insomnia/assets/11976836/235a8f60-f8ae-4ad5-b66b-40275bfa4e07)



Tried a handful of things to circunvent this but nothing seemed to work, e.g.

- using [beforeSend](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using--1) on sentry on sentry config
- using [ignoreErrors](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-) on sentry config
- filtering out Http from integrations on sentry config


Other related findings:
- https://github.com/getsentry/sentry-javascript/issues/6376
- https://forum.sentry.io/t/disabling-automatic-error-capturing-in-javascript-sdk/5039/2
- https://forum.sentry.io/t/typeerror-failed-to-fetch-reported-over-and-overe/8447

## Useful steps to repro/test

- Set Proxy for http and https on insomnia settings with a value like `localhost:8005` that will force the exception
- If you want to avoid having to re-login on every code-edit, you can use the electron console instead, manually try to send `fetch()` by hand to whoami endpoint or a url that doesn't exist.
```
await fetch('https://api.insomnia.rest/whoami').catch(error => {console.log(error)})
```

![image](https://github.com/Kong/insomnia/assets/11976836/0688ac78-9c32-4440-82f8-352fd15a7114)
