### PR TITLE
Fix: GraphQL request export curl body issue and GraphQL payload delete issue[INS-4281]

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -39,6 +39,15 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
   const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
   await expect(statusTag).toContainText('200 OK');
 
+  // Export GraphQL request
+  await page.getByTestId('Dropdown-GraphQL-request-with-number').click();
+  await page.getByText('Copy as cURL').click();
+  const handle = await page.evaluateHandle(() => navigator.clipboard.readText());
+  const clipboardContent = await handle.jsonValue();
+  const exepctResult = JSON.stringify({ query: 'query($inputVar:Int){echoNum(intVar:$inputVar)}', variables: { inputVar: 3 } });
+  // expect exported curl body to be JSON string
+  expect(clipboardContent.split('--data ')[1]?.replace(/[\n\s\']/g, '')).toContain(exepctResult);
+
   const responseBody = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
     has: page.locator('.CodeMirror-activeline'),
   });

--- a/packages/insomnia/src/common/har.ts
+++ b/packages/insomnia/src/common/har.ts
@@ -12,6 +12,7 @@ import { getAuthHeader } from '../network/authentication';
 import * as plugins from '../plugins';
 import * as pluginContexts from '../plugins/context/index';
 import { RenderError } from '../templating/index';
+import { parseGraphQLReqeustBody } from '../utils/graph-ql';
 import { smartEncodeUrl } from '../utils/url/querystring';
 import { getAppVersion } from './constants';
 import { jarFromCookies } from './cookies';
@@ -176,6 +177,7 @@ export async function exportHarWithRequest(
       renderResult.request,
       renderResult.context,
     );
+    parseGraphQLReqeustBody(renderedRequest);
     return exportHarWithRenderedRequest(renderedRequest, addContentLength);
   } catch (err) {
     if (err instanceof RenderError) {

--- a/packages/insomnia/src/network/unit-test-feature.ts
+++ b/packages/insomnia/src/network/unit-test-feature.ts
@@ -1,5 +1,6 @@
 import { stats } from '../models';
 import { getBodyBuffer } from '../models/response';
+import { parseGraphQLReqeustBody } from '../utils/graph-ql';
 import { fetchRequestData, responseTransform, sendCurlAndWriteTimeline, tryToInterpolateRequest, tryToTransformRequestWithPlugins } from './network';
 
 export function getSendRequestCallback() {
@@ -19,17 +20,7 @@ export function getSendRequestCallback() {
     const renderedRequest = await tryToTransformRequestWithPlugins(renderResult);
 
     // TODO: remove this temporary hack to support GraphQL variables in the request body properly
-    if (renderedRequest && renderedRequest.body?.text && renderedRequest.body?.mimeType === 'application/graphql') {
-      try {
-        const parsedBody = JSON.parse(renderedRequest.body.text);
-        if (typeof parsedBody.variables === 'string') {
-          parsedBody.variables = JSON.parse(parsedBody.variables);
-          renderedRequest.body.text = JSON.stringify(parsedBody, null, 2);
-        }
-      } catch (e) {
-        console.error('Failed to parse GraphQL variables', e);
-      }
-    }
+    parseGraphQLReqeustBody(renderedRequest);
 
     const response = await sendCurlAndWriteTimeline(
       renderedRequest,

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -58,7 +58,7 @@ function getGraphQLContent(body: GraphQLBody, query?: string, operationName?: st
     content.variables = variables.length ? variables : undefined;
   }
 
-  // Set empty content after user has deleted the query and variables - NS-132
+  // Set empty content after user has deleted the query and variables - INS-132
   if (!content.query && !content.variables) {
     return '';
   }

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -58,7 +58,7 @@ function getGraphQLContent(body: GraphQLBody, query?: string, operationName?: st
     content.variables = variables.length ? variables : undefined;
   }
 
-  // Set empty content after user has deleted the query and variables, see https://konghq.atlassian.net/browse/INS-132
+  // Set empty content after user has deleted the query and variables - NS-132
   if (!content.query && !content.variables) {
     return '';
   }

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -340,7 +340,7 @@ export const GraphQLEditor: FC<Props> = ({
     } catch (error) {
       console.warn('failed to parse', error);
       if (isString(query) && query.trim() === '') {
-        // update request body
+        // update request body when query is empty
         onChange(getGraphQLContent(state.body, query, ''));
       };
       setState(state => ({

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -45,12 +45,11 @@ function getGraphQLContent(body: GraphQLBody, query?: string, operationName?: st
     content.variables = optionalProps.variables;
   }
 
-  if (query) {
+  if (isString(query)) {
     content.query = query;
   }
 
   // The below items are optional; should be set to undefined if present and empty
-  const isString = (value?: string): value is string => typeof value === 'string' || (value as unknown) instanceof String;
   if (isString(operationName)) {
     content.operationName = operationName.length ? operationName : undefined;
   }
@@ -59,9 +58,15 @@ function getGraphQLContent(body: GraphQLBody, query?: string, operationName?: st
     content.variables = variables.length ? variables : undefined;
   }
 
+  // Set empty content after user has deleted the query and variables, see https://konghq.atlassian.net/browse/INS-132
+  if (!content.query && !content.variables) {
+    return '';
+  }
+
   return JSON.stringify(content);
 }
 
+const isString = (value?: string): value is string => typeof value === 'string' || (value as unknown) instanceof String;
 const isOperationDefinition = (def: DefinitionNode): def is OperationDefinitionNode => def.kind === Kind.OPERATION_DEFINITION;
 
 const fetchGraphQLSchemaForRequest = async ({
@@ -334,6 +339,10 @@ export const GraphQLEditor: FC<Props> = ({
       }));
     } catch (error) {
       console.warn('failed to parse', error);
+      if (isString(query) && query.trim() === '') {
+        // update request body
+        onChange(getGraphQLContent(state.body, query, ''));
+      };
       setState(state => ({
         ...state,
         documentAST: null,

--- a/packages/insomnia/src/utils/graph-ql.ts
+++ b/packages/insomnia/src/utils/graph-ql.ts
@@ -1,8 +1,7 @@
 import { CONTENT_TYPE_GRAPHQL } from '../common/constants';
 import type { RenderedRequest } from '../common/render';
 
-// parse graphql request body since we save entire query variables as string rather then stringified json string
-// see: https://linear.app/insomnia/issue/INS-4281/[bug]-graphql-issues
+// parse graphql request body since we save entire query variables as string rather then stringified json string. - INS-4281
 export function parseGraphQLReqeustBody(renderedRequest: RenderedRequest) {
   if (renderedRequest && renderedRequest.body?.text && renderedRequest.body?.mimeType === CONTENT_TYPE_GRAPHQL) {
     try {

--- a/packages/insomnia/src/utils/graph-ql.ts
+++ b/packages/insomnia/src/utils/graph-ql.ts
@@ -1,0 +1,18 @@
+import { CONTENT_TYPE_GRAPHQL } from '../common/constants';
+import type { RenderedRequest } from '../common/render';
+
+// parse graphql request body since we save entire query variables as string rather then stringified json string
+// see: https://linear.app/insomnia/issue/INS-4281/[bug]-graphql-issues
+export function parseGraphQLReqeustBody(renderedRequest: RenderedRequest) {
+  if (renderedRequest && renderedRequest.body?.text && renderedRequest.body?.mimeType === CONTENT_TYPE_GRAPHQL) {
+    try {
+      const parsedBody = JSON.parse(renderedRequest.body.text);
+      if (typeof parsedBody.variables === 'string') {
+        parsedBody.variables = JSON.parse(parsedBody.variables);
+        renderedRequest.body.text = JSON.stringify(parsedBody, null, 2);
+      }
+    } catch (e) {
+      console.error('Failed to parse GraphQL variables', e);
+    }
+  }
+}


### PR DESCRIPTION
Background
1. When user exports GraphQL request as curl, the Query Variables value is exported as entire string rather than string from JSON.stringify. So user could not use the exported curl script.
2. When user delete both Query & Query Variables in GraphQL editor and switch to JSON body, it will be confusing that the content is not cleared.

- [x] Add the GraphQL request body parse logic when export curl 
- [x] Clear GraphQL request body when user delete both Query & Query Variables 
- [x] Update smoke test for GraphQL request export 
