### PR TITLE
Changing the error message when file not scanned.

### DIFF
--- a/packages/insomnia/src/ui/components/modals/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal.tsx
@@ -537,7 +537,7 @@ const ScanResourcesForm = ({
         {errors && errors.length > 0 && (
           <div className="notice error margin-top-sm">
             <p>
-              <strong>Error while scanning for resources to import:</strong>
+              <strong>Error while scanning for resources to import: </strong>
               {errors[0]}
             </p>
           </div>


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Closes #8051 

I have addressed the issue where the error message lacked proper spacing before the closing tag. The problem was with the strong tag not having a space before closing, which resulted in the incorrect formatting of the error message.

I have added the space before the closing strong tag, and now the message is displayed as expected:

         Error while scanning for resources to import: File is required

Please review the change, and let me know if further adjustments are needed.

Thanks!
