### PR TITLE
perf: test-suit loader improvement - [INS-4400]

### DIFF
--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -609,8 +609,20 @@ export const database = {
     return next([doc]);
   },
 
-  /** get all descendants of a document */
-  withDescendants: async function<T extends BaseModel>(doc: T | null, stopType: string | null = null): Promise<BaseModel[]> {
+  /**
+   * Get all descendants of a document.
+   *
+   * This function retrieves all descendant documents of a given document from the database.
+   * It performs a recursive search, starting from the provided document and continuing
+   * through all child documents, until no more descendants are found or a document of the
+   * specified stop type is encountered.
+   *
+   * @param doc - The document to start the search from. If null, the search starts from the root.
+   * @param stopType - An optional type of document to stop the search at. If a document of this type is encountered, its descendants are not included.
+   * @param queryTypes - An optional array of document types to query. If not provided, all types are queried.
+   * @returns A promise that resolves to an array of all descendant documents.
+   */
+  withDescendants: async function <T extends BaseModel>(doc: T | null, stopType: string | null = null, queryTypes: string[] = []): Promise<BaseModel[]> {
     if (db._empty) {
       return _send<BaseModel[]>('withDescendants', ...arguments);
     }
@@ -626,7 +638,9 @@ export const database = {
 
         const promises: Promise<BaseModel[]>[] = [];
 
-        for (const type of allTypes()) {
+        const types = queryTypes?.length ? queryTypes : allTypes();
+
+        for (const type of types) {
           // If the doc is null, we want to search for parentId === null
           const parentId = doc ? doc._id : null;
           const promise = database.find(type, { parentId });

--- a/packages/insomnia/src/ui/routes/test-suite.tsx
+++ b/packages/insomnia/src/ui/routes/test-suite.tsx
@@ -365,7 +365,7 @@ export const loader: LoaderFunction = async ({
 
   const workspace = await models.workspace.getById(workspaceId);
   invariant(workspace, 'Workspace not found');
-  const workspaceEntities = await database.withDescendants(workspace);
+  const workspaceEntities = await database.withDescendants(workspace, models.request.type, [models.request.type, models.requestGroup.type]);
   const requests: Request[] = workspaceEntities.filter(isRequest);
 
   const unitTestSuite = await database.getWhere<UnitTestSuite>(models.unitTestSuite.type, {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

**Issue**
When the nesting levels are deeper or there are too much children under workspace. The `withDescendants` will take a long time to find all requests.

**Changes**

- [x] Add a `queryType` param for `withDescendants` function to limit the types of database queries
- [x] pass `stopType` and `queryType` when call the `withDescendants` function in test-suit loader
