### PR TITLE
fix: GRPC Bad Duplicate issue. Closes #8216

### DIFF
--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -680,11 +680,11 @@ export const Debug: FC = () => {
           icon: 'terminal',
           action: () => setPasteCurlModalOpen(true),
         },
-          {
-            id: 'from-file',
-            name: 'From File',
-            icon: 'file-import',
-            action: () => setIsImportModalOpen(true),
+        {
+          id: 'from-file',
+          name: 'From File',
+          icon: 'file-import',
+          action: () => setIsImportModalOpen(true),
         }],
       }];
 
@@ -1140,6 +1140,7 @@ export const Debug: FC = () => {
                         )}
                         {isGrpcRequestId(requestId) && grpcState && (
                           <GrpcRequestPane
+                            key={grpcState.requestId}
                             grpcState={grpcState}
                             setGrpcState={setGrpcState}
                             reloadRequests={reloadRequests}


### PR DESCRIPTION
Since the methods and body of the gRPC request pane are loaded within an onMount hook, and the component was not unmounting, subsequent requests were unable to fetch the updated methods and body. As a result, the gRPC panel was not displaying all the relevant data. To address this issue, I provided a key to the component, ensuring that the onMount hook is triggered each time the component is rendered.