### PR TITLE
pin ubuntu version

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   # shared kong github action for security checking
   generate-sbom-and-upload-assets:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       packages: write
       contents: write # publish sbom to GH releases/tag assets
@@ -49,7 +49,7 @@ jobs:
           - os: windows-latest
             csc_link_secret: DESIGNER_WINDOWS_CSC_LINK
             csc_key_password_secret: DESIGNER_WINDOWS_CSC_KEY_PASSWORD
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             csc_link_secret: ''
             csc_key_password_secret: ''
     steps:
@@ -83,7 +83,7 @@ jobs:
           CSC_KEY_PASSWORD: ${{ matrix.csc_key_password_secret != '' && secrets[matrix.csc_key_password_secret] || ''  }}
 
       - name: Package app (Linux only)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         shell: bash
         run: npm run app-package
         env:
@@ -179,7 +179,7 @@ jobs:
         run: npm run artifacts -w insomnia-inso
 
       - name: Create inso Docker Image artifacts
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run: |
           DOCKER_BUILDKIT=1 docker build --tag ${{ env.INSO_PACKAGE_NAME }}:temp ./packages/${{ env.INSO_PACKAGE_NAME }}
           docker save ${{ env.INSO_PACKAGE_NAME }}:temp -o ./packages/${{ env.INSO_PACKAGE_NAME }}/artifacts/${{ env.INSO_DOCKER_TAR }}
@@ -188,7 +188,7 @@ jobs:
       # Automatically uploads to workflow assets
       - name: Scan inso docker artifacts
         id: sbom_action
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         uses: Kong/public-shared-actions/security-actions/scan-docker-image@62643b74f79f6a697b9add1a2f9c069bf9ca1250 # v2.3.0
         with:
           asset_prefix: image-inso-${{ runner.os }}
@@ -226,7 +226,7 @@ jobs:
   update-pull-request:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     needs: build-and-upload-release-artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Get release version
         id: release_version

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   publish:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       NOTARY_REPOSITORY: ${{ env.NOTARY_REPOSITORY }}
       INSO_BINARY_ARTIFACTS_SUBJECTS_AS_FILE: ${{ steps.cli_binary_hashes.outputs.handle }}
@@ -111,8 +111,8 @@ jobs:
           # /github/workspace/artifacts/windows-latest-artifacts/***/dist/squirrel-windows/Insomnia.Core-9.3.0-beta.1-full.nupkg
           # /github/workspace/artifacts/windows-latest-artifacts/***/dist/squirrel-windows/RELEASES
           # /home/runner/work/***/***/artifacts/macos-13-artifacts/***/dist/Insomnia.Core-9.3.0-alpha.7.dmg
-          # /home/runner/work/***/***/artifacts/ubuntu-latest-artifacts/***/dist/Insomnia.Core-9.3.0-alpha.7.deb
-          # /home/runner/work/***/***/artifacts/ubuntu-latest-artifacts/***-inso/artifacts/inso-linux-9.3.0-alpha.7.tar.xz
+          # /home/runner/work/***/***/artifacts/ubuntu-20.04-artifacts/***/dist/Insomnia.Core-9.3.0-alpha.7.deb
+          # /home/runner/work/***/***/artifacts/ubuntu-20.04-artifacts/***-inso/artifacts/inso-linux-9.3.0-alpha.7.tar.xz
           # /home/runner/work/***/***/artifacts/macos-13-artifacts/***-inso/artifacts/inso-macos-13-9.3.0-alpha.7.pkg
           # /home/runner/work/***/***/artifacts/image-inso-Linux-sbom.spdx.json/image-inso-Linux-sbom.spdx.json
           # /home/runner/work/***/***/artifacts/sbom.cyclonedx.json/sbom.cyclonedx.json
@@ -155,7 +155,7 @@ jobs:
 
       - name: Load the Inso CLI Docker Archive
         run: |
-          docker load -i ./artifacts/ubuntu-latest-artifacts/insomnia-inso/artifacts/inso-docker-image.tar
+          docker load -i ./artifacts/ubuntu-20.04-artifacts/insomnia-inso/artifacts/inso-docker-image.tar
           docker image ls
 
       - name: Login to Docker Hub
@@ -247,7 +247,7 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN_FILE_NEW }}
         with:
-          snap: artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.snap
+          snap: artifacts/ubuntu-20.04-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.snap
           release: ${{ contains(github.event.inputs.version, 'beta') && 'beta' || 'stable' }}
 
       - name: Upload .deb to pulp and/or cloudsmith (stable only)
@@ -267,7 +267,7 @@ jobs:
           entrypoint: /entrypoint.sh
           args: >
             release
-            --file artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.deb
+            --file artifacts/ubuntu-20.04-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.deb
             --dist-name ubuntu
             --dist-version focal
             --package-type insomnia

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -30,7 +30,7 @@ jobs:
             build-targets: "zip"
           - os: "windows-latest"
             build-targets: "portable"
-          - os: "ubuntu-latest"
+          - os: "ubuntu-20.04"
             build-targets: "tar.gz"
     steps:
       - name: Checkout branch

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   setup-release-branch:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -13,7 +13,7 @@ jobs:
   semgrep:
     timeout-minutes: 5
     name: Semgrep SAST
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   Test:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
         shell: bash
         run: |
           INSO_VERSION="$(jq .version packages/insomnia-inso/package.json -rj)-run.${{ github.run_number }}"
-          PKG_NAME="inso-ubuntu-latest-$INSO_VERSION"
+          PKG_NAME="inso-ubuntu-20.04-$INSO_VERSION"
           echo "pkg-name=$PKG_NAME" >> $GITHUB_OUTPUT
           echo "inso-version=$INSO_VERSION" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   Test:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the


### PR DESCRIPTION
aiming to fix #7867

blockers
node-libcurl is built using ubuntu-latest and therefore a different glibc version so cli tests fail
playwright seems to fail with ubuntu 20.04 getting first window

may be abandoned unless we can find a stronger reason to pursue further

actions
- build node-libcurl with ubuntu 20
- fix the app.firstWindow() playwright issue

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
