### PR TITLE
fix: snapcraft update [INS-3645]

### DIFF
--- a/.github/workflows/snapcraft-release.yml
+++ b/.github/workflows/snapcraft-release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Package
         shell: bash
-        run: NODE_OPTIONS='--max_old_space_size=6144' BUILD_TARGETS='snap' npm run app-package
+        run: NODE_OPTIONS='--max_old_space_size=6144' npm run package -w insomnia -- --linux snap
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/snapcraft-release.yml
+++ b/.github/workflows/snapcraft-release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Package
         shell: bash
-        run: NODE_OPTIONS='--max_old_space_size=6144' npm run app-package -- --linux snap
+        run: NODE_OPTIONS='--max_old_space_size=6144' BUILD_TARGETS='snap' npm run app-package
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/snapcraft-release.yml
+++ b/.github/workflows/snapcraft-release.yml
@@ -1,0 +1,61 @@
+name: Snapcraft Experiment release
+# This workflow bakes executables of the major platforms for Testing purposes
+on:
+  merge_group:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types:
+      - opened
+      - synchronize
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  PR_NUMBER: ${{ github.event.number }}
+jobs:
+  build-and-upload-artifacts:
+    timeout-minutes: 15
+    # Skip jobs for release PRs
+    # windows on recurring should be portable
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
+          - os: "ubuntu-24.04"
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Bump version
+        shell: bash
+        run: npm --workspaces version prerelease --preid="$(git rev-parse --short HEAD)${{ github.event_name == 'pull_request' && '.pr-$PR_NUMBER' || '' }}" --no-git-tag-version
+
+      - name: Package
+        shell: bash
+        run: NODE_OPTIONS='--max_old_space_size=6144' npm run app-package -- --linux snap
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: ${{ matrix.os }}-artifacts-${{ github.run_number }}
+          path: |
+            packages/insomnia/dist/*.snap

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -141,8 +141,8 @@ const config = {
     ],
   },
   snap: {
-    base: 'core22',
-    plugs: ['gnome-42-2204'],
+    base: 'core24',
+    // plugs: ['gnome-42-2204'],
   },
 };
 

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -142,7 +142,7 @@ const config = {
   },
   snap: {
     base: 'core22',
-    // plugs: ['gnome-46-2404'],
+    plugs: ['gnome-42-2204'],
   },
 };
 

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -141,8 +141,8 @@ const config = {
     ],
   },
   snap: {
-    base: 'core24',
-    plugs: ['gnome-46-2404'],
+    base: 'core22',
+    // plugs: ['gnome-46-2404'],
   },
 };
 

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -141,7 +141,8 @@ const config = {
     ],
   },
   snap: {
-    base: 'core22',
+    base: 'core24',
+    plugs: ['gnome-46-2404'],
   },
 };
 


### PR DESCRIPTION
WIP,

Closes INS-3645

Trying to close #7106, #7138 

Related PR https://github.com/electron-userland/electron-builder/pull/8549/


## Experiments

test1:
- [x] Ubuntu 16, core22 snap baked on 22.04 🔴 - FAIL: sending requests doesn't work
- [x] Ubuntu 18, core22 snap baked on 22.04 ✅ 
- [x] Ubuntu 20, core22 snap baked on 22.04 ✅ 
- [x] Ubuntu 22, core22 snap baked on 22.04 ✅ 
- [x] Ubuntu 24, core22 snap baked on 22.04 ✅ 

test2:
- [x] Ubuntu 22, core22 snap baked on 24.04 ✅ 
- [x] Ubuntu 24, core22 snap baked on 24.04 ✅ 

test3:
- [x] Ubuntu 16, core22 with gnome-42-2204 plug baked on 24.04  🔴 - FAIL - segmentation fault
- [x] Ubuntu 18, core22 with gnome-42-2204 plug baked on 24.04  🔴 - FAIL - segmentation fault

test4:
- [x] Ubuntu 22, core24 snap baked on 24.04 🔴 - FAIL - needs https://github.com/electron-userland/electron-builder/pull/8549 to be fixed
- [x] Ubuntu 24, core24 snap baked on 24.04  🔴 - FAIL - needs https://github.com/electron-userland/electron-builder/pull/8549 to be fixed


## current blocker

using `core24` we get:
```
error while loading shared libraries: libX11.so.6: cannot open shared object file: No such file or directory
```

## Notes
- Might need further changes on electron-builder side first. Initial attempt made is just trying to use only changes on the config on our side.

- Not looked at yet - when running electron-builder to produce the linux-unpacked bits that go into different packaged versions of Insomnia (.deb, .snap, ...) on `ubuntu-latest` or on `ubuntu-22.04` or `ubuntu-20.04` - that could cause different issues with different versions - we need to figure out which one causes lowest amount of trouble. Example - https://github.com/Kong/insomnia/pull/7868

- Downgrading is a trap https://github.com/Kong/insomnia/pull/5555