### PR TITLE
spike replacing pkg with node-sea

### DIFF
--- a/packages/insomnia-inso/generate-sea-binary.sh
+++ b/packages/insomnia-inso/generate-sea-binary.sh
@@ -2,6 +2,7 @@
 
 # This script should generate a node sea binary
 # run with ./packages/insomnia-inso/generate-sea-binary.sh 
+# test with ./packages/insomnia-inso/binaries/inso-sea -h
 
 set -e
 CONFIG_PATH=packages/insomnia-inso/sea-config.json

--- a/packages/insomnia-inso/generate-sea-binary.sh
+++ b/packages/insomnia-inso/generate-sea-binary.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This script should generate a node sea binary
+# run with ./packages/insomnia-inso/generate-sea-binary.sh 
+
+set -e
+CONFIG_PATH=packages/insomnia-inso/sea-config.json
+EXECUTABLE_PATH=packages/insomnia-inso/binaries/inso-sea
+SEAPREP_BLOB_PATH=packages/insomnia-inso/binaries/sea-prep.blob
+
+rm -rf $EXECUTABLE_PATH $SEAPREP_BLOB_PATH
+node --experimental-sea-config $CONFIG_PATH
+cp $(command -v node) $EXECUTABLE_PATH 
+codesign --remove-signature $EXECUTABLE_PATH
+chmod 777 $EXECUTABLE_PATH
+npx postject $EXECUTABLE_PATH NODE_SEA_BLOB $SEAPREP_BLOB_PATH --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 --macho-segment-name NODE_SEA 

--- a/packages/insomnia-inso/sea-config.json
+++ b/packages/insomnia-inso/sea-config.json
@@ -1,0 +1,4 @@
+{
+  "main": "packages/insomnia-inso/dist/index.js",
+  "output": "packages/insomnia-inso/binaries/sea-prep.blob"
+}


### PR DESCRIPTION
motivation: vercel/pkg is no longer maintained and suggests in its readme that node-sea is a viable option

aim: follow nodejs sea docs as a shell script

This is to leave a starting point for us to work on at some point

findings so far:
- didn't work on mac arm returns `Killed: 9` from all commands (SIGKILL)
- requires that all code be bundled, so external mocha, fsevents, and node-libcurl is a problem
- native addons for node (node-libcurl) doesn't work with node-sea but will eventually https://github.com/nodejs/single-executable/discussions/70#discussioncomment-7054406


will need to be abandoned until there is a way to run NaN modules with node-sea

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
