### PR TITLE
transform hyphens to underscores on import

### DIFF
--- a/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
+++ b/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
@@ -5900,7 +5900,7 @@ exports[`Fixtures Import postman-env no-name-input.json 1`] = `
       "_id": "__ENV_1__",
       "_type": "environment",
       "data": {
-        "foo": "production",
+        "foo_and_bar": "production-env",
       },
       "name": "Postman Environment",
       "parentId": "__BASE_ENVIRONMENT_ID__",

--- a/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
+++ b/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
@@ -5840,14 +5840,21 @@ exports[`Fixtures Import postman scripts-import-v2_1-input.json 1`] = `
     {
       "_id": "__GRP_1__",
       "_type": "request_group",
-      "afterResponseScript": "",
+      "afterResponseScript": "console.log('after')",
       "authentication": {},
       "description": "",
-      "environment": {},
+      "environment": {
+        "bob": "something",
+        "dssx": "{{env_var_in_global}}",
+      },
       "metaSortKey": -1622117984000,
       "name": "New Collection",
       "parentId": "__WORKSPACE_ID__",
-      "preRequestScript": "",
+      "preRequestScript": "console.log('pre')",
+      "variable": {
+        "bob": "something",
+        "dssx": "{{env_var_in_global}}",
+      },
     },
     {
       "_id": "__REQ_1__",

--- a/packages/insomnia/src/utils/importers/importers/fixtures/postman-env/no-name-input.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/postman-env/no-name-input.json
@@ -2,14 +2,14 @@
   "id": "fd5ae82a-d4c3-fa38-b53f-cddafb084535",
   "values": [
     {
-      "key": "foo",
-      "value": "production",
+      "key": "foo-and-bar",
+      "value": "production-env",
       "type": "text",
       "enabled": true
     },
     {
-      "key": "bar",
-      "value": "hahah",
+      "key": "disabled-key",
+      "value": "hahah-haha",
       "type": "text",
       "enabled": false
     }

--- a/packages/insomnia/src/utils/importers/importers/fixtures/postman/scripts-import-v2_1-input.json
+++ b/packages/insomnia/src/utils/importers/importers/fixtures/postman/scripts-import-v2_1-input.json
@@ -46,5 +46,37 @@
 			},
 			"response": []
 		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					"console.log('pre')"
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					"console.log('after')"
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "dssx",
+			"value": "{{env-var-in-global}}"
+		},
+		{
+			"key": "bob",
+			"value": "something"
+		}
 	]
 }

--- a/packages/insomnia/src/utils/importers/importers/postman-env.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman-env.ts
@@ -1,5 +1,4 @@
 import { Converter } from '../entities';
-import { replaceHyphens } from './postman';
 
 export const id = 'postman-environment';
 export const name = 'Postman Environment';

--- a/packages/insomnia/src/utils/importers/importers/postman-env.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman-env.ts
@@ -1,4 +1,5 @@
 import { Converter } from '../entities';
+import { replaceHyphens } from './postman';
 
 export const id = 'postman-environment';
 export const name = 'Postman Environment';
@@ -39,9 +40,11 @@ export const convert: Converter<Data> = rawData => {
           if (!enabled) {
             return accumulator;
           }
+          // hyphenated keys are not allowed in nunjucks eg. {{ foo-bar }} -> {{ foo_bar }}
+          const sanitized = replaceHyphens(key);
           return {
             ...accumulator,
-            [key]: value,
+            [sanitized]: value,
           };
         }, {}),
       },

--- a/packages/insomnia/src/utils/importers/importers/postman-env.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman-env.ts
@@ -41,10 +41,10 @@ export const convert: Converter<Data> = rawData => {
             return accumulator;
           }
           // hyphenated keys are not allowed in nunjucks eg. {{ foo-bar }} -> {{ foo_bar }}
-          const sanitized = replaceHyphens(key);
+          const transformedString = key.replace(/-/g, '_');
           return {
             ...accumulator,
-            [sanitized]: value,
+            [transformedString]: value,
           };
         }, {}),
       },

--- a/packages/insomnia/src/utils/importers/importers/postman.test.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.test.ts
@@ -33,9 +33,15 @@ describe('postman', () => {
   })) as HttpsSchemaGetpostmanComJsonCollectionV210;
 
   describe('transformPostmanToNunjucksString', () => {
-    it('should transform a postman request string to an insomnia request string', () => {
+    it('should transform to nunjucks syntax', () => {
       const input = '{{$guid}}abc{{$randomStreetAddress}}def{{$guid}}';
       const output = '{% faker \'guid\' %}abc{% faker \'randomStreetAddress\' %}def{% faker \'guid\' %}';
+      expect(transformPostmanToNunjucksString(input)).toEqual(output);
+      expect(transformPostmanToNunjucksString()).toEqual('');
+    });
+    it('should transform hyphens to underscores', () => {
+      const input = 'abc{{my-env-var}}def{{here-and-here}}ghi';
+      const output = 'abc{{my_env_var}}def{{here_and_here}}ghi';
       expect(transformPostmanToNunjucksString(input)).toEqual(output);
       expect(transformPostmanToNunjucksString()).toEqual('');
     });

--- a/packages/insomnia/src/utils/importers/importers/postman.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.ts
@@ -12,7 +12,6 @@ import {
   Request1 as V200Request1,
   Url,
   UrlEncodedParameter as V200UrlEncodedParameter,
-  Variable2 as V200Variable2,
 } from './postman-2.0.types';
 import {
   Auth as V210Auth,
@@ -26,7 +25,6 @@ import {
   QueryParam,
   Request1 as V210Request1,
   UrlEncodedParameter as V210UrlEncodedParameter,
-  Variable2 as V210Variable2,
 } from './postman-2.1.types';
 
 export const id = 'postman';
@@ -35,7 +33,6 @@ export const description = 'Importer for Postman collections';
 
 type PostmanCollection = V200Schema | V210Schema;
 type EventList = V200EventList | V210EventList;
-type Variable = V200Variable2 | V210Variable2;
 
 type Authetication = V200Auth | V210Auth;
 
@@ -128,19 +125,18 @@ export class ImportPostman {
     this.collection = collection;
   }
 
-  importVariable = (variables: Variable[]) => {
+  importVariable = (variables: { [key: string]: string }[]) => {
     if (variables?.length === 0) {
       return null;
     }
 
-    const variable: { [key: string]: Variable['value'] } = {};
+    const variable: { [key: string]: string } = {};
     for (let i = 0; i < variables.length; i++) {
-
-      const key = transformPostmanToNunjucksString(variables[i].key);
+      const { key, value } = variables[i];
       if (key === undefined) {
         continue;
       }
-      variable[key] = variables[i].value;
+      variable[key] = transformPostmanToNunjucksString(value);
     }
     return variable;
   };
@@ -286,7 +282,7 @@ export class ImportPostman {
       event,
     } = this.collection;
 
-    const postmanVariable = this.importVariable(variable || []);
+    const postmanVariable = this.importVariable((variable as { [key: string]: string }[]) || []);
     const { authentication } = this.importAuthentication(auth);
     const preRequestScript = this.importPreRequestScript(event);
     const afterResponseScript = this.importAfterResponseScript(event);

--- a/packages/insomnia/src/utils/importers/importers/postman.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.ts
@@ -64,10 +64,26 @@ export const transformPostmanToNunjucksString = (inputString?: string | null) =>
   if (!inputString) {
     return '';
   }
-
+  if (typeof inputString !== 'string') {
+    return inputString;
+  }
+  const sanitizedString = replaceHyphens(inputString);
   return postmanTagRegexs.reduce((transformedString, { tag, regex }) => {
     return transformedString.replace(regex, postmanToNunjucksLookup[tag]);
-  }, inputString);
+  }, sanitizedString);
+};
+
+export const replaceHyphens = (input?: string) => {
+  if (!input) {
+    return '';
+  }
+  // Use a regular expression to find and replace the pattern
+  return input.replace(/\{\{([^\}]+)\}\}/g, (_, match) => {
+    // Replace hyphens with underscores within the match
+    const replaced = match.replace(/-/g, '_');
+    // Return the replaced pattern within the curly braces
+    return `{{${replaced}}}`;
+  });
 };
 
 const POSTMAN_SCHEMA_V2_0 =
@@ -119,7 +135,8 @@ export class ImportPostman {
 
     const variable: { [key: string]: Variable['value'] } = {};
     for (let i = 0; i < variables.length; i++) {
-      const key = variables[i].key;
+
+      const key = transformPostmanToNunjucksString(variables[i].key);
       if (key === undefined) {
         continue;
       }


### PR DESCRIPTION
In order to import variables from postman with keys such as one-two-three we need to transform them to one_two_three because our nunjucks library is expecting js object syntax, for example in a js console : (notice the color difference)
```js
{ one_two_three: "works" }
```
```js
{ one-two-three: "doesn't work" }
```

reviewer notes: there might be some cases where the regex doesn't work the way I expect.

the postman types and inconsistent and could be using @types/postman-collection

Related to INS-4041