### PR TITLE
fix(sdk): client cert doesn't work in some cases when enabling pre-request script

### DIFF
--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -167,18 +167,18 @@ export async function initInsomniaObject(
         localVars: localVariables,
     });
 
-    const existClientCert = rawObj.clientCertificates != null && rawObj.clientCertificates.length > 0;
-    const certificate = existClientCert && rawObj.clientCertificates[0] ?
-        {
-            disabled: rawObj.clientCertificates[0].disabled,
-            name: 'The first certificate from Settings',
-            matches: [rawObj.clientCertificates[0].host],
-            key: { src: rawObj.clientCertificates[0].key || '' },
-            cert: { src: rawObj.clientCertificates[0].cert || '' },
-            passphrase: rawObj.clientCertificates[0].passphrase || undefined,
-            pfx: { src: rawObj.clientCertificates[0].pfx || '' }, // PFX or PKCS12 Certificate
-        } :
-        { disabled: true };
+    // const existClientCert = rawObj.clientCertificates != null && rawObj.clientCertificates.length > 0;
+    // const certificate = existClientCert && rawObj.clientCertificates[0] ?
+    //     {
+    //         disabled: rawObj.clientCertificates[0].disabled,
+    //         name: 'The first certificate from Settings',
+    //         matches: [rawObj.clientCertificates[0].host],
+    //         key: { src: rawObj.clientCertificates[0].key || '' },
+    //         cert: { src: rawObj.clientCertificates[0].cert || '' },
+    //         passphrase: rawObj.clientCertificates[0].passphrase || undefined,
+    //         pfx: { src: rawObj.clientCertificates[0].pfx || '' }, // PFX or PKCS12 Certificate
+    //     } :
+    //     { disabled: true };
 
     const proxy = transformToSdkProxyOptions(
         rawObj.settings.httpProxy,
@@ -204,7 +204,9 @@ export async function initInsomniaObject(
         body: toScriptRequestBody(rawObj.request.body),
         auth: toPreRequestAuth(rawObj.request.authentication),
         proxy,
-        certificate,
+        // the certificate is undefined
+        // as it is difficult to find the best cert before rendering
+        certificate: undefined,
         pathParameters: rawObj.request.pathParameters,
     };
     const request = new ScriptRequest(reqOpt);

--- a/packages/insomnia-sdk/src/objects/request.ts
+++ b/packages/insomnia-sdk/src/objects/request.ts
@@ -511,13 +511,18 @@ export function mergeClientCertificates(
         };
 
     if (updatedReq.certificate.pfx && updatedReq.certificate.pfx?.src !== '') {
-        return [{
+        const specifiedCert: ClientCertificate = {
             ...baseCertificate,
             key: null,
             cert: null,
+            name: updatedReq.certificate.name || '',
+            disabled: updatedReq.certificate.disabled || false,
             passphrase: updatedReq.certificate.passphrase || null,
             pfx: updatedReq.certificate.pfx?.src,
-        }];
+            host: '*',
+        };
+
+        return [specifiedCert, ...originalClientCertificates];
     } else if (
         updatedReq &&
         updatedReq.certificate.key &&
@@ -525,7 +530,7 @@ export function mergeClientCertificates(
         updatedReq.certificate.key?.src !== '' &&
         updatedReq.certificate.cert?.src !== ''
     ) {
-        return [{
+        const specifiedCert: ClientCertificate = {
             ...baseCertificate,
 
             _id: '',
@@ -534,15 +539,17 @@ export function mergeClientCertificates(
             modified: 0,
             created: 0,
             isPrivate: false,
-            name: updatedReq.name || '',
-            host: updatedReq.url.getHost() || '',
-            disabled: updatedReq.disabled || false,
+            name: updatedReq.certificate.name || '',
+            disabled: updatedReq.certificate.disabled || false,
+            host: '*',
 
             key: updatedReq.certificate.key?.src,
             cert: updatedReq.certificate.cert?.src,
             passphrase: updatedReq.certificate.passphrase || null,
             pfx: null,
-        }];
+        };
+
+        return [specifiedCert, ...originalClientCertificates];
     }
 
     throw Error('Invalid certificate configuration: "cert+key" and "pfx" can not be set at the same time');

--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -288,18 +288,19 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     preRequestScript: |-
+      const { Certificate } = require('insomnia-collection');
       // print the original one
-      console.log('key:', insomnia.request.certificate.key.src);
-      console.log('cert:', insomnia.request.certificate.cert.src);
-      console.log('passphrass:', insomnia.request.certificate.passphrass);
-      console.log('pfx:', insomnia.request.certificate.pfx.src);
+      // console.log('key:', insomnia.request.certificate.key.src);
+      // console.log('cert:', insomnia.request.certificate.cert.src);
+      // console.log('passphrass:', insomnia.request.certificate.passphrass);
+      // console.log('pfx:', insomnia.request.certificate.pfx.src);
       // update
-      insomnia.request.certificate.update({
-          disabled: true,
-          key: {src: 'invalid.key'},
-          cert: {src: 'invalid.cert'},
+      insomnia.request.certificate = new Certificate({
+          disabled: false,
+          key: {src: ''},
+          cert: {src: ''},
           passphrase: '',
-          pfx: {src: ''},
+          pfx: {src: 'fake.pfx'},
       });    
     _type: request
   - _id: req_89dade2ee9ee42fbb22d588783a9df3e

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -397,7 +397,7 @@ test.describe('pre-request features tests', async () => {
         await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
         // verify
         await page.getByRole('tab', { name: 'Console' }).click();
-        await expect(responsePane).toContainText('fixtures/certificates/fake.pfx'); // original proxy
+        await expect(responsePane).toContainText('Adding SSL P12 certificate');
     });
 
     test('pre: insomnia.test and insomnia.expect can work together', async ({ page }) => {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
