### PR TITLE
fix(sdk): certificate 'disabled' property value gets lost in script execution

### DIFF
--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -166,7 +166,7 @@ export async function initInsomniaObject(
     const existClientCert = rawObj.clientCertificates != null && rawObj.clientCertificates.length > 0;
     const certificate = existClientCert && rawObj.clientCertificates[0] ?
         {
-            disabled: false,
+            disabled: rawObj.clientCertificates[0].disabled,
             name: 'The first certificate from Settings',
             matches: [rawObj.clientCertificates[0].host],
             key: { src: rawObj.clientCertificates[0].key || '' },


### PR DESCRIPTION
…

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Background
In initialization, the `disabled` property is not passed to the sdk's cert object.

### Changes
- [x] Init cert's `disabled` property in insomnia object initialization.

Ref: INS-4470
