### PR TITLE
fix: test-util snippet to proper status code check [no-ticket]

### DIFF
--- a/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
@@ -74,7 +74,7 @@ const getCookies = 'const cookies = insomnia.response.cookies.toObject();';
 
 const checkStatus200 =
   `insomnia.test('Check if status is 200', () => {
-    insomnia.expect(insomnia.response.status).to.eql(200);
+    insomnia.expect(insomnia.response.code).to.eql(200);
 });`;
 
 const expectToEqual = 'insomnia.expect(200).to.eql(200);';


### PR DESCRIPTION
`response.code` returns status code number. Before the snippet we were suggesting was wrong, checking the status code "string" instead.