### PR TITLE
Fix: Environment name input occupy too few space [INS-4630]

### DIFF
--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -395,7 +395,7 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: {
                 </GridList>
                 <div className='flex-1 flex flex-col divide-solid divide-y divide-[--hl-md] overflow-hidden'>
                   <div className='flex items-center justify-between gap-2 w-full px-[--padding-sm] overflow-hidden'>
-                    <Heading className='flex items-center gap-2 text-lg py-2 px-4 overflow-hidden'>
+                    <Heading className='flex items-center flex-grow gap-2 text-lg py-2 px-4 overflow-hidden'>
                       <Icon style={{ color: selectedEnvironment?.color || '' }} className='w-4' icon={selectedEnvironment?.isPrivate ? 'lock' : isUsingGitSync ? ['fab', 'git-alt'] : isUsingInsomniaCloudSync ? 'globe-americas' : 'file-arrow-down'} />
                       <EditableInput
                         value={selectedEnvironment?.name || ''}

--- a/packages/insomnia/src/ui/routes/environments.tsx
+++ b/packages/insomnia/src/ui/routes/environments.tsx
@@ -412,7 +412,7 @@ const Environments = () => {
       <Panel id="pane-one" className='pane-one theme--pane'>
         <div className='flex-1 flex flex-col h-full divide-solid divide-y divide-[--hl-md] overflow-hidden'>
           <div className='flex flex-shrink-0 basis-[--line-height-sm] items-center p-[--padding-sm] justify-between gap-2 w-full overflow-hidden'>
-            <Heading className='flex items-center gap-2 text-lg py-2 px-4 overflow-hidden'>
+            <Heading className='flex flex-grow items-center gap-2 text-lg py-2 px-4 overflow-hidden'>
               <Icon className='w-4' icon={selectedEnvironment?.isPrivate ? 'lock' : isUsingGitSync ? ['fab', 'git-alt'] : isUsingInsomniaCloudSync ? 'globe-americas' : 'file-arrow-down'} />
               <EditableInput
                 value={selectedEnvironment?.name || ''}


### PR DESCRIPTION
**Changes:**
Fix the issue that the environment editor title occupy too few space. Add css to allow it to expand the width.

**Before:**
<img width="974" alt="Screenshot 2024-10-31 at 10 47 11" src="https://github.com/user-attachments/assets/fea58328-c7b2-4c87-a973-5a08613c07cb">

**After**:
<img width="974" alt="Screenshot 2024-10-31 at 10 45 09" src="https://github.com/user-attachments/assets/3b0bcbc1-ccf9-4416-a19a-0e34dc1a1105">
