### PR TITLE
fix: disable request error modal - [INS-4559]

### DIFF
--- a/packages/insomnia-smoke-test/tests/critical/certificates.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/certificates.test.ts
@@ -16,7 +16,6 @@ test('can send request with custom ca root certificate', async ({ app, page }) =
   await page.getByLabel('Request Collection').getByTestId('sends request with certs').press('Enter');
 
   await page.getByRole('button', { name: 'Send', exact: true }).click();
-  await page.getByRole('button', { name: 'Ok', exact: true }).click();
   await page.getByText('Error: SSL peer certificate or SSH remote key was not OK').click();
 
   const fixturePath = getFixturePath('certificates');

--- a/packages/insomnia-smoke-test/tests/smoke/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/app.test.ts
@@ -96,6 +96,5 @@ test('can cancel requests', async ({ app, page }) => {
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 
   await page.getByRole('button', { name: 'Cancel Request' }).click();
-  await page.getByRole('button', { name: 'Ok', exact: true }).click();
   await page.click('text=Request was cancelled');
 });

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -368,10 +368,6 @@ test.describe('pre-request features tests', async () => {
         // send
         await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 
-        // close the alert modal
-        await page.getByRole('code').getByText('Error: Couldn\'t connect to').click();
-        await page.getByRole('button', { name: 'Ok', exact: true }).click();
-
         // verify
         await page.getByRole('tab', { name: 'Console' }).click();
         await expect(responsePane).toContainText('localhost:2222'); // original proxy

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
@@ -51,8 +51,7 @@ test.describe('test hidden window handling', async () => {
     await page.getByLabel('Request Collection').getByTestId('Long running task - post').press('Enter');
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send', exact: true }).click();
 
-    await page.getByRole('code').getByText('Executing script timeout').click();
-    await page.getByRole('button', { name: 'Ok', exact: true }).click();
+    await page.getByText('Executing script timeout').click();
     await page.getByRole('tab', { name: 'Console' }).click();
     await page.getByRole('tab', { name: 'Preview' }).click();
 
@@ -95,8 +94,7 @@ test.describe('test hidden window handling', async () => {
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send', exact: true }).click();
     // await page.getByText('Timeout: Hidden browser window is not responding').click();
 
-    await page.getByRole('code').getByText('Executing script timeout').click();
-    await page.getByRole('button', { name: 'Ok', exact: true }).click();
+    await page.getByText('Executing script timeout').click();
 
     // send the another script with normal script
     await page.getByLabel('Request Collection').getByTestId('simple log').press('Enter');

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
@@ -28,9 +28,6 @@ test.describe('test hidden window handling', async () => {
 
     await page.getByRole('button', { name: 'Cancel Request' }).click();
 
-    // check the alert model message
-    await page.getByRole('code').getByText('Request was cancelled').click();
-    await page.getByRole('button', { name: 'Ok', exact: true }).click();
     // check the response pane message
     await page.click('text=Request was cancelled');
   });

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -51,18 +51,6 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     if (searchParams.has('envVariableMissing') && searchParams.get('undefinedEnvironmentVariables')) {
       setShowEnvVariableMissingModal(true);
       setUndefinedEnvironmentVariables(searchParams.get('undefinedEnvironmentVariables')!);
-    } else {
-      showAlert({
-        title: 'Unexpected Request Failure',
-        message: (
-          <div>
-            <p>The request failed due to an unhandled error:</p>
-            <code className="wide selectable">
-              <pre>{searchParams.get('error')}</pre>
-            </code>
-          </div>
-        ),
-      });
     }
 
     // clean up params


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

close [INS-4559](https://linear.app/insomnia/issue/INS-4559/disable-the-request-failure-alert-modal#comment-42c35ae3)

Changes:

- [x] disable request error alert modal (keep modal for collection runner), always show error in response preview panel
- [x] write script execution error into db and show error in response preview panel
- [x] fix smoke test