### PR TITLE
fix(KeyValue Editor): fix key value focus issue and handle updating params from url

### DIFF
--- a/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-parameters-editor.tsx
@@ -74,8 +74,11 @@ export const RequestParametersEditor: FC<Props> = ({
     );
   }
 
+  const pairsIds = activeRequest.parameters.map((param, index) => param.id || index).join(',');
+
   return (
     <KeyValueEditor
+      key={pairsIds}
       allowMultiline
       namePlaceholder="name"
       valuePlaceholder="value"

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -22,7 +22,7 @@ interface Pair {
   multiline?: boolean | string;
 }
 
-function createEmtyPair() {
+function createEmptyPair() {
   return {
     id: generateId('pair'),
     name: '',
@@ -68,7 +68,7 @@ export const KeyValueEditor: FC<Props> = ({
     initialItems: pairs.length > 0 ? pairs.map(pair => {
       const pairId = pair.id || generateId('pair');
       return { ...pair, id: pairId };
-    }) : [createEmtyPair()],
+    }) : [createEmptyPair()],
     getKey: item => item.id,
   });
 
@@ -101,7 +101,7 @@ export const KeyValueEditor: FC<Props> = ({
       const items = pairsList.items.filter(pair => pair.id !== id);
 
       if (pairsList.items.length === 0) {
-        pairsList.append(createEmtyPair());
+        pairsList.append(createEmptyPair());
       }
 
       onChange(items);
@@ -111,7 +111,7 @@ export const KeyValueEditor: FC<Props> = ({
   const removeAllPairs = useCallback(function removeAllPairs() {
     pairsList.setSelectedKeys(new Set(pairsList.items.map(item => item.id)));
     pairsList.removeSelectedItems();
-    pairsList.append(createEmtyPair());
+    pairsList.append(createEmptyPair());
     onChange([]);
   }, [onChange, pairsList]);
 

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -119,7 +119,6 @@ export const KeyValueEditor: FC<Props> = ({
     getItems: keys =>
       [...keys].map(key => {
         const pair = pairsList.getItem(key);
-        console.log('drag-pair', pair);
         return { 'text/plain': `${pair.id}` };
       }),
     onReorder(e) {
@@ -151,7 +150,6 @@ export const KeyValueEditor: FC<Props> = ({
     renderDragPreview(items) {
       const pair = pairsList.getItem(items[0]['text/plain']);
 
-      console.log({ pair });
       const element = document.querySelector(`[data-key="${pair.id}"]`);
 
       const isFile = pair.type === 'file';
@@ -444,7 +442,6 @@ export const KeyValueEditor: FC<Props> = ({
                 readOnly={pair.disabled || isDisabled}
                 getAutocompleteConstants={() => handleGetAutocompleteNameConstants?.(pair) || []}
                 onChange={name => {
-                  console.log(name);
                   upsertPair({ ...pair, name });
                 }}
               />


### PR DESCRIPTION
Highlights:

- [x] Fixes an issue where typing on the first empty item would lose focus
- [x] Fixes an issue where importing params from the url would not work
- [x] Fixes an issue where having a disabled item and then enabling it wouldn't allow for it to be editable