### PR TITLE
fix ownerAccountId undefined error [INS-4605]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,10 @@
   },
   "cSpell.words": [
     "Dismissable",
+    "getinsomnia",
     "inso",
+    "libcurl",
+    "svgr",
     "xmark"
   ],
 }

--- a/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
@@ -266,7 +266,7 @@ export const InviteModalContainer: FC<{
   const [currentUserAccountId, setCurrentUserAccountId] = useState('');
   const [currentOrgInfo, setCurrentOrgInfo] = useState<OrganizationAuth0 | null>(null);
 
-  const isCurrentUserOrganizationOwner = currentUserAccountId === currentOrgInfo?.metadata.ownerAccountId;
+  const isCurrentUserOrganizationOwner = currentUserAccountId === currentOrgInfo?.metadata?.ownerAccountId;
 
   function getBaseInfo(organizationId: string) {
     return Promise.all([


### PR DESCRIPTION
Fix https://github.com/Kong/insomnia/issues/8121
It seems that the server side does not response '/v1/organizations/${organizationId}' correctly. Frontend can not get org's metadata.
Use optional chaining to solve this.