### PR TITLE
fixes incorrect scrollbar display issue

### DIFF
--- a/packages/insomnia/src/ui/css/styles.css
+++ b/packages/insomnia/src/ui/css/styles.css
@@ -13,6 +13,10 @@
 @tailwind utilities;
 
 
+[data-platform="darwin"] * {
+  scrollbar-width: thin;
+}
+
 html {
   font-size: 11px;
 }

--- a/packages/insomnia/src/ui/css/styles.css
+++ b/packages/insomnia/src/ui/css/styles.css
@@ -12,9 +12,6 @@
 @tailwind components;
 @tailwind utilities;
 
-* {
-  scrollbar-width: thin;
-}
 
 html {
   font-size: 11px;


### PR DESCRIPTION
Here the CSS for scrollbar-width in styles.css is overriding the CSS which is defined for scrollbar in the main.css file (--scrollbar-width: calc(var(--font-size) * 0.6);) due to which the scrollbars are incorrectly loaded in the application

Closes #7732 

![image](https://github.com/user-attachments/assets/d3a868f2-f1be-4582-96ec-b0221a1de029)
