### PR TITLE
Fix: File path fails when used in env vars on Windows [INS-4742]

### DIFF
--- a/packages/insomnia/src/templating/utils.ts
+++ b/packages/insomnia/src/templating/utils.ts
@@ -328,6 +328,6 @@ export interface nunjucksTagContextMenuOptions extends Exclude<ReturnType<typeof
 
 export const responseTagRegex = new RegExp('{% *response *.* %}');
 
-export function sanitizeStrForWin32(path: string) {
-  return path.replace(/\\/g, '\\\\\\\\');
+export function sanitizeStrForWin32(str: string) {
+  return str.replace(/\\/g, '\\\\\\\\');
 }

--- a/packages/insomnia/src/templating/utils.ts
+++ b/packages/insomnia/src/templating/utils.ts
@@ -327,3 +327,7 @@ export interface nunjucksTagContextMenuOptions extends Exclude<ReturnType<typeof
 }
 
 export const responseTagRegex = new RegExp('{% *response *.* %}');
+
+export function sanitizeStrForWin32(path: string) {
+  return path.replace(/\\/g, '\\\\\\\\');
+}

--- a/packages/insomnia/src/ui/components/templating/tag-editor.tsx
+++ b/packages/insomnia/src/ui/components/templating/tag-editor.tsx
@@ -16,9 +16,10 @@ import type { Workspace } from '../../../models/workspace';
 import * as plugins from '../../../plugins';
 import * as pluginContexts from '../../../plugins/context';
 import * as templating from '../../../templating';
-import type {
-  NunjucksParsedTag,
-  NunjucksParsedTagArg,
+import {
+  sanitizeStrForWin32,
+  type NunjucksParsedTag,
+  type NunjucksParsedTagArg,
 } from '../../../templating/utils';
 import * as templateUtils from '../../../templating/utils';
 import { useNunjucks } from '../../context/nunjucks/use-nunjucks';
@@ -104,7 +105,7 @@ export const TagEditor: FC<Props> = props => {
     // Fix strings: arg.value expects an escaped value (based on updateArg logic)
     for (const arg of activeTagData.args) {
       if (typeof arg.value === 'string') {
-        arg.value = arg.value.replace(/\\/g, '\\\\');
+        arg.value = sanitizeStrForWin32(arg.value);
       }
     }
     await Promise.all([
@@ -137,7 +138,7 @@ export const TagEditor: FC<Props> = props => {
     }
     // Fix strings
     if (typeof argValue === 'string') {
-      argValue = argValue.replace(/\\/g, '\\\\');
+      argValue = sanitizeStrForWin32(argValue);
     }
     // Ensure all arguments exist
     const defaultArgs = templateUtils.tokenizeTag(templateUtils.getDefaultFill(
@@ -342,7 +343,7 @@ export const TagEditor: FC<Props> = props => {
             const encoding = argDefinition.encoding || 'utf8';
             argInput = (<input
               type="text"
-              defaultValue={strValue.replace(/\\\\/g, '\\') || ''}
+              defaultValue={sanitizeStrForWin32(strValue)}
               placeholder={placeholder}
               onChange={handleChange}
               data-encoding={encoding}
@@ -365,7 +366,7 @@ export const TagEditor: FC<Props> = props => {
               showFileName
               className="btn btn--clicky btn--super-compact"
               onChange={path => updateArg(path, index)}
-              path={strValue.replace(/\\\\/g, '\\')}
+              path={sanitizeStrForWin32(strValue)}
               itemtypes={argDefinition.itemTypes}
               extensions={argDefinition.extensions}
             />);

--- a/packages/insomnia/src/ui/components/templating/tag-editor.tsx
+++ b/packages/insomnia/src/ui/components/templating/tag-editor.tsx
@@ -17,9 +17,9 @@ import * as plugins from '../../../plugins';
 import * as pluginContexts from '../../../plugins/context';
 import * as templating from '../../../templating';
 import {
-  sanitizeStrForWin32,
   type NunjucksParsedTag,
   type NunjucksParsedTagArg,
+  sanitizeStrForWin32,
 } from '../../../templating/utils';
 import * as templateUtils from '../../../templating/utils';
 import { useNunjucks } from '../../context/nunjucks/use-nunjucks';


### PR DESCRIPTION
## Fix

When we do a double-escape of the `\` slash on `tag-editor.tsx` it solves the issue.

It seems before we were sanitizing the tag in different ways, and that didn't work, but it's unclear how it may have worked years ago. For now this change seems to do the trick

Explored some alternatives, but going down the path of JSON.stringify'ing the argument elsewhere, or trying to sanitize it elsewhere, becomes a trap quickly and doesn't fully work.

<details>

<summary>Investigation details here</summary>

> Note: dragons 🐉 and spaghetti 🍝 , 
>
> this is failing as far back as 2023. Tried with `10.1.1`, `8.5.1` and even `2023.5.8`. Found a bug report about it here: https://github.com/Kong/insomnia/issues/5754 
>
> this is a sandworm/Shai-hulud type of issue for spending time

When using File template tags as value for environment variables in the JSON / non-table view of the Environment Editor, the file path gets stored with a bad path on the environment. 

- Does not seem to happen when setting the file template tag in the new environment table view editor, it's specific to the JSON view
- Throughout the codebase there's a handful of places where we replace `\\\\` to `\\` 
- There's also places where we do the oposite
- By the time we get the values from Env Editor, it's showing up as `\\` - which then magically dissappears when attempting to use the Env variable in a request, so a string like `C:\\Users\\filipe\\Desktop\\test.txt` ends up as `C:\UsersfilipeDesktoptest.txt`
- In other cases it ends up weirder, particularly when using the Packaged app instead of the local development, where it ends up adding the `AppData\Local\insomnia\app-10.2.0` path to the full bad path.
![image](https://github.com/user-attachments/assets/55d37a49-37a8-4313-963f-43083712d6c2)


![image](https://github.com/user-attachments/assets/63c5a6ed-1bff-41b6-8fcf-babe9a469545)

![image](https://github.com/user-attachments/assets/46b3211e-a661-48c3-bcde-fd3e911e33da)
</details>

Closes INS-4742

Closes #5754 