### PR TITLE
fix: generating curl command returns <getTime> error

### DIFF
--- a/packages/insomnia-sdk/src/objects/__tests__/cookies.test.ts
+++ b/packages/insomnia-sdk/src/objects/__tests__/cookies.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { Cookie, CookieJar, CookieList } from '../cookies';
+import { Cookie, CookieJar, CookieList, CookieObject, mergeCookieJar } from '../cookies';
 
 describe('test Cookie object', () => {
     it('test basic operations', () => {
@@ -13,7 +13,7 @@ describe('test Cookie object', () => {
             value: 'value',
             domain: 'inso.com',
             expires: new Date('2015-10-21T07:28:00.000Z'),
-            maxAge: '0',
+            maxAge: 0,
             path: '/',
             secure: true,
             httpOnly: true,
@@ -26,7 +26,7 @@ describe('test Cookie object', () => {
             key: 'myCookie',
             value: 'myCookie',
             expires: '01 Jan 1970 00:00:01 GMT',
-            maxAge: '7',
+            maxAge: 7,
             domain: 'domain.com',
             path: '/',
             secure: true,
@@ -49,12 +49,12 @@ describe('test Cookie object', () => {
         const c1 = new Cookie({
             key: 'c1',
             value: 'c1',
-            maxAge: '1',
+            maxAge: 1,
         });
         const c2 = new Cookie({
             key: 'c2',
             value: 'c2',
-            maxAge: '2',
+            maxAge: 2,
         });
         const CookieListStr = Cookie.unparse([c1, c2]);
         expect(CookieListStr).toEqual(
@@ -65,6 +65,64 @@ describe('test Cookie object', () => {
             Cookie.unparseSingle(cookie1Opt)
         ).toEqual(expectedCookieString);
     });
+
+    it('test cookie transforming', () => {
+        const fakeBaseModel = {
+            _id: '',
+            type: '',
+            parentId: '',
+            modified: 0,
+            created: 0,
+            isPrivate: false,
+            name: '',
+        };
+        const cookieJars = [
+            {
+                cookies: [
+                    {
+                        id: '1',
+                        key: 'c1',
+                        value: 'v1',
+                        expires: null,
+                        domain: 'inso.com',
+                        path: '/',
+                        secure: true,
+                        httpOnly: true,
+                        extensions: [],
+                        creation: new Date(),
+                        creationIndex: 0,
+                        hostOnly: true,
+                        pathIsDefault: true,
+                        lastAccessed: new Date(),
+                    },
+                    {
+                        id: '2',
+                        key: 'c2',
+                        value: 'v2',
+                        expires: new Date('08 Aug 1988 08:08:08 GMT'),
+                        domain: 'inso.com',
+                        path: '/',
+                        secure: true,
+                        httpOnly: true,
+                        extensions: [],
+                        creation: new Date(),
+                        creationIndex: 0,
+                        hostOnly: true,
+                        pathIsDefault: true,
+                        lastAccessed: new Date(),
+                    },
+                ],
+            },
+        ];
+
+        cookieJars.forEach(jar => {
+            const originalJar = { ...fakeBaseModel, ...jar };
+            const sdkJar = new CookieObject(originalJar);
+            const convertedJar = mergeCookieJar(originalJar, sdkJar.jar().toInsomniaCookieJar());
+
+            expect(convertedJar).toEqual(originalJar);
+        });
+    });
 });
 
 describe('test CookieJar', () => {
@@ -73,7 +131,7 @@ describe('test CookieJar', () => {
             key: 'myCookie',
             value: 'myCookie',
             expires: '01 Jan 1970 00:00:01 GMT',
-            maxAge: '7',
+            maxAge: 7,
             domain: 'domain.com',
             path: '/',
             secure: true,

--- a/packages/insomnia-sdk/src/objects/cookies.ts
+++ b/packages/insomnia-sdk/src/objects/cookies.ts
@@ -4,12 +4,19 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { Property, PropertyList } from './properties';
 
-export interface CookieOptions {
+export interface InsomniaCookieExtensions {
+    creation?: Date;
+    creationIndex?: number;
+    lastAccessed?: Date;
+    pathIsDefault?: boolean;
+};
+
+export interface CookieOptions extends InsomniaCookieExtensions {
     id?: string;
     key: string;
     value: string;
     expires?: Date | string | null;
-    maxAge?: string | 'Infinity' | '-Infinity';
+    maxAge?: number | 'Infinity' | '-Infinity';
     domain?: string;
     path?: string;
     secure?: boolean;
@@ -23,6 +30,7 @@ export class Cookie extends Property {
     readonly _kind: string = 'Cookie';
     protected cookie: ToughCookie;
     private extensions?: { key: string; value: string }[];
+    private insoExtensions: InsomniaCookieExtensions = {};
 
     constructor(cookieDef: CookieOptions | string) {
         super();
@@ -46,6 +54,12 @@ export class Cookie extends Property {
 
         this.id = cookieDef.id || '';
         this.cookie = cookie;
+        this.insoExtensions = {
+            creation: cookieDef.creation,
+            creationIndex: cookieDef.creationIndex,
+            lastAccessed: cookieDef.lastAccessed,
+            pathIsDefault: cookieDef.pathIsDefault,
+        };
     }
 
     static _index = 'key';
@@ -94,7 +108,7 @@ export class Cookie extends Property {
             key: cookieObj.key,
             value: cookieObj.value,
             expires: cookieObj.expires || undefined,
-            maxAge: `${cookieObj.maxAge}` || undefined,
+            maxAge: cookieObj.maxAge,
             domain: cookieObj.domain || undefined,
             path: cookieObj.path || undefined,
             secure: cookieObj.secure || false,
@@ -154,6 +168,11 @@ export class Cookie extends Property {
             hostOnly: this.cookie.hostOnly,
             session: this.cookie.extensions?.includes('session'),
             extensions: this.extensions,
+            // extra fields from Insomnia
+            creation: this.insoExtensions.creation,
+            creationIndex: this.insoExtensions.creationIndex,
+            lastAccessed: this.insoExtensions.lastAccessed,
+            pathIsDefault: this.insoExtensions.pathIsDefault,
         };
     };
 }
@@ -202,6 +221,11 @@ export class CookieObject extends CookieList {
                     hostOnly: cookie.hostOnly,
                     session: undefined, // not supported in Insomnia
                     extensions: undefined, // TODO: its format from Insomnia is unknown
+                    // follows are properties from Insomnia
+                    creation: cookie.creation,
+                    creationIndex: cookie.creationIndex,
+                    lastAccessed: cookie.lastAccessed,
+                    pathIsDefault: cookie.pathIsDefault,
                 });
             })
             : [];
@@ -316,11 +340,11 @@ export class CookieJar {
                         secure: cookieObj.secure,
                         httpOnly: cookieObj.httpOnly,
                         extensions: cookieObj.extensions || undefined,
-                        creation: undefined,
-                        creationIndex: undefined,
+                        creation: cookieObj.creation,
+                        creationIndex: cookieObj.creationIndex,
                         hostOnly: cookieObj.hostOnly || undefined,
-                        pathIsDefault: undefined,
-                        lastAccessed: undefined,
+                        pathIsDefault: cookieObj.pathIsDefault,
+                        lastAccessed: cookieObj.lastAccessed,
                     });
                 });
             });

--- a/packages/insomnia-sdk/src/objects/cookies.ts
+++ b/packages/insomnia-sdk/src/objects/cookies.ts
@@ -310,7 +310,7 @@ export class CookieJar {
                         id: cookieObj.id,
                         key: cookieObj.key,
                         value: cookieObj.value,
-                        expires: cookieObj.expires,
+                        expires: cookieObj.expires || 'Infinity', // transform it back to 'Infinity', avoid edge cases
                         domain: cookieObj.domain || undefined,
                         path: cookieObj.path || undefined,
                         secure: cookieObj.secure,

--- a/packages/insomnia/src/common/har.ts
+++ b/packages/insomnia/src/common/har.ts
@@ -258,9 +258,11 @@ export async function exportHarWithRenderedRequest(
 }
 
 function getRequestCookies(renderedRequest: RenderedRequest) {
-  // sanitize null expires property or getCookiesSync will throw error
+  // filter out invalid cookies to avoid getCookiesSync complaining
   const sanitized = renderedRequest.cookieJar.cookies.map(cookie => {
     if (!cookie.expires) {
+      // TODO: null will make getCookiesSync unhappy
+      // probably it should be `undefined` when types of tough cookie is updated
       cookie.expires = 'Infinity';
     }
     return cookie;

--- a/packages/insomnia/src/common/har.ts
+++ b/packages/insomnia/src/common/har.ts
@@ -258,7 +258,15 @@ export async function exportHarWithRenderedRequest(
 }
 
 function getRequestCookies(renderedRequest: RenderedRequest) {
-  const jar = jarFromCookies(renderedRequest.cookieJar.cookies);
+  // sanitize null expires property or getCookiesSync will throw error
+  const sanitized = renderedRequest.cookieJar.cookies.map(cookie => {
+    if (!cookie.expires) {
+      cookie.expires = 'Infinity';
+    }
+    return cookie;
+  });
+
+  const jar = jarFromCookies(sanitized);
   const domainCookies = renderedRequest.url ? jar.getCookiesSync(renderedRequest.url) : [];
   const harCookies: Har.Cookie[] = domainCookies.map(mapCookie);
   return harCookies;


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes
- sanitize `expires` properties before generating

### TODO
- Clean up cookie usages because there are several schemas and consumed by Curl, tough-cookie itself and scripts.