### PR TITLE
Revert "support for removing default org project"

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -21,6 +21,7 @@ import {
 import { useFetcher } from 'react-router-dom';
 
 import {
+  isDefaultOrganizationProject,
   isRemoteProject,
   type Project,
 } from '../../../models/project';
@@ -61,7 +62,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage, h
       icon: 'gear',
       action: () => setIsProjectSettingsModalOpen(true),
     },
-    {
+    ...!isDefaultOrganizationProject(project) ? [{
       id: 'delete',
       name: 'Delete',
       icon: 'trash',
@@ -85,7 +86,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage, h
           },
         });
       },
-    },
+    }] satisfies ProjectActionItem[] : [],
   ];
 
   useEffect(() => {

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1837,6 +1837,4 @@ const ProjectRoute: FC = () => {
   );
 };
 
-ProjectRoute.displayName = 'ProjectRoute';
-
 export default ProjectRoute;


### PR DESCRIPTION
Reverts Kong/insomnia#7854
One issue was discovered after allowing the deletion of default projects in the organization.

When there is only one remote project under an organization and this project is deleted remotely by another collaborator, it does not automatically become a local project. However, this problem does not occur when there are multiple projects within the organization.

Revert this commit before I fix this sync problem.