### PR TITLE
poc: file watcher for timeline

### DIFF
--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -26,7 +26,8 @@ export type HandleChannels =
   | 'webSocket.event.send'
   | 'webSocket.open'
   | 'webSocket.readyState'
-  | 'writeFile';
+  | 'writeFile'
+  | 'readFile';
 
 export const ipcMainHandle = (
   channel: HandleChannels,
@@ -63,7 +64,8 @@ export type MainOnChannels =
   | 'trackSegmentEvent'
   | 'webSocket.close'
   | 'webSocket.closeAll'
-  | 'writeText';
+  | 'writeText'
+  | 'watchFile';
 export type RendererOnChannels =
   'clear-all-models'
   | 'clear-model'
@@ -80,7 +82,8 @@ export type RendererOnChannels =
   | 'toggle-preferences-shortcuts'
   | 'toggle-preferences'
   | 'toggle-sidebar'
-  | 'updaterStatus';
+  | 'updaterStatus'
+  | 'file-changed';
 export const ipcMainOn = (
   channel: MainOnChannels,
   listener: (

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -41,6 +41,8 @@ const grpc: gRPCBridgeAPI = {
   loadMethodsFromReflection: options => ipcRenderer.invoke('grpc.loadMethodsFromReflection', options),
 };
 const main: Window['main'] = {
+  watchFile: options => ipcRenderer.send('watchFile', options),
+  readFile: options => ipcRenderer.invoke('readFile', options),
   loginStateChange: () => ipcRenderer.send('loginStateChange'),
   restart: () => ipcRenderer.send('restart'),
   openInBrowser: options => ipcRenderer.send('openInBrowser', options),

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -8,6 +8,7 @@ import { getSetCookieHeaders } from '../../../common/misc';
 import * as models from '../../../models';
 import { cancelRequestById } from '../../../network/cancellation';
 import { jsonPrettify } from '../../../utils/prettify/json';
+import { useFileWatcher } from '../../hooks/use-file-watcher';
 import { useRequestMetaPatcher } from '../../hooks/use-request';
 import { RequestLoaderData } from '../../routes/request';
 import { useRootLoaderData } from '../../routes/root';
@@ -120,6 +121,8 @@ export const ResponsePane: FC<Props> = ({
     }
   }, [activeRequest, activeResponse]);
 
+  const content = useFileWatcher({ filePath: activeResponse?.timelinePath });
+  console.log('content', content?.substring(content.length - 11, content.length - 1), activeResponse?.timelinePath);
   if (!activeRequest) {
     return <BlankPane type="response" />;
   }

--- a/packages/insomnia/src/ui/hooks/use-file-watcher.ts
+++ b/packages/insomnia/src/ui/hooks/use-file-watcher.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+export const useFileWatcher = ({ filePath }: { filePath?: string }) => {
+  const [fileContent, setFileContent] = useState('');
+
+  useEffect(() => {
+    if (!filePath) {
+      return;
+    }
+    window.main.watchFile({ filePath });
+    window.main.on('file-changed', (event, { content }) => {
+      // console.log(`File changed: ${content}`);
+      setFileContent(content);
+    });
+    window.main.readFile({ filePath }).then((content: string) => {
+      // console.log('read', content);
+      setFileContent(content);
+    });
+    // setFileContent(timelineString);
+  }, [filePath]);
+
+  // const fetchFileContent = async (filePath: string) => {
+
+  //   const rawBuffer = await fs.promises.readFile(filePath);
+  //   const timelineString = rawBuffer.toString();
+  //   // const timelineParsed = timelineString.split('\n').filter(e => e?.trim()).map(e => JSON.parse(e));
+  //   setFileContent(timelineString);
+  // };
+
+  return fileContent;
+};


### PR DESCRIPTION
motivation: our loading indiciator is creating a second state store in a variable which have side effects due to being scoped into a file in the renderer. This is a poc aiming to provide we can use the timeline file as a single state store for loading indicators and other operations.

// old
// step1:time+duration
// new step1+time,step2+time,step3+time
// required change: begin end
// when a begin is found and end is searched for in the file if found a duration is created
// a steps array is generated and isExecution is calucated exactly as now?
// issues: if cancelled or quit the app how can loading logic know loading is complete if no end is found?
// alternate implementation: dont append to timeline instead update it adding durations as they are set, would still have same problem as above


<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
