### PR TITLE
fix(Cookie expires): Invalid date on cookie expires

### DIFF
--- a/packages/insomnia-sdk/src/objects/cookies.ts
+++ b/packages/insomnia-sdk/src/objects/cookies.ts
@@ -8,7 +8,7 @@ export interface CookieOptions {
     id?: string;
     key: string;
     value: string;
-    expires?: Date | string;
+    expires?: Date | string | null;
     maxAge?: string | 'Infinity' | '-Infinity';
     domain?: string;
     path?: string;
@@ -180,8 +180,8 @@ export class CookieObject extends CookieList {
     constructor(cookieJar: InsomniaCookieJar | null) {
         const cookies = cookieJar
             ? cookieJar.cookies.map((cookie: InsomniaCookie): Cookie => {
-                let expires: string | Date = '';
-                if (cookie.expires) {
+                let expires: string | Date | null = null;
+                if (cookie.expires || cookie.expires === 0) {
                     if (typeof cookie.expires === 'number') {
                         expires = new Date(cookie.expires);
                     } else {

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -4,6 +4,7 @@ import { invariant } from '../../utils/invariant';
 invariant(process.type !== 'renderer', 'Native abstractions for Nodejs module unavailable in renderer');
 
 import { Curl, CurlAuth, CurlCode, CurlFeature, CurlHttpVersion, CurlInfoDebug, CurlNetrc, CurlSslOpt } from '@getinsomnia/node-libcurl';
+import { isValid } from 'date-fns';
 import electron from 'electron';
 import fs from 'fs';
 import path from 'path';
@@ -371,7 +372,7 @@ export const createConfiguredCurlInstance = ({
           cookie.hostOnly ? 'FALSE' : 'TRUE',
           cookie.path,
           cookie.secure ? 'TRUE' : 'FALSE',
-          cookie.expires ? Math.round(new Date(cookie.expires).getTime() / 1000) : 0,
+          cookie.expires && isValid(new Date(cookie.expires)) ? Math.round(new Date(cookie.expires).getTime() / 1000) : 0,
           cookie.key,
           cookie.value,
         ].join('\t');

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -254,6 +254,9 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
         globals: globals?.data || undefined,
       },
     });
+    // @TODO This looks overly complicated and could be simplified.
+    // If the timeout promise finishes first the execution promise is still running while it should be cancelled.
+    // Since the execution promise is cancellable and uses an abort controller we should add the timeout to the controller instead
     const output = await Promise.race([timeoutPromise, executionPromise]) as {
       request: Request;
       environment: Record<string, any>;

--- a/packages/insomnia/src/ui/components/cookie-list.tsx
+++ b/packages/insomnia/src/ui/components/cookie-list.tsx
@@ -1,3 +1,4 @@
+import { isValid } from 'date-fns';
 import React, { FC, useCallback, useState } from 'react';
 import { Cookie as ToughCookie } from 'tough-cookie';
 import { v4 as uuidv4 } from 'uuid';
@@ -26,6 +27,10 @@ const CookieRow: FC<{
   deleteCookie: (cookie: Cookie) => void;
 }> = ({ cookie, deleteCookie }) => {
   const [isCookieModalOpen, setIsCookieModalOpen] = useState(false);
+  if (cookie.expires && !isValid(new Date(cookie.expires))) {
+    cookie.expires = null;
+  }
+
   const c = ToughCookie.fromJSON(cookie);
   const cookieString = c ? cookieToString(c) : '';
   return <tr className="selectable" key={cookie.id}>

--- a/packages/insomnia/src/ui/components/modals/cookie-modify-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookie-modify-modal.tsx
@@ -63,6 +63,7 @@ export const CookieModifyModal = ((props: ModalProps & CookieModifyModalOptions)
   if (cookie && cookie.expires && isValid(new Date(cookie.expires))) {
     localDateTime = new Date(cookie.expires).toISOString().slice(0, 16);
   }
+
   let rawDefaultValue;
   if (!cookie) {
     rawDefaultValue = '';

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -374,7 +374,8 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
       return null;
     }
     // disable after-response script here to avoiding rendering it
-    const afterResponseScript = `${mutatedContext.request.afterResponseScript}`;
+    // @TODO This should be handled in a better way. Maybe remove the key from the request object we pass in tryToInterpolateRequest
+    const afterResponseScript = mutatedContext.request.afterResponseScript ? `${mutatedContext.request.afterResponseScript}` : undefined;
     mutatedContext.request.afterResponseScript = '';
 
     window.main.addExecutionStep({ requestId, stepName: 'Rendering request' });


### PR DESCRIPTION
Highlights:

- [x] Fixes an issue where the after-response script would execute even if there was no script defined
- [x] Fixes an issue where cookie expiration dates would be set to an Invalid date when running after-response scripts
- [x] Fixes an issue where invalid expiration dates on cookies would not allow users to copy requests as cURL
- [x] Added extra checks for invalid dates on cookie.expires on both the UI and libcurl to provide fallbacks instead of error

Closes #7604, #7611
Closes INS-4082