### PR TITLE
fix(sdk): defining function behavior in eval is not consistent with the original product

### DIFF
--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -2,8 +2,6 @@ import { initInsomniaObject, InsomniaObject } from 'insomnia-sdk';
 import { Console, mergeClientCertificates, mergeCookieJar, mergeRequests, mergeSettings, type RequestContext } from 'insomnia-sdk';
 import * as _ from 'lodash';
 
-import { invariant } from '../src/utils/invariant';
-
 export interface HiddenBrowserWindowBridgeAPI {
   runScript: (options: { script: string; context: RequestContext }) => Promise<RequestContext>;
 };

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -39,18 +39,11 @@ const runScript = async (
 
   const executionContext = await initInsomniaObject(context, scriptConsole.log);
 
-  const evalInterceptor = (script: string) => {
-    invariant(script && typeof script === 'string', 'eval is called with invalid or empty value');
-    const result = eval(script);
-    return result;
-  };
-
   const AsyncFunction = (async () => { }).constructor;
   const executeScript = AsyncFunction(
     'insomnia',
     'require',
     'console',
-    'eval',
     '_',
     'setTimeout',
     // disable these as they are not supported in web or existing implementation
@@ -70,7 +63,6 @@ const runScript = async (
     executionContext,
     window.bridge.requireInterceptor,
     scriptConsole,
-    evalInterceptor,
     _,
     proxiedSetTimeout,
     undefined,


### PR DESCRIPTION
Add ability for running `eval()` where it adds functions that can be then called later on from the same pre-request/after-response script the `eval()` first happened. (For feature parity with other API clients and Node.js itself)

Example:

```js
const code = `
function get_some_string() {
  return 'aaaa';
}
`;

eval(code);

console.log(get_some_string()); 
```


Closes INS-4668