### PR TITLE
fix: show user logout reason message

### DIFF
--- a/packages/insomnia/src/ui/routes/auth.login.tsx
+++ b/packages/insomnia/src/ui/routes/auth.login.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from 'react-aria-components';
 import { type ActionFunction, redirect, useFetcher, useNavigate } from 'react-router-dom';
 
@@ -49,6 +49,7 @@ export const action: ActionFunction = async ({
 const Login = () => {
   const loginFetcher = useFetcher();
   const navigate = useNavigate();
+  const [message, setMessage] = useState<string | null>(null);
 
   const login = (provider: string) => {
     loginFetcher.submit({
@@ -62,6 +63,14 @@ const Login = () => {
   useEffect(() => {
     window.main.landingPageRendered(LandingPage.Login);
   }, []);
+
+  const logoutMessage = window.localStorage.getItem('logoutMessage');
+  useEffect(() => {
+    if (logoutMessage) {
+      window.localStorage.removeItem('logoutMessage');
+      setMessage(logoutMessage);
+    }
+  }, [logoutMessage]);
 
   return (
     <div
@@ -83,6 +92,7 @@ const Login = () => {
           </span>
           <span className='ml-1 text-[--color-font]'>APIs locally, on Git or in the Cloud.</span>
         </div>
+        {message && <div className="font-bold text-sm text-red-300">{message}</div>}
         <Button
           aria-label='Continue with Google'
           onPress={() => {

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -178,7 +178,7 @@ interface SyncOrgsAndProjectsActionRequest {
 // this action is used to run task that we dont want to block the UI
 export const syncOrgsAndProjectsAction: ActionFunction = async ({ request }) => {
   try {
-    const { organizationId, projectId, asyncTaskList } = await request.json() as SyncOrgsAndProjectsActionRequest;
+    const { organizationId, projectId, asyncTaskList = [] } = await request.json() as SyncOrgsAndProjectsActionRequest;
     const { id: sessionId, accountId } = await userSession.getOrCreate();
 
     const taskPromiseList = [];

--- a/packages/insomnia/src/ui/routes/root.tsx
+++ b/packages/insomnia/src/ui/routes/root.tsx
@@ -91,6 +91,9 @@ const Root = () => {
             break;
 
           case 'insomnia://app/auth/login':
+            if (params.message) {
+              window.localStorage.setItem('logoutMessage', params.message);
+            }
             actionFetcher.submit(
               {},
               {


### PR DESCRIPTION
I noticed that there's a message attached to the app URI when a session expires:
```
[main] Open Deep Link URL insomnia://app/auth/login?message=Your+session+has+expired.+Please+reauthenticate+to+continue+using+Insomnia+Sync.
```

Here's the result of the change:
![Screenshot 2024-10-09 at 15 28 22](https://github.com/user-attachments/assets/4e184bd7-9212-4e3f-95e5-cd792be815d4)



I also included the ability to specify a custom timeout for fetch calls to the API; it's not in use right now but was helpful when debugging some connectivity issues