### PR TITLE
Import postman env in Insomnia project level [INS-4253]

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -364,6 +364,8 @@ test.describe('pre-request features tests', async () => {
 
         await page.getByLabel('Request Collection').getByTestId('test proxies manipulation').press('Enter');
 
+        await page.waitForTimeout(500);
+
         // send
         await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -364,8 +364,6 @@ test.describe('pre-request features tests', async () => {
 
         await page.getByLabel('Request Collection').getByTestId('test proxies manipulation').press('Enter');
 
-        await page.waitForTimeout(500);
-
         // send
         await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 

--- a/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
+++ b/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
@@ -6003,8 +6003,8 @@ exports[`Fixtures > Import postman-env > basic-input.json 1`] = `
         "foo": "production",
       },
       "meta": {
-+       "postmanEnvScope": "environment",
-+     },
+        "postmanEnvScope": "environment",
+      },
       "name": "Production Env",
       "parentId": "__BASE_ENVIRONMENT_ID__",
     },
@@ -6026,8 +6026,8 @@ exports[`Fixtures > Import postman-env > no-name-input.json 1`] = `
         "foo-and-bar": "production-env",
       },
       "meta": {
-+       "postmanEnvScope": "environment",
-+     },
+        "postmanEnvScope": "environment",
+      },
       "name": "Postman Environment",
       "parentId": "__BASE_ENVIRONMENT_ID__",
     },

--- a/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
+++ b/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
@@ -6002,6 +6002,9 @@ exports[`Fixtures > Import postman-env > basic-input.json 1`] = `
       "data": {
         "foo": "production",
       },
+      "meta": {
++       "postmanEnvScope": "environment",
++     },
       "name": "Production Env",
       "parentId": "__BASE_ENVIRONMENT_ID__",
     },
@@ -6022,6 +6025,9 @@ exports[`Fixtures > Import postman-env > no-name-input.json 1`] = `
       "data": {
         "foo-and-bar": "production-env",
       },
+      "meta": {
++       "postmanEnvScope": "environment",
++     },
       "name": "Postman Environment",
       "parentId": "__BASE_ENVIRONMENT_ID__",
     },

--- a/packages/insomnia/src/utils/importers/importers/postman-env.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman-env.ts
@@ -20,13 +20,20 @@ type Data = {
   [key in EnvVar['key']]: EnvVar['value'];
 };
 
+const POSTMAN_ENV_TYPE: Record<string, string> = {
+  'GLOBAL': 'globals',
+  'ENVIRONMENT': 'environment',
+};
+
+const validPostmanEnvTypeList = Object.keys(POSTMAN_ENV_TYPE).map(key => POSTMAN_ENV_TYPE[key]);
+
 export const convert: Converter<Data> = rawData => {
   try {
     const { _postman_variable_scope, name, values } = JSON.parse(
       rawData,
     ) as Environment;
 
-    if (_postman_variable_scope !== 'environment') {
+    if (!validPostmanEnvTypeList.includes(_postman_variable_scope)) {
       return null;
     }
 
@@ -44,6 +51,9 @@ export const convert: Converter<Data> = rawData => {
             [key]: value,
           };
         }, {}),
+        meta: {
+          postmanEnvScope: _postman_variable_scope,
+        },
       },
     ];
   } catch (error) {

--- a/packages/insomnia/src/utils/importers/importers/postman-env.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman-env.ts
@@ -20,12 +20,12 @@ type Data = {
   [key in EnvVar['key']]: EnvVar['value'];
 };
 
-const POSTMAN_ENV_TYPE: Record<string, string> = {
-  'GLOBAL': 'globals',
-  'ENVIRONMENT': 'environment',
+export enum POSTMAN_ENV_TYPE {
+  GLOBAL = 'globals',
+  ENVIRONMENT = 'environment',
 };
 
-const validPostmanEnvTypeList = Object.keys(POSTMAN_ENV_TYPE).map(key => POSTMAN_ENV_TYPE[key]);
+const validPostmanEnvTypeList = Object.values(POSTMAN_ENV_TYPE) as string[];
 
 export const convert: Converter<Data> = rawData => {
   try {


### PR DESCRIPTION
Before:
When importing a Postman environment in the Insomnia project level we create a new empty workspace and the environment doesn't get imported.
When importing a Postman global environment it's not supported.

Now:
When importing a Postman environment in the Insomnia project level we create a new global environment in current project and copy the variables.
When importing a Postman global environment in the Insomnia project level we create a new global environment in current project and copy the variables.