### PR TITLE
chore: move audit away from test [no-ticket]

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,37 @@
+name: Audit App
+
+on:
+  merge_group:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Test:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Audit packages
+        run: npm audit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Install packages
         run: npm ci
 
-      - name: Audit packages
-        run: npm audit
-
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
idea:
- move audit into its own workflow

not done here, but maybe we should think about:
- keep audit in test workflow but split up linting, auditing, unit tests and smoke tests into separate jobs
- ? have a second look at https://github.com/Kong/insomnia/pull/7904 https://github.com/Kong/insomnia/pull/7767 https://github.com/Kong/insomnia/pull/7796
