### PR TITLE
chore: git sync pull push test [INS-4132]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,14 +49,11 @@ jobs:
         run: NODE_OPTIONS='--max_old_space_size=6144' npm run app-build
 
       - name: Smoke test electron app
-        # Partial Smoke test run, for regular CI triggers
-        if: ${{ !startsWith(github.head_ref, 'release/') }}
-        run: npm run test:build -w packages/insomnia-smoke-test -- --project=Smoke
-
-      - name: Prerelease test electron app
-        # Full Smoke test run, for Release PRs
-        if: ${{ startsWith(github.head_ref, 'release/') }}
-        run: npm run test:build -w packages/insomnia-smoke-test -- --project=Default
+        run: |
+          GIT_SYNC_SMOKE_TEST_TOKEN=${{env.GIT_SYNC_SMOKE_TEST_TOKEN}} \
+          npm run test:build -w packages/insomnia-smoke-test -- --project=Smoke
+        env:
+          GIT_SYNC_SMOKE_TEST_TOKEN: ${{ secrets.GIT_SYNC_SMOKE_TEST_TOKEN }}
 
       # This step should always run even when previous steps fail
       - name: Upload smoke test traces

--- a/packages/insomnia-smoke-test/playwright.config.ts
+++ b/packages/insomnia-smoke-test/playwright.config.ts
@@ -3,13 +3,7 @@ import { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   projects: [
     {
-      // Run all tests, runs only on Release PR test workflow
-      name: 'Default',
-      testMatch: /.*\/.*.test.ts/,
-      retries: 0,
-    },
-    {
-      // High-confidence smoke/sanity checks, runs on non-release PR test workflow
+      // High-confidence smoke/sanity checks, runs on release recurring and release builds
       name: 'Smoke',
       testMatch: /smoke\/.*.test.ts/,
       retries: 0,

--- a/packages/insomnia-smoke-test/playwright.config.ts
+++ b/packages/insomnia-smoke-test/playwright.config.ts
@@ -3,7 +3,7 @@ import { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   projects: [
     {
-      // High-confidence smoke/sanity checks, runs on release recurring and release builds
+      // High-confidence smoke/sanity checks, runs on Test App only on Ubuntu
       name: 'Smoke',
       testMatch: /smoke\/.*.test.ts/,
       retries: 0,

--- a/packages/insomnia-smoke-test/tests/smoke/git-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/git-interactions.test.ts
@@ -1,15 +1,26 @@
 import { test } from '../../playwright/test';
 
 test('Git Interactions (clone, checkout branch, pull, push, stage changes, ...)', async ({ page }) => {
+
+    let gitSyncSmokeTestToken = process.env.GIT_SYNC_SMOKE_TEST_TOKEN;
+
+    // read env variable to skip test
+    if (!gitSyncSmokeTestToken) {
+        test.skip();
+    }
+
+    // generate a uuid string
+    const testUUID = crypto.randomUUID();
+
     // git clone
     await page.waitForSelector('[data-test-git-enable="true"]');
     await page.getByLabel('Clone git repository').click();
     await page.getByRole('tab', { name: ' Git' }).click();
     await page.getByPlaceholder('https://github.com/org/repo.git').fill('https://github.com/Kong/insomnia-git-example.git');
-    await page.getByPlaceholder('Name').fill('J');
-    await page.getByPlaceholder('Email').fill('J');
-    await page.getByPlaceholder('MyUser').fill('J');
-    await page.getByPlaceholder('88e7ee63b254e4b0bf047559eafe86ba9dd49507').fill('J');
+    await page.getByPlaceholder('Name').fill('Test User');
+    await page.getByPlaceholder('Email').fill('test@test.com');
+    await page.getByPlaceholder('MyUser').fill('test');
+    await page.getByPlaceholder('88e7ee63b254e4b0bf047559eafe86ba9dd49507').fill(gitSyncSmokeTestToken);
     await page.getByTestId('git-repository-settings-modal__sync-btn').click();
     await page.getByLabel('Toggle preview').click();
 
@@ -36,12 +47,6 @@ test('Git Interactions (clone, checkout branch, pull, push, stage changes, ...)'
     await page.getByText('No changes to commit.').click();
     await page.getByRole('button', { name: 'Close' }).click();
 
-    // push changes
-    // await page.getByTestId('git-dropdown').getByLabel('Git Sync').click();
-    // await page.getByRole('button', { name: ' Push' }).click();
-    // await page.getByText('HTTP Error: 401 Unauthorized').click();
-    // await page.getByRole('button', { name: '' }).click();
-
     // switch back to main branch, which should not have said changes
     await page.getByTestId('git-dropdown').getByLabel('Git Sync').click();
     await page.getByRole('button', { name: 'main' }).click();
@@ -67,6 +72,38 @@ test('Git Interactions (clone, checkout branch, pull, push, stage changes, ...)'
     await page.getByRole('button', { name: ' History' }).click();
     await page.getByRole('cell', { name: 'example commit message' }).click();
     await page.getByRole('cell', { name: 'just now' }).click();
-    await page.getByRole('cell', { name: 'J', exact: true }).click();
+    await page.getByRole('button', { name: 'Done' }).click();
+
+    // push changes test
+    await page.getByTestId('git-dropdown').getByLabel('Git Sync').click();
+    await page.getByRole('button', { name: ' Branches' }).click();
+    await page.getByRole('cell', { name: 'abc(current)' }).click();
+    await page.getByRole('cell', { name: 'push-pull-test' }).click();
+    await page.getByRole('row', { name: 'push-pull-test Checkout' }).getByRole('button').click();
+    await page.getByRole('cell', { name: 'push-pull-test(current)' }).click();
+    await page.getByRole('button', { name: 'Done' }).click();
+    await page.getByTestId('workspace-debug').click();
+    await page.getByLabel('Create in collection').click();
+    await page.getByLabel('New Folder').click();
+    await page.getByLabel('Name', { exact: true }).click();
+    await page.getByLabel('Name', { exact: true }).fill(`My Folder ${testUUID}`);
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+    await page.getByTestId('git-dropdown').getByLabel('Git Sync').click();
+    await page.getByRole('button', { name: ' Commit' }).click();
+    await page.getByRole('cell', { name: `My Folder ${testUUID}` }).locator('label').click();
+    await page.getByPlaceholder('A descriptive message to').click();
+    await page.getByPlaceholder('A descriptive message to').fill(`commit test ${testUUID}`);
+    await page.getByText('Commit Changes').click();
+    await page.getByRole('button', { name: ' Commit' }).click();
+    await page.getByText('No changes to commit.').click();
+    await page.getByRole('button', { name: 'Close' }).click();
+    await page.getByTestId('git-dropdown').getByLabel('Git Sync').click();
+    await page.getByRole('button', { name: ' Push' }).click();
+    await page.getByTestId('git-dropdown').getByLabel('Git Sync').click();
+    await page.getByRole('button', { name: ' Fetch' }).click();
+    await page.getByTestId('git-dropdown').getByLabel('Git Sync').click();
+    await page.getByRole('button', { name: ' History' }).click();
+    await page.getByRole('cell', { name: `commit test ${testUUID}` }).click();
+    await page.getByRole('button', { name: 'Done' }).click();
 
 });

--- a/packages/insomnia-smoke-test/tests/smoke/git-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/git-interactions.test.ts
@@ -1,12 +1,13 @@
 import { test } from '../../playwright/test';
 
 test('Git Interactions (clone, checkout branch, pull, push, stage changes, ...)', async ({ page }) => {
-
-    let gitSyncSmokeTestToken = process.env.GIT_SYNC_SMOKE_TEST_TOKEN;
+    const gitSyncSmokeTestToken = process.env.GIT_SYNC_SMOKE_TEST_TOKEN;
 
     // read env variable to skip test
     if (!gitSyncSmokeTestToken) {
+        console.log('Skipping, set GIT_SYNC_SMOKE_TEST_TOKEN to run, TIP: "gh auth login to get a token" and "export GIT_SYNC_SMOKE_TEST_TOKEN=$(gh auth token)"');
         test.skip();
+        return;
     }
 
     // generate a uuid string


### PR DESCRIPTION
Closes INS-4132

- [x] add a push/pull part to the git interactions test
- [x] add a secret gh token to be able to push on gh actions

notes:
- when the token is not defined, it just skips the test