### PR TITLE
fix: ui improvement when return deferred data in loader

### DIFF
--- a/packages/insomnia/src/ui/hooks/use-loader-defer-data.ts
+++ b/packages/insomnia/src/ui/hooks/use-loader-defer-data.ts
@@ -14,8 +14,8 @@ export const useLoaderDeferData = <T>(deferedDataPromise?: Promise<T>, keepStale
     (async () => {
       try {
         // use keepStaleDataKey to let us know if we should keep the stale data or not
-        // sometimes we want to keep the stale data if we are fetching the same data again
-        // sometimes we want to clear the stale data if we are fetching different data
+        // sometimes we want to keep the stale data (rename a collection -> action submit -> run loader)
+        // sometimes we want to clear the stale data if we are fetching different data (switch to another project -> navigate -> run loader)
         if (keepStaleDataKeyRef.current !== keepStaleDataKey) {
           setData(undefined);
         }

--- a/packages/insomnia/src/ui/hooks/use-loader-defer-data.ts
+++ b/packages/insomnia/src/ui/hooks/use-loader-defer-data.ts
@@ -1,15 +1,23 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-export const useLoaderDeferData = <T>(deferedDataPromise?: Promise<T>): [T | undefined, boolean, any] => {
+export const useLoaderDeferData = <T>(deferedDataPromise?: Promise<T>, keepStaleDataKey?: string): [T | undefined, boolean, any] => {
   const [data, setData] = useState<T>();
   const [error, setError] = useState();
   const [isPending, setIsPending] = useState(true);
+
+  const keepStaleDataKeyRef = useRef(keepStaleDataKey);
+
   useEffect(() => {
     if (deferedDataPromise === undefined) {
       return;
     }
     (async () => {
       try {
+        // use keepStaleDataKey to let us know if we should keep the stale data or not
+        if (keepStaleDataKeyRef.current !== keepStaleDataKey) {
+          setData(undefined);
+        }
+        keepStaleDataKeyRef.current = keepStaleDataKey;
         const data = await deferedDataPromise;
         setIsPending(false);
         setData(data);
@@ -18,7 +26,7 @@ export const useLoaderDeferData = <T>(deferedDataPromise?: Promise<T>): [T | und
         console.log('Failed to load defered data', err);
       }
     })();
-  }, [deferedDataPromise]);
+  }, [deferedDataPromise, keepStaleDataKey]);
 
   return [data, isPending, error];
 };

--- a/packages/insomnia/src/ui/hooks/use-loader-defer-data.ts
+++ b/packages/insomnia/src/ui/hooks/use-loader-defer-data.ts
@@ -14,6 +14,8 @@ export const useLoaderDeferData = <T>(deferedDataPromise?: Promise<T>, keepStale
     (async () => {
       try {
         // use keepStaleDataKey to let us know if we should keep the stale data or not
+        // sometimes we want to keep the stale data if we are fetching the same data again
+        // sometimes we want to clear the stale data if we are fetching different data
         if (keepStaleDataKeyRef.current !== keepStaleDataKey) {
           setData(undefined);
         }

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -590,7 +590,7 @@ const ProjectRoute: FC = () => {
     projectId: string;
   };
   const [learningFeature] = useLoaderDeferData<LearningFeature>(learningFeaturePromise);
-  const [remoteFiles] = useLoaderDeferData<InsomniaFile[]>(remoteFilesPromise);
+  const [remoteFiles] = useLoaderDeferData<InsomniaFile[]>(remoteFilesPromise, projectId);
 
   const allFiles = useMemo(() => {
     return remoteFiles ? [...localFiles, ...remoteFiles] : localFiles;


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
After return deferred data in loader, there is an ui issue:
When we switch project from `A` to `B`, the stale remote project in A will stay for a short time before the remote data fetching finish in `B project`. So we need a key to help us to dertimine if we need to keep stale data.

There are 2 cases:
1. switch to another project: we shouldn't keep stale data
2. other action such as rename a project: the projectId not change, so we should keep the stale data.
 
**In project A**
<img width="1790" alt="image" src="https://github.com/Kong/insomnia/assets/163384738/b84665c2-25fa-4551-949c-1e1bf4c21210">
**Click to switch another project B**
The stale data stay for a short time
<img width="1788" alt="image" src="https://github.com/Kong/insomnia/assets/163384738/3e1c9a9a-0706-4cf9-a3fb-aa1f1793e482">
**Project B fetching finish**
<img width="1743" alt="image" src="https://github.com/Kong/insomnia/assets/163384738/8124c2af-4576-4142-817c-224b9fe7bfd7">

