### PR TITLE
spike: try openssl legacy providers and weak ciphers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/@getinsomnia/node-libcurl": {
-      "version": "2.31.3",
-      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.31.3.tgz",
-      "integrity": "sha512-pek6a7gVthdanjjpf585Pmd2uHrxa+g/3qc0b9aMhBIC7MYPUv3fkkkHyVBppIg/T1FCPRGpkOT7Cmfn3QrCNg==",
+      "version": "2.31.4-alpha.0",
+      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.31.4-alpha.0.tgz",
+      "integrity": "sha512-eED8YQ3aIlodWCOm6vHj2S8K+e2BeKTyVkHXkiPbEpjs6iuXSYNwXHWctEZZRC7HAhV3Yp/DRUsghrbFEdO20w==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -22890,7 +22890,7 @@
         "@bufbuild/protobuf": "^1.8.0",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-node": "^1.4.0",
-        "@getinsomnia/node-libcurl": "^2.31.3",
+        "@getinsomnia/node-libcurl": "^2.31.4-alpha.0",
         "@grpc/grpc-js": "^1.12.0",
         "@grpc/proto-loader": "^0.7.13",
         "@seald-io/nedb": "^4.0.4",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -39,7 +39,7 @@
     "@bufbuild/protobuf": "^1.8.0",
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-node": "^1.4.0",
-    "@getinsomnia/node-libcurl": "^2.31.3",
+    "@getinsomnia/node-libcurl": "^2.31.4-alpha.0",
     "@grpc/grpc-js": "^1.12.0",
     "@grpc/proto-loader": "^0.7.13",
     "@seald-io/nedb": "^4.0.4",


### PR DESCRIPTION
Possibly helps with #5059

related to INS-4508

##  Note for posterity 

_rabbit-hole. dragons. it's the slot machine you already spent too much money on and don't want to leave your chair so someone else will take the big win._

Don't waste too much time retrying to enable legacy and weak ciphers on node-libcurl side. We should burn it all with fire.

One alternative path can be to try to solve the problem on insomnia side with UX:

- Users import the p12 / pfx file - we check the OS - if it's windows or linux we warn them we will also run an extra step, where we use `pkcs12` from `node-forge` (see [this example on SO](https://stackoverflow.com/a/55110537)) to run the equivalent to these two commands bellow to get the key and .crt file (which will work in Windows), and then use those instead right before saving the client certificate:
```bash
openssl pkcs12 -in cert.pfx -clcerts -nokeys -out the-crt-file.crt -legacy
openssl pkcs12 -in cert.pfx -nocerts -out the-key-file.key -legacy
```
- We should also probably have a warning tooltip or similar or hide the pfx/p12 option from windows users we if can guarantee it never works there
- We can also probably print out the above `openssl` commands in a warning modal or something to let users know of the potential solution.
- In the cases where this problem is further compounded due to use of weak ciphers when the users first got the .pfx/.p12 files, which we preemptively don't know - the trick is almost always better for them to use `legacy` magic on openssl on their side, than us trying to add support for those deprecated ciphers on our side.

Life finds a way.