### PR TITLE
chore: add request id

### DIFF
--- a/packages/insomnia/src/ui/insomniaFetch.ts
+++ b/packages/insomnia/src/ui/insomniaFetch.ts
@@ -1,5 +1,6 @@
 
 import { getApiBaseURL, getClientString, INSOMNIA_FETCH_TIME_OUT, PLAYWRIGHT } from '../common/constants';
+import { generateId } from '../common/misc';
 
 interface FetchConfig {
   method: 'POST' | 'PUT' | 'GET' | 'DELETE' | 'PATCH';
@@ -19,6 +20,7 @@ export async function insomniaFetch<T = void>({ method, path, data, sessionId, o
     headers: {
       ...headers,
       'X-Insomnia-Client': getClientString(),
+      'insomnia-request-id': generateId('desk'),
       'X-Origin': origin || getApiBaseURL(),
       ...(sessionId ? { 'X-Session-Id': sessionId } : {}),
       ...(data ? { 'Content-Type': 'application/json' } : {}),


### PR DESCRIPTION
We probably want to send the request with an id for tracing purpose. X- prefix is [deprecated](https://www.rfc-editor.org/rfc/rfc6648). When sending a request with a header key:value (insomnia-request-id: uuid), the API will spit out the response with the id sent.

![image](https://github.com/Kong/insomnia/assets/103070941/579fd632-363c-46bb-b717-2bec525b0e4f)


<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
