### PR TITLE
fix: stop interval when window not focused - [INS-4571]

### DIFF
--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -28,6 +28,7 @@ export type HandleChannels =
   | 'webSocket.open'
   | 'webSocket.readyState'
   | 'writeFile'
+  | 'isWindowFocused'
   | 'extractJsonFileFromPostmanDataDumpArchive';
 
 export const ipcMainHandle = (
@@ -86,7 +87,9 @@ export type RendererOnChannels =
   | 'toggle-preferences-shortcuts'
   | 'toggle-preferences'
   | 'toggle-sidebar'
-  | 'updaterStatus';
+  | 'updaterStatus'
+  | 'main-window-focus'
+  | 'main-window-blur';
 export const ipcMainOn = (
   channel: MainOnChannels,
   listener: (

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -14,6 +14,7 @@ import type { CurlBridgeAPI } from '../network/curl';
 import { cancelCurlRequest, curlRequest } from '../network/libcurl-promise';
 import { addExecutionStep, completeExecutionStep, getExecution, startExecution, type TimingStep, updateLatestStepName } from '../network/request-timing';
 import type { WebSocketBridgeAPI } from '../network/websocket';
+import { isWindowFocused } from '../window-utils';
 import { ipcMainHandle, ipcMainOn, ipcMainOnce, type RendererOnChannels } from './electron';
 import extractPostmanDataDumpHandler from './extractPostmanDataDump';
 import type { gRPCBridgeAPI } from './grpc';
@@ -31,6 +32,7 @@ export interface RendererToMainBridgeAPI {
   setMenuBarVisibility: (visible: boolean) => void;
   installPlugin: typeof installPlugin;
   writeFile: (options: { path: string; content: string }) => Promise<string>;
+  isWindowFocused: () => Promise<boolean>;
   cancelCurlRequest: typeof cancelCurlRequest;
   curlRequest: typeof curlRequest;
   on: (channel: RendererOnChannels, listener: (event: IpcRendererEvent, ...args: any[]) => void) => () => void;
@@ -96,6 +98,10 @@ export function registerMainHandlers() {
     } catch (err) {
       throw new Error(err);
     }
+  });
+
+  ipcMainHandle('isWindowFocused', async () => {
+    return isWindowFocused();
   });
 
   ipcMainHandle('curlRequest', (_, options: Parameters<typeof curlRequest>[0]) => {

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -38,7 +38,7 @@ const DEFAULT_HEIGHT = 720;
 const MINIMUM_WIDTH = 500;
 const MINIMUM_HEIGHT = 400;
 
-const browserWindows = new Map<'Insomnia' | 'HiddenBrowserWindow', ElectronBrowserWindow>();
+export const browserWindows = new Map<'Insomnia' | 'HiddenBrowserWindow', ElectronBrowserWindow>();
 let localStorage: LocalStorage | null = null;
 let hiddenWindowIsBusy = false;
 
@@ -269,6 +269,16 @@ export function createWindow({ firstLaunch }: { firstLaunch?: boolean } = {}): E
     if (browserWindows.get('Insomnia')) {
       browserWindows.delete('Insomnia');
     }
+  });
+
+  mainBrowserWindow.on('focus', () => {
+    console.log('[main] window focus');
+    mainBrowserWindow.webContents.send('main-window-focus');
+  });
+
+  mainBrowserWindow.on('blur', () => {
+    console.log('[main] window blur');
+    mainBrowserWindow.webContents.send('main-window-blur');
   });
 
   const applicationMenu: MenuItemConstructorOptions = {
@@ -792,3 +802,8 @@ export function createWindowsAndReturnMain({ firstLaunch }: { firstLaunch?: bool
   }
   return mainWindow;
 }
+
+export const isWindowFocused = () => {
+  const mainWindow = browserWindows.get('Insomnia');
+  return mainWindow?.isFocused();
+};

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -60,6 +60,7 @@ const main: Window['main'] = {
   curlRequest: options => ipcRenderer.invoke('curlRequest', options),
   cancelCurlRequest: options => ipcRenderer.send('cancelCurlRequest', options),
   writeFile: options => ipcRenderer.invoke('writeFile', options),
+  isWindowFocused: () => ipcRenderer.invoke('isWindowFocused'),
   on: (channel, listener) => {
     ipcRenderer.on(channel, listener);
     return () => ipcRenderer.removeListener(channel, listener);

--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -108,7 +108,7 @@ export const GitSyncDropdown: FC<Props> = ({ gitRepository, isInsomniaSyncEnable
     isCheckingGitChanges.current = true;
     await checkGitChanges(workspaceId);
     isCheckingGitChanges.current = false;
-  }, isWindowFocused ? 1000 : null);
+  }, isWindowFocused ? 30 * 1000 : null);
 
   useEffect(() => {
     if (shouldFetchGitRepoStatus) {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Changes:

- add `isWinsowFocused` bridge
- listen main window `focus` and `blur` event
- get window focus states in the renderer, and when the window is blurred, we should stop getting git changes interval
- add a flag `isCheckingGitChanges ` to record the task status, if the last time task is not finished, skip this time.


Background:
We use a timer in the collection to periodically check the status of the git repository and update db, to display uncommitted changes in the dashboard page.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/60d5c131-6692-4dac-bbb2-ab3e022d1a4b">

