### PR TITLE
Measure back to dashboard duration from collection and report to sentry

### DIFF
--- a/packages/insomnia/src/common/sentry.ts
+++ b/packages/insomnia/src/common/sentry.ts
@@ -17,6 +17,7 @@ export const enum SentryMetrics {
   ORGANIZATION_SWITCH_DURATION = 'organization_switch_duration',
   PROJECT_SWITCH_DURATION = 'project_switch_duration',
   CLOUD_SYNC_DURATION = 'cloud_sync_duration',
+  BACK_TO_DASHBOARD = 'back_to_dashboard',
 };
 
 export const enum LandingPage {

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -742,6 +742,9 @@ export const Debug: FC = () => {
                   data-testid="project"
                   className="px-1 py-1 aspect-square h-7 flex flex-shrink-0 outline-none data-[focused]:outline-none items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
                   to={`/organization/${organizationId}/project/${activeProject._id}`}
+                  onClick={() => {
+                    performance.mark('returnToDashboard:start');
+                  }}
                 >
                   <Icon className='text-xs' icon="chevron-left" />
                 </NavLink>

--- a/packages/insomnia/src/ui/routes/design.tsx
+++ b/packages/insomnia/src/ui/routes/design.tsx
@@ -461,6 +461,9 @@ const Design: FC = () => {
                   data-testid="project"
                   className="px-1 py-1 aspect-square h-7 flex flex-shrink-0 outline-none data-[focused]:outline-none items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
                   to={`/organization/${organizationId}/project/${activeProject._id}`}
+                  onClick={() => {
+                    performance.mark('returnToDashboard:start');
+                  }}
                 >
                   <Icon className='text-xs' icon="chevron-left" />
                 </NavLink>

--- a/packages/insomnia/src/ui/routes/environments.tsx
+++ b/packages/insomnia/src/ui/routes/environments.tsx
@@ -258,6 +258,9 @@ const Environments = () => {
               data-testid="project"
               className="px-1 py-1 aspect-square h-7 flex flex-shrink-0 outline-none data-[focused]:outline-none items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
               to={`/organization/${organizationId}/project/${activeProject._id}`}
+              onClick={() => {
+                performance.mark('returnToDashboard:start');
+              }}
             >
               <Icon className='text-xs' icon="chevron-left" />
             </NavLink>

--- a/packages/insomnia/src/ui/routes/mock-server.tsx
+++ b/packages/insomnia/src/ui/routes/mock-server.tsx
@@ -178,7 +178,14 @@ const MockServerRoute = () => {
         <div className="flex flex-col items-start gap-2 justify-between p-[--padding-sm]">
           <Breadcrumbs className='flex list-none items-center m-0 p-0 gap-2 font-bold w-full'>
             <Breadcrumb className="flex select-none items-center gap-2 text-[--color-font] h-full outline-none data-[focused]:outline-none">
-              <NavLink data-testid="project" className="px-1 py-1 aspect-square h-7 flex flex-shrink-0 outline-none data-[focused]:outline-none items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm" to={`/organization/${organizationId}/project/${projectId}`}>
+                <NavLink
+                  data-testid="project"
+                  className="px-1 py-1 aspect-square h-7 flex flex-shrink-0 outline-none data-[focused]:outline-none items-center justify-center gap-2 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+                  to={`/organization/${organizationId}/project/${projectId}`}
+                  onClick={() => {
+                    performance.mark('returnToDashboard:start');
+                  }}
+                >
                 <Icon className='text-xs' icon="chevron-left" />
               </NavLink>
               <span aria-hidden role="separator" className='text-[--hl-lg] h-4 outline outline-1' />

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1008,6 +1008,22 @@ const ProjectRoute: FC = () => {
     }
   }, [projectId]);
 
+  useEffect(() => {
+    try {
+      // use mark and measure to track the time it takes to return to the dashboard
+      // TODO:
+      // investigate Sentry's React Router integration: https://docs.sentry.io/platforms/javascript/guides/react/features/react-router/
+      // use same approach to track other operations in SentryMetrics
+      const markList = performance.getEntriesByName('returnToDashboard:start', 'mark');
+      if (markList?.length) {
+        performance.mark('returnToDashboard:end');
+        performance.measure(SentryMetrics.BACK_TO_DASHBOARD, 'returnToDashboard:start', 'returnToDashboard:end');
+        performance.clearMarks('returnToDashboard:start');
+        performance.clearMarks('returnToDashboard:end');
+      }
+    } catch (e) { }
+  }, []);
+
   return (
     <ErrorBoundary>
       <Fragment>

--- a/packages/insomnia/src/ui/routes/root.tsx
+++ b/packages/insomnia/src/ui/routes/root.tsx
@@ -1,5 +1,6 @@
 import '../css/styles.css';
 
+import * as Sentry from '@sentry/electron/renderer';
 import type { IpcRendererEvent } from 'electron';
 import React, { useEffect, useState } from 'react';
 import { type LoaderFunction, Outlet, useFetcher, useNavigate, useParams, useRouteLoaderData } from 'react-router-dom';
@@ -218,6 +219,25 @@ const Root = () => {
       },
     );
   }, [actionFetcher, navigate]);
+
+  // use User Timing API to measure performance
+  useEffect(() => {
+    try {
+      // Create the performance observer.
+      const observer = new PerformanceObserver(list => {
+        for (const entry of list.getEntries()) {
+          // Log the entry and all associated details.
+          const { name, duration } = entry;
+          Sentry.metrics.distribution(name, duration, {
+            unit: 'millisecond',
+          });
+        }
+      });
+      observer.observe({ type: 'measure', buffered: true });
+    } catch (e) {
+      // Do nothing if the browser doesn't support this API.
+    }
+  }, []);
 
   return (
     <AIProvider>


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

**Changes:**

- [x] Use User Timing API to measure the time it takes to return to the dashboard from collection
- [x] create a new sentry metric: back_to_dashboard
