### PR TITLE
split test job into app and cli

### DIFF
--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -17,7 +17,7 @@ env:
   PR_NUMBER: ${{ github.event.number }}
 jobs:
   build-and-upload-artifacts:
-    timeout-minutes: 25
+    timeout-minutes: 15
     # Skip jobs for release PRs
     # windows on recurring should be portable
     if: ${{ !startsWith(github.head_ref, 'release/') }}

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -33,6 +33,18 @@ jobs:
       - name: Install packages
         run: npm ci
 
+      - name: Install node version of node-libcurl for inso tests
+        run: node_modules/.bin/node-pre-gyp install --update-binary --directory node_modules/@getinsomnia/node-libcurl
+
+      - name : Build Send Request abstraction
+        run: npm run build:sr -w insomnia
+        
+      - name : Build Inso
+        run: npm run build -w insomnia-inso
+
+      - name: Run Inso bundle tests
+        run: npm run test:bundle -w insomnia-inso
+
       - name: Set Inso CLI variables
         id: inso-variables
         shell: bash
@@ -41,16 +53,7 @@ jobs:
           PKG_NAME="inso-ubuntu-latest-$INSO_VERSION"
           echo "pkg-name=$PKG_NAME" >> $GITHUB_OUTPUT
           echo "inso-version=$INSO_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Install node version of node-libcurl for inso tests
-        run: node_modules/.bin/node-pre-gyp install --update-binary --directory node_modules/@getinsomnia/node-libcurl
-
-      - name : Build Inso
-        run: npm run build -w insomnia-inso
-
-      - name: Run Inso bundle tests
-        run: npm run test:bundle -w insomnia-inso
-
+          
       - name: Package Inso CLI binary
         run: npm run inso-package
         env:

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -17,8 +17,8 @@ concurrency:
 
 jobs:
   Test:
-    timeout-minutes: 25
-    runs-on: ubuntu-latest
+    timeout-minutes: 10s
+    runs-on: ubuntu-lastest
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
           PKG_NAME="inso-ubuntu-latest-$INSO_VERSION"
           echo "pkg-name=$PKG_NAME" >> $GITHUB_OUTPUT
           echo "inso-version=$INSO_VERSION" >> $GITHUB_OUTPUT
-          
+
       - name: Package Inso CLI binary
         run: npm run inso-package
         env:

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   Test:
     timeout-minutes: 10
-    runs-on: ubuntu-lastest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   Test:
-    timeout-minutes: 10s
+    timeout-minutes: 10
     runs-on: ubuntu-lastest
     steps:
       - name: Checkout branch

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -1,0 +1,72 @@
+name: Test CLI
+
+on:
+  merge_group:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Test:
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Set Inso CLI variables
+        id: inso-variables
+        shell: bash
+        run: |
+          INSO_VERSION="$(jq .version packages/insomnia-inso/package.json -rj)-run.${{ github.run_number }}"
+          PKG_NAME="inso-ubuntu-latest-$INSO_VERSION"
+          echo "pkg-name=$PKG_NAME" >> $GITHUB_OUTPUT
+          echo "inso-version=$INSO_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Install node version of node-libcurl for inso tests
+        run: node_modules/.bin/node-pre-gyp install --update-binary --directory node_modules/@getinsomnia/node-libcurl
+
+      - name : Build Inso
+        run: npm run build -w insomnia-inso
+
+      - name: Run Inso bundle tests
+        run: npm run test:bundle -w insomnia-inso
+
+      - name: Package Inso CLI binary
+        run: npm run inso-package
+        env:
+          VERSION: ${{ steps.inso-variables.outputs.inso-version }}
+
+      - name: Run Inso binary tests
+        run: npm run test:binary -w insomnia-inso
+
+      - name: Create Inso CLI artifacts
+        run: npm run inso-package:artifacts
+        env:
+          VERSION: ${{ steps.inso-variables.outputs.inso-version }}
+
+      - name: Upload Inso CLI artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: ${{ steps.inso-variables.outputs.pkg-name }}
+          path: packages/insomnia-inso/artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Test App
 
 on:
   merge_group:
@@ -42,14 +42,8 @@ jobs:
       - name: Type checks
         run: npm run type-check
 
-      - name: Test Insomnia
-        run: npm test -w packages/insomnia
-
-      - name: Test Inso
-        run: npm test -w packages/insomnia-inso
-
-      - name: Test Insomnia Testing
-        run: npm test -w packages/insomnia-testing
+      - name: Unit Tests
+        run: npm test
 
       - name: Build app for smoke tests
         run: NODE_OPTIONS='--max_old_space_size=6144' npm run app-build
@@ -63,44 +57,6 @@ jobs:
         # Full Smoke test run, for Release PRs
         if: ${{ startsWith(github.head_ref, 'release/') }}
         run: npm run test:build -w packages/insomnia-smoke-test -- --project=Default
-
-      - name: Set Inso CLI variables
-        id: inso-variables
-        shell: bash
-        run: |
-          INSO_VERSION="$(jq .version packages/insomnia-inso/package.json -rj)-run.${{ github.run_number }}"
-          PKG_NAME="inso-ubuntu-latest-$INSO_VERSION"
-          echo "pkg-name=$PKG_NAME" >> $GITHUB_OUTPUT
-          echo "inso-version=$INSO_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Install node version of node-libcurl for inso tests
-        run: node_modules/.bin/node-pre-gyp install --update-binary --directory node_modules/@getinsomnia/node-libcurl
-
-      - name : Build Inso
-        run: npm run build -w insomnia-inso
-
-      - name: Run Inso bundle tests
-        run: npm run test:bundle -w insomnia-inso
-
-      - name: Package Inso CLI binary
-        run: npm run inso-package
-        env:
-          VERSION: ${{ steps.inso-variables.outputs.inso-version }}
-
-      - name: Run Inso binary tests
-        run: npm run test:binary -w insomnia-inso
-
-      - name: Create Inso CLI artifacts
-        run: npm run inso-package:artifacts
-        env:
-          VERSION: ${{ steps.inso-variables.outputs.inso-version }}
-
-      - name: Upload Inso CLI artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          if-no-files-found: ignore
-          name: ${{ steps.inso-variables.outputs.pkg-name }}
-          path: packages/insomnia-inso/artifacts
 
       # This step should always run even when previous steps fail
       - name: Upload smoke test traces

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   Test:
-    timeout-minutes: 25
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch

--- a/packages/insomnia-sdk/src/objects/__tests__/cookies.test.ts
+++ b/packages/insomnia-sdk/src/objects/__tests__/cookies.test.ts
@@ -83,7 +83,7 @@ describe('test Cookie object', () => {
                         id: '1',
                         key: 'c1',
                         value: 'v1',
-                        expires: null,
+                        expires: 'Infinity',
                         domain: 'inso.com',
                         path: '/',
                         secure: true,


### PR DESCRIPTION
- split cli and app in order to make it clearer when we are using node-libcurl for electron OR node
- run all unit tests
- reduce timeouts to control test time bloat
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
