### PR TITLE
setNextRequest alternative implementation

### DIFF
--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -43,6 +43,8 @@ const shouldReturnSuccessCode = [
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/after-response.yml wrk_616795 --verbose',
   // select request by id
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/three-requests.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 -i req_6063adcdab5b409e9b4f00f47322df4a',
+  // setNextRequest runs the next request then ends
+  '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/set-next-request.yml wrk_cbc89e',
   // multiple --env-var overrides
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/with-missing-env-vars.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 --env-var firstkey=first --env-var secondkey=second',
   // globals file path env overrides
@@ -56,6 +58,8 @@ const shouldReturnErrorCode = [
   '$PWD/packages/insomnia-inso/bin/inso lint spec packages/insomnia-inso/src/db/fixtures/insomnia-v4/malformed.yaml',
   // after-response script and test
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/after-response-failed-test.yml wrk_616795 --verbose',
+  // failing test
+  '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/set-next-request.yml -i req_6a0343d51ca74de7a2c73e34211354ab',
 ];
 
 describe('inso dev bundle', () => {

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -563,7 +563,9 @@ export const go = (args?: string[]) => {
             // continue to next in workflow queue
             continue;
           }
+          // TODO: add support for skipRequest
           if (res.nextRequestIdOrName) {
+            // TODO: add support for null input to exit 0
             const nextRequest = requestsToRun.find(r => r.name === res.nextRequestIdOrName || r._id === res.nextRequestIdOrName);
             if (nextRequest) {
               workflowQueue = [];

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -565,10 +565,13 @@ export const go = (args?: string[]) => {
           }
           // TODO: add support for skipRequest
           if (res.nextRequestIdOrName) {
+            logger.trace(`setNextRequest(${res.nextRequestIdOrName}) found, adding to workflow queue, and removing any others`);
+
             // TODO: add support for null input to exit 0
             const nextRequest = requestsToRun.find(r => r.name === res.nextRequestIdOrName || r._id === res.nextRequestIdOrName);
             if (nextRequest) {
               workflowQueue = [];
+              // TODO: should we use the same iteration data as previous or next in list?
               workflowQueue.push({ req: nextRequest, iteration: current.iteration, iterationData: current.iterationData });
             }
           }

--- a/packages/insomnia-inso/src/examples/set-next-request.yml
+++ b/packages/insomnia-inso/src/examples/set-next-request.yml
@@ -1,0 +1,113 @@
+_type: export
+__export_format: 4
+__export_date: 2024-10-26T22:34:07.758Z
+__export_source: insomnia.desktop.app:v10.1.1
+resources:
+  - _id: req_5b004a6d43ef4e62a9117b9e08daa61e
+    parentId: wrk_cbc89ea8669648b8970ae684f9ff08b8
+    modified: 1729982030396
+    created: 1729981763331
+    url: localhost:4010/echo
+    name: setNextRequest
+    description: ""
+    method: GET
+    body: {}
+    parameters: []
+    headers:
+      - name: User-Agent
+        value: insomnia/10.1.1
+    authentication: {}
+    metaSortKey: -1729981822482
+    isPrivate: false
+    pathParameters: []
+    afterResponseScript: |+
+      insomnia.execution.setNextRequest("Passing Request");
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: wrk_cbc89ea8669648b8970ae684f9ff08b8
+    parentId: null
+    modified: 1729981758905
+    created: 1729981758905
+    name: test next request
+    description: ""
+    scope: collection
+    _type: workspace
+  - _id: req_6a0343d51ca74de7a2c73e34211354ab
+    parentId: wrk_cbc89ea8669648b8970ae684f9ff08b8
+    modified: 1729981999436
+    created: 1729981846012
+    url: localhost:4010/echo
+    name: Failing Request
+    description: ""
+    method: GET
+    body: {}
+    parameters: []
+    headers:
+      - name: User-Agent
+        value: insomnia/10.1.1
+    authentication: {}
+    preRequestScript: |-
+      insomnia.test('Failing test', () => {
+        insomnia.expect(true).to.eql(false);
+      });
+    metaSortKey: -1729981763231
+    isPrivate: false
+    pathParameters: []
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_704fcb5bf8e047cbaee4f8ca23a97249
+    parentId: wrk_cbc89ea8669648b8970ae684f9ff08b8
+    modified: 1729982010136
+    created: 1729981822432
+    url: localhost:4010/echo
+    name: Passing Request
+    description: ""
+    method: GET
+    body: {}
+    parameters: []
+    headers:
+      - name: User-Agent
+        value: insomnia/10.1.1
+    authentication: {}
+    preRequestScript: |-
+      insomnia.test('Passing test', () => {
+        insomnia.expect(true).to.eql(true);
+      });
+    metaSortKey: -1729981763131
+    isPrivate: false
+    pathParameters: []
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: env_6d416edc2e4fd8b59c75eae67c16f3b21e1e2de2
+    parentId: wrk_cbc89ea8669648b8970ae684f9ff08b8
+    modified: 1729982036362
+    created: 1729981758906
+    name: Base Environment
+    data: {}
+    dataPropertyOrder: {}
+    color: null
+    isPrivate: false
+    metaSortKey: 1729981758906
+    _type: environment
+  - _id: jar_6d416edc2e4fd8b59c75eae67c16f3b21e1e2de2
+    parentId: wrk_cbc89ea8669648b8970ae684f9ff08b8
+    modified: 1729982036362
+    created: 1729981758906
+    name: Default Jar
+    cookies: []
+    _type: cookie_jar

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -166,7 +166,8 @@ export async function getSendRequestCallbackMemDb(environmentId: string, memDB: 
     const headers = headerArray?.reduce((acc, { name, value }) => ({ ...acc, [name.toLowerCase() || '']: value || '' }), []);
     const bodyBuffer = await getBodyBuffer(res) as Buffer;
     const data = bodyBuffer ? bodyBuffer.toString('utf8') : undefined;
-
-    return { status, statusMessage, data, headers, responseTime, timelinePath: requestData.timelinePath, testResults: postMutatedContext.requestTestResults, nextRequestIdOrName: postMutatedContext?.execution?.nextRequestIdOrName };
+    // TODO: find out why requestTestResults can be undefined and eliminate the case so its always an array
+    const testResults = [...(mutatedContext.requestTestResults || []), ...(postMutatedContext.requestTestResults || [])];
+    return { status, statusMessage, data, headers, responseTime, timelinePath: requestData.timelinePath, testResults, nextRequestIdOrName: postMutatedContext?.execution?.nextRequestIdOrName };
   };
 }


### PR DESCRIPTION
@ihexxa as I described in our meeting last week here is an alterative way to implement a workflow queue

Aims:
- Seperate the queue contruction from the implementation so we can share code.
- use a guard pattern at the top of the loop to limit if else clauses
- use early returns in bail cases
- group bail skip and setNextRequest together in order to aid readability, and potentially unit test

Could still be improved but I wanted to show you what I had in my head to help us improve the runner.tsx implementation and achieve a little more code reuse.

Let me know what you think

TODO:

- [ ] figure out why nextRequestIdOrName comes back empty
- [ ] add skip request
- [ ] add support for setNextRequest(null)
- [ ] refactor runner.tsx to share some code with this approach


Closes INS-4604

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
