### PR TITLE
Add annotation for no proxy whitelist [INS-4792]

### DIFF
--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -135,7 +135,7 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
               <TextSetting
                 label="No proxy"
                 setting="noProxy"
-                help="Enter a comma-separated list of hostnames that don’t require a proxy."
+                help="Enter a comma-separated list of hostnames that don’t require a proxy. If you want a domain name to apply to all its subdomains too, prefix it with a dot (e.g. .example.com)."
                 placeholder="localhost,127.0.0.1"
                 disabled={!settings.proxyEnabled}
               />

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -135,7 +135,7 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
               <TextSetting
                 label="No proxy"
                 setting="noProxy"
-                help="Enter a comma-separated list of hostnames that don’t require a proxy. If you want a domain name to apply to all its subdomains too, prefix it with a dot (e.g. .example.com)."
+                help="Enter a comma-separated list of hostnames that do not require a proxy. To include all subdomains of a domain, prefix it with a dot (e.g., .example.com)."
                 placeholder="localhost,127.0.0.1"
                 disabled={!settings.proxyEnabled}
               />


### PR DESCRIPTION
Add some annotation to illustrate how to add a domain to apply to both itself and its subdomains for no proxy config.
![image](https://github.com/user-attachments/assets/e1919e70-5bb7-4dab-8f5c-3b6a4671d391)
