### PR TITLE
Fix the bug that users can not create self hosted mock server [INS-4672]

### DIFF
--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -280,6 +280,7 @@ export const createNewWorkspaceAction: ActionFunction = async ({
     if (mockServerType === 'self-hosted') {
       const mockServerUrl = formData.get('mockServerUrl');
       invariant(typeof mockServerUrl === 'string', 'Mock Server URL is required');
+      mockServerPatch.useInsomniaCloud = false;
       mockServerPatch.url = mockServerUrl;
     }
 


### PR DESCRIPTION
Users can not create self hosted mock server because we omitted the useInsomniaCloud property when creating mock server.