### PR TITLE
fix: editor did not unlock after websocket disconnect

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -223,6 +223,16 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
   useEditorRefresh(reinitialize);
 
   useEffect(() => {
+    if (codeMirror.current) {
+      // https://github.com/Kong/insomnia/issues/8265
+      // we have a unique key for request panel, when connect to websocket, unique will change and component will mount again automatically
+      // but when disconnect, the unique key will not change, so we need to update some configurations manually
+      codeMirror.current.setOption('readOnly', readOnly);
+      codeMirror.current.setOption('keyMap', !readOnly && settings.editorKeyMap ? settings.editorKeyMap : 'default');
+    }
+  }, [readOnly, settings.editorKeyMap]);
+
+  useEffect(() => {
       // Prevent these things if we're type === "password"
       const preventDefault = (_: CodeMirror.Editor, event: Event) => type?.toLowerCase() === 'password' && event.preventDefault();
       codeMirror.current?.on('copy', preventDefault);


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
close #8265