### PR TITLE
fix: request render error not display - [INS-4833]

### DIFF
--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -51,6 +51,19 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
     if (searchParams.has('envVariableMissing') && searchParams.get('undefinedEnvironmentVariables')) {
       setShowEnvVariableMissingModal(true);
       setUndefinedEnvironmentVariables(searchParams.get('undefinedEnvironmentVariables')!);
+    } else {
+      // only for request render error
+      showAlert({
+        title: 'Unexpected Request Failure',
+        message: (
+          <div>
+            <p>The request failed due to an unhandled error:</p>
+            <code className="wide selectable">
+              <pre>{searchParams.get('error')}</pre>
+            </code>
+          </div>
+        ),
+      });
     }
 
     // clean up params


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

In https://github.com/Kong/insomnia/pull/8068, we removed the request error modal because some of the errors are also displayed in the preview panel.
But we ignored the request render error, so we restored the modal box and used it to display rendering errors.

