### PR TITLE
fix: check for open curl

### DIFF
--- a/packages/insomnia/src/main/network/curl.ts
+++ b/packages/insomnia/src/main/network/curl.ts
@@ -343,7 +343,7 @@ const closeCurlConnection = (
   }
 };
 
-const closeAllCurlConnections = (): void => CurlConnections.forEach(curl => curl.close());
+const closeAllCurlConnections = (): void => CurlConnections.forEach(curl => curl.isOpen && curl.close());
 
 const findMany = async (
   options: { responseId: string }

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -161,7 +161,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
       if (requestFileDescriptor && responseBodyPath) {
         closeReadFunction(isMultipart, requestFileDescriptor, requestBodyPath);
       }
-      curl.close();
+      curl.isOpen && curl.close();
     };
 
     // set up response writer
@@ -211,7 +211,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
         elapsedTime: curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000,
         url: curl.getInfo(Curl.info.EFFECTIVE_URL) as string,
       };
-      curl.close();
+      curl.isOpen && curl.close();
       await waitForStreamToFinish(responseBodyWriteStream);
 
       const headerResults = _parseHeaders(rawHeaders);
@@ -221,7 +221,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
     curl.on('error', () => responseBodyWriteStream.end());
     curl.on('error', async (err, code) => {
       const elapsedTime = curl.getInfo(Curl.info.TOTAL_TIME) as number * 1000;
-      curl.close();
+      curl.isOpen && curl.close();
       await waitForStreamToFinish(responseBodyWriteStream);
 
       let error = err + '';


### PR DESCRIPTION
Fixes an edge case where trying to cancel a request (e.g. when upserting a mock) throws an uncaught exception.

<img width="333" alt="image" src="https://github.com/user-attachments/assets/39604805-5aef-41fc-950e-8b2e2ae4e75c">

closes: INS-4334
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
