### PR TITLE
feat: generate insomnia-inso docs from source

### DIFF
--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -33,6 +33,7 @@ import { loadTestSuites, promptTestSuites } from './db/models/unit-test-suite';
 import { matchIdIsh } from './db/models/util';
 import { loadWorkspace, promptWorkspace } from './db/models/workspace';
 import { logTestResult, logTestResultSummary, reporterTypes, type TestReporter } from './reporter';
+import { generateCommandMarkdown, generateDocumentation } from './scripts/docs';
 
 export interface GlobalOptions {
   ci: boolean;
@@ -894,6 +895,12 @@ export const go = (args?: string[]) => {
       logger.debug(`>> ${scriptArgs.slice(1).join(' ')}`);
 
       program.parseAsync(scriptArgs).catch(logErrorAndExit);
+    });
+
+  program.command('generate-docs')
+    .action(() => {
+      generateDocumentation(program);
+      return process.exit(1);
     });
 
   program.parseAsync(args || process.argv).catch(logErrorAndExit);

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -33,7 +33,7 @@ import { loadTestSuites, promptTestSuites } from './db/models/unit-test-suite';
 import { matchIdIsh } from './db/models/util';
 import { loadWorkspace, promptWorkspace } from './db/models/workspace';
 import { logTestResult, logTestResultSummary, reporterTypes, type TestReporter } from './reporter';
-import { generateCommandMarkdown, generateDocumentation } from './scripts/docs';
+import { generateDocumentation } from './scripts/docs';
 
 export interface GlobalOptions {
   ci: boolean;

--- a/packages/insomnia-inso/src/scripts/docs.ts
+++ b/packages/insomnia-inso/src/scripts/docs.ts
@@ -13,54 +13,39 @@ function writeMarkdownFile(fileName: string, content: string): void {
 }
 
 function generateOptionsMarkdown(options: readonly commander.Option[], title: string): string {
-    if (options.length === 0) {
-        return '';
-    }
+    return options.length ? `## ${title}
 
-    return `
-## ${title}
-
-${options.map(option => `- \`${option.flags}\`: ${option.description}\n`).join('')}`;
+${options.map(option => `- \`${option.flags}\`: ${option.description}
+`).join('')}
+` : '';
 }
 
 function generateSubcommandsMarkdown(commandName: string, subcommands: { name: string; description: string }[]): string {
-    if (subcommands.length === 0) {
-        return '';
-    }
+    return subcommands.length ? `## Subcommands
 
-    return `
-## Subcommands
-
-${subcommands.map(sub => `- [\`${commandName} ${sub.name}\`](/insomnia-inso/${commandName.replace(/\s+/g, '_')}_${sub.name.replace(/\s+/g, '_')}/): ${sub.description}`).join('\n')}`;
-}
-
-function generateCommandMarkdownContent(command: commander.Command, programOptions: readonly commander.Option[], parentName?: string): string {
-    const commandName = parentName ? `${parentName} ${command.name()}` : command.name();
-    const usage = command.usage() || '[options]';
-
-    let commandMarkdown = `# ${commandName}\n\n`;
-    commandMarkdown += `## Command Description\n\n${command.description()}\n\n`;
-    commandMarkdown += `## Syntax\n\n\`${commandName} ${usage}\`\n`;
-
-    if (command.options.length > 0) {
-        commandMarkdown += generateOptionsMarkdown(command.options, 'Local Flags');
-    }
-
-    commandMarkdown += generateOptionsMarkdown(programOptions, 'Global Flags');
-    commandMarkdown += generateSubcommandsMarkdown(commandName, command.commands.map(sub => ({
-        name: sub.name(),
-        description: sub.description() || 'No description available',
-    })));
-
-    return commandMarkdown;
+${subcommands.map(sub => `- [\`${commandName} ${sub.name}\`](/insomnia-inso/${commandName.replace(/\s+/g, '_')}_${sub.name.replace(/\s+/g, '_')}/): ${sub.description}
+`).join('')}
+` : '';
 }
 
 export function generateCommandMarkdown(command: commander.Command, programOptions: readonly commander.Option[], parentName?: string): { name: string; fileName: string; description: string; subcommands: readonly commander.Command[] } {
     const commandName = parentName ? `${parentName} ${command.name()}` : command.name();
     const fileName = `${commandName.replace(/\s+/g, '_')}.md`;
 
-    const commandMarkdown = generateCommandMarkdownContent(command, programOptions, parentName);
-    writeMarkdownFile(fileName, commandMarkdown);
+    writeMarkdownFile(fileName, `# ${commandName}
+
+## Command Description
+
+${command.description()}
+
+## Syntax
+
+\`${commandName} ${command.usage() || '[options]'}\`
+
+${command.options.length > 0 ? generateOptionsMarkdown(command.options, 'Local Flags') : ''}${generateOptionsMarkdown(programOptions, 'Global Flags')}${generateSubcommandsMarkdown(commandName, command.commands.map(sub => ({
+    name: sub.name(),
+    description: sub.description() || 'No description available',
+})))}`);
 
     return {
         name: commandName,
@@ -100,7 +85,8 @@ export function generateDocumentation(program: commander.Command): void {
 ${generateOptionsMarkdown(program.options, 'Global Flags')}
 ## Commands
 
-${allCommands.map(({ name, description, fileName }) => `- [\`${name}\`](/insomnia-inso/${fileName.replace('.md', '')}/): ${description}`).join('\n')}
-${allCommands.map(({ name, subcommands }) => generateSubcommandsMarkdown(name, subcommands)).join('\n')}
-`);
+${allCommands.map(({ name, description, fileName }) => `- [\`${name}\`](/insomnia-inso/${fileName.replace('.md', '')}/): ${description}
+`).join('')}
+${allCommands.map(({ name, subcommands }) => `${generateSubcommandsMarkdown(name, subcommands)}
+`).join('')}`);
 }

--- a/packages/insomnia-inso/src/scripts/docs.ts
+++ b/packages/insomnia-inso/src/scripts/docs.ts
@@ -1,0 +1,125 @@
+import path from 'node:path';
+
+import * as commander from 'commander';
+import fs from 'fs';
+
+import { program, version } from '../cli';
+
+const DOCS_DIR = path.join(__dirname, `../../../../reference/insomnia-inso/${version}`);
+
+function writeMarkdownFile(fileName: string, content: string): void {
+    const outputPath = path.join(DOCS_DIR, fileName);
+    fs.writeFileSync(outputPath, content);
+}
+
+function generateOptionsMarkdown(options: readonly commander.Option[], title: string): string {
+    if (options.length === 0) {
+        return '';
+    }
+
+    const optionList = options.map(option => `- \`${option.flags}\`: ${option.description}\n`).join('');
+    return `\n## ${title}\n\n${optionList}`;
+}
+
+function generateSubcommandsMarkdown(commandName: string, subcommands: { name: string; description: string }[]): string {
+    if (subcommands.length === 0) {
+        return '';
+    }
+
+    let subcommandsMarkdown = '\n## Subcommands\n\n';
+    subcommands.forEach(sub => {
+        const subCommandFileName = `${commandName.replace(/\s+/g, '_')}_${sub.name.replace(/\s+/g, '_')}.md`;
+        subcommandsMarkdown += `- [\`${commandName} ${sub.name}\`](${generateFileURL(subCommandFileName)}): ${sub.description}\n`;
+    });
+
+    return subcommandsMarkdown;
+}
+
+function generateCommandMarkdownContent(command: commander.Command, parentName?: string): string {
+    const commandName = parentName ? `${parentName} ${command.name()}` : command.name();
+    const usage = command.usage() || '[options]';
+
+    let commandMarkdown = `# ${commandName}\n\n`;
+    commandMarkdown += `## Command Description\n\n${command.description()}\n\n`;
+    commandMarkdown += `## Syntax\n\n\`${commandName} ${usage}\`\n`;
+
+    if (command.options.length > 0) {
+        commandMarkdown += generateOptionsMarkdown(command.options, 'Local Flags');
+    }
+
+    commandMarkdown += generateOptionsMarkdown(program.options, 'Global Flags');
+    commandMarkdown += generateSubcommandsMarkdown(commandName, command.commands.map(sub => ({
+        name: sub.name(),
+        description: sub.description() || 'No description available',
+    })));
+
+    return commandMarkdown;
+}
+
+function generateCommandMarkdown(command: commander.Command, parentName?: string): { name: string; fileName: string; description: string; subcommands: readonly commander.Command[] } {
+    const commandName = parentName ? `${parentName} ${command.name()}` : command.name();
+    const fileName = `${commandName.replace(/\s+/g, '_')}.md`;
+
+    const commandMarkdown = generateCommandMarkdownContent(command, parentName);
+    writeMarkdownFile(fileName, commandMarkdown);
+
+    return {
+        name: commandName,
+        fileName,
+        description: command.description() || 'No description available',
+        subcommands: command.commands,
+    };
+}
+
+function generateFileURL(fileName: string): string {
+    return `/insomnia-inso/${fileName.replace('.md', '')}/`;
+}
+
+function generateIndexContent(globalOptions: readonly commander.Option[], allCommands: { name: string; description: string; fileName: string; subcommands: any[] }[]): string {
+    let indexContent = '# CLI Documentation \n';
+
+    indexContent += generateOptionsMarkdown(globalOptions, 'Global Flags');
+
+    indexContent += '\n## Commands\n\n';
+    allCommands.forEach(({ name, description, fileName }) => {
+        indexContent += `- [\`${name}\`](${generateFileURL(fileName)}): ${description}\n`;
+    });
+
+    allCommands.forEach(({ name, subcommands }) => {
+        indexContent += generateSubcommandsMarkdown(name, subcommands);
+    });
+
+    return indexContent;
+}
+
+export function generateDocumentation(): void {
+    if (!fs.existsSync(DOCS_DIR)) {
+        fs.mkdirSync(DOCS_DIR, { recursive: true });
+    }
+
+    const allCommands: any[] = [];
+
+    program.commands.forEach(command => {
+        const commandData = generateCommandMarkdown(command, '');
+
+        allCommands.push({
+            name: commandData.name,
+            description: commandData.description,
+            fileName: commandData.fileName,
+            subcommands: commandData.subcommands.map(sub => ({
+                name: sub.name(),
+                description: sub.description() || 'No description available',
+                fileName: `${commandData.name.replace(/\s+/g, '_')}_${sub.name().replace(/\s+/g, '_')}.md`,
+            })),
+        });
+
+        commandData.subcommands.forEach(sub => {
+            generateCommandMarkdown(sub, commandData.name);
+        });
+    });
+
+    const indexContent = generateIndexContent(program.options, allCommands);
+    writeMarkdownFile('index.md', indexContent);
+}
+
+generateDocumentation();

--- a/packages/insomnia-inso/src/scripts/docs.ts
+++ b/packages/insomnia-inso/src/scripts/docs.ts
@@ -33,7 +33,11 @@ export function generateCommandMarkdown(command: commander.Command, programOptio
     const commandName = parentName ? `${parentName} ${command.name()}` : command.name();
     const fileName = `${commandName.replace(/\s+/g, '_')}.md`;
 
-    writeMarkdownFile(fileName, `# ${commandName}
+    writeMarkdownFile(fileName, `---
+title: ${commandName}
+---
+
+# ${commandName}
 
 ## Command Description
 
@@ -44,9 +48,9 @@ ${command.description()}
 \`${commandName} ${command.usage() || '[options]'}\`
 
 ${command.options.length > 0 ? generateOptionsMarkdown(command.options, 'Local Flags') : ''}${generateOptionsMarkdown(programOptions, 'Global Flags')}${generateSubcommandsMarkdown(commandName, command.commands.map(sub => ({
-    name: sub.name(),
-    description: sub.description() || 'No description available',
-})))}`);
+        name: sub.name(),
+        description: sub.description() || 'No description available',
+    })))}`);
 
     return {
         name: commandName,
@@ -82,8 +86,14 @@ export function generateDocumentation(program: commander.Command): void {
         });
     });
 
-    writeMarkdownFile('index.md', `# CLI Documentation 
+    writeMarkdownFile('index.md', `---
+title: CLI Documentation
+---
+
+# CLI Documentation
+
 ${generateOptionsMarkdown(program.options, 'Global Flags')}
+
 ## Commands
 
 ${allCommands.map(({ name, description, fileName }) => `- [\`${name}\`](/insomnia-inso/${fileName.replace('.md', '')}/{{page.release}}/): ${description}

--- a/packages/insomnia-inso/src/scripts/docs.ts
+++ b/packages/insomnia-inso/src/scripts/docs.ts
@@ -1,7 +1,7 @@
+import fs from 'node:fs';
 import path from 'node:path';
 
-import * as commander from 'commander';
-import fs from 'fs';
+import type * as commander from 'commander';
 
 import { version } from '../../package.json';
 

--- a/packages/insomnia-inso/src/scripts/docs.ts
+++ b/packages/insomnia-inso/src/scripts/docs.ts
@@ -5,7 +5,8 @@ import fs from 'fs';
 
 import { version } from '../../package.json';
 
-const DOCS_DIR = path.join(__dirname, `../reference/insomnia-inso/${version}`);
+const majorMinor = version.split('.').slice(0, 2).join('.');
+const DOCS_DIR = path.join(__dirname, `../reference/insomnia-inso/${majorMinor}`);
 
 function writeMarkdownFile(fileName: string, content: string): void {
     const outputPath = path.join(DOCS_DIR, fileName);

--- a/packages/insomnia-inso/src/scripts/docs.ts
+++ b/packages/insomnia-inso/src/scripts/docs.ts
@@ -37,8 +37,6 @@ export function generateCommandMarkdown(command: commander.Command, programOptio
 title: ${commandName}
 ---
 
-# ${commandName}
-
 ## Command Description
 
 ${command.description()}
@@ -89,8 +87,6 @@ export function generateDocumentation(program: commander.Command): void {
     writeMarkdownFile('index.md', `---
 title: CLI Documentation
 ---
-
-# CLI Documentation
 
 ${generateOptionsMarkdown(program.options, 'Global Flags')}
 

--- a/packages/insomnia-inso/src/scripts/docs.ts
+++ b/packages/insomnia-inso/src/scripts/docs.ts
@@ -24,7 +24,7 @@ ${options.map(option => `- \`${option.flags}\`: ${option.description}
 function generateSubcommandsMarkdown(commandName: string, subcommands: { name: string; description: string }[]): string {
     return subcommands.length ? `## Subcommands
 
-${subcommands.map(sub => `- [\`${commandName} ${sub.name}\`](/insomnia-inso/${commandName.replace(/\s+/g, '_')}_${sub.name.replace(/\s+/g, '_')}/{{page.release}}/): ${sub.description}
+${subcommands.map(sub => `- [\`${commandName} ${sub.name}\`](/inso-cli/reference/${commandName.replace(/\s+/g, '_')}_${sub.name.replace(/\s+/g, '_')}/{{page.release}}/): ${sub.description}
 `).join('')}
 ` : '';
 }
@@ -96,7 +96,7 @@ ${generateOptionsMarkdown(program.options, 'Global Flags')}
 
 ## Commands
 
-${allCommands.map(({ name, description, fileName }) => `- [\`${name}\`](/insomnia-inso/${fileName.replace('.md', '')}/{{page.release}}/): ${description}
+${allCommands.map(({ name, description, fileName }) => `- [\`${name}\`](/inso-cli/reference/${fileName.replace('.md', '')}/{{page.release}}/): ${description}
 `).join('')}
 ${allCommands.map(({ name, subcommands }) => `${generateSubcommandsMarkdown(name, subcommands)}
 `).join('')}`);

--- a/packages/insomnia-inso/src/scripts/docs.ts
+++ b/packages/insomnia-inso/src/scripts/docs.ts
@@ -23,7 +23,7 @@ ${options.map(option => `- \`${option.flags}\`: ${option.description}
 function generateSubcommandsMarkdown(commandName: string, subcommands: { name: string; description: string }[]): string {
     return subcommands.length ? `## Subcommands
 
-${subcommands.map(sub => `- [\`${commandName} ${sub.name}\`](/insomnia-inso/${commandName.replace(/\s+/g, '_')}_${sub.name.replace(/\s+/g, '_')}/): ${sub.description}
+${subcommands.map(sub => `- [\`${commandName} ${sub.name}\`](/insomnia-inso/${commandName.replace(/\s+/g, '_')}_${sub.name.replace(/\s+/g, '_')}/{{page.release}}/): ${sub.description}
 `).join('')}
 ` : '';
 }
@@ -85,7 +85,7 @@ export function generateDocumentation(program: commander.Command): void {
 ${generateOptionsMarkdown(program.options, 'Global Flags')}
 ## Commands
 
-${allCommands.map(({ name, description, fileName }) => `- [\`${name}\`](/insomnia-inso/${fileName.replace('.md', '')}/): ${description}
+${allCommands.map(({ name, description, fileName }) => `- [\`${name}\`](/insomnia-inso/${fileName.replace('.md', '')}/{{page.release}}/): ${description}
 `).join('')}
 ${allCommands.map(({ name, subcommands }) => `${generateSubcommandsMarkdown(name, subcommands)}
 `).join('')}`);


### PR DESCRIPTION
Add a script that generates the reference docs for insomnia-inso from the source code. Commander exposes commands, options and descriptions which we can use to generate the markdown files.

This is a WIP to start a convo and an initial implementation, the script doesn't work as it is because `cli.ts` doesn't export `program` and `version`. I've tested it locally by copying the `program` variable into the file and removing the `action` from each command. I've tried exporting the variables, but got a weird error `: ERROR: No loader is configured for ".node"...`.

It generates a folder at the root `reference/insomnia-inso/<version>/`, with an `index.md` file and one file for each command (+subcommands).

There are a few things to consider:
* relative links in the generated markdown files
* figure out a way to include examples in the markdown files, e.g. we could use `program.addHelpText('afterAll', ` 

The end goal would be to have a github action that runs this script and opens a PR against the insomnia-docs repo (where the generated files should live).