### PR TITLE
fix: unpushed notification performance issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4419,10 +4419,11 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.0.tgz",
-      "integrity": "sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
+      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -17832,12 +17833,13 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.0.tgz",
-      "integrity": "sha512-wPMZ8S2TuPadH0sF5irFGjkNLIcRvOSaEe7v+JER8508dyJumm6XZB1u5kztlX0RVq6AzRVndzqcUh6sFIauzA==",
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
+      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.16.0"
+        "@remix-run/router": "1.19.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -17847,13 +17849,14 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.0.tgz",
-      "integrity": "sha512-Q9YaSYvubwgbal2c9DJKfx6hTNoBp3iJDsl+Duva/DwxoJH+OTXkxGpql4iUK2sla/8z4RpjAm6EWx1qUDuopQ==",
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
+      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.16.0",
-        "react-router": "6.23.0"
+        "@remix-run/router": "1.19.2",
+        "react-router": "6.26.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -22130,7 +22133,7 @@
         "react-aria-components": "^1.1.1",
         "react-dom": "^18.2.0",
         "react-resizable-panels": "^2.0.17",
-        "react-router-dom": "^6.22.3",
+        "react-router-dom": "^6.26.2",
         "react-stately": "3.30.1",
         "react-use": "^17.5.0",
         "tailwindcss": "^3.4.3",

--- a/packages/insomnia-smoke-test/tests/smoke/git-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/git-interactions.test.ts
@@ -38,6 +38,8 @@ test('Git Interactions (clone, checkout branch, pull, push, stage changes, ...)'
     // perform some changes and commit them
     await page.locator('pre').filter({ hasText: 'title: Endpoint Security' }).click();
     await page.getByRole('textbox').fill(' test');
+    // make sure the changes are stored
+    await page.waitForTimeout(1000);
     await page.getByTestId('git-dropdown').click();
     await page.getByText('Commit').click();
     await page.getByText('Modified Objects').click();

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -169,7 +169,7 @@
     "react-aria-components": "^1.1.1",
     "react-dom": "^18.2.0",
     "react-resizable-panels": "^2.0.17",
-    "react-router-dom": "^6.22.3",
+    "react-router-dom": "^6.26.2",
     "react-stately": "3.30.1",
     "react-use": "^17.5.0",
     "tailwindcss": "^3.4.3",

--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -74,17 +74,15 @@ export const GitSyncDropdown: FC<Props> = ({ gitRepository, isInsomniaSyncEnable
     workspaceId,
   ]);
 
-  useEffect(() => {
-    if (gitRepository?.uri && gitRepository?._id && gitChangesFetcher.state === 'idle' && !gitChangesFetcher.data && gitRepoDataFetcher.data) {
+  useInterval(() => {
+    // these 2 loaders have been disabled for revalidation, we manually revalidate them here to improve performance
+    if (gitRepository?.uri && gitRepository?._id && gitChangesFetcher.state === 'idle' && gitRepoDataFetcher.data) {
       gitChangesFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/git/changes`);
     }
-  }, [gitChangesFetcher, gitRepoDataFetcher.data, gitRepository?._id, gitRepository?.uri, organizationId, projectId, workspaceId]);
-
-  useEffect(() => {
-    if (gitRepository?.uri && gitRepository?._id && gitCanPushFetcher.state === 'idle' && !gitCanPushFetcher.data && gitRepoDataFetcher.data) {
+    if (gitRepository?.uri && gitRepository?._id && gitCanPushFetcher.state === 'idle' && gitRepoDataFetcher.data) {
       gitCanPushFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/git/can-push`);
     }
-  }, [gitCanPushFetcher, gitRepoDataFetcher.data, gitRepository?._id, gitRepository?.uri, organizationId, projectId, workspaceId]);
+  }, 30 * 1000);
 
   // Only fetch the repo status if we have a repo uri and we don't have the status already
   const shouldFetchGitRepoStatus = Boolean(gitRepository?.uri && gitRepository?._id && gitStatusFetcher.state === 'idle' && !gitStatusFetcher.data && gitRepoDataFetcher.data);

--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -188,7 +188,7 @@ export const GitSyncDropdown: FC<Props> = ({ gitRepository, isInsomniaSyncEnable
     {
       id: 'commit',
       icon: 'check',
-      isDisabled: gitChangesFetcher.data?.changes.length === 0,
+      isDisabled: false,
       label: 'Commit',
       action: () => setIsGitStagingModalOpen(true),
     },
@@ -211,7 +211,7 @@ export const GitSyncDropdown: FC<Props> = ({ gitRepository, isInsomniaSyncEnable
       id: 'push',
       icon: loadingPush ? 'refresh' : 'cloud-upload',
       label: 'Push',
-      isDisabled: !gitCanPushFetcher.data?.canPush,
+      isDisabled: false,
       action: () => handlePush({ force: false }),
     },
     {

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -877,7 +877,10 @@ async function renderApp() {
                                     path: 'changes',
                                     loader: async (...args) =>
                                       (await import('./routes/git-actions')).gitChangesLoader(...args),
-                                    shouldRevalidate: () => {
+                                    shouldRevalidate: ({ formAction }) => {
+                                      if (formAction?.includes('git/commit')) {
+                                        return true;
+                                      }
                                       // disable revalidation for this loader, we will fetch this loader periodically through fetcher.load in component
                                       return false;
                                     },
@@ -886,7 +889,10 @@ async function renderApp() {
                                     path: 'can-push',
                                     loader: async (...args) =>
                                       (await import('./routes/git-actions')).canPushLoader(...args),
-                                    shouldRevalidate: () => {
+                                    shouldRevalidate: ({ formAction }) => {
+                                      if (formAction?.includes('git/push')) {
+                                        return true;
+                                      }
                                       // disable revalidation for this loader, we will fetch this loader periodically through fetcher.load in component
                                       return false;
                                     },

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -877,11 +877,19 @@ async function renderApp() {
                                     path: 'changes',
                                     loader: async (...args) =>
                                       (await import('./routes/git-actions')).gitChangesLoader(...args),
+                                    shouldRevalidate: () => {
+                                      // disable revalidation for this loader, we will fetch this loader periodically through fetcher.load in component
+                                      return false;
+                                    },
                                   },
                                   {
                                     path: 'can-push',
                                     loader: async (...args) =>
                                       (await import('./routes/git-actions')).canPushLoader(...args),
+                                    shouldRevalidate: () => {
+                                      // disable revalidation for this loader, we will fetch this loader periodically through fetcher.load in component
+                                      return false;
+                                    },
                                   },
                                   {
                                     path: 'log',

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -878,7 +878,7 @@ async function renderApp() {
                                     loader: async (...args) =>
                                       (await import('./routes/git-actions')).gitChangesLoader(...args),
                                     shouldRevalidate: ({ formAction }) => {
-                                      if (formAction?.includes('git/commit')) {
+                                      if (formAction?.includes('git')) {
                                         return true;
                                       }
                                       // disable revalidation for this loader, we will fetch this loader periodically through fetcher.load in component
@@ -890,7 +890,7 @@ async function renderApp() {
                                     loader: async (...args) =>
                                       (await import('./routes/git-actions')).canPushLoader(...args),
                                     shouldRevalidate: ({ formAction }) => {
-                                      if (formAction?.includes('git/push')) {
+                                      if (formAction?.includes('git')) {
                                         return true;
                                       }
                                       // disable revalidation for this loader, we will fetch this loader periodically through fetcher.load in component

--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -1079,6 +1079,9 @@ export const pushToGitRemoteAction: ActionFunction = async ({
         providerName,
       },
     });
+    models.workspaceMeta.updateByParentId(workspaceId, {
+      hasUnpushedChanges: false,
+    });
   } catch (err: unknown) {
     if (err instanceof Errors.HttpError) {
       return {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

close #7946 

**Issue reason:**
The `git/can-push` and `git/changes` run too often because of the react-router revalidation mechanism.

**Changes**

- [x] add `shouldRevalidate` option to disable revalidation
- [x] run `fetch.load` in useInterval hook, every 30s
- [x] update `react-router-dom` to fix the `shouldRevalidate` not work (we updated in this pr https://github.com/Kong/insomnia/pull/7795, but it seems to have been replaced because of the conflict)
