### PR TITLE
feat: display uncommit&unpush change - [INS-4138]

### DIFF
--- a/packages/insomnia/src/models/workspace-meta.ts
+++ b/packages/insomnia/src/models/workspace-meta.ts
@@ -1,5 +1,4 @@
 import { database as db } from '../common/database';
-import type { Compare, Status } from '../sync/types';
 import type { BaseModel } from './index';
 
 export const name = 'Workspace Meta';
@@ -21,8 +20,8 @@ export interface BaseWorkspaceMeta {
   parentId: string | null;
   pushSnapshotOnInitialize: boolean;
   syncData: {
-    status: Status;
-    compare: Compare;
+    hasUncommittedChanges: boolean;
+    hasUnpushedChanges: boolean;
   } | null;
 }
 

--- a/packages/insomnia/src/models/workspace-meta.ts
+++ b/packages/insomnia/src/models/workspace-meta.ts
@@ -1,4 +1,5 @@
 import { database as db } from '../common/database';
+import type { Compare, Status } from '../sync/types';
 import type { BaseModel } from './index';
 
 export const name = 'Workspace Meta';
@@ -19,6 +20,10 @@ export interface BaseWorkspaceMeta {
   gitRepositoryId: string | null;
   parentId: string | null;
   pushSnapshotOnInitialize: boolean;
+  syncData: {
+    status: Status;
+    compare: Compare;
+  } | null;
 }
 
 export type WorkspaceMeta = BaseWorkspaceMeta & BaseModel;
@@ -40,6 +45,7 @@ export function init(): BaseWorkspaceMeta {
     gitRepositoryId: null,
     parentId: null,
     pushSnapshotOnInitialize: false,
+    syncData: null,
   };
 }
 

--- a/packages/insomnia/src/models/workspace-meta.ts
+++ b/packages/insomnia/src/models/workspace-meta.ts
@@ -19,10 +19,8 @@ export interface BaseWorkspaceMeta {
   gitRepositoryId: string | null;
   parentId: string | null;
   pushSnapshotOnInitialize: boolean;
-  syncData: {
-    hasUncommittedChanges: boolean;
-    hasUnpushedChanges: boolean;
-  } | null;
+  hasUncommittedChanges: boolean;
+  hasUnpushedChanges: boolean;
 }
 
 export type WorkspaceMeta = BaseWorkspaceMeta & BaseModel;
@@ -44,7 +42,8 @@ export function init(): BaseWorkspaceMeta {
     gitRepositoryId: null,
     parentId: null,
     pushSnapshotOnInitialize: false,
-    syncData: null,
+    hasUncommittedChanges: false,
+    hasUnpushedChanges: false,
   };
 }
 

--- a/packages/insomnia/src/sync/types.ts
+++ b/packages/insomnia/src/sync/types.ts
@@ -107,3 +107,8 @@ export interface Status {
   stage: Stage;
   unstaged: Record<DocumentKey, StageEntry>;
 }
+
+export interface Compare {
+  ahead: number;
+  behind: number;
+}

--- a/packages/insomnia/src/sync/vcs/util.ts
+++ b/packages/insomnia/src/sync/vcs/util.ts
@@ -7,6 +7,7 @@ import { deleteKeys, resetKeys, shouldIgnoreKey } from '../ignore-keys';
 import { deterministicStringify } from '../lib/deterministicStringify';
 import type {
   Branch,
+  Compare,
   DocumentKey,
   MergeConflict,
   Snapshot,
@@ -241,10 +242,7 @@ export function threeWayMerge(
 export function compareBranches(
   a: Branch | null,
   b: Branch | null,
-): {
-  ahead: number;
-  behind: number;
-} {
+): Compare {
   const snapshotsA = a ? a.snapshots : [];
   const snapshotsB = b ? b.snapshots : [];
   const latestA = snapshotsA[snapshotsA.length - 1] || null;

--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -5,7 +5,6 @@ import { useFetcher, useParams, useRevalidator } from 'react-router-dom';
 import { useInterval } from 'react-use';
 
 import { docsGitSync } from '../../../common/documentation';
-import * as models from '../../../models';
 import type { GitRepository } from '../../../models/git-repository';
 import { deleteGitRepository } from '../../../models/helpers/git-repository-operations';
 import { getOauth2FormatName } from '../../../sync/git/utils';
@@ -97,20 +96,6 @@ export const GitSyncDropdown: FC<Props> = ({ gitRepository, isInsomniaSyncEnable
       gitCanPushFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/git/can-push`);
     }
   }, [gitCanPushFetcher, gitRepoDataFetcher.data, gitRepository?._id, gitRepository?.uri, organizationId, projectId, workspaceId]);
-
-  useEffect(() => {
-    if (gitChangesFetcher.data && gitCanPushFetcher.data) {
-      const { canPush } = gitCanPushFetcher.data;
-      const { changes } = gitChangesFetcher.data;
-      // update workspace meta with git sync data, use for show unpushed changes on collection card
-      models.workspaceMeta.updateByParentId(workspaceId, {
-        syncData: {
-          hasUncommittedChanges: changes.length > 0,
-          hasUnpushedChanges: canPush,
-        },
-      });
-    }
-  }, [gitCanPushFetcher.data, gitChangesFetcher.data, workspaceId]);
 
   // Only fetch the repo status if we have a repo uri and we don't have the status already
   const shouldFetchGitRepoStatus = Boolean(gitRepository?.uri && gitRepository?._id && gitStatusFetcher.state === 'idle' && !gitStatusFetcher.data && gitRepoDataFetcher.data);

--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -104,6 +104,7 @@ export const GitSyncDropdown: FC<Props> = ({ gitRepository, isInsomniaSyncEnable
     if (gitChangesFetcher.data && gitCanPushFetcher.data) {
       const { canPush } = gitCanPushFetcher.data;
       const { changes } = gitChangesFetcher.data;
+      // update workspace meta with git sync data, use for show unpushed changes on collection card
       models.workspaceMeta.updateByParentId(workspaceId, {
         syncData: {
           hasUncommittedChanges: changes.length > 0,

--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -88,14 +88,12 @@ export const GitSyncDropdown: FC<Props> = ({ gitRepository, isInsomniaSyncEnable
 
   useEffect(() => {
     if (gitRepository?.uri && gitRepository?._id && gitChangesFetcher.state === 'idle' && !gitChangesFetcher.data && gitRepoDataFetcher.data) {
-      console.log('[git:fetcher] Fetching git changes');
       gitChangesFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/git/changes`);
     }
   }, [gitChangesFetcher, gitRepoDataFetcher.data, gitRepository?._id, gitRepository?.uri, organizationId, projectId, workspaceId]);
 
   useEffect(() => {
     if (gitRepository?.uri && gitRepository?._id && gitCanPushFetcher.state === 'idle' && !gitCanPushFetcher.data && gitRepoDataFetcher.data) {
-      console.log('[git:fetcher] Fetching git can push');
       gitCanPushFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/git/can-push`);
     }
   }, [gitCanPushFetcher, gitRepoDataFetcher.data, gitRepository?._id, gitRepository?.uri, organizationId, projectId, workspaceId]);

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -854,6 +854,11 @@ async function renderApp() {
                                       (await import('./routes/git-actions')).gitChangesLoader(...args),
                                   },
                                   {
+                                    path: 'can-push',
+                                    loader: async (...args) =>
+                                      (await import('./routes/git-actions')).canPushLoader(...args),
+                                  },
+                                  {
                                     path: 'log',
                                     loader: async (...args) =>
                                       (await import('./routes/git-actions')).gitLogLoader(...args),

--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -318,6 +318,31 @@ export const gitChangesLoader: LoaderFunction = async ({
   }
 };
 
+export interface GitCanPushLoaderData {
+  canPush: boolean;
+}
+
+export const canPushLoader: LoaderFunction = async ({ params }): Promise<GitCanPushLoaderData> => {
+  const { workspaceId } = params;
+  invariant(workspaceId, 'Workspace ID is required');
+
+  const workspaceMeta = await models.workspaceMeta.getByParentId(workspaceId);
+
+  const repoId = workspaceMeta?.gitRepositoryId;
+
+  invariant(repoId, 'Workspace is not linked to a git repository');
+
+  const gitRepository = await models.gitRepository.getById(repoId);
+
+  invariant(gitRepository, 'Git Repository not found');
+  let canPush = false;
+  try {
+    canPush = await GitVCS.canPush(gitRepository.credentials);
+  } catch (err) { }
+
+  return { canPush };
+};
+
 // Actions
 type CloneGitActionResult =
   | Response

--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -302,7 +302,10 @@ export const gitChangesLoader: LoaderFunction = async ({
   const branch = await GitVCS.getCurrentBranch();
   try {
     const { changes, statusNames } = await getGitChanges(GitVCS, workspace);
-
+    // update workspace meta with git sync data, use for show uncommit changes on collection card
+    models.workspaceMeta.updateByParentId(workspaceId, {
+      hasUncommittedChanges: changes.length > 0,
+    });
     return {
       branch,
       changes,
@@ -338,6 +341,10 @@ export const canPushLoader: LoaderFunction = async ({ params }): Promise<GitCanP
   let canPush = false;
   try {
     canPush = await GitVCS.canPush(gitRepository.credentials);
+    // update workspace meta with git sync data, use for show unpushed changes on collection card
+    models.workspaceMeta.update(workspaceMeta, {
+      hasUnpushedChanges: canPush,
+    });
   } catch (err) { }
 
   return { canPush };

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -69,7 +69,6 @@ import {
 } from '../../models/project';
 import { isDesign, scopeToActivity, type Workspace, type WorkspaceScope } from '../../models/workspace';
 import type { WorkspaceMeta } from '../../models/workspace-meta';
-import type { Compare, Status } from '../../sync/types';
 import { VCSInstance } from '../../sync/vcs/insomnia-sync';
 import { showModal } from '../../ui/components/modals';
 import { AskModal } from '../../ui/components/modals/ask-modal';
@@ -265,8 +264,8 @@ export interface InsomniaFile {
   workspace?: Workspace;
   apiSpec?: ApiSpec;
   syncData?: {
-    status: Status;
-    compare: Compare;
+    hasUncommittedChanges: boolean;
+    hasUnpushedChanges: boolean;
   } | null;
 }
 
@@ -1014,6 +1013,10 @@ const ProjectRoute: FC = () => {
     }
   }, [projectId]);
 
+  const showUnCommitOrUnpushIndicator = useMemo(() => {
+    return filesWithPresence.some(file => file?.syncData?.hasUncommittedChanges || file?.syncData?.hasUnpushedChanges);
+  }, [filesWithPresence]);
+
   return (
     <ErrorBoundary>
       <Fragment>
@@ -1125,6 +1128,7 @@ const ProjectRoute: FC = () => {
                       >
                         <div className="flex select-none outline-none group-aria-selected:text-[--color-font] relative group-hover:bg-[--hl-xs] group-focus:bg-[--hl-sm] transition-colors gap-2 px-4 items-center h-[--line-height-xs] w-full overflow-hidden text-[--hl]">
                           <span className="group-aria-selected:bg-[--color-surprise] transition-colors top-0 left-0 absolute h-full w-[2px] bg-transparent" />
+                          {(showUnCommitOrUnpushIndicator && item._id === activeProject?._id) && <div className='rounded-full bg-[--color-warning] w-3 h-3 flex-shrink-0' />}
                           <Icon
                             icon={
                               isRemoteProject(item) ? 'globe-americas' : 'laptop'
@@ -1456,6 +1460,13 @@ const ProjectRoute: FC = () => {
                                 />
                                 <span className="truncate">
                                   {item.lastCommit}
+                                </span>
+                              </div>
+                            )}
+                            {(item.syncData?.hasUncommittedChanges || item.syncData?.hasUnpushedChanges) && (
+                              <div className="text-sm text-[--color-warning]">
+                                <span>
+                                  {item.syncData?.hasUncommittedChanges ? 'Uncommitted changes' : 'Unpushed changes'}
                                 </span>
                               </div>
                             )}

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1127,11 +1127,11 @@ const ProjectRoute: FC = () => {
                       >
                         <div className="flex select-none outline-none group-aria-selected:text-[--color-font] relative group-hover:bg-[--hl-xs] group-focus:bg-[--hl-sm] transition-colors gap-2 px-4 items-center h-[--line-height-xs] w-full overflow-hidden text-[--hl]">
                           <span className="group-aria-selected:bg-[--color-surprise] transition-colors top-0 left-0 absolute h-full w-[2px] bg-transparent" />
-                          {(showUnCommitOrUnpushIndicator && item._id === activeProject?._id) && <div className='rounded-full bg-[--color-warning] w-3 h-3 flex-shrink-0' />}
                           <Icon
                             icon={
                               isRemoteProject(item) ? 'globe-americas' : 'laptop'
                             }
+                            className={(showUnCommitOrUnpushIndicator && item._id === activeProject?._id) ? 'text-[--color-warning]' : ''}
                           />
                           <span className="truncate">{item.name}</span>
                           <span className="flex-1" />

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -377,7 +377,6 @@ async function getAllLocalFiles({
       hasUnpushedChanges: workspaceMeta?.hasUnpushedChanges,
     };
   });
-  console.log('fls', files);
   return files;
 }
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -69,6 +69,7 @@ import {
 } from '../../models/project';
 import { isDesign, scopeToActivity, type Workspace, type WorkspaceScope } from '../../models/workspace';
 import type { WorkspaceMeta } from '../../models/workspace-meta';
+import type { Compare, Status } from '../../sync/types';
 import { VCSInstance } from '../../sync/vcs/insomnia-sync';
 import { showModal } from '../../ui/components/modals';
 import { AskModal } from '../../ui/components/modals/ask-modal';
@@ -263,6 +264,10 @@ export interface InsomniaFile {
   mockServer?: MockServer;
   workspace?: Workspace;
   apiSpec?: ApiSpec;
+  syncData?: {
+    status: Status;
+    compare: Compare;
+  } | null;
 }
 
 export interface ProjectIdLoaderData {
@@ -371,6 +376,7 @@ async function getAllLocalFiles({
       mockServer,
       apiSpec,
       workspace,
+      syncData: workspaceMeta?.syncData,
     };
   });
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1463,7 +1463,8 @@ const ProjectRoute: FC = () => {
                               </div>
                             )}
                             {(item.syncData?.hasUncommittedChanges || item.syncData?.hasUnpushedChanges) && (
-                              <div className="text-sm text-[--color-warning]">
+                              <div className="text-sm text-[--color-warning] flex items-center gap-2">
+                                <div className='rounded-full bg-[--color-warning] w-3 h-3 flex-shrink-0' />
                                 <span>
                                   {item.syncData?.hasUncommittedChanges ? 'Uncommitted changes' : 'Unpushed changes'}
                                 </span>

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -378,7 +378,6 @@ async function getAllLocalFiles({
       syncData: workspaceMeta?.syncData,
     };
   });
-  console.log(files);
   return files;
 }
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -379,7 +379,7 @@ async function getAllLocalFiles({
       syncData: workspaceMeta?.syncData,
     };
   });
-
+  console.log(files);
   return files;
 }
 

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -263,10 +263,8 @@ export interface InsomniaFile {
   mockServer?: MockServer;
   workspace?: Workspace;
   apiSpec?: ApiSpec;
-  syncData?: {
-    hasUncommittedChanges: boolean;
-    hasUnpushedChanges: boolean;
-  } | null;
+  hasUncommittedChanges?: boolean;
+  hasUnpushedChanges?: boolean;
 }
 
 export interface ProjectIdLoaderData {
@@ -375,9 +373,11 @@ async function getAllLocalFiles({
       mockServer,
       apiSpec,
       workspace,
-      syncData: workspaceMeta?.syncData,
+      hasUncommittedChanges: workspaceMeta?.hasUncommittedChanges,
+      hasUnpushedChanges: workspaceMeta?.hasUnpushedChanges,
     };
   });
+  console.log('fls', files);
   return files;
 }
 
@@ -1013,7 +1013,7 @@ const ProjectRoute: FC = () => {
   }, [projectId]);
 
   const showUnCommitOrUnpushIndicator = useMemo(() => {
-    return filesWithPresence.some(file => file?.syncData?.hasUncommittedChanges || file?.syncData?.hasUnpushedChanges);
+    return filesWithPresence.some(file => file?.hasUncommittedChanges || file?.hasUnpushedChanges);
   }, [filesWithPresence]);
 
   return (
@@ -1462,11 +1462,11 @@ const ProjectRoute: FC = () => {
                                 </span>
                               </div>
                             )}
-                            {(item.syncData?.hasUncommittedChanges || item.syncData?.hasUnpushedChanges) && (
+                            {(item.hasUncommittedChanges || item.hasUnpushedChanges) && (
                               <div className="text-sm text-[--color-warning] flex items-center gap-2">
                                 <div className='rounded-full bg-[--color-warning] w-3 h-3 flex-shrink-0' />
                                 <span>
-                                  {item.syncData?.hasUncommittedChanges ? 'Uncommitted changes' : 'Unpushed changes'}
+                                  {item.hasUncommittedChanges ? 'Uncommitted changes' : 'Unpushed changes'}
                                 </span>
                               </div>
                             )}

--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -340,9 +340,12 @@ export const syncDataLoader: LoaderFunction = async ({
       remoteBranchesCache[workspaceId] = remoteBranches;
       remoteCompareCache[workspaceId] = compare;
       remoteBackendProjectsCache[workspaceId] = remoteBackendProjects;
-
+      // update workspace meta with sync data, use for show unpushed changes on collection card
       models.workspaceMeta.updateByParentId(workspaceId, {
-        syncData: { status, compare },
+        syncData: {
+          hasUncommittedChanges: Object.keys(status?.unstaged || {}).length > 0 || Object.keys(status?.stage || {}).length > 0,
+          hasUnpushedChanges: compare?.ahead > 0,
+        },
       });
     } catch (e) { }
 

--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -340,12 +340,18 @@ export const syncDataLoader: LoaderFunction = async ({
       remoteBranchesCache[workspaceId] = remoteBranches;
       remoteCompareCache[workspaceId] = compare;
       remoteBackendProjectsCache[workspaceId] = remoteBackendProjects;
+
+      let hasUncommittedChanges = false;
+      if (status?.unstaged && Object.keys(status.unstaged).length > 0) {
+        hasUncommittedChanges = true;
+      }
+      if (status?.stage && Object.keys(status.stage).length > 0) {
+        hasUncommittedChanges = true;
+      }
       // update workspace meta with sync data, use for show unpushed changes on collection card
       models.workspaceMeta.updateByParentId(workspaceId, {
-        syncData: {
-          hasUncommittedChanges: Object.keys(status?.unstaged || {}).length > 0 || Object.keys(status?.stage || {}).length > 0,
-          hasUnpushedChanges: compare?.ahead > 0,
-        },
+        hasUncommittedChanges,
+        hasUnpushedChanges: compare?.ahead > 0,
       });
     } catch (e) { }
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
![image](https://github.com/user-attachments/assets/4f8da0be-a279-4f25-ba7c-699d9d02d035)

Feature: Show uncommitted & unpushed change for both insomnia sync and git sync

**Currently this pr can only show unpush/uncommit status for active project**

Changes: 

- [x] add `hasUnpushedChanges` and `hasUncommittedChanges` to the workspace meta model
- [x] add `can-push` loader to check if there are unpushed changes
- [x] check diff with remote when working in workspace and update workspace meta
- [x] UI: replace the project icon color to mark change

Next step:

- [ ] show inactive project unpush status