### PR TITLE
fix(KeyValue Editor): Pressing enter on an input should update the value

### DIFF
--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -54,6 +54,14 @@ const EditableOneLineEditorModal = ({
     }
   }, [buttonRef]);
 
+  const onKeydown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      setIsOpen(false);
+      onChange(value);
+    }
+  }, [onChange, value]);
+
   useResizeObserver({
     ref: buttonRef,
     onResize: onResize,
@@ -116,13 +124,7 @@ const EditableOneLineEditorModal = ({
                 readOnly={readOnly}
                 getAutocompleteConstants={getAutocompleteConstants}
                 onChange={setValue}
-                onKeyDown={e => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    onChange(value);
-                    setIsOpen(false);
-                  }
-                }}
+                onKeyDown={onKeydown}
               />
             </div>
           </FocusScope>

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -3,6 +3,7 @@ import React, { FC, Fragment, useCallback, useRef, useState } from 'react';
 import { FocusScope } from 'react-aria';
 import { Button, Dialog, DialogTrigger, DropIndicator, GridList, GridListItem, Menu, MenuItem, MenuTrigger, Popover, ToggleButton, Toolbar, useDragAndDrop } from 'react-aria-components';
 import { useListData } from 'react-stately';
+import { createKeybindingsHandler } from 'tinykeys';
 
 import { describeByteSize, generateId } from '../../../common/misc';
 import { useNunjucksEnabled } from '../../context/nunjucks/nunjucks-enabled-context';
@@ -54,13 +55,19 @@ const EditableOneLineEditorModal = ({
     }
   }, [buttonRef]);
 
-  const onKeydown = useCallback((e: KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      setIsOpen(false);
-      onChange(value);
-    }
-  }, [onChange, value]);
+  const onKeydown = useCallback((e: KeyboardEvent, value: string) => {
+    const handler = createKeybindingsHandler({
+      'Enter': e => {
+        e.preventDefault();
+        setIsOpen(false);
+        onChange(value);
+        setValue(value);
+      },
+    });
+
+    handler(e);
+  },
+    [onChange]);
 
   useResizeObserver({
     ref: buttonRef,


### PR DESCRIPTION
Fixes an issue where pressing Enter would use the previous value instead of the current