### PR TITLE
fix: interactivity for components within tooltip body [INS-4773]

### DIFF
--- a/packages/insomnia/src/ui/components/tooltip.tsx
+++ b/packages/insomnia/src/ui/components/tooltip.tsx
@@ -49,14 +49,16 @@ export const Tooltip = (props: Props) => {
   });
 
   return (
-    <div
-      ref={triggerRef}
-      className={tooltipClasses}
-      style={{ position: 'relative', ...style }}
-      {...trigger.triggerProps}
-      onClick={props.onClick}
-    >
-      {children}
+    <>
+      <div
+        ref={triggerRef}
+        className={tooltipClasses}
+        style={{ position: 'relative', ...style }}
+        {...trigger.triggerProps}
+        onClick={props.onClick}
+      >
+        {children}
+      </div>
       {state.isOpen && (
         <OverlayContainer>
           <div
@@ -69,6 +71,6 @@ export const Tooltip = (props: Props) => {
           </div>
         </OverlayContainer>
       )}
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
Attempting to click on links within tooltips would lead to the tooltip being dismissed. This PR fixes the issue by moving the tooltip to be a sibling of the tooltip trigger, which is the correct structure for react-aria tooltips. Ref: https://react-spectrum.adobe.com/react-aria/useTooltipTrigger.html

| Before | After |
|---|---|
| ![Kapture 2024-12-07 at 09 31 28](https://github.com/user-attachments/assets/3e64f38b-e776-43d6-b4d4-9417dc0ac7dd) | ![Kapture 2024-12-07 at 09 33 55](https://github.com/user-attachments/assets/2ba27c0c-d569-4dfd-9057-db2a7c4c0912) |

The `Tooltip` component is used in 45 locations throughout the codebase, and in 23 additional locations via the `HelpTooltip` component.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
