### PR TITLE
Unify mock server route url [INS-4332]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,9 +20,11 @@
     "getinsomnia",
     "inso",
     "libcurl",
+    "mockbin",
     "svgr",
     "unstage",
     "Unstaged",
+    "upsert",
     "xmark"
   ],
 }

--- a/packages/insomnia/src/common/__tests__/constants.test.ts
+++ b/packages/insomnia/src/common/__tests__/constants.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { MockServer } from '../../models/mock-server';
 import {
   ACTIVITY_DEBUG,
   ACTIVITY_HOME,
@@ -89,9 +90,20 @@ describe('getContentTypeName', () => {
 });
 
 describe('getMockSeviceBinUrl', () => {
-  it('should add subdomain when using insomnia cloud', () => {
-    expect(getMockServiceBinURL('xyz', '/my-route', undefined)).toBe('https://xyz.mock.insomnia.rest/my-route');
-    expect(getMockServiceBinURL('mock_123', '/my-route', undefined)).toBe('https://mock-123.mock.insomnia.rest/my-route');
-    expect(getMockServiceBinURL('mock_123', '/my-route', 'http://localhost:8080')).toBe('http://localhost:8080/bin/mock_123/my-route');
+  it('should return correct mock url', () => {
+    expect(getMockServiceBinURL({
+      useInsomniaCloud: true,
+      _id: 'mock_617eac05d9a94e38a1187f9b4400039b',
+      url: '',
+    } as MockServer, '/my-route')).toBe(
+      'https://mock-617eac05d9a94e38a1187f9b4400039b.mock.insomnia.rest/my-route'
+    );
+    expect(getMockServiceBinURL({
+      useInsomniaCloud: false,
+      _id: 'mock_617eac05d9a94e38a1187f9b4400039b',
+      url: 'http://localhost:8080',
+    } as MockServer, '/my-route')).toBe(
+      'http://localhost:8080/bin/mock_617eac05d9a94e38a1187f9b4400039b/my-route'
+    );
   });
 });

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -1,5 +1,6 @@
 import appConfig from '../../config/config.json';
 import { version } from '../../package.json';
+import type { MockServer } from '../models/mock-server';
 import type { KeyCombination } from './settings';
 
 // Vite is filtering out process.env variables that are not prefixed with VITE_.
@@ -120,15 +121,17 @@ export enum UpdateURL {
 export const getApiBaseURL = () => env.INSOMNIA_API_URL || 'https://api.insomnia.rest';
 export const getMockServiceURL = () => env.INSOMNIA_MOCK_API_URL || 'https://mock.insomnia.rest';
 
-export const getMockServiceBinURL = (serverId: string, path: string, customUrl?: string) => {
-  if (serverId && !customUrl) {
+export const getMockServiceBinURL = (mockServer: MockServer, path: string) => {
+  if (!mockServer.useInsomniaCloud) {
+    return `${mockServer.url}/bin/${mockServer._id}${path}`;
+  } else {
     const baseUrl = getMockServiceURL();
     const url = new URL(baseUrl);
-    url.host = serverId.replace('_', '-') + '.' + url.host;
+    url.host = mockServer._id.replace('_', '-') + '.' + url.host;
     return url.origin + path;
   }
-  return customUrl + '/bin/' + serverId + path;
 };
+
 export const getAIServiceURL = () => env.INSOMNIA_AI_URL || 'https://ai-helper.insomnia.rest';
 
 export const getUpdatesBaseURL = () => env.INSOMNIA_UPDATES_URL || 'https://updates.insomnia.rest';

--- a/packages/insomnia/src/ui/components/mocks/mock-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/mocks/mock-url-bar.tsx
@@ -75,8 +75,8 @@ export const MockUrlBar = ({ onPathUpdate, onSend }: { onPathUpdate: (path: stri
         onPress={() => {
           showModal(AlertModal, {
             title: 'Full URL',
-            message: getMockServiceBinURL(mockRoute.parentId, pathInput, mockServer.useInsomniaCloud ? undefined : mockServer.url),
-            onConfirm: () => window.clipboard.writeText(getMockServiceBinURL(mockRoute.parentId, pathInput, mockServer.useInsomniaCloud ? undefined : mockServer.url)),
+            message: getMockServiceBinURL(mockServer, pathInput),
+            onConfirm: () => window.clipboard.writeText(getMockServiceBinURL(mockServer, pathInput)),
             addCancel: true,
             okLabel: 'Copy',
           });
@@ -93,7 +93,7 @@ export const MockUrlBar = ({ onPathUpdate, onSend }: { onPathUpdate: (path: stri
       <Button
         className="bg-[--hl-sm] px-3 rounded-sm aria-pressed:bg-[--hl-xs] data-[pressed]:bg-[--hl-xs]"
         onPress={() => {
-          window.clipboard.writeText(getMockServiceBinURL(mockRoute.parentId, pathInput, mockServer.useInsomniaCloud ? undefined : mockServer.url));
+          window.clipboard.writeText(getMockServiceBinURL(mockServer, pathInput));
         }}
       >
         <Icon icon="copy" />
@@ -142,7 +142,7 @@ export const MockUrlBar = ({ onPathUpdate, onSend }: { onPathUpdate: (path: stri
               label="Generate Client Code"
               onClick={async () => {
                 const request = await models.request.getByParentId(mockRoute._id);
-                request && showModal(GenerateCodeModal, { request: { ...request, url: getMockServiceBinURL(mockRoute.parentId, pathInput, mockServer.useInsomniaCloud ? undefined : mockServer.url) } });
+                request && showModal(GenerateCodeModal, { request: { ...request, url: getMockServiceBinURL(mockServer, pathInput) } });
               }}
             />
           </DropdownItem>

--- a/packages/insomnia/src/ui/routes/mock-route.tsx
+++ b/packages/insomnia/src/ui/routes/mock-route.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Button, Tab, TabList, TabPanel, Tabs, Toolbar } from 'react-aria-components';
 import { type LoaderFunction, useFetcher, useParams, useRouteLoaderData } from 'react-router-dom';
 
-import { CONTENT_TYPE_JSON, CONTENT_TYPE_OTHER, CONTENT_TYPE_PLAINTEXT, CONTENT_TYPE_XML, CONTENT_TYPE_YAML, contentTypesMap, getMockServiceURL, RESPONSE_CODE_REASONS } from '../../common/constants';
+import { CONTENT_TYPE_JSON, CONTENT_TYPE_OTHER, CONTENT_TYPE_PLAINTEXT, CONTENT_TYPE_XML, CONTENT_TYPE_YAML, contentTypesMap, getMockServiceBinURL, getMockServiceURL, RESPONSE_CODE_REASONS } from '../../common/constants';
 import { database as db } from '../../common/database';
 import { getResponseCookiesFromHeaders } from '../../common/har';
 import * as models from '../../models';
@@ -144,7 +144,7 @@ export const MockRouteRoute = () => {
     }
   };
 
-  const createandSendPrivateRequest = (patch: Partial<Request>) =>
+  const createAndSendPrivateRequest = (patch: Partial<Request>) =>
     requestFetcher.submit(JSON.stringify(patch),
       {
         encType: 'application/json',
@@ -205,9 +205,8 @@ export const MockRouteRoute = () => {
       return;
     };
     await upsertMockbinHar(pathInput);
-    const compoundId = mockRoute.parentId + pathInput;
-    createandSendPrivateRequest({
-      url: mockbinUrl + '/bin/' + compoundId,
+    createAndSendPrivateRequest({
+      url: getMockServiceBinURL(mockServer, pathInput),
       method: mockRoute.method,
       headers: mockRoute.headers,
       parentId: mockRoute._id,


### PR DESCRIPTION
The url showed in mock server route url bar and the one used when sending mock request are inconsistent （Insomnia cloud mock-server）.
Use this format uniformly:
https://mock-0f45001983cb4da6ae762ae5abed81f7.mock.insomnia.rest/mockRoutePath