### PR TITLE
Fix new property in request causes existing request show as modified in git sync [INS-4511]

### DIFF
--- a/packages/insomnia/src/common/__tests__/database.test.ts
+++ b/packages/insomnia/src/common/__tests__/database.test.ts
@@ -182,7 +182,7 @@ describe('requestCreate()', () => {
       parentId: 'wrk_123',
     };
     const r = await models.request.create(patch);
-    expect(Object.keys(r).length).toBe(25);
+    expect(Object.keys(r).length).toBe(24);
     expect(r._id).toMatch(/^req_[a-zA-Z0-9]{32}$/);
     expect(r.created).toBeGreaterThanOrEqual(now);
     expect(r.modified).toBeGreaterThanOrEqual(now);

--- a/packages/insomnia/src/models/request.ts
+++ b/packages/insomnia/src/models/request.ts
@@ -20,6 +20,7 @@ import {
 } from '../common/constants';
 import { database as db } from '../common/database';
 import type { OAuth1SignatureMethod } from '../network/o-auth-1/constants';
+import { getOperationType } from '../utils/graph-ql';
 import { deconstructQueryStringToParams } from '../utils/url/querystring';
 import type { BaseModel } from './index';
 
@@ -257,7 +258,6 @@ export interface BaseRequest {
   afterResponseScript?: string;
   parameters: RequestParameter[];
   pathParameters?: RequestPathParameter[];
-  operationType?: OperationTypeNode;
   headers: RequestHeader[];
   authentication: RequestAuthentication | {};
   metaSortKey: number;
@@ -285,7 +285,7 @@ export const isEventStreamRequest = (model: Pick<BaseModel, 'type'>) => (
   isRequest(model) && model.headers?.find(h => h.name === 'Accept')?.value === 'text/event-stream'
 );
 export const isGraphqlSubscriptionRequest = (model: Pick<BaseModel, 'type'>) => (
-  isRequest(model) && model.operationType === OperationTypeNode.SUBSCRIPTION
+  isRequest(model) && getOperationType(model) === OperationTypeNode.SUBSCRIPTION
 );
 
 export function init(): BaseRequest {
@@ -303,7 +303,6 @@ export function init(): BaseRequest {
     isPrivate: false,
     pathParameters: undefined,
     afterResponseScript: undefined,
-    operationType: undefined,
     // Settings
     settingStoreCookies: true,
     settingSendCookies: true,

--- a/packages/insomnia/src/ui/components/editors/body/body-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/body-editor.tsx
@@ -1,5 +1,4 @@
 import clone from 'clone';
-import { type OperationTypeNode } from 'graphql';
 import { lookup } from 'mime-types';
 import React, { type FC, useCallback } from 'react';
 import { Toolbar } from 'react-aria-components';
@@ -50,11 +49,11 @@ export const BodyEditor: FC<Props> = ({
     patchRequest(requestId, { body });
   }, [patchRequest, request.body.mimeType, requestId]);
 
-  const handleGraphQLChange = useCallback((content: string, operationType?: OperationTypeNode) => {
+  const handleGraphQLChange = useCallback((content: string) => {
     const body = typeof CONTENT_TYPE_GRAPHQL !== 'string'
       ? { text: content }
       : { mimeType: CONTENT_TYPE_GRAPHQL.split(';')[0], text: content };
-    patchRequest(requestId, { body, operationType });
+    patchRequest(requestId, { body });
   }, [patchRequest, requestId]);
 
   const handleFormUrlEncodedChange = useCallback((params: RequestBodyParameter[]) => {

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -4,7 +4,7 @@ import type { GraphQLInfoOptions } from 'codemirror-graphql/info';
 import type { ModifiedGraphQLJumpOptions } from 'codemirror-graphql/jump';
 import type { OpenDialogOptions } from 'electron';
 import { readFileSync } from 'fs';
-import { buildClientSchema, type DefinitionNode, type DocumentNode, getIntrospectionQuery, getOperationAST, GraphQLNonNull, GraphQLSchema, Kind, type NonNullTypeNode, type OperationDefinitionNode, OperationTypeNode, parse, typeFromAST } from 'graphql';
+import { buildClientSchema, type DefinitionNode, type DocumentNode, getIntrospectionQuery, GraphQLNonNull, GraphQLSchema, Kind, type NonNullTypeNode, type OperationDefinitionNode, OperationTypeNode, parse, typeFromAST } from 'graphql';
 import type { Maybe } from 'graphql-language-service';
 import React, { type FC, useEffect, useRef, useState } from 'react';
 import { Button, Group, Heading, Toolbar, Tooltip, TooltipTrigger } from 'react-aria-components';
@@ -67,15 +67,6 @@ function getGraphQLContent(body: GraphQLBody, query?: string, operationName?: st
 
 const isString = (value?: string): value is string => typeof value === 'string' || (value as unknown) instanceof String;
 const isOperationDefinition = (def: DefinitionNode): def is OperationDefinitionNode => def.kind === Kind.OPERATION_DEFINITION;
-const getOperationType = (operationName: string, documentAST: DocumentNode | null) => {
-  if (documentAST) {
-    const operationAST = getOperationAST(documentAST, operationName);
-    if (operationAST) {
-      return operationAST.operation;
-    }
-  };
-  return undefined;
-};
 
 const fetchGraphQLSchemaForRequest = async ({
   requestId,
@@ -180,7 +171,7 @@ interface GraphQLBody {
 }
 
 interface Props {
-  onChange: (value: string, type?: OperationTypeNode) => void;
+  onChange: (value: string) => void;
   request: Request;
   environmentId: string;
   className?: string;
@@ -298,13 +289,13 @@ export const GraphQLEditor: FC<Props> = ({
   });
   const changeOperationName = (operationName: string) => {
     const content = getGraphQLContent(state.body, undefined, operationName);
-    onChange(content, getOperationType(operationName, documentAST));
+    onChange(content);
     setState(prevState => ({ ...prevState, body: { ...prevState.body, operationName } }));
   };
   const changeVariables = (variablesInput: string) => {
     try {
       const content = getGraphQLContent(state.body, undefined, operationName, variablesInput);
-      onChange(content, getOperationType(operationName, documentAST));
+      onChange(content);
 
       setState(state => ({
         ...state,
@@ -338,7 +329,7 @@ export const GraphQLEditor: FC<Props> = ({
       }
 
       const content = getGraphQLContent(state.body, query, operationName);
-      onChange(content, getOperationType(operationName, documentAST));
+      onChange(content);
 
       setState(state => ({
         ...state,

--- a/packages/insomnia/src/utils/graph-ql.ts
+++ b/packages/insomnia/src/utils/graph-ql.ts
@@ -1,4 +1,3 @@
-
 import { getOperationAST, parse } from 'graphql';
 
 import { CONTENT_TYPE_GRAPHQL } from '../common/constants';

--- a/packages/insomnia/src/utils/graph-ql.ts
+++ b/packages/insomnia/src/utils/graph-ql.ts
@@ -1,5 +1,9 @@
+
+import { getOperationAST, parse } from 'graphql';
+
 import { CONTENT_TYPE_GRAPHQL } from '../common/constants';
 import type { RenderedRequest } from '../common/render';
+import type { Request } from '../models/request';
 
 // parse graphql request body since we save entire query variables as string rather then stringified json string. - INS-4281
 export function parseGraphQLReqeustBody(renderedRequest: RenderedRequest) {
@@ -14,4 +18,24 @@ export function parseGraphQLReqeustBody(renderedRequest: RenderedRequest) {
       console.error('Failed to parse GraphQL variables', e);
     }
   }
+}
+
+export function getOperationType(request: Request) {
+  if (request.body?.mimeType === CONTENT_TYPE_GRAPHQL) {
+    let documentAST;
+    let requestBody;
+    try {
+      requestBody = JSON.parse(request.body.text || '');
+      documentAST = parse(requestBody?.query || '');
+    } catch (error) {
+      documentAST = null;
+    }
+    if (documentAST) {
+      const operationAST = getOperationAST(documentAST, requestBody?.operationName);
+      if (operationAST) {
+        return operationAST.operation;
+      }
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
**Background**
Currently, When we add a new property to models like Request, we will add the default value of this property in model init method. Otherwise the new property can not be updated due to current design in database.update method which will check if updated keys is valid.

But this will cause all existing models show as modified in git sync, due to current implementation of using YAML stringify method to compare local db content with git origin content. The YAML stringify method will add a new property to the yaml file even the value is undefined.

**Solution**
Instead of adding a new property to request, I have moved the logic to detect if a GraphQL request operation is subscription or not into request model, so no more extra property is needed
