### PR TITLE
Resolve error when user aborts merge in cloud sync [INS-4591]

### DIFF
--- a/packages/insomnia/src/sync/vcs/insomnia-sync.ts
+++ b/packages/insomnia/src/sync/vcs/insomnia-sync.ts
@@ -6,6 +6,13 @@ import { VCS } from './vcs';
 
 let vcs: VCS | null = null;
 
+export class UserAbortResolveMergeConflictError extends Error {
+  constructor(msg: string = 'User aborted merge') {
+    super(msg);
+  }
+  name = 'UserAbortResolveMergeConflictError';
+}
+
 export const VCSInstance = () => {
   if (vcs) {
     return vcs;
@@ -21,9 +28,9 @@ export const VCSInstance = () => {
         handleDone: (conflicts?: MergeConflict[]) => {
           if (conflicts && conflicts.length) {
             resolve(conflicts);
+          } else {
+            reject(new UserAbortResolveMergeConflictError());
           }
-
-          reject(new Error('User aborted merge'));
         },
       });
     });

--- a/packages/insomnia/src/ui/components/modals/sync-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-branches-modal.tsx
@@ -95,12 +95,15 @@ const LocalBranchItem = ({
           doneMessage="Merged"
           confirmMessage='Confirm'
           disabled={isCurrent}
-          onClick={() => mergeBranchFetcher.submit({
-            branch,
-          }, {
-            method: 'POST',
-            action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/branch/merge`,
-          })}
+          onClick={() => {
+            // file://./../../routes/remote-collections.tsx#mergeBranchAction
+            mergeBranchFetcher.submit({
+              branch,
+            }, {
+              method: 'POST',
+              action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/branch/merge`,
+            });
+          }}
         >
           <Icon icon={mergeBranchFetcher.state !== 'idle' ? 'spinner' : 'code-merge'} className={`w-5 ${mergeBranchFetcher.state !== 'idle' ? 'animate-spin' : ''}`} />
           Merge


### PR DESCRIPTION
An error screen could show up if user close the modal when resolving merge conflicts.
![image](https://github.com/user-attachments/assets/9750db76-6239-46f1-bf29-b8d8c1fa7a4c)

Now users can abort resolving merge conflicts decently.
