### PR TITLE
fix: paths in gRPC requests and proto state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13059,7 +13059,7 @@
     },
     "node_modules/grpc-reflection-js": {
       "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/ryanexus/grpc-reflection-js.git#1d769dc539635cac4b46ae7aab57ff4c4b935e90",
+      "resolved": "git+ssh://git@github.com/Kong/grpc-reflection-js.git#f806b5a0dc2092b7a6fb54dfb66c38fb58231774",
       "license": "MIT",
       "dependencies": {
         "@types/google-protobuf": "^3.7.2",
@@ -23095,7 +23095,7 @@
         "fastq": "^1.17.1",
         "graphql": "^16.8.1",
         "graphql-ws": "^5.16.0",
-        "grpc-reflection-js": "ryanexus/grpc-reflection-js#path-prefix",
+        "grpc-reflection-js": "Kong/grpc-reflection-js#master",
         "hawk": "9.0.2",
         "hkdf": "^0.0.2",
         "hosted-git-info": "5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13059,7 +13059,7 @@
     },
     "node_modules/grpc-reflection-js": {
       "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/jackkav/grpc-reflection-js.git#e78663356c362d44e629cfa119d12b63ba615bc0",
+      "resolved": "git+ssh://git@github.com/ryanexus/grpc-reflection-js.git#1d769dc539635cac4b46ae7aab57ff4c4b935e90",
       "license": "MIT",
       "dependencies": {
         "@types/google-protobuf": "^3.7.2",
@@ -23095,7 +23095,7 @@
         "fastq": "^1.17.1",
         "graphql": "^16.8.1",
         "graphql-ws": "^5.16.0",
-        "grpc-reflection-js": "jackkav/grpc-reflection-js#remove-lodash-set",
+        "grpc-reflection-js": "ryanexus/grpc-reflection-js#path-prefix",
         "hawk": "9.0.2",
         "hkdf": "^0.0.2",
         "hosted-git-info": "5.2.1",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -57,7 +57,7 @@
     "fastq": "^1.17.1",
     "graphql": "^16.8.1",
     "graphql-ws": "^5.16.0",
-    "grpc-reflection-js": "jackkav/grpc-reflection-js#remove-lodash-set",
+    "grpc-reflection-js": "ryanexus/grpc-reflection-js#path-prefix",
     "hawk": "9.0.2",
     "hkdf": "^0.0.2",
     "hosted-git-info": "5.2.1",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -57,7 +57,7 @@
     "fastq": "^1.17.1",
     "graphql": "^16.8.1",
     "graphql-ws": "^5.16.0",
-    "grpc-reflection-js": "ryanexus/grpc-reflection-js#path-prefix",
+    "grpc-reflection-js": "Kong/grpc-reflection-js#master",
     "hawk": "9.0.2",
     "hkdf": "^0.0.2",
     "hosted-git-info": "5.2.1",

--- a/packages/insomnia/src/main/ipc/grpc.ts
+++ b/packages/insomnia/src/main/ipc/grpc.ts
@@ -389,7 +389,7 @@ export const start = (
     }
     const methodType = getMethodType(method);
     // Create client
-    const { url } = parseGrpcUrl(request.url);
+    const { url, path } = parseGrpcUrl(request.url);
 
     if (!url) {
       event.reply('grpc.error', request._id, new Error('URL not specified'));
@@ -405,10 +405,11 @@ export const start = (
 
     try {
       const messageBody = JSON.parse(request.body.text || '');
+      const requestPath = path + method.path;
       switch (methodType) {
         case 'unary':
           const unaryCall = client.makeUnaryRequest(
-            method.path,
+            requestPath,
             method.requestSerialize,
             method.responseDeserialize,
             messageBody,
@@ -420,7 +421,7 @@ export const start = (
           break;
         case 'client':
           const clientCall = client.makeClientStreamRequest(
-            method.path,
+            requestPath,
             method.requestSerialize,
             method.responseDeserialize,
             filterDisabledMetaData(request.metadata),
@@ -430,7 +431,7 @@ export const start = (
           break;
         case 'server':
           const serverCall = client.makeServerStreamRequest(
-            method.path,
+            requestPath,
             method.requestSerialize,
             method.responseDeserialize,
             messageBody,
@@ -441,7 +442,7 @@ export const start = (
           break;
         case 'bidi':
           const bidiCall = client.makeBidiStreamRequest(
-            method.path,
+            requestPath,
             method.requestSerialize,
             method.responseDeserialize,
             filterDisabledMetaData(request.metadata));

--- a/packages/insomnia/src/main/ipc/grpc.ts
+++ b/packages/insomnia/src/main/ipc/grpc.ts
@@ -213,12 +213,13 @@ const getMethodsFromReflection = async (
   if (reflectionApi.enabled) {
     return getMethodsFromReflectionServer(reflectionApi);
   }
-    const { url } = parseGrpcUrl(host);
+    const { url, path } = parseGrpcUrl(host);
     const client = new grpcReflection.Client(
       url,
       getChannelCredentials({ url: host, caCertificate, clientCert, clientKey, rejectUnauthorized }),
       grpcOptions,
-      filterDisabledMetaData(metadata)
+      filterDisabledMetaData(metadata),
+      path
     );
     const services = await client.listServices();
     const methodsPromises = services.map(async service => {

--- a/packages/insomnia/src/network/grpc/__tests__/parse-grpc-url.test.ts
+++ b/packages/insomnia/src/network/grpc/__tests__/parse-grpc-url.test.ts
@@ -11,6 +11,7 @@ describe('parseGrpcUrl', () => {
     expect(parseGrpcUrl(input)).toStrictEqual({
       url: expected,
       enableTls: false,
+      path: '',
     });
   });
 
@@ -22,6 +23,7 @@ describe('parseGrpcUrl', () => {
     expect(parseGrpcUrl(input)).toStrictEqual({
       url: expected,
       enableTls: true,
+      path: '',
     });
   });
 
@@ -33,6 +35,7 @@ describe('parseGrpcUrl', () => {
     expect(parseGrpcUrl(input)).toStrictEqual({
       url: expected,
       enableTls: false,
+      path: '',
     });
   });
 
@@ -40,6 +43,7 @@ describe('parseGrpcUrl', () => {
     expect(parseGrpcUrl(input)).toStrictEqual({
       url: '',
       enableTls: false,
+      path: '',
     });
   });
 });

--- a/packages/insomnia/src/network/grpc/parse-grpc-url.ts
+++ b/packages/insomnia/src/network/grpc/parse-grpc-url.ts
@@ -1,13 +1,18 @@
-export const parseGrpcUrl = (grpcUrl: string): { url: string; enableTls: boolean } => {
+export const parseGrpcUrl = (grpcUrl: string): { url: string; enableTls: boolean; path: string } => {
   if (!grpcUrl) {
-    return { url: '', enableTls: false };
+    return { url: '', enableTls: false, path: '' };
   }
-  const lower = grpcUrl.toLowerCase();
-  if (lower.startsWith('grpc://')) {
-    return { url: lower.slice(7), enableTls: false };
+  const url = new URL(grpcUrl);
+  const result = {
+    url: url.host,
+    enableTls: false,
+    path: url.pathname,
+  };
+  if (url.protocol === 'grpcs:') {
+    result.enableTls = true;
   }
-  if (lower.startsWith('grpcs://')) {
-    return { url: lower.slice(8), enableTls: true };
+  if (result.path === '/') {
+    result.path = '';
   }
-  return { url: lower, enableTls: false };
+  return result;
 };

--- a/packages/insomnia/src/network/grpc/parse-grpc-url.ts
+++ b/packages/insomnia/src/network/grpc/parse-grpc-url.ts
@@ -2,13 +2,24 @@ export const parseGrpcUrl = (grpcUrl: string): { url: string; enableTls: boolean
   if (!grpcUrl) {
     return { url: '', enableTls: false, path: '' };
   }
-  const url = new URL(grpcUrl);
+  const lcUrl = grpcUrl.toLowerCase();
+  let url = {
+    protocol: 'grpc:',
+    hostname: lcUrl,
+    pathname: '',
+    port: undefined,
+  } as unknown as URL;
+  if (lcUrl.includes('://')) {
+    try {
+      url = new URL(grpcUrl.toLowerCase());
+    } catch (e) { }
+  }
   const result = {
-    url: url.host,
+    url: `${url.hostname}` + (url.port ? `:${url.port}` : ''),
     enableTls: false,
     path: url.pathname,
   };
-  if (url.protocol === 'grpcs:') {
+  if (url.protocol.toLowerCase() === 'grpcs:') {
     result.enableTls = true;
   }
   if (result.path === '/') {

--- a/packages/insomnia/src/network/grpc/parse-grpc-url.ts
+++ b/packages/insomnia/src/network/grpc/parse-grpc-url.ts
@@ -2,28 +2,12 @@ export const parseGrpcUrl = (grpcUrl: string): { url: string; enableTls: boolean
   if (!grpcUrl) {
     return { url: '', enableTls: false, path: '' };
   }
-  const lcUrl = grpcUrl.toLowerCase();
-  let url = {
-    protocol: 'grpc:',
-    hostname: lcUrl,
-    pathname: '',
-    port: undefined,
-  } as unknown as URL;
-  if (lcUrl.includes('://')) {
-    try {
-      url = new URL(grpcUrl.toLowerCase());
-    } catch (e) { }
-  }
-  const result = {
-    url: `${url.hostname}` + (url.port ? `:${url.port}` : ''),
-    enableTls: false,
-    path: url.pathname,
+  const url = new URL((grpcUrl.includes('://') ? '' : 'grpc://') + grpcUrl.toLowerCase());
+  return {
+    url: url.host,
+    enableTls: url.protocol === 'grpcs:',
+    // remove trailing slashes from pathname; the full request
+    // path is a concatenation of this parsed path + method path
+    path: url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname,
   };
-  if (url.protocol.toLowerCase() === 'grpcs:') {
-    result.enableTls = true;
-  }
-  if (result.path === '/') {
-    result.path = '';
-  }
-  return result;
 };

--- a/packages/insomnia/src/ui/components/dropdowns/grpc-method-dropdown/grpc-method-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/grpc-method-dropdown/grpc-method-dropdown.tsx
@@ -70,6 +70,7 @@ export const GrpcMethodDropdown: FunctionComponent<Props> = ({
   }));
   const selectedPath = selectedMethod?.fullPath;
 
+  console.log(methods, disabled);
   return (
     <Select
       aria-label="Select gRPC method"

--- a/packages/insomnia/src/ui/components/dropdowns/grpc-method-dropdown/grpc-method-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/grpc-method-dropdown/grpc-method-dropdown.tsx
@@ -70,7 +70,6 @@ export const GrpcMethodDropdown: FunctionComponent<Props> = ({
   }));
   const selectedPath = selectedMethod?.fullPath;
 
-  console.log(methods, disabled);
   return (
     <Select
       aria-label="Select gRPC method"

--- a/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
@@ -99,9 +99,9 @@ export interface Props {
   reloadRequests: (requestIds: string[]) => void;
 }
 
-export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave, reloadRequests }) => {
+export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave }) => {
   const modalRef = useRef<ModalHandle>(null);
-  const { workspaceId } = useParams() as { workspaceId: string };
+  const { workspaceId } = useParams() as { workspaceId: string; requestId: string };
 
   const [selectedId, setSelectedId] = useState(defaultId);
   const [protoDirectories, setProtoDirectories] = useState<ExpandedProtoDirectory[]>([]);
@@ -205,7 +205,7 @@ export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave, reloadRe
     if (!filePath) {
       return;
     }
-    if (!await isProtofileValid(filePath)) {
+    if (!(await isProtofileValid(filePath))) {
       return;
     }
     const contents = await fs.promises.readFile(filePath, 'utf-8');
@@ -216,8 +216,7 @@ export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave, reloadRe
     const impacted = await models.grpcRequest.findByProtoFileId(updatedFile._id);
     const requestIds = impacted.map(g => g._id);
     if (requestIds?.length) {
-      requestIds.forEach(requestId => window.main.grpc.cancel(requestId));
-      reloadRequests(requestIds);
+      requestIds.forEach(async requestId => window.main.grpc.cancel(requestId));
     }
   };
 
@@ -294,6 +293,7 @@ export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave, reloadRe
           protoDirectories={protoDirectories}
           selectedId={selectedId}
           handleSelect={id => setSelectedId(id)}
+          handleUnselect={() => setSelectedId('')}
           handleUpdate={handleUpdate}
           handleDelete={handleDeleteFile}
           handleDeleteDirectory={handleDeleteDirectory}
@@ -305,11 +305,10 @@ export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave, reloadRe
             className="btn"
             onClick={event => {
               event.preventDefault();
-              if (typeof onSave === 'function' && selectedId) {
-                onSave(selectedId);
+              if (typeof onSave === 'function') {
+                onSave(selectedId || '');
               }
             }}
-            disabled={!selectedId}
           >
             Save
           </button>

--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
@@ -81,7 +81,24 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
             reflectionApi: activeRequest.reflectionApi,
           },
         });
-      const methods = await window.main.grpc.loadMethodsFromReflection(rendered);
+
+      const workspaceClientCertificates = await models.clientCertificate.findByParentId(workspaceId);
+      const clientCertificate = workspaceClientCertificates.find(c => !c.disabled && urlMatchesCertHost(setDefaultProtocol(c.host, 'grpc:'), rendered.url, false));
+      const caCertificate = (await models.caCertificate.findByParentId(workspaceId));
+      const caCertificatePath = caCertificate && !caCertificate.disabled ? caCertificate.path : undefined;
+      const clientCert = clientCertificate?.cert ? await readFile(clientCertificate?.cert, 'utf8') : undefined;
+      const clientKey = clientCertificate?.key ? await readFile(clientCertificate?.key, 'utf8') : undefined;
+
+      const renderedWithCertificates = {
+        ...rendered,
+        rejectUnauthorized: settings.validateSSL,
+        ...(activeRequest.url.toLowerCase().startsWith('grpcs:') ? {
+          clientCert,
+          clientKey,
+          caCertificate: caCertificatePath ? await readFile(caCertificatePath, 'utf8') : undefined,
+        } : {}),
+      };
+      const methods = await window.main.grpc.loadMethodsFromReflection(renderedWithCertificates);
       setGrpcState({ ...grpcState, methods });
     }
   });

--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
@@ -58,6 +58,10 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
   reloadRequests,
 }) => {
   const { activeRequest } = useRouteLoaderData('request/:requestId') as GrpcRequestLoaderData;
+  const {
+    activeEnvironment,
+  } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
+  const environmentId = activeEnvironment._id;
   const { settings } = useRootLoaderData();
   const [isProtoModalOpen, setIsProtoModalOpen] = useState(false);
   const { requestMessages, running, methods } = grpcState;
@@ -86,10 +90,6 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
   const activeRequestSyncVersion = useActiveRequestSyncVCSVersion();
   const { workspaceId, requestId } = useParams() as { workspaceId: string; requestId: string };
   const patchRequest = useRequestPatcher();
-  const {
-    activeEnvironment,
-  } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
-  const environmentId = activeEnvironment._id;
   // Reset the response pane state when we switch requests, the environment gets modified, or the (Git|Sync)VCS version changes
   const uniquenessKey = `${activeEnvironment.modified}::${requestId}::${gitVersion}::${activeRequestSyncVersion}`;
   const method = methods.find(c => c.fullPath === activeRequest.protoMethodName);
@@ -381,7 +381,11 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
         defaultId={activeRequest.protoFileId}
         onHide={() => setIsProtoModalOpen(false)}
         onSave={async (protoFileId: string) => {
-          if (activeRequest.protoFileId !== protoFileId) {
+          if (!protoFileId) {
+            patchRequest(requestId, { protoFileId: '', protoMethodName: '' });
+            setGrpcState({ ...grpcState, methods: [] });
+            setIsProtoModalOpen(false);
+          } else {
             try {
               const methods = await window.main.grpc.loadMethods(protoFileId);
               patchRequest(requestId, { protoFileId, protoMethodName: '' });
@@ -394,8 +398,6 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                 error,
               });
             }
-          } else {
-            setIsProtoModalOpen(false);
           }
         }}
       />}

--- a/packages/insomnia/src/ui/components/proto-file/proto-file-list.tsx
+++ b/packages/insomnia/src/ui/components/proto-file/proto-file-list.tsx
@@ -20,6 +20,7 @@ interface Props {
   protoDirectories: ExpandedProtoDirectory[];
   selectedId?: string;
   handleSelect: SelectProtoFileHandler;
+  handleUnselect: SelectProtoFileHandler;
   handleDelete: DeleteProtoFileHandler;
   handleUpdate: UpdateProtoFileHandler;
   handleDeleteDirectory: DeleteProtoDirectoryHandler;
@@ -29,6 +30,7 @@ const recursiveRender = (
   indent: number,
   { dir, files, subDirs }: ExpandedProtoDirectory,
   handleSelect: SelectProtoFileHandler,
+  handleUnselect: SelectProtoFileHandler,
   handleUpdate: UpdateProtoFileHandler,
   handleDelete: DeleteProtoFileHandler,
   handleDeleteDirectory: DeleteProtoDirectoryHandler,
@@ -69,7 +71,17 @@ const recursiveRender = (
       onClick={() => handleSelect(f._id)}
     >
       <>
-        <Checkbox className="py-0" isSelected={f._id === selectedId} onChange={isSelected => isSelected && handleSelect(f._id)}>
+        <Checkbox
+          className="py-0"
+          isSelected={f._id === selectedId}
+          onChange={isSelected => {
+            if (isSelected) {
+              handleSelect(f._id);
+            } else {
+              handleUnselect(f._id);
+            }
+          }}
+        >
           {({ isSelected }) => {
             return <>
               {isSelected ?
@@ -115,6 +127,7 @@ const recursiveRender = (
       indent + 1,
       sd,
       handleSelect,
+      handleUnselect,
       handleUpdate,
       handleDelete,
       handleDeleteDirectory,
@@ -133,6 +146,7 @@ export const ProtoFileList: FunctionComponent<Props> = props => (
         0,
         dir,
         props.handleSelect,
+        props.handleUnselect,
         props.handleUpdate,
         props.handleDelete,
         props.handleDeleteDirectory,

--- a/packages/insomnia/src/utils/grpc.ts
+++ b/packages/insomnia/src/utils/grpc.ts
@@ -4,6 +4,9 @@ const GRPC_CONNECTION_ERROR_STRINGS = {
   SERVER_CANCELED: 'CANCELLED',
   TLS_NOT_SUPPORTED: 'WRONG_VERSION_NUMBER',
   BAD_LOCAL_ROOT_CERT: 'unable to get local issuer certificate',
+  UNIMPLEMENTED: 'UNIMPLEMENTED',
+  // this next one will break if we rename the call made from the pane
+  CANNOT_REFLECT: "'grpc.loadMethodsFromReflection': Error: 12",
 };
 
 export function isGrpcConnectionError(error: Error) {
@@ -34,6 +37,12 @@ export function getGrpcConnectionErrorDetails(error: Error) {
   } else if (error.message.includes(GRPC_CONNECTION_ERROR_STRINGS.BAD_LOCAL_ROOT_CERT)) {
     title = 'Local Root Certificate Error';
     message = 'The local root certificate enabled for the host is not valid.\nEither disable the root certificate, or update it with a valid one.';
+  } else if (error.message.includes(GRPC_CONNECTION_ERROR_STRINGS.CANNOT_REFLECT)) {
+    title = 'Reflection Not Supported';
+    message = 'The server has indicated that it does not support reflection. You may need to manually enable it server-side.';
+  } else if (error.message.includes(GRPC_CONNECTION_ERROR_STRINGS.UNIMPLEMENTED)) {
+    title = 'Unimplemented Method';
+    message = 'The server does not support the requested method. Is the .proto file correct?';
   }
 
   return {


### PR DESCRIPTION
To test the majority of this, follow the steps in my comment [here](https://github.com/Kong/insomnia/issues/7744#issuecomment-2578764796)

Changes:

- Makes proto files de-selectable in the dialog
- Fixes request switching losing method list (closes #6963)
- Adds path prefix support (closes #5203, closes #7744)
- Adds user-friendly error messages for common issues (closes #6380)
- Switches to using [Kong/grpc-reflection-js](https://github.com/Kong/grpc-reflection-js)