### PR TITLE
fix(Git Clone): Handle conencting to git repo with conflicts

### DIFF
--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -196,12 +196,24 @@ export class GitVCS {
       http: httpClient,
       repoId,
     };
-    await git.clone({
-      ...this._baseOpts,
-      url,
-      singleBranch: true,
-    });
-    console.log(`[git] Clones repo to ${gitDirectory} from ${url}`);
+    try {
+      await git.clone({
+        ...this._baseOpts,
+        url,
+        singleBranch: true,
+      });
+    } catch (err) {
+      // If we there is a checkout conflict we only want to clone the repo
+      if (err instanceof git.Errors.CheckoutConflictError) {
+        await git.clone({
+          ...this._baseOpts,
+          url,
+          singleBranch: true,
+          noCheckout: true,
+        });
+      }
+    }
+    console.log(`[git] Cloned repo to ${gitDirectory} from ${url}`);
   }
 
   isInitializedForRepo(id: string) {


### PR DESCRIPTION
Highlights:

- [x] When connecting to a git repo and there are conflicts with the existing data we now only clone the repo and let the users pull and resolve any issues

Closes INS-4485