### PR TITLE
Build Linux aarch64 packages using the new GH runner

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -87,7 +87,7 @@ jobs:
           CSC_KEY_PASSWORD: ${{ matrix.csc_key_password_secret != '' && secrets[matrix.csc_key_password_secret] || ''  }}
 
       - name: Package app (Linux only)
-        if: startsWith(matrix.os, 'ubuntu')
+        if: runner.os == 'Linux'
         shell: bash
         run: npm run app-package
         env:
@@ -198,7 +198,7 @@ jobs:
         run: npm run artifacts -w insomnia-inso
 
       - name: Create inso Docker Image artifacts
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: |
           DOCKER_BUILDKIT=1 docker build --tag ${{ env.INSO_PACKAGE_NAME }}:temp ./packages/${{ env.INSO_PACKAGE_NAME }}
           docker save ${{ env.INSO_PACKAGE_NAME }}:temp -o ./packages/${{ env.INSO_PACKAGE_NAME }}/artifacts/${{ env.INSO_DOCKER_TAR }}
@@ -207,10 +207,10 @@ jobs:
       # Automatically uploads to workflow assets
       - name: Scan inso docker artifacts
         id: sbom_action
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         uses: Kong/public-shared-actions/security-actions/scan-docker-image@28d20a1f492927f35b00b317acd78f669c45f88b # v2.7.3
         with:
-          asset_prefix: image-inso-${{ runner.os }}
+          asset_prefix: image-inso-${{ runner.os }}-${{ runner.arch }}
           image: ./packages/${{ env.INSO_PACKAGE_NAME }}/artifacts/${{ env.INSO_DOCKER_TAR }}
           upload-sbom-release-assets: false # No release is publushed yet. Uploads as workflow assets
           skip_cis_scan: true
@@ -221,7 +221,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: ${{ matrix.os }}-artifacts
+          name: ${{ runner.os }}-${{ runner.arch }}-artifacts
           path: |
             packages/insomnia/dist/*.exe
             packages/insomnia/dist/squirrel-windows/*
@@ -237,7 +237,7 @@ jobs:
       - name: Upload source assets for Sentry
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}-sentry
+          name: ${{ runner.os }}-${{ runner.arch }}-sentry
           path: |
             packages/insomnia/build/*.js
             packages/insomnia/build/*.map

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -52,6 +52,9 @@ jobs:
           - os: ubuntu-latest
             csc_link_secret: ''
             csc_key_password_secret: ''
+          - os: ubuntu-24.04-arm
+            csc_link_secret: ''
+            csc_key_password_secret: ''
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -84,7 +87,7 @@ jobs:
           CSC_KEY_PASSWORD: ${{ matrix.csc_key_password_secret != '' && secrets[matrix.csc_key_password_secret] || ''  }}
 
       - name: Package app (Linux only)
-        if: matrix.os == 'ubuntu-latest'
+        if: startsWith(matrix.os, 'ubuntu')
         shell: bash
         run: npm run app-package
         env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -107,15 +107,6 @@ jobs:
           release_id: ${{ steps.core_tag_and_release.outputs.id }}
           tag_name: ${{ env.RELEASE_CORE_TAG }}
           file: "./artifacts/*-artifacts/insomnia/dist/Insomnia.*;./artifacts/*-artifacts/insomnia/dist/squirrel-windows/*;./artifacts/*-artifacts/insomnia-inso/artifacts/inso-*;./artifacts/**/*sbom.{spdx,cyclonedx}.json"
-          # /github/workspace/artifacts/windows-latest-artifacts/***/dist/squirrel-windows/Insomnia.Core-9.3.0-beta.1.exe
-          # /github/workspace/artifacts/windows-latest-artifacts/***/dist/squirrel-windows/Insomnia.Core-9.3.0-beta.1-full.nupkg
-          # /github/workspace/artifacts/windows-latest-artifacts/***/dist/squirrel-windows/RELEASES
-          # /home/runner/work/***/***/artifacts/macos-13-artifacts/***/dist/Insomnia.Core-9.3.0-alpha.7.dmg
-          # /home/runner/work/***/***/artifacts/ubuntu-latest-artifacts/***/dist/Insomnia.Core-9.3.0-alpha.7.deb
-          # /home/runner/work/***/***/artifacts/ubuntu-latest-artifacts/***-inso/artifacts/inso-linux-9.3.0-alpha.7.tar.xz
-          # /home/runner/work/***/***/artifacts/macos-13-artifacts/***-inso/artifacts/inso-macos-13-9.3.0-alpha.7.pkg
-          # /home/runner/work/***/***/artifacts/image-inso-Linux-sbom.spdx.json/image-inso-Linux-sbom.spdx.json
-          # /home/runner/work/***/***/artifacts/sbom.cyclonedx.json/sbom.cyclonedx.json
           prerelease: ${{ env.IS_PRERELEASE }}
           draft: false
 
@@ -153,9 +144,10 @@ jobs:
           RELEASE_VERSION: ${{ env.INSO_VERSION }}
           RELEASE_CHANNEL: ${{ contains(github.event.inputs.version, 'beta') && 'beta' || 'stable' }}
 
+      # TODO: also take care of aarch64 image
       - name: Load the Inso CLI Docker Archive
         run: |
-          docker load -i ./artifacts/ubuntu-latest-artifacts/insomnia-inso/artifacts/inso-docker-image.tar
+          docker load -i ./artifacts/Linux-X64-artifacts/insomnia-inso/artifacts/inso-docker-image.tar
           docker image ls
 
       - name: Login to Docker Hub
@@ -177,7 +169,6 @@ jobs:
           sep-tags: ","
 
       - name: Push Inso CLI docker image tags to Docker Hub
-        id: publish_isno_docker_image
         run: |
           for tag in ${IMAGE_TAGS//,/ }; do \
             docker tag insomnia-inso:temp $tag
@@ -241,15 +232,25 @@ jobs:
         env:
           RELEASE_GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
 
-      - name: Upload to snapcraft (beta and stable only)
+      - name: Upload x64 Linux snap to snapcraft (beta and stable only)
         if: ${{ !contains(github.event.inputs.version, 'alpha') }}
         uses: canonical/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN_FILE_NEW }}
         with:
-          snap: artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.snap
+          snap: artifacts/Linux-X64-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}-x64.snap
           release: ${{ contains(github.event.inputs.version, 'beta') && 'beta' || 'stable' }}
 
+      - name: Upload arm64 Linux to snapcraft (beta and stable only)
+        if: ${{ !contains(github.event.inputs.version, 'alpha') }}
+        uses: canonical/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN_FILE_NEW }}
+        with:
+          snap: artifacts/Linux-ARM64-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}-arm64.snap
+          release: ${{ contains(github.event.inputs.version, 'beta') && 'beta' || 'stable' }}
+
+      # TODO: also release for aarch64 Linux?
       - name: Upload .deb to pulp and/or cloudsmith (stable only)
         if: ${{ !contains(github.event.inputs.version, 'alpha') && !contains(github.event.inputs.version, 'beta') }}
         uses: docker://kong/release-script:latest
@@ -267,7 +268,7 @@ jobs:
           entrypoint: /entrypoint.sh
           args: >
             release
-            --file artifacts/ubuntu-latest-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}.deb
+            --file artifacts/Linux-X64-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}-x64.deb
             --dist-name ubuntu
             --dist-version focal
             --package-type insomnia

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -32,6 +32,8 @@ jobs:
             build-targets: "portable"
           - os: "ubuntu-22.04"
             build-targets: "tar.gz"
+          - os: "ubuntu-24.04-arm"
+            build-targets: "tar.gz"
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Package
         shell: bash
         run: NODE_OPTIONS='--max_old_space_size=6144' BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
-      
+
       # - name: Set publish metadata # Checksum for provenance must be calculated before moving artifacts temporarily
       #   id: metadata
       #   run: |
@@ -66,6 +66,11 @@ jobs:
       #     ARTIFACT_PATH: "packages"
       #     CLI_ARTIFACT_SHAFILE: ${{runner.temp}}/cli.sha256
       #     ELECTRON_ARTIFACT_SHAFILE: ${{runner.temp}}/electron.sha256
+
+      # See https://github.com/electron/electron/issues/42510#issuecomment-2171583086
+      - if: ${{ runner.os == 'Linux' }}
+        name: Lift unprivileged user namespace restrictions
+        run: sudo sysctl kernel/apparmor_restrict_unprivileged_userns=0
 
       - name: Test critical path on packaged electron app
         run: npm run test:package -w packages/insomnia-smoke-test -- --project=Critical

--- a/package-lock.json
+++ b/package-lock.json
@@ -1689,9 +1689,9 @@
       }
     },
     "node_modules/@getinsomnia/node-libcurl": {
-      "version": "2.33.4",
-      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.33.4.tgz",
-      "integrity": "sha512-/ZUyp5W0bGXb2D3Hou9ctPI42jEg0F3U3mdzt6s76EyuNoKP8qn9qSX+L03jWdZq1zXeTXd5Zl4YdOK2gJhWTw==",
+      "version": "2.33.7",
+      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-2.33.7.tgz",
+      "integrity": "sha512-SBT0cUyFqb6vCV0sOGtTfp+hHQI4sNO4fS+omF1GOukV1mt3zTuN0+pSsawjjHOdZ2yqSOVhcC/wfQzgGMD80Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -23077,7 +23077,7 @@
         "@bufbuild/protobuf": "^1.8.0",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-node": "^1.4.0",
-        "@getinsomnia/node-libcurl": "^2.33.2",
+        "@getinsomnia/node-libcurl": "^2.33.7",
         "@grpc/grpc-js": "^1.12.0",
         "@grpc/proto-loader": "^0.7.13",
         "@seald-io/nedb": "^4.0.4",

--- a/packages/insomnia-inso/Dockerfile
+++ b/packages/insomnia-inso/Dockerfile
@@ -11,7 +11,7 @@ COPY ./artifacts/inso-linux-*.tar.xz /tmp/inso.tar.xz
 RUN apt-get update && apt-get install -y xz-utils && rm -rf /var/lib/apt/lists/*
 RUN tar -C /usr/bin -xvf /tmp/inso.tar.xz
 
-FROM --platform=linux/amd64 docker.io/ubuntu:22.04
+FROM docker.io/ubuntu:22.04
 COPY --from=fetch /usr/bin/inso /usr/bin/inso
 RUN chmod +x /usr/bin/inso
 RUN apt-get update && apt-get install -y libstdc++6 && rm -rf /var/lib/apt/lists/*

--- a/packages/insomnia-inso/src/scripts/artifacts.ts
+++ b/packages/insomnia-inso/src/scripts/artifacts.ts
@@ -1,5 +1,6 @@
 // This file is responsible for compressing the binaries for each architecture
 import fs from 'node:fs/promises';
+import process from 'node:process';
 
 import { ProcessEnvOptions, spawn } from 'child_process';
 import path from 'path';
@@ -27,7 +28,7 @@ const spawnCompressProcess = (cwd: ProcessEnvOptions['cwd']) => {
       platform === 'win32' ? '-a -cf' : '-cJf',
       platform === 'win32'
         ? `inso-windows-${version}.zip`
-        : `inso-linux-${version}.tar.xz`,
+        : `inso-linux-${process.arch}-${version}.tar.xz`,
       platform === 'win32' ? 'inso.exe' : 'inso',
     ], { cwd, shell: platform === 'win32' });
   }

--- a/packages/insomnia-smoke-test/playwright/paths.ts
+++ b/packages/insomnia-smoke-test/playwright/paths.ts
@@ -28,14 +28,28 @@ export const randomDataPath = () => path.join(os.tmpdir(), 'insomnia-smoke-test'
 export const INSOMNIA_DATA_PATH = randomDataPath();
 
 // Packaged app paths
-const pathLookup: Record<string, string> = {
+const pathLookup: Record<string, string | Record<string, string>> = {
   win32: path.join('win-unpacked', 'Insomnia.exe'),
   darwin: path.join('mac-universal', 'Insomnia.app', 'Contents', 'MacOS', 'Insomnia'),
-  linux: path.join('linux-unpacked', 'insomnia'),
+  linux: {
+    x64: path.join('linux-unpacked', 'insomnia'),
+    arm64: path.join('linux-arm64-unpacked', 'insomnia'),
+  },
 };
+
+let binaryPath: string;
+const platformPath = pathLookup[process.platform]
+if (typeof platformPath === 'string') {
+  binaryPath = platformPath
+} else if (process.arch in platformPath) {
+  binaryPath = platformPath[process.arch]
+} else {
+  throw new Error(`Cannot find binary path for ${process.platform} ${process.arch}`)
+}
+
 export const cwd = path.resolve(__dirname, '..', '..', 'insomnia');
 const repoRoot = path.resolve(__dirname, '..', '..', '..');
-const insomniaBinary = path.join(cwd, 'dist', pathLookup[process.platform]);
+const insomniaBinary = path.join(cwd, 'dist', binaryPath);
 const electronBinary = path.join(repoRoot, 'node_modules', '.bin', process.platform === 'win32' ? 'electron.cmd' : 'electron');
 
 export const executablePath = bundleType() === 'package' ? insomniaBinary : electronBinary;

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -101,7 +101,7 @@ const config = {
     artifactName: `${BINARY_PREFIX}-\${version}-portable.\${ext}`,
   },
   linux: {
-    artifactName: `${BINARY_PREFIX}-\${version}.\${ext}`,
+    artifactName: `${BINARY_PREFIX}-\${version}-\${arch}.\${ext}`,
     executableName: 'insomnia',
     synopsis: 'The Collaborative API Client and Design Tool',
     category: 'Development',

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -39,7 +39,7 @@
     "@bufbuild/protobuf": "^1.8.0",
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-node": "^1.4.0",
-    "@getinsomnia/node-libcurl": "^2.33.2",
+    "@getinsomnia/node-libcurl": "^2.33.7",
     "@grpc/grpc-js": "^1.12.0",
     "@grpc/proto-loader": "^0.7.13",
     "@seald-io/nedb": "^4.0.4",


### PR DESCRIPTION
This PR tries to build one more artifact using the new GH ARM64 Linux runner (https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/).

I maintain the Insomnia flatpak on FlatHub (https://github.com/flathub/rest.insomnia.Insomnia) and building the application from source has been difficult. The environment for the compile/build phase is fully offline, which means any dependencies must be obtained beforehand, which in turn requires declaring them in the flatpak manifest. It is impossible to do this by hand for a large project like this. There is [a tool](https://github.com/flatpak/flatpak-builder-tools/tree/master/node) to help generate this , but it doesn't support git sources, which this application depends on.

I've stumbled upon the news that GHA added ARM64 Linux runners and decided to give this a try. If it works and it's acceptable, hopefully we can rely on the official aarch64 linux binaries in the future.