### PR TITLE
feat: support inso global env id / filepath

### DIFF
--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -45,6 +45,8 @@ const shouldReturnSuccessCode = [
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/three-requests.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 -i req_6063adcdab5b409e9b4f00f47322df4a',
   // multiple --env-var overrides
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/with-missing-env-vars.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 --env-var firstkey=first --env-var secondkey=second',
+  // globals file path env overrides
+  '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/with-missing-env-vars.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 --globals packages/insomnia-inso/src/examples/global-environment.yml',
 ];
 
 const shouldReturnErrorCode = [

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -321,6 +321,7 @@ export const go = (args?: string[]) => {
   You can also point it at a git repository folder, or an Insomnia export file.
 
   Examples:
+  $ inso run collection
   $ inso run test
   $ inso lint spec
   $ inso export spec
@@ -329,13 +330,10 @@ export const go = (args?: string[]) => {
   Inso also supports configuration files, by default it will look for .insorc in the current/provided working directory.
   $ inso export spec --config /some/path/.insorc
 `)
-    // TODO: make fallback dir clearer
-    .option('-w, --workingDir <dir>', 'set working directory, to look for files: .insorc, .insomnia folder, *.db.json', '')
-    // TODO: figure out how to remove this option
-    .option('--exportFile <file>', 'set the Insomna export file read from', '')
+    .option('-w, --workingDir <dir>', 'set working directory/file: .insomnia folder, *.db.json, export.yaml', '')
     .option('--verbose', 'show additional logs while running the command', false)
     .option('--ci', 'run in CI, disables all prompts, defaults to false', false)
-    .option('--config <path>', 'path to configuration file containing above options', '')
+    .option('--config <path>', 'path to configuration file containing above options (.insorc)', '')
     .option('--printOptions', 'print the loaded options', false);
 
   const run = program.command('run')

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -14,14 +14,17 @@ import { type RequestTestResult } from 'insomnia-sdk';
 import { generate, runTestsCli } from 'insomnia-testing';
 import orderedJSON from 'json-order';
 import { parseArgsStringToArgv } from 'string-argv';
+import { v4 as uuidv4 } from 'uuid';
 
 import packageJson from '../package.json';
 import { exportSpecification, writeFileWithCliOptions } from './commands/export-specification';
 import { getRuleSetFileFromFolderByFilename, lintSpecification } from './commands/lint-specification';
-import { Database, loadDb } from './db';
+import { Database, isFile, loadDb } from './db';
+import { insomniaExportAdapter } from './db/adapters/insomnia-adapter';
 import { loadApiSpec, promptApiSpec } from './db/models/api-spec';
 import { loadEnvironment, promptEnvironment } from './db/models/environment';
 import { loadTestSuites, promptTestSuites } from './db/models/unit-test-suite';
+import { matchIdIsh } from './db/models/util';
 import { loadWorkspace, promptWorkspace } from './db/models/workspace';
 
 export interface GlobalOptions {
@@ -429,7 +432,7 @@ export const go = (args?: string[]) => {
     .option('-t, --requestNamePattern <regex>', 'run requests that match the regex', '')
     .option('-i, --item <requestid>', 'request or folder id to run', collect, [])
     .option('-e, --env <identifier>', 'environment to use', '')
-    .option('-g, --globals <identifier>', 'global environment to use', '')
+    .option('-g, --globals <identifier>', 'global environment to use (filepath or id)', '')
     .option('--delay-request <duration>', 'milliseconds to delay between requests', '0')
     .option('--env-var <key=value>', 'override environment variables', collect, [])
     .option('-n, --iteration-count <count>', 'number of times to repeat', '1')
@@ -484,11 +487,36 @@ export const go = (args?: string[]) => {
 
       // Find environment
       const workspaceId = workspace._id;
-      const globalEnvironment = options.globals ? loadEnvironment(db, workspaceId, options.globals) : null;
-      let environment = options.env ? loadEnvironment(db, workspaceId, options.env) : await promptEnvironment(db, !!options.ci, workspaceId);
-      if (globalEnvironment) {
-        environment = { ...globalEnvironment, ...environment };
+      // get global env by id from nedb or gitstore, or first element from file
+      // smell: mutates db
+      if (options.globals) {
+        const isGlobalFile = await isFile(options.globals);
+        if (!isGlobalFile) {
+          const globalEnv = db.Environment.find(env => matchIdIsh(env, options.globals) || env.name === options.globals);
+          if (!globalEnv) {
+            logger.warn('No global environment found with id or name', options.globals);
+            return process.exit(1);
+          }
+          if (globalEnv) {
+            // attach this global env to the workspace
+            db.WorkspaceMeta = [{ activeGlobalEnvironmentId: globalEnv._id, _id: `wrkm_${uuidv4().replace(/-/g, '')}`, type: 'WorkspaceMeta', parentId: workspaceId, name: '' }];
+          }
+        }
+        if (isGlobalFile) {
+          const globalEnvDb = await insomniaExportAdapter(options.globals, ['Environment']);
+          logger.trace('--globals is a file path, loading from file, global env selection is not currently supported, taking first element');
+          const firstGlobalEnv = globalEnvDb?.Environment?.[0];
+          if (!firstGlobalEnv) {
+            logger.warn('No environments found in the file', options.globals);
+            return process.exit(1);
+          }
+          // mutate db to include the global envs
+          db.Environment = [...db.Environment, ...globalEnvDb.Environment];
+          // attach this global env to the workspace
+          db.WorkspaceMeta = [{ activeGlobalEnvironmentId: firstGlobalEnv._id, _id: `wrkm_${uuidv4().replace(/-/g, '')}`, type: 'WorkspaceMeta', parentId: workspaceId, name: '' }];
+        }
       }
+      const environment = options.env ? loadEnvironment(db, workspaceId, options.env) : await promptEnvironment(db, !!options.ci, workspaceId);
       if (!environment) {
         logger.fatal('No environment identified; cannot run requests without a valid environment.');
         return process.exit(1);

--- a/packages/insomnia-inso/src/db/adapters/insomnia-adapter.ts
+++ b/packages/insomnia-inso/src/db/adapters/insomnia-adapter.ts
@@ -117,3 +117,4 @@ const insomniaAdapter: DbAdapter = async (filePath, filterTypes) => {
 };
 
 export default insomniaAdapter;
+export const insomniaExportAdapter = insomniaAdapter;

--- a/packages/insomnia-inso/src/db/index.ts
+++ b/packages/insomnia-inso/src/db/index.ts
@@ -11,6 +11,7 @@ import type {
   UnitTest,
   UnitTestSuite,
   Workspace,
+  WorkspaceMeta,
 } from './models/types';
 
 export interface Database {
@@ -19,6 +20,7 @@ export interface Database {
   Request: BaseModel[];
   RequestGroup: BaseModel[];
   Workspace: Workspace[];
+  WorkspaceMeta: WorkspaceMeta[];
   UnitTestSuite: UnitTestSuite[];
   UnitTest: UnitTest[];
 }
@@ -29,6 +31,7 @@ export const emptyDb = (): Database => ({
   Request: [],
   RequestGroup: [],
   Workspace: [],
+  WorkspaceMeta: [],
   UnitTest: [],
   UnitTestSuite: [],
 });

--- a/packages/insomnia-inso/src/db/index.ts
+++ b/packages/insomnia-inso/src/db/index.ts
@@ -43,7 +43,7 @@ interface Options {
   filterTypes?: (keyof Database)[];
 }
 
-const isFile = async (path: string) => {
+export const isFile = async (path: string) => {
   try {
     return (await stat(path)).isFile();
   } catch (error) {

--- a/packages/insomnia-inso/src/db/models/environment.ts
+++ b/packages/insomnia-inso/src/db/models/environment.ts
@@ -2,7 +2,7 @@
 import { AutoComplete } from 'enquirer';
 
 import { logger } from '../../cli';
-import type { Database } from '../index';
+import { type Database } from '../index';
 import type { Environment } from './types';
 import { ensureSingle, generateIdIsh, getDbChoice, matchIdIsh } from './util';
 
@@ -25,13 +25,10 @@ export const loadEnvironment = (
     return null;
   }
 
-  // Get the sub environments
-  const baseWorkspaceEnv = loadBaseEnvironmentForWorkspace(db, workspaceId);
-
   // If no identifier, return base environment
   if (!identifier) {
     logger.trace('No sub environments found, using base environment');
-    return baseWorkspaceEnv;
+    return loadBaseEnvironmentForWorkspace(db, workspaceId);
   }
 
   logger.trace(

--- a/packages/insomnia-inso/src/db/models/types.ts
+++ b/packages/insomnia-inso/src/db/models/types.ts
@@ -44,6 +44,8 @@ interface BaseWorkspace {
     description: string;
 }
 
+export type WorkspaceMeta = BaseModel & { activeGlobalEnvironmentId: string };
+
 export type Workspace = BaseModel & BaseWorkspace;
 
 export type InsomniaRequest = BaseModel & {

--- a/packages/insomnia-inso/src/examples/global-environment.yml
+++ b/packages/insomnia-inso/src/examples/global-environment.yml
@@ -22,13 +22,15 @@ resources:
       apiKey: global
       base_path: /v3
       newkey: /v3
-      first: first
-      second: second
+      firstkey: first
+      secondkey: second
     dataPropertyOrder:
       "&":
         - apiKey
         - newkey
         - base_path
+        - firstkey
+        - secondkey
     color: null
     isPrivate: false
     metaSortKey: 1728298565336

--- a/packages/insomnia-inso/src/examples/global-environment.yml
+++ b/packages/insomnia-inso/src/examples/global-environment.yml
@@ -1,0 +1,35 @@
+_type: export
+__export_format: 4
+__export_date: 2024-10-07T10:58:13.163Z
+__export_source: insomnia.desktop.app:v10.1.0-beta.2
+resources:
+  - _id: wrk_542d3604f4814c68a67b10e8e210d448
+    type: Workspace
+    parentId: proj_1023628c50a84a1ea37ddb82b735db3c
+    modified: 1728298565335
+    created: 1728298565335
+    name: GlobalEnv
+    description: ""
+    scope: environment
+    _type: workspace
+  - _id: env_dcf0363e684fae59a4ac57c09c208674caa8a64a
+    type: Environment
+    parentId: wrk_542d3604f4814c68a67b10e8e210d448
+    modified: 1728298634375
+    created: 1728298565336
+    name: Base Environment
+    data:
+      apiKey: global
+      base_path: /v3
+      newkey: /v3
+      first: first
+      second: second
+    dataPropertyOrder:
+      "&":
+        - apiKey
+        - newkey
+        - base_path
+    color: null
+    isPrivate: false
+    metaSortKey: 1728298565336
+    _type: environment

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -488,7 +488,7 @@ export const sendActionImp = async ({
   window.main.startExecution({ requestId });
   const requestData = await fetchRequestData(requestId);
   window.main.addExecutionStep({ requestId, stepName: 'Executing pre-request script' });
-  const mutatedContext = await tryToExecutePreRequestScript(requestData, workspaceId, userUploadEnvironment, iteration, iterationCount);
+  const mutatedContext = await tryToExecutePreRequestScript(requestData, userUploadEnvironment, iteration, iterationCount);
   if ('error' in mutatedContext) {
     throw {
       error: mutatedContext.error,

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -413,9 +413,8 @@ export const sendAction: ActionFunction = async ({ request, params }) => {
   const { shouldPromptForPathAfterResponse, ignoreUndefinedEnvVariable } = await request.json() as SendActionParams;
 
   try {
-    return await sendActionImp({
+    return await sendActionImplementation({
       requestId,
-      workspaceId,
       shouldPromptForPathAfterResponse,
       ignoreUndefinedEnvVariable,
     });
@@ -466,9 +465,8 @@ export interface RunnerContextForRequest {
   responseId: string;
 }
 
-export const sendActionImp = async ({
+export const sendActionImplementation = async ({
   requestId,
-  workspaceId,
   userUploadEnvironment,
   shouldPromptForPathAfterResponse,
   ignoreUndefinedEnvVariable,
@@ -476,8 +474,7 @@ export const sendActionImp = async ({
   iteration,
   iterationCount,
 }: {
-  requestId: string;
-  workspaceId: string;
+    requestId: string;
   shouldPromptForPathAfterResponse: boolean | undefined;
   ignoreUndefinedEnvVariable: boolean | undefined;
   testResultCollector?: RunnerContextForRequest;

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -33,7 +33,7 @@ import { ResponseTimer } from '../components/response-timer';
 import { getTimeAndUnit } from '../components/tags/time-tag';
 import { ResponseTimelineViewer } from '../components/viewers/response-timeline-viewer';
 import type { OrganizationLoaderData } from './organization';
-import { type CollectionRunnerContext, type RunnerSource, sendActionImp } from './request';
+import { type CollectionRunnerContext, type RunnerSource, sendActionImplementation } from './request';
 import { useRootLoaderData } from './root';
 import type { Child, WorkspaceLoaderData } from './workspace';
 
@@ -944,9 +944,8 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
 
           await new Promise(resolve => setTimeout(resolve, delay));
 
-          const mutatedContext = await sendActionImp({
+          const mutatedContext = await sendActionImplementation({
             requestId: targetRequest.id,
-            workspaceId,
             iteration: i + 1,
             iterationCount,
             userUploadEnvironment: wrapAroundIterationOverIterationData(userUploadEnvs, i),


### PR DESCRIPTION
motivation: in order to support globals in prerequest scripts when running against a single file export, we would like to load a second file containing global environments.

todo:
- [x] implement
- [x] test
- [x] figure out how importing files would work
- [x] raise active global lookup fetch
- [x] add ws meta support


notes:
- import the global file into the db object, then assign the activeGlobalEnvironmentId in the workspace meta in order for it to be respected by prerequest scripts
- alternatively we could override the env object with the global in prerequest logic

closes INS-4425

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
