### PR TITLE
fix: file not synced after switch sync method -[INS-4347]

### DIFF
--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -352,7 +352,7 @@ export const canPushLoader: LoaderFunction = async ({ params }): Promise<GitCanP
   try {
     canPush = await GitVCS.canPush(gitRepository.credentials);
     // update workspace meta with git sync data, use for show unpushed changes on collection card
-    models.workspaceMeta.update(workspaceMeta, {
+    models.workspaceMeta.updateByParentId(workspaceId, {
       hasUnpushedChanges: canPush,
     });
   } catch (err) { }

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -72,7 +72,7 @@ export const loader: LoaderFunction = async ({ params }): Promise<RequestLoaderD
   const activeWorkspaceMeta = await models.workspaceMeta.getByParentId(workspaceId);
   invariant(activeWorkspaceMeta, 'Active workspace meta not found');
   // NOTE: loaders shouldnt mutate data, this should be moved somewhere else
-  await models.workspaceMeta.update(activeWorkspaceMeta, { activeRequestId: requestId });
+  await models.workspaceMeta.updateByParentId(workspaceId, { activeRequestId: requestId });
   if (isGrpcRequestId(requestId)) {
     return {
       activeRequest,


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

**Issue detail**
Sometimes after switch sync method. The file has become not synced.

**Root cause**
When using `models.xx.update` function, sometimes will update model by stale data. After switch to Insomnia Sync, we will delete `gitRepositoryId` in workspaceMeta and delete the corresponding gitrepository. But the workspaceMeta will be overwritten by the stale data, so there is `gitRepositoryId` in meta but no 
gitrepository data.
![image](https://github.com/user-attachments/assets/a39f486e-c9c7-45a2-9e99-a58fe5679756)
