### PR TITLE
fix: folder scripts are not executed if request script is not enabled

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -205,6 +205,8 @@ resources:
     environmentPropertyOrder: null
     metaSortKey: -1668533312225
     _type: request_group
+    preRequestScript: |-
+      insomnia.environment.set('onlySetByFolderPreScript', 888);
   - _id: req_89dade2ee9ee42fbb22d588783a9df3c
     parentId: fld_01de564274824ecaad272330339ea6b2
     modified: 1636707449231
@@ -1215,12 +1217,11 @@ resources:
     settingEncodeUrl: true
     settingRebuildPath: true
     settingFollowRedirects: global
-    preRequestScript: |-
-      insomnia.environment.set('onlySetByFolderScript', 888);
+    preRequestScript: ''
     body:
       mimeType: "application/json"
       text: |-
         {
-          "onlySetByFolderScript": {{ onlySetByFolderScript }}
+          "onlySetByFolderPreScript": {{ onlySetByFolderPreScript }}
         }
     _type: request

--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -1194,3 +1194,33 @@ resources:
           "setByScript": "{{ setByScript }}"
         }
     _type: request
+  - _id: req_89dade2ee9ee42fbb22d588783a9df20
+    parentId: fld_01de564274824ecaad272330339ea6b2
+    modified: 1636707449231
+    created: 1636141014552
+    url: http://127.0.0.1:4010/echo
+    name: run parent scripts only
+    description: ""
+    method: POST
+    parameters: []
+    headers:
+      - name: 'Content-Type'
+        value: 'application/json'
+    authentication: {}
+    metaSortKey: -1636141014553
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    preRequestScript: |-
+      insomnia.environment.set('onlySetByFolderScript', 888);
+    body:
+      mimeType: "application/json"
+      text: |-
+        {
+          "onlySetByFolderScript": {{ onlySetByFolderScript }}
+        }
+    _type: request

--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -207,6 +207,8 @@ resources:
     _type: request_group
     preRequestScript: |-
       insomnia.environment.set('onlySetByFolderPreScript', 888);
+    afterResponseScript: |-
+      insomnia.environment.unset('onlySetByFolderPreScript');
   - _id: req_89dade2ee9ee42fbb22d588783a9df3c
     parentId: fld_01de564274824ecaad272330339ea6b2
     modified: 1636707449231

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -174,12 +174,12 @@ test.describe('pre-request features tests', async () => {
                 asyncTaskDone: true,
             },
         },
-        // {
-        //     name: 'can manipulate global envs',
-        //     expectedBody: {
-        //         setByScript: 'setByScript',
-        //     },
-        // },
+        {
+            name: 'run parent scripts only',
+            expectedBody: {
+                'onlySetByFolderScript': 888,
+            },
+        },
     ];
 
     for (let i = 0; i < testCases.length; i++) {

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -177,7 +177,7 @@ test.describe('pre-request features tests', async () => {
         {
             name: 'run parent scripts only',
             expectedBody: {
-                'onlySetByFolderScript': 888,
+                'onlySetByFolderPreScript': 888,
             },
         },
     ];

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -26,7 +26,7 @@ import { Response } from '../../models/response';
 import { isWebSocketRequest, isWebSocketRequestId, WebSocketRequest } from '../../models/websocket-request';
 import { WebSocketResponse } from '../../models/websocket-response';
 import { getAuthHeader } from '../../network/authentication';
-import { fetchRequestData, tryToExecutePreRequestScript, responseTransform, sendCurlAndWriteTimeline, tryToExecuteAfterResponseScript, tryToInterpolateRequest, tryToTransformRequestWithPlugins } from '../../network/network';
+import { fetchRequestData, responseTransform, sendCurlAndWriteTimeline, tryToExecuteAfterResponseScript, tryToExecutePreRequestScript, tryToInterpolateRequest, tryToTransformRequestWithPlugins } from '../../network/network';
 import { RenderErrorSubType } from '../../templating';
 import { invariant } from '../../utils/invariant';
 import { SegmentEvent } from '../analytics';

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -26,7 +26,7 @@ import { Response } from '../../models/response';
 import { isWebSocketRequest, isWebSocketRequestId, WebSocketRequest } from '../../models/websocket-request';
 import { WebSocketResponse } from '../../models/websocket-response';
 import { getAuthHeader } from '../../network/authentication';
-import { fetchRequestData, getPreRequestScriptOutput, responseTransform, savePatchesMadeByScript, sendCurlAndWriteTimeline, tryToExecuteAfterResponseScript, tryToInterpolateRequest, tryToTransformRequestWithPlugins } from '../../network/network';
+import { fetchRequestData, tryToExecutePreRequestScript, responseTransform, sendCurlAndWriteTimeline, tryToExecuteAfterResponseScript, tryToInterpolateRequest, tryToTransformRequestWithPlugins } from '../../network/network';
 import { RenderErrorSubType } from '../../templating';
 import { invariant } from '../../utils/invariant';
 import { SegmentEvent } from '../analytics';
@@ -367,8 +367,9 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
   try {
     window.main.startExecution({ requestId });
     const requestData = await fetchRequestData(requestId);
+
     window.main.addExecutionStep({ requestId, stepName: 'Executing pre-request script' });
-    const mutatedContext = await getPreRequestScriptOutput(requestData, workspaceId);
+    const mutatedContext = await tryToExecutePreRequestScript(requestData, workspaceId);
     window.main.completeExecutionStep({ requestId });
     if (mutatedContext === null) {
       return null;
@@ -421,29 +422,14 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
     const shouldWriteToFile = shouldPromptForPathAfterResponse && is2XXWithBodyPath;
 
     mutatedContext.request.afterResponseScript = afterResponseScript;
-    if (requestData.request.afterResponseScript) {
-      const baseEnvironment = await models.environment.getOrCreateForParentId(workspaceId);
-      const cookieJar = await models.cookieJar.getOrCreateForParentId(workspaceId);
-      const globals = mutatedContext.globals;
+    window.main.addExecutionStep({ requestId, stepName: 'Executing after-response script' });
+    await tryToExecuteAfterResponseScript({
+      ...requestData,
+      ...mutatedContext,
+      response,
+    });
+    window.main.completeExecutionStep({ requestId });
 
-      window.main.addExecutionStep({ requestId, stepName: 'Executing after-response script' });
-
-      const postMutatedContext = await tryToExecuteAfterResponseScript({
-        ...requestData,
-        ...mutatedContext,
-        baseEnvironment,
-        cookieJar,
-        response,
-        globals,
-      });
-      window.main.completeExecutionStep({ requestId });
-      if (!postMutatedContext?.request) {
-        // exiy early if there was a problem with the pre-request script
-        // TODO: improve error message?
-        return null;
-      }
-      await savePatchesMadeByScript(postMutatedContext, requestData.environment, baseEnvironment, globals);
-    }
     if (!shouldWriteToFile) {
       const response = await models.response.create(responsePatch, requestData.settings.maxHistoryResponses);
       await models.requestMeta.update(requestMeta, { activeResponseId: response._id });


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes
- fix: check joined script length instead of current script state
- added tests
- refactored and flattened functions for running scripts, and timing of the after-response script step will always be displayed, which is consistent with pre script step.

Ref: INS-4107 #7637 