### PR TITLE
fix(GraphQL Editor): make inputValueDeprecation optional and change variable mode to json

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -108,7 +108,7 @@ export interface CodeEditorProps {
 const normalizeMimeType = (mode?: string) => {
   const mimeType = mode ? mode.split(';')[0] : 'text/plain';
   if (mimeType.includes('graphql-variables')) {
-    return 'graphql-variables';
+    return 'application/json';
   } else if (mimeType.includes('graphql')) {
     // Because graphQL plugin doesn't recognize application/graphql content-type
     return 'graphql';


### PR DESCRIPTION
Highlights:

- [x] Changes the variables mode to json to fix an issue where variables require a leading comma and are not used in the end.
- [x] Makes the inputValueDeprecation optional since there are introspection APIs that do not support it and fetching the schema fails on them

Closes INS-4229