### PR TITLE
fix: always take the latest operation name instead of prev state's

### DIFF
--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -302,8 +302,9 @@ export const GraphQLEditor: FC<Props> = ({
     try {
       const documentAST = parse(query);
       const operations = documentAST.definitions.filter(isOperationDefinition)?.map(def => def.name?.value || '').filter(Boolean) || [];
+
       // default to first operation when none selected
-      let operationName = state.body.operationName || operations[0] || '';
+      let operationName = operations[0] || '';
       if (operations.length && state.body.operationName) {
         const operationsChanged = state.operations.join() !== operations.join();
         const operationNameWasChanged = !operations.includes(state.body.operationName);


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Background:
The gql editor reads `state.body.operationName` for getting operation name but it may refer to the last state, read `operations[0]` to get the latest ast's op name.

Ref: INS-3966, #7455

### Changes:
- [x] fix: always take the latest operation name instead of prev state's
