### PR TITLE
fix: enable copying auth tokens when visible

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -187,11 +187,6 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     codeMirror.current.on('blur', () => codeMirror.current?.getTextArea().parentElement?.removeAttribute('data-focused'));
     codeMirror.current.on('focus', () => codeMirror.current?.getTextArea().parentElement?.setAttribute('data-focused', 'on'));
     codeMirror.current.on('keyHandled', (_: CodeMirror.Editor, _keyName: string, event: Event) => event.stopPropagation());
-    // Prevent these things if we're type === "password"
-    const preventDefault = (_: CodeMirror.Editor, event: Event) => type?.toLowerCase() === 'password' && event.preventDefault();
-    codeMirror.current.on('copy', preventDefault);
-    codeMirror.current.on('cut', preventDefault);
-    codeMirror.current.on('dragstart', preventDefault);
 
     // Actually set the value
     codeMirror.current?.setValue(defaultValue || '');
@@ -206,7 +201,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
         id,
       );
     }
-  }, [defaultValue, getAutocompleteConstants, handleGetRenderContext, handleRender, onBlur, onKeyDown, onPaste, placeholder, readOnly, settings.autocompleteDelay, settings.editorKeyMap, settings.hotKeyRegistry, settings.nunjucksPowerUserMode, settings.showVariableSourceAndValue, type, eventListeners, id]);
+  }, [defaultValue, getAutocompleteConstants, handleGetRenderContext, handleRender, onBlur, onKeyDown, onPaste, placeholder, readOnly, settings.autocompleteDelay, settings.editorKeyMap, settings.hotKeyRegistry, settings.nunjucksPowerUserMode, settings.showVariableSourceAndValue, eventListeners, id]);
 
   const cleanUpEditor = useCallback(() => {
     codeMirror.current?.toTextArea();
@@ -226,6 +221,20 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
   }, [cleanUpEditor, initEditor]);
 
   useEditorRefresh(reinitialize);
+
+  useEffect(() => {
+      // Prevent these things if we're type === "password"
+      const preventDefault = (_: CodeMirror.Editor, event: Event) => type?.toLowerCase() === 'password' && event.preventDefault();
+      codeMirror.current?.on('copy', preventDefault);
+      codeMirror.current?.on('cut', preventDefault);
+      codeMirror.current?.on('dragstart', preventDefault);
+
+      return () => {
+        codeMirror.current?.off('copy', preventDefault);
+        codeMirror.current?.off('cut', preventDefault);
+        codeMirror.current?.off('dragstart', preventDefault);
+      };
+  }, [type]);
 
   useEffect(() => {
     const fn = misc.debounce((doc: CodeMirror.Editor) => {


### PR DESCRIPTION
## What this PR does

This pull request fix the copy of unhidden auth tokens. This PR register a cleanup function inside the useEffect that removes the event function that blocks copying.

Closes #8145

Test:
![test-auth-token](https://github.com/user-attachments/assets/21f0b499-4966-49a2-9f78-ca6f90afa2d9)

