### PR TITLE
feat(Git Sync): Support for multiple files on the same repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13611,31 +13611,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "node_modules/isomorphic-git": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.27.1.tgz",
-      "integrity": "sha512-X32ph5zIWfT75QAqW2l3JCIqnx9/GWd17bRRehmn3qmWc34OYbSXY6Cxv0o9bIIY+CWugoN4nQFHNA+2uYf2nA==",
-      "dev": true,
-      "dependencies": {
-        "async-lock": "^1.4.1",
-        "clean-git-ref": "^2.0.1",
-        "crc-32": "^1.2.0",
-        "diff3": "0.0.3",
-        "ignore": "^5.1.4",
-        "minimisted": "^2.0.0",
-        "pako": "^1.0.10",
-        "pify": "^4.0.1",
-        "readable-stream": "^3.4.0",
-        "sha.js": "^2.4.9",
-        "simple-get": "^4.0.1"
-      },
-      "bin": {
-        "isogit": "cli.cjs"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
@@ -22168,7 +22143,7 @@
         "gsap": "^3.12.5",
         "highlight.js": "^11.9.0",
         "httplease-asap": "^0.6.0",
-        "isomorphic-git": "1.27.1",
+        "isomorphic-git": "1.25.7",
         "json-diff-kit": "^1.0.23",
         "json-order": "^1.1.3",
         "less": "^4.2.0",
@@ -23248,6 +23223,31 @@
         "@esbuild/win32-arm64": "0.20.2",
         "@esbuild/win32-ia32": "0.20.2",
         "@esbuild/win32-x64": "0.20.2"
+      }
+    },
+    "packages/insomnia/node_modules/isomorphic-git": {
+      "version": "1.25.7",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.25.7.tgz",
+      "integrity": "sha512-KE10ejaIsEpQ+I/apS33qqTjyzCXgOniEaL32DwNbXtboKG8H3cu+RiBcdp3G9w4MpOOTQfGPsWp4i8UxRfDLg==",
+      "dev": true,
+      "dependencies": {
+        "async-lock": "^1.1.0",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "minimisted": "^2.0.0",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^3.4.0",
+        "sha.js": "^2.4.9",
+        "simple-get": "^4.0.1"
+      },
+      "bin": {
+        "isogit": "cli.cjs"
+      },
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13612,12 +13612,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isomorphic-git": {
-      "version": "1.25.7",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.25.7.tgz",
-      "integrity": "sha512-KE10ejaIsEpQ+I/apS33qqTjyzCXgOniEaL32DwNbXtboKG8H3cu+RiBcdp3G9w4MpOOTQfGPsWp4i8UxRfDLg==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.27.1.tgz",
+      "integrity": "sha512-X32ph5zIWfT75QAqW2l3JCIqnx9/GWd17bRRehmn3qmWc34OYbSXY6Cxv0o9bIIY+CWugoN4nQFHNA+2uYf2nA==",
       "dev": true,
       "dependencies": {
-        "async-lock": "^1.1.0",
+        "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
         "crc-32": "^1.2.0",
         "diff3": "0.0.3",
@@ -22168,7 +22168,7 @@
         "gsap": "^3.12.5",
         "highlight.js": "^11.9.0",
         "httplease-asap": "^0.6.0",
-        "isomorphic-git": "1.25.7",
+        "isomorphic-git": "1.27.1",
         "json-diff-kit": "^1.0.23",
         "json-order": "^1.1.3",
         "less": "^4.2.0",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -151,7 +151,7 @@
     "gsap": "^3.12.5",
     "highlight.js": "^11.9.0",
     "httplease-asap": "^0.6.0",
-    "isomorphic-git": "1.25.7",
+    "isomorphic-git": "1.27.1",
     "json-diff-kit": "^1.0.23",
     "json-order": "^1.1.3",
     "less": "^4.2.0",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -151,7 +151,7 @@
     "gsap": "^3.12.5",
     "highlight.js": "^11.9.0",
     "httplease-asap": "^0.6.0",
-    "isomorphic-git": "1.27.1",
+    "isomorphic-git": "1.25.7",
     "json-diff-kit": "^1.0.23",
     "json-order": "^1.1.3",
     "less": "^4.2.0",

--- a/packages/insomnia/src/models/helpers/git-repository-operations.ts
+++ b/packages/insomnia/src/models/helpers/git-repository-operations.ts
@@ -6,6 +6,8 @@ export const createGitRepository = async (workspaceId: string, repo: Partial<Git
   const meta = await models.workspaceMeta.getOrCreateByParentId(workspaceId);
   await models.workspaceMeta.update(meta, {
     gitRepositoryId: newRepo._id,
+    // @TODO Get the main/master branch name here
+    cachedGitRepositoryBranch: 'main',
   });
 };
 

--- a/packages/insomnia/src/sync/git/ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/ne-db-client.ts
@@ -59,23 +59,6 @@ export class NeDBClient {
     // When git is reading from NeDb, reset keys we wish to ignore to their original values
     resetKeys(doc);
 
-    // It would be nice to be able to add this check here but we can't since
-    // isomorphic-git may have just deleted the workspace from the FS. This
-    // happens frequently during branch checkouts and merges
-    //
-    if (doc.type !== models.workspace.type) {
-      const ancestors = await db.withAncestors(doc);
-      const workspace = ancestors.find(isWorkspace);
-
-      if (workspace?._id !== this._workspaceId) {
-        throw new Error('EXTERNAL_WORKSPACE');
-      }
-    }
-
-    if (doc.type === models.workspace.type && doc._id !== this._workspaceId) {
-      throw new Error('EXTERNAL_WORKSPACE');
-    }
-
     const raw = Buffer.from(YAML.stringify(doc), 'utf8');
 
     if (options.encoding) {
@@ -102,10 +85,6 @@ export class NeDBClient {
 
     if (type !== doc.type) {
       throw new Error(`Doc type does not match file path [${doc.type} != ${type || 'null'}]`);
-    }
-
-    if (isWorkspace(doc) && doc._id !== this._workspaceId) {
-      throw new Error('EXTERNAL_WORKSPACE');
     }
 
     if (isWorkspace(doc)) {

--- a/packages/insomnia/src/sync/git/routable-fs-client.ts
+++ b/packages/insomnia/src/sync/git/routable-fs-client.ts
@@ -17,11 +17,19 @@ export function routableFSClient(
   const execMethod = async (method: Methods, filePath: string, ...args: any[]) => {
     filePath = path.normalize(filePath);
 
-    for (const prefix of Object.keys(otherFS)) {
-      if (filePath.indexOf(path.normalize(prefix)) === 0) {
-        // TODO: remove non-null assertion
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return otherFS[prefix].promises[method]!(filePath, ...args);
+    try {
+      for (const prefix of Object.keys(otherFS)) {
+        if (filePath.indexOf(path.normalize(prefix)) === 0) {
+      // TODO: remove non-null assertion
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const result = otherFS[prefix].promises[method]!(filePath, ...args);
+
+          return result;
+        }
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message !== 'EXTERNAL_WORKSPACE') {
+        throw err;
       }
     }
 

--- a/packages/insomnia/src/ui/routes/design.tsx
+++ b/packages/insomnia/src/ui/routes/design.tsx
@@ -86,7 +86,7 @@ export const loader: LoaderFunction = async ({
 }): Promise<LoaderData> => {
   const { workspaceId } = params;
   invariant(workspaceId, 'Workspace ID is required');
-  const apiSpec = await models.apiSpec.getByParentId(workspaceId);
+  const apiSpec = await models.apiSpec.getOrCreateForParentId(workspaceId);
   invariant(apiSpec, 'API spec not found');
   const workspace = await models.workspace.getById(workspaceId);
   invariant(workspace, 'Workspace not found');

--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -587,6 +587,13 @@ export const cloneGitRepoAction: ActionFunction = async ({
         const docPath = path.join(modelDir, docFileName);
         const docYaml = await fsClient.promises.readFile(docPath);
         const doc: models.BaseModel = YAML.parse(docYaml.toString());
+        const existingRecord = await database.get(doc.type, doc._id);
+
+        // Skip existing records
+        if (existingRecord) {
+          continue;
+        }
+
         if (isWorkspace(doc)) {
           doc.parentId = project._id;
           doc.scope = scope;
@@ -603,7 +610,6 @@ export const cloneGitRepoAction: ActionFunction = async ({
     for (const workspace of allWorkspaces) {
       if (workspace._id !== workspaceId) {
         const allRelatedRecords = await database.withDescendants(workspace);
-
         for (const record of allRelatedRecords) {
           await database.remove(record);
         }


### PR DESCRIPTION
## Highlights:

- [x] UX for choosing which file to clone
- [x] Each file that is cloned is isolated from others as it is a separate git repo
- [x] Update tests

<img width="821" alt="image" src="https://github.com/user-attachments/assets/eb37a4ef-c34e-444a-992b-e30965ffbccd">

## Blockers:
- [x] There's an issue where when pushing one collection removes the other workspaces from the repo
- [ ] [Conflicts between other workspaces are blocked since isomorphic-git doesn't support merges with conflicts](https://github.com/isomorphic-git/isomorphic-git/issues/325)

---

## Logic for Git Sync:

The structure of Insomnia files in the git repository is stored inside a folder named `📁 .insomnia`.
For example a Collection with a Request will be stored in a repository like this:
```
.
└── .insomnia/
    ├── Workspace/
    │   └── wrk_c9eee6d3eff145e9a83f83c1a91ebd7d.yml
    ├── Request/
    │   └── req_8b75cc5c6d804e2a8eeb990634cbac62.yml
    └── Environment/
        └── env_92493b7aaf0049d1be35f7758edf746e.yml
```

In Insomnia when we clone a repository:
- Anything inside the `📁 .insomnia` folder is mapped to NeDB
- Anything related to git inside the `📁 .git` folder is mapped to a folder for that workspace inside version control named `📁 git`
- All other files get mapped inside a folder for that workspace inside version control named `📁 other`
- Git uses these mappings to check if a file has been updated or deleted.

Currently if we add another Collection to the repository will create a structure like this:
```
.
└── .insomnia/
    ├── Workspace/
    │   ├── wrk_c9eee6d3eff145e9a83f83c1a91ebd7d.yml
    │   └── wrk_7611b6018dcd4867ba928fcf060d0139.yml
    ├── Request/
    │   ├── req_8b75cc5c6d804e2a8eeb990634cbac62.yml
    │   └── req_e045d7a223474f388e530edee5e877f7.yml
    └── Environment/
        ├── env_92493b7aaf0049d1be35f7758edf746e.yml
        └── env_1907bca338254a9bab501a8e3bd62b6d.yml
```

## Requirements:

- When cloning a workspace we want it to be isolated.
This is so that when someone is working on a specific branch on a specific Workspace it doesn't affect other Workspaces of the same repo that are cloned locally.
- Backwards compatibillity

## Limitations from the approaches that have been tried:

### Use the filesystem routing to only map related records of a single Workspace to NeDB:
- When git clone or pull runs the order of the files that are stored is not guaranteed.
This means that anything that requires walking the tree to check if a Request belongs to a specific Workspace is not reliable.
e.g. we can't know for sure if the Request `req_8b75cc5c6d804e2a8eeb990634cbac62` belongs to Workspace `wrk_c9eee6d3eff145e9a83f83c1a91ebd7d` or `wrk_7611b6018dcd4867ba928fcf060d0139`.

### Map all Workspaces and all their records to NeDB:
- This is what is happening now and creates a lot of issues:
  - Pulling or changing branches on one Workspaces affects other Workspaces which is not the desired UX
  - Constantly creates Merge Conflicts which are [not supported currently by isomorphic-git](https://github.com/isomorphic-git/isomorphic-git/issues/325)
  - Can lead to data loss in case the code doesn't handle specific edge cases for pull/push etc.
  
## Other approaches:

### Store workspaces in the `📁 .insomnia` folder to separate the data per workspace:
The above example would look like this:
```
.
└── .insomnia/
    ├── wrk_c9eee6d3eff145e9a83f83c1a91ebd7d/
    │   ├── Workspace/
    │   │   └── wrk_c9eee6d3eff145e9a83f83c1a91ebd7d.yml
    │   ├── Request/
    │   │   └── req_8b75cc5c6d804e2a8eeb990634cbac62.yml
    │   └── Environment/
    │       └── env_92493b7aaf0049d1be35f7758edf746e.yml
    └── wrk_7611b6018dcd4867ba928fcf060d0139/
        ├── Workspace/
        │   └── wrk_7611b6018dcd4867ba928fcf060d0139.yml
        ├── Request/
        │   └── req_e045d7a223474f388e530edee5e877f7.yml
        └── Environment/
            └── env_1907bca338254a9bab501a8e3bd62b6d.yml      
```

➕ Pros:
- Simple to separate each workspace

➖ Cons:
- Will break the git functionality for previous versions of the app
- Requires existing repos to re-connect with git

Closes INS-4277