### PR TITLE
fix(sdk): failed to transform proxy port between sdk and renderer

### DIFF
--- a/packages/insomnia-sdk/src/objects/__tests__/proxy-configs.test.ts
+++ b/packages/insomnia-sdk/src/objects/__tests__/proxy-configs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { ProxyConfig, ProxyConfigList } from '../proxy-configs';
+import { ProxyConfig, ProxyConfigList, transformToSdkProxyOptions } from '../proxy-configs';
 import { Url } from '../urls';
 
 describe('test ProxyConfig object', () => {
@@ -15,6 +15,7 @@ describe('test ProxyConfig object', () => {
             authenticate: true,
             username: 'proxy_username',
             password: 'proxy_password',
+            protocol: 'https:',
         });
 
         expect(
@@ -23,15 +24,8 @@ describe('test ProxyConfig object', () => {
             ['http', 'https']
         );
 
-        proxyConfig.updateProtocols(['http']);
-        expect(
-            proxyConfig.getProtocols()
-        ).toEqual(
-            ['http']
-        );
-
         expect(proxyConfig.getProxyUrl()).toEqual(
-            'proxy_username:proxy_password@proxy.com:8080'
+            'https://proxy_username:proxy_password@proxy.com:8080'
         );
 
         expect(
@@ -49,9 +43,26 @@ describe('test ProxyConfig object', () => {
             authenticate: true,
             username: 'proxy_username',
             password: 'proxy_password',
+            protocol: 'https:',
         }));
 
         const matchedProxyConfigDef = configList.resolve(new Url('http://sub.example.com:80/path'));
         expect(matchedProxyConfigDef?.host).toEqual('proxy.com');
+    });
+
+    const proxyUrls = [
+        'http://wormhole',
+        'http://wormhole:0',
+        'https://localhost',
+        'http://user:pass@localhost:666',
+        'http://user:pass@localhost:0',
+        'http://user:pass@localhost',
+    ];
+
+    proxyUrls.forEach(url => {
+        it(`test proxy transforming: ${url}`, () => {
+            const proxy = new ProxyConfig(transformToSdkProxyOptions(url, '', true, ''));
+            expect(proxy.getProxyUrl()).toEqual(url);
+        });
     });
 });

--- a/packages/insomnia-sdk/src/objects/index.ts
+++ b/packages/insomnia-sdk/src/objects/index.ts
@@ -10,3 +10,4 @@ export * from './request-info';
 export * from './async_objects';
 export * from './test';
 export * from './execution';
+export * from './proxy-configs';

--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -8,6 +8,7 @@ import { CookieObject } from './cookies';
 import { Environment, Variables } from './environments';
 import { Execution } from './execution';
 import type { RequestContext } from './interfaces';
+import { transformToSdkProxyOptions } from './proxy-configs';
 import { Request as ScriptRequest, type RequestOptions, toScriptRequestBody } from './request';
 import { RequestInfo } from './request-info';
 import { Response as ScriptResponse } from './response';
@@ -179,39 +180,12 @@ export async function initInsomniaObject(
         } :
         { disabled: true };
 
-    const bestProxy = rawObj.settings.httpsProxy || rawObj.settings.httpProxy;
-    const enabledProxy = rawObj.settings.proxyEnabled && bestProxy !== '';
-    const bypassProxyList = rawObj.settings.noProxy ?
-        rawObj.settings.noProxy
-            .split(',')
-            .map(urlStr => urlStr.trim()) :
-        [];
-    const proxy = {
-        disabled: !enabledProxy,
-        match: '<all_urls>',
-        bypass: bypassProxyList,
-        host: '',
-        port: 0,
-        tunnel: false,
-        authenticate: false,
-        username: '',
-        password: '',
-    };
-    if (bestProxy !== '') {
-        const portStartPos = bestProxy.indexOf(':');
-        if (portStartPos > 0) {
-            proxy.host = bestProxy.slice(0, portStartPos);
-            const port = bestProxy.slice(portStartPos + 1);
-            try {
-                proxy.port = parseInt(port);
-            } catch (e) {
-                throw Error(`Invalid proxy port: ${bestProxy}`);
-            }
-        } else {
-            proxy.host = bestProxy;
-            proxy.port = 0;
-        }
-    }
+    const proxy = transformToSdkProxyOptions(
+        rawObj.settings.httpsProxy,
+        rawObj.settings.httpProxy,
+        rawObj.settings.proxyEnabled,
+        rawObj.settings.noProxy,
+    );
 
     const reqUrl = toUrlObject(rawObj.request.url);
     reqUrl.addQueryParams(

--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -181,8 +181,8 @@ export async function initInsomniaObject(
         { disabled: true };
 
     const proxy = transformToSdkProxyOptions(
-        rawObj.settings.httpsProxy,
         rawObj.settings.httpProxy,
+        rawObj.settings.httpsProxy,
         rawObj.settings.proxyEnabled,
         rawObj.settings.noProxy,
     );

--- a/packages/insomnia-sdk/src/objects/proxy-configs.ts
+++ b/packages/insomnia-sdk/src/objects/proxy-configs.ts
@@ -37,7 +37,7 @@ export class ProxyConfig extends Property {
     static port?: number = undefined;
     static tunnel: boolean = false; // unsupported
     static username: string = '';
-    static protocol: string = 'http:';
+    static protocol: string = 'https:';
 
     constructor(def: {
         id?: string;
@@ -202,8 +202,8 @@ export function transformToSdkProxyOptions(
     if (bestProxy !== '') {
         let sanitizedProxy = bestProxy;
         if (bestProxy.indexOf('://') === -1) {
-            console.warn(`The protocol is missing and adding 'http:' protocol: ${bestProxy}`);
-            sanitizedProxy = 'http://' + bestProxy;
+            console.warn(`The protocol is missing and adding 'https:' protocol: ${bestProxy}`);
+            sanitizedProxy = 'https://' + bestProxy;
         }
 
         try {

--- a/packages/insomnia-sdk/src/objects/proxy-configs.ts
+++ b/packages/insomnia-sdk/src/objects/proxy-configs.ts
@@ -4,13 +4,15 @@ import { Url, UrlMatchPattern, UrlMatchPatternList } from './urls';
 export interface ProxyConfigOptions {
     match: string;
     host: string;
-    port: number;
+    port?: number;
     tunnel: boolean;
     disabled?: boolean;
     authenticate: boolean;
     username: string;
     password: string;
+    // follows are for compatibility with Insomnia
     bypass?: string[];
+    protocol: string;
 }
 
 export class ProxyConfig extends Property {
@@ -19,21 +21,23 @@ export class ProxyConfig extends Property {
 
     host: string;
     match: string;
-    port: number;
+    port?: number;
     tunnel: boolean;
     authenticate: boolean;
     username: string;
     password: string;
     bypass: string[]; // it is for compatibility with Insomnia's bypass list
+    protocol: string;
 
     static authenticate: boolean = false;
     static bypass: UrlMatchPatternList<UrlMatchPattern> = new UrlMatchPatternList<UrlMatchPattern>(undefined, []);
     static host: string = '';
     static match: string = '';
     static password: string = '';
-    static port: number = 0;
+    static port?: number = undefined;
     static tunnel: boolean = false; // unsupported
     static username: string = '';
+    static protocol: string = 'http:';
 
     constructor(def: {
         id?: string;
@@ -42,13 +46,14 @@ export class ProxyConfig extends Property {
 
         match: string;
         host: string;
-        port: number;
+        port?: number;
         tunnel: boolean;
         disabled?: boolean;
         authenticate: boolean;
         username: string;
         password: string;
         bypass?: string[];
+        protocol: string;
     }) {
         super();
 
@@ -65,6 +70,7 @@ export class ProxyConfig extends Property {
         this.username = def.username;
         this.password = def.password;
         this.bypass = def.bypass || [];
+        this.protocol = def.protocol;
     }
 
     static override _index: string = 'key';
@@ -81,11 +87,13 @@ export class ProxyConfig extends Property {
 
     getProxyUrl(): string {
         // http://proxy_username:proxy_password@proxy.com:8080
-        // TODO: check if port is not given
+        const portSegment = this.port === undefined ? '' : `:${this.port}`;
+
         if (this.authenticate) {
-            return `${this.username}:${this.password}@${this.host}:${this.port}`;
+            return `${this.protocol}//${this.username}:${this.password}@${this.host}${portSegment}`;
         }
-        return `${this.host}:${this.port}`;
+        return `${this.protocol}//${this.host}${portSegment}`;
+
     }
 
     test(url?: string) {
@@ -104,7 +112,7 @@ export class ProxyConfig extends Property {
     update(options: {
         host: string;
         match: string;
-        port: number;
+        port?: number;
         tunnel: boolean;
         authenticate: boolean;
         username: string;
@@ -119,17 +127,15 @@ export class ProxyConfig extends Property {
         this.password = options.password;
     }
 
-    updateProtocols(protocols: string[]) {
-        const protoSeparator = this.match.indexOf('://');
-        if (protoSeparator <= 0 || protoSeparator >= this.match.length) {
-            throw Error('updateProtocols: invalid protocols, no protocol is detected');
-        }
-
-        this.match = protocols.join('+') + this.match.slice(protoSeparator);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    updateProtocols(_protocols: string[]) {
+        // In Insomnia there is no whitelist while there is a blacklist
+        throw Error('updateProtocols is not supported in Insomnia');
     }
 }
 
-// myProxyConfig = new ProxyConfigList({}, [
+// example:
+// myProxyConfigs = new ProxyConfigList({}, [
 //     {match: 'https://example.com/*', host: 'proxy.com', port: 8080, tunnel: true},
 //     {match: 'http+https://example2.com/*', host: 'proxy2.com'},
 // ]);
@@ -165,6 +171,59 @@ export class ProxyConfigList<T extends ProxyConfig> extends PropertyList<T> {
         }
         return null;
     }
+}
 
-    // toObject(excludeDisabledopt, nullable, caseSensitiveopt, nullable, multiValueopt, nullable, sanitizeKeysopt) → {Object}
+export function transformToSdkProxyOptions(
+    httpProxy: string,
+    httpsProxy: string,
+    proxyEnabled: boolean,
+    noProxy: string,
+) {
+    const bestProxy = httpsProxy || httpProxy || '';
+    const enabledProxy = proxyEnabled && bestProxy.trim() !== '';
+    const bypassProxyList = noProxy ?
+        noProxy
+            .split(',')
+            .map(urlStr => urlStr.trim()) :
+        [];
+    const proxy: ProxyConfigOptions = {
+        disabled: !enabledProxy,
+        match: '<all_urls>',
+        bypass: bypassProxyList,
+        host: '',
+        port: undefined,
+        tunnel: false,
+        authenticate: false,
+        username: '',
+        password: '',
+        protocol: 'http',
+    };
+
+    if (bestProxy !== '') {
+        let sanitizedProxy = bestProxy;
+        if (bestProxy.indexOf('://') === -1) {
+            console.warn(`The protocol is missing and adding 'http:' protocol: ${bestProxy}`);
+            sanitizedProxy = 'http://' + bestProxy;
+        }
+
+        try {
+            const sanitizedProxyUrlOptions = new URL(sanitizedProxy); // it should just work in node and browser
+
+            if (sanitizedProxyUrlOptions.port !== '') {
+                proxy.port = parseInt(sanitizedProxyUrlOptions.port, 10);
+            }
+
+            proxy.protocol = sanitizedProxyUrlOptions.protocol;
+            proxy.host = sanitizedProxyUrlOptions.hostname;
+            proxy.username = sanitizedProxyUrlOptions.username;
+            proxy.password = sanitizedProxyUrlOptions.password;
+            if (proxy.username || proxy.password) {
+                proxy.authenticate = true;
+            }
+        } catch (e) {
+            throw `Failed to parse proxy (${sanitizedProxy}): ${e.message}`;
+        }
+    }
+
+    return proxy;
 }

--- a/packages/insomnia-sdk/src/objects/request.ts
+++ b/packages/insomnia-sdk/src/objects/request.ts
@@ -402,6 +402,7 @@ export class Request extends Property {
                 authenticate: this.proxy.authenticate,
                 username: this.proxy.username,
                 password: this.proxy.password,
+                protocol: this.proxy.protocol,
             } : undefined,
             certificate: this.certificate ? {
                 name: this.certificate?.name,

--- a/packages/insomnia-sdk/src/objects/urls.ts
+++ b/packages/insomnia-sdk/src/objects/urls.ts
@@ -461,7 +461,10 @@ export class UrlMatchPattern extends Property {
     // TODO: the url can not start with -
 
     getProtocols(): string[] {
-        // the pattern could be <all_urls>
+        if (this.pattern === '<all_urls>') {
+            return ['http', 'https', 'file'];
+        }
+
         const protocolEndPos = this.pattern.indexOf('://');
         if (protocolEndPos < 0) {
             return [];

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/electron/renderer';
+import { SENTRY_OPTIONS } from 'insomnia/src/common/sentry';
 import { initInsomniaObject, InsomniaObject } from 'insomnia-sdk';
 import { Console, mergeClientCertificates, mergeCookieJar, mergeRequests, mergeSettings, type RequestContext } from 'insomnia-sdk';
 import * as _ from 'lodash';
@@ -6,9 +8,15 @@ export interface HiddenBrowserWindowBridgeAPI {
   runScript: (options: { script: string; context: RequestContext }) => Promise<RequestContext>;
 };
 
+export function initializeSentry() {
+  Sentry.init({
+    ...SENTRY_OPTIONS,
+  });
+}
+
 window.bridge.onmessage(async (data, callback) => {
   window.bridge.setBusy(true);
-  console.log('[hidden-browser-window] recieved message', data);
+
   try {
     const timeout = data.context.timeout || 5000;
     const timeoutPromise = new window.bridge.Promise(resolve => {
@@ -19,7 +27,7 @@ window.bridge.onmessage(async (data, callback) => {
     const result = await window.bridge.Promise.race([timeoutPromise, runScript(data)]);
     callback(result);
   } catch (err) {
-    console.error('error', err);
+    Sentry.captureException(err);
     const errMessage = err.message ? `message: ${err.message}; stack: ${err.stack}` : err;
     callback({ error: errMessage });
   } finally {
@@ -32,7 +40,6 @@ window.bridge.onmessage(async (data, callback) => {
 const runScript = async (
   { script, context }: { script: string; context: RequestContext },
 ): Promise<RequestContext> => {
-  console.log(script);
   const scriptConsole = new Console();
 
   const executionContext = await initInsomniaObject(context, scriptConsole.log);
@@ -77,9 +84,6 @@ const runScript = async (
   const updatedCookieJar = mergeCookieJar(context.cookieJar, mutatedContextObject.cookieJar);
 
   await window.bridge.appendFile(context.timelinePath, scriptConsole.dumpLogs());
-
-  console.log('mutatedInsomniaObject', mutatedContextObject);
-  console.log('context', context);
 
   return {
     ...context,

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -8,11 +8,9 @@ export interface HiddenBrowserWindowBridgeAPI {
   runScript: (options: { script: string; context: RequestContext }) => Promise<RequestContext>;
 };
 
-export function initializeSentry() {
-  Sentry.init({
-    ...SENTRY_OPTIONS,
-  });
-}
+Sentry.init({
+  ...SENTRY_OPTIONS,
+});
 
 window.bridge.onmessage(async (data, callback) => {
   window.bridge.setBusy(true);
@@ -27,8 +25,12 @@ window.bridge.onmessage(async (data, callback) => {
     const result = await window.bridge.Promise.race([timeoutPromise, runScript(data)]);
     callback(result);
   } catch (err) {
-    Sentry.captureException(err);
     const errMessage = err.message ? `message: ${err.message}; stack: ${err.stack}` : err;
+    Sentry.captureException(errMessage, {
+      tags: {
+        source: 'hidden-window',
+      },
+    });
     callback({ error: errMessage });
   } finally {
     window.bridge.setBusy(false);


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes

- [x] Update the transforming logic between the sdk and the renderer
- [x] Disable some methods of the `proxy-config` class as they are not supported
- [x] Make `port` optional for the `proxy-config` as it could not be specified
- [x] Added some tests 
- [x] Enable sentry reporting for script errors

The reported Eample: https://konghq.sentry.io/issues/6077030929/?environment=development&project=6311804&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=1

Ref: #7976, INS-4636
