### PR TITLE
fix: keep project dropdown in place

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -127,10 +127,15 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
           </Tooltip>
         </TooltipTrigger>
       }
+      {project.hasUncommittedOrUnpushedChanges && (
+        <div className='group-focus:hidden group-hover:hidden aspect-square h-6 flex items-center justify-center'>
+          <Icon icon="circle" className='w-2 h-2' color="var(--color-warning)" />
+        </div>
+      )}
       <MenuTrigger>
         <Button
           aria-label="Project Actions"
-          className="opacity-0 flex items-center hover:opacity-100 focus:opacity-100 data-[pressed]:opacity-100 group-focus:flex group-hover:flex group-focus:opacity-100 group-hover:opacity-100 justify-center h-6 aspect-square aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+          className="opacity-0 hidden items-center hover:opacity-100 focus:opacity-100 data-[pressed]:opacity-100 data-[pressed]:flex group-focus:flex group-hover:flex group-focus:opacity-100 group-hover:opacity-100 justify-center h-6 aspect-square aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
         >
           <Icon icon="caret-down" />
         </Button>

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -135,7 +135,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
       <MenuTrigger>
         <Button
           aria-label="Project Actions"
-          className="opacity-0 hidden items-center hover:opacity-100 focus:opacity-100 data-[pressed]:opacity-100 group-focus:flex group-hover:flex group-focus:opacity-100 group-hover:opacity-100 justify-center h-6 aspect-square aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+          className="opacity-0 flex items-center hover:opacity-100 focus:opacity-100 data-[pressed]:opacity-100 group-focus:flex group-hover:flex group-focus:opacity-100 group-hover:opacity-100 justify-center h-6 aspect-square aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
         >
           <Icon icon="caret-down" />
         </Button>

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -127,11 +127,6 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
           </Tooltip>
         </TooltipTrigger>
       }
-      {project.hasUncommittedOrUnpushedChanges && (
-        <div className='group-focus:hidden group-hover:hidden aspect-square h-6 flex items-center justify-center'>
-          <Icon icon="circle" className='w-2 h-2' color="var(--color-warning)" />
-        </div>
-      )}
       <MenuTrigger>
         <Button
           aria-label="Project Actions"

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1102,6 +1102,11 @@ const ProjectRoute: FC = () => {
                             }
                           />
                           <span className={'truncate'}>{item.name}</span>
+                          {item.hasUncommittedOrUnpushedChanges && (
+                            <div className='aspect-square h-6 flex items-center justify-center'>
+                              <Icon icon="circle" className='w-2 h-2' color="var(--color-warning)" />
+                            </div>
+                          )}
                           <span className="flex-1" />
                           {item.presence.length > 0 && (
                             <AvatarGroup

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1102,11 +1102,6 @@ const ProjectRoute: FC = () => {
                             }
                           />
                           <span className={'truncate'}>{item.name}</span>
-                          {item.hasUncommittedOrUnpushedChanges && (
-                            <div className='aspect-square h-6 flex items-center justify-center'>
-                              <Icon icon="circle" className='w-2 h-2' color="var(--color-warning)" />
-                            </div>
-                          )}
                           <span className="flex-1" />
                           {item.presence.length > 0 && (
                             <AvatarGroup


### PR DESCRIPTION
We weren't applying the same styles when the button was pressed