### PR TITLE
Try to fix smoke test flaky

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -361,6 +361,8 @@ test.describe('pre-request features tests', async () => {
         await page.locator('[name="httpsProxy"]').fill('localhost:2222');
         await page.locator('[name="noProxy"]').fill('http://a.com,https://b.com');
         await page.locator('.app').press('Escape');
+        // add 1s timeout to ensure noProxy settings is applied - INS-4155
+        await page.waitForTimeout(1000);
 
         await page.getByLabel('Request Collection').getByTestId('test proxies manipulation').press('Enter');
 


### PR DESCRIPTION
Add 1s timeout to ensure noProxy settings is applied for failed smoke test