### PR TITLE
fix: issue with parsing PKCS12 files on Windows [INS-4508]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/@getinsomnia/node-libcurl": {
-      "version": "2.31.4",
-      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.31.4.tgz",
-      "integrity": "sha512-QRVWqb8Zob0ObJi6T/WTZQ3E8tpSCuvMQVIPi2b3ukOy8HJLu0mVutCwFgtdGVfDIbFu/qX0Om9Q7FrsJ5c0UA==",
+      "version": "2.31.5-alpha.0",
+      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.31.5-alpha.0.tgz",
+      "integrity": "sha512-TKV0NRLJgPYULNzUxQpn5ESQXLRCztZbFKQDl4QHOHYb2QoBNF+sMpS7m1sDHfEbwcXjx2hGm27WtdxNg/FRCQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -22890,7 +22890,7 @@
         "@bufbuild/protobuf": "^1.8.0",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-node": "^1.4.0",
-        "@getinsomnia/node-libcurl": "^2.31.4",
+        "@getinsomnia/node-libcurl": "^2.31.5-alpha.0",
         "@grpc/grpc-js": "^1.12.0",
         "@grpc/proto-loader": "^0.7.13",
         "@seald-io/nedb": "^4.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/@getinsomnia/node-libcurl": {
-      "version": "2.31.5-alpha.0",
-      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.31.5-alpha.0.tgz",
-      "integrity": "sha512-TKV0NRLJgPYULNzUxQpn5ESQXLRCztZbFKQDl4QHOHYb2QoBNF+sMpS7m1sDHfEbwcXjx2hGm27WtdxNg/FRCQ==",
+      "version": "2.31.5-alpha.1",
+      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.31.5-alpha.1.tgz",
+      "integrity": "sha512-c8s6rnXpFO/QauQk+mKwNriS8NFgSz5oycWXMSFAxAvn/8JKnGGMwABV8JJZk5UBby1xr9pvcRFkbjIcadNWAQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -22890,7 +22890,7 @@
         "@bufbuild/protobuf": "^1.8.0",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-node": "^1.4.0",
-        "@getinsomnia/node-libcurl": "^2.31.5-alpha.0",
+        "@getinsomnia/node-libcurl": "^2.31.5-alpha.1",
         "@grpc/grpc-js": "^1.12.0",
         "@grpc/proto-loader": "^0.7.13",
         "@seald-io/nedb": "^4.0.4",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -39,7 +39,7 @@
     "@bufbuild/protobuf": "^1.8.0",
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-node": "^1.4.0",
-    "@getinsomnia/node-libcurl": "^2.31.5-alpha.0",
+    "@getinsomnia/node-libcurl": "^2.31.5-alpha.1",
     "@grpc/grpc-js": "^1.12.0",
     "@grpc/proto-loader": "^0.7.13",
     "@seald-io/nedb": "^4.0.4",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -39,7 +39,7 @@
     "@bufbuild/protobuf": "^1.8.0",
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-node": "^1.4.0",
-    "@getinsomnia/node-libcurl": "^2.31.4",
+    "@getinsomnia/node-libcurl": "^2.31.5-alpha.0",
     "@grpc/grpc-js": "^1.12.0",
     "@grpc/proto-loader": "^0.7.13",
     "@seald-io/nedb": "^4.0.4",


### PR DESCRIPTION
Related to INS-4508 and #5059

Uses node-libcurl alpha version with change added in https://github.com/Kong/node-libcurl/pull/71


Follow-up to previous attempt (https://github.com/Kong/node-libcurl/pull/69 / https://github.com/Kong/insomnia/pull/8192#issue-2680538708)