### PR TITLE
Fix/mask auth passwords

### DIFF
--- a/packages/insomnia/src/ui/components/editors/auth/aws-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/aws-auth.tsx
@@ -14,6 +14,7 @@ export const AWSAuth: FC = () => (
     <AuthInputRow
       label="Secret Access Key"
       property="secretAccessKey"
+      mask={true}
     />
     <AuthInputRow
       label="Region"
@@ -29,6 +30,6 @@ export const AWSAuth: FC = () => (
       label="Session Token"
       property="sessionToken"
       help="Optional token used for multi-factor authentication"
-    />
+    /> 
   </AuthTableBody>
 );

--- a/packages/insomnia/src/ui/components/editors/auth/aws-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/aws-auth.tsx
@@ -30,6 +30,6 @@ export const AWSAuth: FC = () => (
       label="Session Token"
       property="sessionToken"
       help="Optional token used for multi-factor authentication"
-    /> 
+    />
   </AuthTableBody>
 );

--- a/packages/insomnia/src/ui/components/editors/auth/basic-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/basic-auth.tsx
@@ -8,7 +8,7 @@ export const BasicAuth: FC<{ disabled?: boolean }> = ({ disabled = false }) => (
   <AuthTableBody>
     <AuthToggleRow label="Enabled" property="disabled" invert disabled={disabled} />
     <AuthInputRow label="Username" property="username" disabled={disabled} />
-    <AuthInputRow label="Password" property="password" disabled={disabled} />
+    <AuthInputRow label="Password" property="password" mask disabled={disabled} />
     <AuthToggleRow
       label="Use ISO 8859-1"
       help="Check this to use ISO-8859-1 encoding instead of default UTF-8"

--- a/packages/insomnia/src/ui/components/editors/auth/bearer-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/bearer-auth.tsx
@@ -7,7 +7,7 @@ import { AuthToggleRow } from './components/auth-toggle-row';
 export const BearerAuth: FC<{ disabled?: boolean }> = ({ disabled = false }) => (
   <AuthTableBody>
     <AuthToggleRow label="Enabled" property="disabled" invert disabled={disabled} />
-    <AuthInputRow label='Token' property='token' disabled={disabled} />
+    <AuthInputRow label='Token' property='token' mask disabled={disabled} />
     <AuthInputRow label='Prefix' property='prefix' disabled={disabled} />
   </AuthTableBody>
 );

--- a/packages/insomnia/src/ui/components/editors/auth/hawk-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/hawk-auth.tsx
@@ -13,7 +13,7 @@ export const HawkAuth: FC = () => (
   <AuthTableBody>
     <AuthToggleRow label="Enabled" property="disabled" invert />
     <AuthInputRow label='Auth Id' property='id' />
-    <AuthInputRow label='Auth Key' property='key' />
+    <AuthInputRow label='Auth Key' property='key' mask />
     <AuthSelectRow
       label='Algorithm'
       property='algorithm'

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-1-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-1-auth.tsx
@@ -45,9 +45,9 @@ export const OAuth1Auth: FC = () => {
     <AuthTableBody>
       <AuthToggleRow label="Enabled" property="disabled" invert />
       <AuthInputRow label='Consumer Key' property='consumerKey' />
-      <AuthInputRow label='Consumer Secret' property='consumerSecret' />
+      <AuthInputRow label='Consumer Secret' property='consumerSecret' mask />
       <AuthInputRow label='Token Key' property='tokenKey' />
-      <AuthInputRow label='Token Secret' property='tokenSecret' />
+      <AuthInputRow label='Token Secret' property='tokenSecret' mask />
       <AuthSelectRow label='Signature Method' property='signatureMethod' options={signatureMethodOptions} />
       {signatureMethod === SIGNATURE_METHOD_RSA_SHA1 && <AuthPrivateKeyRow label='Private Key' property='privateKey' />}
       <AuthInputRow label='Callback URL' property='callback' />


### PR DESCRIPTION
Not all password/secret fields have the mask option assigned, causing them to be plaintext and easily readable from a distance. API key authentication does this already, but many other authentication types such as Basic auth does not do this. Password was always plaintext. 

With this PR this has been resolved. I've added the "mask" option to AuthInputRow password/secret fields. This also ties into the "Reveal passwords" setting. If turned off, password/secret fields are hidden and can be revealed with the Eye icon/button.

Closes #8106 