### PR TITLE
Fixed copying credential In Auth: Basic were username and password input needed to copied by users

### DIFF
--- a/packages/insomnia/src/ui/components/editors/auth/basic-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/basic-auth.tsx
@@ -8,7 +8,7 @@ export const BasicAuth: FC<{ disabled?: boolean }> = ({ disabled = false }) => (
   <AuthTableBody>
     <AuthToggleRow label="Enabled" property="disabled" invert disabled={disabled} />
     <AuthInputRow label="Username" property="username" disabled={disabled} />
-    <AuthInputRow label="Password" property="password" mask disabled={disabled} />
+    <AuthInputRow label="Password" property="password" disabled={disabled} />
     <AuthToggleRow
       label="Use ISO 8859-1"
       help="Check this to use ISO-8859-1 encoding instead of default UTF-8"


### PR DESCRIPTION
There is a issue with the Api testing section from were we send GET , POST And Other useful action many users complained about when they go Auth Section and from dropdown select body method and when they need enter username and password there is mask function which blocks copying password its small but annoying thing and based on tradeoffs we read some comments and taught its better to allow user give ability to copy credentials due to ease of use than make it hidden that we can implement later and that why we choose to remove mask since its all testing purposes we don't need to think about hiding stuff at least for now hope you will understood 