### PR TITLE
fix(cli): the cli runner should be able to run requests with workspace id by correct order

### DIFF
--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -38,17 +38,17 @@ const shouldReturnSuccessCode = [
   // export file
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-smoke-test/fixtures/simple.yaml -e env_2eecf85b7f wrk_0702a5',
   // with regex filter
-  '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-smoke-test/fixtures/simple.yaml -e env_2eecf85b7f --requestNamePattern "example http" wrk_0702a5',
+  '$PWD/packages/insomnia-inso/bin/inso run collection wrk_0702a57d75d44255a8cecd2c5fa87809 -w packages/insomnia-smoke-test/fixtures/simple.yaml -e env_2eecf85b7f --requestNamePattern "example http" wrk_0702a5',
   // after-response script and test
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/after-response.yml wrk_616795 --verbose',
   // select request by id
-  '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/three-requests.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 -i req_6063adcdab5b409e9b4f00f47322df4a',
+  '$PWD/packages/insomnia-inso/bin/inso run collection wrk_c992d40 -w packages/insomnia-inso/src/examples/three-requests.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 -i req_6063adcdab5b409e9b4f00f47322df4a',
   // setNextRequest runs the next request then ends
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/set-next-request.yml wrk_cbc89e',
   // multiple --env-var overrides
-  '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/with-missing-env-vars.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 --env-var firstkey=first --env-var secondkey=second',
+  '$PWD/packages/insomnia-inso/bin/inso run collection wrk_c992d40ce76f4a3cb44c5fdb8435cbeb -w packages/insomnia-inso/src/examples/with-missing-env-vars.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 --env-var firstkey=first --env-var secondkey=second',
   // globals file path env overrides
-  '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/with-missing-env-vars.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 --globals packages/insomnia-inso/src/examples/global-environment.yml',
+  '$PWD/packages/insomnia-inso/bin/inso run collection wrk_c992d40ce76f4a3cb44c5fdb8435cbeb -w packages/insomnia-inso/src/examples/with-missing-env-vars.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 --globals packages/insomnia-inso/src/examples/global-environment.yml',
 ];
 
 const shouldReturnErrorCode = [
@@ -120,7 +120,7 @@ describe('inso dev bundle', () => {
     });
 
     it('iterationData and iterationCount args work', async () => {
-      const input = '$PWD/packages/insomnia-inso/bin/inso run collection -d packages/insomnia-smoke-test/fixtures/files/runner-data.json -w packages/insomnia-inso/src/examples/three-requests.yml -n 2 -i req_3fd28aabbb18447abab1f45e6ee4bdc1 -e env_86e135 --verbose';
+      const input = '$PWD/packages/insomnia-inso/bin/inso run collection wrk_c992d40 -d packages/insomnia-smoke-test/fixtures/files/runner-data.json -w packages/insomnia-inso/src/examples/three-requests.yml -n 2 -i req_3fd28aabbb18447abab1f45e6ee4bdc1 -e env_86e135 --verbose';
       const result = await runCliFromRoot(input);
       if (result.code !== 0) {
         console.log(result);
@@ -130,7 +130,7 @@ describe('inso dev bundle', () => {
     });
 
     it('send request with client cert and key', async () => {
-      const input = '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/db/fixtures/nedb --requestNamePattern "withCertAndCA" --verbose "Insomnia Designer"';
+      const input = '$PWD/packages/insomnia-inso/bin/inso run collection wrk_0b96eff84c1c4eaa9c6e67ad74bbc85b -w packages/insomnia-inso/src/db/fixtures/nedb --requestNamePattern "withCertAndCA" --verbose "Insomnia Designer"';
       const result = await runCliFromRoot(input);
       if (result.code !== 0) {
         console.log(result);
@@ -140,13 +140,13 @@ describe('inso dev bundle', () => {
     });
 
     it('send request with settings enabled (by testing followRedirects)', async () => {
-      const input = '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/db/fixtures/nedb --requestNamePattern "withSettings" --verbose "Insomnia Designer"';
+      const input = '$PWD/packages/insomnia-inso/bin/inso run collection wrk_0b96eff84c1c4eaa9c6e67ad74bbc85b -w packages/insomnia-inso/src/db/fixtures/nedb --requestNamePattern "withSettings" --verbose "Insomnia Designer"';
       const result = await runCliFromRoot(input);
       expect(result.stdout).not.toContain("Issue another request to this URL: 'https://insomnia.rest/'");
     });
 
     it('run collection: run requests in specified order', async () => {
-      const input = '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/three-requests.yml -i req_6063adcdab5b409e9b4f00f47322df4a -i req_3fd28aabbb18447abab1f45e6ee4bdc1 -e env_86e135 --verbose';
+      const input = '$PWD/packages/insomnia-inso/bin/inso run collection wrk_c992d40 -w packages/insomnia-inso/src/examples/three-requests.yml -i req_6063adcdab5b409e9b4f00f47322df4a -i req_3fd28aabbb18447abab1f45e6ee4bdc1 -e env_86e135 --verbose';
       const result = await runCliFromRoot(input);
 
       expect(result.code).toBe(0);

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -10,6 +10,7 @@ import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from 'insomnia/src/common/con
 import { getSendRequestCallbackMemDb } from 'insomnia/src/common/send-request';
 import { init, type as EnvironmentType, UserUploadEnvironment } from 'insomnia/src/models/environment';
 import { Request } from 'insomnia/src/models/request';
+import { RequestGroup } from 'insomnia/src/models/request-group';
 import { deserializeNDJSON } from 'insomnia/src/utils/ndjson';
 import { type RequestTestResult } from 'insomnia-sdk';
 import { generate, runTestsCli } from 'insomnia-testing';
@@ -24,6 +25,7 @@ import { Database, isFile, loadDb } from './db';
 import { insomniaExportAdapter } from './db/adapters/insomnia-adapter';
 import { loadApiSpec, promptApiSpec } from './db/models/api-spec';
 import { loadEnvironment, promptEnvironment } from './db/models/environment';
+import { BaseModel } from './db/models/types';
 import { loadTestSuites, promptTestSuites } from './db/models/unit-test-suite';
 import { matchIdIsh } from './db/models/util';
 import { loadWorkspace, promptWorkspace } from './db/models/workspace';
@@ -187,7 +189,7 @@ const getRequestsToRunFromListOrWorkspace = (db: Database, workspaceId: string, 
   const hasItems = item.length > 0;
   if (hasItems) {
     const folderIds = item.filter(id => db.RequestGroup.find(rg => rg._id === id));
-    const allRequestGroupIds = getRequestGroupIdsRecursively(folderIds);
+    const allRequestGroupIds = [...folderIds, ...getRequestGroupIdsRecursively(folderIds)];
     const folderRequests = db.Request.filter(req => allRequestGroupIds.includes(req.parentId)) as Request[];
     const reqItems = db.Request.filter(req => item.includes(req._id)) as Request[];
 
@@ -479,18 +481,7 @@ export const go = (args?: string[]) => {
         pathToSearch,
         filterTypes: [],
       });
-      if (identifier && options.item.length) {
-        logger.fatal('Providing both workspace and item list is not supported');
-        return process.exit(1);
-      }
-      if (options.item.length) {
-        const matches = [
-          ...db.Request.filter(req => options.item.includes(req._id)),
-          ...db.RequestGroup.filter(rg => options.item.includes(rg._id)),
-        ];
-        // overwrite identifier if found in request list parents
-        identifier = matches.find(req => req.parentId.startsWith('wrk_'))?.parentId;
-      }
+
       const workspace = await getWorkspaceOrFallback(db, identifier, options.ci);
       if (!workspace) {
         logger.fatal('No workspace found in the provided data store or fallbacks.');
@@ -533,6 +524,7 @@ export const go = (args?: string[]) => {
         logger.fatal('No environment identified; cannot run requests without a valid environment.');
         return process.exit(1);
       }
+
       let requestsToRun = getRequestsToRunFromListOrWorkspace(db, workspaceId, options.item);
       if (options.requestNamePattern) {
         requestsToRun = requestsToRun.filter(req => req.name.match(new RegExp(options.requestNamePattern)));
@@ -543,13 +535,58 @@ export const go = (args?: string[]) => {
       }
 
       // sort requests
-      if (options.item.length) {
+      const isRunningFolder = options.item.length === 1 && options.item[0].startsWith('fld_');
+      if (options.item.length && !isRunningFolder) {
         const requestOrder = new Map<string, number>();
         options.item.forEach((reqId: string, order: number) => requestOrder.set(reqId, order + 1));
         requestsToRun = requestsToRun.sort((a, b) => (requestOrder.get(a._id) || requestsToRun.length) - (requestOrder.get(b._id) || requestsToRun.length));
       } else {
+        const getAllParentGroupSortKeys = (doc: BaseModel): number[] => {
+          const parentFolder = db.RequestGroup.find(rg => rg._id === doc.parentId);
+          if (parentFolder === undefined) {
+            return [];
+          }
+          return [(parentFolder as RequestGroup).metaSortKey, ...getAllParentGroupSortKeys(parentFolder)];
+        };
+
         // sort by metaSortKey (manual sorting order)
-        requestsToRun = requestsToRun.sort((a, b) => a.metaSortKey - b.metaSortKey);
+        requestsToRun = requestsToRun.map(request => {
+          const allParentGroupSortKeys = getAllParentGroupSortKeys(request as BaseModel);
+
+          return {
+            ancestors: allParentGroupSortKeys.reverse(),
+            request,
+          };
+        }).sort((a, b) => {
+          let compareResult = 0;
+
+          let i = 0, j = 0;
+          for (; i < a.ancestors.length && j < b.ancestors.length; i++, j++) {
+            const aSortKey = a.ancestors[i];
+            const bSortKey = b.ancestors[j];
+            if (aSortKey < bSortKey) {
+              compareResult = -1;
+              break;
+            } else if (aSortKey > bSortKey) {
+              compareResult = 1;
+              break;
+            }
+          }
+          if (compareResult !== 0) {
+            return compareResult;
+          }
+
+          if (a.ancestors.length === b.ancestors.length) {
+            return a.request.metaSortKey - b.request.metaSortKey;
+          }
+
+          if (i < a.ancestors.length) {
+            return a.ancestors[i] - b.request.metaSortKey;
+          } else if (j < b.ancestors.length) {
+            return a.request.metaSortKey - b.ancestors[j];
+          }
+          return 0;
+        }).map(({ request }) => request);
       }
 
       try {

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -9,6 +9,7 @@ import fs from 'fs';
 import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from 'insomnia/src/common/constants';
 import { getSendRequestCallbackMemDb } from 'insomnia/src/common/send-request';
 import { init, type as EnvironmentType, UserUploadEnvironment } from 'insomnia/src/models/environment';
+import { Request } from 'insomnia/src/models/request';
 import { deserializeNDJSON } from 'insomnia/src/utils/ndjson';
 import { type RequestTestResult } from 'insomnia-sdk';
 import { generate, runTestsCli } from 'insomnia-testing';
@@ -23,8 +24,6 @@ import { Database, isFile, loadDb } from './db';
 import { insomniaExportAdapter } from './db/adapters/insomnia-adapter';
 import { loadApiSpec, promptApiSpec } from './db/models/api-spec';
 import { loadEnvironment, promptEnvironment } from './db/models/environment';
-import { Request } from './db/models/request';
-import { BaseModel } from './db/models/types';
 import { loadTestSuites, promptTestSuites } from './db/models/unit-test-suite';
 import { matchIdIsh } from './db/models/util';
 import { loadWorkspace, promptWorkspace } from './db/models/workspace';
@@ -189,14 +188,14 @@ const getRequestsToRunFromListOrWorkspace = (db: Database, workspaceId: string, 
   if (hasItems) {
     const folderIds = item.filter(id => db.RequestGroup.find(rg => rg._id === id));
     const allRequestGroupIds = getRequestGroupIdsRecursively(folderIds);
-    const folderRequests = db.Request.filter(req => allRequestGroupIds.includes(req.parentId));
-    const reqItems = db.Request.filter(req => item.includes(req._id));
+    const folderRequests = db.Request.filter(req => allRequestGroupIds.includes(req.parentId)) as Request[];
+    const reqItems = db.Request.filter(req => item.includes(req._id)) as Request[];
 
     return [...reqItems, ...folderRequests];
   }
 
   const allRequestGroupIds = getRequestGroupIdsRecursively([workspaceId]);
-  return db.Request.filter(req => [workspaceId, ...allRequestGroupIds].includes(req.parentId));
+  return db.Request.filter(req => [workspaceId, ...allRequestGroupIds].includes(req.parentId)) as Request[];
 };
 // adds support for repeating args in commander.js eg. -i 1 -i 2 -i 3
 const collect = (val: string, memo: string[]) => {
@@ -759,7 +758,7 @@ Test results:`);
 };
 
 const getNextRequestOffset = (
-  leftRequestsToRun: BaseModel[],
+  leftRequestsToRun: Request[],
   nextRequestIdOrName: string
 ) => {
   const idMatchOffset = leftRequestsToRun.findIndex(req => req._id.trim() === nextRequestIdOrName.trim());

--- a/packages/insomnia/src/ui/components/modals/cli-preview-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cli-preview-modal.tsx
@@ -6,10 +6,10 @@ import type { WorkspaceLoaderData } from '../../routes/workspace';
 import { CopyButton } from '../base/copy-button';
 import { Icon } from '../icon';
 
-export const CLIPreviewModal = ({ onClose, requestIds, allSelected, iterationCount, delay, filePath, bail }: { onClose: () => void; requestIds: string[]; allSelected: boolean; iterationCount: number; delay: number; filePath: string; bail: boolean }) => {
+export const CLIPreviewModal = ({ onClose, requestIds, keepManualOrder, iterationCount, delay, filePath, bail }: { onClose: () => void; requestIds: string[]; keepManualOrder: boolean; iterationCount: number; delay: number; filePath: string; bail: boolean }) => {
   const { workspaceId } = useParams() as { workspaceId: string };
   const { activeEnvironment } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
-  const workspaceIdOrRequestIds = allSelected ? workspaceId.slice(0, 10) : '-i ' + requestIds.join(' -i ');
+  const workspaceIdOrRequestIds = keepManualOrder ? workspaceId.slice(0, 10) : '-i ' + requestIds.join(' -i ');
   const iterationCountArgument = iterationCount > 1 ? ` -n ${iterationCount}` : '';
   const delayArgument = delay > 0 ? ` --delay-request ${delay}` : '';
   const iterationFilePath = filePath ? ` -d "${filePath}"` : '';

--- a/packages/insomnia/src/ui/components/modals/cli-preview-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cli-preview-modal.tsx
@@ -6,15 +6,26 @@ import type { WorkspaceLoaderData } from '../../routes/workspace';
 import { CopyButton } from '../base/copy-button';
 import { Icon } from '../icon';
 
-export const CLIPreviewModal = ({ onClose, requestIds, keepManualOrder, iterationCount, delay, filePath, bail }: { onClose: () => void; requestIds: string[]; keepManualOrder: boolean; iterationCount: number; delay: number; filePath: string; bail: boolean }) => {
+function generateCommandArgumentsForRequests(workspaceId: string, targetFolderId: string | null, requestIds: string[], keepManualOrder: boolean) {
+  const shortWorkspaceId = workspaceId.slice(0, 10);
+
+  if (targetFolderId !== null && targetFolderId !== '') {
+    return keepManualOrder
+      ? shortWorkspaceId + ' -i ' + targetFolderId
+      : shortWorkspaceId + ' -i ' + requestIds.join(' -i ');
+  }
+  return keepManualOrder ? shortWorkspaceId : shortWorkspaceId + ' -i ' + requestIds.join(' -i ');
+}
+
+export const CLIPreviewModal = ({ onClose, requestIds, targetFolderId, keepManualOrder, iterationCount, delay, filePath, bail }: { onClose: () => void; requestIds: string[]; targetFolderId: string | null; keepManualOrder: boolean; iterationCount: number; delay: number; filePath: string; bail: boolean }) => {
   const { workspaceId } = useParams() as { workspaceId: string };
   const { activeEnvironment } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
-  const workspaceIdOrRequestIds = keepManualOrder ? workspaceId.slice(0, 10) : '-i ' + requestIds.join(' -i ');
+  const workspaceIdAndRequestIds = generateCommandArgumentsForRequests(workspaceId, targetFolderId, requestIds, keepManualOrder);
   const iterationCountArgument = iterationCount > 1 ? ` -n ${iterationCount}` : '';
   const delayArgument = delay > 0 ? ` --delay-request ${delay}` : '';
   const iterationFilePath = filePath ? ` -d "${filePath}"` : '';
   const bailArgument = bail ? ' --bail' : '';
-  const cliCommand = `inso run collection ${workspaceIdOrRequestIds} -e ${activeEnvironment._id.slice(0, 10)}${iterationCountArgument}${delayArgument}${iterationFilePath}${bailArgument}`;
+  const cliCommand = `inso run collection ${workspaceIdAndRequestIds} -e ${activeEnvironment._id.slice(0, 10)}${iterationCountArgument}${delayArgument}${iterationFilePath}${bailArgument}`;
 
   return (
     <ModalOverlay

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -247,19 +247,11 @@ export const Runner: FC<{}> = () => {
       return true;
     }
 
-    const index = requestRows.findIndex((row: RequestRow, index: number) => {
+    const changedItemIndex = requestRows.findIndex((row: RequestRow, index: number) => {
       return row.id !== reqList.items[index].id;
     });
 
-    return index === -1;
-    requestRows.forEach((row: RequestRow, index: number) => {
-      if (row.id !== reqList.items[index].id) {
-        changed = true;
-      }
-
-    });
-
-    return changed;
+    return changedItemIndex === -1;
   }, [requestRows, reqList]);
 
   const { dragAndDropHooks: requestsDnD } = useDragAndDrop({

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -471,6 +471,16 @@ export const Runner: FC<{}> = () => {
     setDeletedItems([...deletedItems, item._id]);
   };
 
+  const selectedRequestIdsForCliCommand =
+    targetFolderId !== null && targetFolderId !== ''
+      ? Array.from(reqList.items)
+        .filter(item => item.parentId === targetFolderId)
+        .map(item => item.id)
+        .filter(id => new Set(reqList.selectedKeys).has(id))
+      : Array.from(reqList.items)
+        .map(item => item.id)
+        .filter(id => new Set(reqList.selectedKeys).has(id));
+
   return (
     <>
       <Panel id="pane-one" className='pane-one theme--pane' minSize={35} maxSize={90}>
@@ -707,7 +717,8 @@ export const Runner: FC<{}> = () => {
             {showCLIModal && (
               <CLIPreviewModal
                 onClose={() => setShowCLIModal(false)}
-                requestIds={Array.from(reqList.items).map(item => item.id).filter(id => new Set(reqList.selectedKeys).has(id))}
+                requestIds={selectedRequestIdsForCliCommand}
+                targetFolderId={targetFolderId}
                 keepManualOrder={!isConsistencyChanged}
                 iterationCount={iterationCount}
                 delay={delay}

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -240,6 +240,24 @@ export const Runner: FC<{}> = () => {
     },
   });
 
+  const isConsistencyChanged = useMemo(() => {
+    if (requestRows.length !== reqList.items.length) {
+      return true;
+    } else if (Array.from(reqList.selectedKeys).length !== requestRows.length) {
+      return true;
+    }
+
+    let changed = false;
+    requestRows.forEach((row: RequestRow, index: number) => {
+      if (row.id !== reqList.items[index].id) {
+        changed = true;
+      }
+
+    });
+
+    return changed;
+  }, [requestRows, reqList]);
+
   const { dragAndDropHooks: requestsDnD } = useDragAndDrop({
     getItems: keys => {
       return [...keys].map(key => {
@@ -694,7 +712,7 @@ export const Runner: FC<{}> = () => {
               <CLIPreviewModal
                 onClose={() => setShowCLIModal(false)}
                 requestIds={Array.from(reqList.items).map(item => item.id).filter(id => new Set(reqList.selectedKeys).has(id))}
-                allSelected={Array.from(reqList.selectedKeys).length === Array.from(reqList.items).length}
+                keepManualOrder={!isConsistencyChanged}
                 iterationCount={iterationCount}
                 delay={delay}
                 filePath={file?.path || ''}

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -247,7 +247,11 @@ export const Runner: FC<{}> = () => {
       return true;
     }
 
-    let changed = false;
+    const index = requestRows.findIndex((row: RequestRow, index: number) => {
+      return row.id !== reqList.items[index].id;
+    });
+
+    return index === -1;
     requestRows.forEach((row: RequestRow, index: number) => {
       if (row.id !== reqList.items[index].id) {
         changed = true;

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -251,7 +251,7 @@ export const Runner: FC<{}> = () => {
       return row.id !== reqList.items[index].id;
     });
 
-    return changedItemIndex === -1;
+    return changedItemIndex !== -1;
   }, [requestRows, reqList]);
 
   const { dragAndDropHooks: requestsDnD } = useDragAndDrop({

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -243,15 +243,11 @@ export const Runner: FC<{}> = () => {
   const isConsistencyChanged = useMemo(() => {
     if (requestRows.length !== reqList.items.length) {
       return true;
-    } else if (Array.from(reqList.selectedKeys).length !== requestRows.length) {
+    } else if (reqList.selectedKeys !== 'all' && Array.from(reqList.selectedKeys).length !== requestRows.length) {
       return true;
     }
 
-    const changedItemIndex = requestRows.findIndex((row: RequestRow, index: number) => {
-      return row.id !== reqList.items[index].id;
-    });
-
-    return changedItemIndex !== -1;
+    return requestRows.some((row: RequestRow, index: number) => row.id !== reqList.items[index].id);
   }, [requestRows, reqList]);
 
   const { dragAndDropHooks: requestsDnD } = useDragAndDrop({

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -105,6 +105,7 @@ interface RequestRow {
   id: string;
   name: string;
   ancestorNames: string[];
+  ancestorIds: string[];
   method: string;
   url: string;
   parentId: string;
@@ -198,22 +199,18 @@ export const Runner: FC<{}> = () => {
 
   const requestRows: RequestRow[] = collection
     .filter(item => {
-      if (targetFolderId) {
-        return item.doc.parentId === targetFolderId;
-      }
-      return true;
-    })
-    .filter(item => {
       getEntityById.set(item.doc._id, item);
       return isRequest(item.doc);
     })
     .map((item: Child) => {
       const ancestorNames: string[] = [];
+      const ancestorIds: string[] = [];
       if (item.ancestors) {
         item.ancestors.forEach(ancestorId => {
           const ancestor = getEntityById.get(ancestorId);
           if (ancestor && isRequestGroup(ancestor?.doc)) {
             ancestorNames.push(ancestor?.doc.name);
+            ancestorIds.push(ancestor?.doc._id);
           }
         });
       }
@@ -224,17 +221,24 @@ export const Runner: FC<{}> = () => {
         id: item.doc._id,
         name: item.doc.name,
         ancestorNames,
+        ancestorIds,
         method: requestDoc.method,
         url: item.doc.url,
         parentId: item.doc.parentId,
       };
+    })
+    .filter(item => {
+      if (targetFolderId) {
+        return item.ancestorIds.includes(targetFolderId);
+      }
+      return true;
     });
 
   const reqList = useListData({
     initialItems: requestRows,
     filter: item => {
       if (targetFolderId) {
-        return item.parentId === targetFolderId;
+        return item.ancestorIds.includes(targetFolderId);
       }
       return true;
     },
@@ -470,7 +474,7 @@ export const Runner: FC<{}> = () => {
   const selectedRequestIdsForCliCommand =
     targetFolderId !== null && targetFolderId !== ''
       ? Array.from(reqList.items)
-        .filter(item => item.parentId === targetFolderId)
+        .filter(item => item.ancestorIds.includes(targetFolderId))
         .map(item => item.id)
         .filter(id => new Set(reqList.selectedKeys).has(id))
       : Array.from(reqList.items)

--- a/packages/insomnia/src/ui/routes/workspace.tsx
+++ b/packages/insomnia/src/ui/routes/workspace.tsx
@@ -233,6 +233,7 @@ export const workspaceLoader: LoaderFunction = async ({
 
     return childrenWithChildren;
   };
+
   const requestTree = await getCollectionTree({
     parentId: activeWorkspace._id,
     level: 0,


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes:
- [x] UI: only generate runner CLI command with workspace id, when requests order in runner is consistent with workspace requests order
- [x] CLI: run requests by manual sorting order, when no `-i` option has been set
- [x] UI: "run folder" should include all sub folders

Ref: INS-4760