### PR TITLE
fix(sdk): get response size from bytesRead value

### DIFF
--- a/packages/insomnia-sdk/src/objects/__tests__/request.test.ts
+++ b/packages/insomnia-sdk/src/objects/__tests__/request.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { Header, HeaderList } from '../headers';
-import { calculateRequestSize, mergeRequestBody, Request, RequestBody, RequestBodyOptions, toScriptRequestBody } from '../request';
+import { calculatePayloadSize, mergeRequestBody, Request, RequestBody, RequestBodyOptions, toScriptRequestBody } from '../request';
 
 describe('test request and response objects', () => {
     it('test RequestBody methods', () => {
@@ -145,8 +145,8 @@ describe('test request and response objects', () => {
     ];
 
     reqBodyTestCases.forEach(({ body, headers, expectedTotal }) => {
-        it(`test calculateRequestSize: ${body.raw}`, () => {
-            const reqSize = calculateRequestSize(new RequestBody(body), headers);
+        it(`test calculatePayloadSize: ${body.raw}`, () => {
+            const reqSize = calculatePayloadSize(new RequestBody(body).toString(), headers);
 
             expect(reqSize.total).toEqual(expectedTotal);
         });

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -654,6 +654,7 @@ export interface sendCurlAndWriteTimelineResponse extends ResponsePatch {
   statusMessage: string;
   cookies: Cookie[];
   timeline: string[];
+  bytesRead: number;
 }
 
 export async function sendCurlAndWriteTimeline(

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -654,7 +654,7 @@ export interface sendCurlAndWriteTimelineResponse extends ResponsePatch {
   statusMessage: string;
   cookies: Cookie[];
   timeline: string[];
-  bytesRead: number;
+  bytesRead?: number;
 }
 
 export async function sendCurlAndWriteTimeline(


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes
- [x] Make `insomnia.response.size()` returning value from `bytesRead` from context instead of from `Content-Length` header

INS-4873