### PR TITLE
chore: update-changelog job not working [no-ticket]

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -3,7 +3,7 @@ name: "Update Changelog"
 
 on:
   release:
-    types: [released]
+    types: [published]
 
 
 jobs:


### PR DESCRIPTION
Related to https://github.com/Kong/insomnia/pull/7677

Not sure yet why the job wouldn't trigger. Could be a permissions issue.

In this one we're changing the event type to publish just to see if anything at all shows up.


https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release