### PR TITLE
perf: return deferred data in permission loader

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
 import { isRemoteProject } from '../../../models/project';
+import { useLoaderDeferData } from '../../hooks/use-loader-defer-data';
 import type { OrganizationFeatureLoaderData } from '../../routes/organization';
 import { useRootLoaderData } from '../../routes/root';
 import type { WorkspaceLoaderData } from '../../routes/workspace';
@@ -30,11 +31,11 @@ export const WorkspaceSyncDropdown: FC = () => {
     }
   }, [organizationId, permissionsFetcher]);
 
-  const { features } = permissionsFetcher.data || {
-    features: {
-      gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
-    },
-  };
+  const { featuresPromise } = permissionsFetcher.data || {};
+  const [features = {
+    gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
+  }] = useLoaderDeferData(featuresPromise);
+
   if (!userSession.id) {
     return null;
   }

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -7,6 +7,7 @@ import { docsTemplateTags } from '../../../common/documentation';
 import { debounce } from '../../../common/misc';
 import type { Environment } from '../../../models/environment';
 import { isRemoteProject } from '../../../models/project';
+import { useLoaderDeferData } from '../../hooks/use-loader-defer-data';
 import type { OrganizationFeatureLoaderData } from '../../routes/organization';
 import type { WorkspaceLoaderData } from '../../routes/workspace';
 import { EditableInput } from '../editable-input';
@@ -31,11 +32,11 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: {
     }
   }, [organizationId, permissionsFetcher]);
 
-  const { features } = permissionsFetcher.data || {
-    features: {
-      gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
-    },
-  };
+  const { featuresPromise } = permissionsFetcher.data || {};
+  const [features = {
+    gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
+  }] = useLoaderDeferData(featuresPromise);
+
   const createEnvironmentFetcher = useFetcher();
   const deleteEnvironmentFetcher = useFetcher();
   const updateEnvironmentFetcher = useFetcher();

--- a/packages/insomnia/src/ui/hooks/use-loader-defer-data.ts
+++ b/packages/insomnia/src/ui/hooks/use-loader-defer-data.ts
@@ -25,7 +25,7 @@ export const useLoaderDeferData = <T>(deferedDataPromise?: Promise<T>, keepStale
         setData(data);
       } catch (err) {
         setError(err);
-        console.log('Failed to load defered data', err);
+        console.warn('Failed to load defered data', err);
       }
     })();
   }, [deferedDataPromise, keepStaleDataKey]);

--- a/packages/insomnia/src/ui/routes/environments.tsx
+++ b/packages/insomnia/src/ui/routes/environments.tsx
@@ -15,6 +15,7 @@ import { EnvironmentEditor, type EnvironmentEditorHandle, type EnvironmentInfo }
 import { Icon } from '../components/icon';
 import { useDocBodyKeyboardShortcuts } from '../components/keydown-binder';
 import { showAlert } from '../components/modals';
+import { useLoaderDeferData } from '../hooks/use-loader-defer-data';
 import type { OrganizationFeatureLoaderData } from './organization';
 import type { WorkspaceLoaderData } from './workspace';
 
@@ -34,11 +35,10 @@ const Environments = () => {
     }
   }, [organizationId, permissionsFetcher]);
 
-  const { features } = permissionsFetcher.data || {
-    features: {
-      gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
-    },
-  };
+  const { featuresPromise } = permissionsFetcher.data || {};
+  const [features = {
+    gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
+  }] = useLoaderDeferData(featuresPromise);
 
   const createEnvironmentFetcher = useFetcher();
   const deleteEnvironmentFetcher = useFetcher();

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -612,16 +612,16 @@ const ProjectRoute: FC = () => {
   }, [organizationId, permissionsFetcher.load]);
 
   const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
-  const { features, billing, storage } = permissionsFetcher.data || {
-    features: {
-      gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
-      orgBasicRbac: { enabled: false, reason: 'Insomnia API unreachable' },
-    },
-    billing: {
-      isActive: true,
-    },
-    storage: 'cloud_plus_local',
-  };
+
+  const { featuresPromise, billingPromise, storagePromise } = permissionsFetcher.data || {};
+  const [features = {
+    gitSync: { enabled: false, reason: 'Insomnia API unreachable' },
+    orgBasicRbac: { enabled: false, reason: 'Insomnia API unreachable' },
+  }] = useLoaderDeferData(featuresPromise);
+  const [billing = {
+    isActive: true,
+  }] = useLoaderDeferData(billingPromise);
+  const [storage = 'cloud_plus_local'] = useLoaderDeferData(storagePromise);
   const [projectListFilter, setProjectListFilter] = useLocalStorage(`${organizationId}:project-list-filter`, '');
   const [workspaceListFilter, setWorkspaceListFilter] = useLocalStorage(`${projectId}:workspace-list-filter`, '');
   const [workspaceListScope, setWorkspaceListScope] = useLocalStorage(`${projectId}:workspace-list-scope`, 'all');


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

> Any [fetcher.load](https://reactrouter.com/en/main/hooks/use-fetcher#fetcherloadhref-options) calls that are active on the page will be re-executed as part of revalidation
We use `fetcher.load` to load `organizationPermissionsLoader`, and it will block route navigation (such as switch between organization).

So any fetcher.load will block route navigation such as switch between orgs or projects

**Changes**

- [x] return deferred data in `organizationPermissionsLoader`
- [x] use `useLoaderDeferData` hook to deal with the deferred data in every place we fetch this loader