### PR TITLE
Fix empty query paramter value in editor will generate url params without equal sign issue

### DIFF
--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -652,7 +652,7 @@ export const responseTransform = async (patch: ResponsePatch, environmentId: str
 };
 export const transformUrl = (url: string, params: RequestParameter[], authentication: RequestAuthentication, shouldEncode: boolean) => {
   const authQueryParam = getAuthQueryParams(authentication);
-  const customUrl = joinUrlAndQueryString(url, buildQueryStringFromParams(authQueryParam ? params.concat([authQueryParam]) : params));
+  const customUrl = joinUrlAndQueryString(url, buildQueryStringFromParams(authQueryParam ? params.concat([authQueryParam]) : params, true, { strictNullHandling: true }));
   const isUnixSocket = customUrl.match(/https?:\/\/unix:\//);
   if (!isUnixSocket) {
     return { finalUrl: smartEncodeUrl(customUrl, shouldEncode, { strictNullHandling: true }) };


### PR DESCRIPTION
**Background**
If user leaves an empty value for query paramter in editor like below:
<img width="496" alt="Screenshot 2024-09-19 at 16 20 55" src="https://github.com/user-attachments/assets/f9c5f95a-d151-424c-8042-8bbd9eac9612">
The generated url params will be `foo=bar&foo1&foo2=bar2`.
But in URL PREVIEW and Generate Code it will display as `foo=bar&foo1=&foo2=bar2`.
The fix will make empty value url params behaves same in generated url.

Closes https://github.com/Kong/insomnia/issues/7965
