### PR TITLE
feat: enable cancellation and introduce runner result pane

### DIFF
--- a/packages/insomnia/src/models/runner-test-result.ts
+++ b/packages/insomnia/src/models/runner-test-result.ts
@@ -54,6 +54,7 @@ export function init() {
     avgRespTime: 0,
     iterationResults: [],
     responsesInfo: [],
+    version: '1',
   };
 }
 

--- a/packages/insomnia/src/models/runner-test-result.ts
+++ b/packages/insomnia/src/models/runner-test-result.ts
@@ -22,6 +22,12 @@ export interface RunnerResultPerRequest {
   // TODO: add request name, url, etc
 }
 
+export interface ResponseInfo {
+  responseId: string;
+  originalRequestName: string;
+  originalRequestId: string;
+}
+
 export interface BaseRunnerTestResult {
   source: RunnerSource;
   // environmentId: string;
@@ -29,7 +35,7 @@ export interface BaseRunnerTestResult {
   duration: number; // millisecond
   avgRespTime: number; // millisecond
   iterationResults: RunnerResultPerRequest[][];
-  responseIds: string[];
+  responsesInfo: ResponseInfo[];
   version: '1';
 }
 
@@ -47,7 +53,7 @@ export function init() {
     duration: 0,
     avgRespTime: 0,
     iterationResults: [],
-    responseIds: [],
+    responsesInfo: [],
   };
 }
 

--- a/packages/insomnia/src/models/runner-test-result.ts
+++ b/packages/insomnia/src/models/runner-test-result.ts
@@ -14,14 +14,23 @@ export const canDuplicate = false;
 
 export const canSync = false;
 
+export interface RunnerResultPerRequest {
+  results: RequestTestResult[];
+  requestName: string;
+  requestUrl: string;
+  responseCode: number;
+  // TODO: add request name, url, etc
+}
+
 export interface BaseRunnerTestResult {
   source: RunnerSource;
   // environmentId: string;
   iterations: number;
   duration: number; // millisecond
   avgRespTime: number; // millisecond
-  results: RequestTestResult[];
+  iterationResults: RunnerResultPerRequest[][];
   responseIds: string[];
+  version: '1';
 }
 
 export type RunnerTestResult = BaseModel & BaseRunnerTestResult;
@@ -37,7 +46,7 @@ export function init() {
     iterations: 0,
     duration: 0,
     avgRespTime: 0,
-    results: [],
+    iterationResults: [],
     responseIds: [],
   };
 }

--- a/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
@@ -10,13 +10,13 @@ type TargetTestType = 'all' | 'passed' | 'failed' | 'skipped';
 const filterClassnames = 'mx-1 w-[6rem] text-center rounded-md h-[--line-height-xxs] text-sm cursor-pointer outline-none select-none px-2 py-1 hover:bg-[rgba(var(--color-surprise-rgb),50%)] text-[--hl] aria-selected:text-[--color-font-surprise] hover:text-[--color-font-surprise] aria-selected:bg-[rgba(var(--color-surprise-rgb),40%)] transition-colors duration-300';
 const activeFilterClassnames = 'text-white mx-1 w-[6rem] text-center rounded-md h-[--line-height-xxs] text-sm cursor-pointer outline-none select-none px-2 py-1 bg-[rgba(var(--color-surprise-rgb),50%)] text-[--hl] aria-selected:text-[--color-font-surprise] text-[--color-font-surprise] aria-selected:bg-[rgba(var(--color-surprise-rgb),40%)] transition-colors duration-300';
 
-interface RequestTestResultRowsProps {
+export interface RequestTestResultRowsProps {
   requestTestResults: RequestTestResult[];
   resultFilter: string;
   targetTests: string;
 }
 
-const RequestTestResultRows: FC<RequestTestResultRowsProps> = ({
+export const RequestTestResultRows: FC<RequestTestResultRowsProps> = ({
   requestTestResults,
   resultFilter,
   targetTests,
@@ -106,9 +106,9 @@ export const RequestTestResultPane: FC<Props> = ({
 
   const noTestFoundPage = (
     <div className="text-center mt-5">
-      <div className="">No test results found</div>
+      <div className="">No test result found</div>
       <div className="text-sm text-neutral-400">
-        Run the tests to see the results.
+        Add test cases in scripts and run them to see results.
       </div>
     </div>
   );

--- a/packages/insomnia/src/ui/components/panes/runner-result-history-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-result-history-pane.tsx
@@ -1,5 +1,4 @@
 import { format } from 'date-fns';
-import type { RequestTestResult } from 'insomnia-sdk';
 import React, { type FC } from 'react';
 import { Cell, Column, ColumnResizer, ResizableTableContainer, Row, Table, TableBody, TableHeader, TooltipTrigger } from 'react-aria-components';
 
@@ -23,17 +22,24 @@ export const RunnerResultHistoryPane: FC<Props> = ({
     let failedCount = 0;
     let skippedCount = 0;
 
-    runnerResult.results.forEach((result: RequestTestResult) => {
-      if (result.status === 'failed') {
-        failedCount++;
+    for (let i = 0; i < runnerResult.iterationResults.length; i++) { // iterations
+      for (let j = 0; j < runnerResult.iterationResults[i].length; j++) { // requests
+        for (let k = 0; k < runnerResult.iterationResults[i][j].results.length; k++) { // test cases
+          const result = runnerResult.iterationResults[i][j].results[k];
+
+          if (result.status === 'failed') {
+            failedCount++;
+          }
+          if (result.status === 'skipped') {
+            skippedCount++;
+          }
+          if (result.status === 'passed') {
+            passedCount++;
+          }
+        }
       }
-      if (result.status === 'skipped') {
-        skippedCount++;
-      }
-      if (result.status === 'passed') {
-        passedCount++;
-      }
-    });
+    }
+
     // const startedAt = new Date(runnerResult.created).toString(); // TODO: should be endedat
     const { number: durationNumber, unit: durationUnit } = getTimeAndUnit(runnerResult.duration);
     const createdAt = format(runnerResult.created, 'yyyy-MM-dd HH:MM:ss');

--- a/packages/insomnia/src/ui/components/panes/runner-result-history-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-result-history-pane.tsx
@@ -42,7 +42,7 @@ export const RunnerResultHistoryPane: FC<Props> = ({
 
     // const startedAt = new Date(runnerResult.created).toString(); // TODO: should be endedat
     const { number: durationNumber, unit: durationUnit } = getTimeAndUnit(runnerResult.duration);
-    const createdAt = format(runnerResult.created, 'yyyy-MM-dd HH:MM:ss');
+    const createdAt = format(runnerResult.created, 'yyyy-MM-dd HH:mm:ss');
 
     return (
       <Row

--- a/packages/insomnia/src/ui/components/panes/runner-result-history-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-result-history-pane.tsx
@@ -47,14 +47,14 @@ export const RunnerResultHistoryPane: FC<Props> = ({
     return (
       <Row
         key={runnerResult._id}
-        className="leading-9 hover:bg-neutral-900"
+        className="cursor-pointer leading-9 hover:bg-neutral-900"
         style={{ 'outline': 'none' }}
         onAction={() => {
           gotoExecutionResult(runnerResult._id);
           gotoTestResultsTab();
         }}
       >
-        <Cell className="capitalize cursor-pointer hover:underline">
+        <Cell className="capitalize hover:underline">
           {failedCount === 0 ?
             <i className="fa fa-circle-check fa-1x mr-2 text-green-500" /> :
             <i className="fa fa-circle-xmark fa-1x mr-2 text-red-500" />}

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -1,9 +1,6 @@
-// import crypto from 'crypto';
-// import type { RequestTestResult } from 'insomnia-sdk';
 import React, { type FC, useState } from 'react';
 import { Toolbar } from 'react-aria-components';
 
-// import { fuzzyMatch } from '../../../common/misc';
 import type { BaseRunnerTestResult, RunnerResultPerRequest } from '../../../models/runner-test-result';
 import { RequestTestResultRows } from './request-test-result-pane';
 
@@ -11,90 +8,6 @@ type TargetTestType = 'all' | 'passed' | 'failed' | 'skipped';
 
 const filterClassnames = 'mx-1 w-[6rem] text-center rounded-md h-[--line-height-xxs] text-sm cursor-pointer outline-none select-none px-2 py-1 hover:bg-[rgba(var(--color-surprise-rgb),50%)] text-[--hl] aria-selected:text-[--color-font-surprise] hover:text-[--color-font-surprise] aria-selected:bg-[rgba(var(--color-surprise-rgb),40%)] transition-colors duration-300';
 const activeFilterClassnames = 'text-white mx-1 w-[6rem] text-center rounded-md h-[--line-height-xxs] text-sm cursor-pointer outline-none select-none px-2 py-1 bg-[rgba(var(--color-surprise-rgb),50%)] text-[--hl] aria-selected:text-[--color-font-surprise] text-[--color-font-surprise] aria-selected:bg-[rgba(var(--color-surprise-rgb),40%)] transition-colors duration-300';
-
-// interface RunnerTestResultRowsProps {
-//   results: RunnerResultPerRequest[];
-//   resultFilter: string;
-//   targetTests: string;
-// }
-
-// const RunnerTestResultRows: FC<RunnerTestResultRowsProps> = ({
-//   results,
-//   resultFilter,
-//   targetTests,
-// }: RunnerTestResultRowsProps) => {
-//   const testResultRows = results
-//     .filter(result => {
-//       switch (targetTests) {
-//         case 'all':
-//           return true;
-//         case 'passed':
-//           return result.status === 'passed';
-//         case 'failed':
-//           return result.status === 'failed';
-//         case 'skipped':
-//           return result.status === 'skipped';
-//         default:
-//           throw Error(`unexpected target test type ${targetTests}`);
-//       }
-//     })
-//     .filter(result => {
-//       if (resultFilter.trim() === '') {
-//         return true;
-//       }
-
-//       return Boolean(fuzzyMatch(
-//         resultFilter,
-//         result.testCase,
-//         { splitSpace: false, loose: true }
-//       )?.indexes);
-//     })
-//     .map((result, i: number) => {
-//       const key = crypto
-//         .createHash('sha1')
-//         .update(`${result.testCase}"-${i}`)
-//         .digest('hex');
-
-//       const statusText = {
-//         passed: 'PASS',
-//         failed: 'FAIL',
-//         skipped: 'SKIP',
-//       }[result.status];
-//       const statusTagColor = {
-//         passed: 'bg-lime-600',
-//         failed: 'bg-red-600',
-//         skipped: 'bg-slate-600',
-//       }[result.status];
-
-//       const executionTime = <span className={result.executionTime < 300 ? 'text-white-500' : 'text-red-500'} >
-//         {result.executionTime === 0 ? '< 0.1' : `${result.executionTime.toFixed(1)}`}
-//       </span>;
-//       const statusTag = <div className={`text-xs rounded p-[2px] inline-block w-16 text-center font-semibold ${statusTagColor}`}>
-//         {statusText}
-//       </div >;
-//       const message = <>
-//         <span className='capitalize'>{result.testCase}</span>
-//         <span className='text-neutral-400'>{result.errorMessage ? ' | ' + result.errorMessage : ''}</span>
-//       </>;
-//       const testCategory = result.category === 'pre-request' ? 'Pre-request Test' :
-//         result.category === 'after-response' ? 'After-response Test' : 'Unknown';
-
-//       return (
-//         <div key={key} data-testid="test-result-row">
-//           <div className="flex w-full my-3 text-base">
-//             <div className="leading-4 m-auto mx-1">
-//               <span className="mr-2 ml-2" >{statusTag}</span>
-//             </div>
-//             <div className="leading-4 mr-2">
-//               <div className='mr-2 my-1 w-auto text-nowrap'>{message}</div>
-//               <div className='text-sm text-neutral-400 my-1'>{`${testCategory} (`}{executionTime}{' ms)'}</div>
-//             </div>
-//           </div>
-//         </div>);
-//     });
-
-//   return <>{testResultRows}</>;
-// };
 
 interface Props {
   result: BaseRunnerTestResult | null;

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -1,0 +1,187 @@
+// import crypto from 'crypto';
+// import type { RequestTestResult } from 'insomnia-sdk';
+import React, { type FC, useState } from 'react';
+import { Toolbar } from 'react-aria-components';
+
+// import { fuzzyMatch } from '../../../common/misc';
+import type { BaseRunnerTestResult, RunnerResultPerRequest } from '../../../models/runner-test-result';
+import { RequestTestResultRows } from './request-test-result-pane';
+
+type TargetTestType = 'all' | 'passed' | 'failed' | 'skipped';
+
+const filterClassnames = 'mx-1 w-[6rem] text-center rounded-md h-[--line-height-xxs] text-sm cursor-pointer outline-none select-none px-2 py-1 hover:bg-[rgba(var(--color-surprise-rgb),50%)] text-[--hl] aria-selected:text-[--color-font-surprise] hover:text-[--color-font-surprise] aria-selected:bg-[rgba(var(--color-surprise-rgb),40%)] transition-colors duration-300';
+const activeFilterClassnames = 'text-white mx-1 w-[6rem] text-center rounded-md h-[--line-height-xxs] text-sm cursor-pointer outline-none select-none px-2 py-1 bg-[rgba(var(--color-surprise-rgb),50%)] text-[--hl] aria-selected:text-[--color-font-surprise] text-[--color-font-surprise] aria-selected:bg-[rgba(var(--color-surprise-rgb),40%)] transition-colors duration-300';
+
+// interface RunnerTestResultRowsProps {
+//   results: RunnerResultPerRequest[];
+//   resultFilter: string;
+//   targetTests: string;
+// }
+
+// const RunnerTestResultRows: FC<RunnerTestResultRowsProps> = ({
+//   results,
+//   resultFilter,
+//   targetTests,
+// }: RunnerTestResultRowsProps) => {
+//   const testResultRows = results
+//     .filter(result => {
+//       switch (targetTests) {
+//         case 'all':
+//           return true;
+//         case 'passed':
+//           return result.status === 'passed';
+//         case 'failed':
+//           return result.status === 'failed';
+//         case 'skipped':
+//           return result.status === 'skipped';
+//         default:
+//           throw Error(`unexpected target test type ${targetTests}`);
+//       }
+//     })
+//     .filter(result => {
+//       if (resultFilter.trim() === '') {
+//         return true;
+//       }
+
+//       return Boolean(fuzzyMatch(
+//         resultFilter,
+//         result.testCase,
+//         { splitSpace: false, loose: true }
+//       )?.indexes);
+//     })
+//     .map((result, i: number) => {
+//       const key = crypto
+//         .createHash('sha1')
+//         .update(`${result.testCase}"-${i}`)
+//         .digest('hex');
+
+//       const statusText = {
+//         passed: 'PASS',
+//         failed: 'FAIL',
+//         skipped: 'SKIP',
+//       }[result.status];
+//       const statusTagColor = {
+//         passed: 'bg-lime-600',
+//         failed: 'bg-red-600',
+//         skipped: 'bg-slate-600',
+//       }[result.status];
+
+//       const executionTime = <span className={result.executionTime < 300 ? 'text-white-500' : 'text-red-500'} >
+//         {result.executionTime === 0 ? '< 0.1' : `${result.executionTime.toFixed(1)}`}
+//       </span>;
+//       const statusTag = <div className={`text-xs rounded p-[2px] inline-block w-16 text-center font-semibold ${statusTagColor}`}>
+//         {statusText}
+//       </div >;
+//       const message = <>
+//         <span className='capitalize'>{result.testCase}</span>
+//         <span className='text-neutral-400'>{result.errorMessage ? ' | ' + result.errorMessage : ''}</span>
+//       </>;
+//       const testCategory = result.category === 'pre-request' ? 'Pre-request Test' :
+//         result.category === 'after-response' ? 'After-response Test' : 'Unknown';
+
+//       return (
+//         <div key={key} data-testid="test-result-row">
+//           <div className="flex w-full my-3 text-base">
+//             <div className="leading-4 m-auto mx-1">
+//               <span className="mr-2 ml-2" >{statusTag}</span>
+//             </div>
+//             <div className="leading-4 mr-2">
+//               <div className='mr-2 my-1 w-auto text-nowrap'>{message}</div>
+//               <div className='text-sm text-neutral-400 my-1'>{`${testCategory} (`}{executionTime}{' ms)'}</div>
+//             </div>
+//           </div>
+//         </div>);
+//     });
+
+//   return <>{testResultRows}</>;
+// };
+
+interface Props {
+  result: BaseRunnerTestResult | null;
+}
+
+export const RunnerTestResultPane: FC<Props> = ({
+  result,
+}) => {
+  const [targetTests, setTargetTests] = useState<TargetTestType>('all');
+  const [resultFilter, setResultFilter] = useState('');
+
+  const noTestFoundPage = (
+    <div className="text-center mt-5">
+      <div className="">No test result found</div>
+      <div className="text-sm text-neutral-400">
+        Add test cases in scripts and run them to see results.
+      </div>
+    </div>
+  );
+  if (!result || result.iterationResults.length === 0) {
+    return noTestFoundPage;
+  }
+
+  const selectAllTests = () => setTargetTests('all');
+  const selectPassedTests = () => setTargetTests('passed');
+  const selectFailedTests = () => setTargetTests('failed');
+  const selectSkippedTests = () => setTargetTests('skipped');
+
+  const resultsByIteration = result.iterationResults.map((iterationResults: RunnerResultPerRequest[], i: number) => {
+    const key = `runner-test-result-iteration-${i + 1}`;
+
+    if (Array.isArray(iterationResults)) {
+      const resultByRequest = iterationResults.map((requestTestResult: RunnerResultPerRequest, i: number) => {
+        const key = `request-test-result-${i}`;
+        return <div key={key}>
+          <div className="pl-3">
+            <span className="">
+              {requestTestResult.requestName}
+            </span>
+            <span className="text-sm text-neutral-400">
+              {` - ${requestTestResult.requestUrl}`}
+            </span>
+          </div>
+          <RequestTestResultRows
+            requestTestResults={requestTestResult.results}
+            resultFilter={resultFilter}
+            targetTests={targetTests}
+          />
+        </div>;
+      });
+
+      return <div key={key} className="pt-6 pb-6 border-dashed border-b border-b-[--hl-md]">
+        <div className="uppercase font-bold pl-3 mb-3 leading-10"> Iterations {i + 1} </div>
+        <div className='border-solid border-1 border-gray-600' />
+        {resultByRequest}
+      </div>;
+    } else {
+      return <div key={key}>Invalid test result format</div>;
+    }
+  });
+
+  return <>
+    <div className='h-full flex flex-col divide-y divide-solid divide-[--hl-md]'>
+      <div className='h-[calc(100%-var(--line-height-sm))]'>
+        <Toolbar className="flex items-center h-[--line-height-sm] flex-row text-[var(--font-size-sm)] box-border overflow-x-auto border-solid border-b border-b-[--hl-md] pl-2">
+          <button className={targetTests === 'all' ? activeFilterClassnames : filterClassnames} onClick={selectAllTests} >All</button>
+          <button className={targetTests === 'passed' ? activeFilterClassnames : filterClassnames} onClick={selectPassedTests} >Passed</button>
+          <button className={targetTests === 'failed' ? activeFilterClassnames : filterClassnames} onClick={selectFailedTests} >Failed</button>
+          <button className={targetTests === 'skipped' ? activeFilterClassnames : filterClassnames} onClick={selectSkippedTests} >Skipped</button>
+        </Toolbar>
+        <div className="overflow-y-auto w-auto overflow-x-auto h-[calc(100%-var(--line-height-sm))]">
+          {resultsByIteration}
+        </div>
+      </div>
+      <Toolbar className="flex items-center h-[--line-height-sm] flex-shrink-0 flex-row text-[var(--font-size-sm)] box-border overflow-x-auto">
+        <input
+          key="test-results-filter"
+          type="text"
+          className='flex-1 pl-3'
+          title="Filter test results"
+          defaultValue={resultFilter || ''}
+          placeholder='Filter test results with name'
+          onChange={e => {
+            setResultFilter(e.target.value);
+          }}
+        />
+      </Toolbar>
+    </div>
+  </>;
+};

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -44,7 +44,7 @@ export const RunnerTestResultPane: FC<Props> = ({
         const key = `request-test-result-${i}`;
         return <div key={key}>
           <div className="pl-3">
-            <span className="">
+            <span>
               {requestTestResult.requestName}
             </span>
             <span className="text-sm text-neutral-400">

--- a/packages/insomnia/src/ui/components/response-timer.tsx
+++ b/packages/insomnia/src/ui/components/response-timer.tsx
@@ -39,14 +39,14 @@ export const ResponseTimer: FunctionComponent<Props> = ({ handleCancel, activeRe
               className='flex w-full leading-8'
             >
               <div className='w-3/4 ml-1 text-left text-md content-center leading-8'>
-                <span className="leading-8">
+                <span className="leading-8 w-1/5">
                   {
                     record.duration ?
                       (<i className="fa fa-circle-check fa-1x mr-2 text-green-500" />) :
                       (<i className="fa fa-spinner fa-spin fa-1x mr-2" />)
                   }
                 </span>
-                <span className="inline-block align-top text-clip">
+                <span className="inline-block align-top text-clip w-4/5">
                   {record.stepName}
                 </span>
               </div>

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -150,7 +150,10 @@ export const loader: LoaderFunction = async ({ params, request }) => {
     invariant(activeWorkspaceMeta, 'Workspace meta not found');
     const activeRequestId = activeWorkspaceMeta.activeRequestId;
     const activeRequest = activeRequestId ? await models.request.getById(activeRequestId) : null;
-    const isDisplayingRunner = request.url.endsWith('/runner') || request.url.endsWith('/runner?refresh-pane');
+    // TODO(george): we should remove this after enabling the sidebar for the runner
+    const startOfQuery = request.url.indexOf('?');
+    const urlWithoutQuery = startOfQuery > 0 ? request.url.slice(0, startOfQuery) : request.url;
+    const isDisplayingRunner = urlWithoutQuery.endsWith('/runner');
     if (activeRequest && !isDisplayingRunner) {
       return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${activeRequestId}`);
     }

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -150,7 +150,7 @@ export const loader: LoaderFunction = async ({ params, request }) => {
     invariant(activeWorkspaceMeta, 'Workspace meta not found');
     const activeRequestId = activeWorkspaceMeta.activeRequestId;
     const activeRequest = activeRequestId ? await models.request.getById(activeRequestId) : null;
-    const isDisplayingRunner = request.url.endsWith('/runner') || request.url.endsWith('/runner?test-end');
+    const isDisplayingRunner = request.url.endsWith('/runner') || request.url.endsWith('/runner?refresh-pane');
     if (activeRequest && !isDisplayingRunner) {
       return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${activeRequestId}`);
     }

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -380,7 +380,7 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
     });
   } catch (err) {
     console.log('[request] Failed to send request', err);
-    const e = err.error;
+    const e = err.error || err;
 
     if (err.response && err.requestMeta && err.response._id) {
       // this part is for persisting useful info (e.g. timeline) for debugging, even there is an error


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes:
- [x] Introduce runner result pane and divide results by iteration and request
- [x] Enable cancellation for the runner
- [x] fix the option name of advanced setting
- [x] display cursor for whole row on history
- [x] show some indication while view a historical run
- [x] disable advanced settings with default value
- [x] add separators in console
- [x] show error alert
- [x] display iteration in timing

<img width="450" alt="Screenshot 2024-08-27 at 16 27 00" src="https://github.com/user-attachments/assets/f8df6062-be44-41d3-b8e9-01e72e8617c8">

<img width="613" alt="Screenshot 2024-08-27 at 16 26 42" src="https://github.com/user-attachments/assets/d79fa17e-2e04-4277-9470-a29635a149dd">


Ref: INS-4339, INS-4340, INS-4346