### PR TITLE
feat: Context menu for Nunjucks tag[INS-4273]

### DIFF
--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -2,7 +2,7 @@ import type { IpcMainEvent, IpcMainInvokeEvent, MenuItemConstructorOptions, Open
 import { app, BrowserWindow, clipboard, dialog, ipcMain, Menu, shell } from 'electron';
 
 import { fnOrString } from '../../common/misc';
-import type { NunjucksParsedTagArg } from '../../templating/utils';
+import { extractNunjucksTagFromCoords, type NunjucksParsedTagArg, type NunjucksTagContextMenuAction } from '../../templating/utils';
 import { localTemplateTags } from '../../ui/components/templating/local-template-tags';
 import { invariant } from '../../utils/invariant';
 
@@ -71,6 +71,7 @@ export type MainOnChannels =
 export type RendererOnChannels =
   'clear-all-models'
   | 'clear-model'
+  | 'nunjucks-context-menu-command'
   | 'context-menu-command'
   | 'grpc.data'
   | 'grpc.end'
@@ -111,50 +112,78 @@ const getTemplateValue = (arg: NunjucksParsedTagArg) => {
   return arg.defaultValue;
 };
 export function registerElectronHandlers() {
-  ipcMainOn('show-context-menu', (event, options) => {
+  ipcMainOn('show-context-menu', (event, options: { key: string; nunjucksTag: ReturnType<typeof extractNunjucksTagFromCoords> }) => {
+    const { key, nunjucksTag } = options;
+    const sendNunjuckTagContextMsg = (type: NunjucksTagContextMenuAction) => {
+      event.sender.send('context-menu-command', { key, nunjucksTag: { ...nunjucksTag, type } });
+    };
     try {
-      const template: MenuItemConstructorOptions[] = [
-        {
-          role: 'cut',
-        },
-        {
-          role: 'copy',
-        },
-        {
-          role: 'paste',
-        },
-        { type: 'separator' },
-        ...localTemplateTags
-          // sort alphabetically
-          .sort((a, b) => fnOrString(a.templateTag.displayName).localeCompare(fnOrString(b.templateTag.displayName)))
-          .map(l => {
-            const actions = l.templateTag.args?.[0];
-            const additionalArgs = l.templateTag.args?.slice(1);
-            const hasSubmenu = actions?.options?.length;
-            return {
-              label: fnOrString(l.templateTag.displayName),
-              ...(!hasSubmenu ?
-                {
+      const baseTemplate: MenuItemConstructorOptions[] = nunjucksTag ?
+        [
+          {
+            label: 'Edit',
+            click: () => sendNunjuckTagContextMsg('edit'),
+          },
+          {
+            label: 'Copy',
+            click: () => {
+              clipboard.writeText(nunjucksTag.template);
+            },
+          },
+          {
+            label: 'Cut',
+            click: () => {
+              clipboard.writeText(nunjucksTag.template);
+              sendNunjuckTagContextMsg('delete');
+            },
+          },
+          {
+            label: 'Delete',
+            click: () => sendNunjuckTagContextMsg('delete'),
+          },
+          { type: 'separator' },
+        ] :
+        [
+          {
+            role: 'cut',
+          },
+          {
+            role: 'copy',
+          },
+          {
+            role: 'paste',
+          },
+          { type: 'separator' },
+        ];
+      const localTemplate: MenuItemConstructorOptions[] = localTemplateTags
+        // sort alphabetically
+        .sort((a, b) => fnOrString(a.templateTag.displayName).localeCompare(fnOrString(b.templateTag.displayName)))
+        .map(l => {
+          const actions = l.templateTag.args?.[0];
+          const additionalArgs = l.templateTag.args?.slice(1);
+          const hasSubmenu = actions?.options?.length;
+          return {
+            label: fnOrString(l.templateTag.displayName),
+            ...(!hasSubmenu ?
+              {
+                click: () => {
+                  const tag = `{% ${l.templateTag.name} ${l.templateTag.args?.map(getTemplateValue).join(', ')} %}`;
+                  event.sender.send('context-menu-command', { key, tag });
+                },
+              } :
+              {
+                submenu: actions?.options?.map(action => ({
+                  label: fnOrString(action.displayName),
                   click: () => {
-                    const tag = `{% ${l.templateTag.name} ${l.templateTag.args?.map(getTemplateValue).join(', ')} %}`;
-                    event.sender.send('context-menu-command', { key: options.key, tag });
+                    const additionalTagFields = additionalArgs.length ? ', ' + additionalArgs.map(getTemplateValue).join(', ') : '';
+                    const tag = `{% ${l.templateTag.name} '${action.value}'${additionalTagFields} %}`;
+                    event.sender.send('context-menu-command', { key, tag });
                   },
-                } :
-                {
-                  submenu: actions?.options?.map(action => ({
-                    label: fnOrString(action.displayName),
-                    click: () => {
-                      const additionalTagFields = additionalArgs.length ? ', ' + additionalArgs.map(getTemplateValue).join(', ') : '';
-                      const tag = `{% ${l.templateTag.name} '${action.value}'${additionalTagFields} %}`;
-                      event.sender.send('context-menu-command', { key: options.key, tag });
-                    },
-                  })),
-                }),
-            };
-          }),
-
-      ];
-      const menu = Menu.buildFromTemplate(template);
+                })),
+              }),
+          };
+        });
+      const menu = Menu.buildFromTemplate([...baseTemplate, ...localTemplate]);
       const win = BrowserWindow.fromWebContents(event.sender);
       invariant(win, 'expected window');
       menu.popup({ window: win });

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -71,7 +71,6 @@ export type MainOnChannels =
 export type RendererOnChannels =
   'clear-all-models'
   | 'clear-model'
-  | 'nunjucks-context-menu-command'
   | 'context-menu-command'
   | 'grpc.data'
   | 'grpc.end'

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/electron/main';
+import type { MarkerRange } from 'codemirror';
 import { app, BrowserWindow, type IpcRendererEvent, shell } from 'electron';
 import fs from 'fs';
 
@@ -37,7 +38,7 @@ export interface RendererToMainBridgeAPI {
   curl: CurlBridgeAPI;
   trackSegmentEvent: (options: { event: string; properties?: Record<string, unknown> }) => void;
   trackPageView: (options: { name: string }) => void;
-  showContextMenu: (options: { key: string }) => void;
+  showContextMenu: (options: { key: string; nunjucksTag?: { template: string; range: MarkerRange } }) => void;
   database: {
     caCertificate: {
       create: (options: { parentId: string; path: string }) => Promise<string>;

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -229,7 +229,6 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
   useEffect(() => {
     const unsubscribe = window.main.on('context-menu-command', (_, { key, tag, nunjucksTag }) => {
       if (id === key) {
-        console.log('enter context menu cmd');
         if (nunjucksTag) {
           const { type, template, range } = nunjucksTag as nunjucksTagContextMenuOptions;
           switch (type) {


### PR DESCRIPTION
Show different context menu when right clicks on Nunjucks tag in editor. 
Add and improve the edit/copy/cut/delete action in context menu. 
Currently copy and cut is not working since they do not copy tag real value.
Add delete action to delete the tag and edit action to edit the tag just like left click on tag.
<img width="268" alt="Screenshot 2024-08-12 at 10 06 32" src="https://github.com/user-attachments/assets/35f8bc14-f798-48cb-8112-26f925938dcc"><img width="325" alt="Screenshot 2024-08-12 at 10 17 55" src="https://github.com/user-attachments/assets/52d31233-560f-481d-900b-fb63750135c4">

Changes: 
- Add handler when user right clicks on Nunjucks tag and get range and template data.
- Modify the ipcMain and ipcRenderer listeners to handle Nunjucks tag right click.
- Add edit/copy/cut/delete action handler.
