### PR TITLE
Fix for Infinity issue while generating the test case

### DIFF
--- a/packages/insomnia/src/ui/routes/test-suite.tsx
+++ b/packages/insomnia/src/ui/routes/test-suite.tsx
@@ -282,7 +282,11 @@ const UnitTestItemView = ({
             const numbers = variables
               .map(x => parseInt(x.match(/(\d+)/)?.[0] || ''))
               ?.filter(x => !isNaN(x));
-            const highestNumberedConstant = Math.max(...numbers);
+            let highestNumberedConstant = Math.max(...numbers);
+            // if value is empty, highestNumberedConstant will be -Infinity, so setting it to zero
+            if (highestNumberedConstant == -Infinity) {
+              highestNumberedConstant = 0;
+            }
             const variableName = 'response' + (highestNumberedConstant + 1);
             return [
               {

--- a/packages/insomnia/src/ui/routes/test-suite.tsx
+++ b/packages/insomnia/src/ui/routes/test-suite.tsx
@@ -284,7 +284,7 @@ const UnitTestItemView = ({
               ?.filter(x => !isNaN(x));
             let highestNumberedConstant = Math.max(...numbers);
             // if value is empty, highestNumberedConstant will be -Infinity, so setting it to zero
-            if (highestNumberedConstant == -Infinity) {
+            if (highestNumberedConstant === -Infinity) {
               highestNumberedConstant = 0;
             }
             const variableName = 'response' + (highestNumberedConstant + 1);


### PR DESCRIPTION
Fix for Infinity issue while generating the test case. 
When value is empty, Math.max() is called with empty value which gives results in -Infinity.

Closes #6848 
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
