### PR TITLE
fix: Use SSE for storage control updates

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -202,7 +202,14 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
                     } else if (type === 'local' && project.remoteId && !projectType) {
                       setProjectType('local');
                     } else {
-                      console.log('submitting form data', type);
+                      if (!type) {
+                        showAlert({
+                          title: 'Project type not selected',
+                          message: 'Please select a project type before continuing',
+                        });
+                        return;
+                      }
+
                       updateProjectFetcher.submit(formData, {
                         action: `/organization/${organizationId}/project/${project._id}/update`,
                         method: 'post',

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -189,9 +189,6 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
                     <Icon icon="x" />
                   </Button>
                 </div>
-                {isDefaultOrganizationProject(project) && <p>
-                  <Icon icon="info-circle" /> This is the default project for your organization. You can not delete it or change its type.
-                </p>}
                 <form
                   className='flex flex-col gap-4'
                   onSubmit={e => {
@@ -229,7 +226,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
                         className="py-1 placeholder:italic w-full pl-2 pr-7 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font] focus:outline-none focus:ring-1 focus:ring-[--hl-md] transition-colors"
                       />
                     </TextField>
-                    <RadioGroup name="type" defaultValue={project.remoteId ? 'remote' : 'local'} className="flex flex-col gap-2">
+                    <RadioGroup name="type" defaultValue={storage === 'cloud_plus_local' ? project.remoteId ? 'remote' : 'local' : storage !== 'cloud_only' ? 'local' : 'remote'} className="flex flex-col gap-2">
                       <Label className="text-sm text-[--hl]">
                         Project type
                       </Label>

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -52,6 +52,8 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
   const isRemoteProjectInconsistent = isRemoteProject(project) && storage === 'local_only';
   const isLocalProjectInconsistent = !isRemoteProject(project) && storage === 'cloud_only';
   const isProjectInconsistent = isRemoteProjectInconsistent || isLocalProjectInconsistent;
+  const showStorageRestrictionMessage = storage !== 'cloud_plus_local';
+
   const projectActionList: ProjectActionItem[] = [
     {
       id: 'settings',
@@ -304,7 +306,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
                     <div className="flex items-center gap-2 text-sm">
                       <Icon icon="info-circle" />
                       <span>
-                        {isProjectInconsistent && `The organization owner mandates that projects must be created and stored ${storage.split('_').join(' ')}.`} You can optionally enable Git Sync
+                        {showStorageRestrictionMessage && `The organization owner mandates that projects must be created and stored ${storage.split('_').join(' ')}.`} You can optionally enable Git Sync
                       </span>
                     </div>
                     <div className='flex items-center gap-2'>

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -202,6 +202,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
                     } else if (type === 'local' && project.remoteId && !projectType) {
                       setProjectType('local');
                     } else {
+                      console.log('submitting form data', type);
                       updateProjectFetcher.submit(formData, {
                         action: `/organization/${organizationId}/project/${project._id}/update`,
                         method: 'post',

--- a/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, type FC, type PropsWithChildren, useContext, useEffect, useState } from 'react';
-import { useFetcher, useParams, useRevalidator, useRouteLoaderData } from 'react-router-dom';
+import { useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
 import { insomniaFetch } from '../../../ui/insomniaFetch';
 import type { ProjectIdLoaderData } from '../../routes/project';
@@ -86,7 +86,6 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
   const syncStorageRuleFetcher = useFetcher();
   const syncProjectsFetcher = useFetcher();
   const syncDataFetcher = useFetcher();
-  const { revalidate } = useRevalidator();
 
   // Update presence when the user switches org, projects, workspaces
   useEffect(() => {
@@ -121,7 +120,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
 
   useEffect(() => {
     const sessionId = userSession.id;
-    if (sessionId && remoteId) {
+    if (sessionId) {
       try {
         const source = new EventSource(`insomnia-event-source://v1/teams/${sanitizeTeamId(organizationId)}/streams?sessionId=${sessionId}`);
 
@@ -160,12 +159,12 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
                 action: `/organization/${organizationId}/sync-projects`,
                 method: 'POST',
               });
-            } else if (event.type === 'FileDeleted' && event.team === organizationId && event.project === remoteId) {
+            } else if (event.type === 'FileDeleted' && event.team === organizationId && remoteId && event.project === remoteId) {
               syncProjectsFetcher.submit({}, {
                 action: `/organization/${organizationId}/sync-projects`,
                 method: 'POST',
               });
-            } else if (['BranchDeleted', 'FileChanged'].includes(event.type) && event.team === organizationId && event.project === remoteId) {
+            } else if (['BranchDeleted', 'FileChanged'].includes(event.type) && event.team === organizationId && remoteId && event.project === remoteId) {
               syncDataFetcher.submit({}, {
                 method: 'POST',
                 action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/sync-data`,
@@ -184,7 +183,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
       }
     }
     return;
-  }, [organizationId, projectId, remoteId, revalidate, syncDataFetcher, syncOrganizationsFetcher, syncProjectsFetcher, syncStorageRuleFetcher, userSession.id, workspaceId]);
+  }, [organizationId, projectId, remoteId, syncDataFetcher, syncOrganizationsFetcher, syncProjectsFetcher, syncStorageRuleFetcher, userSession.id, workspaceId]);
 
   return (
     <InsomniaEventStreamContext.Provider

--- a/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
@@ -62,7 +62,7 @@ export interface UserPresence {
 }
 
 interface UserPresenceEvent extends UserPresence {
-  type: 'PresentUserLeave' | 'PresentStateChanged' | 'OrganizationChanged';
+  type: 'PresentUserLeave' | 'PresentStateChanged' | 'OrganizationChanged' | 'StorageRuleChanged';
 }
 
 export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children }) => {
@@ -83,6 +83,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
 
   const [presence, setPresence] = useState<UserPresence[]>([]);
   const syncOrganizationsFetcher = useFetcher();
+  const syncStorageRuleFetcher = useFetcher();
   const syncProjectsFetcher = useFetcher();
   const syncDataFetcher = useFetcher();
   const { revalidate } = useRevalidator();
@@ -147,6 +148,13 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
                 action: '/organization/sync',
                 method: 'POST',
               });
+            } else if (event.type === 'StorageRuleChanged' && event.team && event.team.includes('org_')) {
+              const orgId = event.team;
+
+              syncStorageRuleFetcher.submit({}, {
+                action: `/organization/${orgId}/sync-storage-rule`,
+                method: 'POST',
+              });
             } else if (event.type === 'TeamProjectChanged' && event.team === organizationId) {
               syncProjectsFetcher.submit({}, {
                 action: `/organization/${organizationId}/sync-projects`,
@@ -176,7 +184,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
       }
     }
     return;
-  }, [organizationId, projectId, remoteId, revalidate, syncDataFetcher, syncOrganizationsFetcher, syncProjectsFetcher, userSession.id, workspaceId]);
+  }, [organizationId, projectId, remoteId, revalidate, syncDataFetcher, syncOrganizationsFetcher, syncProjectsFetcher, syncStorageRuleFetcher, userSession.id, workspaceId]);
 
   return (
     <InsomniaEventStreamContext.Provider

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -197,6 +197,20 @@ async function renderApp() {
                     shouldRevalidate: data => data.currentParams.organizationId !== data.nextParams.organizationId,
                   },
                   {
+                    path: 'storage-rule',
+                    loader: async (...args) =>
+                      (
+                        await import('./routes/organization')
+                      ).organizationStorageLoader(...args),
+                  },
+                  {
+                    path: 'sync-storage-rule',
+                    action: async (...args) =>
+                      (
+                        await import('./routes/organization')
+                      ).syncOrganizationStorageRuleAction(...args),
+                  },
+                  {
                     path: 'sync-projects',
                     action: async (...args) =>
                       (

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -80,7 +80,7 @@ export const createNewProjectAction: ActionFunction = async ({ request, params }
       }
 
       if (newCloudProject.error === 'PROJECT_STORAGE_RESTRICTION') {
-        error = 'The owner of the organization allows only Local Vault project creation, please try again.';
+        error = newCloudProject.message ?? 'The owner of the organization allows only Local Vault project creation.';
       }
 
       return {

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -391,15 +391,14 @@ export const organizationStorageLoader: LoaderFunction = async ({ params }): Pro
       sessionId,
     });
 
-    const storageRule = await storageRuleResponse.then(res => res);
-
-    invariant(storageRule, 'Failed to load storageRule');
-
-    inMemoryStorageRuleCache.set(organizationId, storageRule);
-
     // Return the value
     return {
-      storagePromise: Promise.resolve(storageRule?.storage || DefaultStorage),
+      storagePromise: storageRuleResponse.then(res => {
+        if (res) {
+          inMemoryStorageRuleCache.set(organizationId, res);
+        }
+        return res?.storage || DefaultStorage;
+      }),
     };
   } catch (err) {
     return {

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -256,9 +256,7 @@ async function syncStorageRule(sessionId: string, organizationId: string) {
 
     invariant(storageRule, 'Failed to load storageRule');
 
-    const cacheKey = `${organizationId}:storage-rule`;
-
-    inMemoryStorageRuleCache.set(cacheKey, storageRule);
+    inMemoryStorageRuleCache.set(organizationId, storageRule);
   } catch (error) {
     console.log('[storageRule] Failed to load storage rules', error);
   }
@@ -377,9 +375,7 @@ export const organizationStorageLoader: LoaderFunction = async ({ params }): Pro
   const { organizationId } = params as { organizationId: string };
   const { id: sessionId } = await userSession.getOrCreate();
 
-  const cacheKey = `${organizationId}:storage-rule`;
-
-  const storageRule = inMemoryStorageRuleCache.get(cacheKey);
+  const storageRule = inMemoryStorageRuleCache.get(organizationId);
 
   if (storageRule) {
     return {
@@ -397,7 +393,7 @@ export const organizationStorageLoader: LoaderFunction = async ({ params }): Pro
 
     invariant(storageRule, 'Failed to load storageRule');
 
-    inMemoryStorageRuleCache.set(cacheKey, storageRule);
+    inMemoryStorageRuleCache.set(organizationId, storageRule);
 
     // Return the value
     return {

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -393,7 +393,7 @@ export const organizationStorageLoader: LoaderFunction = async ({ params }): Pro
   // Try to load from cache
   const cachedResponse = await cache.match(cacheKey);
 
-  if (cachedResponse) {
+  if (cachedResponse && Object.keys(cachedResponse).length > 0) {
     const storageRule = await cachedResponse.json();
 
     return {

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -248,13 +248,11 @@ async function migrateProjectsUnderOrganization(personalOrganizationId: string, 
 
 async function syncStorageRule(sessionId: string, organizationId: string) {
   try {
-    const [storageRule] = await Promise.all([
-      insomniaFetch<StorageRule | undefined>({
+    const storageRule = await insomniaFetch<StorageRule | undefined>({
         method: 'GET',
         path: `/v1/organizations/${organizationId}/storage-rule`,
         sessionId,
-      }),
-    ]);
+    });
 
     invariant(storageRule, 'Failed to load storageRule');
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -474,6 +474,12 @@ interface LearningFeature {
   cta: string;
   url: string;
 }
+
+interface OrgAndProjectData {
+  organizationId: string;
+  projectId: string;
+}
+
 const getLearningFeature = async (fallbackLearningFeature: LearningFeature) => {
   let learningFeature = fallbackLearningFeature;
   const lastFetchedString = window.localStorage.getItem('learning-feature-last-fetch');
@@ -605,7 +611,7 @@ const ProjectRoute: FC = () => {
   const { presence } = useInsomniaEventStreamContext();
   const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>({ key: `permissions:${organizationId}` });
   const storageRuleFetcher = useFetcher<OrganizationStorageLoaderData>({ key: `storage-rule:${organizationId}` });
-  const [lastLoadedOrganizationId, setLastLoadedOrganizationId] = useState('');
+  const [lastLoadedOrgIdAndProjectId, setLastLoadedOrgIdAndProjectId] = useState<OrgAndProjectData>();
 
   useEffect(() => {
     if (!isScratchpadOrganizationId(organizationId)) {
@@ -617,12 +623,12 @@ const ProjectRoute: FC = () => {
   useEffect(() => {
     const isIdleAndUninitialized = storageRuleFetcher.state === 'idle' && !storageRuleFetcher.data && !isScratchpadOrganizationId(organizationId);
 
-    if (isIdleAndUninitialized || lastLoadedOrganizationId !== organizationId) {
+    if (isIdleAndUninitialized || lastLoadedOrgIdAndProjectId?.organizationId !== organizationId || lastLoadedOrgIdAndProjectId?.projectId !== projectId) {
       storageRuleFetcher.load(`/organization/${organizationId}/storage-rule`);
       // Update the state tracking the last loaded organization ID
-      setLastLoadedOrganizationId(organizationId);
+      setLastLoadedOrgIdAndProjectId({ organizationId, projectId });
     }
-  }, [lastLoadedOrganizationId, organizationId, storageRuleFetcher]);
+  }, [lastLoadedOrgIdAndProjectId, organizationId, projectId, storageRuleFetcher]);
 
   const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -631,9 +631,11 @@ const ProjectRoute: FC = () => {
     isActive: true,
   }] = useLoaderDeferData(billingPromise);
 
-  const { storage } = storageRuleFetcher.data || {
+  const { storagePromise } = storageRuleFetcher.data || {
     storage: DefaultStorage,
   };
+
+  const [storage = 'cloud_plus_local'] = useLoaderDeferData(storagePromise);
 
   const [projectListFilter, setProjectListFilter] = useLocalStorage(`${organizationId}:project-list-filter`, '');
   const [workspaceListFilter, setWorkspaceListFilter] = useLocalStorage(`${projectId}:workspace-list-filter`, '');

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -605,7 +605,6 @@ const ProjectRoute: FC = () => {
   const { presence } = useInsomniaEventStreamContext();
   const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>({ key: `permissions:${organizationId}` });
   const storageRuleFetcher = useFetcher<OrganizationStorageLoaderData>({ key: `storage-rule:${organizationId}` });
-  const [lastLoadedOrganizationId, setLastLoadedOrganizationId] = useState('');
 
   useEffect(() => {
     if (!isScratchpadOrganizationId(organizationId)) {
@@ -615,14 +614,11 @@ const ProjectRoute: FC = () => {
   }, [organizationId, permissionsFetcher.load]);
 
   useEffect(() => {
-    const isIdleAndUninitialized = storageRuleFetcher.state === 'idle' && !storageRuleFetcher.data && !isScratchpadOrganizationId(organizationId);
-
-    if (isIdleAndUninitialized || lastLoadedOrganizationId !== organizationId) {
-      storageRuleFetcher.load(`/organization/${organizationId}/storage-rule`);
-      // Update the state tracking the last loaded organization ID
-      setLastLoadedOrganizationId(organizationId);
+    if (!isScratchpadOrganizationId(organizationId)) {
+      const load = storageRuleFetcher.load;
+      load(`/organization/${organizationId}/storage-rule`);
     }
-  }, [lastLoadedOrganizationId, organizationId, storageRuleFetcher]);
+  }, [organizationId, storageRuleFetcher.load]);
 
   const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -474,12 +474,6 @@ interface LearningFeature {
   cta: string;
   url: string;
 }
-
-interface OrgAndProjectData {
-  organizationId: string;
-  projectId: string;
-}
-
 const getLearningFeature = async (fallbackLearningFeature: LearningFeature) => {
   let learningFeature = fallbackLearningFeature;
   const lastFetchedString = window.localStorage.getItem('learning-feature-last-fetch');
@@ -611,7 +605,7 @@ const ProjectRoute: FC = () => {
   const { presence } = useInsomniaEventStreamContext();
   const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>({ key: `permissions:${organizationId}` });
   const storageRuleFetcher = useFetcher<OrganizationStorageLoaderData>({ key: `storage-rule:${organizationId}` });
-  const [lastLoadedOrgIdAndProjectId, setLastLoadedOrgIdAndProjectId] = useState<OrgAndProjectData>();
+  const [lastLoadedOrganizationId, setLastLoadedOrganizationId] = useState('');
 
   useEffect(() => {
     if (!isScratchpadOrganizationId(organizationId)) {
@@ -623,12 +617,12 @@ const ProjectRoute: FC = () => {
   useEffect(() => {
     const isIdleAndUninitialized = storageRuleFetcher.state === 'idle' && !storageRuleFetcher.data && !isScratchpadOrganizationId(organizationId);
 
-    if (isIdleAndUninitialized || lastLoadedOrgIdAndProjectId?.organizationId !== organizationId || lastLoadedOrgIdAndProjectId?.projectId !== projectId) {
+    if (isIdleAndUninitialized || lastLoadedOrganizationId !== organizationId) {
       storageRuleFetcher.load(`/organization/${organizationId}/storage-rule`);
       // Update the state tracking the last loaded organization ID
-      setLastLoadedOrgIdAndProjectId({ organizationId, projectId });
+      setLastLoadedOrganizationId(organizationId);
     }
-  }, [lastLoadedOrgIdAndProjectId, organizationId, projectId, storageRuleFetcher]);
+  }, [lastLoadedOrganizationId, organizationId, storageRuleFetcher]);
 
   const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -605,7 +605,7 @@ const ProjectRoute: FC = () => {
   const { presence } = useInsomniaEventStreamContext();
   const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>({ key: `permissions:${organizationId}` });
   const storageRuleFetcher = useFetcher<OrganizationStorageLoaderData>({ key: `storage-rule:${organizationId}` });
-  // const [lastLoadedOrganizationId, setLastLoadedOrganizationId] = useState('');
+  const [lastLoadedOrganizationId, setLastLoadedOrganizationId] = useState('');
 
   useEffect(() => {
     if (!isScratchpadOrganizationId(organizationId)) {
@@ -617,12 +617,12 @@ const ProjectRoute: FC = () => {
   useEffect(() => {
     const isIdleAndUninitialized = storageRuleFetcher.state === 'idle' && !storageRuleFetcher.data && !isScratchpadOrganizationId(organizationId);
 
-    if (isIdleAndUninitialized) {
+    if (isIdleAndUninitialized || lastLoadedOrganizationId !== organizationId) {
       storageRuleFetcher.load(`/organization/${organizationId}/storage-rule`);
       // Update the state tracking the last loaded organization ID
-      // setLastLoadedOrganizationId(organizationId);
+      setLastLoadedOrganizationId(organizationId);
     }
-  }, [organizationId, storageRuleFetcher]);
+  }, [lastLoadedOrganizationId, organizationId, storageRuleFetcher]);
 
   const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -813,18 +813,12 @@ const ProjectRoute: FC = () => {
   };
 
   const createNewProjectFetcher = useFetcher({
-    key: `${organizationId}-create-new-project`,
+    key: `${organizationId}-${projectId}-create-new-project`,
   });
 
-  const [createNewProjectFetcherData, setCreateNewProjectFetcherData] = useState(createNewProjectFetcher.data);
-
   useEffect(() => {
-    setCreateNewProjectFetcherData(createNewProjectFetcher.data);
-  }, [createNewProjectFetcher.data]);
-
-  useEffect(() => {
-    if (createNewProjectFetcherData && createNewProjectFetcherData.error && createNewProjectFetcher.state === 'idle') {
-      if (createNewProjectFetcherData.error === 'NEEDS_TO_UPGRADE') {
+    if (createNewProjectFetcher.data && createNewProjectFetcher.data.error && createNewProjectFetcher.state === 'idle') {
+      if (createNewProjectFetcher.data.error === 'NEEDS_TO_UPGRADE') {
         showModal(AskModal, {
           title: 'Upgrade your plan',
           message: 'You are currently on the Free plan where you can invite as many collaborators as you want as long as you don\'t have more than one project. Since you have more than one project, you need to upgrade to "Individual" or above to continue.',
@@ -836,7 +830,7 @@ const ProjectRoute: FC = () => {
             }
           },
         });
-      } else if (createNewProjectFetcherData.error === 'FORBIDDEN') {
+      } else if (createNewProjectFetcher.data.error === 'FORBIDDEN') {
         showAlert({
           title: 'Could not create project.',
           message: 'You do not have permission to create a project in this organization.',
@@ -844,14 +838,11 @@ const ProjectRoute: FC = () => {
       } else {
         showAlert({
           title: 'Could not create project.',
-          message: createNewProjectFetcherData.error,
+          message: createNewProjectFetcher.data.error,
         });
       }
-
-      // Reset the local state to clear the error
-      setCreateNewProjectFetcherData(null);
     }
-  }, [createNewProjectFetcher.state, createNewProjectFetcherData]);
+  }, [createNewProjectFetcher.state, createNewProjectFetcher.data]);
 
   const isGitSyncEnabled = features.gitSync.enabled;
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -635,8 +635,6 @@ const ProjectRoute: FC = () => {
     storage: DefaultStorage,
   };
 
-  console.log('[project] Loaded', { storage });
-
   const [projectListFilter, setProjectListFilter] = useLocalStorage(`${organizationId}:project-list-filter`, '');
   const [workspaceListFilter, setWorkspaceListFilter] = useLocalStorage(`${projectId}:workspace-list-filter`, '');
   const [workspaceListScope, setWorkspaceListScope] = useLocalStorage(`${projectId}:workspace-list-scope`, 'all');

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -605,7 +605,7 @@ const ProjectRoute: FC = () => {
   const { presence } = useInsomniaEventStreamContext();
   const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>({ key: `permissions:${organizationId}` });
   const storageRuleFetcher = useFetcher<OrganizationStorageLoaderData>({ key: `storage-rule:${organizationId}` });
-  const [lastLoadedOrganizationId, setLastLoadedOrganizationId] = useState('');
+  // const [lastLoadedOrganizationId, setLastLoadedOrganizationId] = useState('');
 
   useEffect(() => {
     if (!isScratchpadOrganizationId(organizationId)) {
@@ -617,12 +617,12 @@ const ProjectRoute: FC = () => {
   useEffect(() => {
     const isIdleAndUninitialized = storageRuleFetcher.state === 'idle' && !storageRuleFetcher.data && !isScratchpadOrganizationId(organizationId);
 
-    if (isIdleAndUninitialized || lastLoadedOrganizationId !== organizationId) {
+    if (isIdleAndUninitialized) {
       storageRuleFetcher.load(`/organization/${organizationId}/storage-rule`);
       // Update the state tracking the last loaded organization ID
-      setLastLoadedOrganizationId(organizationId);
+      // setLastLoadedOrganizationId(organizationId);
     }
-  }, [lastLoadedOrganizationId, organizationId, storageRuleFetcher]);
+  }, [organizationId, storageRuleFetcher]);
 
   const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -631,11 +631,9 @@ const ProjectRoute: FC = () => {
     isActive: true,
   }] = useLoaderDeferData(billingPromise);
 
-  const { storagePromise } = storageRuleFetcher.data || {
-    storage: DefaultStorage,
-  };
+  const { storagePromise } = storageRuleFetcher.data || {};
 
-  const [storage = 'cloud_plus_local'] = useLoaderDeferData(storagePromise);
+  const [storage = DefaultStorage] = useLoaderDeferData(storagePromise);
 
   const [projectListFilter, setProjectListFilter] = useLocalStorage(`${organizationId}:project-list-filter`, '');
   const [workspaceListFilter, setWorkspaceListFilter] = useLocalStorage(`${projectId}:workspace-list-filter`, '');

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1476,6 +1476,18 @@ const ProjectRoute: FC = () => {
                   <form
                     className='flex flex-col gap-4'
                     onSubmit={e => {
+                      e.preventDefault();
+                      const formData = new FormData(e.currentTarget);
+                      const type = formData.get('type');
+
+                      if (!type) {
+                        showAlert({
+                          title: 'Project type not selected',
+                          message: 'Please select a project type before continuing',
+                        });
+                        return;
+                      }
+
                       createNewProjectFetcher.submit(e.currentTarget, {
                         action: `/organization/${organizationId}/project/new`,
                         method: 'post',

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1606,6 +1606,14 @@ const ProjectRoute: FC = () => {
                       } else if (type === 'local' && activeProject?.remoteId && !projectType) {
                         setProjectType('local');
                       } else {
+                        if (!type) {
+                          showAlert({
+                            title: 'Project type not selected',
+                            message: 'Please select a project type before continuing',
+                          });
+                          return;
+                        }
+
                         updateProjectFetcher.submit(formData, {
                           action: `/organization/${organizationId}/project/${projectId}/update`,
                           method: 'post',

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -598,12 +598,14 @@ const ProjectRoute: FC = () => {
 
   const { userSession } = useRootLoaderData();
   const pullFileFetcher = useFetcher();
+  const updateProjectFetcher = useFetcher();
   const loadingBackendProjects = useFetchers().filter(fetcher => fetcher.formAction === `/organization/${organizationId}/project/${projectId}/remote-collections/pull`).map(f => f.formData?.get('backendProjectId'));
 
   const { organizations } = useOrganizationLoaderData();
   const { presence } = useInsomniaEventStreamContext();
   const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>({ key: `permissions:${organizationId}` });
   const storageRuleFetcher = useFetcher<OrganizationStorageLoaderData>({ key: `storage-rule:${organizationId}` });
+  const [lastLoadedOrganizationId, setLastLoadedOrganizationId] = useState('');
 
   useEffect(() => {
     if (!isScratchpadOrganizationId(organizationId)) {
@@ -615,10 +617,12 @@ const ProjectRoute: FC = () => {
   useEffect(() => {
     const isIdleAndUninitialized = storageRuleFetcher.state === 'idle' && !storageRuleFetcher.data && !isScratchpadOrganizationId(organizationId);
 
-    if (isIdleAndUninitialized) {
+    if (isIdleAndUninitialized || lastLoadedOrganizationId !== organizationId) {
       storageRuleFetcher.load(`/organization/${organizationId}/storage-rule`);
+      // Update the state tracking the last loaded organization ID
+      setLastLoadedOrganizationId(organizationId);
     }
-  }, [organizationId, storageRuleFetcher]);
+  }, [lastLoadedOrganizationId, organizationId, storageRuleFetcher]);
 
   const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
 
@@ -641,6 +645,8 @@ const ProjectRoute: FC = () => {
   const [workspaceListSortOrder, setWorkspaceListSortOrder] = useLocalStorage(`${projectId}:workspace-list-sort-order`, 'modified-desc');
   const [importModalType, setImportModalType] = useState<'file' | 'clipboard' | 'uri' | null>(null);
   const [isNewProjectModalOpen, setIsNewProjectModalOpen] = useState(false);
+  const [isUpdateProjectModalOpen, setIsUpdateProjectModalOpen] = useState(false);
+  const [projectType, setProjectType] = useState<'local' | 'remote' | ''>('');
   const organization = organizations.find(o => o.id === organizationId);
   const isUserOwner = organization && userSession.accountId && isOwnerOfOrganization({ organization, accountId: userSession.accountId });
   const isPersonalOrg = organization && isPersonalOrganization(organization);
@@ -1211,6 +1217,7 @@ const ProjectRoute: FC = () => {
                       <Icon icon="exclamation-triangle" className='mr-2' />
                       The organization owner mandates that projects must be created and stored {storage.split('_').join(' ')}. However, you can optionally enable Git Sync.
                     </p>
+                    <Button onPress={() => setIsUpdateProjectModalOpen(true)} className="flex items-center justify-center border border-solid border-white px-2 py-1 rounded-sm">Update</Button>
                   </div>
                 </div>}
                 <div className="flex max-w-xl justify-between w-full gap-2 p-[--padding-md]">
@@ -1547,6 +1554,180 @@ const ProjectRoute: FC = () => {
                           className="hover:no-underline bg-[--color-surprise] hover:bg-opacity-90 border border-solid border-[--hl-md] py-2 px-3 text-[--color-font-surprise] transition-colors rounded-sm"
                         >
                           Create
+                        </Button>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+              )}
+            </Dialog>
+          </Modal>
+        </ModalOverlay>
+        <ModalOverlay
+          isOpen={isUpdateProjectModalOpen}
+          onOpenChange={isOpen => {
+            setProjectType('');
+            setIsUpdateProjectModalOpen(isOpen);
+          }}
+          isDismissable
+          className="w-full h-[--visual-viewport-height] fixed z-10 top-0 left-0 flex items-center justify-center bg-black/30"
+        >
+          <Modal
+            onOpenChange={isOpen => {
+              setProjectType('');
+              setIsUpdateProjectModalOpen(isOpen);
+            }}
+            className="max-w-2xl w-full rounded-md border border-solid border-[--hl-sm] p-[--padding-lg] max-h-full bg-[--color-bg] text-[--color-font]"
+          >
+            <Dialog
+              className="outline-none"
+            >
+              {({ close }) => (
+                <div className='flex flex-col gap-4'>
+                  <div className='flex gap-2 items-center justify-between'>
+                    <Heading className='text-2xl'>{projectType === 'local' ? 'Confirm conversion to local storage' : projectType === 'remote' ? 'Confirm cloud synchronization' : 'Project Settings'}</Heading>
+                    <Button
+                      className="flex flex-shrink-0 items-center justify-center aspect-square h-6 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+                      onPress={close}
+                    >
+                      <Icon icon="x" />
+                    </Button>
+                  </div>
+                  <form
+                    className='flex flex-col gap-4'
+                    onSubmit={e => {
+                      e.preventDefault();
+                      const formData = new FormData(e.currentTarget);
+                      const type = formData.get('type');
+                      // If the project is local and the user is trying to change it to remote
+                      if (type === 'remote' && !activeProject?.remoteId && !projectType) {
+                        setProjectType('remote');
+                        // If the project is remote and the user is trying to change it to local
+                      } else if (type === 'local' && activeProject?.remoteId && !projectType) {
+                        setProjectType('local');
+                      } else {
+                        updateProjectFetcher.submit(formData, {
+                          action: `/organization/${organizationId}/project/${projectId}/update`,
+                          method: 'post',
+                        });
+
+                        close();
+                      }
+                    }}
+                  >
+                    <div className={`flex flex-col gap-4 ${projectType ? 'hidden' : ''}`}>
+                      <TextField
+                        autoFocus
+                        name="name"
+                        defaultValue={activeProject?.name}
+                        className="group relative flex-1 flex flex-col gap-2"
+                      >
+                        <Label className='text-sm text-[--hl]'>
+                          Project name
+                        </Label>
+                        <Input
+                          placeholder="My project"
+                          className="py-1 placeholder:italic w-full pl-2 pr-7 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font] focus:outline-none focus:ring-1 focus:ring-[--hl-md] transition-colors"
+                        />
+                      </TextField>
+                      <RadioGroup name="type" defaultValue={storage === 'cloud_plus_local' ? activeProject?.remoteId ? 'remote' : 'local' : storage !== 'cloud_only' ? 'local' : 'remote'} className="flex flex-col gap-2">
+                        <Label className="text-sm text-[--hl]">
+                          Project type
+                        </Label>
+                        <div className="flex gap-2">
+                          <Radio
+                            isDisabled={storage === 'local_only'}
+                            value="remote"
+                            className="data-[selected]:border-[--color-surprise] flex-1 data-[disabled]:opacity-25 data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
+                          >
+                            <div className='flex items-center gap-2'>
+                              <Icon icon="globe" />
+                              <Heading className="text-lg font-bold">Cloud Sync</Heading>
+                            </div>
+                            <p className='pt-2'>
+                              Encrypted and synced securely to the cloud, ideal for out of the box collaboration.
+                            </p>
+                          </Radio>
+                          <Radio
+                            isDisabled={storage === 'cloud_only'}
+                            value="local"
+                            className="data-[selected]:border-[--color-surprise] flex-1 data-[disabled]:opacity-25 data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
+                          >
+                            <div className='flex items-center gap-2'>
+                              <Icon icon="laptop" />
+                              <Heading className="text-lg font-bold">Local Vault</Heading>
+                            </div>
+                            <p className="pt-2">
+                              Stored locally only with no cloud. Ideal when collaboration is not needed.
+                            </p>
+                          </Radio>
+                        </div>
+                      </RadioGroup>
+                    </div>
+
+                    {projectType === 'local' && (
+                      <div className='text-[--color-font] flex flex-col gap-4'>
+                        <div className='flex flex-col gap-4'>
+                          <p>
+                            We will be converting your Cloud Sync project into a local project, and permanently remove all cloud data for this project from the cloud.
+                          </p>
+                          <ul className='text-left flex flex-col gap-2'>
+                            <li><i className="fa fa-check text-emerald-600" /> The project will be 100% stored locally.</li>
+                            <li><i className="fa fa-check text-emerald-600" /> Your collaborators will not be able to push and pull files anymore.</li>
+                            <li><i className="fa fa-check text-emerald-600" /> The project will become local also for every existing collaborator.</li>
+                          </ul>
+                          <p>
+                            You can still use Git Sync for local projects without using the cloud, and you can synchronize a local project back to the cloud if you decide to do so.
+                          </p>
+                          <p className='flex gap-2 items-center'>
+                            <Icon icon="triangle-exclamation" className='text-[--color-warning]' />
+                            Remember to pull your latest project updates before this operation
+                          </p>
+                        </div>
+                      </div>
+                    )}
+                    {projectType === 'remote' && (
+                      <div className='text-[--color-font] flex flex-col gap-4'>
+                        <div className='flex flex-col gap-4'>
+                          <p>
+                            We will be synchronizing your local project to Insomnia's Cloud in a secure encrypted format which will enable cloud collaboration.
+                          </p>
+                          <ul className='text-left flex flex-col gap-2'>
+                            <li><i className="fa fa-check text-emerald-600" /> Your data in the cloud is encrypted and secure.</li>
+                            <li><i className="fa fa-check text-emerald-600" /> You can now collaborate with any amount of users and use cloud features.</li>
+                            <li><i className="fa fa-check text-emerald-600" /> Your project will be always available on any client after logging in.</li>
+                          </ul>
+                          <p>
+                            You can still use Git Sync for cloud projects.
+                          </p>
+                        </div>
+                      </div>
+                    )}
+                    <div className="flex justify-between gap-2 items-center">
+                      <div className="flex items-center gap-2 text-sm">
+                        <Icon icon="info-circle" />
+                        <span>
+                          {showStorageRestrictionMessage && `The organization owner mandates that projects must be created and stored ${storage.split('_').join(' ')}.`} You can optionally enable Git Sync
+                        </span>
+                      </div>
+                      <div className='flex items-center gap-2'>
+                        <Button
+                          onPress={() => {
+                            if (projectType) {
+                              setProjectType('');
+                            } else {
+                              close();
+                            }
+                          }}
+                          className="hover:no-underline hover:bg-opacity-90 border border-solid border-[--hl-md] py-2 px-3 text-[--color-font] transition-colors rounded-sm"
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          type="submit"
+                          className="hover:no-underline bg-[--color-surprise] hover:bg-opacity-90 border border-solid border-[--hl-md] py-2 px-3 text-[--color-font-surprise] transition-colors rounded-sm"
+                        >
+                          {projectType ? 'Confirm' : 'Update'}
                         </Button>
                       </div>
                     </div>


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.


If this PR fixes a bug or regression, please make sure to add a test.
-->

## Fixes Implemented:
- [x] Implemented immediate display of error messages when admins change storage rules for the cloud application.
- [x] Added listener for the new StorageRuleChanged message.
- [x] Display the server error messages for PROJECT_STORAGE_RESTRICTION errors.
- [x] Addressed the issue where attempting to create a new cloud project as a member displayed an error modal, which reappeared when trying to create a local vault project subsequently.
- [x] Always show a warning message when creating or updating a project if the storage rule is not cloud_plus_local.

## Notes for Team Discussion:
1. The fourth fix on the list is a quick solution. If preferred, I can revert this change and address it more efficiently in a separate PR.
2. For handling storage rules, I utilized network cache instead of localStorage. If there are concerns about this approach, let's use localStorage or discuss about alternative solutions.

Closes INS-4113
Related BE PR INS-4108