### PR TITLE
fix: refresh storage rule when org change

### DIFF
--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -605,11 +605,11 @@ const ProjectRoute: FC = () => {
   const permissionsFetcher = useFetcher<OrganizationFeatureLoaderData>({ key: `permissions:${organizationId}` });
 
   useEffect(() => {
-    const isIdleAndUninitialized = permissionsFetcher.state === 'idle' && !permissionsFetcher.data && !isScratchpadOrganizationId(organizationId);
-    if (isIdleAndUninitialized) {
-      permissionsFetcher.load(`/organization/${organizationId}/permissions`);
+    if (!isScratchpadOrganizationId(organizationId)) {
+      const load = permissionsFetcher.load;
+      load(`/organization/${organizationId}/permissions`);
     }
-  }, [organizationId, permissionsFetcher]);
+  }, [organizationId, permissionsFetcher.load]);
 
   const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
   const { features, billing, storage } = permissionsFetcher.data || {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Fix: Refetch /storage-rule when organization change everytime.
