### PR TITLE
fix: prevent unparseable response cookie from causing request to fail [INS-4851]

### DIFF
--- a/packages/insomnia-sdk/src/objects/__tests__/cookies.test.ts
+++ b/packages/insomnia-sdk/src/objects/__tests__/cookies.test.ts
@@ -68,7 +68,16 @@ describe('test Cookie object', () => {
         const malformedCookieString = '=gingerale';
         expect(
             Cookie.parse(malformedCookieString)
-        ).toBeFalsy();
+        ).toEqual({
+            key: '',
+            value: 'gingerale',
+            expires: 'Infinity',
+            hostOnly: false,
+            httpOnly: false,
+            maxAge: null,
+            secure: false,
+            session: false,
+        });
     });
 
     it('test cookie transforming', () => {

--- a/packages/insomnia-sdk/src/objects/__tests__/cookies.test.ts
+++ b/packages/insomnia-sdk/src/objects/__tests__/cookies.test.ts
@@ -64,6 +64,11 @@ describe('test Cookie object', () => {
         expect(
             Cookie.unparseSingle(cookie1Opt)
         ).toEqual(expectedCookieString);
+
+        const malformedCookieString = '=gingerale';
+        expect(
+            Cookie.parse(malformedCookieString)
+        ).toBeFalsy();
     });
 
     it('test cookie transforming', () => {

--- a/packages/insomnia-sdk/src/objects/cookies.ts
+++ b/packages/insomnia-sdk/src/objects/cookies.ts
@@ -29,7 +29,6 @@ export interface CookieOptions extends InsomniaCookieExtensions {
 export class Cookie extends Property {
     override readonly _kind: string = 'Cookie';
     protected cookie: ToughCookie;
-    public isValid: boolean = true;
     private extensions?: { key: string; value: string }[];
     private insoExtensions: InsomniaCookieExtensions = {};
 
@@ -39,7 +38,6 @@ export class Cookie extends Property {
         if (typeof cookieDef === 'string') {
             const cookieDefParsed = Cookie.parse(cookieDef);
             if (!cookieDefParsed) {
-                this.isValid = false;
                 throw Error('failed to parse cookie, the cookie string seems invalid');
             }
             cookieDef = cookieDefParsed;
@@ -71,10 +69,9 @@ export class Cookie extends Property {
     }
 
     static parse(cookieStr: string) {
-        const cookieObj = ToughCookie.parse(cookieStr);
+        const cookieObj = ToughCookie.parse(cookieStr, { loose: true });
         if (!cookieObj) {
-            // throw Error('failed to parse cookie, the cookie string seems invalid');
-            return false;
+            throw Error('failed to parse cookie, the cookie string seems invalid');
         }
 
         const hostOnly = cookieObj.extensions?.includes('HostOnly') || false;

--- a/packages/insomnia-sdk/src/objects/cookies.ts
+++ b/packages/insomnia-sdk/src/objects/cookies.ts
@@ -29,6 +29,7 @@ export interface CookieOptions extends InsomniaCookieExtensions {
 export class Cookie extends Property {
     override readonly _kind: string = 'Cookie';
     protected cookie: ToughCookie;
+    public isValid: boolean = true;
     private extensions?: { key: string; value: string }[];
     private insoExtensions: InsomniaCookieExtensions = {};
 
@@ -38,6 +39,7 @@ export class Cookie extends Property {
         if (typeof cookieDef === 'string') {
             const cookieDefParsed = Cookie.parse(cookieDef);
             if (!cookieDefParsed) {
+                this.isValid = false;
                 throw Error('failed to parse cookie, the cookie string seems invalid');
             }
             cookieDef = cookieDefParsed;
@@ -71,7 +73,8 @@ export class Cookie extends Property {
     static parse(cookieStr: string) {
         const cookieObj = ToughCookie.parse(cookieStr);
         if (!cookieObj) {
-            throw Error('failed to parse cookie, the cookie string seems invalid');
+            // throw Error('failed to parse cookie, the cookie string seems invalid');
+            return false;
         }
 
         const hostOnly = cookieObj.extensions?.includes('HostOnly') || false;

--- a/packages/insomnia-sdk/src/objects/response.ts
+++ b/packages/insomnia-sdk/src/objects/response.ts
@@ -52,7 +52,7 @@ export class Response extends Property {
         this.body = options.body || '';
         this.code = options.code;
         this.cookies = new CookieList(
-            (options.cookie?.map(cookie => new Cookie(cookie)) || []).filter(cookie => cookie.isValid),
+            options.cookie?.map(cookie => new Cookie(cookie)) || [],
         );
         this.headers = new HeaderList(
             undefined,
@@ -294,7 +294,7 @@ export function toScriptResponse(
                 {},
             ).map(
                 setCookieHeader => Cookie.parse(setCookieHeader.value)
-        ).filter(cookie => cookie !== false)
+        )
         : [];
 
     const responseOption = {

--- a/packages/insomnia-sdk/src/objects/response.ts
+++ b/packages/insomnia-sdk/src/objects/response.ts
@@ -52,7 +52,7 @@ export class Response extends Property {
         this.body = options.body || '';
         this.code = options.code;
         this.cookies = new CookieList(
-            options.cookie?.map(cookie => new Cookie(cookie)) || [],
+            (options.cookie?.map(cookie => new Cookie(cookie)) || []).filter(cookie => cookie.isValid),
         );
         this.headers = new HeaderList(
             undefined,
@@ -294,7 +294,7 @@ export function toScriptResponse(
                 {},
             ).map(
                 setCookieHeader => Cookie.parse(setCookieHeader.value)
-        )
+        ).filter(cookie => cookie !== false)
         : [];
 
     const responseOption = {

--- a/packages/insomnia-sdk/src/objects/send-request.ts
+++ b/packages/insomnia-sdk/src/objects/send-request.ts
@@ -243,7 +243,7 @@ async function curlOutputToResponse(
                 };
             }
 
-            return cookieObj;
+            return undefined;
         })
         .filter(cookieOpt => cookieOpt !== undefined);
 

--- a/packages/insomnia-sdk/src/objects/send-request.ts
+++ b/packages/insomnia-sdk/src/objects/send-request.ts
@@ -226,8 +226,8 @@ async function curlOutputToResponse(
     // TODO: tackle stream field but currently it is just a duplication of body
     const cookies = cookieHeaders
         .map(cookieHeader => {
-            const cookieObj = Cookie.parse(cookieHeader.value || '');
-            if (cookieObj != null) {
+            const cookieObj = Cookie.parse(cookieHeader.value || '', { loose: true });
+            if (cookieObj) {
                 return {
                     key: cookieObj.key,
                     value: cookieObj.value,
@@ -243,7 +243,7 @@ async function curlOutputToResponse(
                 };
             }
 
-            return undefined;
+            return cookieObj;
         })
         .filter(cookieOpt => cookieOpt !== undefined);
 

--- a/packages/insomnia/src/common/har.ts
+++ b/packages/insomnia/src/common/har.ts
@@ -282,7 +282,7 @@ export function getResponseCookiesFromHeaders(headers: Har.Cookie[]) {
       let cookie: null | undefined | ToughCookie = null;
 
       try {
-        cookie = ToughCookie.parse(harCookie.value || '');
+        cookie = ToughCookie.parse(harCookie.value || '', { loose: true });
       } catch (error) { }
 
       if (cookie === null || cookie === undefined) {

--- a/packages/insomnia/src/ui/components/modals/cookie-modify-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookie-modify-modal.tsx
@@ -180,7 +180,7 @@ export const CookieModifyModal = ((props: ModalProps & CookieModifyModalOptions)
                         onChange={event => {
                           try {
                             // NOTE: Perform toJSON so we have a plain JS object instead of Cookie instance
-                            const parsed = ToughCookie.parse(event.target.value)?.toJSON();
+                            const parsed = ToughCookie.parse(event.target.value, { loose: true })?.toJSON();
                             if (parsed) {
                               // Make sure cookie has an id
                               parsed.id = cookie.id;

--- a/packages/insomnia/src/ui/components/viewers/response-cookies-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-cookies-viewer.tsx
@@ -15,7 +15,7 @@ export const ResponseCookiesViewer: FC<Props> = props => {
     let cookie: Cookie | undefined | null = null;
 
     try {
-      cookie = h ? Cookie.parse(h.value || '') : null;
+      cookie = h ? Cookie.parse(h.value || '', { loose: true }) : null;
     } catch (err) {
       console.warn('Failed to parse set-cookie header', h);
     }


### PR DESCRIPTION
In order to prevent malformed cookies from throwing application errors for otherwise successful requests, this PR changes to loose cookie parsing so that a set-cookie header sent as `"=value"` will be transformed into `key: "", value: "value"`. We are choosing to retain RFC-compliant types so a missing key will be an empty string as opposed to `null` or `undefined`.

One caveat is: since the cookie is malformed, it will not be added to the cookie jar.