### PR TITLE
Avoid encoding queryParams when request.settingEncodeUrl is set to false

### DIFF
--- a/packages/insomnia/src/ui/components/rendered-query-string.tsx
+++ b/packages/insomnia/src/ui/components/rendered-query-string.tsx
@@ -83,7 +83,7 @@ export const RenderedQueryString: FC<Props> = ({ request }) => {
         }
 
         const mergedParams = [...parameters, ...renderedAuthQueryParams];
-        const qs = buildQueryStringFromParams(mergedParams);
+        const qs = buildQueryStringFromParams(mergedParams, false, { encodeParams: request.settingEncodeUrl });
         const fullUrl = joinUrlAndQueryString(url, qs);
         const encoded = smartEncodeUrl(fullUrl, request.settingEncodeUrl, { strictNullHandling: true });
         setPreviewString(encoded === '' ? defaultPreview : encoded);


### PR DESCRIPTION
When `request.settingEncodeUrl` is set to false it is currently ignored by `buildQueryStringFromParams` hence creating a discrepancy between editing parameters in the URL bar at the top ( whose params aren't encoded as expected ), and editing parameters from `request-parameters-editor` which end up being encoded independently from `request.settingEncodeUrl`.

Closes #7873