### PR TITLE
Fix csv line break issue when upload runner data

### DIFF
--- a/packages/insomnia/src/ui/components/modals/upload-runner-data-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/upload-runner-data-modal.tsx
@@ -77,7 +77,8 @@ export const UploadDataModal = ({ onUploadFile, onClose, userUploadData }: Uploa
           setInvalidFileReason('Upload JSON file can not be parsed');
         }
       } else if (file.type === 'text/csv') {
-        const csvRows = content.split('\n').map(row => row.split(','));
+        // Replace CRLF (Windows line break) and CR (Mac link break) with \n, then split into csv arrays
+        const csvRows = content.replace(/\r\n|\r/g, '\n').split('\n').map(row => row.split(','));
         // at least 2 rows required for csv
         if (csvRows.length > 1) {
           const csvHeaders = csvRows[0];


### PR DESCRIPTION
Fix CSV split issue when user uploads runner data with different types of line breaks:
- **LF** (\n) in Linux
- **CRLF**(\r\n) in windows
- **CR**(\r) in Mac

Closes https://github.com/Kong/insomnia/issues/7947
