### PR TITLE
Preserve the original Authorization headers when importing [INS-4269]

### DIFF
--- a/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
+++ b/packages/insomnia/src/utils/importers/importers/__snapshots__/index.test.ts.snap
@@ -4479,6 +4479,10 @@ exports[`Fixtures > Import postman > complex-v2_0_fromHeaders-input.json 1`] = `
       "description": "<br>See [Display the specified project.](#display-the-specified-project) for the returned attributes.",
       "headers": [
         {
+          "name": "Authorization",
+          "value": "Bearer {{token}}",
+        },
+        {
           "name": "Accept",
           "value": "application/json",
         },
@@ -4519,6 +4523,10 @@ exports[`Fixtures > Import postman > complex-v2_0_fromHeaders-input.json 1`] = `
       },
       "description": "<br>See [Display the specified project.](#display-the-specified-project) for the returned attributes.",
       "headers": [
+        {
+          "name": "Authorization",
+          "value": "AWS4-HMAC-SHA256 Credential=<accessKeyId>/20220110/<region>/<service>/aws4_request, SignedHeaders=accept;content-type;host;x-amz-date;x-amz-security-token, Signature=ed270ed6ad1cad3513f6edad9692e4496e321e44954c70a86504eea5e0ef1ff5",
+        },
         {
           "name": "Accept",
           "value": "application/json",
@@ -4575,6 +4583,10 @@ exports[`Fixtures > Import postman > complex-v2_0_fromHeaders-input.json 1`] = `
       "description": "<br>See [Display the specified project.](#display-the-specified-project) for the returned attributes.",
       "headers": [
         {
+          "name": "Authorization",
+          "value": "Basic am9obkBleGFtcGxlLmNvbTphYmMxMjM=",
+        },
+        {
           "name": "Accept",
           "value": "application/json",
         },
@@ -4620,6 +4632,10 @@ exports[`Fixtures > Import postman > complex-v2_0_fromHeaders-input.json 1`] = `
 Child projects are provided as references; i.e. they only contain the <code>self</code> attribute.
 </aside>",
       "headers": [
+        {
+          "name": "Authorization",
+          "value": "Digest username="Username", realm="Realm", nonce="Nonce", uri="//api/v1/report?start_date_min=2019-01-01T00%3A00%3A00%2B00%3A00&start_date_max=2019-01-01T23%3A59%3A59%2B00%3A00&projects[]=%2Fprojects%2F1&include_child_projects=1&search_query=meeting&columns[]=project&include_project_data=1&sort[]=-duration", algorithm="MD5", response="f3f762321e158aefe103529eda4ddb7c", opaque="Opaque"",
+        },
         {
           "name": "Accept",
           "value": "application/json",
@@ -4676,6 +4692,10 @@ Omitted fields will not be updated, even when using the \`PUT\` method.
 Changing a project's parent or children is currently not possible.
 </aside>",
       "headers": [
+        {
+          "name": "Authorization",
+          "value": "OAuth realm="Realm",oauth_consumer_key="Consumer%20Key",oauth_token="Access%20Token",oauth_signature_method="HMAC-SHA1",oauth_timestamp="Timestamp",oauth_nonce="Nonce",oauth_version="Version",oauth_callback="Callback%20URL",oauth_verifier="Verifier",oauth_signature="TwJvZVasVWTL6X%2Bz3lmuiyvaX2Q%3D"",
+        },
         {
           "name": "Accept",
           "value": "application/json",
@@ -4756,7 +4776,13 @@ exports[`Fixtures > Import postman > complex-v2_0-input.json 1`] = `
         ],
       },
       "description": "First Request",
-      "headers": [],
+      "headers": [
+        {
+          "description": "",
+          "name": "Authorization",
+          "value": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+        },
+      ],
       "metaSortKey": -1622117983998,
       "method": "POST",
       "name": "{{base_url}}/api/users",
@@ -4786,7 +4812,13 @@ exports[`Fixtures > Import postman > complex-v2_0-input.json 1`] = `
         ],
       },
       "description": "First Request",
-      "headers": [],
+      "headers": [
+        {
+          "description": "",
+          "name": "Authorization",
+          "value": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+        },
+      ],
       "metaSortKey": -1622117983997,
       "method": "POST",
       "name": "Urlencoded Form Test",
@@ -4934,7 +4966,12 @@ exports[`Fixtures > Import postman > complex-v2_1-input.json 1`] = `
         ],
       },
       "description": "First Request",
-      "headers": [],
+      "headers": [
+        {
+          "name": "Authorization",
+          "value": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+        },
+      ],
       "metaSortKey": -1622117983998,
       "method": "POST",
       "name": "{{base_url}}/api/users",
@@ -4964,7 +5001,12 @@ exports[`Fixtures > Import postman > complex-v2_1-input.json 1`] = `
         ],
       },
       "description": "First Request",
-      "headers": [],
+      "headers": [
+        {
+          "name": "Authorization",
+          "value": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+        },
+      ],
       "metaSortKey": -1622117983997,
       "method": "POST",
       "name": "Urlencoded Form Test",

--- a/packages/insomnia/src/utils/importers/importers/postman.test.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.test.ts
@@ -84,7 +84,7 @@ describe('postman', () => {
     });
 
     describe('awsv4', () => {
-      it('should not duplicate headers', () => {
+      it('get auth info from header', () => {
         const request: Request1 = {
           header: [
             {
@@ -99,7 +99,7 @@ describe('postman', () => {
         };
         const schema = postmanSchema({ requests: [request] });
         const postman = new ImportPostman(schema);
-        const { authentication, headers } = postman.importRequestItem({ request }, 'n/a');
+        const { authentication } = postman.importRequestItem({ request }, 'n/a');
 
         expect(authentication).toEqual({
           accessKeyId: '<accessKeyId>',
@@ -110,12 +110,11 @@ describe('postman', () => {
           sessionToken: 'someTokenSomethingSomething',
           type: 'iam',
         });
-        expect(headers).toEqual([]);
       });
     });
 
     describe('basic', () => {
-      it('returns a simple basic auth and does not duplicate authorization header', () => {
+      it('returns a simple basic auth', () => {
         const username = 'ziltoid';
         const password = 'theOmniscient';
         const token = Buffer.from(`${username}:${password}`).toString('base64');
@@ -134,7 +133,7 @@ describe('postman', () => {
         };
         const schema = postmanSchema({ requests: [request] });
         const postman = new ImportPostman(schema);
-        const { authentication, headers } = postman.importRequestItem({ request }, 'n/a');
+        const { authentication } = postman.importRequestItem({ request }, 'n/a');
 
         expect(authentication).toEqual({
           type: 'basic',
@@ -142,10 +141,6 @@ describe('postman', () => {
           username: 'ziltoid',
           password: 'theOmniscient',
         });
-        expect(headers).toEqual([{
-          name: nonAuthHeader.key,
-          value: nonAuthHeader.value,
-        }]);
       });
     });
 
@@ -163,7 +158,7 @@ describe('postman', () => {
         };
         const schema = postmanSchema({ requests: [request] });
         const postman = new ImportPostman(schema);
-        const { authentication, headers } = postman.importRequestItem({ request }, 'n/a');
+        const { authentication } = postman.importRequestItem({ request }, 'n/a');
 
         expect(authentication).toEqual({
           type: 'bearer',
@@ -171,10 +166,6 @@ describe('postman', () => {
           token: '{{token}}',
           prefix: '',
         });
-        expect(headers).toEqual([{
-          name: nonAuthHeader.key,
-          value: nonAuthHeader.value,
-        }]);
       });
 
       it('handles multiple spaces', () => {
@@ -205,7 +196,7 @@ describe('postman', () => {
         };
         const schema = postmanSchema({ requests: [request] });
         const postman = new ImportPostman(schema);
-        const { authentication, headers } = postman.importRequestItem({ request }, 'n/a');
+        const { authentication } = postman.importRequestItem({ request }, 'n/a');
 
         expect(authentication).toEqual({
           type: 'bearer',
@@ -213,7 +204,6 @@ describe('postman', () => {
           token: '',
           prefix: '',
         });
-        expect(headers).toEqual([]);
       });
     });
 
@@ -229,7 +219,7 @@ describe('postman', () => {
         };
         const schema = postmanSchema({ requests: [request] });
         const postman = new ImportPostman(schema);
-        const { authentication, headers } = postman.importRequestItem({ request }, 'n/a');
+        const { authentication } = postman.importRequestItem({ request }, 'n/a');
 
         expect(authentication).toEqual({
           type: 'digest',
@@ -237,7 +227,6 @@ describe('postman', () => {
           username: username,
           password: '',
         });
-        expect(headers).toEqual([]);
       });
     });
 
@@ -252,7 +241,7 @@ describe('postman', () => {
         };
         const schema = postmanSchema({ requests: [request] });
         const postman = new ImportPostman(schema);
-        const { authentication, headers } = postman.importRequestItem({ request }, 'n/a');
+        const { authentication } = postman.importRequestItem({ request }, 'n/a');
 
         expect(authentication).toEqual({
           callback: 'Callback%20URL',
@@ -270,7 +259,6 @@ describe('postman', () => {
           verifier: 'Verifier',
           version: 'Version',
         });
-        expect(headers).toEqual([]);
       });
     });
   });

--- a/packages/insomnia/src/utils/importers/importers/postman.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman.ts
@@ -444,7 +444,10 @@ export class ImportPostman {
     // It is a business logic decision to remove the "Authorization" header.
     // If you think about it, this makes sense because if you've used Insomnia to fill out an Authorization form (e.g. Basic Auth), you wouldn't then also want the header to be added separately.
     // If users want to manually set up these headers they still absolutely can, of course, but we try to keep things simple and help users out.
-    const headers = originalHeaders.filter(h => !isAuthorizationHeader(h));
+    // const headers = originalHeaders.filter(h => !isAuthorizationHeader(h));
+
+    // preserve the original headers according to requirements from 'Progressive' INS-4269
+    const headers = originalHeaders;
 
     if (!authentication) {
       if (authorizationHeader) {


### PR DESCRIPTION
Customer need to preserve the original Authorization headers when import from postman.