### PR TITLE
Change file card dropdown menu item name from Duplicate to Duplicate / Move

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -110,9 +110,9 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
           </Button>
         }
       >
-        <DropdownItem aria-label='Duplicate'>
+        <DropdownItem aria-label='Duplicate / Move'>
           <ItemContent
-            label="Duplicate"
+            label="Duplicate / Move"
             icon="copy"
             onClick={() => setIsDuplicateModalOpen(true)}
           />


### PR DESCRIPTION
Users need move but we can not implement real move for now. Just change the name.