### PR TITLE
Improve WSDL import [INS-4291]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "insomnia",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
         "packages/insomnia-testing",
@@ -36,6 +37,7 @@
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
+        "patch-package": "^8.0.0",
         "prettier": "3.5.3",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "tslib": "2.0.1",
@@ -7934,6 +7936,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
@@ -12884,6 +12893,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -14479,6 +14498,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -14811,6 +14846,19 @@
       "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/isarray": {
       "version": "2.0.5",
@@ -15369,6 +15417,26 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.2.1.tgz",
+      "integrity": "sha512-Lp6HbbBgosLmJbjx0pBLbgvx68FaFU1sdkmBuckmhhJ88kL13OA51CDtR2yJB50eCNMH9wRqtQNNiAqQH4YXnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -15410,6 +15478,16 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonlint-mod-fixed": {
@@ -15659,6 +15737,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/koa": {
@@ -17903,6 +17991,23 @@
       "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
       "dev": true
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openapi-types": {
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
@@ -18039,6 +18144,16 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/own-keys": {
@@ -18213,6 +18328,116 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/path-exists": {
@@ -20530,6 +20755,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "test:smoke:dev": "npm run test:dev -w insomnia-smoke-test -- --project=Smoke",
     "test:smoke:build": "npm run test:build -w insomnia-smoke-test -- --project=Smoke",
     "test:smoke:package": "npm run test:package -w insomnia-smoke-test -- --project=Smoke",
-    "test:crit:package": "npm run test:package -w insomnia-smoke-test -- --project=Critical"
+    "test:crit:package": "npm run test:package -w insomnia-smoke-test -- --project=Critical",
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",
@@ -54,6 +55,7 @@
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "patch-package": "^8.0.0",
     "prettier": "3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "tslib": "2.0.1",

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -38,7 +38,9 @@ describe('importRaw()', () => {
 
     const projectToImportTo = await project.create();
 
-    const scanResult = await importUtil.scanResources([content]);
+    const scanResult = await importUtil.scanResources([{
+      contentStr: content,
+    }]);
 
     expect(scanResult[0].type?.id).toBe('curl');
     expect(scanResult[0].errors.length).toBe(0);
@@ -66,7 +68,9 @@ describe('importRaw()', () => {
 
     const existingWorkspace = await workspace.create();
 
-    const scanResult = await importUtil.scanResources([content]);
+    const scanResult = await importUtil.scanResources([{
+      contentStr: content,
+    }]);
 
     expect(scanResult[0].type?.id).toBe('curl');
     expect(scanResult[0].errors.length).toBe(0);
@@ -88,7 +92,9 @@ describe('importRaw()', () => {
     const fixturePath = path.join(__dirname, '..', '__fixtures__', 'postman', 'aws-signature-auth-v2_0-input.json');
     const content = fs.readFileSync(fixturePath, 'utf8').toString();
     const projectToImportTo = await project.create();
-    const scanResult = await importUtil.scanResources([content]);
+    const scanResult = await importUtil.scanResources([{
+      contentStr: content,
+    }]);
 
     expect(scanResult[0].type?.id).toBe('postman');
     expect(scanResult[0].errors.length).toBe(0);
@@ -113,7 +119,9 @@ describe('importRaw()', () => {
 
     const existingWorkspace = await workspace.create();
 
-    const scanResult = await importUtil.scanResources([content]);
+    const scanResult = await importUtil.scanResources([{
+      contentStr: content,
+    }]);
 
     expect(scanResult[0].type?.id).toBe('postman');
     expect(scanResult[0].errors.length).toBe(0);
@@ -134,7 +142,9 @@ describe('importRaw()', () => {
     const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'endpoint-security-input.yaml');
     const content = fs.readFileSync(fixturePath, 'utf8').toString();
 
-    const scanResult = await importUtil.scanResources([content]);
+    const scanResult = await importUtil.scanResources([{
+      contentStr: content,
+    }]);
 
     expect(scanResult[0].type?.id).toBe('openapi3');
     expect(scanResult[0].errors.length).toBe(0);

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -16,6 +16,7 @@ import { isWebSocketRequest, type WebSocketRequest } from '../models/websocket-r
 import { isWorkspace, type Workspace } from '../models/workspace';
 import type { CurrentPlan } from '../ui/routes/organization';
 import { convert, type InsomniaImporter } from '../utils/importers/convert';
+import type { ImportEntry } from '../utils/importers/entities';
 import { id as postmanEnvImporterId } from '../utils/importers/importers/postman-env';
 import { invariant } from '../utils/invariant';
 import { database as db } from './database';
@@ -67,14 +68,9 @@ export async function fetchImportContentFromURI({ uri }: { uri: string }) {
   return content;
 }
 
-export interface ImportFileDetail {
-  contentStr: string;
-  oriFileName: string;
-}
-
 export interface PostmanDataDumpRawData {
-  collectionList: ImportFileDetail[];
-  envList: ImportFileDetail[];
+  collectionList: ImportEntry[];
+  envList: ImportEntry[];
 }
 
 export async function getFilesFromPostmanExportedDataDump(filePath: string): Promise<PostmanDataDumpRawData> {
@@ -115,12 +111,12 @@ interface ResourceCacheType {
 
 let resourceCacheList: ResourceCacheType[] = [];
 
-export async function scanResources(contentList: string[] | ImportFileDetail[]): Promise<ScanResult[]> {
+export async function scanResources(importEntries: ImportEntry[]): Promise<ScanResult[]> {
   resourceCacheList = [];
   const results = await Promise.allSettled(
-    contentList.map(async content => {
-      const contentStr = typeof content === 'string' ? content : content.contentStr;
-      const oriFileName = typeof content === 'string' ? '' : content.oriFileName;
+    importEntries.map(async importEntry => {
+      const contentStr = importEntry.contentStr;
+      const oriFileName = importEntry.oriFileName || '';
 
       let result: ConvertResult | null = null;
 
@@ -139,7 +135,7 @@ export async function scanResources(contentList: string[] | ImportFileDetail[]):
             },
           };
         } else {
-          result = (await convert(contentStr)) as unknown as ConvertResult;
+          result = (await convert(importEntry)) as unknown as ConvertResult;
         }
       } catch (err: unknown) {
         if (err instanceof Error) {

--- a/packages/insomnia/src/plugins/context/data.ts
+++ b/packages/insomnia/src/plugins/context/data.ts
@@ -34,7 +34,9 @@ export const init = (activeProjectId?: string) => ({
           uri,
         });
 
-        await scanResources([content]);
+        await scanResources([{
+          contentStr: content,
+        }]);
 
         await importResourcesToProject({
           projectId: activeProjectId,
@@ -44,7 +46,9 @@ export const init = (activeProjectId?: string) => ({
         if (!activeProjectId) {
           return;
         }
-        await scanResources([content]);
+        await scanResources([{
+          contentStr: content,
+        }]);
 
         await importResourcesToProject({
           projectId: activeProjectId,

--- a/packages/insomnia/src/ui/components/modals/paste-curl-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/paste-curl-modal.tsx
@@ -21,7 +21,9 @@ export const PasteCurlModal = ({
   useEffect(() => {
     async function parseCurlToRequest() {
       try {
-        const { data } = await convert(defaultValue || '');
+        const { data } = await convert({
+          contentStr: defaultValue || '',
+        });
         const { resources } = data;
         const importedRequest = resources[0];
         setIsValid(true);
@@ -54,7 +56,9 @@ export const PasteCurlModal = ({
                 return;
               }
               try {
-                const { data } = await convert(value);
+                const { data } = await convert({
+                  contentStr: value,
+                });
                 const { resources } = data;
                 const importedRequest = resources[0];
                 setIsValid(true);

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -1185,7 +1185,9 @@ export const generateCollectionFromApiSpecAction: ActionFunction = async ({ para
     throw new Error('Error Generating Configuration');
   }
 
-  await scanResources([apiSpec.contents]);
+  await scanResources([{
+    contentStr: apiSpec.contents,
+  }]);
 
   await importResourcesToWorkspace({
     workspaceId,
@@ -1227,7 +1229,9 @@ export const generateCollectionAndTestsAction: ActionFunction = async ({ params 
     throw new Error('Error Generating Configuration');
   }
 
-  const resources = await scanResources([apiSpec.contents]);
+  const resources = await scanResources([{
+    contentStr: apiSpec.contents,
+  }]);
 
   const allRequestsFromResources = resources.reduce(
     (accumulator, scanResult) => accumulator.concat(scanResult.requests ?? []),

--- a/packages/insomnia/src/ui/routes/import.tsx
+++ b/packages/insomnia/src/ui/routes/import.tsx
@@ -6,7 +6,6 @@ import type { PostmanDataDumpRawData } from '../../common/import';
 import {
   fetchImportContentFromURI,
   getFilesFromPostmanExportedDataDump,
-  type ImportFileDetail,
   importResourcesToProject,
   importResourcesToWorkspace,
   scanResources,
@@ -20,6 +19,7 @@ import {
   pushSnapshotOnInitialize,
 } from '../../sync/vcs/initialize-backend-project';
 import { VCSInstance } from '../../sync/vcs/insomnia-sync';
+import type { ImportEntry } from '../../utils/importers/entities';
 import { invariant } from '../../utils/invariant';
 import { fetchAndCacheOrganizationStorageRule } from './organization';
 
@@ -31,7 +31,7 @@ export const scanForResourcesAction: ActionFunction = async ({ request }): Promi
     invariant(typeof source === 'string', 'Source is required.');
     invariant(['file', 'uri', 'clipboard'].includes(source), 'Unsupported import type');
 
-    const contentList: ImportFileDetail[] = [];
+    const contentList: ImportEntry[] = [];
     if (source === 'uri') {
       const uri = formData.get('uri');
       if (typeof uri !== 'string' || uri === '') {
@@ -81,7 +81,7 @@ export const scanForResourcesAction: ActionFunction = async ({ request }): Promi
           ];
         }
 
-        function trans({ contentStr, oriFileName }: ImportFileDetail): ImportFileDetail {
+        function trans({ contentStr, oriFileName }: ImportEntry): ImportEntry {
           return {
             contentStr,
             oriFileName: `${oriFileName} in ${path.basename(zipFilePath)}`,
@@ -99,6 +99,7 @@ export const scanForResourcesAction: ActionFunction = async ({ request }): Promi
         contentList.push({
           contentStr: await fetchImportContentFromURI({ uri }),
           oriFileName: path.basename(filePath),
+          oriFilePath: filePath,
         });
       }
     } else {

--- a/packages/insomnia/src/utils/importers/__tests__/convert.test.ts
+++ b/packages/insomnia/src/utils/importers/__tests__/convert.test.ts
@@ -6,7 +6,9 @@ import { convert, dotInKeyNameInvariant } from '../convert';
 describe('Import errors', () => {
   it('fail to find importer', async () => {
     try {
-      await convert('foo');
+      await convert({
+        contentStr: 'foo',
+      });
       fail('Should have thrown error');
     } catch (err) {
       expect(err.message).toBe('No importers found for file');

--- a/packages/insomnia/src/utils/importers/convert.ts
+++ b/packages/insomnia/src/utils/importers/convert.ts
@@ -20,6 +20,7 @@ export interface ConvertResult {
 
 export const convert = async (importEntry: ImportEntry) => {
   const importers = (await import('./importers')).importers;
+  const errMsgList: string[] = [];
   for (const importer of importers) {
     let resources;
     if (importer.acceptFilePath === true) {
@@ -33,6 +34,13 @@ export const convert = async (importEntry: ImportEntry) => {
     if (!resources) {
       continue;
     }
+
+    if ('convertErrorMessage' in resources) {
+      // ConvertErrorResult
+      errMsgList.push(`Error in importer ${importer.name}: ${resources.convertErrorMessage}`);
+      continue;
+    }
+
     dotInKeyNameInvariant(resources);
 
     // Each postman's collection has its variable, we map it to request group's environment in Insomnia
@@ -59,7 +67,7 @@ export const convert = async (importEntry: ImportEntry) => {
     return convertedResult;
   }
 
-  throw new Error('No importers found for file');
+  throw new Error(errMsgList.length > 0 ? errMsgList.join('\n') : 'No importers found for file');
 };
 
 // this checks invalid keys ahead, or nedb would return an error in importing.

--- a/packages/insomnia/src/utils/importers/convert.ts
+++ b/packages/insomnia/src/utils/importers/convert.ts
@@ -1,4 +1,4 @@
-import type { ImportRequest } from './entities';
+import type { ImportEntry, ImportRequest } from './entities';
 import { setDefaults } from './utils';
 
 export interface InsomniaImporter {
@@ -18,10 +18,17 @@ export interface ConvertResult {
   };
 }
 
-export const convert = async (rawData: string) => {
+export const convert = async (importEntry: ImportEntry) => {
   const importers = (await import('./importers')).importers;
   for (const importer of importers) {
-    const resources = await importer.convert(rawData);
+    let resources;
+    if (importer.acceptFilePath === true) {
+      // FileImporter
+      resources = await importer.convert(importEntry);
+    } else {
+      // ContentStrImporter
+      resources = await importer.convert(importEntry.contentStr);
+    }
 
     if (!resources) {
       continue;

--- a/packages/insomnia/src/utils/importers/convert.ts
+++ b/packages/insomnia/src/utils/importers/convert.ts
@@ -24,7 +24,7 @@ export const convert = async (importEntry: ImportEntry) => {
   for (const importer of importers) {
     let resources;
     if (importer.acceptFilePath === true) {
-      // FileImporter
+      // FilePathImporter
       resources = await importer.convert(importEntry);
     } else {
       // ContentStrImporter

--- a/packages/insomnia/src/utils/importers/entities.ts
+++ b/packages/insomnia/src/utils/importers/entities.ts
@@ -100,12 +100,12 @@ interface ContentStrImporter extends BaseImporter {
   convert: Converter;
 }
 
-interface FileImporter extends BaseImporter {
+interface FilePathImporter extends BaseImporter {
   acceptFilePath: true;
   convert: FilePathConverter;
 }
 
-export type Importer = ContentStrImporter | FileImporter;
+export type Importer = ContentStrImporter | FilePathImporter;
 
 export interface ImportEntry {
   contentStr: string;

--- a/packages/insomnia/src/utils/importers/entities.ts
+++ b/packages/insomnia/src/utils/importers/entities.ts
@@ -83,9 +83,30 @@ export type Converter<T extends {} = {}> = (
   rawData: string,
 ) => ImportRequest<T>[] | Promise<ImportRequest<T>[] | null> | null;
 
-export interface Importer {
+export type FilePathConverter<T extends {} = {}> = (
+  importEntry: ImportEntry,
+) => ImportRequest<T>[] | Promise<ImportRequest<T>[] | null> | null;
+
+interface BaseImporter {
   id: string;
   name: string;
   description: string;
+}
+
+interface ContentStrImporter extends BaseImporter {
+  acceptFilePath?: false;
   convert: Converter;
+}
+
+interface FileImporter extends BaseImporter {
+  acceptFilePath: true;
+  convert: FilePathConverter;
+}
+
+export type Importer = ContentStrImporter | FileImporter;
+
+export interface ImportEntry {
+  contentStr: string;
+  oriFileName?: string;
+  oriFilePath?: string;
 }

--- a/packages/insomnia/src/utils/importers/entities.ts
+++ b/packages/insomnia/src/utils/importers/entities.ts
@@ -53,7 +53,7 @@ export interface QueryString extends Comment {
 
 export type ImportRequestType = 'environment' | 'request' | 'request_group' | 'workspace';
 
-export interface ImportRequest<T extends {} = {}> extends Comment {
+export interface ImportRequest extends Comment {
   _id?: string;
   // @TODO Fix me
   _type?: string;
@@ -65,7 +65,7 @@ export interface ImportRequest<T extends {} = {}> extends Comment {
   httpVersion?: string;
   method?: string;
   name?: string;
-  data?: T;
+  data?: object;
   description?: string;
   parameters?: Parameter[];
   parentId?: string | null;
@@ -79,13 +79,15 @@ export interface ImportRequest<T extends {} = {}> extends Comment {
   scope?: string;
 }
 
-export type Converter<T extends {} = {}> = (
-  rawData: string,
-) => ImportRequest<T>[] | Promise<ImportRequest<T>[] | null> | null;
+interface ConvertErrorResult {
+  convertErrorMessage: string;
+}
 
-export type FilePathConverter<T extends {} = {}> = (
-  importEntry: ImportEntry,
-) => ImportRequest<T>[] | Promise<ImportRequest<T>[] | null> | null;
+type ConvertResult = ImportRequest[] | ConvertErrorResult | null;
+
+export type Converter = (rawData: string) => ConvertResult | Promise<ConvertResult>;
+
+export type FilePathConverter = (importEntry: ImportEntry) => ConvertResult | Promise<ConvertResult>;
 
 interface BaseImporter {
   id: string;

--- a/packages/insomnia/src/utils/importers/importers/index.test.ts
+++ b/packages/insomnia/src/utils/importers/importers/index.test.ts
@@ -30,7 +30,9 @@ describe('Fixtures', () => {
         const inputContents = fs.readFileSync(path.join(dir, input), 'utf8');
         expect(typeof inputContents).toBe('string');
 
-        const results = await convert(inputContents);
+        const results = await convert({
+          contentStr: inputContents,
+        });
         results.data.__export_date = '';
         expect(results.data).toMatchSnapshot();
 

--- a/packages/insomnia/src/utils/importers/importers/postman-env.ts
+++ b/packages/insomnia/src/utils/importers/importers/postman-env.ts
@@ -16,8 +16,6 @@ interface Environment {
   _postman_variable_scope: 'environment' | string;
 }
 
-type Data = Record<EnvVar['key'], EnvVar['value']>;
-
 export enum POSTMAN_ENV_TYPE {
   GLOBAL = 'globals',
   ENVIRONMENT = 'environment',
@@ -25,7 +23,7 @@ export enum POSTMAN_ENV_TYPE {
 
 const validPostmanEnvTypeList = Object.values(POSTMAN_ENV_TYPE) as string[];
 
-export const convert: Converter<Data> = rawData => {
+export const convert: Converter = rawData => {
   try {
     const { _postman_variable_scope, name, values } = JSON.parse(rawData) as Environment;
 

--- a/packages/insomnia/src/utils/importers/importers/wsdl.ts
+++ b/packages/insomnia/src/utils/importers/importers/wsdl.ts
@@ -1,3 +1,7 @@
+import { DOMParser } from '@xmldom/xmldom';
+// Since there are restrictions that let it not generate full sample request, it's hard-coded in apiconnect-wsdl, so we use patch-package to patch the files in apiconnect-wsdl to remove the restrictions
+// The version of apiconnect-wsdl is locked to 2.0.36. If you need to use a newer version in the future, make sure to update the patch file; otherwise, the program may break.
+// https://www.npmjs.com/package/patch-package
 import {
   findWSDLForServiceName,
   getJsonForWSDL,
@@ -6,12 +10,13 @@ import {
   type Swagger,
 } from 'apiconnect-wsdl';
 
-import type { Converter } from '../entities';
+import type { FilePathConverter } from '../entities';
 import * as postman from './postman';
 
 export const id = 'wsdl';
 export const name = 'WSDL';
 export const description = 'Importer for WSDL files';
+export const acceptFilePath = true;
 
 const pathToSwagger = (swagger: any, path: string[]) => {
   return path.reduce((acc, v: string) => {
@@ -81,6 +86,7 @@ const convertToPostman = (items: Swagger[]) => {
   };
 };
 
+// input can be a file path or a file content string
 const convertWsdlToPostman = async (input: string) => {
   const wsdls = await getJsonForWSDL(input);
   const { services } = getWSDLServices(wsdls);
@@ -93,14 +99,25 @@ const convertWsdlToPostman = async (input: string) => {
   return convertToPostman(items);
 };
 
-export const convert: Converter = async rawData => {
+export const convert: FilePathConverter = async importEntry => {
+  const rawData = importEntry.contentStr;
   try {
-    if (rawData.indexOf('wsdl:definition') !== -1) {
-      const postmanData = await convertWsdlToPostman(`<?xml version="1.0" encoding="UTF-8" ?>${rawData}`);
-      postmanData.info.schema += 'collection.json';
-      const postmanJson = JSON.stringify(postmanData);
-      return postman.convert(postmanJson);
+    if (!verifyWsdl(rawData)) {
+      return null;
     }
+    let input;
+    if (importEntry.oriFilePath) {
+      // here we prioritize using the original file path because the apiconnect-wsdl library can recognize 'import', 'include' tags in a wsdl file and find the referenced xsd files automatically.
+      input = importEntry.oriFilePath;
+    } else {
+      input = `<?xml version="1.0" encoding="UTF-8" ?>${rawData}`;
+    }
+    const postmanData = await convertWsdlToPostman(
+      input,
+    );
+    postmanData.info.schema += 'collection.json';
+    const postmanJson = JSON.stringify(postmanData);
+    return postman.convert(postmanJson);
   } catch (error) {
     console.error(error);
     // Nothing
@@ -108,3 +125,15 @@ export const convert: Converter = async rawData => {
 
   return null;
 };
+
+const wsdlNamespaceUri = 'http://schemas.xmlsoap.org/wsdl/';
+
+function verifyWsdl(fileContent: string) {
+  try {
+    const mainWsdlDocument = new DOMParser().parseFromString(fileContent, 'text/xml');
+    return mainWsdlDocument.documentElement.namespaceURI === wsdlNamespaceUri &&
+      mainWsdlDocument.documentElement.localName === 'definitions';
+  } catch (error) {
+    return false;
+  }
+}

--- a/packages/insomnia/src/utils/importers/importers/wsdl.ts
+++ b/packages/insomnia/src/utils/importers/importers/wsdl.ts
@@ -101,10 +101,16 @@ const convertWsdlToPostman = async (input: string) => {
 
 export const convert: FilePathConverter = async importEntry => {
   const rawData = importEntry.contentStr;
+
   try {
     if (!verifyWsdl(rawData)) {
       return null;
     }
+  } catch (error) {
+    return null;
+  }
+
+  try {
     let input;
     if (importEntry.oriFilePath) {
       // here we prioritize using the original file path because the apiconnect-wsdl library can recognize 'import', 'include' tags in a wsdl file and find the referenced xsd files automatically.
@@ -112,18 +118,16 @@ export const convert: FilePathConverter = async importEntry => {
     } else {
       input = `<?xml version="1.0" encoding="UTF-8" ?>${rawData}`;
     }
-    const postmanData = await convertWsdlToPostman(
-      input,
-    );
+    const postmanData = await convertWsdlToPostman(input);
     postmanData.info.schema += 'collection.json';
     const postmanJson = JSON.stringify(postmanData);
     return postman.convert(postmanJson);
   } catch (error) {
     console.error(error);
-    // Nothing
+    return {
+      convertErrorMessage: error.message,
+    };
   }
-
-  return null;
 };
 
 const wsdlNamespaceUri = 'http://schemas.xmlsoap.org/wsdl/';
@@ -131,8 +135,10 @@ const wsdlNamespaceUri = 'http://schemas.xmlsoap.org/wsdl/';
 function verifyWsdl(fileContent: string) {
   try {
     const mainWsdlDocument = new DOMParser().parseFromString(fileContent, 'text/xml');
-    return mainWsdlDocument.documentElement.namespaceURI === wsdlNamespaceUri &&
-      mainWsdlDocument.documentElement.localName === 'definitions';
+    return (
+      mainWsdlDocument.documentElement.namespaceURI === wsdlNamespaceUri &&
+      mainWsdlDocument.documentElement.localName === 'definitions'
+    );
   } catch (error) {
     return false;
   }

--- a/patches/README.txt
+++ b/patches/README.txt
@@ -1,0 +1,2 @@
+This folder contains the patch files used to modify npm dependencies.
+See https://www.npmjs.com/package/patch-package

--- a/patches/apiconnect-wsdl+2.0.36.patch
+++ b/patches/apiconnect-wsdl+2.0.36.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/apiconnect-wsdl/lib/generateExamples.js b/node_modules/apiconnect-wsdl/lib/generateExamples.js
+index a4cbc96..56d5c82 100644
+--- a/node_modules/apiconnect-wsdl/lib/generateExamples.js
++++ b/node_modules/apiconnect-wsdl/lib/generateExamples.js
+@@ -50,7 +50,7 @@ function generateExamples(swagger, req) {
+             totalLength += swagger.definitions[nsName].example.length;
+         }
+     }
+-    if (totalLength > 1000000) {
++    if (totalLength > Number.MAX_SAFE_INTEGER) {
+         for (let nsName in swagger.definitions) {
+             if (swagger.definitions[nsName].example) {
+                 delete swagger.definitions[nsName].example;
+@@ -66,8 +66,8 @@ function exampleXMLForType(nsName, definitions, detailMap, req) {
+     let context = {
+         nesting: 0,
+         propertyCount: 0,
+-        nestingLimit: 10,
+-        breadthLimit: 50,
++        nestingLimit: Number.MAX_SAFE_INTEGER,
++        breadthLimit: Number.MAX_SAFE_INTEGER,
+         detailMap: detailMap
+     };
+     if (xso) {
+@@ -150,9 +150,9 @@ function generateElement(name, xso, definitions, nsStack, context, inOneOf, req)
+         pop(nsStack);
+         context.nesting--;
+         context.propertyCount++;
+-        if (context.propertyCount > 200) {
++        /* if (context.propertyCount > 200) {
+             context.breadthLimit = 5;
+-        }
++        } */
+ 
+         // If this is a polymorphic type, then add an xsi:type and comment
+         let xsiType = '';


### PR DESCRIPTION
When importing WSDL files, the file may depend on other XSD files. We haven't parsed referenced XSD files before.
Now we pass the file path of the WSDL to apiconnect-wsdl to let it parse all referenced xsd files.

Also, there are restrictions that prevent it from generating a full sample request. It's hard-coded in apiconnect-wsdl, so we use patch-package to patch the files in apiconnect-wsdl to remove the restrictions
https://www.npmjs.com/package/patch-package

Finally, I added the logic to show the detailed error message within the importer as our customer requested.