### PR TITLE
force vite to always wipe cache

### DIFF
--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -43,6 +43,7 @@ export default defineConfig(({ mode }) => {
       // these packages are only used in web worker, Vite won't be able to discover the import on the initial scan，so we need to include them here to let vite pre-bundle them
       // https://vitejs.dev/guide/dep-pre-bundling.html#customizing-the-behavior
       include: ['@stoplight/spectral-core', '@stoplight/spectral-ruleset-bundler/with-loader', '@stoplight/spectral-rulesets'],
+      force: true,
     },
     plugins: [
       // Allows us to import modules that will be resolved by Node's require() function.


### PR DESCRIPTION
- often the app doesnt start in dev without wiping the cache
- we also found an instance where the vite cache used outdates dependencies even after a npm run clean.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
