### PR TITLE
Rename local-storage to electron-storage

### DIFF
--- a/packages/insomnia/src/common/__tests__/electron-storage.test.ts
+++ b/packages/insomnia/src/common/__tests__/electron-storage.test.ts
@@ -2,59 +2,59 @@ import fs from 'fs';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import LocalStorage from '../../main/local-storage';
+import ElectronStorage from '../../main/electron-storage';
 
-describe('LocalStorage()', () => {
+describe('Test electron storage()', () => {
   afterEach(() => {
     vi.clearAllTimers();
   });
 
   it('create directory', () => {
-    const basePath = `/tmp/insomnia-localstorage-${Math.random()}`;
+    const basePath = `/tmp/insomnia-electronstorage-${Math.random()}`;
 
-    const ls = new LocalStorage(basePath);
-    expect(ls).toBeInstanceOf(LocalStorage);
+    const ls = new ElectronStorage(basePath);
+    expect(ls).toBeInstanceOf(ElectronStorage);
 
     const dir = fs.readdirSync(basePath);
     expect(dir.length).toEqual(0);
   });
 
   it('does basic operations', () => {
-    const basePath = `/tmp/insomnia-localstorage-${Math.random()}`;
-    const localStorage = new LocalStorage(basePath);
+    const basePath = `/tmp/insomnia-electronstorage-${Math.random()}`;
+    const electronStorage = new ElectronStorage(basePath);
 
     // Test get and set
-    localStorage.setItem('foo', 'bar 1');
-    localStorage.setItem('foo', 'bar');
-    expect(localStorage.getItem('foo', 'BAD')).toBe('bar');
+    electronStorage.setItem('foo', 'bar 1');
+    electronStorage.setItem('foo', 'bar');
+    expect(electronStorage.getItem('foo', 'BAD')).toBe('bar');
 
     // Test Object storage
-    localStorage.setItem('obj', {
+    electronStorage.setItem('obj', {
       foo: 'bar',
       arr: [1, 2, 3],
     });
-    expect(localStorage.getItem('obj')).toEqual({
+    expect(electronStorage.getItem('obj')).toEqual({
       foo: 'bar',
       arr: [1, 2, 3],
     });
 
     // Test default values
-    expect(localStorage.getItem('dne', 'default')).toEqual('default');
-    expect(localStorage.getItem('dne')).toEqual('default');
+    expect(electronStorage.getItem('dne', 'default')).toEqual('default');
+    expect(electronStorage.getItem('dne')).toEqual('default');
   });
 
   it('does handles malformed files', () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
-    const basePath = `/tmp/insomnia-localstorage-${Math.random()}`;
-    const localStorage = new LocalStorage(basePath);
+    const basePath = `/tmp/insomnia-electronstorage-${Math.random()}`;
+    const electronStorage = new ElectronStorage(basePath);
 
     // Assert default is returned on bad JSON
     fs.writeFileSync(path.join(basePath, 'key'), '{bad JSON');
-    expect(localStorage.getItem('key', 'default')).toBe('default');
+    expect(electronStorage.getItem('key', 'default')).toBe('default');
 
     // Assert that writing our file actually works
     fs.writeFileSync(path.join(basePath, 'key'), '{"good": "JSON"}');
-    expect(localStorage.getItem('key', 'default')).toEqual({
+    expect(electronStorage.getItem('key', 'default')).toEqual({
       good: 'JSON',
     });
     expect(consoleErrorSpy).toHaveBeenCalled();
@@ -62,22 +62,22 @@ describe('LocalStorage()', () => {
 
   it('does handles failing to write file', () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
-    const basePath = `/tmp/insomnia-localstorage-${Math.random()}`;
-    const localStorage = new LocalStorage(basePath);
+    const basePath = `/tmp/insomnia-electronstorage-${Math.random()}`;
+    const electronStorage = new ElectronStorage(basePath);
     fs.rmdirSync(basePath);
-    localStorage.setItem('key', 'value');
+    electronStorage.setItem('key', 'value');
 
     // Since the above operation failed to write, we should now get back
     // the default value
-    expect(localStorage.getItem('key', 'different')).toBe('different');
+    expect(electronStorage.getItem('key', 'different')).toBe('different');
     expect(consoleErrorSpy).toHaveBeenCalled();
   });
 
   it('stores a key', () => {
     vi.useFakeTimers();
-    const basePath = `/tmp/insomnia-localstorage-${Math.random()}`;
-    const localStorage = new LocalStorage(basePath);
-    localStorage.setItem('foo', 'bar');
+    const basePath = `/tmp/insomnia-electronstorage-${Math.random()}`;
+    const electronStorage = new ElectronStorage(basePath);
+    electronStorage.setItem('foo', 'bar');
 
     // Force debouncer to flush
     vi.runOnlyPendingTimers();
@@ -92,11 +92,11 @@ describe('LocalStorage()', () => {
 
   it('debounces key sets', () => {
     vi.useFakeTimers();
-    const basePath = `/tmp/insomnia-localstorage-${Math.random()}`;
-    const localStorage = new LocalStorage(basePath);
-    localStorage.setItem('foo', 'bar1');
-    localStorage.setItem('another', 10);
-    localStorage.setItem('foo', 'bar3');
+    const basePath = `/tmp/insomnia-electronstorage-${Math.random()}`;
+    const electronStorage = new ElectronStorage(basePath);
+    electronStorage.setItem('foo', 'bar1');
+    electronStorage.setItem('another', 10);
+    electronStorage.setItem('foo', 'bar3');
     expect(fs.readdirSync(basePath).length).toEqual(0);
 
     // Force debouncer to flush

--- a/packages/insomnia/src/main/electron-storage.ts
+++ b/packages/insomnia/src/main/electron-storage.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-class LocalStorage {
+class ElectronStorage {
   _buffer: Record<string, string> = {};
   _timeouts: Record<string, NodeJS.Timeout> = {};
   _basePath: string | null = null;
@@ -11,7 +11,7 @@ class LocalStorage {
     // Debounce writes on a per key basis
     fs.mkdirSync(basePath, { recursive: true });
 
-    console.log(`[localstorage] Initialized at ${basePath}`);
+    console.log(`[ElectronStorage] Initialized at ${basePath}`);
   }
 
   setItem<T>(key: string, obj?: T) {
@@ -39,7 +39,7 @@ class LocalStorage {
     try {
       return JSON.parse(contents);
     } catch (error) {
-      console.error(`[localstorage] Failed to parse item from LocalStorage: ${error}`);
+      console.error(`[ElectronStorage] Failed to parse item from electron storage: ${error}`);
       return defaultObj;
     }
   }
@@ -61,7 +61,7 @@ class LocalStorage {
       try {
         fs.writeFileSync(path, contents);
       } catch (error) {
-        console.error(`[localstorage] Failed to save to LocalStorage: ${error}`);
+        console.error(`[ElectronStorage] Failed to save to electron storage: ${error}`);
       }
     }
   }
@@ -72,4 +72,4 @@ class LocalStorage {
   }
 }
 
-export default LocalStorage;
+export default ElectronStorage;


### PR DESCRIPTION
**Changes:**
Currently, we have a `local-storage.ts` file used to persistent data in local file.
Since the name is confused with browser native `localStorage` in render process, rename it to electron-storage to make it more clear.

After this change, `localStorage` points to the browser native localStorage in render process.
`electron-storage` is the persistent storage to save data in local files in main process