### PR TITLE
fix: scroll bar ui

### DIFF
--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -112,7 +112,7 @@ export const RequestPane: FC<Props> = ({
         </ErrorBoundary>
       </PaneHeader>
       <Tabs aria-label='Request pane tabs' className="flex-1 w-full h-full flex flex-col">
-        <TabList className='w-full flex-shrink-0  overflow-x-auto border-solid scro border-b border-b-[--hl-md] bg-[--color-bg] flex items-center h-[--line-height-sm]' aria-label='Request pane tabs'>
+        <TabList className='scrollbar-thin w-full flex-shrink-0  overflow-x-auto border-solid scro border-b border-b-[--hl-md] bg-[--color-bg] flex items-center h-[--line-height-sm]' aria-label='Request pane tabs'>
           <Tab
             className='flex-shrink-0 h-full flex items-center justify-between cursor-pointer gap-2 outline-none select-none px-3 py-1 text-[--hl] aria-selected:text-[--color-font]  hover:bg-[--hl-sm] hover:text-[--color-font] aria-selected:bg-[--hl-xs] aria-selected:focus:bg-[--hl-sm] aria-selected:hover:bg-[--hl-sm] focus:bg-[--hl-sm] transition-colors duration-300'
             id='params'

--- a/packages/insomnia/src/ui/css/main.css
+++ b/packages/insomnia/src/ui/css/main.css
@@ -2960,6 +2960,10 @@ input.editable {
 ::-webkit-scrollbar-corner {
   background: transparent;
 }
+.scrollbar-thin::-webkit-scrollbar {
+  width: 3px;
+  height: 3px;
+}
 .shortcuts td.options {
   width: 0.1em;
 }

--- a/packages/insomnia/src/ui/css/styles.css
+++ b/packages/insomnia/src/ui/css/styles.css
@@ -13,10 +13,6 @@
 @tailwind utilities;
 
 
-[data-platform="darwin"] * {
-  scrollbar-width: thin;
-}
-
 html {
   font-size: 11px;
 }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

This CSS style will override all the other scrollbar styles defined in `main.css`, make the scroll bar display abnormally.

**changes**:

- add a `.scrollbar-thin` class
- delete the origin `[data-platform="darwin"] *` scrollbar style

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b974a621-b054-4c7c-a2ce-ff8d432b7a62">

After delete:
<img width="308" alt="image" src="https://github.com/user-attachments/assets/51ef5da9-f831-412f-9bcd-c83e9038b647">

