### PR TITLE
chore: Tidy up GH actions [INS-4761]

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -51,7 +51,7 @@ jobs:
         run: npm ci
 
       - name: Download all artifacts from release-build.yml
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: release-build.yml


### PR DESCRIPTION
Closes INS-4761

Dec 5 there will be potentially breaking changes
https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/

We might need to force `ubuntu-22` on some of the recurring/release jobs