### PR TITLE
Nunjuck Tag Performance enhance in editor[INS-4243]

### DIFF
--- a/packages/insomnia/src/common/documentation.ts
+++ b/packages/insomnia/src/common/documentation.ts
@@ -11,6 +11,8 @@ export const docsIntroductionInsomnia = insomniaDocs('/insomnia/get-started');
 export const docsWorkingWithDesignDocs = insomniaDocs('/insomnia/design-documents');
 export const docsUnitTesting = insomniaDocs('/insomnia/unit-testing');
 export const docsIntroductionToInsoCLI = insomniaDocs('/inso-cli/introduction');
+export const docsPreRequestScript = insomniaDocs('/insomnia/pre-request-script');
+export const docsAfterResponseScript = insomniaDocs('/insomnia/after-response-script');
 
 export const docsGitAccessToken = {
   github: 'https://docs.github.com/github/authenticating-to-github/creating-a-personal-access-token',
@@ -36,5 +38,13 @@ export const documentationLinks = {
   introductionToInsoCLI: {
     title: 'Introduction to Inso CLI',
     url: docsIntroductionToInsoCLI,
+  },
+  introductionToPreRequestScript: {
+    title: 'Pre-request Script Overview',
+    url: docsPreRequestScript,
+  },
+  introductionToAfterResponseScript: {
+    title: 'After-Response Script Overview',
+    url: docsAfterResponseScript,
   },
 } as const;

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -51,7 +51,7 @@ export interface RenderContextAndKeys {
   }[];
 }
 
-export type HandleGetRenderContext = () => Promise<RenderContextAndKeys>;
+export type HandleGetRenderContext = (contextCacheKey?: string) => Promise<RenderContextAndKeys>;
 
 export type HandleRender = <T>(object: T, contextCacheKey?: string | null) => Promise<T>;
 

--- a/packages/insomnia/src/templating/utils.ts
+++ b/packages/insomnia/src/templating/utils.ts
@@ -313,3 +313,5 @@ export function extractNunjucksTagFromCoords(
 export interface nunjucksTagContextMenuOptions extends Exclude<ReturnType<typeof extractNunjucksTagFromCoords>, void> {
   type: NunjucksTagContextMenuAction;
 }
+
+export const responseTagRegex = new RegExp('{% *response *.* %}');

--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -449,6 +449,7 @@ export const CodeEditor = memo(forwardRef<CodeEditorHandle, CodeEditorProps>(({
         handleRender,
         handleGetRenderContext,
         settings.showVariableSourceAndValue,
+        id,
       );
     }
     // Make URLs clickable
@@ -469,7 +470,7 @@ export const CodeEditor = memo(forwardRef<CodeEditorHandle, CodeEditorProps>(({
         codeMirror.current.foldCode(from, to);
       }
     }
-  }, [defaultValue, dynamicHeight, extraKeys, filter, getAutocompleteConstants, getAutocompleteSnippets, handleGetRenderContext, handleRender, hideGutters, hideLineNumbers, hintOptions, indentSize, indentWithTabs, infoOptions, jumpOptions, maybePrettifyAndSetValue, mode, noLint, noMatchBrackets, noStyleActiveLine, onClickLink, pinToBottom, placeholder, readOnly, settings.autocompleteDelay, settings.editorKeyMap, settings.editorLineWrapping, settings.hotKeyRegistry, settings.nunjucksPowerUserMode, settings.showVariableSourceAndValue, uniquenessKey, onPaste, persistState]);
+  }, [hideGutters, hideLineNumbers, placeholder, settings.editorLineWrapping, settings.editorKeyMap, settings.hotKeyRegistry, settings.autocompleteDelay, settings.nunjucksPowerUserMode, settings.showVariableSourceAndValue, noLint, readOnly, noMatchBrackets, indentSize, hintOptions, infoOptions, dynamicHeight, jumpOptions, noStyleActiveLine, indentWithTabs, extraKeys, handleRender, mode, getAutocompleteConstants, getAutocompleteSnippets, persistState, maybePrettifyAndSetValue, defaultValue, filter, onClickLink, uniquenessKey, handleGetRenderContext, pinToBottom, onPaste, id]);
 
   const cleanUpEditor = useCallback(() => {
     codeMirror.current?.toTextArea();
@@ -540,6 +541,7 @@ export const CodeEditor = memo(forwardRef<CodeEditorHandle, CodeEditorProps>(({
             case 'edit':
               showModal(NunjucksModal, {
                 template: template,
+                editorId: id,
                 onDone: (template: string | null) => {
                   const { from, to } = range;
                   codeMirror.current?.replaceRange(template!, from, to);

--- a/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
@@ -102,9 +102,9 @@ async function _highlightNunjucksTags(this: CodeMirror.Editor, render: HandleRen
       const isCursorInToken = isSameLine && cursor.ch > tok.start && cursor.ch < tok.end;
       const isFocused = this.hasFocus();
       if (!renderContextCache) {
-        // renderContextCache is created if nunjuck tags have been found.
-        // for each nunjuck tag, it will call _updateElementText to update the text.
-        // In order to avoid duplicate renderContext function call for variable type tags, cache the renderContext result here
+        // renderContextCache is created if any nunjuck tag has been found.
+        // For each nunjuck tag, it will call _updateElementText to update the text. This function will use renderContext to get context for text update.
+        // In order to avoid renderContext being called many times especially when there's numbers of env variables, we cache the renderContext result here.
         // The cache will not applied to mouseenter listeners since the context may change later.
         renderContextCache = await renderContext();
       }

--- a/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
@@ -147,7 +147,7 @@ async function _highlightNunjucksTags(this: CodeMirror.Editor, render: HandleRen
           renderString,
           mark,
           tok.string,
-          // use cached renderContext to avoid duplicated renderCotext call for every token refer: https://github.com/Kong/insomnia/issues/4645
+          // use cached renderContext to avoid duplicated renderCotext call for every token. Refer: https://github.com/Kong/insomnia/issues/4645
           renderContextCache,
           showVariableSourceAndValue,
         );

--- a/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
@@ -144,7 +144,6 @@ async function _highlightNunjucksTags(this: CodeMirror.Editor, render: HandleRen
           renderString,
           mark,
           tok.string,
-          // use renderContext with cache key so that it will share the same RenderContext Cache with renderString function
           renderContextWithCacheKey,
           showVariableSourceAndValue,
         );
@@ -156,7 +155,7 @@ async function _highlightNunjucksTags(this: CodeMirror.Editor, render: HandleRen
           renderString,
           mark,
           tok.string,
-          renderContext,
+          renderContextWithCacheKey,
           showVariableSourceAndValue,
         );
       });

--- a/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
@@ -102,6 +102,10 @@ async function _highlightNunjucksTags(this: CodeMirror.Editor, render: HandleRen
       const isCursorInToken = isSameLine && cursor.ch > tok.start && cursor.ch < tok.end;
       const isFocused = this.hasFocus();
       if (!renderContextCache) {
+        // renderContextCache is created if nunjuck tags have been found.
+        // for each nunjuck tag, it will call _updateElementText to update the text.
+        // In order to avoid duplicate renderContext function call for variable type tags, cache the renderContext result here
+        // The cache will not applied to mouseenter listeners since the context may change later.
         renderContextCache = await renderContext();
       }
 

--- a/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
@@ -270,7 +270,7 @@ async function _updateElementText(
   render: HandleRender,
   mark: CodeMirror.TextMarker<CodeMirror.MarkerRange>,
   text: string,
-  renderContext: HandleGetRenderContext | Awaited<ReturnType<HandleGetRenderContext>>,
+  renderContext: HandleGetRenderContext,
   showVariableSourceAndValue: boolean
 ) {
   const el = mark.replacedWith!;
@@ -322,7 +322,7 @@ async function _updateElementText(
     } else {
       // Render if it's a variable
       title = await render(str);
-      const context = typeof renderContext === 'function' ? await renderContext() : renderContext;
+      const context = await renderContext();
       const con = context.context.getKeysContext();
       const contextForKey = con.keyContext[cleanedStr];
       // Only prefix the title with context, if context is found

--- a/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts
@@ -57,7 +57,7 @@ async function _highlightNunjucksTags(this: CodeMirror.Editor, render: HandleRen
 
   // Only mark up Nunjucks tokens that are in the viewport
   const vp = this.getViewport();
-  let renderContextCache: any;
+  let renderContextCache;
 
   for (let lineNo = vp.from; lineNo < vp.to; lineNo++) {
     const line = this.getLineTokens(lineNo);

--- a/packages/insomnia/src/ui/components/modals/nunjucks-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/nunjucks-modal.tsx
@@ -16,11 +16,13 @@ interface State {
   isTag: boolean;
   template: string;
   onDone: Function;
+  editorId?: string;
 }
 
 interface NunjucksModalOptions {
   template: string;
   onDone: Function;
+  editorId?: string;
 }
 
 export interface NunjucksModalHandle {
@@ -33,17 +35,19 @@ export const NunjucksModal = forwardRef<NunjucksModalHandle, ModalProps & Props>
     isTag: false,
     template: '',
     onDone: () => { },
+    editorId: '',
   });
 
   useImperativeHandle(ref, () => ({
     hide: () => {
       modalRef.current?.hide();
     },
-    show: ({ onDone, template }) => {
+    show: ({ onDone, template, editorId }) => {
       setState({
         isTag: template.indexOf('{%') === 0,
         template,
         onDone,
+        editorId,
       });
       modalRef.current?.show();
     },
@@ -61,7 +65,7 @@ export const NunjucksModal = forwardRef<NunjucksModalHandle, ModalProps & Props>
   const title = isTag ? 'Tag' : 'Variable';
   let editor: JSX.Element | null = null;
   if (isTag) {
-    editor = <TagEditor onChange={handleTemplateChange} defaultValue={template} workspace={workspace} />;
+    editor = <TagEditor onChange={handleTemplateChange} defaultValue={template} workspace={workspace} editorId={state.editorId} />;
   } else {
     editor = <VariableEditor onChange={handleTemplateChange} defaultValue={template} />;
   }

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Button, Dialog, DropIndicator, GridList, GridListItem, Heading, Label, ListBoxItem, Menu, MenuTrigger, Modal, ModalOverlay, Popover, Text, useDragAndDrop } from 'react-aria-components';
 import { useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
-import { docsTemplateTags } from '../../../common/documentation';
+import { docsAfterResponseScript, docsTemplateTags } from '../../../common/documentation';
 import { debounce } from '../../../common/misc';
 import type { Environment } from '../../../models/environment';
 import { isRemoteProject } from '../../../models/project';
@@ -438,9 +438,17 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: {
                 </div>
               </div>
               <div className='flex items-center gap-2 justify-between'>
-                <p className='text-sm italic'>
-                  * Environment data can be used for <a href={docsTemplateTags}>Nunjucks Templating</a> in your requests.
-                </p>
+                <div className='flex flex-col gap-1'>
+                  {/* Warning message when user uses response tag in environment variable and suggest to user after-response script INS-4243 */}
+                  {/{% *response *.* %}/.test(JSON.stringify(selectedEnvironment?.data)) &&
+                    <p className='text-sm italic warning'>
+                      <Icon icon="exclamation-circle" /><a href={docsAfterResponseScript}> We suggest to save your response into an environment variable using after-response script.</a>
+                    </p>
+                  }
+                  <p className='text-sm italic'>
+                    * Environment data can be used for <a href={docsTemplateTags}>Nunjucks Templating</a> in your requests.
+                  </p>
+                </div>
                 <Button
                   onPress={close}
                   className="hover:no-underline hover:bg-opacity-90 border border-solid border-[--hl-md] py-2 px-3 text-[--color-font] transition-colors rounded-sm"

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -1,5 +1,5 @@
 import type { IconName, IconProp } from '@fortawesome/fontawesome-svg-core';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Dialog, DropIndicator, GridList, GridListItem, Heading, Label, ListBoxItem, Menu, MenuTrigger, Modal, ModalOverlay, Popover, Text, useDragAndDrop } from 'react-aria-components';
 import { useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
@@ -7,6 +7,7 @@ import { docsAfterResponseScript, docsTemplateTags } from '../../../common/docum
 import { debounce } from '../../../common/misc';
 import type { Environment } from '../../../models/environment';
 import { isRemoteProject } from '../../../models/project';
+import { responseTagRegex } from '../../../templating/utils';
 import { useLoaderDeferData } from '../../hooks/use-loader-defer-data';
 import type { OrganizationFeatureLoaderData } from '../../routes/organization';
 import type { WorkspaceLoaderData } from '../../routes/workspace';
@@ -54,6 +55,12 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: {
   const isUsingGitSync = Boolean(features.gitSync.enabled && (activeWorkspaceMeta?.gitRepositoryId || !isRemoteProject(activeProject)));
 
   const selectedEnvironment = [baseEnvironment, ...subEnvironments].find(env => env._id === selectedEnvironmentId);
+  const hasResponseTagEnvironmentVariable = useMemo(() => {
+    if (selectedEnvironment) {
+      return responseTagRegex.test(JSON.stringify(selectedEnvironment.data));
+    }
+    return false;
+  }, [selectedEnvironment]);
 
   const environmentActionsList: {
     id: string;
@@ -440,7 +447,7 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: {
               <div className='flex items-center gap-2 justify-between'>
                 <div className='flex flex-col gap-1'>
                   {/* Warning message when user uses response tag in environment variable and suggest to user after-response script INS-4243 */}
-                  {/{% *response *.* %}/.test(JSON.stringify(selectedEnvironment?.data)) &&
+                  {hasResponseTagEnvironmentVariable &&
                     <p className='text-sm italic warning'>
                       <Icon icon="exclamation-circle" /><a href={docsAfterResponseScript}> We suggest to save your response into an environment variable using after-response script.</a>
                     </p>

--- a/packages/insomnia/src/ui/components/templating/tag-editor.tsx
+++ b/packages/insomnia/src/ui/components/templating/tag-editor.tsx
@@ -5,6 +5,7 @@ import { Button } from 'react-aria-components';
 import { useMount } from 'react-use';
 
 import { database as db } from '../../../common/database';
+import { docsAfterResponseScript } from '../../../common/documentation';
 import { delay, fnOrString } from '../../../common/misc';
 import { metaSortKeySort } from '../../../common/sorting';
 import * as models from '../../../models';
@@ -24,12 +25,14 @@ import { useNunjucks } from '../../context/nunjucks/use-nunjucks';
 import { Dropdown, DropdownItem, DropdownSection, ItemContent } from '../base/dropdown';
 import { FileInputButton } from '../base/file-input-button';
 import { HelpTooltip } from '../help-tooltip';
+import { Icon } from '../icon';
 import { localTemplateTags } from './local-template-tags';
 
 interface Props {
   defaultValue: string;
   onChange: (...args: any[]) => any;
   workspace: Workspace;
+  editorId?: string;
 }
 
 interface State {
@@ -296,6 +299,12 @@ export const TagEditor: FC<Props> = props => {
             <option value="custom">-- Custom --</option>
           </select>
         </label>
+        {/* Warning message when user uses response tag in environment variable and suggest to user after-response script INS-4243 */}
+        {activeTagDefinition?.name === 'response' && props.editorId?.includes('environment') &&
+          <p className='text-sm warning mt-2'>
+            <Icon icon="exclamation-circle" /><a href={docsAfterResponseScript}> We suggest to save your response into an environment variable using after-response script.</a>
+          </p>
+        }
       </div>
       {activeTagDefinition?.args.map((argDefinition: NunjucksParsedTagArg, index) => {
         // Decide whether or not to show it

--- a/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
+++ b/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
@@ -30,12 +30,12 @@ export const useNunjucks = () => {
     });
   }, [requestData?.activeRequest, workspaceData?.activeWorkspace, workspaceData?.activeEnvironment._id]);
 
-  const handleGetRenderContext: HandleGetRenderContext = useCallback(async () => {
-    const context = await fetchRenderContext();
+  const handleGetRenderContext: HandleGetRenderContext = useCallback(async (contextCacheKey?: string) => {
+    const context = contextCacheKey && getRenderContextPromiseCache[contextCacheKey] ?
+      await await getRenderContextPromiseCache[contextCacheKey] : await fetchRenderContext();
     const keys = getKeys(context, NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME);
     return { context, keys };
   }, [fetchRenderContext]);
-
   /**
    * Heavily optimized render function
    *

--- a/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
+++ b/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
@@ -32,7 +32,7 @@ export const useNunjucks = () => {
 
   const handleGetRenderContext: HandleGetRenderContext = useCallback(async (contextCacheKey?: string) => {
     const context = contextCacheKey && getRenderContextPromiseCache[contextCacheKey] ?
-      await await getRenderContextPromiseCache[contextCacheKey] : await fetchRenderContext();
+      await getRenderContextPromiseCache[contextCacheKey] : await fetchRenderContext();
     const keys = getKeys(context, NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME);
     return { context, keys };
   }, [fetchRenderContext]);

--- a/packages/insomnia/types/codemirror.d.ts
+++ b/packages/insomnia/types/codemirror.d.ts
@@ -16,6 +16,7 @@ interface InsomniaExtensions {
     handleRender: HandleRender,
     handleGetRenderContext?: HandleGetRenderContext,
     showVariableSourceAndValue?: boolean,
+    editorId?: string,
   ) => void;
   isHintDropdownActive: () => boolean;
   makeLinksClickable: (handleClick: LinkClickCallback) => void;


### PR DESCRIPTION
**Background**
Before the after-response script feature, users are using response tag to save response body as environment variable. 

Due to the limitation of current Nunjuck-tag design, for every response tag used in environment variable, we will send a separate request if the response meets re-send condition during the request sending process.

For legacy users using numbers of response tag as environment variable, they will find it very slow on sending requests even they do not use that environment variable.

We will add a warning message when users are editing environments and response tag is found as a variable value which suggests users to use after-response script instead.

**Changes:**
- Use cached renderContext for multiple Nunjuck tags rendering to avoid unnecessary duplicate getRenderContext call in code-editor 

https://github.com/user-attachments/assets/b71cf38b-d5c3-4092-b61d-84c2785227aa


https://github.com/user-attachments/assets/9997173d-c3b0-4526-806c-ba46af9b376d

- Add a warning message suggesting user to use after-script response in environment variable instead of response tag
<img width="768" alt="Screenshot 2024-09-06 at 13 35 49" src="https://github.com/user-attachments/assets/9cd14424-00de-4358-9f65-2c4cd266788e"><img width="1151" alt="Screenshot 2024-09-06 at 15 13 19" src="https://github.com/user-attachments/assets/7cba0d83-21d2-4bfe-992d-36292a7eba66">

Ref: [INS-4243] https://github.com/Kong/insomnia/issues/4645

