### PR TITLE
Allow deleting default project in org and fix sync issue [INS-4342] [INS-4311]

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -21,7 +21,6 @@ import {
 import { useFetcher } from 'react-router-dom';
 
 import {
-  isDefaultOrganizationProject,
   isRemoteProject,
   type Project,
 } from '../../../models/project';
@@ -62,7 +61,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage, h
       icon: 'gear',
       action: () => setIsProjectSettingsModalOpen(true),
     },
-    ...!isDefaultOrganizationProject(project) ? [{
+    {
       id: 'delete',
       name: 'Delete',
       icon: 'trash',
@@ -86,7 +85,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage, h
           },
         });
       },
-    }] satisfies ProjectActionItem[] : [],
+    },
   ];
 
   useEffect(() => {

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -218,7 +218,7 @@ export const syncProjects = async (organizationId: string) => {
   const user = await models.userSession.getOrCreate();
   const teamProjects = await getAllTeamProjects(organizationId);
   // ensure we don't sync projects in the wrong place
-  if (teamProjects.length > 0 && user.id && !isScratchpadOrganizationId(organizationId)) {
+  if (Array.isArray(teamProjects) && user.id && !isScratchpadOrganizationId(organizationId)) {
     await syncTeamProjects({
       organizationId,
       teamProjects,


### PR DESCRIPTION
Add delete option for the default project and fix sync issue.

One issue was discovered after allowing the deletion of default projects in the organization.
When there is only one remote project under an organization and this project is deleted remotely by another collaborator, it does not automatically become a local project. However, this problem does not occur when there are multiple projects within the organization.