### PR TITLE
feat(Markdown Preview): always enable preview

### DIFF
--- a/packages/insomnia/src/ui/components/markdown-editor.tsx
+++ b/packages/insomnia/src/ui/components/markdown-editor.tsx
@@ -34,7 +34,6 @@ export const MarkdownEditor = forwardRef<CodeEditorHandle, Props>(({
       className="w-full h-full flex flex-col overflow-hidden"
       aria-label="Markdown editor tabs"
       defaultSelectedKey={defaultValue ? 'preview' : 'write'}
-      disabledKeys={[defaultValue ? '' : 'preview']}
     >
       <TabList className="w-full flex-shrink-0 overflow-x-auto border-solid border-b border-b-[--hl-md] px-2 bg-[--color-bg] flex items-center gap-2 h-[--line-height-sm]" aria-label="Request scripts tabs">
         <Tab


### PR DESCRIPTION
Highlights:

- [x] Allows switching to preview even when there is no content