### PR TITLE
feat(runner): support several cases for setNextRequest

### DIFF
--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -231,7 +231,11 @@ export async function initInsomniaObject(
         pathParameters: rawObj.request.pathParameters,
     };
     const request = new ScriptRequest(reqOpt);
-    const execution = new Execution({ location: rawObj.execution.location });
+    const execution = new Execution({
+        location: rawObj.execution.location,
+        skipRequest: rawObj.execution.skipRequest,
+        nextRequestIdOrName: rawObj.execution.nextRequestIdOrName,
+    });
 
     const responseBody = await readBodyFromPath(rawObj.response);
     const response = rawObj.response ? toScriptResponse(request, rawObj.response, responseBody) : undefined;

--- a/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
@@ -29,7 +29,7 @@ resources:
       });
       insomnia.test.skip('req1-pre-check-skipped', () => {
         insomnia.expect(200).to.eql(200);
-      });  
+      });
 
       if (insomnia.iterationData.get('scope') === 'uploda data') {
       	insomnia.execution.setNextRequest('req3');
@@ -233,6 +233,82 @@ resources:
           insomnia.expect(insomnia.response.code).to.eql(200);
       });
     metaSortKey: -1636141014555
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_76bf52b201cf47269f5845795a7f0000
+    parentId: wrk_418cad89191c418395abfeb2277fd26f
+    modified: 1636707449230
+    created: 1636141014550
+    url: http://127.0.0.1:4010/echo
+    name: req0
+    description: ""
+    method: POST
+    body: {}
+    parameters: []
+    headers: []
+    authentication: {}
+    afterResponseScript: |-
+      insomnia.test.skip('req0-post-check', () => {
+        insomnia.expect(200).to.eql(200);
+      });
+      insomnia.execution.setNextRequest('req02');
+    metaSortKey: -1636141014552
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_76bf52b201cf47269f5845795a7f0001
+    parentId: wrk_418cad89191c418395abfeb2277fd26f
+    modified: 1636707449231
+    created: 1636141014551
+    url: http://127.0.0.1:4010/echo
+    name: req01
+    description: ""
+    method: POST
+    body: {}
+    parameters: []
+    headers: []
+    authentication: {}
+    afterResponseScript: |-
+      insomnia.test('req01-post-check', () => {
+        insomnia.expect(200).to.eql(200);
+      });
+    metaSortKey: -1636141014551
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_76bf52b201cf47269f5845795a7f0002
+    parentId: wrk_418cad89191c418395abfeb2277fd26f
+    modified: 1636707449232
+    created: 1636141014552
+    url: http://127.0.0.1:4010/echo
+    name: req02
+    description: ""
+    method: POST
+    body: {}
+    parameters: []
+    headers: []
+    authentication: {}
+    afterResponseScript: |-
+      insomnia.test('req02-post-check', () => {
+        insomnia.expect(200).to.eql(200);
+      });
+    metaSortKey: -1636141014550
     isPrivate: false
     settingStoreCookies: true
     settingSendCookies: true

--- a/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
@@ -180,3 +180,64 @@ resources:
     isPrivate: true
     metaSortKey: 1725267312624
     _type: environment
+  - _id: req_76bf52b201cf47269f5845795a7fe688
+    parentId: wrk_418cad89191c418395abfeb2277fd26f
+    modified: 1636707449231
+    created: 1636141014552
+    url: http://127.0.0.1:4010/echo
+    name: req4
+    description: ""
+    method: POST
+    body: {}
+    parameters: []
+    headers: []
+    authentication: {}
+    preRequestScript: |-
+      const executed = insomnia.environment.get('executed') || 0;
+      if (executed < 2) {
+        insomnia.environment.set('executed', executed + 1);
+        insomnia.execution.setNextRequest('req4');
+      }
+    metaSortKey: -1636141014555
+    isPrivate: false
+    afterResponseScript: |-
+      insomnia.test('req4-post-check', () => {
+          insomnia.expect(insomnia.response.code).to.eql(200);
+      });
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_76bf52b201cf47269f5845795a7fe689
+    parentId: wrk_418cad89191c418395abfeb2277fd26f
+    modified: 1636707449231
+    created: 1636141014552
+    url: http://127.0.0.1:4010/echo
+    name: req5
+    description: ""
+    method: POST
+    body: {}
+    parameters: []
+    headers: []
+    authentication: {}
+    afterResponseScript: |-
+      const executed = insomnia.environment.get('executedReq5') || 0;
+      if (executed < 2) {
+        insomnia.environment.set('executedReq5', executed + 1);
+        insomnia.execution.setNextRequest('req5');
+      }
+      insomnia.test('req5-post-check', () => {
+          insomnia.expect(insomnia.response.code).to.eql(200);
+      });
+    metaSortKey: -1636141014555
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -116,6 +116,9 @@ test.describe('runner features tests', async () => {
 
         // select requests to test
         await page.locator('text=Select All').click();
+        await page.locator('.item-req0').click();
+        await page.locator('.item-req01').click();
+        await page.locator('.item-req02').click();
 
         // send
         await page.getByTestId('request-pane').getByRole('button', { name: 'Run' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -179,4 +179,26 @@ test.describe('runner features tests', async () => {
 
         await verifyResultRows(page, 3, 0, 3, expectedTestOrder, 1);
     });
+
+    test('skip req01 with setNextRequest', async ({ page }) => {
+        await page.getByTestId('run-collection-btn-quick').click();
+
+        await page.locator('.item-req0').click();
+        await page.locator('.item-req01').click();
+        await page.locator('.item-req02').click();
+
+        // send
+        await page.getByRole('button', { name: 'Run', exact: true }).click();
+
+        // check result
+        await page.getByText('1 / 2').first().click();
+
+        const expectedTestOrder = [
+            'req0-post-check',
+            // 'req01-post-check' is skipped
+            'req02-post-check',
+        ];
+
+        await verifyResultRows(page, 1, 1, 2, expectedTestOrder, 1);
+    });
 });

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -33,6 +33,8 @@ test.describe('runner features tests', async () => {
         const testResults = page.getByTestId(`runner-test-result-iteration-${iteration}`).getByTestId('test-result-row');
         const testResultCount = await testResults.count();
 
+        expect(expectedTestOrder.length).toEqual(testResultCount);
+
         for (let i = 0; i < testResultCount; i++) {
             const resultMsg = await testResults.nth(i).textContent();
             if (resultMsg?.startsWith('PASS')) {
@@ -135,5 +137,55 @@ test.describe('runner features tests', async () => {
             'expected 200 to deeply equal 201',
         ]);
 
+    });
+
+    test('run req4 3 times with setNextRequest the pre-request script', async ({ page }) => {
+        await page.getByTestId('run-collection-btn-quick').click();
+
+        // select requests to test
+        await page.locator('text=Select All').click();
+        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req1' }).locator('.react-aria-Checkbox').click();
+        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req2' }).locator('.react-aria-Checkbox').click();
+        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req3' }).locator('.react-aria-Checkbox').click();
+        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req5' }).locator('.react-aria-Checkbox').click();
+
+        // send
+        await page.getByRole('button', { name: 'Run', exact: true }).click();
+
+        // check result
+        await page.getByText('ITERATION 1').click();
+
+        const expectedTestOrder = [
+            'req4-post-check',
+            'req4-post-check',
+            'req4-post-check',
+        ];
+
+        await verifyResultRows(page, 3, 0, 3, expectedTestOrder, 1);
+    });
+
+    test('run req5 3 times with setNextRequest in the after-response script', async ({ page }) => {
+        await page.getByTestId('run-collection-btn-quick').click();
+
+        // select requests to test
+        await page.locator('text=Select All').click();
+        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req1' }).locator('.react-aria-Checkbox').click();
+        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req2' }).locator('.react-aria-Checkbox').click();
+        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req3' }).locator('.react-aria-Checkbox').click();
+        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req4' }).locator('.react-aria-Checkbox').click();
+
+        // send
+        await page.getByRole('button', { name: 'Run', exact: true }).click();
+
+        // check result
+        await page.getByText('ITERATION 1').click();
+
+        const expectedTestOrder = [
+            'req5-post-check',
+            'req5-post-check',
+            'req5-post-check',
+        ];
+
+        await verifyResultRows(page, 3, 0, 3, expectedTestOrder, 1);
     });
 });

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -59,8 +59,8 @@ test.describe('runner features tests', async () => {
         await page.getByTestId('run-collection-btn-quick').click();
 
         // select requests to test
-        await page.locator('text=Select All').click();
-        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req3' }).locator('.react-aria-Checkbox').click();
+        await page.locator('.item-req1').click();
+        await page.locator('.item-req2').click();
 
         // send
         await page.getByTestId('request-pane').getByRole('button', { name: 'Run' }).click();
@@ -83,6 +83,7 @@ test.describe('runner features tests', async () => {
             expect(summarizedPassedCount).toEqual(expectedPassed);
             expect(summarizedTotalCount).toEqual(expectedTotal);
         };
+        await page.getByText('6 / 8').click();
         await verifyTestCounts(6, 8);
 
         const expectedTestOrder = [
@@ -142,18 +143,13 @@ test.describe('runner features tests', async () => {
     test('run req4 3 times with setNextRequest the pre-request script', async ({ page }) => {
         await page.getByTestId('run-collection-btn-quick').click();
 
-        // select requests to test
-        await page.locator('text=Select All').click();
-        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req1' }).locator('.react-aria-Checkbox').click();
-        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req2' }).locator('.react-aria-Checkbox').click();
-        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req3' }).locator('.react-aria-Checkbox').click();
-        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req5' }).locator('.react-aria-Checkbox').click();
+        await page.locator('.item-req4').click();
 
         // send
         await page.getByRole('button', { name: 'Run', exact: true }).click();
 
         // check result
-        await page.getByText('ITERATION 1').click();
+        await page.getByText('3 / 3').first().click();
 
         const expectedTestOrder = [
             'req4-post-check',
@@ -167,18 +163,13 @@ test.describe('runner features tests', async () => {
     test('run req5 3 times with setNextRequest in the after-response script', async ({ page }) => {
         await page.getByTestId('run-collection-btn-quick').click();
 
-        // select requests to test
-        await page.locator('text=Select All').click();
-        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req1' }).locator('.react-aria-Checkbox').click();
-        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req2' }).locator('.react-aria-Checkbox').click();
-        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req3' }).locator('.react-aria-Checkbox').click();
-        await page.locator('#runner-request-list').getByRole('gridcell', { name: 'req4' }).locator('.react-aria-Checkbox').click();
+        await page.locator('.item-req5').click();
 
         // send
         await page.getByRole('button', { name: 'Run', exact: true }).click();
 
         // check result
-        await page.getByText('ITERATION 1').click();
+        await page.getByText('3 / 3').first().click();
 
         const expectedTestOrder = [
             'req5-post-check',

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -59,8 +59,8 @@ test.describe('runner features tests', async () => {
         await page.getByTestId('run-collection-btn-quick').click();
 
         // select requests to test
-        await page.locator('.item-req1').click();
-        await page.locator('.item-req2').click();
+        await page.locator('.runner-request-list-req1').click();
+        await page.locator('.runner-request-list-req2').click();
 
         // send
         await page.getByTestId('request-pane').getByRole('button', { name: 'Run' }).click();
@@ -116,9 +116,9 @@ test.describe('runner features tests', async () => {
 
         // select requests to test
         await page.locator('text=Select All').click();
-        await page.locator('.item-req0').click();
-        await page.locator('.item-req01').click();
-        await page.locator('.item-req02').click();
+        await page.locator('.runner-request-list-req0').click();
+        await page.locator('.runner-request-list-req01').click();
+        await page.locator('.runner-request-list-req02').click();
 
         // send
         await page.getByTestId('request-pane').getByRole('button', { name: 'Run' }).click();
@@ -146,7 +146,7 @@ test.describe('runner features tests', async () => {
     test('run req4 3 times with setNextRequest the pre-request script', async ({ page }) => {
         await page.getByTestId('run-collection-btn-quick').click();
 
-        await page.locator('.item-req4').click();
+        await page.locator('.runner-request-list-req4').click();
 
         // send
         await page.getByRole('button', { name: 'Run', exact: true }).click();
@@ -166,7 +166,7 @@ test.describe('runner features tests', async () => {
     test('run req5 3 times with setNextRequest in the after-response script', async ({ page }) => {
         await page.getByTestId('run-collection-btn-quick').click();
 
-        await page.locator('.item-req5').click();
+        await page.locator('.runner-request-list-req5').click();
 
         // send
         await page.getByRole('button', { name: 'Run', exact: true }).click();
@@ -186,9 +186,9 @@ test.describe('runner features tests', async () => {
     test('skip req01 with setNextRequest', async ({ page }) => {
         await page.getByTestId('run-collection-btn-quick').click();
 
-        await page.locator('.item-req0').click();
-        await page.locator('.item-req01').click();
-        await page.locator('.item-req02').click();
+        await page.locator('.runner-request-list-req0').click();
+        await page.locator('.runner-request-list-req01').click();
+        await page.locator('.runner-request-list-req02').click();
 
         // send
         await page.getByRole('button', { name: 'Run', exact: true }).click();

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -311,7 +311,7 @@ export async function savePatchesMadeByScript(
 }
 
 export const tryToExecuteScript = async (context: RequestAndContextAndOptionalResponse) => {
-  const { script, request, environment, timelinePath, responseId, baseEnvironment, clientCertificates, cookieJar, response, globals, userUploadEnvironment, iteration, iterationCount, ancestors, eventName } = context;
+  const { script, request, environment, timelinePath, responseId, baseEnvironment, clientCertificates, cookieJar, response, globals, userUploadEnvironment, iteration, iterationCount, ancestors, eventName, execution } = context;
   invariant(script, 'script must be provided');
 
   const settings = await models.settings.get();
@@ -356,6 +356,7 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
           data: userUploadEnvironment.data || {},
         } : undefined,
         execution: {
+          ...execution, // keep some existing properties in the after-response script from the pre-request script
           location: requestLocation,
         },
       },

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -1,6 +1,6 @@
 import clone from 'clone';
 import fs from 'fs';
-import type { RequestContext, RequestTestResult } from 'insomnia-sdk';
+import type { ExecutionOption, RequestContext, RequestTestResult } from 'insomnia-sdk';
 import orderedJSON from 'json-order';
 import { join as pathJoin } from 'path';
 
@@ -448,6 +448,7 @@ interface RequestContextForScript {
   ancestors: (Request | RequestGroup | Workspace | Project | MockRoute | MockServer)[];
   globals?: Environment; // there could be no global environment
   settings: Settings;
+  execution?: ExecutionOption;
 }
 
 type RequestAndContextAndResponse = RequestContextForScript & {

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -625,7 +625,7 @@ export const sendActionImplementation = async ({
   if (!shouldWriteToFile) {
     const response = await models.response.create(responsePatch, requestData.settings.maxHistoryResponses);
     await models.requestMeta.update(requestMeta, { activeResponseId: response._id });
-    return mutatedContext;
+    return postMutatedContext;
   }
 
   if (requestMeta.downloadPath) {

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -607,7 +607,7 @@ export const Runner: FC<{}> = () => {
                       const parentFolderContainer = parentFolders.length > 0 ? <span className="ml-2">{parentFolders}</span> : null;
 
                       return (
-                        <RequestItem textValue={item.name} className='text-[--color-font] border border-solid border-transparent' style={{ 'outline': 'none' }}>
+                        <RequestItem textValue={item.name} className={`item-${item.name} text-[--color-font] border border-solid border-transparent`} style={{ 'outline': 'none' }}>
                           {parentFolderContainer}
                           <span className={`ml-2 uppercase text-xs http-method-${item.method}`}>{item.method}</span>
                           <span className="ml-2 hover:underline cursor-pointer text-[--hl]" onClick={() => goToRequest(item.id)}>{item.name}</span>

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -607,7 +607,7 @@ export const Runner: FC<{}> = () => {
                       const parentFolderContainer = parentFolders.length > 0 ? <span className="ml-2">{parentFolders}</span> : null;
 
                       return (
-                        <RequestItem textValue={item.name} className={`item-${item.name} text-[--color-font] border border-solid border-transparent`} style={{ 'outline': 'none' }}>
+                        <RequestItem textValue={item.name} className={`runner-request-list-${item.name} text-[--color-font] border border-solid border-transparent`} style={{ 'outline': 'none' }}>
                           {parentFolderContainer}
                           <span className={`ml-2 uppercase text-xs http-method-${item.method}`}>{item.method}</span>
                           <span className="ml-2 hover:underline cursor-pointer text-[--hl]" onClick={() => goToRequest(item.id)}>{item.name}</span>


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes
- [x] Enabled `setNextRequest` in the after-response script
- [x] Enabled pointing next request to self with `setNextRequest`
- [x] Made `setNextRequest` callings work together from pre-request and after-response scripts
- [x] Added smoke tests
- [x] Removed "ignore undefined value" config as they are always ignored

Ref: INS-4556, #7628 

