### PR TITLE
runner improvements (multiple tabs)-[INS-4779]

### DIFF
--- a/packages/insomnia-inso/tsconfig.json
+++ b/packages/insomnia-inso/tsconfig.json
@@ -21,7 +21,7 @@
     "sourceMap": true,
     /* Runs in the DOM NOTE: this is inconsistent with reality */
     "lib": [
-      "ES2020",
+      "ES2023",
       "DOM",
       "DOM.Iterable"
     ],

--- a/packages/insomnia-sdk/tsconfig.json
+++ b/packages/insomnia-sdk/tsconfig.json
@@ -20,7 +20,7 @@
     "jsx": "react",
     /* If your code runs in the DOM: */
     "lib": [
-      "es2022",
+      "es2023",
       "dom",
       "dom.iterable"
     ],

--- a/packages/insomnia/src/ui/components/document-tab.tsx
+++ b/packages/insomnia/src/ui/components/document-tab.tsx
@@ -21,7 +21,7 @@ export const DocumentTab = ({ organizationId, projectId, workspaceId, className 
           key={item.id}
           to={`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/${item.id}`}
           className={({ isActive, isPending }) => classnames('text-center rounded-full px-2', {
-            'text-[--color-font] bg-[--color-surprise]': isActive,
+            'text-[--color-font-surprise] bg-[--color-surprise]': isActive,
             'animate-pulse': isPending,
           })}
           data-testid={`workspace-${item.id}`}

--- a/packages/insomnia/src/ui/components/tabs/tabList.tsx
+++ b/packages/insomnia/src/ui/components/tabs/tabList.tsx
@@ -56,6 +56,7 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
     closeTabById,
     closeAllTabsUnderWorkspace,
     closeAllTabsUnderProject,
+    batchCloseTabs,
     updateTabById,
     updateProjectName,
     updateWorkspaceName,
@@ -98,11 +99,14 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
     if (docType === models.workspace.type) {
       // delete all tabs of this workspace
       closeAllTabsUnderWorkspace?.(docId);
+    } else if (docType === models.requestGroup.type) {
+      // when delete a folder, we need also delete the corresponding folder runner tab(if exists)
+      batchCloseTabs?.([docId, `runner_${docId}`]);
     } else {
       // delete tab by id
       closeTabById(docId);
     }
-  }, [closeAllTabsUnderProject, closeAllTabsUnderWorkspace, closeTabById]);
+  }, [batchCloseTabs, closeAllTabsUnderProject, closeAllTabsUnderWorkspace, closeTabById]);
 
   const handleUpdate = useCallback(async (doc: models.BaseModel, patches: Partial<models.BaseModel>[] = []) => {
     const patchObj: Record<string, any> = {};

--- a/packages/insomnia/src/ui/context/app/insomnia-tab-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-tab-context.tsx
@@ -20,6 +20,7 @@ interface ContextProps {
   changeActiveTab: (id: string) => void;
   closeAllTabsUnderWorkspace?: (workspaceId: string) => void;
   closeAllTabsUnderProject?: (projectId: string) => void;
+  batchCloseTabs?: (ids: string[]) => void;
   updateProjectName?: (projectId: string, name: string) => void;
   updateWorkspaceName?: (projectId: string, name: string) => void;
   updateTabById?: (tabId: string, patches: Partial<BaseTab>) => void;
@@ -117,6 +118,38 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       activeTabId: currentTabs.activeTabId === id ? newTabList[Math.max(index - 1, 0)]?.id : currentTabs.activeTabId as string,
     });
     uiEventBus.emit(UIEventType.CLOSE_TAB, [id]);
+  }, [navigate, organizationId, projectId, updateInsomniaTabs]);
+
+  const batchCloseTabs = useCallback((deleteIds: string[]) => {
+    const currentTabs = appTabsRef?.current?.[organizationId];
+    if (!currentTabs) {
+      return;
+    }
+
+    if (currentTabs.tabList.every(tab => deleteIds.includes(tab.id))) {
+      navigate(`/organization/${organizationId}/project/${projectId}`);
+      updateInsomniaTabs({
+        organizationId,
+        tabList: [],
+        activeTabId: '',
+      });
+      uiEventBus.emit(UIEventType.CLOSE_TAB, 'all');
+      return;
+    }
+
+    const index = currentTabs.tabList.findIndex(tab => deleteIds.includes(tab.id));
+    const newTabList = currentTabs.tabList.filter(tab => !deleteIds.includes(tab.id));
+    if (deleteIds.includes(currentTabs.activeTabId || '')) {
+      const url = newTabList[Math.max(index - 1, 0)]?.url;
+      navigate(url);
+    }
+
+    updateInsomniaTabs({
+      organizationId,
+      tabList: newTabList,
+      activeTabId: deleteIds.includes(currentTabs.activeTabId || '') ? newTabList[Math.max(index - 1, 0)]?.id : currentTabs.activeTabId as string,
+    });
+    uiEventBus.emit(UIEventType.CLOSE_TAB, deleteIds);
   }, [navigate, organizationId, projectId, updateInsomniaTabs]);
 
   const closeAllTabsUnderWorkspace = useCallback((workspaceId: string) => {
@@ -334,6 +367,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
         closeAllTabsUnderProject,
         closeAllTabs,
         closeOtherTabs,
+        batchCloseTabs,
         addTab,
         updateTabById,
         changeActiveTab,

--- a/packages/insomnia/src/ui/context/app/insomnia-tab-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-tab-context.tsx
@@ -4,6 +4,7 @@ import { useLocalStorage } from 'react-use';
 
 import type { BaseTab } from '../../components/tabs/tab';
 import type { OrganizationTabs } from '../../components/tabs/tabList';
+import uiEventBus, { UIEventType } from '../../eventBus';
 
 interface UpdateInsomniaTabParams {
   organizationId: string;
@@ -97,6 +98,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
         tabList: [],
         activeTabId: '',
       });
+      uiEventBus.emit(UIEventType.CLOSE_TAB, [id]);
       return;
     }
 
@@ -114,6 +116,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       tabList: newTabList,
       activeTabId: currentTabs.activeTabId === id ? newTabList[Math.max(index - 1, 0)]?.id : currentTabs.activeTabId as string,
     });
+    uiEventBus.emit(UIEventType.CLOSE_TAB, [id]);
   }, [navigate, organizationId, projectId, updateInsomniaTabs]);
 
   const closeAllTabsUnderWorkspace = useCallback((workspaceId: string) => {
@@ -121,6 +124,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
     if (!currentTabs) {
       return;
     }
+    const closeIds = currentTabs.tabList.filter(tab => tab.workspaceId === workspaceId).map(tab => tab.id);
     const newTabList = currentTabs.tabList.filter(tab => tab.workspaceId !== workspaceId);
 
     updateInsomniaTabs({
@@ -128,6 +132,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       tabList: newTabList,
       activeTabId: '',
     });
+    uiEventBus.emit(UIEventType.CLOSE_TAB, closeIds);
   }, [organizationId, updateInsomniaTabs]);
 
   const closeAllTabsUnderProject = useCallback((projectId: string) => {
@@ -135,6 +140,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
     if (!currentTabs) {
       return;
     }
+    const closeIds = currentTabs.tabList.filter(tab => tab.projectId === projectId).map(tab => tab.id);
     const newTabList = currentTabs.tabList.filter(tab => tab.projectId !== projectId);
 
     updateInsomniaTabs({
@@ -142,6 +148,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       tabList: newTabList,
       activeTabId: '',
     });
+    uiEventBus.emit(UIEventType.CLOSE_TAB, closeIds);
   }, [organizationId, updateInsomniaTabs]);
 
   const closeAllTabs = useCallback(() => {
@@ -151,6 +158,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       tabList: [],
       activeTabId: '',
     });
+    uiEventBus.emit(UIEventType.CLOSE_TAB, 'all');
   }, [navigate, organizationId, projectId, updateInsomniaTabs]);
 
   const closeOtherTabs = useCallback((id: string) => {
@@ -171,6 +179,8 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       tabList: [reservedTab],
       activeTabId: id,
     });
+    const closeIds = currentTabs.tabList.filter(tab => tab.id !== id).map(tab => tab.id);
+    uiEventBus.emit(UIEventType.CLOSE_TAB, closeIds);
   }, [navigate, organizationId, updateInsomniaTabs]);
 
   const updateTabById = useCallback((tabId: string, patches: Partial<BaseTab>) => {

--- a/packages/insomnia/src/ui/context/app/insomnia-tab-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-tab-context.tsx
@@ -99,7 +99,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
         tabList: [],
         activeTabId: '',
       });
-      uiEventBus.emit(UIEventType.CLOSE_TAB, [id]);
+      uiEventBus.emit(UIEventType.CLOSE_TAB, organizationId, [id]);
       return;
     }
 
@@ -117,7 +117,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       tabList: newTabList,
       activeTabId: currentTabs.activeTabId === id ? newTabList[Math.max(index - 1, 0)]?.id : currentTabs.activeTabId as string,
     });
-    uiEventBus.emit(UIEventType.CLOSE_TAB, [id]);
+    uiEventBus.emit(UIEventType.CLOSE_TAB, organizationId, [id]);
   }, [navigate, organizationId, projectId, updateInsomniaTabs]);
 
   const batchCloseTabs = useCallback((deleteIds: string[]) => {
@@ -133,7 +133,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
         tabList: [],
         activeTabId: '',
       });
-      uiEventBus.emit(UIEventType.CLOSE_TAB, 'all');
+      uiEventBus.emit(UIEventType.CLOSE_TAB, organizationId, 'all');
       return;
     }
 
@@ -149,7 +149,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       tabList: newTabList,
       activeTabId: deleteIds.includes(currentTabs.activeTabId || '') ? newTabList[Math.max(index - 1, 0)]?.id : currentTabs.activeTabId as string,
     });
-    uiEventBus.emit(UIEventType.CLOSE_TAB, deleteIds);
+    uiEventBus.emit(UIEventType.CLOSE_TAB, organizationId, deleteIds);
   }, [navigate, organizationId, projectId, updateInsomniaTabs]);
 
   const closeAllTabsUnderWorkspace = useCallback((workspaceId: string) => {
@@ -165,7 +165,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       tabList: newTabList,
       activeTabId: '',
     });
-    uiEventBus.emit(UIEventType.CLOSE_TAB, closeIds);
+    uiEventBus.emit(UIEventType.CLOSE_TAB, organizationId, closeIds);
   }, [organizationId, updateInsomniaTabs]);
 
   const closeAllTabsUnderProject = useCallback((projectId: string) => {
@@ -181,7 +181,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       tabList: newTabList,
       activeTabId: '',
     });
-    uiEventBus.emit(UIEventType.CLOSE_TAB, closeIds);
+    uiEventBus.emit(UIEventType.CLOSE_TAB, organizationId, closeIds);
   }, [organizationId, updateInsomniaTabs]);
 
   const closeAllTabs = useCallback(() => {
@@ -191,7 +191,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       tabList: [],
       activeTabId: '',
     });
-    uiEventBus.emit(UIEventType.CLOSE_TAB, 'all');
+    uiEventBus.emit(UIEventType.CLOSE_TAB, organizationId, 'all');
   }, [navigate, organizationId, projectId, updateInsomniaTabs]);
 
   const closeOtherTabs = useCallback((id: string) => {
@@ -213,7 +213,7 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
       activeTabId: id,
     });
     const closeIds = currentTabs.tabList.filter(tab => tab.id !== id).map(tab => tab.id);
-    uiEventBus.emit(UIEventType.CLOSE_TAB, closeIds);
+    uiEventBus.emit(UIEventType.CLOSE_TAB, organizationId, closeIds);
   }, [navigate, organizationId, updateInsomniaTabs]);
 
   const updateTabById = useCallback((tabId: string, patches: Partial<BaseTab>) => {

--- a/packages/insomnia/src/ui/context/app/runner-context.tsx
+++ b/packages/insomnia/src/ui/context/app/runner-context.tsx
@@ -9,9 +9,10 @@ interface RunnerState {
   delay: number;
   uploadData: UploadDataType[];
   advancedConfig: Record<string, boolean>;
+  file: File | null;
 }
 
-type RunnerStateMap = Record<string, RunnerState>;
+type RunnerStateMap = Record<string, Partial<RunnerState> | undefined>;
 interface ContextProps {
   runnerStateMap: RunnerStateMap;
   updateRunnerState: (runnerId: string, patch: Partial<RunnerState>) => void;

--- a/packages/insomnia/src/ui/context/app/runner-context.tsx
+++ b/packages/insomnia/src/ui/context/app/runner-context.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, type FC, type PropsWithChildren, useCallback, useContext, useState } from 'react';
+import type { Selection } from 'react-aria-components';
+
+import type { UploadDataType } from '../../components/modals/upload-runner-data-modal';
+
+interface RunnerState {
+  selectedKeys: Selection;
+  iterationCount: number;
+  delay: number;
+  uploadData: UploadDataType[];
+  advancedConfig: Record<string, boolean>;
+}
+
+type RunnerStateMap = Record<string, RunnerState>;
+interface ContextProps {
+  runnerStateMap: RunnerStateMap;
+  updateRunnerState: (runnerId: string, patch: Partial<RunnerState>) => void;
+}
+const RunnerContext = createContext<ContextProps>({
+  runnerStateMap: {},
+  updateRunnerState: () => { },
+});
+
+export const RunnerProvider: FC<PropsWithChildren> = ({ children }) => {
+
+  const [runnerState, setRunnerState] = useState<RunnerStateMap>({});
+
+  const updateRunnerState = useCallback((runnerId: string, patch: Partial<RunnerState>) => {
+    setRunnerState(prevState => ({
+      ...prevState,
+      [runnerId]: { ...prevState[runnerId], ...patch },
+    }));
+  }, []);
+
+  return (
+    <RunnerContext.Provider
+      value={{
+        runnerStateMap: runnerState,
+        updateRunnerState,
+      }}
+    >
+      {children}
+    </RunnerContext.Provider>
+  );
+};
+
+export const useRunnerContext = () => useContext(RunnerContext);

--- a/packages/insomnia/src/ui/context/app/runner-context.tsx
+++ b/packages/insomnia/src/ui/context/app/runner-context.tsx
@@ -1,7 +1,8 @@
-import React, { createContext, type FC, type PropsWithChildren, useCallback, useContext, useState } from 'react';
+import React, { createContext, type FC, type PropsWithChildren, useCallback, useContext, useEffect, useState } from 'react';
 import type { Selection } from 'react-aria-components';
 
 import type { UploadDataType } from '../../components/modals/upload-runner-data-modal';
+import uiEventBus, { UIEventType } from '../../eventBus';
 import type { RequestRow } from '../../routes/runner';
 
 interface RunnerState {
@@ -34,6 +35,32 @@ export const RunnerProvider: FC<PropsWithChildren> = ({ children }) => {
       [runnerId]: { ...prevState[runnerId], ...patch },
     }));
   }, []);
+
+  const handleTabClose = useCallback((ids: 'all' | string[]) => {
+    if (ids === 'all') {
+      setRunnerState({});
+      return;
+    }
+
+    setRunnerState(prevState => {
+      const newState = { ...prevState };
+      ids.forEach(id => {
+        // runner tab id starts with 'runner' prefix, but the runnerId in this context doesn't have the prefix, so we need to remove it
+        if (id.startsWith('runner')) {
+          const runnerId = id.replace('runner_', '');
+          delete newState[runnerId];
+        }
+      });
+      return newState;
+    });
+  }, []);
+
+  useEffect(() => {
+    uiEventBus.on(UIEventType.CLOSE_TAB, handleTabClose);
+    return () => {
+      uiEventBus.off(UIEventType.CLOSE_TAB, handleTabClose);
+    };
+  }, [handleTabClose]);
 
   return (
     <RunnerContext.Provider

--- a/packages/insomnia/src/ui/context/app/runner-context.tsx
+++ b/packages/insomnia/src/ui/context/app/runner-context.tsx
@@ -1,8 +1,9 @@
-import React, { createContext, type FC, type PropsWithChildren, useCallback, useContext, useEffect, useState } from 'react';
+import React, { createContext, type FC, type PropsWithChildren, useCallback, useContext, useEffect } from 'react';
 import type { Selection } from 'react-aria-components';
 
 import type { UploadDataType } from '../../components/modals/upload-runner-data-modal';
 import uiEventBus, { UIEventType } from '../../eventBus';
+import useStateRef from '../../hooks/use-state-ref';
 import type { RequestRow } from '../../routes/runner';
 
 interface RunnerState {
@@ -15,10 +16,17 @@ interface RunnerState {
   reqList: RequestRow[];
 }
 
-type RunnerStateMap = Record<string, Partial<RunnerState> | undefined>;
+interface OrgRunnerStateMap {
+  [runnerId: string]: Partial<RunnerState>;
+}
+
+interface RunnerStateMap {
+  [orgId: string]: OrgRunnerStateMap;
+};
 interface ContextProps {
   runnerStateMap: RunnerStateMap;
-  updateRunnerState: (runnerId: string, patch: Partial<RunnerState>) => void;
+  runnerStateRef?: React.MutableRefObject<RunnerStateMap>;
+  updateRunnerState: (organizationId: string, runnerId: string, patch: Partial<RunnerState>) => void;
 }
 const RunnerContext = createContext<ContextProps>({
   runnerStateMap: {},
@@ -27,33 +35,46 @@ const RunnerContext = createContext<ContextProps>({
 
 export const RunnerProvider: FC<PropsWithChildren> = ({ children }) => {
 
-  const [runnerState, setRunnerState] = useState<RunnerStateMap>({});
+  const [runnerState, setRunnerState, runnerStateRef] = useStateRef<RunnerStateMap>({});
 
-  const updateRunnerState = useCallback((runnerId: string, patch: Partial<RunnerState>) => {
-    setRunnerState(prevState => ({
-      ...prevState,
-      [runnerId]: { ...prevState[runnerId], ...patch },
-    }));
-  }, []);
+  const updateRunnerState = useCallback((organizationId: string, runnerId: string, patch: Partial<RunnerState>) => {
+    setRunnerState(prevState => {
+      const newState = {
+        ...prevState,
+        [organizationId]: {
+          ...prevState[organizationId],
+          [runnerId]: { ...prevState[organizationId]?.[runnerId], ...patch },
+        },
+      };
+      return newState;
+    });
+  }, [setRunnerState]);
 
-  const handleTabClose = useCallback((ids: 'all' | string[]) => {
+  const handleTabClose = useCallback((organizationId: string, ids: 'all' | string[]) => {
     if (ids === 'all') {
-      setRunnerState({});
+      setRunnerState(prevState => {
+        const newState = { ...prevState };
+        delete newState[organizationId];
+        return newState;
+      });
       return;
     }
 
     setRunnerState(prevState => {
-      const newState = { ...prevState };
+      const newOrgState = { ...prevState?.[organizationId] };
       ids.forEach(id => {
         // runner tab id starts with 'runner' prefix, but the runnerId in this context doesn't have the prefix, so we need to remove it
         if (id.startsWith('runner')) {
           const runnerId = id.replace('runner_', '');
-          delete newState[runnerId];
+          delete newOrgState[runnerId];
         }
       });
-      return newState;
+      return {
+        ...prevState,
+        [organizationId]: newOrgState,
+      };
     });
-  }, []);
+  }, [setRunnerState]);
 
   useEffect(() => {
     uiEventBus.on(UIEventType.CLOSE_TAB, handleTabClose);
@@ -66,6 +87,7 @@ export const RunnerProvider: FC<PropsWithChildren> = ({ children }) => {
     <RunnerContext.Provider
       value={{
         runnerStateMap: runnerState,
+        runnerStateRef,
         updateRunnerState,
       }}
     >

--- a/packages/insomnia/src/ui/context/app/runner-context.tsx
+++ b/packages/insomnia/src/ui/context/app/runner-context.tsx
@@ -2,6 +2,7 @@ import React, { createContext, type FC, type PropsWithChildren, useCallback, use
 import type { Selection } from 'react-aria-components';
 
 import type { UploadDataType } from '../../components/modals/upload-runner-data-modal';
+import type { RequestRow } from '../../routes/runner';
 
 interface RunnerState {
   selectedKeys: Selection;
@@ -10,6 +11,7 @@ interface RunnerState {
   uploadData: UploadDataType[];
   advancedConfig: Record<string, boolean>;
   file: File | null;
+  reqList: RequestRow[];
 }
 
 type RunnerStateMap = Record<string, Partial<RunnerState> | undefined>;

--- a/packages/insomnia/src/ui/eventBus.ts
+++ b/packages/insomnia/src/ui/eventBus.ts
@@ -1,0 +1,37 @@
+type EventHandler = (...args: any[]) => void;
+
+export enum UIEventType {
+  CLOSE_TAB = 'closeTab',
+}
+class EventBus {
+  private events: Record<UIEventType, EventHandler[]> = {
+    [UIEventType.CLOSE_TAB]: [],
+  };
+
+  // Subscribe to event
+  on(event: UIEventType, handler: EventHandler): void {
+    if (!this.events[event]) {
+      this.events[event] = [];
+    }
+    this.events[event].push(handler);
+  }
+
+  // Unsubscribe from event
+  off(event: UIEventType, handler: EventHandler): void {
+    if (!this.events[event]) {
+      return;
+    }
+    this.events[event] = this.events[event].filter(h => h !== handler);
+  }
+
+  // emit event
+  emit(event: UIEventType, ...args: any[]): void {
+    if (!this.events[event]) {
+      return;
+    }
+    this.events[event].forEach(handler => handler(...args));
+  }
+}
+
+const uiEventBus = new EventBus();
+export default uiEventBus;

--- a/packages/insomnia/src/ui/hooks/use-runner-request-list.tsx
+++ b/packages/insomnia/src/ui/hooks/use-runner-request-list.tsx
@@ -8,7 +8,7 @@ import { useRunnerContext } from '../context/app/runner-context';
 import type { RequestRow } from '../routes/runner';
 import type { Child, WorkspaceLoaderData } from '../routes/workspace';
 
-export const useRunnerRequestList = (targetFolderId: string, runnerId: string) => {
+export const useRunnerRequestList = (organizationId: string, targetFolderId: string, runnerId: string) => {
   const { collection } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
   const entityMapRef = useRef(new Map<string, Child>());
 
@@ -51,18 +51,18 @@ export const useRunnerRequestList = (targetFolderId: string, runnerId: string) =
       });
   }, [collection, targetFolderId]);
 
-  const { runnerStateMap, updateRunnerState } = useRunnerContext();
+  const { runnerStateMap, runnerStateRef, updateRunnerState } = useRunnerContext();
 
   useEffect(() => {
-    if (!runnerStateMap[runnerId]) {
-      updateRunnerState(runnerId, {
+    if (!runnerStateRef?.current?.[organizationId]?.[runnerId]) {
+      updateRunnerState(organizationId, runnerId, {
         reqList: requestRows,
       });
     }
-  }, [requestRows, runnerId, runnerStateMap, updateRunnerState]);
+  }, [organizationId, requestRows, runnerId, runnerStateRef, updateRunnerState]);
 
   return {
-    reqList: runnerStateMap[runnerId]?.reqList || [],
+    reqList: runnerStateMap[organizationId]?.[runnerId]?.reqList || [],
     requestRows,
     entityMap: entityMapRef.current,
   };

--- a/packages/insomnia/src/ui/hooks/use-runner-request-list.tsx
+++ b/packages/insomnia/src/ui/hooks/use-runner-request-list.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useRouteLoaderData } from 'react-router-dom';
-import { useListData } from 'react-stately';
-import { usePrevious } from 'react-use';
 
 import { isRequest, type Request } from '../../models/request';
 import { isRequestGroup } from '../../models/request-group';
 import { invariant } from '../../utils/invariant';
+import { useRunnerContext } from '../context/app/runner-context';
 import type { RequestRow } from '../routes/runner';
 import type { Child, WorkspaceLoaderData } from '../routes/workspace';
 
-export const useRunnerRequestList = (workspaceId: string, targetFolderId: string) => {
+export const useRunnerRequestList = (targetFolderId: string, runnerId: string) => {
   const { collection } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
   const entityMapRef = useRef(new Map<string, Child>());
 
@@ -52,24 +51,18 @@ export const useRunnerRequestList = (workspaceId: string, targetFolderId: string
       });
   }, [collection, targetFolderId]);
 
-  const reqList = useListData({
-    initialItems: requestRows,
-  });
-
-  const previousWorkspaceId = usePrevious(workspaceId);
-  const previousTargetFolderId = usePrevious(targetFolderId);
+  const { runnerStateMap, updateRunnerState } = useRunnerContext();
 
   useEffect(() => {
-    if ((previousWorkspaceId && previousWorkspaceId !== workspaceId) || (previousTargetFolderId !== undefined && previousTargetFolderId !== targetFolderId)) {
-      // reset the list when workspace changes
-      const keys = reqList.items.map(item => item.id);
-      reqList.remove(...keys);
-      reqList.append(...requestRows);
+    if (!runnerStateMap[runnerId]) {
+      updateRunnerState(runnerId, {
+        reqList: requestRows,
+      });
     }
-  }, [reqList, requestRows, workspaceId, targetFolderId, previousWorkspaceId, previousTargetFolderId]);
+  }, [requestRows, runnerId, runnerStateMap, updateRunnerState]);
 
   return {
-    reqList,
+    reqList: runnerStateMap[runnerId]?.reqList || [],
     requestRows,
     entityMap: entityMapRef.current,
   };

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -58,6 +58,7 @@ import { Toast } from '../components/toast';
 import { useAIContext } from '../context/app/ai-context';
 import { InsomniaEventStreamProvider } from '../context/app/insomnia-event-stream-context';
 import { InsomniaTabProvider } from '../context/app/insomnia-tab-context';
+import { RunnerProvider } from '../context/app/runner-context';
 import { useOrganizationPermissions } from '../hooks/use-organization-features';
 import { syncProjects } from './project';
 import { useRootLoaderData } from './root';
@@ -879,7 +880,9 @@ const OrganizationRoute = () => {
             </nav>
           </div>}
           <div className='[grid-area:Content] overflow-hidden border-b border-[--hl-md]'>
-            <Outlet />
+              <RunnerProvider>
+                <Outlet />
+              </RunnerProvider>
           </div>
           <div className="relative [grid-area:Statusbar] flex items-center overflow-hidden">
             <TooltipTrigger>

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -820,9 +820,9 @@ function startExecution(workspaceId: string) {
   runnerExecutions.set(workspaceId, {});
 }
 
-function stopExecution(workspaceId: string) {
-  runnerExecutions.delete(workspaceId);
-}
+// function stopExecution(workspaceId: string) {
+//   runnerExecutions.delete(workspaceId);
+// }
 
 function updateExecution(workspaceId: string, executionInfo: ExecutionInfo) {
   const info = runnerExecutions.get(workspaceId);

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -817,10 +817,6 @@ function startExecution(workspaceId: string) {
   runnerExecutions.set(workspaceId, {});
 }
 
-// function stopExecution(workspaceId: string) {
-//   runnerExecutions.delete(workspaceId);
-// }
-
 function updateExecution(workspaceId: string, executionInfo: ExecutionInfo) {
   const info = runnerExecutions.get(workspaceId);
   runnerExecutions.set(workspaceId, {
@@ -840,7 +836,6 @@ function cancelExecution(workspaceId: string) {
     window.main.completeExecutionStep({ requestId: activeRequestId });
     window.main.updateLatestStepName({ requestId: workspaceId, stepName: 'Done' });
     window.main.completeExecutionStep({ requestId: workspaceId });
-    // stopExecution(workspaceId);
   }
 }
 const wrapAroundIterationOverIterationData = (list?: UserUploadEnvironment[], currentIteration?: number): UserUploadEnvironment | undefined => {

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -30,6 +30,7 @@ import { RunnerTestResultPane } from '../components/panes/runner-test-result-pan
 import { ResponseTimer } from '../components/response-timer';
 import { getTimeAndUnit } from '../components/tags/time-tag';
 import { ResponseTimelineViewer } from '../components/viewers/response-timeline-viewer';
+import { useRunnerContext } from '../context/app/runner-context';
 import { useRunnerRequestList } from '../hooks/use-runner-request-list';
 import type { OrganizationLoaderData } from './organization';
 import { type CollectionRunnerContext, type RunnerSource, sendActionImplementation } from './request';
@@ -121,23 +122,27 @@ export const Runner: FC<{}> = () => {
     workspaceId: string;
     direction: 'vertical' | 'horizontal';
   };
-  const [iterationCount, setIterationCount] = useState<number>(1);
-  const [delay, setDelay] = useState<number>(0);
-  const [uploadData, setUploadData] = useState<UploadDataType[]>([]);
   const [file, setFile] = useState<File | null>(null);
-  const [bail, setBail] = useState<boolean>(true);
   const [isRunning, setIsRunning] = useState(false);
 
-  const runnerId = targetFolderId ? `${workspaceId}-${targetFolderId}` : workspaceId;
-
-  invariant(iterationCount, 'iterationCount should not be null');
+  const runnerId = targetFolderId ? targetFolderId : workspaceId;
 
   const { settings } = useRootLoaderData();
   const [showUploadModal, setShowUploadModal] = useState(false);
   const [showCLIModal, setShowCLIModal] = useState(false);
   const [direction, setDirection] = useState<'horizontal' | 'vertical'>(settings.forceVerticalLayout ? 'vertical' : 'horizontal');
 
+  const { runnerStateMap, updateRunnerState } = useRunnerContext();
+  const { iterationCount = 1, delay = 0, selectedKeys, advancedConfig, uploadData = [] } = runnerStateMap[runnerId] || {};
+  invariant(iterationCount, 'iterationCount should not be null');
+
   const { reqList, requestRows, entityMap } = useRunnerRequestList(workspaceId, targetFolderId);
+  const reqListRef = React.useRef(reqList);
+
+  useEffect(() => {
+    // sync the selected keys
+    reqListRef?.current?.setSelectedKeys(selectedKeys || new Set([]));
+  }, [runnerId, selectedKeys]);
 
   useEffect(() => {
     if (settings.forceVerticalLayout) {
@@ -243,7 +248,7 @@ export const Runner: FC<{}> = () => {
       iterationCount,
       userUploadEnvs,
       delay,
-      bail,
+      bail: advancedConfig?.bail || true,
       targetFolderId: targetFolderId || '',
     };
     submit(
@@ -265,9 +270,12 @@ export const Runner: FC<{}> = () => {
     if (Array.from(reqList.selectedKeys).length === Array.from(reqList.items).length) {
       // unselect all
       reqList.setSelectedKeys(new Set([]));
+      updateRunnerState(runnerId, { selectedKeys: new Set([]) });
     } else {
       // select all
-      reqList.setSelectedKeys(new Set(reqList.items.map(item => item.id)));
+      const allKeys = reqList.items.map(item => item.id);
+      reqList.setSelectedKeys(new Set(allKeys));
+      updateRunnerState(runnerId, { selectedKeys: new Set(allKeys) });
     }
   };
 
@@ -279,12 +287,6 @@ export const Runner: FC<{}> = () => {
     };
     readResults();
   }, [runnerId]);
-
-  useEffect(() => {
-    if (uploadData.length >= 1) {
-      setIterationCount(uploadData.length);
-    }
-  }, [setIterationCount, uploadData]);
 
   const [timingSteps, setTimingSteps] = useState<TimingStep[]>([]);
   const [totalTime, setTotalTime] = useState({
@@ -444,7 +446,7 @@ export const Runner: FC<{}> = () => {
                         onChange={e => {
                           try {
                             if (parseInt(e.target.value, 10) > 0) {
-                              setIterationCount(parseInt(e.target.value, 10));
+                              updateRunnerState(runnerId, { iterationCount: parseInt(e.target.value, 10) });
                             }
                           } catch (ex) { }
                         }}
@@ -462,7 +464,7 @@ export const Runner: FC<{}> = () => {
                           try {
                             const delay = parseInt(e.target.value, 10);
                             if (delay >= 0) {
-                              setDelay(delay); // also update the temp settings
+                              updateRunnerState(runnerId, { delay }); // also update the temp settings
                             }
                           } catch (ex) { }
                         }}
@@ -557,8 +559,10 @@ export const Runner: FC<{}> = () => {
                     items={reqList.items}
                     selectionMode="multiple"
                     selectedKeys={reqList.selectedKeys}
-                    onSelectionChange={reqList.setSelectedKeys}
-                    defaultSelectedKeys={allKeys}
+                    onSelectionChange={keys => {
+                      reqList.setSelectedKeys(keys);
+                      updateRunnerState(runnerId, { selectedKeys: keys });
+                    }}
                     aria-label="Request Collection"
                     dragAndDropHooks={requestsDnD}
                     className="w-full h-full leading-8 text-base overflow-auto"
@@ -617,10 +621,17 @@ export const Runner: FC<{}> = () => {
                     <label className="flex items-center gap-2">
                       <input
                         name='bail'
-                        onChange={() => setBail(!bail)}
+                        onChange={() => {
+                          updateRunnerState(runnerId, {
+                            advancedConfig: {
+                              ...advancedConfig,
+                              bail: !advancedConfig?.bail,
+                            },
+                          });
+                        }}
                         type="checkbox"
                         disabled={isRunning}
-                        checked={bail}
+                        checked={advancedConfig?.bail}
                       />
                       Stop run if an error occurs
                     </label>
@@ -668,14 +679,17 @@ export const Runner: FC<{}> = () => {
                 iterationCount={iterationCount}
                 delay={delay}
                 filePath={file?.path || ''}
-                bail={bail}
+                bail={advancedConfig?.bail}
               />
             )}
             {showUploadModal && (
               <UploadDataModal
                 onUploadFile={(file, uploadData) => {
                   setFile(file);
-                  setUploadData(uploadData); // also update the temp settings
+                  updateRunnerState(runnerId, {
+                    uploadData,
+                    iterationCount: uploadData.length >= 1 ? uploadData.length : iterationCount,
+                  });
                 }}
                 userUploadData={uploadData}
                 onClose={() => setShowUploadModal(false)}
@@ -859,7 +873,7 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
 
   const { requests, iterationCount, delay, userUploadEnvs, bail, targetFolderId } = await request.json() as runCollectionActionParams;
   const source: RunnerSource = 'runner';
-  const runnerId = targetFolderId ? `${workspaceId}-${targetFolderId}` : workspaceId;
+  const runnerId = targetFolderId ? targetFolderId : workspaceId;
 
   let testCtx: CollectionRunnerContext = {
     source,

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -138,10 +138,10 @@ export const Runner: FC<{}> = () => {
   const [direction, setDirection] = useState<'horizontal' | 'vertical'>(settings.forceVerticalLayout ? 'vertical' : 'horizontal');
 
   const { runnerStateMap, updateRunnerState } = useRunnerContext();
-  const { iterationCount = 1, delay = 0, selectedKeys = new Set<Key>(), advancedConfig = defaultAdvancedConfig, uploadData = [], file } = runnerStateMap[runnerId] || {};
+  const { iterationCount = 1, delay = 0, selectedKeys = new Set<Key>(), advancedConfig = defaultAdvancedConfig, uploadData = [], file } = runnerStateMap?.[organizationId]?.[runnerId] || {};
   invariant(iterationCount, 'iterationCount should not be null');
 
-  const { reqList, requestRows, entityMap } = useRunnerRequestList(targetFolderId, runnerId);
+  const { reqList, requestRows, entityMap } = useRunnerRequestList(organizationId, targetFolderId, runnerId);
 
   useEffect(() => {
     if (settings.forceVerticalLayout) {
@@ -191,7 +191,7 @@ export const Runner: FC<{}> = () => {
       } else if (event.target.dropPosition === 'after') {
         newList = moveAfter(reqList, event.target.key, event.keys);
       }
-      updateRunnerState(runnerId, { reqList: newList });
+      updateRunnerState(organizationId, runnerId, { reqList: newList });
     },
     renderDragPreview(items) {
       return (
@@ -269,11 +269,11 @@ export const Runner: FC<{}> = () => {
   const onToggleSelection = () => {
     if (Array.from(selectedKeys).length === reqList.length) {
       // unselect all
-      updateRunnerState(runnerId, { selectedKeys: new Set([]) });
+      updateRunnerState(organizationId, runnerId, { selectedKeys: new Set([]) });
     } else {
       // select all
       const allKeys = reqList.map(item => item.id);
-      updateRunnerState(runnerId, { selectedKeys: new Set(allKeys) });
+      updateRunnerState(organizationId, runnerId, { selectedKeys: new Set(allKeys) });
     }
   };
 
@@ -444,7 +444,7 @@ export const Runner: FC<{}> = () => {
                         onChange={e => {
                           try {
                             if (parseInt(e.target.value, 10) > 0) {
-                              updateRunnerState(runnerId, { iterationCount: parseInt(e.target.value, 10) });
+                              updateRunnerState(organizationId, runnerId, { iterationCount: parseInt(e.target.value, 10) });
                             }
                           } catch (ex) { }
                         }}
@@ -462,7 +462,7 @@ export const Runner: FC<{}> = () => {
                           try {
                             const delay = parseInt(e.target.value, 10);
                             if (delay >= 0) {
-                              updateRunnerState(runnerId, { delay }); // also update the temp settings
+                              updateRunnerState(organizationId, runnerId, { delay }); // also update the temp settings
                             }
                           } catch (ex) { }
                         }}
@@ -558,7 +558,7 @@ export const Runner: FC<{}> = () => {
                     selectionMode="multiple"
                     selectedKeys={selectedKeys}
                     onSelectionChange={keys => {
-                      updateRunnerState(runnerId, { selectedKeys: keys });
+                      updateRunnerState(organizationId, runnerId, { selectedKeys: keys });
                     }}
                     aria-label="Request Collection"
                     dragAndDropHooks={requestsDnD}
@@ -619,7 +619,7 @@ export const Runner: FC<{}> = () => {
                       <input
                         name='bail'
                         onChange={() => {
-                          updateRunnerState(runnerId, {
+                          updateRunnerState(organizationId, runnerId, {
                             advancedConfig: {
                               ...advancedConfig,
                               bail: !advancedConfig?.bail,
@@ -682,7 +682,7 @@ export const Runner: FC<{}> = () => {
             {showUploadModal && (
               <UploadDataModal
                 onUploadFile={(file, uploadData) => {
-                  updateRunnerState(runnerId, {
+                  updateRunnerState(organizationId, runnerId, {
                     uploadData,
                     file,
                     iterationCount: uploadData.length >= 1 ? uploadData.length : iterationCount,

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -1,9 +1,9 @@
 import { type RequestContext } from 'insomnia-sdk';
 import porderedJSON from 'json-order';
-import React, { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { type FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Checkbox, DropIndicator, GridList, GridListItem, type GridListItemProps, Heading, type Key, Tab, TabList, TabPanel, Tabs, Toolbar, TooltipTrigger, useDragAndDrop } from 'react-aria-components';
 import { Panel, PanelResizeHandle } from 'react-resizable-panels';
-import { type ActionFunction, type LoaderFunction, redirect, useNavigate, useParams, useRouteLoaderData, useSearchParams, useSubmit } from 'react-router-dom';
+import { type ActionFunction, type LoaderFunction, useNavigate, useParams, useRouteLoaderData, useSearchParams, useSubmit } from 'react-router-dom';
 import { useInterval } from 'react-use';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -109,43 +109,11 @@ export interface RequestRow {
 };
 
 export const Runner: FC<{}> = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const [errorMsg, setErrorMsg] = useState<null | string>(null);
 
   const { currentPlan } = useRouteLoaderData('/organization') as OrganizationLoaderData;
   const targetFolderId = searchParams.get('folder') || '';
-  const shouldRefreshRef = useRef(false);
-
-  useEffect(() => {
-    if (searchParams.has('refresh-pane') || searchParams.has('error')) {
-      const copySearchParams = new URLSearchParams(searchParams);
-      if (searchParams.has('refresh-pane')) {
-        shouldRefreshRef.current = true;
-        copySearchParams.delete('refresh-pane');
-      }
-
-      if (searchParams.has('error')) {
-        setErrorMsg(searchParams.get('error'));
-        // TODO: this should be removed when we are able categorized errors better and display them in different ways.
-        showAlert({
-          title: 'Unexpected Runner Failure',
-          message: (
-            <div>
-              <p>The runner failed due to an unhandled error:</p>
-              <code className="wide selectable">
-                <pre>{searchParams.get('error')}</pre>
-              </code>
-            </div>
-          ),
-        });
-        copySearchParams.delete('error');
-      } else {
-        setErrorMsg(null);
-      }
-
-      setSearchParams(copySearchParams);
-    }
-  }, [searchParams, setSearchParams]);
 
   const { organizationId, projectId, workspaceId } = useParams() as {
     organizationId: string;
@@ -159,6 +127,8 @@ export const Runner: FC<{}> = () => {
   const [file, setFile] = useState<File | null>(null);
   const [bail, setBail] = useState<boolean>(true);
   const [isRunning, setIsRunning] = useState(false);
+
+  const runnerId = targetFolderId ? `${workspaceId}-${targetFolderId}` : workspaceId;
 
   invariant(iterationCount, 'iterationCount should not be null');
 
@@ -282,6 +252,7 @@ export const Runner: FC<{}> = () => {
         method: 'post',
         encType: 'application/json',
         action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/runner/run`,
+        navigate: false,
       }
     );
   };
@@ -303,11 +274,11 @@ export const Runner: FC<{}> = () => {
   const [testHistory, setTestHistory] = useState<RunnerTestResult[]>([]);
   useEffect(() => {
     const readResults = async () => {
-      const results = await models.runnerTestResult.findByParentId(workspaceId) || [];
+      const results = await models.runnerTestResult.findByParentId(runnerId) || [];
       setTestHistory(results.reverse());
     };
     readResults();
-  }, [workspaceId]);
+  }, [runnerId]);
 
   useEffect(() => {
     if (uploadData.length >= 1) {
@@ -340,9 +311,23 @@ export const Runner: FC<{}> = () => {
     refreshTimeline();
   }, [executionResult, errorMsg]);
 
+  const showErrorAlert = (error: string) => {
+    showAlert({
+      title: 'Unexpected Runner Failure',
+      message: (
+        <div>
+          <p>The runner failed due to an unhandled error:</p>
+          <code className="wide selectable">
+            <pre>{error}</pre>
+          </code>
+        </div>
+      ),
+    });
+  };
+
   useInterval(() => {
     const refreshPanes = async () => {
-      const latestTimingSteps = await window.main.getExecution({ requestId: workspaceId });
+      const latestTimingSteps = await window.main.getExecution({ requestId: runnerId });
       if (latestTimingSteps) {
         // there is a timingStep item and it is not ended (duration is not assigned)
         const isRunning = latestTimingSteps.length > 0 && latestTimingSteps[latestTimingSteps.length - 1].stepName !== 'Done';
@@ -351,21 +336,22 @@ export const Runner: FC<{}> = () => {
         if (isRunning) {
           const duration = Date.now() - latestTimingSteps[latestTimingSteps.length - 1].startedAt;
           const { number: durationNumber, unit: durationUnit } = getTimeAndUnit(duration);
-
           setTimingSteps(latestTimingSteps);
           setTotalTime({
             duration: durationNumber,
             unit: durationUnit,
           });
         } else {
-          if (shouldRefreshRef.current) {
-            const results = await models.runnerTestResult.findByParentId(workspaceId) || [];
-            setTestHistory(results.reverse());
-            if (results.length > 0) {
-              const latestResult = results[0];
-              setExecutionResult(latestResult);
-            }
-            shouldRefreshRef.current = false;
+          const results = await models.runnerTestResult.findByParentId(runnerId) || [];
+          setTestHistory(results.reverse());
+          const { error } = getExecution(runnerId);
+          if (error) {
+            showErrorAlert(error);
+            updateExecution(runnerId, { error: '' });
+          }
+          if (results.length > 0) {
+            const latestResult = results[0];
+            setExecutionResult(latestResult);
           }
         }
       }
@@ -373,6 +359,17 @@ export const Runner: FC<{}> = () => {
 
     refreshPanes();
   }, 1000);
+
+  useEffect(() => {
+    setIsRunning(false);
+    setTimingSteps([]);
+    setTotalTime({
+      duration: 0,
+      unit: 'ms',
+    });
+    setExecutionResult(null);
+    setErrorMsg(null);
+  }, [runnerId]);
 
   const { passedTestCount, totalTestCount, testResultCountTagColor } = useMemo(() => {
     let passedTestCount = 0;
@@ -731,7 +728,7 @@ export const Runner: FC<{}> = () => {
           </TabList>
           <TabPanel className='w-full flex-1 flex flex-col overflow-hidden' id='console'>
             <ResponseTimelineViewer
-              key={workspaceId}
+              key={runnerId}
               timeline={timelines}
             />
           </TabPanel>
@@ -750,8 +747,8 @@ export const Runner: FC<{}> = () => {
             {isRunning &&
               <div className="h-full w-full text-md flex items-center">
                 <ResponseTimer
-                  handleCancel={() => cancelExecution(workspaceId)}
-                  activeRequestId={workspaceId}
+                  handleCancel={() => cancelExecution(runnerId)}
+                  activeRequestId={runnerId}
                   steps={timingSteps}
                 />
               </div>
@@ -798,31 +795,39 @@ const RequestItem = (
 // This is required for tracking the active request for one runner execution
 // Then in runner cancellation, both the active request and the runner execution will be canceled
 // TODO(george): Potentially it could be merged with maps in request-timing.ts and cancellation.ts
-const runnerExecutions = new Map<string, string>();
+interface ExecutionInfo {
+  activeRequestId?: string;
+  error?: string;
+};
+const runnerExecutions = new Map<string, ExecutionInfo>();
 function startExecution(workspaceId: string) {
-  runnerExecutions.set(workspaceId, '');
+  runnerExecutions.set(workspaceId, {});
 }
 
 function stopExecution(workspaceId: string) {
   runnerExecutions.delete(workspaceId);
 }
 
-function updateExecution(workspaceId: string, requestId: string) {
-  runnerExecutions.set(workspaceId, requestId);
+function updateExecution(workspaceId: string, executionInfo: ExecutionInfo) {
+  const info = runnerExecutions.get(workspaceId);
+  runnerExecutions.set(workspaceId, {
+    ...info,
+    ...executionInfo,
+  });
 }
 
 function getExecution(workspaceId: string) {
-  return runnerExecutions.get(workspaceId);
+  return runnerExecutions.get(workspaceId) || {};
 }
 
 function cancelExecution(workspaceId: string) {
-  const activeRequestId = getExecution(workspaceId);
+  const { activeRequestId } = getExecution(workspaceId);
   if (activeRequestId) {
     cancelRequestById(activeRequestId);
     window.main.completeExecutionStep({ requestId: activeRequestId });
     window.main.updateLatestStepName({ requestId: workspaceId, stepName: 'Done' });
     window.main.completeExecutionStep({ requestId: workspaceId });
-    stopExecution(workspaceId);
+    // stopExecution(workspaceId);
   }
 }
 const wrapAroundIterationOverIterationData = (list?: UserUploadEnvironment[], currentIteration?: number): UserUploadEnvironment | undefined => {
@@ -852,6 +857,7 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
 
   const { requests, iterationCount, delay, userUploadEnvs, bail, targetFolderId } = await request.json() as runCollectionActionParams;
   const source: RunnerSource = 'runner';
+  const runnerId = targetFolderId ? `${workspaceId}-${targetFolderId}` : workspaceId;
 
   let testCtx: CollectionRunnerContext = {
     source,
@@ -876,12 +882,12 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
     },
   };
 
-  window.main.startExecution({ requestId: workspaceId });
+  window.main.startExecution({ requestId: runnerId });
   window.main.addExecutionStep({
-    requestId: workspaceId,
+    requestId: runnerId,
     stepName: 'Initializing',
   });
-  startExecution(workspaceId);
+  startExecution(runnerId);
 
   try {
     for (let i = 0; i < iterationCount; i++) {
@@ -893,7 +899,7 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
       let j = 0;
       while (j < requests.length) {
         // TODO: we might find a better way to do runner cancellation
-        if (getExecution(workspaceId) === undefined) {
+        if (getExecution(runnerId) === undefined) {
           throw 'Runner has been stopped';
         }
 
@@ -928,9 +934,11 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
             }
           }
 
-          updateExecution(workspaceId, targetRequest.id);
+          updateExecution(runnerId, {
+            activeRequestId: targetRequest.id,
+          });
           window.main.updateLatestStepName({
-            requestId: workspaceId,
+            requestId: runnerId,
             stepName: `Iteration ${i + 1} - Executing ${j + 1} of ${requests.length} requests - "${targetRequest.name}"`,
           });
 
@@ -1023,17 +1031,21 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
       };
     }
 
-    window.main.updateLatestStepName({ requestId: workspaceId, stepName: 'Done' });
-    window.main.completeExecutionStep({ requestId: workspaceId });
+    window.main.updateLatestStepName({ requestId: runnerId, stepName: 'Done' });
+    window.main.completeExecutionStep({ requestId: runnerId });
   } catch (e) {
     // the error could be from third party
-    const errMsg = encodeURIComponent(e.error || e);
-    return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/runner?refresh-pane&error=${errMsg}&folder=${targetFolderId}`);
+    const errMsg = e.error || e;
+    updateExecution(runnerId, {
+      error: errMsg,
+    });
+    return null;
+    // return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/runner?refresh-pane&error=${errMsg}&folder=${targetFolderId}`);
   } finally {
-    cancelExecution(workspaceId);
+    cancelExecution(runnerId);
 
     await models.runnerTestResult.create({
-      parentId: workspaceId,
+      parentId: runnerId,
       source: testCtx.source,
       iterations: testCtx.iterationCount,
       duration: testCtx.duration,
@@ -1042,8 +1054,8 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
       responsesInfo: testCtx.responsesInfo,
     });
   }
-
-  return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/runner?refresh-pane&folder=${targetFolderId}`);
+  return null;
+  // return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/runner?refresh-pane&folder=${targetFolderId}`);
 };
 
 export const collectionRunnerStatusLoader: LoaderFunction = async ({ params }) => {

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -15,6 +15,7 @@ import * as models from '../../models';
 import type { UserUploadEnvironment } from '../../models/environment';
 import type { RunnerResultPerRequest, RunnerTestResult } from '../../models/runner-test-result';
 import { cancelRequestById } from '../../network/cancellation';
+import { moveAfter, moveBefore } from '../../utils';
 import { invariant } from '../../utils/invariant';
 import { SegmentEvent } from '../analytics';
 import { Dropdown, DropdownItem, ItemContent } from '../components/base/dropdown';
@@ -136,16 +137,10 @@ export const Runner: FC<{}> = () => {
   const [direction, setDirection] = useState<'horizontal' | 'vertical'>(settings.forceVerticalLayout ? 'vertical' : 'horizontal');
 
   const { runnerStateMap, updateRunnerState } = useRunnerContext();
-  const { iterationCount = 1, delay = 0, selectedKeys, advancedConfig = defaultAdvancedConfig, uploadData = [], file } = runnerStateMap[runnerId] || {};
+  const { iterationCount = 1, delay = 0, selectedKeys = new Set<Key>(), advancedConfig = defaultAdvancedConfig, uploadData = [], file } = runnerStateMap[runnerId] || {};
   invariant(iterationCount, 'iterationCount should not be null');
 
-  const { reqList, requestRows, entityMap } = useRunnerRequestList(workspaceId, targetFolderId);
-  const reqListRef = React.useRef(reqList);
-
-  useEffect(() => {
-    // sync the selected keys
-    reqListRef?.current?.setSelectedKeys(selectedKeys || new Set([]));
-  }, [runnerId, selectedKeys]);
+  const { reqList, requestRows, entityMap } = useRunnerRequestList(targetFolderId, runnerId);
 
   useEffect(() => {
     if (settings.forceVerticalLayout) {
@@ -169,14 +164,14 @@ export const Runner: FC<{}> = () => {
   }, [settings.forceVerticalLayout, direction]);
 
   const isConsistencyChanged = useMemo(() => {
-    if (requestRows.length !== reqList.items.length) {
+    if (requestRows.length !== reqList.length) {
       return true;
-    } else if (reqList.selectedKeys !== 'all' && Array.from(reqList.selectedKeys).length !== requestRows.length) {
+    } else if (selectedKeys !== 'all' && Array.from(selectedKeys).length !== requestRows.length) {
       return true;
     }
 
-    return requestRows.some((row: RequestRow, index: number) => row.id !== reqList.items[index].id);
-  }, [requestRows, reqList]);
+    return requestRows.some((row: RequestRow, index: number) => row.id !== reqList[index].id);
+  }, [reqList, requestRows, selectedKeys]);
 
   const { dragAndDropHooks: requestsDnD } = useDragAndDrop({
     getItems: keys => {
@@ -189,11 +184,13 @@ export const Runner: FC<{}> = () => {
       });
     },
     onReorder: event => {
+      let newList = reqList;
       if (event.target.dropPosition === 'before') {
-        reqList.moveBefore(event.target.key, event.keys);
+        newList = moveBefore(reqList, event.target.key, event.keys);
       } else if (event.target.dropPosition === 'after') {
-        reqList.moveAfter(event.target.key, event.keys);
+        newList = moveAfter(reqList, event.target.key, event.keys);
       }
+      updateRunnerState(runnerId, { reqList: newList });
     },
     renderDragPreview(items) {
       return (
@@ -204,7 +201,7 @@ export const Runner: FC<{}> = () => {
     },
     renderDropIndicator(target) {
       if (target.type === 'item') {
-        const item = reqList.items.find(item => item.id === target.key);
+        const item = reqList.find(item => item.id === target.key);
         if (item) {
           return (
             <DropIndicator
@@ -229,9 +226,8 @@ export const Runner: FC<{}> = () => {
 
     window.main.trackSegmentEvent({ event: SegmentEvent.collectionRunExecute, properties: { plan: currentPlan?.type || 'scratchpad', iterations: iterationCount } });
 
-    const selected = new Set(reqList.selectedKeys);
-    const requests = Array.from(reqList.items)
-      .filter(item => selected.has(item.id));
+    const selected = new Set(selectedKeys);
+    const requests = reqList.filter(item => selected.has(item.id));
 
     // convert uploadData to environment data
     const userUploadEnvs = uploadData.map(data => {
@@ -270,14 +266,12 @@ export const Runner: FC<{}> = () => {
     navigate(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${requestId}`);
   };
   const onToggleSelection = () => {
-    if (Array.from(reqList.selectedKeys).length === Array.from(reqList.items).length) {
+    if (Array.from(selectedKeys).length === reqList.length) {
       // unselect all
-      reqList.setSelectedKeys(new Set([]));
       updateRunnerState(runnerId, { selectedKeys: new Set([]) });
     } else {
       // select all
-      const allKeys = reqList.items.map(item => item.id);
-      reqList.setSelectedKeys(new Set(allKeys));
+      const allKeys = reqList.map(item => item.id);
       updateRunnerState(runnerId, { selectedKeys: new Set(allKeys) });
     }
   };
@@ -409,11 +403,11 @@ export const Runner: FC<{}> = () => {
     setSelectedTab('test-results');
   }, [setSelectedTab]);
 
-  const allKeys = reqList.items.map(item => item.id);
+  const allKeys = reqList.map(item => item.id);
   const disabledKeys = useMemo(() => {
     return isRunning ? allKeys : [];
   }, [isRunning, allKeys]);
-  const isDisabled = isRunning || Array.from(reqList.selectedKeys).length === 0;
+  const isDisabled = isRunning || Array.from(selectedKeys).length === 0;
 
   const [deletedItems, setDeletedItems] = useState<string[]>([]);
   const deleteHistoryItem = (item: RunnerTestResult) => {
@@ -423,13 +417,13 @@ export const Runner: FC<{}> = () => {
 
   const selectedRequestIdsForCliCommand =
     targetFolderId !== null && targetFolderId !== ''
-      ? Array.from(reqList.items)
+      ? reqList
         .filter(item => item.ancestorIds.includes(targetFolderId))
         .map(item => item.id)
-        .filter(id => new Set(reqList.selectedKeys).has(id))
-      : Array.from(reqList.items)
+        .filter(id => selectedKeys === 'all' || selectedKeys.has(id))
+      : reqList
         .map(item => item.id)
-        .filter(id => new Set(reqList.selectedKeys).has(id));
+        .filter(id => selectedKeys === 'all' || selectedKeys.has(id));
 
   return (
     <>
@@ -548,9 +542,9 @@ export const Runner: FC<{}> = () => {
                 <Toolbar className="w-full flex-shrink-0 h-[--line-height-sm] border-b border-solid border-[--hl-md] flex items-center px-2">
                   <span className="mr-2">
                     {
-                      Array.from(reqList.selectedKeys).length === Array.from(reqList.items).length ?
+                      Array.from(selectedKeys).length === Array.from(reqList).length ?
                         <span onClick={onToggleSelection}><i style={{ color: 'rgb(74 222 128)' }} className="fa fa-square-check fa-1x h-4 mr-2" /> <span className="cursor-pointer" >Unselect All</span></span> :
-                        Array.from(reqList.selectedKeys).length === 0 ?
+                        Array.from(selectedKeys).length === 0 ?
                           <span onClick={onToggleSelection}><i className="fa fa-square fa-1x h-4 mr-2" /> <span className="cursor-pointer" >Select All</span></span> :
                           <span onClick={onToggleSelection}><i style={{ color: 'rgb(74 222 128)' }} className="fa fa-square-minus fa-1x h-4 mr-2" /> <span className="cursor-pointer" >Select All</span></span>
                     }
@@ -559,11 +553,10 @@ export const Runner: FC<{}> = () => {
                 <PaneBody placeholder className='p-0'>
                   <GridList
                     id="runner-request-list"
-                    items={reqList.items}
+                    items={reqList}
                     selectionMode="multiple"
-                    selectedKeys={reqList.selectedKeys}
+                    selectedKeys={selectedKeys}
                     onSelectionChange={keys => {
-                      reqList.setSelectedKeys(keys);
                       updateRunnerState(runnerId, { selectedKeys: keys });
                     }}
                     aria-label="Request Collection"

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -109,6 +109,10 @@ export interface RequestRow {
   parentId: string;
 };
 
+const defaultAdvancedConfig = {
+  bail: true,
+};
+
 export const Runner: FC<{}> = () => {
   const [searchParams] = useSearchParams();
   const [errorMsg, setErrorMsg] = useState<null | string>(null);
@@ -122,7 +126,6 @@ export const Runner: FC<{}> = () => {
     workspaceId: string;
     direction: 'vertical' | 'horizontal';
   };
-  const [file, setFile] = useState<File | null>(null);
   const [isRunning, setIsRunning] = useState(false);
 
   const runnerId = targetFolderId ? targetFolderId : workspaceId;
@@ -133,7 +136,7 @@ export const Runner: FC<{}> = () => {
   const [direction, setDirection] = useState<'horizontal' | 'vertical'>(settings.forceVerticalLayout ? 'vertical' : 'horizontal');
 
   const { runnerStateMap, updateRunnerState } = useRunnerContext();
-  const { iterationCount = 1, delay = 0, selectedKeys, advancedConfig, uploadData = [] } = runnerStateMap[runnerId] || {};
+  const { iterationCount = 1, delay = 0, selectedKeys, advancedConfig = defaultAdvancedConfig, uploadData = [], file } = runnerStateMap[runnerId] || {};
   invariant(iterationCount, 'iterationCount should not be null');
 
   const { reqList, requestRows, entityMap } = useRunnerRequestList(workspaceId, targetFolderId);
@@ -248,7 +251,7 @@ export const Runner: FC<{}> = () => {
       iterationCount,
       userUploadEnvs,
       delay,
-      bail: advancedConfig?.bail || true,
+      bail: advancedConfig?.bail,
       targetFolderId: targetFolderId || '',
     };
     submit(
@@ -685,9 +688,9 @@ export const Runner: FC<{}> = () => {
             {showUploadModal && (
               <UploadDataModal
                 onUploadFile={(file, uploadData) => {
-                  setFile(file);
                   updateRunnerState(runnerId, {
                     uploadData,
+                    file,
                     iterationCount: uploadData.length >= 1 ? uploadData.length : iterationCount,
                   });
                 }}

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -1053,7 +1053,6 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
       error: errMsg,
     });
     return null;
-    // return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/runner?refresh-pane&error=${errMsg}&folder=${targetFolderId}`);
   } finally {
     cancelExecution(runnerId);
 
@@ -1068,7 +1067,6 @@ export const runCollectionAction: ActionFunction = async ({ request, params }) =
     });
   }
   return null;
-  // return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/runner?refresh-pane&folder=${targetFolderId}`);
 };
 
 export const collectionRunnerStatusLoader: LoaderFunction = async ({ params }) => {

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -306,6 +306,8 @@ export const Runner: FC<{}> = () => {
       if (executionResult) {
         const mergedTimelines = await aggregateAllTimelines(errorMsg, executionResult);
         setTimelines(mergedTimelines);
+      } else {
+        setTimelines([]);
       }
     };
     refreshTimeline();
@@ -325,51 +327,51 @@ export const Runner: FC<{}> = () => {
     });
   };
 
-  useInterval(() => {
-    const refreshPanes = async () => {
-      const latestTimingSteps = await window.main.getExecution({ requestId: runnerId });
-      if (latestTimingSteps) {
-        // there is a timingStep item and it is not ended (duration is not assigned)
-        const isRunning = latestTimingSteps.length > 0 && latestTimingSteps[latestTimingSteps.length - 1].stepName !== 'Done';
-        setIsRunning(isRunning);
+  const refreshPanes = useCallback(async () => {
+    const latestTimingSteps = await window.main.getExecution({ requestId: runnerId });
+    let isRunning = false;
+    if (latestTimingSteps) {
+    // there is a timingStep item and it is not ended (duration is not assigned)
+      isRunning = latestTimingSteps.length > 0 && latestTimingSteps[latestTimingSteps.length - 1].stepName !== 'Done';
+    }
+    setIsRunning(isRunning);
 
-        if (isRunning) {
-          const duration = Date.now() - latestTimingSteps[latestTimingSteps.length - 1].startedAt;
-          const { number: durationNumber, unit: durationUnit } = getTimeAndUnit(duration);
-          setTimingSteps(latestTimingSteps);
-          setTotalTime({
-            duration: durationNumber,
-            unit: durationUnit,
-          });
-        } else {
-          const results = await models.runnerTestResult.findByParentId(runnerId) || [];
-          setTestHistory(results.reverse());
-          const { error } = getExecution(runnerId);
-          if (error) {
-            showErrorAlert(error);
-            updateExecution(runnerId, { error: '' });
-          }
-          if (results.length > 0) {
-            const latestResult = results[0];
-            setExecutionResult(latestResult);
-          }
+    if (isRunning) {
+      const duration = Date.now() - latestTimingSteps[latestTimingSteps.length - 1].startedAt;
+      const { number: durationNumber, unit: durationUnit } = getTimeAndUnit(duration);
+      setTimingSteps(latestTimingSteps);
+      setTotalTime({
+        duration: durationNumber,
+        unit: durationUnit,
+      });
+    } else {
+      const results = await models.runnerTestResult.findByParentId(runnerId) || [];
+      // show execution result
+      if (results.length > 0) {
+        setTestHistory(results.reverse());
+        const latestResult = results[0];
+        setExecutionResult(latestResult);
+        const { error } = getExecution(runnerId);
+        if (error) {
+          setErrorMsg(error);
+          showErrorAlert(error);
+          updateExecution(runnerId, { error: '' });
         }
+      } else {
+        // show initial empty panel
+        setExecutionResult(null);
+        setErrorMsg(null);
       }
-    };
+    }
+  }, [runnerId]);
 
+  useInterval(() => {
     refreshPanes();
-  }, 1000);
+  }, isRunning ? 1000 : null);
 
   useEffect(() => {
-    setIsRunning(false);
-    setTimingSteps([]);
-    setTotalTime({
-      duration: 0,
-      unit: 'ms',
-    });
-    setExecutionResult(null);
-    setErrorMsg(null);
-  }, [runnerId]);
+    refreshPanes();
+  }, [refreshPanes]);
 
   const { passedTestCount, totalTestCount, testResultCountTagColor } = useMemo(() => {
     let passedTestCount = 0;

--- a/packages/insomnia/src/ui/routes/runner.tsx
+++ b/packages/insomnia/src/ui/routes/runner.tsx
@@ -129,6 +129,7 @@ export const Runner: FC<{}> = () => {
   };
   const [isRunning, setIsRunning] = useState(false);
 
+  // For backward compatibility，the runnerId we use for testResult in database is no prefix with 'runner_'
   const runnerId = targetFolderId ? targetFolderId : workspaceId;
 
   const { settings } = useRootLoaderData();

--- a/packages/insomnia/src/utils/index.ts
+++ b/packages/insomnia/src/utils/index.ts
@@ -1,6 +1,76 @@
+import type { Key } from 'react-stately';
+
 export const scrollElementIntoView = (element: HTMLElement, options?: ScrollIntoViewOptions) => {
   if (element) {
     // @ts-expect-error -- scrollIntoViewIfNeeded is not a standard method
     element.scrollIntoViewIfNeeded ? element.scrollIntoViewIfNeeded() : element.scrollIntoView(options);
   }
+};
+
+// modify base on react-spectrum
+// https://github.com/adobe/react-spectrum/blob/main/packages/%40react-stately/data/src/useListData.ts#L279
+function move<T>(list: T[], indices: number[], toIndex: number): T[] {
+  // Shift the target down by the number of items being moved from before the target
+  toIndex -= indices.filter(index => index < toIndex).length;
+
+  const moves = indices.map(from => ({
+    from,
+    to: toIndex++,
+  }));
+
+  // Shift later from indices down if they have a larger index
+  for (let i = 0; i < moves.length; i++) {
+    const a = moves[i].from;
+    for (let j = i; j < moves.length; j++) {
+      const b = moves[j].from;
+
+      if (b > a) {
+        moves[j].from--;
+      }
+    }
+  }
+
+  // Interleave the moves so they can be applied one by one rather than all at once
+  for (let i = 0; i < moves.length; i++) {
+    const a = moves[i];
+    for (let j = moves.length - 1; j > i; j--) {
+      const b = moves[j];
+
+      if (b.from < a.to) {
+        a.to++;
+      } else {
+        b.from++;
+      }
+    }
+  }
+
+  const copy = list.slice();
+  for (const move of moves) {
+    const [item] = copy.splice(move.from, 1);
+    copy.splice(move.to, 0, item);
+  }
+
+  return copy;
+}
+export const moveBefore = (list: any[], key: Key, keys: Iterable<Key>) => {
+  const toIndex = list.findIndex(item => item.id === key);
+  if (toIndex === -1) {
+    return list;
+  }
+
+  // Find indices of keys to move. Sort them so that the order in the list is retained.
+  const keyArray = Array.isArray(keys) ? keys : [...keys];
+  const indices = keyArray.map(key => list.findIndex(item => item.id === key)).sort((a, b) => a - b);
+  return move(list, indices, toIndex);
+};
+
+export const moveAfter = (list: any[], key: Key, keys: Iterable<Key>) => {
+  const toIndex = list.findIndex(item => item.id === key);
+  if (toIndex === -1) {
+    return list;
+  }
+
+  const keyArray = Array.isArray(keys) ? keys : [...keys];
+  const indices = keyArray.map(key => list.findIndex(item => item.id === key)).sort((a, b) => a - b);
+  return move(list, indices, toIndex + 1);
 };


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

**Changes**

- runnerId: use for save runner test result and query runner execution state
  - collection runner use workspaceId as runnerId
  - folder runner use folderId as runnerId
- maintain all the runner states in a Context, so that we can keep the state when switching between runner tabs
  - request list (we need to keep order)
  - selected request
  - iteration count/delay
  - upload data
  - advanced config
- change runner execution status display logic
  - not return redirect in `runCollectionAction`
  - if there is an error, store it in `runnerExecutions`
- add a  common `EventBus` class
  - listen tab close event and clear runner context state in callbeck 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/877cbd94-a927-4d89-8711-b5a694820396" />

