### PR TITLE
fix: can't match project when last visit page is dashboard

### DIFF
--- a/packages/insomnia/src/utils/router.ts
+++ b/packages/insomnia/src/utils/router.ts
@@ -12,7 +12,7 @@ export const enum AsyncTask {
   SyncProjects,
 }
 
-const getMathParams = (location: string) => {
+const getMatchParams = (location: string) => {
   const workspaceMatch = matchPath(
     {
       path: '/organization/:organizationId/project/:projectId/workspace/:workspaceId',
@@ -43,7 +43,7 @@ export const getInitialRouteForOrganization = async ({
   // Check if the last visited project exists and redirect to it
   if (prevOrganizationLocation) {
 
-    const match = getMathParams(prevOrganizationLocation);
+    const match = getMatchParams(prevOrganizationLocation);
 
     if (match && match.params.organizationId && match.params.projectId) {
       const existingProject = await models.project.getById(match.params.projectId);

--- a/packages/insomnia/src/utils/router.ts
+++ b/packages/insomnia/src/utils/router.ts
@@ -1,4 +1,4 @@
-import { matchPath } from 'react-router-dom';
+import { matchPath, type PathMatch } from 'react-router-dom';
 
 import { database } from '../common/database';
 import * as models from '../models';
@@ -11,6 +11,27 @@ export const enum AsyncTask {
   MigrateProjects,
   SyncProjects,
 }
+
+const getMathParams = (location: string) => {
+  const workspaceMatch = matchPath(
+    {
+      path: '/organization/:organizationId/project/:projectId/workspace/:workspaceId',
+      end: false,
+    },
+    location
+  );
+
+  const projectMatch = matchPath(
+    {
+      path: '/organization/:organizationId/project/:projectId',
+      end: false,
+    },
+    location
+  );
+
+  return (workspaceMatch || projectMatch) as PathMatch<'organizationId' | 'projectId' | 'workspaceId'> | null;
+};
+
 export const getInitialRouteForOrganization = async ({
   organizationId,
   navigateToWorkspace = false,
@@ -21,13 +42,8 @@ export const getInitialRouteForOrganization = async ({
   );
   // Check if the last visited project exists and redirect to it
   if (prevOrganizationLocation) {
-    const match = matchPath(
-      {
-        path: '/organization/:organizationId/project/:projectId/workspace/:workspaceId',
-        end: false,
-      },
-      prevOrganizationLocation
-    );
+
+    const match = getMathParams(prevOrganizationLocation);
 
     if (match && match.params.organizationId && match.params.projectId) {
       const existingProject = await models.project.getById(match.params.projectId);


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

related to #7755 

Fix: 
when a user last history is '/organization/:organizationId/project/:projectId', will failed to get match params.