### PR TITLE
fix(runner): the runner CLI command should be generated according to the specified order

### DIFF
--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -693,7 +693,7 @@ export const Runner: FC<{}> = () => {
             {showCLIModal && (
               <CLIPreviewModal
                 onClose={() => setShowCLIModal(false)}
-                requestIds={Array.from(reqList.selectedKeys) as string[]}
+                requestIds={Array.from(reqList.items).map(item => item.id).filter(id => new Set(reqList.selectedKeys).has(id))}
                 allSelected={Array.from(reqList.selectedKeys).length === Array.from(reqList.items).length}
                 iterationCount={iterationCount}
                 delay={delay}


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Change
- [x] In generating runner CLI command, get request ids according to the order and filter out unselected ones.

Ref: INS-4757
