### PR TITLE
fix(Delete Environment): Don't show empty view when deleting an environment

### DIFF
--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -83,13 +83,17 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: {
             addCancel: true,
             okLabel: 'Delete',
             onConfirm: async () => {
-              deleteEnvironmentFetcher.submit({
-                environmentId: environment._id,
-              },
+              deleteEnvironmentFetcher.submit(
+                {
+                  environmentId: environment._id,
+                },
                 {
                   method: 'post',
                   action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/environment/delete`,
-                });
+                }
+              );
+
+              setSelectedEnvironmentId(baseEnvironment._id);
             },
           });
         },

--- a/packages/insomnia/src/ui/routes/environments.tsx
+++ b/packages/insomnia/src/ui/routes/environments.tsx
@@ -87,13 +87,17 @@ const Environments = () => {
             addCancel: true,
             okLabel: 'Delete',
             onConfirm: async () => {
-              deleteEnvironmentFetcher.submit({
-                environmentId: environment._id,
-              },
+              deleteEnvironmentFetcher.submit(
+                {
+                  environmentId: environment._id,
+                },
                 {
                   method: 'post',
                   action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/environment/delete`,
-                });
+                }
+              );
+
+              setSelectedEnvironmentId(baseEnvironment._id);
             },
           });
         },


### PR DESCRIPTION
Highlights:

- [x] When deleting an environment in either the Global Environment view or the Collection environment modal we now navigate to the base environment instead of showing an empty view