### PR TITLE
fix(sdk): misc fixes and improvements

### DIFF
--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -116,7 +116,7 @@ describe('inso dev bundle', () => {
       if (result.code !== 0) {
         console.log(result);
       }
-      expect(result.stdout).toContain('log: "we did it: 200"');
+      expect(result.stdout).toContain('log: we did it: 200');
     });
 
     it('iterationData and iterationCount args work', async () => {

--- a/packages/insomnia-sdk/src/objects/console.ts
+++ b/packages/insomnia-sdk/src/objects/console.ts
@@ -14,8 +14,11 @@ export class Console {
     // TODO: support replacing substitution
     printLog = (rows: Row[], level: LogLevel, ...values: any) => {
         try {
+            const content = values.map((a: any) => JSON.stringify(a, null, 2).replace('\\n', '\n'))
+                .join(' ');
             const row = {
-                value: `${level}: ` + values.map((a: any) => JSON.stringify(a, null, 2)).join('\n'),
+                // TODO: also support formating e.g. \t
+                value: `${level}: ${content}`,
                 name: 'Text',
                 timestamp: Date.now(),
             };
@@ -65,4 +68,13 @@ export class Console {
         return this.rows
             .map(row => JSON.stringify(row) + '\n');
     };
+}
+
+let builtInConsole = new Console();
+export function getConsole() {
+    return builtInConsole;
+}
+export function getNewConsole() {
+    builtInConsole = new Console();
+    return builtInConsole;
 }

--- a/packages/insomnia-sdk/src/objects/console.ts
+++ b/packages/insomnia-sdk/src/objects/console.ts
@@ -6,13 +6,6 @@ export interface Row {
     timestamp: number;
 }
 
-const escapeMap: Record<string, string> = {
-    '\\f': '\f',
-    '\\n': '\n',
-    '\\t': '\t',
-    '\\v': '\v',
-};
-
 class Console {
     rows: Row[] = [];
 
@@ -23,14 +16,7 @@ class Console {
         try {
             const content = values.map(
                 (value: any) => {
-                    const valueStr = JSON.stringify(value, null, 2);
-
-                    let escapedValueStr = valueStr;
-                    Object.keys(escapeMap).forEach(toEscape => {
-                        escapedValueStr = escapedValueStr.replace(toEscape, escapeMap[toEscape]);
-                    });
-
-                    return escapedValueStr;
+                    return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
                 }
             ).join(' ');
 

--- a/packages/insomnia-sdk/src/objects/console.ts
+++ b/packages/insomnia-sdk/src/objects/console.ts
@@ -6,6 +6,13 @@ export interface Row {
     timestamp: number;
 }
 
+const escapeMap: Record<string, string> = {
+    '\\f': '\f',
+    '\\n': '\n',
+    '\\t': '\t',
+    '\\v': '\v',
+};
+
 class Console {
     rows: Row[] = [];
 
@@ -14,10 +21,20 @@ class Console {
     // TODO: support replacing substitution
     printLog = (rows: Row[], level: LogLevel, ...values: any) => {
         try {
-            const content = values.map((a: any) => JSON.stringify(a, null, 2).replace('\\n', '\n'))
-                .join(' ');
+            const content = values.map(
+                (value: any) => {
+                    const valueStr = JSON.stringify(value, null, 2);
+
+                    let escapedValueStr = valueStr;
+                    Object.keys(escapeMap).forEach(toEscape => {
+                        escapedValueStr = escapedValueStr.replace(toEscape, escapeMap[toEscape]);
+                    });
+
+                    return escapedValueStr;
+                }
+            ).join(' ');
+
             const row = {
-                // TODO: also support formating e.g. \t
                 value: `${level}: ${content}`,
                 name: 'Text',
                 timestamp: Date.now(),

--- a/packages/insomnia-sdk/src/objects/console.ts
+++ b/packages/insomnia-sdk/src/objects/console.ts
@@ -6,7 +6,7 @@ export interface Row {
     timestamp: number;
 }
 
-export class Console {
+class Console {
     rows: Row[] = [];
 
     constructor() { }
@@ -71,7 +71,7 @@ export class Console {
 }
 
 let builtInConsole = new Console();
-export function getConsole() {
+export function getExistingConsole() {
     return builtInConsole;
 }
 export function getNewConsole() {

--- a/packages/insomnia-sdk/src/objects/environments.ts
+++ b/packages/insomnia-sdk/src/objects/environments.ts
@@ -1,3 +1,4 @@
+import { getConsole } from './console';
 import { getInterpolator } from './interpolator';
 
 export class Environment {
@@ -22,6 +23,10 @@ export class Environment {
     };
 
     set = (variableName: string, variableValue: boolean | number | string) => {
+        if (variableValue === null) {
+            getConsole().warn(`Variable "${variableName}" has a null value`);
+            return;
+        }
         this.kvs.set(variableName, variableValue);
     };
 

--- a/packages/insomnia-sdk/src/objects/environments.ts
+++ b/packages/insomnia-sdk/src/objects/environments.ts
@@ -100,6 +100,11 @@ export class Variables {
     };
 
     set = (variableName: string, variableValue: boolean | number | string) => {
+        if (variableValue === null) {
+            getConsole().warn(`Variable "${variableName}" has a null value`);
+            return;
+        }
+
         this.localVars.set(variableName, variableValue);
     };
 

--- a/packages/insomnia-sdk/src/objects/environments.ts
+++ b/packages/insomnia-sdk/src/objects/environments.ts
@@ -1,4 +1,4 @@
-import { getConsole } from './console';
+import { getExistingConsole } from './console';
 import { getInterpolator } from './interpolator';
 
 export class Environment {
@@ -24,7 +24,7 @@ export class Environment {
 
     set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
         if (variableValue === null) {
-            getConsole().warn(`Variable "${variableName}" has a null value`);
+            getExistingConsole().warn(`Variable "${variableName}" has a null value`);
             return;
         }
         this.kvs.set(variableName, variableValue);
@@ -101,7 +101,7 @@ export class Variables {
 
     set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
         if (variableValue === null) {
-            getConsole().warn(`Variable "${variableName}" has a null value`);
+            getExistingConsole().warn(`Variable "${variableName}" has a null value`);
             return;
         }
 

--- a/packages/insomnia-sdk/src/objects/environments.ts
+++ b/packages/insomnia-sdk/src/objects/environments.ts
@@ -3,7 +3,7 @@ import { getInterpolator } from './interpolator';
 
 export class Environment {
     private _name: string;
-    private kvs = new Map<string, boolean | number | string>();
+    private kvs = new Map<string, boolean | number | string | undefined>();
 
     constructor(name: string, jsonObject: object | undefined) {
         this._name = name;
@@ -22,7 +22,7 @@ export class Environment {
         return this.kvs.get(variableName);
     };
 
-    set = (variableName: string, variableValue: boolean | number | string) => {
+    set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
         if (variableValue === null) {
             getConsole().warn(`Variable "${variableName}" has a null value`);
             return;
@@ -99,7 +99,7 @@ export class Variables {
         return finalVal;
     };
 
-    set = (variableName: string, variableValue: boolean | number | string) => {
+    set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
         if (variableValue === null) {
             getConsole().warn(`Variable "${variableName}" has a null value`);
             return;

--- a/packages/insomnia-sdk/src/objects/response.ts
+++ b/packages/insomnia-sdk/src/objects/response.ts
@@ -158,7 +158,7 @@ export class Response extends Property {
             throw Error('dataURI(): response body is not defined');
         }
 
-        return `data:${contentInfo.contentType};baseg4, <base64-encoded-body>`;
+        return `data:${contentInfo.contentType};baseg4, ${bodyInBase64}`;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -184,7 +184,6 @@ export class Response extends Property {
         try {
             const contentLength = this.headers.get('Content-Length');
             // TODO: improve this by manual counting
-            console.log(this.headers.get('Content-Length'));
             return contentLength == null ? -1 : parseInt(contentLength.valueOf());
         } catch (e) {
             throw Error('size: ${e}');

--- a/packages/insomnia-sdk/src/objects/test.ts
+++ b/packages/insomnia-sdk/src/objects/test.ts
@@ -20,7 +20,7 @@ export async function test(
             testCase: msg,
             status: 'failed',
             executionTime,
-            errorMessage: `${e}`,
+            errorMessage: `error: ${e} | ACTUAL: ${e.actual} | EXPECTED: ${e.expected}`,
             category: 'unknown',
         });
     }

--- a/packages/insomnia-sdk/src/objects/urls.ts
+++ b/packages/insomnia-sdk/src/objects/urls.ts
@@ -9,6 +9,10 @@ export function setUrlSearchParams(provider: any) {
 export interface QueryParamOptions {
     key: string;
     value: string;
+    type?: string;
+    multiline?: string | boolean;
+    disabled?: boolean;
+    fileName?: string;
 }
 
 export class QueryParam extends Property {
@@ -17,8 +21,12 @@ export class QueryParam extends Property {
     key: string;
     value: string;
     type?: string;
+    // the `multiline` and `fileName` are properties from Insomnia
+    // they are added here to avoid being dropped
+    multiline?: string | boolean;
+    fileName?: string;
 
-    constructor(options: { key: string; value: string; type?: string } | string) {
+    constructor(options: QueryParamOptions | string) {
         super();
 
         if (typeof options === 'string') {
@@ -27,6 +35,9 @@ export class QueryParam extends Property {
                 this.key = optionsObj.key;
                 this.value = optionsObj.value;
                 this.type = optionsObj.type;
+                this.multiline = optionsObj.multiline;
+                this.disabled = optionsObj.disabled;
+                this.fileName = optionsObj.fileName;
             } catch (e) {
                 throw Error(`invalid QueryParam options ${e}`);
             }
@@ -34,6 +45,9 @@ export class QueryParam extends Property {
             this.key = options.key;
             this.value = options.value;
             this.type = options.type;
+            this.multiline = options.multiline;
+            this.disabled = options.disabled;
+            this.fileName = options.fileName;
         } else {
             throw Error('unknown options for new QueryParam');
         }

--- a/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
@@ -29,7 +29,7 @@ test.describe('after-response script features tests', async () => {
 
         const responsePane = page.getByTestId('response-pane');
         await expect(responsePane).toContainText('PASS');
-        await expect(responsePane).toContainText('FAILunhappy tests | AssertionError: expected 199 to deeply equal 200After-response Test');
+        await expect(responsePane).toContainText('FAILunhappy tests | error: AssertionError: expected 199 to deeply equal 200 | ACTUAL: 199 | EXPECTED: 200');
     });
 
     test('environment and baseEnvironment can be persisted', async ({ page }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -410,7 +410,7 @@ test.describe('pre-request features tests', async () => {
         await page.getByRole('tab', { name: 'Tests' }).click();
 
         const responsePane = page.getByTestId('response-pane');
-        expect(responsePane).toContainText('FAILunhappy tests | AssertionError: expected 199 to deeply equal 200Pre-request Test');
+        expect(responsePane).toContainText('FAILunhappy tests | error: AssertionError: expected 199 to deeply equal 200 | ACTUAL: 199 | EXPECTED: 200Pre-request Test');
         expect(responsePane).toContainText('PASShappy tests');
     });
 

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/electron/renderer';
 import { SENTRY_OPTIONS } from 'insomnia/src/common/sentry';
 import { initInsomniaObject, InsomniaObject } from 'insomnia-sdk';
-import { Console, mergeClientCertificates, mergeCookieJar, mergeRequests, mergeSettings, type RequestContext } from 'insomnia-sdk';
+import { getNewConsole, mergeClientCertificates, mergeCookieJar, mergeRequests, mergeSettings, type RequestContext } from 'insomnia-sdk';
 import * as _ from 'lodash';
 
 export interface HiddenBrowserWindowBridgeAPI {
@@ -48,7 +48,7 @@ function translateTestHandlers(script: string): string {
 const runScript = async (
   { script, context }: { script: string; context: RequestContext },
 ): Promise<RequestContext> => {
-  const scriptConsole = new Console();
+  const scriptConsole = getNewConsole();
 
   const executionContext = await initInsomniaObject(context, scriptConsole.log);
 

--- a/packages/insomnia/src/scriptExecutor.ts
+++ b/packages/insomnia/src/scriptExecutor.ts
@@ -1,7 +1,7 @@
 import { appendFile } from 'node:fs/promises';
 
 import { initInsomniaObject, InsomniaObject } from 'insomnia-sdk';
-import { Console, mergeClientCertificates, mergeCookieJar, mergeRequests, mergeSettings, type RequestContext } from 'insomnia-sdk';
+import { getNewConsole, mergeClientCertificates, mergeCookieJar, mergeRequests, mergeSettings, type RequestContext } from 'insomnia-sdk';
 import * as _ from 'lodash';
 
 import { invariant } from '../src/utils/invariant';
@@ -11,7 +11,7 @@ export const runScript = async (
   { script, context }: { script: string; context: RequestContext },
 ): Promise<RequestContext> => {
   // console.log(script);
-  const scriptConsole = new Console();
+  const scriptConsole = getNewConsole();
 
   const executionContext = await initInsomniaObject(context, scriptConsole.log);
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Also with some minor fixes.

### Changes
- [x] Request Body: in transforming, included some request body properties, such as multiline, fileName and disabled
- [x] Console: support escape sequences such as `\n` and print params in one line (instead of multiple lines)
- [x] Reject setting `null` to environment
- [x] In test output, also show completed version of Actual value and Expected value, originally it is truncated.

### Multipart body
<img width="526" alt="Screenshot 2025-01-15 at 15 36 01" src="https://github.com/user-attachments/assets/f668f346-5c02-4b70-ba84-4db713116eee" />

### log output
<img width="524" alt="Screenshot 2025-01-17 at 14 11 22" src="https://github.com/user-attachments/assets/40917a0b-e7ed-462e-a185-5a6fb83a5757" />

### In test, actual got value is 200, and expected value is a long string.
<img width="733" alt="Screenshot 2025-01-16 at 17 10 35" src="https://github.com/user-attachments/assets/463a1bd2-2d61-415b-898f-15f53e370957" />


Ref: INS-4795, #8240 