### PR TITLE
feat: Insomnia vault key management UI[INS-4715]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1707,6 +1707,19 @@
         "node": ">= 20.18.0"
       }
     },
+    "node_modules/@getinsomnia/srp-js": {
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@getinsomnia/srp-js/-/srp-js-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-Svgv1ifeZnGJyofOKXfpLiGYD8zRSGYMUQjZVfckHuFFYmjSSyy17yzYkI0MVcSByG+x5jAlFkJCflOrKn3wQw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node-forge": "^1.3.1",
+        "blakejs": "^1.2.1",
+        "jsbn": "^1.1.0",
+        "node-forge": "^1.3.1",
+        "tweetnacl": "^1.0.3"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.0.tgz",
@@ -23071,6 +23084,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@getinsomnia/api-client": "0.0.4",
+        "@getinsomnia/srp-js": "1.0.0-alpha.1",
         "@sentry/electron": "^5.1.0",
         "@stoplight/spectral-core": "^1.18.3",
         "@stoplight/spectral-formats": "^1.6.0",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -93,6 +93,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@getinsomnia/api-client": "0.0.4",
+    "@getinsomnia/srp-js": "1.0.0-alpha.1",
     "@sentry/electron": "^5.1.0",
     "@stoplight/spectral-core": "^1.18.3",
     "@stoplight/spectral-formats": "^1.6.0",

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -192,6 +192,8 @@ async function _unsetSessionData() {
     symmetricKey: {} as JsonWebKey,
     publicKey: {} as JsonWebKey,
     encPrivateKey: {} as crypt.AESMessage,
+    vaultSalt: '',
+    vaultKey: '',
   });
 }
 

--- a/packages/insomnia/src/common/settings.ts
+++ b/packages/insomnia/src/common/settings.ts
@@ -145,4 +145,7 @@ export interface Settings {
   useBulkParametersEditor: boolean;
   validateAuthSSL: boolean;
   validateSSL: boolean;
+  // vault related settings
+  saveVaultKeyLocally: boolean;
+  enableVaultInScripts: boolean;
 }

--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -15,6 +15,7 @@ import { backupIfNewerVersionAvailable } from './main/backup';
 import { ipcMainOn, ipcMainOnce, registerElectronHandlers } from './main/ipc/electron';
 import { registergRPCHandlers } from './main/ipc/grpc';
 import { registerMainHandlers } from './main/ipc/main';
+import { registerSecretStorageHandlers } from './main/ipc/secret-storage';
 import { registerCurlHandlers } from './main/network/curl';
 import { registerWebSocketHandlers } from './main/network/websocket';
 import { watchProxySettings } from './main/proxy';
@@ -64,6 +65,7 @@ app.on('ready', async () => {
   registergRPCHandlers();
   registerWebSocketHandlers();
   registerCurlHandlers();
+  registerSecretStorageHandlers();
 
   /**
  * There's no option that prevents Electron from fetching spellcheck dictionaries from Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from fetching.

--- a/packages/insomnia/src/main/electron-storage.ts
+++ b/packages/insomnia/src/main/electron-storage.ts
@@ -44,6 +44,21 @@ class ElectronStorage {
     }
   }
 
+  deleteItem(key: string) {
+    clearTimeout(this._timeouts[key]);
+    delete this._buffer[key];
+
+    const path = this._getKeyPath(key);
+
+    try {
+      fs.unlinkSync(path);
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        console.error(`[localstorage] Failed to delete item from LocalStorage: ${error}`);
+      }
+    }
+  }
+
   _flush() {
     const keys = Object.keys(this._buffer);
 

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -28,7 +28,12 @@ export type HandleChannels =
   | 'webSocket.open'
   | 'webSocket.readyState'
   | 'writeFile'
-  | 'extractJsonFileFromPostmanDataDumpArchive';
+  | 'extractJsonFileFromPostmanDataDumpArchive'
+  | 'secretStorage.setSecret'
+  | 'secretStorage.getSecret'
+  | 'secretStorage.deleteSecret'
+  | 'secretStorage.encryptString'
+  | 'secretStorage.decryptString';
 
 export const ipcMainHandle = (
   channel: HandleChannels,

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -17,7 +17,7 @@ import type { WebSocketBridgeAPI } from '../network/websocket';
 import { ipcMainHandle, ipcMainOn, ipcMainOnce, type RendererOnChannels } from './electron';
 import extractPostmanDataDumpHandler from './extractPostmanDataDump';
 import type { gRPCBridgeAPI } from './grpc';
-
+import type { secretStorageBridgeAPI } from './secret-storage';
 export interface RendererToMainBridgeAPI {
   loginStateChange: () => void;
   openInBrowser: (url: string) => void;
@@ -37,6 +37,7 @@ export interface RendererToMainBridgeAPI {
   webSocket: WebSocketBridgeAPI;
   grpc: gRPCBridgeAPI;
   curl: CurlBridgeAPI;
+  secretStorage: secretStorageBridgeAPI;
   trackSegmentEvent: (options: { event: string; properties?: Record<string, unknown> }) => void;
   trackPageView: (options: { name: string }) => void;
   showContextMenu: (options: { key: string; nunjucksTag?: { template: string; range: MarkerRange } }) => void;

--- a/packages/insomnia/src/main/ipc/secret-storage.ts
+++ b/packages/insomnia/src/main/ipc/secret-storage.ts
@@ -1,7 +1,7 @@
 import { safeStorage } from 'electron';
 
-import LocalStorage from '../local-storage';
-import { initLocalStorage } from '../window-utils';
+import LocalStorage from '../electron-storage';
+import { initElectronStorage } from '../window-utils';
 import { ipcMainHandle } from './electron';
 
 export interface secretStorageBridgeAPI {
@@ -24,7 +24,7 @@ let localStorage: LocalStorage | null = null;
 
 const getLocalStorage = () => {
   if (!localStorage) {
-    localStorage = initLocalStorage();
+    localStorage = initElectronStorage();
   }
   return localStorage;
 };

--- a/packages/insomnia/src/main/ipc/secret-storage.ts
+++ b/packages/insomnia/src/main/ipc/secret-storage.ts
@@ -1,0 +1,77 @@
+import { safeStorage } from 'electron';
+
+import LocalStorage from '../local-storage';
+import { initLocalStorage } from '../window-utils';
+import { ipcMainHandle } from './electron';
+
+export interface secretStorageBridgeAPI {
+  setSecret: typeof setSecret;
+  getSecret: typeof getSecret;
+  deleteSecret: typeof deleteSecret;
+  encryptString: (raw: string) => Promise<string>;
+  decryptString: (cipherText: string) => Promise<string>;
+}
+
+export function registerSecretStorageHandlers() {
+  ipcMainHandle('secretStorage.setSecret', (_, key, secret) => setSecret(key, secret));
+  ipcMainHandle('secretStorage.getSecret', (_, key) => getSecret(key));
+  ipcMainHandle('secretStorage.deleteSecret', (_, key) => deleteSecret(key));
+  ipcMainHandle('secretStorage.encryptString', (_, raw) => encryptString(raw));
+  ipcMainHandle('secretStorage.decryptString', (_, raw) => decryptString(raw));
+}
+
+let localStorage: LocalStorage | null = null;
+
+const getLocalStorage = () => {
+  if (!localStorage) {
+    localStorage = initLocalStorage();
+  }
+  return localStorage;
+};
+
+const setSecret = async (key: string, secret: string) => {
+  try {
+    const secretStorage = getLocalStorage();
+    const encrypted = encryptString(secret);
+    secretStorage.setItem(key, encrypted);
+  } catch (error) {
+    console.error(`Can not save secret ${error.toString()}`);
+    return Promise.reject(error);
+  }
+};
+
+const getSecret = async (key: string) => {
+  try {
+    const secretStorage = getLocalStorage();
+    const encrypted = secretStorage.getItem(key, '');
+    return encrypted === '' ? null : decryptString(encrypted);
+  } catch (error) {
+    console.error(`Can not get secret ${error.toString()}`);
+    return Promise.reject(null);
+  }
+};
+
+const deleteSecret = async (key: string) => {
+  try {
+    const secretStorage = getLocalStorage();
+    secretStorage.deleteItem(key);
+  } catch (error) {
+    console.error(`Can not delele secret ${error.toString()}`);
+    return Promise.reject(error);
+  }
+};
+
+const encryptString = (raw: string) => {
+  if (safeStorage.isEncryptionAvailable()) {
+    return safeStorage.encryptString(raw).toString('hex');
+  }
+  return raw;
+};
+
+const decryptString = (cipherText: string) => {
+  const buffer = Buffer.from(cipherText, 'hex');
+  if (safeStorage.isEncryptionAvailable()) {
+    return safeStorage.decryptString(buffer);
+  }
+  return cipherText;
+};

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -803,6 +803,7 @@ export const setZoom = (transformer: (current: number) => number) => () => {
 function initElectronStorage() {
   const electronStoragePath = path.join(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'localStorage');
   electronStorage = new ElectronStorage(electronStoragePath);
+  return electronStorage;
 }
 
 export function createWindowsAndReturnMain({ firstLaunch }: { firstLaunch?: boolean } = {}) {

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -802,7 +802,9 @@ export const setZoom = (transformer: (current: number) => number) => () => {
 
 function initElectronStorage() {
   const electronStoragePath = path.join(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'localStorage');
-  electronStorage = new ElectronStorage(electronStoragePath);
+  if (!electronStorage) {
+    electronStorage = new ElectronStorage(electronStoragePath);
+  }
   return electronStorage;
 }
 

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -800,7 +800,7 @@ export const setZoom = (transformer: (current: number) => number) => () => {
   electronStorage?.setItem('zoomFactor', actual);
 };
 
-function initElectronStorage() {
+export function initElectronStorage() {
   const electronStoragePath = path.join(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'localStorage');
   if (!electronStorage) {
     electronStorage = new ElectronStorage(electronStoragePath);

--- a/packages/insomnia/src/models/settings.ts
+++ b/packages/insomnia/src/models/settings.ts
@@ -70,6 +70,8 @@ export function init(): BaseSettings {
     useBulkParametersEditor: false,
     validateAuthSSL: true,
     validateSSL: true,
+    saveVaultKeyLocally: true,
+    enableVaultInScripts: false,
   };
 }
 

--- a/packages/insomnia/src/models/user-session.ts
+++ b/packages/insomnia/src/models/user-session.ts
@@ -11,6 +11,8 @@ export interface BaseUserSession {
   symmetricKey: JsonWebKey;
   publicKey: JsonWebKey;
   encPrivateKey: AESMessage;
+  vaultSalt?: string;
+  vaultKey?: string;
 };
 
 export interface HashedUserSession {
@@ -34,6 +36,8 @@ export function init(): BaseUserSession {
     symmetricKey: {} as JsonWebKey,
     publicKey: {} as JsonWebKey,
     encPrivateKey: {} as AESMessage,
+    vaultKey: '',
+    vaultSalt: '',
   };
 }
 

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils as _webUtils } from 'electron';
 
 import type { gRPCBridgeAPI } from './main/ipc/grpc';
+import type { secretStorageBridgeAPI } from './main/ipc/secret-storage';
 import type { CurlBridgeAPI } from './main/network/curl';
 import type { WebSocketBridgeAPI } from './main/network/websocket';
 import { invariant } from './utils/invariant';
@@ -40,6 +41,15 @@ const grpc: gRPCBridgeAPI = {
   loadMethods: options => ipcRenderer.invoke('grpc.loadMethods', options),
   loadMethodsFromReflection: options => ipcRenderer.invoke('grpc.loadMethodsFromReflection', options),
 };
+
+const secretStorage: secretStorageBridgeAPI = {
+  setSecret: (key, secret) => ipcRenderer.invoke('secretStorage.setSecret', key, secret),
+  getSecret: key => ipcRenderer.invoke('secretStorage.getSecret', key),
+  deleteSecret: key => ipcRenderer.invoke('secretStorage.deleteSecret', key),
+  encryptString: raw => ipcRenderer.invoke('secretStorage.encryptString', raw),
+  decryptString: cipherText => ipcRenderer.invoke('secretStorage.decryptString', cipherText),
+};
+
 const main: Window['main'] = {
   startExecution: options => ipcRenderer.send('startExecution', options),
   addExecutionStep: options => ipcRenderer.send('addExecutionStep', options),
@@ -67,6 +77,7 @@ const main: Window['main'] = {
   webSocket,
   grpc,
   curl,
+  secretStorage,
   trackSegmentEvent: options => ipcRenderer.send('trackSegmentEvent', options),
   trackPageView: options => ipcRenderer.send('trackPageView', options),
   showContextMenu: options => ipcRenderer.send('show-context-menu', options),

--- a/packages/insomnia/src/ui/components/base/copy-button.tsx
+++ b/packages/insomnia/src/ui/components/base/copy-button.tsx
@@ -1,21 +1,25 @@
-import React, { type FC, useCallback, useState } from 'react';
+import React, { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
 import { useInterval } from 'react-use';
 
 import { Button, type ButtonProps } from '../themed-button';
 
+export interface CopyBtnHanlde {
+  copy: () => void;
+}
 interface Props extends ButtonProps {
   confirmMessage?: string;
   content: string;
   title?: string;
 }
 
-export const CopyButton: FC<Props> = ({
-  children,
-  confirmMessage,
-  content,
-  title,
-  ...buttonProps
-}) => {
+export const CopyButton = forwardRef<CopyBtnHanlde, Props>((props, ref) => {
+  const {
+    children,
+    confirmMessage,
+    content,
+    title,
+    ...buttonProps
+  } = props;
   const [showConfirmation, setshowConfirmation] = useState(false);
   const onClick = useCallback(async (event: React.MouseEvent) => {
     event.preventDefault();
@@ -30,6 +34,15 @@ export const CopyButton: FC<Props> = ({
   useInterval(() => {
     setshowConfirmation(false);
   }, 2000);
+
+  useImperativeHandle(ref, () => ({
+    copy: () => {
+      if (content) {
+        window.clipboard.writeText(content);
+        setshowConfirmation(true);
+      }
+    },
+  }), [content]);
 
   const confirm = typeof confirmMessage === 'string' ? confirmMessage : 'Copied';
   return (
@@ -47,4 +60,4 @@ export const CopyButton: FC<Props> = ({
       )}
     </Button>
   );
-};
+});

--- a/packages/insomnia/src/ui/components/base/copy-button.tsx
+++ b/packages/insomnia/src/ui/components/base/copy-button.tsx
@@ -1,25 +1,23 @@
-import React, { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
+import React, { type FC, useCallback, useState } from 'react';
 import { useInterval } from 'react-use';
 
 import { Button, type ButtonProps } from '../themed-button';
 
-export interface CopyBtnHanlde {
-  copy: () => void;
-}
 interface Props extends ButtonProps {
   confirmMessage?: string;
+  showConfirmation?: boolean;
   content: string;
   title?: string;
 }
 
-export const CopyButton = forwardRef<CopyBtnHanlde, Props>((props, ref) => {
-  const {
-    children,
-    confirmMessage,
-    content,
-    title,
-    ...buttonProps
-  } = props;
+export const CopyButton: FC<Props> = ({
+  children,
+  confirmMessage,
+  showConfirmation: showConfirmationProp = false,
+  content,
+  title,
+  ...buttonProps
+}) => {
   const [showConfirmation, setshowConfirmation] = useState(false);
   const onClick = useCallback(async (event: React.MouseEvent) => {
     event.preventDefault();
@@ -35,15 +33,6 @@ export const CopyButton = forwardRef<CopyBtnHanlde, Props>((props, ref) => {
     setshowConfirmation(false);
   }, 2000);
 
-  useImperativeHandle(ref, () => ({
-    copy: () => {
-      if (content) {
-        window.clipboard.writeText(content);
-        setshowConfirmation(true);
-      }
-    },
-  }), [content]);
-
   const confirm = typeof confirmMessage === 'string' ? confirmMessage : 'Copied';
   return (
     <Button
@@ -51,7 +40,7 @@ export const CopyButton = forwardRef<CopyBtnHanlde, Props>((props, ref) => {
       title={title}
       onClick={onClick}
     >
-      {showConfirmation ? (
+      {(showConfirmation || showConfirmationProp) ? (
         <span>
           {confirm} <i className="fa fa-check-circle-o" />
         </span>
@@ -60,4 +49,4 @@ export const CopyButton = forwardRef<CopyBtnHanlde, Props>((props, ref) => {
       )}
     </Button>
   );
-});
+};

--- a/packages/insomnia/src/ui/components/modals/input-vault-key-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/input-vault-key-modal.tsx
@@ -1,0 +1,178 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Dialog, Heading, Input, Modal, ModalOverlay } from 'react-aria-components';
+import { useFetcher } from 'react-router-dom';
+
+import { useRootLoaderData } from '../../routes/root';
+import { Icon } from '../icon';
+import { VaultKeyDisplayInput } from '../settings/vault-key-panel';
+import { showModal } from '.';
+import { AskModal } from './ask-modal';
+
+export interface InputVaultKeyModalProps {
+  onClose: (vaultKey?: string) => void;
+  allowClose?: boolean;
+}
+
+export const InputVaultKeyModal = (props: InputVaultKeyModalProps) => {
+  const { onClose, allowClose = true } = props;
+  const { userSession } = useRootLoaderData();
+  const [vaultKey, setVaultKey] = useState('');
+  const [error, setError] = useState('');
+  const [resetDone, setResetDone] = useState(false);
+  const resetVaultKeyFetcher = useFetcher();
+  const validateVaultKeyFetcher = useFetcher();
+  const isLoading = resetVaultKeyFetcher.state !== 'idle' || validateVaultKeyFetcher.state !== 'idle';
+
+  useEffect(() => {
+    // close modal and return new vault key after reset
+    if (resetVaultKeyFetcher.data && !resetVaultKeyFetcher.data.error && resetVaultKeyFetcher.state === 'idle') {
+      const newVaultKey = resetVaultKeyFetcher.data;
+      setVaultKey(newVaultKey);
+      setResetDone(true);
+    };
+  }, [resetVaultKeyFetcher.data, resetVaultKeyFetcher.state]);
+
+  useEffect(() => {
+    if (resetVaultKeyFetcher?.data?.error && resetVaultKeyFetcher.state === 'idle') {
+      setError(resetVaultKeyFetcher.data.error);
+    }
+  }, [resetVaultKeyFetcher.data, resetVaultKeyFetcher.state]);
+
+  useEffect(() => {
+    (async () => {
+      // close modal and return user input vault key if srp validation success
+      if (validateVaultKeyFetcher.data && !validateVaultKeyFetcher.data.error && validateVaultKeyFetcher.state === 'idle') {
+        onClose(validateVaultKeyFetcher.data.vaultKey);
+      };
+    })();
+  }, [validateVaultKeyFetcher.data, validateVaultKeyFetcher.state, onClose, userSession]);
+
+  useEffect(() => {
+    if (validateVaultKeyFetcher?.data?.error && validateVaultKeyFetcher.state === 'idle') {
+      setError(validateVaultKeyFetcher.data.error);
+    }
+  }, [validateVaultKeyFetcher.data, validateVaultKeyFetcher.state]);
+
+  const handleValidateVaultKey = () => {
+    setError('');
+    validateVaultKeyFetcher.submit(
+      {
+        vaultKey, saveVaultKey: true,
+      },
+      {
+        action: '/auth/validateVaultKey',
+        method: 'POST',
+        encType: 'application/json',
+      });
+  };
+
+  const resetVaultKey = () => {
+    showModal(AskModal, {
+      title: 'Reset Vault Key',
+      message: 'Are you sure you sure to reset vault key? This will clear all secrets in private environment among all devices.',
+      yesText: 'Yes',
+      noText: 'No',
+      onDone: async (yes: boolean) => {
+        if (yes) {
+          // todo clear all local secrets
+          resetVaultKeyFetcher.submit('', {
+            action: '/auth/resetVaultKey',
+            method: 'POST',
+          });
+        }
+      },
+    });
+  };
+
+  return (
+    <ModalOverlay
+      isOpen
+      onOpenChange={isOpen => {
+        !isOpen && onClose();
+      }}
+      className="w-full h-[--visual-viewport-height] fixed z-10 top-0 left-0 flex items-start justify-center bg-black/30"
+    >
+      <Modal
+        className="max-h-[75%] overflow-auto flex flex-col w-full max-w-3xl rounded-md border border-solid border-[--hl-sm] p-[--padding-lg] bg-[--color-bg] text-[--color-font] m-24"
+        onOpenChange={isOpen => {
+          !isOpen && onClose();
+        }}
+      >
+        <Dialog
+          className="outline-none flex-1 h-full flex flex-col overflow-hidden"
+        >
+          {({ close }) => (
+            <div className='flex-1 flex flex-col gap-4 overflow-hidden'>
+              <div className='flex gap-2 items-center justify-between'>
+                <Heading slot="title" className='text-2xl'>
+                  {resetDone ? 'Reset Vault Key' : 'Enter Vault Key'}
+                </Heading>
+                {allowClose &&
+                  <Button
+                    className="flex flex-shrink-0 items-center justify-center aspect-square h-6 aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+                    onPress={close}
+                  >
+                    <Icon icon="x" />
+                  </Button>
+                }
+              </div>
+              {!resetDone ?
+                (
+                  <>
+                    <div className='rounded grow shrink-0 w-full basis-12 flex flex-col gap-3 select-none'>
+                      <label>
+                        Unlock all secrets by entering the vault key
+                      </label>
+                      <Input
+                        className='py-1 w-full pl-2 pr-7 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font]'
+                        placeholder='Enter Vault Key'
+                        value={vaultKey}
+                        onChange={e => setVaultKey(e.target.value)}
+                      />
+                    </div>
+                    {error &&
+                      <p className="notice error margin-top-sm no-margin-bottom">{error}</p>
+                    }
+                    <div className="flex justify-between mt-2 items-center">
+                      <div>
+                        <span className='faint text-sm'>Forget Vault Key?</span>
+                        <Button
+                          className="px-4 py-1 h-full underline text-[--color-info] text-sm transition-all "
+                          onPress={resetVaultKey}
+                        >
+                          Reset Vault Key
+                        </Button>
+                      </div>
+                      <Button
+                        className="hover:no-underline ml-4 flex items-center gap-2 bg-[--color-surprise] hover:bg-opacity-90 border border-solid border-[--hl-md] py-2 px-3 text-[--color-font-surprise] transition-colors rounded-sm"
+                        onPress={handleValidateVaultKey}
+                        isDisabled={isLoading || !vaultKey}
+                      >
+                        {isLoading && <Icon icon="spinner" className="text-[--color-font] animate-spin m-auto inline-block mr-2" />}
+                        Unlock
+                      </Button>
+                    </div>
+                  </>
+                ) :
+                (
+                  <>
+                    <div>Please save or download the vault key which will be needed when you login again.</div>
+                    <VaultKeyDisplayInput vaultKey={vaultKey} />
+                    <div className="flex justify-end mt-2 items-center">
+                      <Button
+                        className="hover:no-underline ml-4 flex items-center gap-2 bg-[--color-surprise] hover:bg-opacity-90 border border-solid border-[--hl-md] py-2 px-3 text-[--color-font-surprise] transition-colors rounded-sm"
+                        onPress={() => onClose(vaultKey)}
+                      >
+                        OK
+                      </Button>
+                    </div>
+                  </>
+                )
+              }
+            </div>
+          )}
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+};

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -20,6 +20,7 @@ import { BooleanSetting } from './boolean-setting';
 import { EnumSetting } from './enum-setting';
 import { NumberSetting } from './number-setting';
 import { TextSetting } from './text-setting';
+import { VaultKeyPanel } from './vault-key-panel';
 
 export const General: FC = () => {
   const {
@@ -268,6 +269,7 @@ export const General: FC = () => {
           help="If checked, validates SSL certificates during authentication flows."
         />
       </div>
+      {isLoggedIn && <VaultKeyPanel />}
 
       {updatesSupported() && (
         <Fragment>

--- a/packages/insomnia/src/ui/components/settings/vault-key-panel.tsx
+++ b/packages/insomnia/src/ui/components/settings/vault-key-panel.tsx
@@ -1,11 +1,12 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Button } from 'react-aria-components';
 import { useFetcher } from 'react-router-dom';
+import { useInterval } from 'react-use';
 
 import { getProductName } from '../../../common/constants';
 import { decryptVaultKeyFromSession, deleteVaultKeyFromStorage, saveVaultKeyIfNecessary } from '../../../utils/vault';
 import { useRootLoaderData } from '../../routes/root';
-import { type CopyBtnHanlde, CopyButton } from '../base/copy-button';
+import { CopyButton } from '../base/copy-button';
 import { HelpTooltip } from '../help-tooltip';
 import { Icon } from '../icon';
 import { showError, showModal } from '../modals';
@@ -14,7 +15,11 @@ import { InputVaultKeyModal } from '../modals/input-vault-key-modal';
 import { BooleanSetting } from './boolean-setting';
 
 export const VaultKeyDisplayInput = ({ vaultKey }: { vaultKey: string }) => {
-  const copyBtnRef = useRef<CopyBtnHanlde>(null);
+  const [showCopyConfirmation, setShowCopyConfirmation] = useState(false);
+
+  useInterval(() => {
+    setShowCopyConfirmation(false);
+  }, 2000);
 
   const donwloadVaultKey = async () => {
     const { canceled, filePath: outputPath } = await window.dialog.showSaveDialog({
@@ -35,12 +40,24 @@ export const VaultKeyDisplayInput = ({ vaultKey }: { vaultKey: string }) => {
 
   return (
     <div className="flex items-center gap-3 bg-[--hl-xs] px-2 py-1 border border-solid border-[--hl-sm] w-full">
-      <div className="w-[calc(100%-50px)] truncate" onDoubleClick={() => copyBtnRef.current?.copy()}>{vaultKey}</div>
+      <div
+        className="w-[calc(100%-50px)] truncate"
+        onDoubleClick={(event: React.MouseEvent) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (vaultKey) {
+            window.clipboard.writeText(vaultKey);
+          };
+          setShowCopyConfirmation(true);
+        }}
+      >
+        {vaultKey}
+      </div>
       <CopyButton
         size="small"
-        ref={copyBtnRef}
         content={vaultKey}
         title="Copy Vault Key"
+        showConfirmation={showCopyConfirmation}
         style={{ borderWidth: 0 }}
       >
         <i className="fa fa-copy" />

--- a/packages/insomnia/src/ui/components/settings/vault-key-panel.tsx
+++ b/packages/insomnia/src/ui/components/settings/vault-key-panel.tsx
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from 'react-aria-components';
 import { useFetcher } from 'react-router-dom';
@@ -28,14 +27,10 @@ export const VaultKeyDisplayInput = ({ vaultKey }: { vaultKey: string }) => {
       return;
     }
 
-    const to = fs.createWriteStream(outputPath);
-
-    to.on('error', err => {
-      console.warn('Failed to save vault key', err);
+    await window.main.writeFile({
+      path: outputPath,
+      content: vaultKey,
     });
-
-    to.write(vaultKey);
-    to.end();
   };
 
   return (

--- a/packages/insomnia/src/ui/components/settings/vault-key-panel.tsx
+++ b/packages/insomnia/src/ui/components/settings/vault-key-panel.tsx
@@ -1,0 +1,207 @@
+import fs from 'fs';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from 'react-aria-components';
+import { useFetcher } from 'react-router-dom';
+
+import { getProductName } from '../../../common/constants';
+import { decryptVaultKeyFromSession, deleteVaultKeyFromStorage, saveVaultKeyIfNecessary } from '../../../utils/vault';
+import { useRootLoaderData } from '../../routes/root';
+import { type CopyBtnHanlde, CopyButton } from '../base/copy-button';
+import { HelpTooltip } from '../help-tooltip';
+import { Icon } from '../icon';
+import { showError, showModal } from '../modals';
+import { AskModal } from '../modals/ask-modal';
+import { InputVaultKeyModal } from '../modals/input-vault-key-modal';
+import { BooleanSetting } from './boolean-setting';
+
+export const VaultKeyDisplayInput = ({ vaultKey }: { vaultKey: string }) => {
+  const copyBtnRef = useRef<CopyBtnHanlde>(null);
+
+  const donwloadVaultKey = async () => {
+    const { canceled, filePath: outputPath } = await window.dialog.showSaveDialog({
+      title: 'Download Vault Key',
+      buttonLabel: 'Save',
+      defaultPath: `${getProductName()}-vault-key-${Date.now()}.txt`,
+    });
+
+    if (canceled || !outputPath) {
+      return;
+    }
+
+    const to = fs.createWriteStream(outputPath);
+
+    to.on('error', err => {
+      console.warn('Failed to save vault key', err);
+    });
+
+    to.write(vaultKey);
+    to.end();
+  };
+
+  return (
+    <div className="flex items-center gap-3 bg-[--hl-xs] px-2 py-1 border border-solid border-[--hl-sm] w-full">
+      <div className="w-[calc(100%-50px)] truncate" onDoubleClick={() => copyBtnRef.current?.copy()}>{vaultKey}</div>
+      <CopyButton
+        size="small"
+        ref={copyBtnRef}
+        content={vaultKey}
+        title="Copy Vault Key"
+        style={{ borderWidth: 0 }}
+      >
+        <i className="fa fa-copy" />
+      </CopyButton>
+      <Button onPress={donwloadVaultKey}>
+        <i className="fa-solid fa-download" />
+      </Button>
+    </div>
+
+  );
+};
+
+export const VaultKeyPanel = () => {
+  const { userSession, settings } = useRootLoaderData();
+  const { saveVaultKeyLocally } = settings;
+  const [isGenerating, setGenerating] = useState(false);
+  const [vaultKeyValue, setVaultKeyValue] = useState('');
+  const [showInputVaultKeyModal, setShowModal] = useState(false);
+  const { accountId, vaultKey, vaultSalt } = userSession;
+  const vaultKeyFetcher = useFetcher();
+  const vaultSaltFetcher = useFetcher();
+  const vaultSaltExists = typeof vaultSalt === 'string' && vaultSalt.length > 0;
+  const vaultKeyExists = typeof vaultKey === 'string' && vaultKey.length > 0;
+
+  const showVaultKey = useCallback(async () => {
+    if (vaultKey) {
+      // decrypt vault key saved in user session
+      const decryptedVaultKey = await decryptVaultKeyFromSession(vaultKey, false);
+      setVaultKeyValue(decryptedVaultKey);
+    }
+  }, [vaultKey]);
+
+  useEffect(() => {
+    if (vaultKeyExists) {
+      showVaultKey();
+    }
+  }, [showVaultKey, vaultKeyExists]);
+
+  useEffect(() => {
+    if (vaultKeyFetcher.data && !vaultKeyFetcher.data.error && vaultKeyFetcher.state === 'idle') {
+      setGenerating(false);
+      setVaultKeyValue(vaultKeyFetcher.data);
+    };
+  }, [vaultKeyFetcher.data, vaultKeyFetcher.state]);
+
+  useEffect(() => {
+    if (vaultKeyFetcher.data && vaultKeyFetcher.data.error && vaultKeyFetcher.state === 'idle') {
+      setGenerating(false);
+      // user has created vault key in another device;
+      if (vaultKeyFetcher.data.error.toLowerCase().includes('conflict')) {
+        // get vault salt from server
+        vaultSaltFetcher.submit('', {
+          action: '/auth/updateVaultSalt',
+          method: 'POST',
+        });
+        showModal(AskModal, {
+          title: 'Vault Key Already Exists',
+          message: 'You have generated the vault key in other device. Please input your vault key',
+          yesText: 'OK',
+          noText: 'Cancel',
+        });
+      } else {
+        showError({
+          title: 'Can not generate vault key',
+          message: vaultKeyFetcher.data.error,
+        });
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- vaultSaltFetcher should only be triggered once
+  }, [vaultKeyFetcher.data, vaultKeyFetcher.state]);
+
+  const generateVaultKey = async () => {
+    setGenerating(true);
+    vaultKeyFetcher.submit('', {
+      action: '/auth/createVaultKey',
+      method: 'POST',
+    });
+  };
+
+  const handleModalClose = (newVaultKey?: string) => {
+    if (newVaultKey) {
+      setVaultKeyValue(newVaultKey);
+    };
+    setShowModal(false);
+  };
+
+  useEffect(() => {
+    // save or delete vault key to keychain
+    if (saveVaultKeyLocally) {
+      if (vaultKeyValue.length > 0) {
+        saveVaultKeyIfNecessary(accountId, vaultKeyValue);
+      };
+    } else {
+      deleteVaultKeyFromStorage(accountId);
+    };
+  }, [saveVaultKeyLocally, accountId, vaultKeyValue]);
+
+  return (
+    <div>
+      {/* Show Gen Vault button when vault salt does not exist */}
+      {!vaultSaltExists &&
+        <div className="form-row pad-top-sm justify-start">
+          <Button
+            className={`flex items-center btn btn--outlined btn--super-compact ${isGenerating ? 'w-56' : 'w-48'}`}
+            onPress={generateVaultKey}
+            isDisabled={isGenerating}
+          >
+            {isGenerating && <Icon icon="spinner" className="text-[--color-font] animate-spin m-auto inline-block mr-2" />}
+            Generate Vault Key
+            <HelpTooltip className="space-left">
+              Generate an encryption key to save secrets in private environment. This ensures all secrets are securely stored and encrypted locally.
+            </HelpTooltip>
+          </Button>
+        </div>
+      }
+      {vaultSaltExists && vaultKeyExists && vaultKeyValue !== '' &&
+        <>
+          <div className="form-row pad-top-sm flex-col">
+            <div className="mb-[var(--padding-xs)]">
+              <span className="font-semibold">Vault Key</span>
+              <HelpTooltip className="space-left">The vault key will be needed when you login again.</HelpTooltip>
+            </div>
+            <VaultKeyDisplayInput vaultKey={vaultKeyValue} />
+          </div>
+          <div className="form-row pad-top-sm">
+            <BooleanSetting
+              label="Save encrypted vault key locally"
+              setting="saveVaultKeyLocally"
+            />
+          </div>
+          <div className="form-row pad-top-sm">
+            <BooleanSetting
+              label="Enable vault in scripts"
+              help="Allow pre-request and after-response script to access vault secrets."
+              setting='enableVaultInScripts'
+            />
+          </div>
+        </>
+      }
+      {/* User has not input vault key after re-login */}
+      {vaultSaltExists && !vaultKeyExists &&
+        <div className="form-row pad-top-sm justify-start">
+          <Button
+            className="flex items-center w-48 btn btn--outlined btn--super-compact"
+            onPress={() => setShowModal(true)}
+          >
+            Enter Vault Key
+            <HelpTooltip className="space-left">
+              Enter your vault key to unlock all local secrets.
+            </HelpTooltip>
+          </Button>
+        </div>
+      }
+      {showInputVaultKeyModal &&
+        <InputVaultKeyModal onClose={handleModalClose} />
+      }
+    </div>
+  );
+};

--- a/packages/insomnia/src/ui/components/toast.tsx
+++ b/packages/insomnia/src/ui/components/toast.tsx
@@ -19,8 +19,8 @@ const INSOMNIA_NOTIFICATIONS_SEEN = 'insomnia::notifications::seen';
 
 export interface ToastNotification {
   key: string;
-  url: string;
-  cta: string;
+  url?: string;
+  cta?: string;
   message: string;
 }
 
@@ -132,24 +132,26 @@ export const Toast: FC = () => {
             Dismiss
           </button>
           &nbsp;&nbsp;
-          <Link
-            button
-            className="btn btn--super-super-compact btn--outlined no-wrap"
-            onClick={() => {
-              if (notification) {
-                // Hide the currently showing notification
-                setVisible(false);
-                // Give time for toast to fade out, then remove it
-                setTimeout(() => {
-                  setNotification(null);
-                  checkForNotifications();
-                }, 1000);
-              }
-            }}
-            href={notification.url}
-          >
-            {notification.cta}
-          </Link>
+          {notification.url && notification.cta &&
+            <Link
+              button
+              className="btn btn--super-super-compact btn--outlined no-wrap"
+              onClick={() => {
+                if (notification) {
+                  // Hide the currently showing notification
+                  setVisible(false);
+                  // Give time for toast to fade out, then remove it
+                  setTimeout(() => {
+                    setNotification(null);
+                    checkForNotifications();
+                  }, 1000);
+                }
+              }}
+              href={notification.url}
+            >
+              {notification.cta}
+            </Link>
+          }
         </footer>
       </div>
     </div>

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -1129,6 +1129,26 @@ async function renderApp() {
                 action: async (...args) => (await import('./routes/auth.authorize')).action(...args),
                 element: <Authorize />,
               },
+              {
+                path: 'updateVaultSalt',
+                action: async (...args) => (await import('./routes/auth.vaultKey')).updateVaultSaltAction(...args),
+              },
+              {
+                path: 'createVaultKey',
+                action: async (...args) => (await import('./routes/auth.vaultKey')).createVaultKeyAction(...args),
+              },
+              {
+                path: 'validateVaultKey',
+                action: async (...args) => (await import('./routes/auth.vaultKey')).validateVaultKeyAction(...args),
+              },
+              {
+                path: 'resetVaultKey',
+                action: async (...args) => (await import('./routes/auth.vaultKey')).resetVaultKeyAction(...args),
+              },
+              {
+                path: 'clearVaultKey',
+                action: async (...args) => (await import('./routes/auth.vaultKey')).clearVaultKeyAction(...args),
+              },
             ],
           },
         ],

--- a/packages/insomnia/src/ui/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/ui/routes/auth.authorize.tsx
@@ -2,10 +2,14 @@ import React, { Fragment } from 'react';
 import { Button, Heading } from 'react-aria-components';
 import { type ActionFunction, redirect, useFetcher, useFetchers, useNavigate } from 'react-router-dom';
 
+import { userSession as sessionModel } from '../../models';
 import { invariant } from '../../utils/invariant';
+import { getVaultKeyFromStorage } from '../../utils/vault';
 import { SegmentEvent } from '../analytics';
 import { getLoginUrl, submitAuthCode } from '../auth-session-provider';
 import { Icon } from '../components/icon';
+import { insomniaFetch } from '../insomniaFetch';
+import { validateVaultKey } from './auth.vaultKey';
 
 export const action: ActionFunction = async ({
   request,
@@ -27,6 +31,36 @@ export const action: ActionFunction = async ({
     event: SegmentEvent.loginSuccess,
   });
   window.localStorage.setItem('hasUserLoggedInBefore', 'true');
+  const userSession = await sessionModel.getOrCreate();
+  const { accountId, id: sessionId } = userSession;
+  try {
+    // check vault salt exists in server
+    const { salt: vaultSalt } = await insomniaFetch<{
+      salt?: string;
+      error?: string;
+    }>({
+      method: 'GET',
+      path: '/v1/user/vault',
+      sessionId,
+    });
+    if (vaultSalt) {
+      // save vault salt to session
+      await sessionModel.update(userSession, { vaultSalt });
+      // get vault key saved in local
+      const localVaultKey = await getVaultKeyFromStorage(accountId);
+      if (localVaultKey) {
+        // validate vault key with server
+        const validateResult = await validateVaultKey(userSession, localVaultKey, vaultSalt);
+        if (validateResult) {
+          // Encrypt vault key and save encrypted vault key & raw vault salt to session
+          const encryptedVaultKey = await window.main.secretStorage.encryptString(localVaultKey);
+          await sessionModel.update(userSession, { vaultKey: encryptedVaultKey, vaultSalt });
+        };
+      }
+    };
+  } catch (err) {
+    console.error(err);
+  };
 
   return redirect('/organization');
 };

--- a/packages/insomnia/src/ui/routes/auth.vaultKey.ts
+++ b/packages/insomnia/src/ui/routes/auth.vaultKey.ts
@@ -1,0 +1,224 @@
+import * as srp from '@getinsomnia/srp-js';
+import { ipcRenderer } from 'electron';
+import { type ActionFunction } from 'react-router-dom';
+
+import { userSession as sessionModel } from '../../models';
+import type { UserSession } from '../../models/user-session';
+import { base64encode, saveVaultKeyIfNecessary } from '../../utils/vault';
+import type { ToastNotification } from '../components/toast';
+import { insomniaFetch } from '../insomniaFetch';
+
+const {
+  Buffer,
+  Client,
+  generateAES256Key,
+  getRandomHex,
+  params,
+  srpGenKey,
+} = srp;
+interface FetchError {
+  error?: string;
+  message?: string;
+}
+
+export const vaultKeyParams = params[2048];
+const vaultKeyRequestBathPath = '/v1/user/vault';
+
+const createVaultKeyRequest = async (sessionId: string, salt: string, verifier: string) =>
+  insomniaFetch<FetchError>({
+    method: 'POST',
+    path: vaultKeyRequestBathPath,
+    data: { salt, verifier },
+    sessionId,
+  }).catch(error => {
+    console.error(error);;
+  });
+
+const resetVaultKeyRequest = async (sessionId: string, salt: string, verifier: string) =>
+  insomniaFetch<FetchError>({
+    method: 'POST',
+    path: `${vaultKeyRequestBathPath}/reset`,
+    sessionId,
+    data: { salt, verifier },
+  }).catch(error => {
+    console.error(error);;
+  });
+
+export const saveVaultKey = async (session: UserSession, vaultKey: string) => {
+  const { accountId } = session;
+  // save encrypted vault key and vault salt to session
+  const encryptedVaultKey = await window.main.secretStorage.encryptString(vaultKey);
+  await sessionModel.update(session, { vaultKey: encryptedVaultKey });
+
+  await saveVaultKeyIfNecessary(accountId, vaultKey);
+};
+
+const createVaultKey = async (type: 'create' | 'reset' = 'create') => {
+  const userSession = await sessionModel.getOrCreate();
+  const { accountId, id: sessionId } = userSession;
+
+  // const vaultKey = await getVaultKeyRequest(sessionId);
+  const vaultSalt = await getRandomHex();
+  const newVaultKey = await generateAES256Key();
+  const base64encodedVaultKey = base64encode(JSON.stringify(newVaultKey));
+
+  try {
+    // Compute the verifier
+    const verifier = srp
+      .computeVerifier(
+        vaultKeyParams,
+        Buffer.from(vaultSalt, 'hex'),
+        Buffer.from(accountId, 'utf8'),
+        Buffer.from(base64encodedVaultKey, 'base64'),
+      )
+      .toString('hex');
+    // send or reset saltAuth & verifier to server
+    if (type === 'create') {
+      const response = await createVaultKeyRequest(sessionId, vaultSalt, verifier);
+      if (response?.error) {
+        return { error: `${response?.error}: ${response?.message}` };
+      };
+    } else {
+      const response = await resetVaultKeyRequest(sessionId, vaultSalt, verifier);
+      if (response?.error) {
+        return { error: `${response?.error}: ${response?.message}` };
+      };
+    };
+
+    // save encrypted vault key and vault salt to session
+    await sessionModel.update(userSession, { vaultSalt: vaultSalt });
+    await saveVaultKey(userSession, base64encodedVaultKey);
+    return base64encodedVaultKey;
+  } catch (error) {
+    return { error: error.toString() };
+  }
+};
+
+export const validateVaultKey = async (session: UserSession, vaultKey: string, vaultSalt: string) => {
+  const { id: sessionId, accountId } = session;
+  const secret1 = await srpGenKey();
+  const srpClient = new Client(
+    vaultKeyParams,
+    Buffer.from(vaultSalt, 'hex'),
+    Buffer.from(accountId, 'utf8'),
+    Buffer.from(vaultKey, 'base64'),
+    Buffer.from(secret1, 'hex'),
+  );
+  // ~~~~~~~~~~~~~~~~~~~~~ //
+  // Compute and Submit A  //
+  // ~~~~~~~~~~~~~~~~~~~~~ //
+  const srpA = srpClient.computeA().toString('hex');
+  const { sessionStarterId, srpB, error: verifyAError } = await insomniaFetch<{
+    sessionStarterId: string;
+    srpB: string;
+    error?: string;
+    message?: string;
+  }>({
+    method: 'POST',
+    path: '/v1/user/vault-verify-a',
+    data: { srpA },
+    sessionId,
+  });
+  // ~~~~~~~~~~~~~~~~~~~~~ //
+  // Compute and Submit M1 //
+  // ~~~~~~~~~~~~~~~~~~~~~ //
+  srpClient.setB(new Buffer(srpB, 'hex'));
+  const srpM1 = srpClient.computeM1().toString('hex');
+  const { srpM2, error: verifyM1Error } = await insomniaFetch<{
+    srpM2: string;
+    error?: string;
+    message?: string;
+  }>({
+    method: 'POST',
+    path: '/v1/user/vault-verify-m1',
+    data: { srpM1, sessionStarterId },
+    sessionId,
+  });
+  if (verifyAError || verifyM1Error) {
+    return false;
+  }
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~ //
+  // Verify Server Identity M2 //
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~ //
+  srpClient.checkM2(new Buffer(srpM2, 'hex'));
+  const srpK = srpClient.computeK().toString('hex');
+  return srpK;
+};
+
+export const createVaultKeyAction: ActionFunction = async () => {
+  return createVaultKey('create');
+};
+
+export const resetVaultKeyAction: ActionFunction = async () => {
+  return createVaultKey('reset');
+};
+
+export const updateVaultSaltAction: ActionFunction = async () => {
+  const userSession = await sessionModel.getOrCreate();
+  const { id: sessionId } = userSession;
+  const { salt: vaultSalt } = await insomniaFetch<{
+    salt?: string;
+    error?: string;
+  }>({
+    method: 'GET',
+    path: '/v1/user/vault',
+    sessionId,
+  });
+  if (vaultSalt) {
+    await sessionModel.update(userSession, { vaultSalt });
+  };
+  return vaultSalt;
+};
+
+export const clearVaultKeyAction: ActionFunction = async ({ request }) => {
+  const { sessionId: resetVaultClientSessionId } = await request.json();
+
+  const userSession = await sessionModel.getOrCreate();
+  const { id: sessionId } = userSession;
+  const { salt: newVaultSalt } = await insomniaFetch<{
+    salt?: string;
+    error?: string;
+  }>({
+    method: 'GET',
+    path: '/v1/user/vault',
+    sessionId,
+  }).catch(error => {
+    console.error(`failed to get vault salt ${error.toString()}`);
+  }) || {};
+  // User on other device has reset the vault key.
+  if (resetVaultClientSessionId !== sessionId) {
+    // Update vault salt and delelte vault key from session
+    sessionModel.update(userSession, { vaultSalt: newVaultSalt, vaultKey: '' });
+    // show notification
+    const notification: ToastNotification = {
+      key: 'Vault key reset',
+      message: 'Your vault key has been reset, all you local secrets have been deleted.',
+    };
+    ipcRenderer.emit('show-notification', null, notification);
+    return true;
+  }
+  return false;
+};
+
+export const validateVaultKeyAction: ActionFunction = async ({ request }) => {
+  const { vaultKey, saveVaultKey: saveVaultKeyLocally = false } = await request.json();
+  const userSession = await sessionModel.getOrCreate();
+  const { vaultSalt } = userSession;
+
+  if (!vaultSalt) {
+    return { error: 'Please generate a vault key from preference first' };
+  }
+
+  try {
+    const validateResult = await validateVaultKey(userSession, vaultKey, vaultSalt);
+    if (!validateResult) {
+      return { error: 'Invalid vault key, please check and input again' };
+    }
+    if (saveVaultKeyLocally) {
+      await saveVaultKey(userSession, vaultKey);
+    };
+    return { vaultKey, srpK: validateResult };
+  } catch (error) {
+    return { error: error.toString() };
+  };
+};

--- a/packages/insomnia/src/utils/vault.ts
+++ b/packages/insomnia/src/utils/vault.ts
@@ -1,0 +1,49 @@
+import { settings } from '../models';
+
+export const base64encode = (input: string | JsonWebKey) => {
+  const inputStr = typeof input === 'string' ? input : JSON.stringify(input);
+  return Buffer.from(inputStr, 'utf-8').toString('base64');
+};
+
+export const base64decode = (base64Str: string, toObject: boolean) => {
+  try {
+    const decodedStr = Buffer.from(base64Str, 'base64').toString('utf-8');
+    if (toObject) {
+      return JSON.parse(decodedStr);
+    }
+    return decodedStr;
+  } catch (error) {
+    console.error(`failed to base64 decode string ${base64Str}`);
+  }
+  return base64Str;
+};
+
+export const decryptVaultKeyFromSession = async (vaultKey: string, toJsonWebKey: boolean) => {
+  if (vaultKey) {
+    const decryptedVaultKey = await window.main.secretStorage.decryptString(vaultKey);
+    if (toJsonWebKey) {
+      return base64decode(decryptedVaultKey, true);
+    };
+    return decryptedVaultKey;
+  }
+  return '';
+};
+
+const getVaultSecretKey = (accountId: string) => `vault_${accountId}`;
+
+export const saveVaultKeyIfNecessary = async (accountId: string, vaultKey: string) => {
+  const userSetting = await settings.getOrCreate();
+  const { saveVaultKeyLocally } = userSetting;
+  if (saveVaultKeyLocally) {
+    await window.main.secretStorage.setSecret(getVaultSecretKey(accountId), vaultKey);
+  }
+};
+
+export const getVaultKeyFromStorage = async (accountId: string) => {
+  const savedVaultKey = await window.main.secretStorage.getSecret(getVaultSecretKey(accountId));
+  return savedVaultKey;
+};
+
+export const deleteVaultKeyFromStorage = async (accountId: string) => {
+  await window.main.secretStorage.deleteSecret(getVaultSecretKey(accountId));
+};


### PR DESCRIPTION
**Changes:** 
As part of the Insomnia vault feature, this PR includes the UI changes for vault key management.
The vault key is used to encrypt local secret environment variables.

Add a new UI in Preferences page for vault key generation:
<img width="712" alt="Screenshot 2025-01-15 at 10 18 10" src="https://github.com/user-attachments/assets/6fb97a5c-24dc-4ccb-89fa-4329b3af7f6c" />

When user has logged on other devices/re-login, user needs to enter the vault key for validation. We also provide reset feature if the vault key is lost.
<img width="600" alt="Screenshot 2025-01-15 at 10 18 17" src="https://github.com/user-attachments/assets/3d6277ca-b38c-4c96-806a-ffa217cb60d0" />

There will be two new options related to vault key: 
User could choose to save the encrypted vault key locally to avoid entering vault key after re-login. The vault key is encrypted using OS native secret manager(like KeyChain in MacOS).
There's another option to choose whether to allow pre-request/post-response scripts to access secret environment variables
<img width="713" alt="Screenshot 2025-01-15 at 10 18 54" src="https://github.com/user-attachments/assets/876eb0a6-38bf-4902-a0bd-a3a75892cb73" />

