### PR TITLE
fix: help to handle @ when it is not encoded in url

### DIFF
--- a/packages/insomnia-sdk/src/objects/__tests__/urls.test.ts
+++ b/packages/insomnia-sdk/src/objects/__tests__/urls.test.ts
@@ -154,6 +154,14 @@ describe('test Url object', () => {
             url: '{{ baseUrl }}/tom@any.com',
         },
         {
+            testName: '@ is used in auth and path',
+            url: 'user:pass@a.com/tom@any.com',
+        },
+        {
+            testName: '@ is used in auth',
+            url: 'user:pass@a.com/',
+        },
+        {
             testName: '@ is used in path with path params, targs and hash',
             url: '{{ baseUrl }}/:path__{{ _.pathSuffix }}/tom@any.com#hash',
         },

--- a/packages/insomnia-sdk/src/objects/__tests__/urls.test.ts
+++ b/packages/insomnia-sdk/src/objects/__tests__/urls.test.ts
@@ -149,6 +149,14 @@ describe('test Url object', () => {
             testName: 'hybrid of path params and tags',
             url: '{{ baseUrl }}/:path_{{ _.pathSuffix }}',
         },
+        {
+            testName: '@ is used in path',
+            url: '{{ baseUrl }}/tom@any.com',
+        },
+        {
+            testName: '@ is used in path with path params, targs and hash',
+            url: '{{ baseUrl }}/:path__{{ _.pathSuffix }}/tom@any.com#hash',
+        },
     ];
 
     urlParsingTests.forEach(testCase => {

--- a/packages/insomnia-sdk/src/objects/urls.ts
+++ b/packages/insomnia-sdk/src/objects/urls.ts
@@ -197,7 +197,8 @@ export class Url extends PropertyBase {
         const potentialStartOfAuth = protocol === '' ? 0 : endOfProto + 3;
         let endOfAuth = urlStr.indexOf('@', potentialStartOfAuth);
         const startOfPathname = urlStr.indexOf('/', endOfProto >= 0 ? endOfProto + 3 : 0);
-        if (endOfAuth < startOfPathname) {
+        const atCharIsBeforePath = endOfAuth < startOfPathname;
+        if (atCharIsBeforePath) { // this checks if unencoded '@' appears in path
             if (endOfAuth >= 0 && potentialStartOfAuth < endOfAuth) { // e.g., '@insomnia.com' will be ignored
                 const authStr = endOfAuth >= 0 ? urlStr.slice(potentialStartOfAuth, endOfAuth) : '';
                 const authParts = authStr?.split(':');
@@ -207,6 +208,7 @@ export class Url extends PropertyBase {
                 auth = { username: authParts[0], password: authParts[1] };
             }
         } else {
+            // don't do anything if @ appears in path
             endOfAuth = -1;
         }
 

--- a/packages/insomnia-sdk/src/objects/urls.ts
+++ b/packages/insomnia-sdk/src/objects/urls.ts
@@ -188,20 +188,26 @@ export class Url extends PropertyBase {
     static parse(urlStr: string): UrlOptions | undefined {
         // the URL API (for web) is not leveraged here because the input string could contain tags for interpolation
         // which will be encoded, then it would introduce confusion for users in manipulation
+        // TODO: but it still would be better to rely on the URL API
 
         const endOfProto = urlStr.indexOf('://');
         const protocol = endOfProto >= 0 ? urlStr.slice(0, endOfProto + 1) : '';
 
+        let auth: undefined | { username: string; password: string } = undefined;
         const potentialStartOfAuth = protocol === '' ? 0 : endOfProto + 3;
-        const endOfAuth = urlStr.indexOf('@', potentialStartOfAuth);
-        let auth = undefined;
-        if (endOfAuth >= 0 && potentialStartOfAuth < endOfAuth) { // e.g., '@insomnia.com' will be ignored
-            const authStr = endOfAuth >= 0 ? urlStr.slice(potentialStartOfAuth, endOfAuth) : '';
-            const authParts = authStr?.split(':');
-            if (authParts.length < 2) {
-                throw Error('new Url(): failed to parse auth in url ${urlStr}');
+        let endOfAuth = urlStr.indexOf('@', potentialStartOfAuth);
+        const startOfPathname = urlStr.indexOf('/', endOfProto >= 0 ? endOfProto + 3 : 0);
+        if (endOfAuth < startOfPathname) {
+            if (endOfAuth >= 0 && potentialStartOfAuth < endOfAuth) { // e.g., '@insomnia.com' will be ignored
+                const authStr = endOfAuth >= 0 ? urlStr.slice(potentialStartOfAuth, endOfAuth) : '';
+                const authParts = authStr?.split(':');
+                if (authParts.length < 2) {
+                    throw Error(`new Url(): failed to parse auth in url ${urlStr}`);
+                }
+                auth = { username: authParts[0], password: authParts[1] };
             }
-            auth = { username: authParts[0], password: authParts[1] };
+        } else {
+            endOfAuth = -1;
         }
 
         const startOfHash = urlStr.indexOf('#');
@@ -224,7 +230,6 @@ export class Url extends PropertyBase {
             );
         }
 
-        const startOfPathname = urlStr.indexOf('/', endOfProto >= 0 ? endOfProto + 3 : 0);
         const path = new Array<string>();
         if (startOfPathname >= 0) {
             let endOfPathname = urlStr.length;


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Background
Normally `@` is one URL separator and should be encoded if it used in path, but users normally don't aware of this, which will cause url parsing fail.

### Changes
- fix: help to handle @ when it is not encoded in url
- added UTs

Ref: INS-4083, #7603 