### PR TITLE
spike: 2nd pass to optimize test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,13 +61,15 @@ jobs:
             package-lock.json
             packages/*/package-lock.json
       - run: npm ci
-      - name: Build app for smoke tests
-        run: NODE_OPTIONS='--max_old_space_size=6144' npm run app-build
       - uses: actions/cache@v4
+        id: cache-build
         with:
            key: cache-build
            path: packages/insomnia/build
            restore-keys: cache-build
+      - if: steps.cache-build.outputs.cache-hit != 'true'
+        name: Build app for smoke tests
+        run: NODE_OPTIONS='--max_old_space_size=6144' npm run app-build
 
   SmokeTest:
     needs: BuildForSmokeTests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,48 +16,89 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Test:
+  Install:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout branch
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'
           cache-dependency-path: package-lock.json
+      - run: npm ci
 
-      - name: Install packages
-        run: npm ci
+  Lint:
+    needs: Install
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - run: npm ci --prefer-offline
+      - run: npm run lint
+      - run: npm run lint:markdown
+      - run: npm run type-check
 
-      - name: Lint
-        run: npm run lint
+  Test:
+    needs: Install
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - run: npm ci --prefer-offline
+      - run: npm test
 
-      - name: Lint markdown
-        run: npm run lint:markdown
-
-      - name: Type checks
-        run: npm run type-check
-
-      - name: Unit Tests
-        run: npm test
-
+  BuildForSmokeTests:
+    needs: Install
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - run: npm ci --prefer-offline
       - name: Build app for smoke tests
         run: NODE_OPTIONS='--max_old_space_size=6144' npm run app-build
+      - uses: actions/cache@v4
+        with:
+           key: cache-build
+           path: packages/insomnia/build
 
-      - name: Smoke test electron app
-        run: |
+  SmokeTest:
+    needs: BuildForSmokeTests
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - run: npm ci --prefer-offline
+      - uses: actions/cache@v4
+        with:
+           key: cache-build
+           path: packages/insomnia/build
+      - run: |
           GIT_SYNC_SMOKE_TEST_TOKEN=${{env.GIT_SYNC_SMOKE_TEST_TOKEN}} \
           npm run test:build -w packages/insomnia-smoke-test -- --project=Smoke
         env:
           GIT_SYNC_SMOKE_TEST_TOKEN: ${{ secrets.GIT_SYNC_SMOKE_TEST_TOKEN }}
-
-      # This step should always run even when previous steps fail
-      - name: Upload smoke test traces
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   Install:
-    timeout-minutes: 20
+    timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +25,9 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            packages/*/package-lock.json
       - run: npm ci
 
   Lint:
@@ -38,7 +40,9 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            packages/*/package-lock.json
       - run: npm ci --prefer-offline
       - run: npm run lint
       - run: npm run lint:markdown
@@ -54,7 +58,9 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            packages/*/package-lock.json
       - run: npm ci --prefer-offline
       - run: npm test
 
@@ -68,7 +74,9 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            packages/*/package-lock.json
       - run: npm ci --prefer-offline
       - name: Build app for smoke tests
         run: NODE_OPTIONS='--max_old_space_size=6144' npm run app-build
@@ -76,6 +84,7 @@ jobs:
         with:
            key: cache-build
            path: packages/insomnia/build
+           restore-keys: cache-build
 
   SmokeTest:
     needs: BuildForSmokeTests
@@ -87,12 +96,15 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            packages/*/package-lock.json
       - run: npm ci --prefer-offline
       - uses: actions/cache@v4
         with:
            key: cache-build
            path: packages/insomnia/build
+           restore-keys: cache-build
       - run: |
           GIT_SYNC_SMOKE_TEST_TOKEN=${{env.GIT_SYNC_SMOKE_TEST_TOKEN}} \
           npm run test:build -w packages/insomnia-smoke-test -- --project=Smoke

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Install:
-    timeout-minutes: 1
+  Lint:
+    timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,28 +29,12 @@ jobs:
             package-lock.json
             packages/*/package-lock.json
       - run: npm ci
-
-  Lint:
-    needs: Install
-    timeout-minutes: 20
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: 'npm'
-          cache-dependency-path: |
-            package-lock.json
-            packages/*/package-lock.json
-      - run: npm ci --prefer-offline
       - run: npm run lint
       - run: npm run lint:markdown
       - run: npm run type-check
 
   Test:
-    needs: Install
-    timeout-minutes: 20
+    timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,12 +45,11 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             packages/*/package-lock.json
-      - run: npm ci --prefer-offline
+      - run: npm ci
       - run: npm test
 
   BuildForSmokeTests:
-    needs: Install
-    timeout-minutes: 20
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +60,7 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             packages/*/package-lock.json
-      - run: npm ci --prefer-offline
+      - run: npm ci
       - name: Build app for smoke tests
         run: NODE_OPTIONS='--max_old_space_size=6144' npm run app-build
       - uses: actions/cache@v4
@@ -88,7 +71,7 @@ jobs:
 
   SmokeTest:
     needs: BuildForSmokeTests
-    timeout-minutes: 20
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +82,7 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             packages/*/package-lock.json
-      - run: npm ci --prefer-offline
+      - run: npm ci
       - uses: actions/cache@v4
         with:
            key: cache-build


### PR DESCRIPTION
Core Idea: reduce Test job duration for day-to-day CI and also for when we are doing Releases.

Alternate take on https://github.com/Kong/insomnia/pull/7767

Split Test App into different separate jobs and make use of shared cache.

Pros: 
- small duration improvements (more can be achieved with sharding the smoke tests, as seen in PR #7767 
- if any of the jobs fails, we can just re-trigger the one that failed (could be useful in beta/ga releases)

Cons:
- test.yml becomes a bit split, maybe a slight bit more terse to read?