### PR TITLE
Add restrictions when creating, editing mock server [INS-4667] [INS-4645]

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -24,6 +24,7 @@ import {
   isRemoteProject,
   type Project,
 } from '../../../models/project';
+import { ORG_STORAGE_RULE, type OrgStorageRuleType } from '../../routes/organization';
 import { Icon } from '../icon';
 import { showAlert, showModal } from '../modals';
 import { AskModal } from '../modals/ask-modal';
@@ -31,7 +32,7 @@ import { AskModal } from '../modals/ask-modal';
 interface Props {
   project: Project & { hasUncommittedOrUnpushedChanges?: boolean };
   organizationId: string;
-  storage: 'cloud_only' | 'local_only' | 'cloud_plus_local';
+  storage: OrgStorageRuleType;
 }
 
 interface ProjectActionItem {
@@ -48,10 +49,10 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
   const updateProjectFetcher = useFetcher();
   const [projectType, setProjectType] = useState<'local' | 'remote' | ''>('');
 
-  const isRemoteProjectInconsistent = isRemoteProject(project) && storage === 'local_only';
-  const isLocalProjectInconsistent = !isRemoteProject(project) && storage === 'cloud_only';
+  const isRemoteProjectInconsistent = isRemoteProject(project) && storage === ORG_STORAGE_RULE.LOCAL_ONLY;
+  const isLocalProjectInconsistent = !isRemoteProject(project) && storage === ORG_STORAGE_RULE.CLOUD_ONLY;
   const isProjectInconsistent = isRemoteProjectInconsistent || isLocalProjectInconsistent;
-  const showStorageRestrictionMessage = storage !== 'cloud_plus_local';
+  const showStorageRestrictionMessage = storage !== ORG_STORAGE_RULE.CLOUD_PLUS_LOCAL;
 
   const projectActionList: ProjectActionItem[] = [
     {
@@ -123,7 +124,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
             offset={4}
             className="border select-none text-sm max-w-xs border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] text-[--color-font] px-4 py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
           >
-            {`This project type is not allowed by the organization owner. You can manually convert it to use ${storage === 'cloud_only' ? 'Cloud Sync' : 'Local Vault'}.`}
+            {`This project type is not allowed by the organization owner. You can manually convert it to use ${storage === ORG_STORAGE_RULE.CLOUD_ONLY ? 'Cloud Sync' : 'Local Vault'}.`}
           </Tooltip>
         </TooltipTrigger>
       }
@@ -238,13 +239,13 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
                         className="py-1 placeholder:italic w-full pl-2 pr-7 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font] focus:outline-none focus:ring-1 focus:ring-[--hl-md] transition-colors"
                       />
                     </TextField>
-                    <RadioGroup name="type" defaultValue={storage === 'cloud_plus_local' ? project.remoteId ? 'remote' : 'local' : storage !== 'cloud_only' ? 'local' : 'remote'} className="flex flex-col gap-2">
+                    <RadioGroup name="type" defaultValue={storage === ORG_STORAGE_RULE.CLOUD_PLUS_LOCAL ? project.remoteId ? 'remote' : 'local' : storage !== ORG_STORAGE_RULE.CLOUD_ONLY ? 'local' : 'remote'} className="flex flex-col gap-2">
                       <Label className="text-sm text-[--hl]">
                         Project type
                       </Label>
                       <div className="flex gap-2">
                         <Radio
-                          isDisabled={storage === 'local_only'}
+                          isDisabled={storage === ORG_STORAGE_RULE.LOCAL_ONLY}
                           value="remote"
                           className="data-[selected]:border-[--color-surprise] flex-1 data-[disabled]:opacity-25 data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
                         >
@@ -257,7 +258,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
                           </p>
                         </Radio>
                         <Radio
-                          isDisabled={storage === 'cloud_only'}
+                          isDisabled={storage === ORG_STORAGE_RULE.CLOUD_ONLY}
                           value="local"
                           className="data-[selected]:border-[--color-surprise] flex-1 data-[disabled]:opacity-25 data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
                         >

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -24,7 +24,7 @@ import {
   isRemoteProject,
   type Project,
 } from '../../../models/project';
-import { ORG_STORAGE_RULE, type OrgStorageRuleType } from '../../routes/organization';
+import { ORG_STORAGE_RULE } from '../../routes/organization';
 import { Icon } from '../icon';
 import { showAlert, showModal } from '../modals';
 import { AskModal } from '../modals/ask-modal';
@@ -32,7 +32,7 @@ import { AskModal } from '../modals/ask-modal';
 interface Props {
   project: Project & { hasUncommittedOrUnpushedChanges?: boolean };
   organizationId: string;
-  storage: OrgStorageRuleType;
+  storage: ORG_STORAGE_RULE;
 }
 
 interface ProjectActionItem {

--- a/packages/insomnia/src/ui/components/editors/mock-response-extractor.tsx
+++ b/packages/insomnia/src/ui/components/editors/mock-response-extractor.tsx
@@ -11,6 +11,7 @@ import { getContentTypeName, getMimeTypeFromContentType } from '../../../common/
 import type { ResponseHeader } from '../../../models/response';
 import { invariant } from '../../../utils/invariant';
 import { isInMockContentTypeList, useMockRoutePatcher } from '../../routes/mock-route';
+import type { OrganizationLoaderData } from '../../routes/organization';
 import type { RequestLoaderData } from '../../routes/request';
 import type { WorkspaceLoaderData } from '../../routes/workspace';
 import { HelpTooltip } from '../help-tooltip';
@@ -19,10 +20,44 @@ import { showModal, showPrompt } from '../modals';
 import { AlertModal } from '../modals/alert-modal';
 
 export const MockResponseExtractor = () => {
+  // file://./../../routes/request.tsx#loader
+  const requestLoaderData = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const { activeResponse } = requestLoaderData;
+  let { mockServerAndRoutes } = requestLoaderData;
+
+  // file://./../../routes/workspace.tsx#workspaceLoader
   const {
+    activeProject,
     activeWorkspace,
   } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
-  const { mockServerAndRoutes, activeResponse } = useRouteLoaderData('request/:requestId') as RequestLoaderData;
+  const isLocalProject = !activeProject?.remoteId;
+  const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
+  const isEnterprise = currentPlan?.type.includes('enterprise');
+
+  // In a local project, users are not allowed to create a cloud mock server, only enterprise users can create a self-hosted mock server.
+  // In a local project, users without enterprise plan can't create cloud mock server route from a request response
+  // In a local project, users who are with an enterprise plan but does not have an existing self-hosted mock server need to create a self-hosted mock server manually before they create a self-hosted mock server route from a request response
+  // In a local project, users who are with an enterprise plan and have existing self-hosted mock servers as well can create a mock server route from a request response in existing self-hosted mock servers
+  let tipPreventingUserFromCreatingMockRoute = '';
+  let canOnlyChooseExistingMockServer = false;
+  if (isLocalProject) {
+    if (!isEnterprise) {
+      tipPreventingUserFromCreatingMockRoute = `You can't create a cloud mock server route in a local project.
+Please alter your project to a cloud project to create a cloud mock server route.
+If you want to create a self-hosted mock server route, you need to upgrade to an enterprise plan.`;
+    } else {
+      mockServerAndRoutes = mockServerAndRoutes.filter(({ useInsomniaCloud }) => !useInsomniaCloud);
+      if (mockServerAndRoutes.length === 0) {
+        // does not have existing self-hosted mock server
+        tipPreventingUserFromCreatingMockRoute = `You can't create a cloud mock server route in a local project.
+If you want to create a self-hosted mock server route from a request response in a local project, please create a self-hosted mock server in project panel manually first.`;
+      } else {
+        // has existing self-hosted mock server
+        canOnlyChooseExistingMockServer = true;
+      }
+    }
+  }
+
   const patchMockRoute = useMockRoutePatcher();
   const navigate = useNavigate();
   const {
@@ -31,7 +66,11 @@ export const MockResponseExtractor = () => {
     workspaceId,
   } = useParams();
   const fetcher = useFetcher();
-  const [selectedMockServer, setSelectedMockServer] = useState('');
+  const [selectedMockServer, setSelectedMockServer] = useState(
+    canOnlyChooseExistingMockServer
+      ? mockServerAndRoutes[0]._id
+      : ''
+  );
   const [selectedMockRoute, setSelectedMockRoute] = useState('');
   const maybeMimeType = activeResponse && getMimeTypeFromContentType(activeResponse.contentType);
   const mimeType = maybeMimeType && isInMockContentTypeList(maybeMimeType) ? maybeMimeType : 'text/plain';
@@ -40,176 +79,188 @@ export const MockResponseExtractor = () => {
       <div className="flex place-content-center text-9xl pb-8 text-[--hl-md]">
         <Icon icon="cube" />
       </div>
-      <div className="flex place-content-center pb-2">
-        Transform this
-        {activeResponse?.contentType ? getContentTypeName(activeResponse?.contentType) === 'Other' ? '' : ` ${getContentTypeName(activeResponse?.contentType)}` : ''} response to a new mock route or overwrite an existing one.
-      </div>
-      <form
-        onSubmit={async e => {
-          e.preventDefault();
-          if (selectedMockServer && selectedMockRoute) {
-            if (activeResponse) {
-              // TODO: move this out of the renderer, and upsert mock
-              const body = await fs.readFile(activeResponse.bodyPath);
+      {tipPreventingUserFromCreatingMockRoute
+        ? (
+          <div className="flex place-content-center pb-2 whitespace-pre-line">
+            {tipPreventingUserFromCreatingMockRoute}
+          </div>
+        )
+        : (<>
+          <div className="flex place-content-center pb-2">
+            Transform this
+            {activeResponse?.contentType ? getContentTypeName(activeResponse?.contentType) === 'Other' ? '' : ` ${getContentTypeName(activeResponse?.contentType)}` : ''} response to a new mock route or overwrite an existing one.
+          </div>
+          <form
+            onSubmit={async e => {
+              e.preventDefault();
+              if (selectedMockServer && selectedMockRoute) {
+                if (activeResponse) {
+                  // TODO: move this out of the renderer, and upsert mock
+                  const body = await fs.readFile(activeResponse.bodyPath);
 
-              patchMockRoute(selectedMockRoute, {
-                body: body.toString(),
-                mimeType,
-                statusCode: activeResponse.statusCode,
-                headers: activeResponse.headers,
-              });
-            }
-            return;
-          }
-          let path = '/new-route';
-          try {
-            path = activeResponse ? new URL(activeResponse.url).pathname : '/new-route';
-          } catch (e) {
-            console.log(e);
-          }
-          // Create new mock server and route
-          if (!selectedMockServer) {
-            showPrompt({
-              title: 'Create Mock Route',
-              defaultValue: path,
-              label: 'Name',
-              onComplete: async name => {
-                invariant(activeResponse, 'Active response must be defined');
-                const body = await fs.readFile(activeResponse.bodyPath);
-                // auth mechanism is too sensitive to allow content length checks
-                const headersWithoutContentLength: ResponseHeader[] = activeResponse.headers.filter(h => h.name.toLowerCase() !== 'content-length');
-                fetcher.submit(
-                  JSON.stringify({
-                    name: name,
+                  patchMockRoute(selectedMockRoute, {
                     body: body.toString(),
                     mimeType,
                     statusCode: activeResponse.statusCode,
-                    headers: headersWithoutContentLength,
-                    mockServerName: activeWorkspace.name,
-                  }),
-                  {
-                    encType: 'application/json',
-                    method: 'post',
-                    action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/mock-server/mock-route/new`,
-                  }
-                );
-              },
-            });
-            return;
-          }
-          // Create new mock route
-          if (!selectedMockRoute) {
-            showPrompt({
-              title: 'Create Mock Route',
-              defaultValue: path,
-              label: 'Name',
-              onComplete: async name => {
-                invariant(activeResponse, 'Active response must be defined');
-                const body = await fs.readFile(activeResponse.bodyPath);
-                const hasRouteInServer = mockServerAndRoutes.find(s => s._id === selectedMockServer)?.routes
-                  .find(r => r.name === name && r.method.toUpperCase() === 'GET');
-                if (hasRouteInServer) {
-                  showModal(AlertModal, {
-                    title: 'Error',
-                    message: `Path "${name}" and method must be unique. Please enter a different name.`,
+                    headers: activeResponse.headers,
                   });
-                  return;
-                };
-                // auth mechanism is too sensitive to allow content length checks
-                const headersWithoutContentLength: ResponseHeader[] = activeResponse.headers.filter(h => h.name.toLowerCase() !== 'content-length');
-                fetcher.submit(
-                  JSON.stringify({
-                    name: name,
-                    parentId: selectedMockServer,
-                    body: body.toString(),
-                    mimeType,
-                    statusCode: activeResponse.statusCode,
-                    headers: headersWithoutContentLength,
-                  }),
-                  {
-                    encType: 'application/json',
-                    method: 'post',
-                    action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/mock-server/mock-route/new`,
-                  }
-                );
-              },
-            });
-          }
+                }
+                return;
+              }
+              let path = '/new-route';
+              try {
+                path = activeResponse ? new URL(activeResponse.url).pathname : '/new-route';
+              } catch (e) {
+                console.log(e);
+              }
+              // Create new mock server and route
+              if (!selectedMockServer) {
+                showPrompt({
+                  title: 'Create Mock Route',
+                  defaultValue: path,
+                  label: 'Name',
+                  onComplete: async name => {
+                    invariant(activeResponse, 'Active response must be defined');
+                    const body = await fs.readFile(activeResponse.bodyPath);
+                    // auth mechanism is too sensitive to allow content length checks
+                    const headersWithoutContentLength: ResponseHeader[] = activeResponse.headers.filter(h => h.name.toLowerCase() !== 'content-length');
+                    // file://./../../routes/actions.tsx#createMockRouteAction
+                    fetcher.submit(
+                      JSON.stringify({
+                        name: name,
+                        body: body.toString(),
+                        mimeType,
+                        statusCode: activeResponse.statusCode,
+                        headers: headersWithoutContentLength,
+                        mockServerName: activeWorkspace.name,
+                      }),
+                      {
+                        encType: 'application/json',
+                        method: 'post',
+                        action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/mock-server/mock-route/new`,
+                      }
+                    );
+                  },
+                });
+                return;
+              }
+              // Create new mock route
+              if (!selectedMockRoute) {
+                showPrompt({
+                  title: 'Create Mock Route',
+                  defaultValue: path,
+                  label: 'Name',
+                  onComplete: async name => {
+                    invariant(activeResponse, 'Active response must be defined');
+                    const body = await fs.readFile(activeResponse.bodyPath);
+                    const hasRouteInServer = mockServerAndRoutes.find(s => s._id === selectedMockServer)?.routes
+                      .find(r => r.name === name && r.method.toUpperCase() === 'GET');
+                    if (hasRouteInServer) {
+                      showModal(AlertModal, {
+                        title: 'Error',
+                        message: `Path "${name}" and method must be unique. Please enter a different name.`,
+                      });
+                      return;
+                    };
+                    // auth mechanism is too sensitive to allow content length checks
+                    const headersWithoutContentLength: ResponseHeader[] = activeResponse.headers.filter(h => h.name.toLowerCase() !== 'content-length');
+                    fetcher.submit(
+                      JSON.stringify({
+                        name: name,
+                        parentId: selectedMockServer,
+                        body: body.toString(),
+                        mimeType,
+                        statusCode: activeResponse.statusCode,
+                        headers: headersWithoutContentLength,
+                      }),
+                      {
+                        encType: 'application/json',
+                        method: 'post',
+                        action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/mock-server/mock-route/new`,
+                      }
+                    );
+                  },
+                });
+              }
 
-        }}
-      >
-        <div className="form-row">
-          <div className="form-control form-control--outlined">
-            <label>
-              Choose Mock Server
-              <HelpTooltip position="top" className="space-left">
-                Select from created mock servers to add the route to
-              </HelpTooltip>
-              <select
-                value={selectedMockServer}
-                onChange={event => {
-                  const selected = event.currentTarget.value;
-                  setSelectedMockServer(selected);
-                  setSelectedMockRoute('');
-                }}
-              >
-                <option value="">-- Create new --</option>
-                {mockServerAndRoutes
-                  .map(w => (
-                    <option key={w._id} value={w._id}>
-                      {w.name}
-                    </option>
-                  ))
-                }
-              </select>
-            </label>
-          </div>
-        </div>
-        <div className="form-row">
-          <div className="form-control form-control--outlined">
-            <label>
-              Choose Mock Route
-              <HelpTooltip position="top" className="space-left">
-                Select from created mock routes to overwrite with this response
-              </HelpTooltip>
-              <select
-                value={selectedMockRoute}
-                onChange={event => {
-                  const selected = event.currentTarget.value;
-                  setSelectedMockRoute(selected);
-                }}
-              >
-                <option value="">-- Create new --</option>
-                {mockServerAndRoutes.find(s => s._id === selectedMockServer)?.routes
-                  .map(w => (
-                    <option key={w._id} value={w._id}>
-                      {w.name}
-                    </option>
-                  ))
-                }
-              </select>
-            </label>
-          </div>
-        </div>
-        <div className="flex mt-2">
-          <Button
-            type="submit"
-            className="mr-2 hover:no-underline bg-opacity-100 bg-[rgba(var(--color-surprise-rgb),var(--tw-bg-opacity))] hover:bg-opacity-90 border border-solid border-[--hl-md] py-2 px-3 text-[--color-font-surprise] aria-pressed:bg-opacity-80 focus:ring-[--hl-md] transition-colors rounded-sm"
-          >
-            {selectedMockRoute ? 'Overwrite' : 'Create'}
-          </Button>
-          <Button
-            isDisabled={!selectedMockServer || !selectedMockRoute}
-            onPress={() => {
-              const mockWorkspaceId = mockServerAndRoutes.find(s => s._id === selectedMockServer)?.parentId;
-              navigate(`/organization/${organizationId}/project/${projectId}/workspace/${mockWorkspaceId}/mock-server/mock-route/${selectedMockRoute}`);
             }}
-            className="flex items-center justify-center py-2 px-3 gap-2 bg-[--hl-xxs] aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
           >
-            Go to mock
-          </Button>
-        </div>
-      </form>
+            <div className="form-row">
+              <div className="form-control form-control--outlined">
+                <label>
+                  Choose Mock Server
+                  <HelpTooltip position="top" className="space-left">
+                    Select from created mock servers to add the route to
+                  </HelpTooltip>
+                  <select
+                    value={selectedMockServer}
+                    onChange={event => {
+                      const selected = event.currentTarget.value;
+                      setSelectedMockServer(selected);
+                      setSelectedMockRoute('');
+                    }}
+                  >
+                    {!canOnlyChooseExistingMockServer && (
+                      <option value="">-- Create new --</option>
+                    )}
+                    {mockServerAndRoutes
+                      .map(w => (
+                        <option key={w._id} value={w._id}>
+                          {w.name}
+                        </option>
+                      ))
+                    }
+                  </select>
+                </label>
+              </div>
+            </div>
+            <div className="form-row">
+              <div className="form-control form-control--outlined">
+                <label>
+                  Choose Mock Route
+                  <HelpTooltip position="top" className="space-left">
+                    Select from created mock routes to overwrite with this response
+                  </HelpTooltip>
+                  <select
+                    value={selectedMockRoute}
+                    onChange={event => {
+                      const selected = event.currentTarget.value;
+                      setSelectedMockRoute(selected);
+                    }}
+                  >
+                    <option value="">-- Create new --</option>
+                    {mockServerAndRoutes.find(s => s._id === selectedMockServer)?.routes
+                      .map(w => (
+                        <option key={w._id} value={w._id}>
+                          {w.name}
+                        </option>
+                      ))
+                    }
+                  </select>
+                </label>
+              </div>
+            </div>
+            <div className="flex mt-2">
+              <Button
+                type="submit"
+                className="mr-2 hover:no-underline bg-opacity-100 bg-[rgba(var(--color-surprise-rgb),var(--tw-bg-opacity))] hover:bg-opacity-90 border border-solid border-[--hl-md] py-2 px-3 text-[--color-font-surprise] aria-pressed:bg-opacity-80 focus:ring-[--hl-md] transition-colors rounded-sm"
+              >
+                {selectedMockRoute ? 'Overwrite' : 'Create'}
+              </Button>
+              <Button
+                isDisabled={!selectedMockServer || !selectedMockRoute}
+                onPress={() => {
+                  const mockWorkspaceId = mockServerAndRoutes.find(s => s._id === selectedMockServer)?.parentId;
+                  navigate(`/organization/${organizationId}/project/${projectId}/workspace/${mockWorkspaceId}/mock-server/mock-route/${selectedMockRoute}`);
+                }}
+                className="flex items-center justify-center py-2 px-3 gap-2 bg-[--hl-xxs] aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+              >
+                Go to mock
+              </Button>
+            </div>
+          </form>
+        </>)
+      }
     </div>
   );
 };

--- a/packages/insomnia/src/ui/components/modals/mock-server-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/mock-server-settings-modal.tsx
@@ -1,25 +1,50 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button, Dialog, Heading, Input, Label, Link, Modal, ModalOverlay, Radio, RadioGroup, TextField } from 'react-aria-components';
 import { useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
 import { invariant } from '../../../utils/invariant';
-import type { OrganizationLoaderData } from '../../routes/organization';
+import { fetchAndCacheOrganizationStorageRule, ORG_STORAGE_RULE, type OrganizationLoaderData, type OrgStorageRuleType } from '../../routes/organization';
 import type { ProjectIdLoaderData } from '../../routes/project';
 import { Icon } from '../icon';
 import { showModal } from '.';
 import { AlertModal } from './alert-modal';
 
-export const MockServerSettingsModal = ({ onClose }: { onClose: () => void }) => {
+export function useAvailableMockServerType(isLocalProject: boolean) {
   const { organizationId, projectId } = useParams<{ organizationId: string; projectId: string }>();
+  const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
+  const [orgStorageRule, setOrgStorageRule] = useState<OrgStorageRuleType>(ORG_STORAGE_RULE.CLOUD_PLUS_LOCAL);
+  useEffect(() => {
+    fetchAndCacheOrganizationStorageRule(organizationId as string).then(setOrgStorageRule);
+  }, [organizationId]);
+
+  const isEnterprise = currentPlan?.type.includes('enterprise');
+  const isSelfHostedDisabled = !isEnterprise || orgStorageRule === ORG_STORAGE_RULE.CLOUD_ONLY;
+  const isCloudProjectDisabled = isLocalProject || orgStorageRule === ORG_STORAGE_RULE.LOCAL_ONLY;
+  return {
+    isSelfHostedDisabled,
+    isCloudProjectDisabled,
+    organizationId,
+    projectId,
+    isEnterprise,
+    isLocalProject,
+  };
+}
+
+export const MockServerSettingsModal = ({ onClose }: { onClose: () => void }) => {
+  // file://./../../routes/project.tsx#projectIdLoader
+  const projectData = useRouteLoaderData('/project/:projectId') as ProjectIdLoaderData | null;
+  const isLocalProject = !projectData?.activeProject?.remoteId;
+  const {
+    isSelfHostedDisabled,
+    isCloudProjectDisabled,
+    organizationId,
+    projectId,
+    isEnterprise,
+  } = useAvailableMockServerType(isLocalProject);
   const fetcher = useFetcher({
     key: `${organizationId}-create-mock-server`,
   });
-  const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
-  const projectData = useRouteLoaderData('/project/:projectId') as ProjectIdLoaderData | null;
-  const isLocalProject = !projectData?.activeProject?.remoteId;
-  const isEnterprise = currentPlan?.type.includes('enterprise');
-  const isSelfHostedDisabled = !isEnterprise;
-  const isCloudProjectDisabled = isLocalProject;
+
   const canOnlyCreateSelfHosted = isLocalProject && isEnterprise;
   const defaultServerType = canOnlyCreateSelfHosted ? 'self-hosted' : 'cloud';
   const [serverType, setServerType] = useState<'self-hosted' | 'cloud'>(defaultServerType);
@@ -83,6 +108,7 @@ export const MockServerSettingsModal = ({ onClose }: { onClose: () => void }) =>
                     }
                   }
 
+                  // file://./../../routes/actions.tsx#createNewWorkspaceAction
                   fetcher.submit(
                     {
                       name,

--- a/packages/insomnia/src/ui/components/modals/mock-server-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/mock-server-settings-modal.tsx
@@ -3,7 +3,7 @@ import { Button, Dialog, Heading, Input, Label, Link, Modal, ModalOverlay, Radio
 import { useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
 import { invariant } from '../../../utils/invariant';
-import { fetchAndCacheOrganizationStorageRule, ORG_STORAGE_RULE, type OrganizationLoaderData, type OrgStorageRuleType } from '../../routes/organization';
+import { fetchAndCacheOrganizationStorageRule, ORG_STORAGE_RULE, type OrganizationLoaderData } from '../../routes/organization';
 import type { ProjectIdLoaderData } from '../../routes/project';
 import { Icon } from '../icon';
 import { showModal } from '.';
@@ -12,7 +12,7 @@ import { AlertModal } from './alert-modal';
 export function useAvailableMockServerType(isLocalProject: boolean) {
   const { organizationId, projectId } = useParams<{ organizationId: string; projectId: string }>();
   const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
-  const [orgStorageRule, setOrgStorageRule] = useState<OrgStorageRuleType>(ORG_STORAGE_RULE.CLOUD_PLUS_LOCAL);
+  const [orgStorageRule, setOrgStorageRule] = useState<ORG_STORAGE_RULE>(ORG_STORAGE_RULE.CLOUD_PLUS_LOCAL);
   useEffect(() => {
     fetchAndCacheOrganizationStorageRule(organizationId as string).then(setOrgStorageRule);
   }, [organizationId]);

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -1146,9 +1146,6 @@ async function renderApp() {
 
   // Store the last location in local storage
   router.subscribe(({ location, navigation }) => {
-    if (location.pathname && navigation.location?.pathname) {
-      console.log('navigating', location.pathname, navigation.location?.pathname);
-    }
     const match = matchPath(
       {
         path: '/organization/:organizationId',

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -1146,6 +1146,9 @@ async function renderApp() {
 
   // Store the last location in local storage
   router.subscribe(({ location, navigation }) => {
+    if (location.pathname && navigation.location?.pathname) {
+      console.log('navigating', location.pathname, navigation.location?.pathname);
+    }
     const match = matchPath(
       {
         path: '/organization/:organizationId',

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -249,22 +249,6 @@ async function migrateProjectsUnderOrganization(personalOrganizationId: string, 
   }
 };
 
-async function syncStorageRule(sessionId: string, organizationId: string) {
-  try {
-    const storageRule = await insomniaFetch<StorageRule | undefined>({
-      method: 'GET',
-      path: `/v1/organizations/${organizationId}/storage-rule`,
-      sessionId,
-    });
-
-    invariant(storageRule, 'Failed to load storageRule');
-
-    inMemoryStorageRuleCache.set(organizationId, storageRule);
-  } catch (error) {
-    console.log('[storageRule] Failed to load storage rules', error);
-  }
-}
-
 export const indexLoader: LoaderFunction = async () => {
   const { id: sessionId, accountId } = await userSession.getOrCreate();
   if (sessionId) {
@@ -302,20 +286,6 @@ export const syncOrganizationsAction: ActionFunction = async () => {
 
   if (sessionId) {
     await syncOrganizations(sessionId, accountId);
-  }
-
-  return null;
-};
-
-export const syncOrganizationStorageRuleAction: ActionFunction = async ({ params }) => {
-  const { organizationId } = params;
-
-  invariant(organizationId, 'Organization ID is required');
-
-  const { id: sessionId } = await userSession.getOrCreate();
-
-  if (sessionId) {
-    await syncStorageRule(sessionId, organizationId);
   }
 
   return null;
@@ -366,9 +336,17 @@ export interface Billing {
   accessDenied: boolean;
 }
 
-export const DefaultStorage = 'cloud_plus_local';
+export enum ORG_STORAGE_RULE {
+  CLOUD_PLUS_LOCAL = 'cloud_plus_local',
+  CLOUD_ONLY = 'cloud_only',
+  LOCAL_ONLY = 'local_only',
+};
+
+// https://stackoverflow.com/a/59496175/5714454
+export type OrgStorageRuleType = `${ORG_STORAGE_RULE}`;
+
 export interface StorageRule {
-  storage: 'cloud_plus_local' | 'cloud_only' | 'local_only';
+  storage: OrgStorageRuleType;
   isOverridden: boolean;
 }
 
@@ -377,7 +355,7 @@ export interface OrganizationFeatureLoaderData {
   billingPromise: Promise<Billing>;
 }
 export interface OrganizationStorageLoaderData {
-  storagePromise: Promise<'cloud_plus_local' | 'cloud_only' | 'local_only'>;
+  storagePromise: Promise<OrgStorageRuleType>;
 }
 
 // Create an in-memory storage to store the storage rules
@@ -385,39 +363,53 @@ export const inMemoryStorageRuleCache: Map<string, StorageRule> = new Map<string
 
 export const organizationStorageLoader: LoaderFunction = async ({ params }): Promise<OrganizationStorageLoaderData> => {
   const { organizationId } = params as { organizationId: string };
+  return {
+    storagePromise: fetchAndCacheOrganizationStorageRule(organizationId),
+  };
+};
+
+export const syncOrganizationStorageRuleAction: ActionFunction = async ({ params }) => {
+  const { organizationId } = params;
+  await fetchAndCacheOrganizationStorageRule(organizationId, true);
+  return null;
+};
+
+export async function fetchAndCacheOrganizationStorageRule(
+  organizationId: string | undefined,
+  forceFetch: boolean = false,
+): Promise<OrgStorageRuleType> {
+  invariant(organizationId, 'Organization ID is required');
+
+  if (isScratchpadOrganizationId(organizationId)) {
+    return ORG_STORAGE_RULE.LOCAL_ONLY;
+  }
+  if (!forceFetch) {
+    const storageRule = inMemoryStorageRuleCache.get(organizationId);
+    if (storageRule) {
+      return storageRule.storage;
+    }
+  }
   const { id: sessionId } = await userSession.getOrCreate();
 
-  const storageRule = inMemoryStorageRuleCache.get(organizationId);
-
-  if (storageRule) {
-    return {
-      storagePromise: Promise.resolve(storageRule.storage),
-    };
-  }
-
   // Otherwise fetch from the API
-  try {
-    const storageRuleResponse = insomniaFetch<StorageRule | undefined>({
-      method: 'GET',
-      path: `/v1/organizations/${organizationId}/storage-rule`,
-      sessionId,
-    });
-
-    // Return the value
-    return {
-      storagePromise: storageRuleResponse.then(res => {
-        if (res) {
-          inMemoryStorageRuleCache.set(organizationId, res);
-        }
-        return res?.storage || DefaultStorage;
-      }),
-    };
-  } catch (err) {
-    return {
-      storagePromise: Promise.resolve(DefaultStorage),
-    };
-  }
-};
+  return await insomniaFetch<StorageRule | undefined>({
+    method: 'GET',
+    path: `/v1/organizations/${organizationId}/storage-rule`,
+    sessionId,
+    onlyResolveOnSuccess: true,
+  }).then(
+    res => {
+      if (res) {
+        inMemoryStorageRuleCache.set(organizationId, res);
+      }
+      return res?.storage || ORG_STORAGE_RULE.CLOUD_PLUS_LOCAL;
+    },
+    err => {
+      console.log('[storageRule] Failed to load storage rules', err.message);
+      return ORG_STORAGE_RULE.CLOUD_PLUS_LOCAL;
+    }
+  );
+}
 
 export const organizationPermissionsLoader: LoaderFunction = async ({ params }): Promise<OrganizationFeatureLoaderData> => {
   const { organizationId } = params as { organizationId: string };

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -342,11 +342,8 @@ export enum ORG_STORAGE_RULE {
   LOCAL_ONLY = 'local_only',
 };
 
-// https://stackoverflow.com/a/59496175/5714454
-export type OrgStorageRuleType = `${ORG_STORAGE_RULE}`;
-
 export interface StorageRule {
-  storage: OrgStorageRuleType;
+  storage: ORG_STORAGE_RULE;
   isOverridden: boolean;
 }
 
@@ -355,7 +352,7 @@ export interface OrganizationFeatureLoaderData {
   billingPromise: Promise<Billing>;
 }
 export interface OrganizationStorageLoaderData {
-  storagePromise: Promise<OrgStorageRuleType>;
+  storagePromise: Promise<ORG_STORAGE_RULE>;
 }
 
 // Create an in-memory storage to store the storage rules
@@ -377,7 +374,7 @@ export const syncOrganizationStorageRuleAction: ActionFunction = async ({ params
 export async function fetchAndCacheOrganizationStorageRule(
   organizationId: string | undefined,
   forceFetch: boolean = false,
-): Promise<OrgStorageRuleType> {
+): Promise<ORG_STORAGE_RULE> {
   invariant(organizationId, 'Organization ID is required');
 
   if (isScratchpadOrganizationId(organizationId)) {

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -90,7 +90,7 @@ import { TimeFromNow } from '../components/time-from-now';
 import { useInsomniaEventStreamContext } from '../context/app/insomnia-event-stream-context';
 import { useLoaderDeferData } from '../hooks/use-loader-defer-data';
 import { useOrganizationPermissions } from '../hooks/use-organization-features';
-import { DefaultStorage, type OrganizationLoaderData, type OrganizationStorageLoaderData, useOrganizationLoaderData } from './organization';
+import { ORG_STORAGE_RULE, type OrganizationLoaderData, type OrganizationStorageLoaderData, useOrganizationLoaderData } from './organization';
 import { useRootLoaderData } from './root';
 
 interface TeamProject {
@@ -642,6 +642,7 @@ const ProjectRoute: FC = () => {
   useEffect(() => {
     if (!isScratchpadOrganizationId(organizationId)) {
       const load = storageRuleFetcher.load;
+      // file://./organization.tsx#organizationStorageLoader
       load(`/organization/${organizationId}/storage-rule`);
     }
   }, [organizationId, storageRuleFetcher.load]);
@@ -650,7 +651,7 @@ const ProjectRoute: FC = () => {
 
   const { storagePromise } = storageRuleFetcher.data || {};
 
-  const [storage = DefaultStorage] = useLoaderDeferData(storagePromise);
+  const [storage = ORG_STORAGE_RULE.CLOUD_PLUS_LOCAL] = useLoaderDeferData(storagePromise);
 
   const [projectListFilter, setProjectListFilter] = useLocalStorage(`${organizationId}:project-list-filter`, '');
   const [workspaceListFilter, setWorkspaceListFilter] = useLocalStorage(`${projectId}:workspace-list-filter`, '');
@@ -960,11 +961,11 @@ const ProjectRoute: FC = () => {
         },
       },
   ];
-  const defaultStorageSelection = storage === 'local_only' ? 'local' : 'remote';
-  const isRemoteProjectInconsistent = activeProject && isRemoteProject(activeProject) && storage === 'local_only';
-  const isLocalProjectInconsistent = activeProject && !isRemoteProject(activeProject) && storage === 'cloud_only';
+  const defaultStorageSelection = storage === ORG_STORAGE_RULE.LOCAL_ONLY ? 'local' : 'remote';
+  const isRemoteProjectInconsistent = activeProject && isRemoteProject(activeProject) && storage === ORG_STORAGE_RULE.LOCAL_ONLY;
+  const isLocalProjectInconsistent = activeProject && !isRemoteProject(activeProject) && storage === ORG_STORAGE_RULE.CLOUD_ONLY;
   const isProjectInconsistent = isRemoteProjectInconsistent || isLocalProjectInconsistent;
-  const showStorageRestrictionMessage = storage !== 'cloud_plus_local';
+  const showStorageRestrictionMessage = storage !== ORG_STORAGE_RULE.CLOUD_PLUS_LOCAL;
 
   useEffect(() => {
     window.main.landingPageRendered(LandingPage.ProjectDashboard);
@@ -1593,7 +1594,7 @@ const ProjectRoute: FC = () => {
                       </Label>
                       <div className="flex gap-2">
                         <Radio
-                          isDisabled={storage === 'local_only'}
+                          isDisabled={storage === ORG_STORAGE_RULE.LOCAL_ONLY}
                           value="remote"
                           className="flex-1 data-[selected]:border-[--color-surprise] data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] data-[disabled]:opacity-25 hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
                         >
@@ -1606,7 +1607,7 @@ const ProjectRoute: FC = () => {
                           </p>
                         </Radio>
                         <Radio
-                          isDisabled={storage === 'cloud_only'}
+                          isDisabled={storage === ORG_STORAGE_RULE.CLOUD_ONLY}
                           value="local"
                           className="flex-1 data-[selected]:border-[--color-surprise] data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] data-[disabled]:opacity-25 hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
                         >
@@ -1723,13 +1724,13 @@ const ProjectRoute: FC = () => {
                           className="py-1 placeholder:italic w-full pl-2 pr-7 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font] focus:outline-none focus:ring-1 focus:ring-[--hl-md] transition-colors"
                         />
                       </TextField>
-                      <RadioGroup name="type" defaultValue={storage === 'cloud_plus_local' ? activeProject?.remoteId ? 'remote' : 'local' : storage !== 'cloud_only' ? 'local' : 'remote'} className="flex flex-col gap-2">
+                      <RadioGroup name="type" defaultValue={storage === ORG_STORAGE_RULE.CLOUD_PLUS_LOCAL ? activeProject?.remoteId ? 'remote' : 'local' : storage !== ORG_STORAGE_RULE.CLOUD_ONLY ? 'local' : 'remote'} className="flex flex-col gap-2">
                         <Label className="text-sm text-[--hl]">
                           Project type
                         </Label>
                         <div className="flex gap-2">
                           <Radio
-                            isDisabled={storage === 'local_only'}
+                            isDisabled={storage === ORG_STORAGE_RULE.LOCAL_ONLY}
                             value="remote"
                             className="data-[selected]:border-[--color-surprise] flex-1 data-[disabled]:opacity-25 data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
                           >
@@ -1742,7 +1743,7 @@ const ProjectRoute: FC = () => {
                             </p>
                           </Radio>
                           <Radio
-                            isDisabled={storage === 'cloud_only'}
+                            isDisabled={storage === ORG_STORAGE_RULE.CLOUD_ONLY}
                             value="local"
                             className="data-[selected]:border-[--color-surprise] flex-1 data-[disabled]:opacity-25 data-[selected]:ring-2 data-[selected]:ring-[--color-surprise] hover:bg-[--hl-xs] focus:bg-[--hl-sm] border border-solid border-[--hl-md] rounded p-4 focus:outline-none transition-colors"
                           >


### PR DESCRIPTION
There are two types of mock server. One is cloud mock server which is hosted on Insomnia backend. The other is self-hosted mock server which is hosted by enterprise users themselves.
Cloud mock server were allowed to be created in cloud projects by any logined users.
Self-hosted mock server were only allowed to be created by enterprise users.

But there were on situation that we did not take into account, which is that one organization may have its storage rule which can restrict the type of projects in it, including the type of mock servers in it.

So I add this restriction when user create a mock server (in packages/insomnia/src/ui/components/modals/mock-server-settings-modal.tsx) or editing an existing mock server (in packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx).

Also I defined a enum ORG_STORAGE_RULE in packages/insomnia/src/ui/routes/organization.tsx to reuse it anywhere we need to refer to organization storage rule.

Add some tips and limits for these situations when creating mock server route from response in local project:
1. In a local project, users are not allowed to create a cloud mock server, only enterprise users can create a self-hosted mock server.
2. In a local project, users without enterprise plan can't create cloud mock server route from a request response.
3. In a local project, users who are with a enterprise plan but does not have an existing self-hosted mock server need to create a self-hosted mock server manually before they create a self-hosted mock server route from a request response.
4. In a local project, users who are with a enterprise plan and have an existing self-hosted mock server as well can create a mock server route from a request response.