### PR TITLE
fix: persist cookies from response together with ones from after-response script

### DIFF
--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -2,7 +2,6 @@ import clone from 'clone';
 import fs from 'fs';
 import orderedJSON from 'json-order';
 import { join as pathJoin } from 'path';
-import { Cookie as ToughCookie } from 'tough-cookie';
 
 import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from '../common/constants';
 import { database as db } from '../common/database';


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Background
Cookies from response are persisted. When after-response script is enabled, it will persisted in `savePatchesMadeByScript` but it doesn't include cookies from response.

Fixes #7808 INS-4264

### Changes
- [x] cookies from response should also persisted together with ones from after-response
