### PR TITLE
fix(Dropdown/Menus): Options shouldn't autoselect if the menu overlaps with the trigger button

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -716,7 +716,7 @@ export const CodeEditor = memo(forwardRef<CodeEditorHandle, CodeEditorProps>(({
                   >
                     <Icon icon="clock" />
                   </Button>
-                  <Popover className="min-w-max">
+                  <Popover className="min-w-max overflow-y-hidden flex flex-col">
                     <Menu
                       aria-label="Filter history menu"
                       selectionMode="single"
@@ -736,7 +736,7 @@ export const CodeEditor = memo(forwardRef<CodeEditorHandle, CodeEditorProps>(({
                         name: filter,
                         key: index,
                       }))}
-                      className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                      className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                     >
                       {item => (
                         <MenuItem

--- a/packages/insomnia/src/ui/components/design-empty-state.tsx
+++ b/packages/insomnia/src/ui/components/design-empty-state.tsx
@@ -92,7 +92,7 @@ export const DesignEmptyState: FC<Props> = ({ onImport }) => {
               <span>Import OpenAPI</span>
               <Icon icon="caret-down" />
             </Button>
-            <Popover className="min-w-max">
+            <Popover className="min-w-max overflow-y-hidden flex flex-col">
               <Menu
                 aria-label='Import OpenAPI Dropdown'
                 selectionMode="single"
@@ -100,7 +100,7 @@ export const DesignEmptyState: FC<Props> = ({ onImport }) => {
                   importActionsList.find(({ id }) => key === id)?.action();
                 }}
                 items={importActionsList}
-                className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
               >
                 {item => (
                   <MenuItem

--- a/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/auth-dropdown.tsx
@@ -254,10 +254,10 @@ export const AuthDropdown: FC<Props> = ({ authentication, authTypes = defaultTyp
         </SelectValue>
         <Icon icon="caret-down" />
       </Button>
-      <Popover className="min-w-max">
+      <Popover className="min-w-max overflow-y-hidden flex flex-col">
         <ListBox
           items={authTypeSections}
-          className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+          className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
         >
           {section => (
             <Section>

--- a/packages/insomnia/src/ui/components/dropdowns/content-type-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/content-type-dropdown.tsx
@@ -177,10 +177,10 @@ export const ContentTypeDropdown: FC = () => {
         </SelectValue>
         <Icon icon="caret-down" />
       </Button>
-      <Popover className="min-w-max">
+      <Popover className="min-w-max overflow-y-hidden flex flex-col">
         <ListBox
           items={contentTypeSections}
-          className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+          className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
         >
           {section => (
             <Section>

--- a/packages/insomnia/src/ui/components/dropdowns/grpc-method-dropdown/grpc-method-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/grpc-method-dropdown/grpc-method-dropdown.tsx
@@ -111,10 +111,10 @@ export const GrpcMethodDropdown: FunctionComponent<Props> = ({
         </SelectValue>
         <Icon icon="caret-down" />
       </Button>
-      <Popover className="min-w-max max-w-xs">
+      <Popover className="min-w-max max-w-xs overflow-y-hidden flex flex-col">
         <ListBox
           items={sections}
-          className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+          className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
         >
           {section => (
             <Section key={section.id}>

--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -140,7 +140,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
         >
           <Icon icon="caret-down" />
         </Button>
-        <Popover className="min-w-max">
+        <Popover className="min-w-max overflow-y-hidden flex flex-col">
           <Menu
             aria-label="Project Actions Menu"
             selectionMode="single"
@@ -148,7 +148,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storage })
               projectActionList.find(({ id }) => key === id)?.action(project._id, project.name);
             }}
             items={projectActionList}
-            className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+            className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
           >
             {item => (
               <MenuItem

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -276,13 +276,13 @@ export const RequestActionsDropdown = ({
         >
           <Icon icon="caret-down" />
         </Button>
-        <Popover className="min-w-max">
+        <Popover className="min-w-max overflow-y-hidden flex flex-col">
           <Menu
             aria-label="Request Actions Menu"
             selectionMode="single"
             onAction={key => requestActionList.find(i => i.items.find(a => a.id === key))?.items.find(a => a.id === key)?.action()}
             items={requestActionList}
-            className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+            className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
           >
             {section => (
               <Section className='flex-1 flex flex-col'>

--- a/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -305,13 +305,13 @@ export const RequestGroupActionsDropdown = ({
         >
           <Icon icon="caret-down" />
         </Button>
-        <Popover className="min-w-max">
+        <Popover className="min-w-max overflow-y-hidden flex flex-col" >
           <Menu
             aria-label="Request Group Actions Menu"
             selectionMode="single"
             onAction={key => requestGroupActionItems.find(i => i.items.find(a => a.id === key))?.items.find(a => a.id === key)?.action()}
             items={requestGroupActionItems}
-            className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+            className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto h-full focus:outline-none"
           >
             {section => (
               <Section className='flex-1 flex flex-col'>

--- a/packages/insomnia/src/ui/components/dropdowns/websocket-preview-mode.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/websocket-preview-mode.tsx
@@ -45,10 +45,10 @@ export const WebSocketPreviewMode: FC<Props> = ({ previewMode, onSelect }) => {
         </SelectValue>
         <Icon icon="caret-down" />
       </Button>
-      <Popover className="min-w-max">
+      <Popover className="min-w-max overflow-y-hidden flex flex-col">
         <ListBox
           items={contentTypes}
-          className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+          className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
         >
           {item => (
             <ListBoxItem

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
@@ -277,13 +277,13 @@ export const WorkspaceDropdown: FC<{}> = () => {
           <span className="truncate" title={activeWorkspace.name}>{activeWorkspace.name}</span>
           <Icon icon="caret-down" />
         </Button>
-        <Popover className="min-w-max">
+        <Popover className="min-w-max overflow-y-hidden flex flex-col">
           <Menu
             aria-label="Create in project actions"
             selectionMode="single"
             onAction={key => actionlist.find(i => i.items.find(a => a.id === key))?.items.find(a => a.id === key)?.action()}
             items={actionlist}
-            className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+            className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
           >
             {section => (
               <Section className='flex-1 flex flex-col'>

--- a/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
@@ -569,11 +569,11 @@ export const RequestScriptEditor: FC<Props> = ({
               <Icon icon="code" />
               {menu.name}
             </Button>
-            <Popover className="min-w-max">
+            <Popover className="min-w-max overflow-y-hidden flex flex-col">
               <Menu
                 aria-label="Create a new request"
                 selectionMode="single"
-                className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                 items={menu.items}
               >
                 {section => {

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -412,9 +412,9 @@ export const KeyValueEditor: FC<Props> = ({
                   >
                     <Icon icon="caret-down" />
                   </Button>
-                  <Popover className="min-w-max">
+                  <Popover className="min-w-max overflow-y-hidden flex flex-col">
                     <Menu
-                      className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                      className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                       aria-label="Create a new request"
                       selectionMode="single"
                       selectedKeys={[selectedValueType]}

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -321,7 +321,7 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: {
                             >
                               <Icon icon="caret-down" />
                             </Button>
-                            <Popover className="min-w-max">
+                            <Popover className="min-w-max overflow-y-hidden flex flex-col">
                               <Menu
                                 aria-label="Environment Actions menu"
                                 selectionMode="single"
@@ -331,7 +331,7 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: {
                                     ?.action(item);
                                 }}
                                 items={environmentActionsList}
-                                className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                                className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                               >
                                 {item => (
                                   <MenuItem
@@ -356,7 +356,7 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: {
                               >
                                 <Icon icon="plus-circle" />
                               </Button>
-                              <Popover className="min-w-max">
+                              <Popover className="min-w-max overflow-y-hidden flex flex-col">
                                 <Menu
                                   aria-label="Create Environment menu"
                                   selectionMode="single"
@@ -366,7 +366,7 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: {
                                       ?.action(item);
                                   }}
                                   items={createEnvironmentActionsList}
-                                  className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                                  className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                                 >
                                   {item => (
                                     <MenuItem

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -84,10 +84,10 @@ const UntrackedProject = ({
             </SelectValue>
             <Icon icon="caret-down" />
           </Button>
-          <Popover className="min-w-max">
+          <Popover className="min-w-max overflow-y-hidden flex flex-col">
             <ListBox
               items={organizations}
-              className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+              className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
             >
               {item => (
                 <ListBoxItem
@@ -181,9 +181,9 @@ const UntrackedWorkspace = ({
             </SelectValue>
             <Icon icon="caret-down" />
           </Button>
-          <Popover className="min-w-max">
+          <Popover className="min-w-max overflow-y-hidden flex flex-col">
             <ListBox
-              className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+              className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
               items={projects.map(project => ({
                 ...project,
                 id: project._id,

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -841,7 +841,7 @@ export const Debug: FC = () => {
                 >
                   <Icon icon="sort" />
                 </Button>
-                <Popover className="min-w-max">
+                <Popover className="min-w-max overflow-y-hidden flex flex-col">
                   <ListBox
                     items={SORT_ORDERS.map(order => {
                       return {
@@ -849,7 +849,7 @@ export const Debug: FC = () => {
                         name: sortOrderName[order],
                       };
                     })}
-                    className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                    className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                   >
                     {item => (
                       <ListBoxItem
@@ -912,13 +912,13 @@ export const Debug: FC = () => {
                 >
                   <Icon icon="plus-circle" />
                 </Button>
-                <Popover className="min-w-max">
+                <Popover className="min-w-max overflow-y-hidden flex flex-col">
                   <Menu
                     aria-label="Create a new request"
                     selectionMode="single"
                     onAction={key => createInCollectionActionList.find(i => i.items.find(a => a.id === key))?.items.find(a => a.id === key)?.action()}
                     items={createInCollectionActionList}
-                    className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                    className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                   >
                     {section => (
                       <Section className='flex-1 flex flex-col'>

--- a/packages/insomnia/src/ui/routes/design.tsx
+++ b/packages/insomnia/src/ui/routes/design.tsx
@@ -517,7 +517,7 @@ const Design: FC = () => {
               >
                 <Icon icon="gear" />
               </Button>
-              <Popover className="min-w-max">
+              <Popover className="min-w-max overflow-y-hidden flex flex-col">
                 <Menu
                   aria-label="Spec actions menu"
                   selectionMode="single"
@@ -531,7 +531,7 @@ const Design: FC = () => {
                     }
                   }}
                   items={specActionList}
-                  className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                  className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                 >
                   {item => (
                     <MenuItem

--- a/packages/insomnia/src/ui/routes/environments.tsx
+++ b/packages/insomnia/src/ui/routes/environments.tsx
@@ -334,7 +334,7 @@ const Environments = () => {
                     >
                       <Icon icon="caret-down" />
                     </Button>
-                    <Popover className="min-w-max">
+                    <Popover className="min-w-max overflow-y-hidden flex flex-col">
                       <Menu
                         aria-label="Environment Actions"
                         selectionMode="single"
@@ -344,7 +344,7 @@ const Environments = () => {
                             ?.action(item);
                         }}
                         items={environmentActionsList}
-                        className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                        className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                       >
                         {item => (
                           <MenuItem
@@ -369,7 +369,7 @@ const Environments = () => {
                       >
                         <Icon icon="plus-circle" />
                       </Button>
-                      <Popover className="min-w-max">
+                      <Popover className="min-w-max overflow-y-hidden flex flex-col">
                         <Menu
                           aria-label="New Environment"
                           selectionMode="single"
@@ -379,7 +379,7 @@ const Environments = () => {
                               ?.action(item);
                           }}
                           items={createEnvironmentActionsList}
-                          className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                          className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                         >
                           {item => (
                             <MenuItem

--- a/packages/insomnia/src/ui/routes/mock-server.tsx
+++ b/packages/insomnia/src/ui/routes/mock-server.tsx
@@ -318,7 +318,7 @@ const MockServerRoute = () => {
                     >
                       <Icon icon="caret-down" />
                     </Button>
-                    <Popover className="min-w-max">
+                    <Popover className="min-w-max overflow-y-hidden flex flex-col">
                       <Menu
                         aria-label="Mock Route Action Menu"
                         selectionMode="single"
@@ -328,7 +328,7 @@ const MockServerRoute = () => {
                             ?.action(item._id, item.name);
                         }}
                         items={mockRouteActionList}
-                        className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                        className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                       >
                         {item => (
                           <MenuItem

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1007,10 +1007,10 @@ const ProjectRoute: FC = () => {
                     </SelectValue>
                     <Icon icon="caret-down" />
                   </Button>
-                  <Popover className="min-w-max">
+                  <Popover className="min-w-max overflow-y-hidden flex flex-col">
                     <ListBox
                       items={organizations}
-                      className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                      className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                     >
                       {item => (
                         <ListBoxItem
@@ -1269,7 +1269,7 @@ const ProjectRoute: FC = () => {
                     >
                       <Icon icon="sort" />
                     </Button>
-                    <Popover className="min-w-max">
+                    <Popover className="min-w-max overflow-y-hidden flex flex-col">
                       <ListBox
                         items={DASHBOARD_SORT_ORDERS.map(order => {
                           return {
@@ -1277,7 +1277,7 @@ const ProjectRoute: FC = () => {
                             name: dashboardSortOrderName[order],
                           };
                         })}
-                        className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                        className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                       >
                         {item => (
                           <ListBoxItem
@@ -1312,7 +1312,7 @@ const ProjectRoute: FC = () => {
                     >
                       <Icon icon="plus-circle" /> Create
                     </Button>
-                    <Popover className="min-w-max">
+                    <Popover className="min-w-max overflow-y-hidden flex flex-col">
                       <Menu
                         aria-label="Create in project actions"
                         selectionMode="single"
@@ -1325,7 +1325,7 @@ const ProjectRoute: FC = () => {
                           }
                         }}
                         items={createInProjectActionList}
-                        className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                        className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                       >
                         {item => (
                           <MenuItem

--- a/packages/insomnia/src/ui/routes/test-suite.tsx
+++ b/packages/insomnia/src/ui/routes/test-suite.tsx
@@ -168,14 +168,14 @@ const UnitTestItemView = ({
             </SelectValue>
             <Icon icon="caret-down" />
           </Button>
-          <Popover className="min-w-max">
+          <Popover className="min-w-max overflow-y-hidden flex flex-col">
             <ListBox
               items={requests.map(request => ({
                 ...request,
                 id: request._id,
                 key: request._id,
               }))}
-              className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[50vh] focus:outline-none"
+              className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
             >
               {request => (
                 <ListBoxItem

--- a/packages/insomnia/src/ui/routes/unit-test.tsx
+++ b/packages/insomnia/src/ui/routes/unit-test.tsx
@@ -402,7 +402,7 @@ const TestRoute: FC = () => {
                         >
                           <Icon icon="caret-down" />
                         </Button>
-                        <Popover className="min-w-max">
+                        <Popover className="min-w-max overflow-y-hidden flex flex-col">
                           <Menu
                             aria-label="Unit Test Actions Menu"
                             selectionMode="single"
@@ -412,7 +412,7 @@ const TestRoute: FC = () => {
                                 ?.action(item._id, item.name);
                             }}
                             items={testSuiteActionList}
-                            className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto max-h-[85vh] focus:outline-none"
+                            className="border select-none text-sm min-w-max border-solid border-[--hl-sm] shadow-lg bg-[--color-bg] py-2 rounded-md overflow-y-auto focus:outline-none"
                           >
                             {item => (
                               <MenuItem


### PR DESCRIPTION
Highlights:

- [x] Fixes an issue where opening a dropdown/menu/select would automatically select an option if the menu overlaps with the trigger button

Closes INS-4813
Closes #8242