### PR TITLE
feat(Proxy): use the system proxy option to always use the system proxy settings on insomnia requests

### DIFF
--- a/packages/insomnia/src/main/proxy.ts
+++ b/packages/insomnia/src/main/proxy.ts
@@ -23,6 +23,8 @@ async function updateProxy() {
     if (httpsProxy) {
       proxyRules.push(`https=${parseProxyFromUrl(httpsProxy)}`);
     }
+
+    session.defaultSession.resolveProxy;
     // Set proxy rules in the main session https://www.electronjs.org/docs/latest/api/structures/proxy-config
     session.defaultSession.setProxy({
       proxyRules: proxyRules.join(';'),
@@ -32,10 +34,11 @@ async function updateProxy() {
         // @TODO Add all our API urls here to bypass the proxy to work as before with axios.
         // We can add an option in settings to use the proxy for insomnia API requests and not include them here.
       ].join(','),
+      mode: 'system',
     });
     return;
   }
-  session.defaultSession.setProxy({ proxyRules: '', proxyBypassRules: '' });
+  session.defaultSession.setProxy({ proxyRules: '', proxyBypassRules: '', mode: 'system' });
 }
 
 export async function watchProxySettings() {


### PR DESCRIPTION
Highlights:
- [x] Use the `system` option in the proxy mode in the electron session to use the system proxy settings when running network requests

Closes #7969



## How to test:

- Install `squid` on one computer (e.g. `sudo apt install squid`
- Then replace `/etc/squid/squid.conf` config with this one:
```plaintext
# Squid normally listens on port 3128
http_port 3128

# Define allowed network
acl allowed_network src 192.168.1.0/24

# Define Safe Ports
acl SSL_ports port 443
acl Safe_ports port 80      # HTTP
acl Safe_ports port 443     # HTTPS
acl CONNECT method CONNECT

# Only allow requests to Safe Ports
http_access deny !Safe_ports
http_access deny CONNECT !SSL_ports

# Allow access from allowed network
http_access allow allowed_network

# Deny all other access and return 403 Forbidden
http_access deny all
deny_info 403:access_denied all
```
- then restart squid `sudo systemctl restart squid`
- next on a Windows machine, go to Properties > Proxy settings and setup a proxy pointing to the machine you are running `squid` on, example:
![image](https://github.com/user-attachments/assets/a3176222-6681-401f-bac8-78b85bb8360f)

- and add 2 Outbound firewall rules to your windows machine (go to firewall, Advanced Firewall settings), one to block all traffic to port 80 and 443, and another to allow all traffic to `squid` proxy port (in default case is `3128`

![image](https://github.com/user-attachments/assets/4451b681-77ef-4120-8761-91847a206a89)

- next if you use latest beta or latest develop, when you login, you will get error like reported in #7969 
- if you use the release recurring build of this PR, it will work, you will be able to login, without configuring any proxy settings on insomnia side

