### PR TITLE
feat: Enhanced the Body Editor to support the JSON MIME type, ensuring proper handling and formatting.

### DIFF
--- a/packages/insomnia/src/ui/components/editors/body/body-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/body-editor.tsx
@@ -9,6 +9,7 @@ import {
   CONTENT_TYPE_FORM_DATA,
   CONTENT_TYPE_FORM_URLENCODED,
   CONTENT_TYPE_GRAPHQL,
+  CONTENT_TYPE_JSON,
   getContentTypeFromHeaders,
 } from '../../../../common/constants';
 import { documentationLinks } from '../../../../common/documentation';
@@ -119,6 +120,8 @@ export const BodyEditor: FC<Props> = ({
       return <FileEditor key={uniqueKey} onChange={handleFileChange} path={fileName || ''} />;
     } else if (mimeType === CONTENT_TYPE_GRAPHQL) {
       return <GraphQLEditor key={uniqueKey} uniquenessKey={uniqueKey} request={request} workspaceId={workspaceId} environmentId={environmentId} onChange={handleGraphQLChange} />;
+    } else if (mimeType === CONTENT_TYPE_JSON) {
+      return <RawEditor uniquenessKey={uniqueKey} contentType={mimeType || 'application/json'} content={request.body.text || ''} onChange={handleRawChange} />;
     } else if (!isBodyEmpty) {
       const contentType = getContentTypeFromHeaders(request.headers) || mimeType;
       return <RawEditor uniquenessKey={uniqueKey} contentType={contentType || 'text/plain'} content={request.body.text || ''} onChange={handleRawChange} />;


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
### Issue

This was done in order to address the below open issue
**CLOSES**: [Be able to change the code highlight from editor #8227](https://github.com/Kong/insomnia/issues/8227)

### Changes

Implemented a condition in the `renderBodyEditor` function of the request body editor to support JSON MIME types, enabling proper formatting even when the `Content-Type` is not explicitly set to `application/json`.

![image](https://github.com/user-attachments/assets/a9b7e569-fc2a-440f-8e7a-811648d45d5a)
![image](https://github.com/user-attachments/assets/ab533cd5-5caa-4fdf-9cfa-a1b336b821d6)
