### PR TITLE
Polish the tip text for handling the conflicts when merging or pulling [INS-4862]

### DIFF
--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -742,7 +742,7 @@ export class VCS {
 
     if (preConflicts.length) {
       console.log('[sync] Merge failed', preConflicts);
-      throw new Error('Please commit current changes or revert them before merging');
+      throw new Error('Please commit current local changes or discard them before merging');
     }
 
     const shouldDoNothing1 = latestSnapshotOther && latestSnapshotOther.id === rootSnapshotId;

--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -249,6 +249,7 @@ export const SyncDropdown: FC<Props> = ({ gitSyncEnabled }) => {
         icon: pullFetcher.state !== 'idle' ? 'refresh' : 'cloud-download',
         isDisabled: behind === 0 || pullFetcher.state !== 'idle',
         action: () => {
+          // file://./../../routes/remote-collections.tsx#pullFromRemoteAction
           pullFetcher.submit({}, {
             method: 'POST',
             action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/insomnia-sync/pull`,


### PR DESCRIPTION
This PR is from this issue: https://github.com/Kong/insomnia/issues/7017
The potential reason for this issue is that when we add extra fields to a database model, The vcs thinks that there are uncommitted local changes caused by the new field and actions like pull are forbidden under such condition. Then user click the 'Discard all changes' button to revert to last commit, but the new field is added back automatically at once. So users find that there are still local changes and complain that 'Discard all changes' button not working.
The right way to handle this situation is to generate a commit after the new field is added. But there may be other changes made by the users and could be added to the commit altogether, which is unexpected by the user.

I polished the tip text to suggest users to try to commit local changes first. Maybe it can help solving the problem.