### PR TITLE
chore: update AI service URL to use 'https://ai-helper.insomnia.rest' [INS-4367]

### DIFF
--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -71,7 +71,7 @@ export const test = baseTest.extend<{
       INSOMNIA_DATA_PATH: dataPath,
       INSOMNIA_API_URL: webServerUrl,
       INSOMNIA_APP_WEBSITE_URL: webServerUrl + '/website',
-      INSOMNIA_AI_URL: webServerUrl + '/ai',
+      INSOMNIA_AI_URL: webServerUrl + '/ai-helper',
       INSOMNIA_GITHUB_API_URL: webServerUrl + '/github-api/graphql',
       INSOMNIA_GITLAB_API_URL: webServerUrl + '/gitlab-api',
       INSOMNIA_UPDATES_URL: webServerUrl || 'https://updates.insomnia.rest',

--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -71,7 +71,7 @@ export const test = baseTest.extend<{
       INSOMNIA_DATA_PATH: dataPath,
       INSOMNIA_API_URL: webServerUrl,
       INSOMNIA_APP_WEBSITE_URL: webServerUrl + '/website',
-      INSOMNIA_AI_URL: webServerUrl + '/ai-helper',
+      INSOMNIA_AI_URL: webServerUrl + '/ai',
       INSOMNIA_GITHUB_API_URL: webServerUrl + '/github-api/graphql',
       INSOMNIA_GITLAB_API_URL: webServerUrl + '/gitlab-api',
       INSOMNIA_UPDATES_URL: webServerUrl || 'https://updates.insomnia.rest',

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -127,7 +127,7 @@ export const getMockServiceBinURL = (serverId: string, path: string, customUrl?:
   }
   return customUrl + '/bin/' + serverId + path;
 };
-export const getAIServiceURL = () => env.INSOMNIA_AI_URL || 'https://ai.insomnia.rest';
+export const getAIServiceURL = () => env.INSOMNIA_AI_URL || 'https://ai-helper.insomnia.rest';
 
 export const getUpdatesBaseURL = () => env.INSOMNIA_UPDATES_URL || 'https://updates.insomnia.rest';
 


### PR DESCRIPTION
To support moving the ai.insomnia.rest into another subdomain (ai-helper.insomnia.rest).

Related to INS-4367
