### PR TITLE
fix(Git Clone): redirect using incorrect organizationId

### DIFF
--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -521,7 +521,15 @@ export const cloneGitRepoAction: ActionFunction = async ({
     const existingWorkspace = await models.workspace.getById(workspace._id);
 
     if (existingWorkspace) {
-      return redirect(`/organization/${existingWorkspace.parentId}/project/${existingWorkspace.parentId}/workspace/${existingWorkspace._id}/debug`);
+      const project = await models.project.getById(existingWorkspace.parentId);
+      if (!project) {
+        return {
+          errors: ['It seems that the repository being cloned is connected to an orphaned workspace. Please move that workspace to a project and try again.'],
+        };
+      }
+
+      const organizationId = project?.parentId;
+      return redirect(`/organization/${organizationId}/project/${project._id}/workspace/${existingWorkspace._id}/debug`);
     }
 
     // Loop over all model folders in root


### PR DESCRIPTION
Highlights:

- [x] Fixes an issue where cloning a git repo that already exists in the app would redirect to the wrong organizationId