### PR TITLE
Fetch error handing revisited

### DIFF
--- a/packages/insomnia/src/ui/insomniaFetch.ts
+++ b/packages/insomnia/src/ui/insomniaFetch.ts
@@ -34,7 +34,7 @@ export async function insomniaFetch<T = void>({
   origin,
   headers,
   onlyResolveOnSuccess = false,
-  timeout = INSOMNIA_FETCH_TIME_OUT,
+  timeout,
 }: FetchConfig): Promise<T> {
   const config: RequestInit = {
     method,
@@ -49,7 +49,7 @@ export async function insomniaFetch<T = void>({
       ...(PLAYWRIGHT ? { 'X-Mockbin-Test': 'true' } : {}),
     },
     ...(data ? { body: JSON.stringify(data) } : {}),
-    signal: AbortSignal.timeout(timeout),
+    signal: AbortSignal.timeout(timeout || INSOMNIA_FETCH_TIME_OUT),
   };
   if (sessionId === undefined) {
     throw new Error(`No session ID provided to ${method}:${path}`);

--- a/packages/insomnia/src/ui/insomniaFetch.ts
+++ b/packages/insomnia/src/ui/insomniaFetch.ts
@@ -11,17 +11,8 @@ interface FetchConfig {
   retries?: number;
   origin?: string;
   headers?: Record<string, string>;
-  onlyResolveOnSuccess?: boolean;
   timeout?: number;
-}
-
-export class ResponseFailError extends Error {
-  constructor(msg: string, response: Response) {
-    super(msg);
-    this.response = response;
-  }
-  response;
-  name = 'ResponseFailError';
+  onlyResolveOnSuccess?: boolean;
 }
 
 // Adds headers, retries and opens deep links returned from the api
@@ -33,8 +24,8 @@ export async function insomniaFetch<T = void>({
   organizationId,
   origin,
   headers,
-  onlyResolveOnSuccess = false,
   timeout,
+  onlyResolveOnSuccess,
 }: FetchConfig): Promise<T> {
   const config: RequestInit = {
     method,
@@ -61,27 +52,26 @@ export async function insomniaFetch<T = void>({
     if (uri) {
       window.main.openDeepLink(uri);
     }
-    const isJson =
-      response.headers.get('content-type')?.includes('application/json') ||
-      path.match(/\.json$/);
-    if (onlyResolveOnSuccess && !response.ok) {
-      let errMsg = '';
-      if (isJson) {
-        try {
-          const json = await response.json();
-          if (typeof json?.message === 'string') {
-            errMsg = json.message;
-          }
-        } catch (err) {}
+    const contentType = response.headers.get('content-type');
+    const isJson = contentType?.includes('application/json') || path.match(/\.json$/);
+
+    // assume the backend is sending us a meaningful error message
+    if (isJson && !response.ok && onlyResolveOnSuccess) {
+      try {
+        const json = await response.json();
+        throw ({
+          message: json?.message || '',
+          error: json?.error || '',
+        });
+      } catch (err) {
+        throw err;
       }
-      throw new ResponseFailError(errMsg, response);
     }
     return isJson ? response.json() : response.text();
   } catch (err) {
     if (err.name === 'AbortError') {
       throw new Error('insomniaFetch timed out');
-    } else {
-      throw err;
     }
+    throw err;
   }
 }


### PR DESCRIPTION
motivation: inconsistency in how the fetch errors were being parsed and evaluated, eg json is parsed twice in order to get the error message in one place but not another.

goal: type the output of insomniaFetch when a known backend error message is returned, and flatten the try catch if else nesting complexity of insomniaFetch

options:
1. use a custom Error type, with both message and errorType eg ResponseFailError but with more
2. return `Promise<T> | Promise<{message:string,errorType:string}>`
3. return an Error/ErrorCause with the api error within


This PR is meant to push this discussion with: @yaoweiprc @gatzjames

Using the exception and wrapping it has some rough edges in nodejs/chromium space because they dont both have error cause implementations.  

TODO:
- [ ] discuss error typing options with api team
- [ ] standardise the way we deal with these within the app and website at a function typing level
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
