### PR TITLE
chore: add smoke tests for global envs

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/collection-for-global-environments.yaml
+++ b/packages/insomnia-smoke-test/fixtures/collection-for-global-environments.yaml
@@ -1,0 +1,120 @@
+_type: export
+__export_format: 4
+__export_date: 2024-10-10T08:43:54.626Z
+__export_source: insomnia.desktop.app:v10.1.0-beta.2
+resources:
+  - _id: req_05d360edc7724a3ea4ff91fac2165521
+    parentId: wrk_c0fb97811e7644ed979a60dff28e16e0
+    modified: 1728549768587
+    created: 1670587797191
+    url: localhost:4010/
+    name: New Request
+    description: ""
+    method: GET
+    body:
+      mimeType: text/plain
+      text: |-
+        {{ _.exampleObject.anotherString }}
+        {{ _.exampleString }}
+        {{ _.exampleNumber }}
+        {{ _.exampleObject.anotherNumber }}
+        {{ _['global-base'] }}
+        {{ _['global-sub'] }}
+    parameters: []
+    headers:
+      - name: Content-Type
+        value: text/plain
+    authentication: {}
+    metaSortKey: -1670587797191
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: wrk_c0fb97811e7644ed979a60dff28e16e0
+    parentId: null
+    modified: 1728549792915
+    created: 1728549673757
+    name: collection-for-global-environments
+    description: ""
+    scope: collection
+    _type: workspace
+  - _id: env_cd7a3555ee4a4840b9d16ff5522cefbe
+    parentId: wrk_c0fb97811e7644ed979a60dff28e16e0
+    modified: 1670587811762
+    created: 1670587793246
+    name: Base Environment
+    data:
+      exampleString: baseenv0
+      exampleNumber: 1001
+      exampleObject:
+        anotherString: baseenv1
+        anotherNumber: 1001
+    dataPropertyOrder:
+      "&":
+        - exampleString
+        - exampleNumber
+        - exampleObject
+      "&~|exampleObject":
+        - anotherString
+        - anotherNumber
+    color: null
+    isPrivate: false
+    metaSortKey: 1670587793246
+    _type: environment
+  - _id: jar_559d8cd02c5d4ec2a6220a9ad0cfbec7
+    parentId: wrk_c0fb97811e7644ed979a60dff28e16e0
+    modified: 1670587793248
+    created: 1670587793248
+    name: Default Jar
+    cookies: []
+    _type: cookie_jar
+  - _id: env_21d872b03ba2458fb86e0cdf242428c4
+    parentId: env_cd7a3555ee4a4840b9d16ff5522cefbe
+    modified: 1670587818649
+    created: 1670587812382
+    name: ExampleA
+    data:
+      exampleString: subenvA0
+      exampleNumber: 1111
+      exampleObject:
+        anotherString: subenvA1
+        anotherNumber: 1111
+    dataPropertyOrder:
+      "&":
+        - exampleString
+        - exampleNumber
+        - exampleObject
+      "&~|exampleObject":
+        - anotherString
+        - anotherNumber
+    color: null
+    isPrivate: false
+    metaSortKey: 1670587812382
+    _type: environment
+  - _id: env_03237e870e584a71b5414a0769dcc524
+    parentId: env_cd7a3555ee4a4840b9d16ff5522cefbe
+    modified: 1670587831933
+    created: 1670587826837
+    name: ExampleB
+    data:
+      exampleString: subenvB0
+      exampleNumber: 2222
+      exampleObject:
+        anotherString: subenvB1
+        anotherNumber: 2222
+    dataPropertyOrder:
+      "&":
+        - exampleString
+        - exampleNumber
+        - exampleObject
+      "&~|exampleObject":
+        - anotherString
+        - anotherNumber
+    color: null
+    isPrivate: false
+    metaSortKey: 1670587826837
+    _type: environment

--- a/packages/insomnia-smoke-test/fixtures/global-environment.yaml
+++ b/packages/insomnia-smoke-test/fixtures/global-environment.yaml
@@ -1,0 +1,48 @@
+_type: export
+__export_format: 4
+__export_date: 2024-10-10T08:37:38.994Z
+__export_source: insomnia.desktop.app:v10.1.0-beta.2
+resources:
+  - _id: wrk_3eacc557f63b415b87da4a4beca0b633
+    type: Workspace
+    parentId: proj_c00dc2578d6f4004b5e37067b3a905e6
+    modified: 1728549301584
+    created: 1728549301584
+    name: global-environment
+    description: ""
+    scope: environment
+    _type: workspace
+  - _id: env_79ebf2bae010a0a90446ab15afa0d8382a61afa1
+    type: Environment
+    parentId: wrk_3eacc557f63b415b87da4a4beca0b633
+    modified: 1728549418314
+    created: 1728549301585
+    name: Base Environment
+    data:
+      global-base: 4444
+      exampleString: globalenv0
+    dataPropertyOrder:
+      "&":
+        - global-base
+        - exampleString
+    color: null
+    isPrivate: false
+    metaSortKey: 1728549301585
+    _type: environment
+  - _id: env_1543ee03d0dd41adb18199742ce67749
+    type: Environment
+    parentId: env_79ebf2bae010a0a90446ab15afa0d8382a61afa1
+    modified: 1728549426890
+    created: 1728549316977
+    name: New Environment
+    data:
+      global-sub: 55555
+      exampleString: globalenv1
+    dataPropertyOrder:
+      "&":
+        - global-sub
+        - exampleString
+    color: null
+    isPrivate: true
+    metaSortKey: 1728549316977
+    _type: environment

--- a/packages/insomnia-smoke-test/tests/smoke/global-environments.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/global-environments.test.ts
@@ -1,0 +1,45 @@
+import { loadFixture } from '../../playwright/paths';
+import { test } from '../../playwright/test';
+
+test.describe('Global Environments', async () => {
+
+    test('create a new global environment', async ({ page }) => {
+        await page.getByLabel('Create in project').click();
+        await page.getByLabel('Create', { exact: true }).getByText('Environment').click();
+        await page.getByRole('button', { name: 'Create', exact: true }).click();
+        await page.getByTestId('CreateEnvironmentDropdown').click();
+        await page.getByText('Private environment').click();
+        await page.getByLabel('Project Actions').click();
+        await page.getByText('Duplicate').click();
+        await page.getByText('New Environment (Copy)').click();
+    });
+
+    test('import and use a global environment from a collection', async ({ app, page }) => {
+        await loadFixtureFile('collection-for-global-environments.yaml', app, page);
+        await loadFixtureFile('global-environment.yaml', app, page);
+
+        await page.getByRole('link', { name: 'collection-for-global-' }).click();
+        await page.getByTestId('New Request').getByLabel('GET New Request', { exact: true }).click();
+        await page.getByRole('button', { name: 'Send' }).click();
+        await page.getByRole('heading', { name: '2 environment variables are' }).click();
+        await page.getByRole('button', { name: 'Cancel' }).click();
+        await page.getByLabel('Manage Environments').click();
+        await page.getByPlaceholder('Choose a global environment').click();
+        await page.getByRole('option', { name: 'global-environment' }).click();
+        await page.getByText('New Environment').click();
+        await page.getByTestId('underlay').click();
+        await page.getByRole('button', { name: 'Send' }).click();
+        await page.getByRole('tab', { name: 'Console' }).click();
+        await page.locator('pre').filter({ hasText: '| 4444' }).click();
+        await page.locator('pre').filter({ hasText: '| 55555' }).click();
+    });
+
+});
+async function loadFixtureFile(fixture: string, app, page) {
+    const text = await loadFixture(fixture);
+    await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+    await page.getByLabel('Import').click();
+    await page.locator('[data-test-id="import-from-clipboard"]').click();
+    await page.getByRole('button', { name: 'Scan' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+}


### PR DESCRIPTION
adds 2 new smoke tests to cover global environments

1) tries to create a new global environment and a couple sub-environments within it (would maybe have caught global env dropdown issue  https://github.com/Kong/insomnia/pull/8062 )
2) imports a collection and a global-environment and tries to send a request that depends on global-environment and its sub-environment first without activating it, which will trigger missing env variables error, and then activating it (previously uncovered flow by smoke tests)
