### PR TITLE
fix(runner): extend insomnia.variables.set lifetime to whole execution period

### DIFF
--- a/packages/insomnia-sdk/src/objects/__tests__/environments.test.ts
+++ b/packages/insomnia-sdk/src/objects/__tests__/environments.test.ts
@@ -10,6 +10,7 @@ describe('test Variables object', () => {
             environmentVars: new Environment('environments', {}),
             collectionVars: new Environment('baseEnvironment', {}),
             iterationDataVars: new Environment('iterationData', {}),
+            localVars: new Environment('local', {}),
         });
 
         const uuidAnd777 = variables.replaceIn('{{    $randomUUID }}{{value  }}');
@@ -28,22 +29,33 @@ describe('test Variables object', () => {
             environmentVars: new Environment('environments', {}),
             collectionVars: new Environment('baseEnvironment', {}),
             iterationDataVars: new Environment('iterationData', {}),
+            localVars: new Environment('local', {}),
         });
         const normalVariables = new Variables({
             globalVars: new Environment('globals', { scope: 'global', value: 'global-value' }),
             environmentVars: new Environment('environments', { scope: 'subEnv', value: 'subEnv-value' }),
             collectionVars: new Environment('baseEnvironment', { scope: 'baseEnv', value: 'baseEnv-value' }),
             iterationDataVars: new Environment('iterationData', {}),
+            localVars: new Environment('local', {}),
         });
         const variablesWithIterationData = new Variables({
             globalVars: new Environment('globals', { scope: 'global', value: 'global-value' }),
             environmentVars: new Environment('environments', { scope: 'subEnv', value: 'subEnv-value' }),
             collectionVars: new Environment('baseEnvironment', { scope: 'baseEnv', value: 'baseEnv-value' }),
             iterationDataVars: new Environment('iterationData', { scope: 'iterationData', value: 'iterationData-value' }),
+            localVars: new Environment('local', {}),
+        });
+        const variablesWithLocalData = new Variables({
+            globalVars: new Environment('globals', { scope: 'global', value: 'global-value' }),
+            environmentVars: new Environment('environments', { scope: 'subEnv', value: 'subEnv-value' }),
+            collectionVars: new Environment('baseEnvironment', { scope: 'baseEnv', value: 'baseEnv-value' }),
+            iterationDataVars: new Environment('iterationData', { scope: 'iterationData', value: 'iterationData-value' }),
+            localVars: new Environment('local', { scope: 'local', value: 'local-value' }),
         });
 
         expect(globalOnlyVariables.get('value')).toEqual('global-value');
         expect(normalVariables.get('value')).toEqual('subEnv-value');
         expect(variablesWithIterationData.get('value')).toEqual('iterationData-value');
+        expect(variablesWithLocalData.get('value')).toEqual('local-value');
     });
 });

--- a/packages/insomnia-sdk/src/objects/environments.ts
+++ b/packages/insomnia-sdk/src/objects/environments.ts
@@ -56,13 +56,14 @@ export class Variables {
             collectionVars: Environment;
             environmentVars: Environment;
             iterationDataVars: Environment;
+            localVars: Environment;
         },
     ) {
         this.globalVars = args.globalVars;
         this.collectionVars = args.collectionVars;
         this.environmentVars = args.environmentVars;
         this.iterationDataVars = args.iterationDataVars;
-        this.localVars = new Environment('__localVars', {});
+        this.localVars = args.localVars;
     }
 
     has = (variableName: string) => {
@@ -115,5 +116,9 @@ export class Variables {
             (ctx, obj) => ({ ...ctx, ...obj }),
             {},
         );
+    };
+
+    localVarsToObject = () => {
+        return this.localVars.toObject();
     };
 }

--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -146,8 +146,8 @@ export async function initInsomniaObject(
     // Mapping rule for the environment user uploaded in collection runner
     const iterationData = rawObj.iterationData ?
         new Environment(rawObj.iterationData.name, rawObj.iterationData.data) : new Environment('iterationData', {});
-    const localVariables = rawObj.variables ?
-        new Environment(rawObj.variables.name, rawObj.variables.data) : new Environment('localVariables', {});
+    const localVariables = rawObj.transientVariables ?
+        new Environment(rawObj.transientVariables.name, rawObj.transientVariables.data) : new Environment('transientVariables', {});
     const cookies = new CookieObject(rawObj.cookieJar);
     // TODO: update follows when post-request script and iterationData are introduced
     const requestInfo = new RequestInfo({

--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -110,7 +110,7 @@ export class InsomniaObject {
             environment: this.environment.toObject(),
             baseEnvironment: this.baseEnvironment.toObject(),
             iterationData: this.iterationData.toObject(),
-            variables: this.variables.toObject(),
+            variables: this.variables.localVarsToObject(),
             request: this.request,
             settings: this.settings,
             clientCertificates: this.clientCertificates,
@@ -146,6 +146,8 @@ export async function initInsomniaObject(
     // Mapping rule for the environment user uploaded in collection runner
     const iterationData = rawObj.iterationData ?
         new Environment(rawObj.iterationData.name, rawObj.iterationData.data) : new Environment('iterationData', {});
+    const localVariables = rawObj.variables ?
+        new Environment(rawObj.variables.name, rawObj.variables.data) : new Environment('localVariables', {});
     const cookies = new CookieObject(rawObj.cookieJar);
     // TODO: update follows when post-request script and iterationData are introduced
     const requestInfo = new RequestInfo({
@@ -161,6 +163,7 @@ export async function initInsomniaObject(
         environmentVars: environment,
         collectionVars: baseEnvironment,
         iterationDataVars: iterationData,
+        localVars: localVariables,
     });
 
     const existClientCert = rawObj.clientCertificates != null && rawObj.clientCertificates.length > 0;

--- a/packages/insomnia-sdk/src/objects/interfaces.ts
+++ b/packages/insomnia-sdk/src/objects/interfaces.ts
@@ -30,5 +30,5 @@ export interface RequestContext {
     requestTestResults?: RequestTestResult[];
     requestInfo: RequestInfoOption;
     execution: ExecutionOption;
-    variables?: Omit<IEnvironment, 'id'>;
+    transientVariables?: Omit<IEnvironment, 'id'>;
 }

--- a/packages/insomnia-sdk/src/objects/interfaces.ts
+++ b/packages/insomnia-sdk/src/objects/interfaces.ts
@@ -30,4 +30,5 @@ export interface RequestContext {
     requestTestResults?: RequestTestResult[];
     requestInfo: RequestInfoOption;
     execution: ExecutionOption;
+    variables?: Omit<IEnvironment, 'id'>;
 }

--- a/packages/insomnia-smoke-test/fixtures/after-response-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/after-response-collection.yaml
@@ -42,7 +42,7 @@ resources:
     body:
       mimeType: "application/json"
       text: |-
-        {}      
+        {}
     parameters: []
     headers:
       - name: 'Content-Type'
@@ -74,7 +74,40 @@ resources:
     body:
       mimeType: "application/json"
       text: |-
-        {}      
+        {}
+    parameters: []
+    headers:
+      - name: 'Content-Type'
+        value: 'application/json'
+    authentication: {}
+    metaSortKey: -1707809028499
+    isPrivate: false
+    pathParameters: []
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_244fe815da6c4342a17f0cfd98cf6402
+    parentId: wrk_6b9b8455fd784462ae19cd51d7156f86
+    modified: 1707809218855
+    created: 1707808697304
+    url: http://127.0.0.1:4010/echo
+    name: transient var
+    description: ""
+    method: POST
+    preRequestScript: |-
+      insomnia.variables.set('var', 666);
+    afterResponseScript: |-
+      insomnia.test('check var', () => {
+        insomnia.expect(insomnia.variables.get('var')).to.eql(666);
+      });
+    body:
+      mimeType: "application/json"
+      text: |-
+        {}
     parameters: []
     headers:
       - name: 'Content-Type'

--- a/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
@@ -317,3 +317,59 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
+  - _id: req_76bf52b201cf47269f5845795a711000
+    parentId: wrk_418cad89191c418395abfeb2277fd26f
+    modified: 1636707449232
+    created: 1636141014552
+    url: http://127.0.0.1:4010/echo
+    name: set-var1
+    description: ""
+    method: POST
+    body: {}
+    parameters: []
+    headers: []
+    authentication: {}
+    preRequestScript: |-
+      insomnia.variables.set('var1', 666);
+    afterResponseScript: |-
+      insomnia.test('set-var1-check', () => {
+        insomnia.expect(insomnia.variables.get('var1')).to.eql(666);
+      });
+    metaSortKey: 163
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
+  - _id: req_76bf52b201cf47269f5845795a711001
+    parentId: wrk_418cad89191c418395abfeb2277fd26f
+    modified: 1636707449232
+    created: 1636141014552
+    url: http://127.0.0.1:4010/echo
+    name: read-var1
+    description: ""
+    method: POST
+    body: {}
+    parameters: []
+    headers: []
+    authentication: {}
+    preRequestScript: |-
+      insomnia.test('read-var1-pre-check', () => {
+        insomnia.expect(insomnia.variables.get('var1')).to.eql(666);
+      });
+    afterResponseScript: |-
+      insomnia.test('read-var1-post-check', () => {
+        insomnia.expect(insomnia.variables.get('var1')).to.eql(666);
+      });
+    metaSortKey: 164
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request

--- a/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
@@ -58,4 +58,22 @@ test.describe('after-response script features tests', async () => {
             '__fromAfterScript': 'environment',
         });
     });
+
+    test('set transient var', async ({ page }) => {
+        const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+        await page.getByLabel('Request Collection').getByTestId('transient var').press('Enter');
+
+        // send
+        await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+
+        // verify response
+        await page.waitForSelector('[data-testid="response-status-tag"]:visible');
+        await expect(statusTag).toContainText('200 OK');
+
+        // verify
+        await page.getByRole('tab', { name: 'Tests' }).click();
+
+        const rows = page.getByTestId('test-result-row');
+        await expect(rows.first()).toContainText('PASS');
+    });
 });

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -204,4 +204,25 @@ test.describe('runner features tests', async () => {
 
         await verifyResultRows(page, 1, 1, 2, expectedTestOrder, 1);
     });
+
+    test('can read variables during whole execution', async ({ page }) => {
+        await page.getByTestId('run-collection-btn-quick').click();
+
+        await page.locator('.runner-request-list-set-var1').click();
+        await page.locator('.runner-request-list-read-var1').click();
+
+        // send
+        await page.getByRole('button', { name: 'Run', exact: true }).click();
+
+        // check result
+        await page.getByText('3 / 3').first().click();
+
+        const expectedTestOrder = [
+            'set-var1-check',
+            'read-var1-pre-check',
+            'read-var1-post-check',
+        ];
+
+        await verifyResultRows(page, 3, 0, 3, expectedTestOrder, 1);
+    });
 });

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -119,6 +119,8 @@ test.describe('runner features tests', async () => {
         await page.locator('.runner-request-list-req0').click();
         await page.locator('.runner-request-list-req01').click();
         await page.locator('.runner-request-list-req02').click();
+        await page.locator('.runner-request-list-set-var1').click();
+        await page.locator('.runner-request-list-read-var1').click();
 
         // send
         await page.getByTestId('request-pane').getByRole('button', { name: 'Run' }).click();

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -63,7 +63,7 @@ export async function buildRenderContext(
     rootGlobalEnvironment,
     subGlobalEnvironment,
     userUploadEnvironment,
-    variables,
+    transientVariables,
     baseContext = {},
   }: {
     ancestors?: RenderContextAncestor[];
@@ -72,7 +72,7 @@ export async function buildRenderContext(
       rootGlobalEnvironment?: Environment | null;
       subGlobalEnvironment?: Environment | null;
       userUploadEnvironment?: UserUploadEnvironment;
-      variables?: Environment;
+      transientVariables?: Environment;
     baseContext?: Record<string, any>;
   },
 ) {
@@ -142,10 +142,10 @@ export async function buildRenderContext(
   }
 
   // script local variables (insomnia.variable.set) has highest priority
-  if (variables) {
+  if (transientVariables) {
     const ordered = orderedJSON.order(
-      variables.data,
-      variables.dataPropertyOrder,
+      transientVariables.data,
+      transientVariables.dataPropertyOrder,
       JSON_ORDER_SEPARATOR,
     );
     envObjects.push(ordered);
@@ -366,7 +366,7 @@ interface BaseRenderContextOptions {
   rootGlobalEnvironment?: Environment;
   subGlobalEnvironment?: Environment;
   userUploadEnvironment?: UserUploadEnvironment;
-  variables?: Environment;
+  transientVariables?: Environment;
   purpose?: RenderPurpose;
   extraInfo?: ExtraRenderInfo;
   ignoreUndefinedEnvVariable?: boolean;
@@ -381,7 +381,7 @@ export async function getRenderContext(
     environment,
     baseEnvironment,
     userUploadEnvironment,
-    variables,
+    transientVariables,
     ancestors: _ancestors,
     purpose,
     extraInfo,
@@ -490,8 +490,8 @@ export async function getRenderContext(
     getKeySource(userUploadEnvironment.data || {}, inKey, userUploadEnvironment.name || 'uploadData');
   }
 
-  if (variables) {
-    getKeySource(variables.data || {}, inKey, variables.name || 'scriptLocalVariables');
+  if (transientVariables) {
+    getKeySource(transientVariables.data || {}, inKey, transientVariables.name || 'scriptLocalVariables');
   }
 
   // Add meta data helper function
@@ -526,7 +526,7 @@ export async function getRenderContext(
     rootEnvironment,
     subEnvironment: subEnvironment || undefined,
     userUploadEnvironment,
-    variables,
+    transientVariables,
     baseContext,
   });
 }
@@ -593,7 +593,7 @@ export async function getRenderedRequestAndContext(
     environment,
     baseEnvironment,
     userUploadEnvironment,
-    variables,
+    transientVariables,
     extraInfo,
     purpose,
     ignoreUndefinedEnvVariable,
@@ -603,7 +603,7 @@ export async function getRenderedRequestAndContext(
   const workspace = ancestors.find(isWorkspace);
   const parentId = workspace ? workspace._id : 'n/a';
   const cookieJar = await models.cookieJar.getOrCreateForParentId(parentId);
-  const renderContext = await getRenderContext({ request, environment, ancestors, purpose, extraInfo, baseEnvironment, userUploadEnvironment, variables });
+  const renderContext = await getRenderContext({ request, environment, ancestors, purpose, extraInfo, baseEnvironment, userUploadEnvironment, transientVariables });
 
   // HACK: Switch '#}' to '# }' to prevent Nunjucks from barfing
   // https://github.com/kong/insomnia/issues/895

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -63,6 +63,7 @@ export async function buildRenderContext(
     rootGlobalEnvironment,
     subGlobalEnvironment,
     userUploadEnvironment,
+    variables,
     baseContext = {},
   }: {
     ancestors?: RenderContextAncestor[];
@@ -71,6 +72,7 @@ export async function buildRenderContext(
       rootGlobalEnvironment?: Environment | null;
       subGlobalEnvironment?: Environment | null;
       userUploadEnvironment?: UserUploadEnvironment;
+      variables?: Environment;
     baseContext?: Record<string, any>;
   },
 ) {
@@ -129,11 +131,21 @@ export async function buildRenderContext(
     }
   }
 
-  // user upload env in collection runner has highest priority
+  // user upload env in collection runner has highest priority except local variables
   if (userUploadEnvironment) {
     const ordered = orderedJSON.order(
       userUploadEnvironment.data,
       userUploadEnvironment.dataPropertyOrder,
+      JSON_ORDER_SEPARATOR,
+    );
+    envObjects.push(ordered);
+  }
+
+  // script local variables (insomnia.variable.set) has highest priority
+  if (variables) {
+    const ordered = orderedJSON.order(
+      variables.data,
+      variables.dataPropertyOrder,
       JSON_ORDER_SEPARATOR,
     );
     envObjects.push(ordered);
@@ -354,6 +366,7 @@ interface BaseRenderContextOptions {
   rootGlobalEnvironment?: Environment;
   subGlobalEnvironment?: Environment;
   userUploadEnvironment?: UserUploadEnvironment;
+  variables?: Environment;
   purpose?: RenderPurpose;
   extraInfo?: ExtraRenderInfo;
   ignoreUndefinedEnvVariable?: boolean;
@@ -368,6 +381,7 @@ export async function getRenderContext(
     environment,
     baseEnvironment,
     userUploadEnvironment,
+    variables,
     ancestors: _ancestors,
     purpose,
     extraInfo,
@@ -476,6 +490,10 @@ export async function getRenderContext(
     getKeySource(userUploadEnvironment.data || {}, inKey, userUploadEnvironment.name || 'uploadData');
   }
 
+  if (variables) {
+    getKeySource(variables.data || {}, inKey, variables.name || 'scriptLocalVariables');
+  }
+
   // Add meta data helper function
   const baseContext: BaseRenderContext = {
     getMeta: () => ({
@@ -508,6 +526,7 @@ export async function getRenderContext(
     rootEnvironment,
     subEnvironment: subEnvironment || undefined,
     userUploadEnvironment,
+    variables,
     baseContext,
   });
 }
@@ -574,6 +593,7 @@ export async function getRenderedRequestAndContext(
     environment,
     baseEnvironment,
     userUploadEnvironment,
+    variables,
     extraInfo,
     purpose,
     ignoreUndefinedEnvVariable,
@@ -583,7 +603,7 @@ export async function getRenderedRequestAndContext(
   const workspace = ancestors.find(isWorkspace);
   const parentId = workspace ? workspace._id : 'n/a';
   const cookieJar = await models.cookieJar.getOrCreateForParentId(parentId);
-  const renderContext = await getRenderContext({ request, environment, ancestors, purpose, extraInfo, baseEnvironment, userUploadEnvironment });
+  const renderContext = await getRenderContext({ request, environment, ancestors, purpose, extraInfo, baseEnvironment, userUploadEnvironment, variables });
 
   // HACK: Switch '#}' to '# }' to prevent Nunjucks from barfing
   // https://github.com/kong/insomnia/issues/895

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -164,7 +164,7 @@ export async function getSendRequestCallbackMemDb(environmentId: string, memDB: 
     const postMutatedContext = await tryToExecuteAfterResponseScript({
       ...requestData,
       ...mutatedContext,
-      variables: mutatedContext.variables || transientVariables,
+      transientVariables: mutatedContext.transientVariables || transientVariables,
       response,
     });
     // TODO: figure out how to handle this error

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
 
 import { type BaseModel, types as modelTypes } from '../models';
 import * as models from '../models';
@@ -122,7 +123,17 @@ export async function getSendRequestCallbackMemDb(environmentId: string, memDB: 
   return async function sendRequest(requestId: string, iteration?: number) {
     const requestData = await fetchInsoRequestData(requestId, environmentId);
     const getCurrentRowOfIterationData = wrapAroundIterationOverIterationData(iterationData, iteration);
-    const mutatedContext = await tryToExecutePreRequestScript(requestData, getCurrentRowOfIterationData, iteration, iterationCount);
+    const transientVariables = {
+      ...models.environment.init(),
+      _id: uuidv4(),
+      type: models.environment.type,
+      parentId: requestData.environment.parentId,
+      modified: 0,
+      created: Date.now(),
+      name: 'Transient Environment',
+      data: {},
+    };
+    const mutatedContext = await tryToExecutePreRequestScript(requestData, transientVariables, getCurrentRowOfIterationData, iteration, iterationCount);
     if (mutatedContext === null) {
       console.error('Time out while executing pre-request script');
       return null;
@@ -153,6 +164,7 @@ export async function getSendRequestCallbackMemDb(environmentId: string, memDB: 
     const postMutatedContext = await tryToExecuteAfterResponseScript({
       ...requestData,
       ...mutatedContext,
+      variables: mutatedContext.variables || transientVariables,
       response,
     });
     // TODO: figure out how to handle this error

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -97,8 +97,8 @@ const runScript = async (
       name: context.iterationData.name,
       data: mutatedContextObject.iterationData,
     } : undefined,
-    variables: {
-      name: context.variables?.name || 'localVariables',
+    transientVariables: {
+      name: context.transientVariables?.name || 'transientVariables',
       data: mutatedContextObject.variables,
     },
     request: updatedRequest,

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -98,8 +98,7 @@ const runScript = async (
       data: mutatedContextObject.iterationData,
     } : undefined,
     variables: {
-      id: context.variables.id,
-      name: context.variables.name,
+      name: context.variables?.name || 'localVariables',
       data: mutatedContextObject.variables,
     },
     request: updatedRequest,

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -97,6 +97,11 @@ const runScript = async (
       name: context.iterationData.name,
       data: mutatedContextObject.iterationData,
     } : undefined,
+    variables: {
+      id: context.variables.id,
+      name: context.variables.name,
+      data: mutatedContextObject.variables,
+    },
     request: updatedRequest,
     execution: mutatedContextObject.execution,
     settings: updatedSettings,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -542,6 +542,7 @@ export const tryToInterpolateRequest = async ({
   extraInfo,
   baseEnvironment,
   userUploadEnvironment,
+  variables,
   ignoreUndefinedEnvVariable,
 }: {
   request: Request;
@@ -550,6 +551,7 @@ export const tryToInterpolateRequest = async ({
   extraInfo?: ExtraRenderInfo;
   baseEnvironment?: Environment;
     userUploadEnvironment?: UserUploadEnvironment;
+    variables?: Environment;
   ignoreUndefinedEnvVariable?: boolean;
 }
 ) => {
@@ -559,6 +561,7 @@ export const tryToInterpolateRequest = async ({
       environment,
       baseEnvironment,
       userUploadEnvironment,
+      variables,
       purpose,
       extraInfo,
       ignoreUndefinedEnvVariable,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -180,7 +180,7 @@ export const tryToExecutePreRequestScript = async (
     responseId,
     ancestors,
   }: Awaited<ReturnType<typeof fetchRequestData>>,
-  variables: Environment,
+  transientVariables: Environment,
   userUploadEnvironment?: UserUploadEnvironment,
   iteration?: number,
   iterationCount?: number,
@@ -225,7 +225,7 @@ export const tryToExecutePreRequestScript = async (
     ancestors,
     eventName: 'prerequest',
     settings,
-    variables,
+    transientVariables,
   });
   if (!mutatedContext || 'error' in mutatedContext) {
     return {
@@ -252,7 +252,7 @@ export const tryToExecutePreRequestScript = async (
     requestTestResults: mutatedContext.requestTestResults,
     userUploadEnvironment: mutatedContext.userUploadEnvironment,
     execution: mutatedContext.execution,
-    variables: mutatedContext.variables,
+    transientVariables: mutatedContext.transientVariables,
   };
 };
 
@@ -330,7 +330,7 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
     ancestors,
     eventName,
     execution,
-    variables,
+    transientVariables,
   } = context;
   invariant(script, 'script must be provided');
 
@@ -379,7 +379,7 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
           ...execution, // keep some existing properties in the after-response script from the pre-request script
           location: requestLocation,
         },
-        variables,
+        transientVariables,
       },
     });
     if ('error' in originalOutput) {
@@ -423,14 +423,14 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
       userUploadEnvironment.dataPropertyOrder = userUploadEnvPropertyOrder.map;
     }
 
-    if (output?.variables !== undefined) {
+    if (output?.transientVariables !== undefined) {
       const variablesPropertyOrder = orderedJSON.parse(
-        JSON.stringify(output?.variables?.data || {}),
+        JSON.stringify(output?.transientVariables?.data || {}),
         JSON_ORDER_PREFIX,
         JSON_ORDER_SEPARATOR,
       );
-      variables.data = output?.variables?.data || {};
-      variables.dataPropertyOrder = variablesPropertyOrder.map;
+      transientVariables.data = output?.transientVariables?.data || {};
+      transientVariables.dataPropertyOrder = variablesPropertyOrder.map;
     }
 
     return {
@@ -444,7 +444,7 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
       userUploadEnvironment,
       requestTestResults: output.requestTestResults,
       execution: output.execution,
-      variables,
+      transientVariables,
     };
   } catch (err) {
     await fs.promises.appendFile(
@@ -481,7 +481,7 @@ interface RequestContextForScript {
   globals?: Environment; // there could be no global environment
   settings: Settings;
   execution?: ExecutionOption;
-  variables: Environment;
+  transientVariables: Environment;
 }
 
 type RequestAndContextAndResponse = RequestContextForScript & {
@@ -542,7 +542,7 @@ export const tryToInterpolateRequest = async ({
   extraInfo,
   baseEnvironment,
   userUploadEnvironment,
-  variables,
+  transientVariables,
   ignoreUndefinedEnvVariable,
 }: {
   request: Request;
@@ -551,7 +551,7 @@ export const tryToInterpolateRequest = async ({
   extraInfo?: ExtraRenderInfo;
   baseEnvironment?: Environment;
     userUploadEnvironment?: UserUploadEnvironment;
-    variables?: Environment;
+    transientVariables?: Environment;
   ignoreUndefinedEnvVariable?: boolean;
 }
 ) => {
@@ -561,7 +561,7 @@ export const tryToInterpolateRequest = async ({
       environment,
       baseEnvironment,
       userUploadEnvironment,
-      variables,
+      transientVariables,
       purpose,
       extraInfo,
       ignoreUndefinedEnvVariable,

--- a/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
@@ -513,6 +513,7 @@ export const RequestScriptEditor: FC<Props> = ({
         environmentVars: new Environment('environment', {}),
         collectionVars: new Environment('collection', {}),
         iterationDataVars: new Environment('data', {}),
+        localVars: new Environment('data', {}),
       }),
       request: new ScriptRequest({
         url: new Url('http://placeholder.com'),

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -6,6 +6,7 @@ import { GRAPHQL_TRANSPORT_WS_PROTOCOL, MessageType } from 'graphql-ws';
 import type { RequestTestResult } from 'insomnia-sdk';
 import { extension as mimeExtension } from 'mime-types';
 import { type ActionFunction, type LoaderFunction, redirect } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
 
 import { version } from '../../../package.json';
 import { CONTENT_TYPE_EVENT_STREAM, CONTENT_TYPE_GRAPHQL, CONTENT_TYPE_JSON, METHOD_GET, METHOD_POST } from '../../common/constants';
@@ -17,7 +18,7 @@ import type { TimingStep } from '../../main/network/request-timing';
 import type { BaseModel } from '../../models';
 import * as models from '../../models';
 import type { CookieJar } from '../../models/cookie-jar';
-import type { UserUploadEnvironment } from '../../models/environment';
+import type { Environment, UserUploadEnvironment } from '../../models/environment';
 import { type GrpcRequest, isGrpcRequestId } from '../../models/grpc-request';
 import type { GrpcRequestMeta } from '../../models/grpc-request-meta';
 import * as requestOperations from '../../models/helpers/request-operations';
@@ -458,6 +459,7 @@ export interface CollectionRunnerContext {
   iterationResults: RunnerResultPerRequestPerIteration;
   done: boolean;
   responsesInfo: ResponseInfo[];
+  variables: Environment;
 }
 
 export interface RunnerContextForRequest {
@@ -479,6 +481,7 @@ export const sendActionImplementation = async ({
   testResultCollector,
   iteration,
   iterationCount,
+  transientVariables,
 }: {
     requestId: string;
   shouldPromptForPathAfterResponse: boolean | undefined;
@@ -487,12 +490,24 @@ export const sendActionImplementation = async ({
     iteration?: number;
     iterationCount?: number;
     userUploadEnvironment?: UserUploadEnvironment;
+    transientVariables?: Environment;
 }) => {
   window.main.startExecution({ requestId });
   const requestData = await fetchRequestData(requestId);
   const requestMeta = await models.requestMeta.getByParentId(requestId);
+  transientVariables = transientVariables || {
+    ...models.environment.init(),
+    _id: uuidv4(),
+    type: models.environment.type,
+    parentId: requestData.environment.parentId,
+    modified: 0,
+    created: Date.now(),
+    name: 'Transient Environment',
+    data: {},
+  };
+
   window.main.addExecutionStep({ requestId, stepName: 'Executing pre-request script' });
-  const mutatedContext = await tryToExecutePreRequestScript(requestData, userUploadEnvironment, iteration, iterationCount);
+  const mutatedContext = await tryToExecutePreRequestScript(requestData, transientVariables, userUploadEnvironment, iteration, iterationCount);
   if ('error' in mutatedContext) {
     throw {
       // create response with error info, so that we can store response in db and show it in response viewer
@@ -578,6 +593,7 @@ export const sendActionImplementation = async ({
   const postMutatedContext = await tryToExecuteAfterResponseScript({
     ...requestData,
     ...mutatedContext,
+    variables: mutatedContext.variables || transientVariables,
     response,
     iteration,
     iterationCount,

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -459,7 +459,7 @@ export interface CollectionRunnerContext {
   iterationResults: RunnerResultPerRequestPerIteration;
   done: boolean;
   responsesInfo: ResponseInfo[];
-  variables: Environment;
+  transientVariables: Environment;
 }
 
 export interface RunnerContextForRequest {
@@ -555,7 +555,7 @@ export const sendActionImplementation = async ({
     extraInfo: undefined,
     baseEnvironment: mutatedContext.baseEnvironment,
     userUploadEnvironment: mutatedContext.userUploadEnvironment,
-    variables: mutatedContext.variables,
+    transientVariables: mutatedContext.transientVariables,
     ignoreUndefinedEnvVariable,
   });
   const renderedRequest = await tryToTransformRequestWithPlugins(renderedResult);
@@ -594,7 +594,7 @@ export const sendActionImplementation = async ({
   const postMutatedContext = await tryToExecuteAfterResponseScript({
     ...requestData,
     ...mutatedContext,
-    variables: mutatedContext.variables || transientVariables,
+    transientVariables: mutatedContext.transientVariables || transientVariables,
     response,
     iteration,
     iterationCount,

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -555,6 +555,7 @@ export const sendActionImplementation = async ({
     extraInfo: undefined,
     baseEnvironment: mutatedContext.baseEnvironment,
     userUploadEnvironment: mutatedContext.userUploadEnvironment,
+    variables: mutatedContext.variables,
     ignoreUndefinedEnvVariable,
   });
   const renderedRequest = await tryToTransformRequestWithPlugins(renderedResult);

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -6,6 +6,7 @@ import { Panel, PanelResizeHandle } from 'react-resizable-panels';
 import { type ActionFunction, type LoaderFunction, redirect, useNavigate, useParams, useRouteLoaderData, useSearchParams, useSubmit } from 'react-router-dom';
 import { useListData } from 'react-stately';
 import { useInterval } from 'react-use';
+import { v4 as uuidv4 } from 'uuid';
 
 import { Tooltip } from '../../../src/ui/components/tooltip';
 import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from '../../common/constants';
@@ -892,6 +893,16 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
     iterationResults: [],
     done: false,
     responsesInfo: [],
+    variables: {
+      ...models.environment.init(),
+      _id: uuidv4(),
+      type: models.environment.type,
+      parentId: '',
+      modified: 0,
+      created: Date.now(),
+      name: 'Transient Environment',
+      data: {},
+    },
   };
 
   window.main.startExecution({ requestId: workspaceId });
@@ -968,6 +979,7 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
             shouldPromptForPathAfterResponse: false,
             ignoreUndefinedEnvVariable: true,
             testResultCollector: resultCollector,
+            transientVariables: testCtx.variables,
           }) as RequestContext | null;
           if (mutatedContext?.execution?.nextRequestIdOrName) {
             nextRequestIdOrName = mutatedContext.execution.nextRequestIdOrName || '';

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -893,14 +893,14 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
     iterationResults: [],
     done: false,
     responsesInfo: [],
-    variables: {
+    transientVariables: {
       ...models.environment.init(),
       _id: uuidv4(),
       type: models.environment.type,
       parentId: '',
       modified: 0,
       created: Date.now(),
-      name: 'Transient Environment',
+      name: 'Transient Variables',
       data: {},
     },
   };
@@ -979,7 +979,7 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
             shouldPromptForPathAfterResponse: false,
             ignoreUndefinedEnvVariable: true,
             testResultCollector: resultCollector,
-            transientVariables: testCtx.variables,
+            transientVariables: testCtx.transientVariables,
           }) as RequestContext | null;
           if (mutatedContext?.execution?.nextRequestIdOrName) {
             nextRequestIdOrName = mutatedContext.execution.nextRequestIdOrName || '';


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Background
When `insomnia.variables.set` sets a variable, the variable should exist during whole runner execution period. Currently it is dropped after requesting.

### Changes
- [x] Wired up predefined local variables from runner to script runtime
- [x] Input local variables to the rendering step 
- [x] Added and updated tests

Ref: INS-4665, #8148 