### PR TITLE
fix(cli): insomnia.variables.set should persist variables during runner execution period

### DIFF
--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -8,7 +8,7 @@ import { cosmiconfig } from 'cosmiconfig';
 import fs from 'fs';
 import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from 'insomnia/src/common/constants';
 import { getSendRequestCallbackMemDb } from 'insomnia/src/common/send-request';
-import { UserUploadEnvironment } from 'insomnia/src/models/environment';
+import { init, type as EnvironmentType, UserUploadEnvironment } from 'insomnia/src/models/environment';
 import { deserializeNDJSON } from 'insomnia/src/utils/ndjson';
 import { type RequestTestResult } from 'insomnia-sdk';
 import { generate, runTestsCli } from 'insomnia-testing';
@@ -535,7 +535,17 @@ export const go = (args?: string[]) => {
         const iterationCount = parseInt(options.iterationCount, 10);
 
         const iterationData = await pathToIterationData(options.iterationData, options.envVar);
-        const sendRequest = await getSendRequestCallbackMemDb(environment._id, db, { validateSSL: !options.disableCertValidation }, iterationData, iterationCount);
+        const transientVariables = {
+          ...init(),
+          _id: uuidv4(),
+          type: EnvironmentType,
+          parentId: '',
+          modified: 0,
+          created: Date.now(),
+          name: 'Transient Variables',
+          data: {},
+        };
+        const sendRequest = await getSendRequestCallbackMemDb(environment._id, db, { validateSSL: !options.disableCertValidation }, transientVariables, iterationData, iterationCount);
         let success = true;
         for (let i = 0; i < iterationCount; i++) {
           let reqIndex = 0;

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -400,8 +400,19 @@ export const go = (args?: string[]) => {
         return process.exit(1);
       }
 
+      const transientVariables = {
+        ...init(),
+        _id: uuidv4(),
+        type: EnvironmentType,
+        parentId: '',
+        modified: 0,
+        created: Date.now(),
+        name: 'Transient Variables',
+        data: {},
+      };
+
       try {
-        const sendRequest = await getSendRequestCallbackMemDb(environment._id, db, { validateSSL: !options.disableCertValidation });
+        const sendRequest = await getSendRequestCallbackMemDb(environment._id, db, transientVariables, { validateSSL: !options.disableCertValidation });
         // Generate test file
         const testFileContents = generate(suites.map(suite => ({
           name: suite.name,
@@ -545,7 +556,7 @@ export const go = (args?: string[]) => {
           name: 'Transient Variables',
           data: {},
         };
-        const sendRequest = await getSendRequestCallbackMemDb(environment._id, db, { validateSSL: !options.disableCertValidation }, transientVariables, iterationData, iterationCount);
+        const sendRequest = await getSendRequestCallbackMemDb(environment._id, db, transientVariables, { validateSSL: !options.disableCertValidation }, iterationData, iterationCount);
         let success = true;
         for (let i = 0; i < iterationCount; i++) {
           let reqIndex = 0;

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -35,7 +35,7 @@ const wrapAroundIterationOverIterationData = (list?: UserUploadEnvironment[], cu
   return list[(currentIteration + 1) % list.length];
 };
 
-export async function getSendRequestCallbackMemDb(environmentId: string, memDB: any, settingsOverrides?: SettingsOverride, iterationData?: UserUploadEnvironment[], iterationCount?: number) {
+export async function getSendRequestCallbackMemDb(environmentId: string, memDB: any, settingsOverrides?: SettingsOverride, transientVariables: Environment, iterationData?: UserUploadEnvironment[], iterationCount?: number) {
   // Initialize the DB in-memory and fill it with data if we're given one
   await database.init(
     modelTypes(),
@@ -123,16 +123,7 @@ export async function getSendRequestCallbackMemDb(environmentId: string, memDB: 
   return async function sendRequest(requestId: string, iteration?: number) {
     const requestData = await fetchInsoRequestData(requestId, environmentId);
     const getCurrentRowOfIterationData = wrapAroundIterationOverIterationData(iterationData, iteration);
-    const transientVariables = {
-      ...models.environment.init(),
-      _id: uuidv4(),
-      type: models.environment.type,
-      parentId: requestData.environment.parentId,
-      modified: 0,
-      created: Date.now(),
-      name: 'Transient Environment',
-      data: {},
-    };
+
     const mutatedContext = await tryToExecutePreRequestScript(requestData, transientVariables, getCurrentRowOfIterationData, iteration, iterationCount);
     if (mutatedContext === null) {
       console.error('Time out while executing pre-request script');

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { v4 as uuidv4 } from 'uuid';
 
 import { type BaseModel, types as modelTypes } from '../models';
 import * as models from '../models';

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -34,7 +34,7 @@ const wrapAroundIterationOverIterationData = (list?: UserUploadEnvironment[], cu
   return list[(currentIteration + 1) % list.length];
 };
 
-export async function getSendRequestCallbackMemDb(environmentId: string, memDB: any, settingsOverrides?: SettingsOverride, transientVariables: Environment, iterationData?: UserUploadEnvironment[], iterationCount?: number) {
+export async function getSendRequestCallbackMemDb(environmentId: string, memDB: any, transientVariables: Environment, settingsOverrides?: SettingsOverride, iterationData?: UserUploadEnvironment[], iterationCount?: number) {
   // Initialize the DB in-memory and fill it with data if we're given one
   await database.init(
     modelTypes(),

--- a/packages/insomnia/src/scriptExecutor.ts
+++ b/packages/insomnia/src/scriptExecutor.ts
@@ -76,6 +76,10 @@ export const runScript = async (
       name: context.baseEnvironment.name,
       data: mutatedContextObject.baseEnvironment,
     },
+    transientVariables: {
+      name: context.transientVariables?.name || 'transientVariables',
+      data: mutatedContextObject.variables,
+    },
     request: updatedRequest,
     settings: updatedSettings,
     clientCertificates: updatedCertificates,


### PR DESCRIPTION

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

This change focuses on CLI.

### Changes

- [x] Init transient variables in CLI runner
- [x] Wire transient variables up to the sendRequest and scriptExecutor

Ref: #8148, INS-4647

