### PR TITLE
run withDescendents with filters

### DIFF
--- a/packages/insomnia/src/sync/git/ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/ne-db-client.ts
@@ -156,7 +156,9 @@ export class NeDBClient {
       ];
     } else if (type !== null && id === null) {
       const workspace = await db.get(models.workspace.type, this._workspaceId);
-      const children = await db.withDescendants(workspace, null, [type]);
+      const modelTypesWithinFolders = [models.request.type, models.grpcRequest.type, models.webSocketRequest.type];
+      const typeFilter = modelTypesWithinFolders.includes(type) ? [models.requestGroup.type, type] : [type];
+      const children = await db.withDescendants(workspace, null, typeFilter);
       docs = children.filter(d => d.type === type && !d.isPrivate);
     } else {
       throw this._errMissing(filePath);

--- a/packages/insomnia/src/sync/git/ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/ne-db-client.ts
@@ -150,10 +150,12 @@ export class NeDBClient {
         models.mockRoute.type,
         models.mockServer.type,
       ];
-    } else if (type !== null && id === null) {
+    } else if (type === models.workspace.type && id === null) {
       const workspace = await db.get(models.workspace.type, this._workspaceId);
       const children = await db.withDescendants(workspace);
       docs = children.filter(d => d.type === type && !d.isPrivate);
+    } else if (type !== null && id === null) {
+      // Do nothing
     } else {
       throw this._errMissing(filePath);
     }

--- a/packages/insomnia/src/sync/git/ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/ne-db-client.ts
@@ -15,7 +15,6 @@ import { SystemError } from './system-error';
 export class NeDBClient {
   _workspaceId: string;
   _projectId: string;
-  children: any;
 
   constructor(workspaceId: string, projectId: string) {
     if (!workspaceId) {
@@ -24,10 +23,7 @@ export class NeDBClient {
 
     this._workspaceId = workspaceId;
     this._projectId = projectId;
-    console.log('CREATE INSTANCE');
-    db.withDescendants({ type: 'Workspace', _id: workspaceId }).then(children => {
-      this.children = children;
-    });
+
   }
 
   static createClient(workspaceId: string, projectId: string): PromiseFsClient {


### PR DESCRIPTION
motivation: large git sync collection block the main event loops by running withDescentants 15 times on each tab navigation

rather than fetching all descendants 15 times
we just fetch the types we need, the problem is we need to also fetch all the folders

ideas:

1. stop doing this altogether
1a. just read and write to files and not a fake filestore-nedb adapter
2. do it in a more optimized way
2a. run this in a different conetxt so it doesn't need to be re-evaluated on navigation.
2b. run it faster by fetching a list of all folders in a workspace and iterations over the types using an $in query

Related: INS-4503

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
