### PR TITLE
make runners conventional

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -41,9 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # macos-13 supports both intel and apple silicon on inso cli properly
-          # macos-latest is defaulting to apple silicon and breaks inso cli retrocompatibility
-          - os: macos-13
+          - os: macos-latest-large
             csc_link_secret: DESIGNER_MAC_CSC_LINK
             csc_key_password_secret: DESIGNER_MAC_CSC_KEY_PASSWORD
           - os: windows-latest
@@ -52,7 +50,7 @@ jobs:
           - os: ubuntu-latest
             csc_link_secret: ''
             csc_key_password_secret: ''
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-latest-arm
             csc_link_secret: ''
             csc_key_password_secret: ''
     steps:
@@ -76,13 +74,13 @@ jobs:
 
       # If this step fails its possible apple has new license terms which need to be accepted by logging into https://developer.apple.com/account
       - name: Package app (MacOS only)
-        if: matrix.os == 'macos-13'
+        if: runner.os == 'macOS'
         shell: bash
         run: npm run app-package
         env:
           NODE_OPTIONS: '--max_old_space_size=6144'
-          APPLE_ID: ${{ matrix.os == 'macos-13' && secrets.DESIGNER_APPLE_ID || '' }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.os == 'macos-13' && secrets.DESIGNER_APPLE_ID_PASSWORD || '' }}
+          APPLE_ID: ${{ runner.os == 'macOS' && secrets.DESIGNER_APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ runner.os == 'macOS' && secrets.DESIGNER_APPLE_ID_PASSWORD || '' }}
           CSC_LINK: ${{ matrix.csc_link_secret != '' && secrets[matrix.csc_link_secret] || '' }}
           CSC_KEY_PASSWORD: ${{ matrix.csc_key_password_secret != '' && secrets[matrix.csc_key_password_secret] || ''  }}
 
@@ -95,12 +93,12 @@ jobs:
 
       # creates unpacked electron-builder contents that can be signed afterwards
       - name: Package unpacked app (Windows only)
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         shell: bash
         run: NODE_OPTIONS='--max_old_space_size=6144' npm run package:windows:unpacked -w insomnia
 
       - name: Move .dll and .exe files to /tosign (PowerShell)
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           New-Item -Path "packages/insomnia/dist/win-unpacked/tosign" -ItemType Directory -Force
@@ -110,7 +108,7 @@ jobs:
 
       # signs unpacked electron-builder contents, in this case only the .exe
       - name: Code-sign unpacked .exe (Windows only)
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         uses: sslcom/esigner-codesign@develop
         with:
           command: batch_sign
@@ -123,7 +121,7 @@ jobs:
           override: true
 
       - name: Move .dll and .exe files back to win-unpacked and delete /tosign
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           Get-ChildItem -Path "packages/insomnia/dist/win-unpacked/signed" -Filter *.dll | Move-Item -Destination "packages/insomnia/dist/win-unpacked"
@@ -133,7 +131,7 @@ jobs:
 
       # re-packages the now code-signed electron-builder contents into a squirrel installer
       - name: Package dist app (Windows only)
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         shell: bash
         run: |
           docker pull ghcr.io/sslcom/codesigner-win:latest
@@ -155,7 +153,7 @@ jobs:
           VERSION: ${{ env.INSO_VERSION }}
 
       - name: Code-sign & create Inso CLI installer (macOS only)
-        if: matrix.os == 'macos-13'
+        if: runner.os == 'macOS'
         run: ./src/scripts/macos-pkg.sh
         shell: bash
         working-directory: ./packages/${{ env.INSO_PACKAGE_NAME }}
@@ -168,7 +166,7 @@ jobs:
           VERSION: ${{ env.INSO_VERSION }}
 
       - name: Notarize Inso CLI installer (macOS only)
-        if:  matrix.os == 'macos-13'
+        if:  runner.os == 'macOS'
         uses: lando/notarize-action@v2
         with:
           product-path: ./packages/${{ env.INSO_PACKAGE_NAME }}/artifacts/inso-${{ matrix.os }}-${{ env.INSO_VERSION }}.pkg
@@ -179,13 +177,13 @@ jobs:
           verbose: true
 
       - name: Staple Inso CLI installer (macOS only)
-        if: matrix.os == 'macos-13'
+        if: runner.os == 'macOS'
         uses: BoundfoxStudios/action-xcode-staple@v1
         with:
           product-path: ./packages/${{ env.INSO_PACKAGE_NAME }}/artifacts/inso-${{ matrix.os }}-${{ env.INSO_VERSION }}.pkg
 
       - name: Notarize Inso CLI binary (macOS only)
-        if: matrix.os == 'macos-13'
+        if: runner.os == 'macOS'
         uses: lando/notarize-action@v2
         with:
           product-path: ./packages/${{ env.INSO_PACKAGE_NAME }}/binaries/inso

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -71,6 +71,17 @@ jobs:
         run: |
           echo "INSO_VERSION=$(jq .version ./packages/${{ env.INSO_PACKAGE_NAME }}/package.json -rj)" >> $GITHUB_ENV
 
+      - name: Install snapcraft (Linux arm64 only)
+        if: runner.os == 'Linux' && runner.arch == 'arm64'
+        shell: bash
+        run: sudo snap install snapcraft --classic 
+
+      - name: Package app (Linux only)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: npm run app-package
+        env:
+          NODE_OPTIONS: '--max_old_space_size=6144'
 
       # If this step fails its possible apple has new license terms which need to be accepted by logging into https://developer.apple.com/account
       - name: Package app (MacOS only)
@@ -83,13 +94,6 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ runner.os == 'macOS' && secrets.DESIGNER_APPLE_ID_PASSWORD || '' }}
           CSC_LINK: ${{ matrix.csc_link_secret != '' && secrets[matrix.csc_link_secret] || '' }}
           CSC_KEY_PASSWORD: ${{ matrix.csc_key_password_secret != '' && secrets[matrix.csc_key_password_secret] || ''  }}
-
-      - name: Package app (Linux only)
-        if: runner.os == 'Linux'
-        shell: bash
-        run: npm run app-package
-        env:
-          NODE_OPTIONS: '--max_old_space_size=6144'
 
       # creates unpacked electron-builder contents that can be signed afterwards
       - name: Package unpacked app (Windows only)

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   # shared kong github action for security checking
   generate-sbom-and-upload-assets:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
       contents: write # publish sbom to GH releases/tag assets
@@ -47,10 +47,10 @@ jobs:
           - os: windows-latest
             csc_link_secret: ''
             csc_key_password_secret: ''
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             csc_link_secret: ''
             csc_key_password_secret: ''
-          - os: ubuntu-latest-arm
+          - os: ubuntu-24.04-arm
             csc_link_secret: ''
             csc_key_password_secret: ''
     steps:
@@ -244,7 +244,7 @@ jobs:
   update-pull-request:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     needs: build-and-upload-release-artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Get release version
         id: release_version

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   publish:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       NOTARY_REPOSITORY: ${{ env.NOTARY_REPOSITORY }}
       INSO_BINARY_ARTIFACTS_SUBJECTS_AS_FILE: ${{ steps.cli_binary_hashes.outputs.handle }}

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -30,9 +30,9 @@ jobs:
             build-targets: zip
           - os: windows-latest
             build-targets: portable
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             build-targets: tar.gz
-          - os: ubuntu-latest-arm
+          - os: ubuntu-24.04-arm
             build-targets: tar.gz
     steps:
       - name: Checkout branch

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -26,14 +26,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: "macos-latest"
-            build-targets: "zip"
-          - os: "windows-latest"
-            build-targets: "portable"
-          - os: "ubuntu-22.04"
-            build-targets: "tar.gz"
-          - os: "ubuntu-24.04-arm"
-            build-targets: "tar.gz"
+          - os: macos-latest-large
+            build-targets: zip
+          - os: windows-latest
+            build-targets: portable
+          - os: ubuntu-latest
+            build-targets: tar.gz
+          - os: ubuntu-latest-arm
+            build-targets: tar.gz
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -55,17 +55,6 @@ jobs:
       - name: Package
         shell: bash
         run: NODE_OPTIONS='--max_old_space_size=6144' BUILD_TARGETS='${{ matrix.build-targets }}' npm run app-package
-
-      # - name: Set publish metadata # Checksum for provenance must be calculated before moving artifacts temporarily
-      #   id: metadata
-      #   run: |
-      #     INSO_VERSION=$(jq .version packages/insomnia-inso/package.json -rj)
-      #     echo "INSO_VERSION=${INSO_VERSION}" >> $GITHUB_ENV
-      #     ./.github/scripts/generate-binary-digest.sh
-      #   env:
-      #     ARTIFACT_PATH: "packages"
-      #     CLI_ARTIFACT_SHAFILE: ${{runner.temp}}/cli.sha256
-      #     ELECTRON_ARTIFACT_SHAFILE: ${{runner.temp}}/electron.sha256
 
       # See https://github.com/electron/electron/issues/42510#issuecomment-2171583086
       - if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   setup-release-branch:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -13,7 +13,7 @@ jobs:
   semgrep:
     timeout-minutes: 5
     name: Semgrep SAST
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   Test:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
         shell: bash
         run: |
           INSO_VERSION="$(jq .version packages/insomnia-inso/package.json -rj)-run.${{ github.run_number }}"
-          PKG_NAME="inso-ubuntu-latest-$INSO_VERSION"
+          PKG_NAME="inso-ubuntu-24.04-$INSO_VERSION"
           echo "pkg-name=$PKG_NAME" >> $GITHUB_OUTPUT
           echo "inso-version=$INSO_VERSION" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   Test:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   Test:
     timeout-minutes: 20
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -26,8 +26,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
-          cache: 'npm'
+          node-version-file: .nvmrc
+          cache: npm
           cache-dependency-path: package-lock.json
 
       - name: Install packages

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the


### PR DESCRIPTION
moves macos from 13 to 14
ensures test and builds all use ubuntu 24 rather than a mix of 22 and 24
ubuntu-latest-arm might not exist as an alias

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
