### PR TITLE
Fix can not unset global Environment issue[INS-4611]

### DIFF
--- a/packages/insomnia/src/ui/components/environment-picker.tsx
+++ b/packages/insomnia/src/ui/components/environment-picker.tsx
@@ -113,7 +113,7 @@ export const EnvironmentPicker = ({
                   return match;
                 }}
                 onSelectionChange={key => {
-                  if (key === 'all' || !key) {
+                  if (key === 'all' || key === null) {
                     return;
                   }
 


### PR DESCRIPTION
**Changes:**
"No Global Environment" is not working now.
Fix the logic in onSelectionChange to post update active global environment when selection key is empty string
<img width="326" alt="Screenshot 2024-10-25 at 10 16 02" src="https://github.com/user-attachments/assets/9a8d99d0-b91f-431f-a295-2639dff8d0f3">
