### PR TITLE
fix: support *.localhost resolution RFC 6761 [INS-4739]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/@getinsomnia/node-libcurl": {
-      "version": "2.31.3",
-      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.31.3.tgz",
-      "integrity": "sha512-pek6a7gVthdanjjpf585Pmd2uHrxa+g/3qc0b9aMhBIC7MYPUv3fkkkHyVBppIg/T1FCPRGpkOT7Cmfn3QrCNg==",
+      "version": "2.31.4",
+      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.31.4.tgz",
+      "integrity": "sha512-QRVWqb8Zob0ObJi6T/WTZQ3E8tpSCuvMQVIPi2b3ukOy8HJLu0mVutCwFgtdGVfDIbFu/qX0Om9Q7FrsJ5c0UA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -22890,7 +22890,7 @@
         "@bufbuild/protobuf": "^1.8.0",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-node": "^1.4.0",
-        "@getinsomnia/node-libcurl": "^2.31.3",
+        "@getinsomnia/node-libcurl": "^2.31.4",
         "@grpc/grpc-js": "^1.12.0",
         "@grpc/proto-loader": "^0.7.13",
         "@seald-io/nedb": "^4.0.4",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -39,7 +39,7 @@
     "@bufbuild/protobuf": "^1.8.0",
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-node": "^1.4.0",
-    "@getinsomnia/node-libcurl": "^2.31.3",
+    "@getinsomnia/node-libcurl": "^2.31.4",
     "@grpc/grpc-js": "^1.12.0",
     "@grpc/proto-loader": "^0.7.13",
     "@seald-io/nedb": "^4.0.4",


### PR DESCRIPTION
Closes INS-4739
Closes https://github.com/Kong/insomnia/issues/8160

Fix was done on node-libcurl, bumping to curl >= 7.85.0 where this was initially added. Details: https://github.com/Kong/node-libcurl/pull/70

## how to test

Spin up insomnia with this change try to hit both `http://localhost` and `http://something.localhost` - both should resolve to 127.0.0.1 / ::1


![image](https://github.com/user-attachments/assets/a61fd583-64d1-4961-b38d-5c4f5fb4786d)
