### PR TITLE
fix: handle login when opening org logged out [INS-4330]

### DIFF
--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -27,12 +27,6 @@ export const action: ActionFunction = async ({
     event: SegmentEvent.loginSuccess,
   });
   window.localStorage.setItem('hasUserLoggedInBefore', 'true');
-  const specificOrgRedirectAfterAuthorize = window.localStorage.getItem('specificOrgRedirectAfterAuthorize');
-  if (specificOrgRedirectAfterAuthorize && specificOrgRedirectAfterAuthorize !== '') {
-    window.localStorage.removeItem('specificOrgRedirectAfterAuthorize');
-    return redirect(`/organization/${specificOrgRedirectAfterAuthorize}`);
-  }
-
   return redirect('/organization');
 };
 

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -27,6 +27,11 @@ export const action: ActionFunction = async ({
     event: SegmentEvent.loginSuccess,
   });
   window.localStorage.setItem('hasUserLoggedInBefore', 'true');
+  const specificOrgRedirectAfterAuthorize = window.localStorage.getItem('specificOrgRedirectAfterAuthorize');
+  if (specificOrgRedirectAfterAuthorize && specificOrgRedirectAfterAuthorize !== '') {
+    window.localStorage.removeItem('specificOrgRedirectAfterAuthorize');
+    return redirect(`/organization/${specificOrgRedirectAfterAuthorize}`);
+  }
 
   return redirect('/organization');
 };

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -27,6 +27,7 @@ export const action: ActionFunction = async ({
     event: SegmentEvent.loginSuccess,
   });
   window.localStorage.setItem('hasUserLoggedInBefore', 'true');
+
   return redirect('/organization');
 };
 

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -277,6 +277,12 @@ export const indexLoader: LoaderFunction = async () => {
     const personalOrganizationId = personalOrganization.id;
     await migrateProjectsUnderOrganization(personalOrganizationId, sessionId);
 
+    const specificOrgRedirectAfterAuthorize = window.localStorage.getItem('specificOrgRedirectAfterAuthorize');
+    if (specificOrgRedirectAfterAuthorize && specificOrgRedirectAfterAuthorize !== '') {
+      window.localStorage.removeItem('specificOrgRedirectAfterAuthorize');
+      return redirect(`/organization/${specificOrgRedirectAfterAuthorize}`);
+    }
+
     if (personalOrganization) {
       return redirect(`/organization/${personalOrganizationId}`);
     }


### PR DESCRIPTION
Closes INS-4330

When a user clicks "Open" on the website to open an organization in the electron app, but they are logged out on the electron app, we will now try to

1) log them in using the normal app authorize flow, 
2) and then navigate them to the organization they intended to open


Before, they would click on Open, but nothing would happen on the app if they were logged out.


### Notes

To test locally, spin up the app, and then make sure you point to to `node_modules/electron/dist/Electron.app` when trying to open the deep links:

<img width="379" alt="image" src="https://github.com/user-attachments/assets/4d2dc258-217a-42ea-8e5d-80adcfc53aaf">

Otherwise the deep links will get caught by any production installation you might have of Insomnia