### PR TITLE
fix(Git Sync): Filtering deleted files out of staged changes

### DIFF
--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -509,7 +509,7 @@ export class GitVCS {
     const status = await this.statusWithContent();
 
     const unstagedChanges = status.filter(({ workdir, stage }) => stage.status !== workdir.status);
-    const stagedChanges = status.filter(({ head, workdir, stage }) => head.status !== workdir.status && stage.status !== head.status && stage.status !== 0);
+    const stagedChanges = status.filter(({ head, stage }) => stage.status !== head.status);
 
     return {
       staged: stagedChanges.map(({ filepath, head, workdir, stage }) => ({


### PR DESCRIPTION
Highlights:
- [x] Fixes an issue with how we filter changes to calculate what is considered as staged.
- [x] Tested with all variations of https://isomorphic-git.org/docs/en/statusMatrix#:~:text=//%20example%20StatusMatrix