### PR TITLE
fix: support headers as metadata with gRPC + reflection

### DIFF
--- a/packages/insomnia/src/main/ipc/grpc.ts
+++ b/packages/insomnia/src/main/ipc/grpc.ts
@@ -218,7 +218,7 @@ const getMethodsFromReflection = async (
       url,
       getChannelCredentials({ url: host, caCertificate, clientCert, clientKey, rejectUnauthorized }),
       grpcOptions,
-      filterDisabledMetaData(metadata),
+      filterDisabledOrInvalidMetaData(metadata),
       path
     );
     const services = await client.listServices();
@@ -414,7 +414,7 @@ export const start = (
             method.requestSerialize,
             method.responseDeserialize,
             messageBody,
-            filterDisabledMetaData(request.metadata),
+            filterDisabledOrInvalidMetaData(request.metadata),
             onUnaryResponse(event, request._id),
           );
           unaryCall.on('status', (status: StatusObject) => event.reply('grpc.status', request._id, status));
@@ -425,7 +425,7 @@ export const start = (
             requestPath,
             method.requestSerialize,
             method.responseDeserialize,
-            filterDisabledMetaData(request.metadata),
+            filterDisabledOrInvalidMetaData(request.metadata),
             onUnaryResponse(event, request._id));
           clientCall.on('status', (status: StatusObject) => event.reply('grpc.status', request._id, status));
           grpcCalls.set(request._id, clientCall);
@@ -436,7 +436,7 @@ export const start = (
             method.requestSerialize,
             method.responseDeserialize,
             messageBody,
-            filterDisabledMetaData(request.metadata),
+            filterDisabledOrInvalidMetaData(request.metadata),
           );
           onStreamingResponse(event, serverCall, request._id);
           grpcCalls.set(request._id, serverCall);
@@ -446,7 +446,7 @@ export const start = (
             requestPath,
             method.requestSerialize,
             method.responseDeserialize,
-            filterDisabledMetaData(request.metadata));
+            filterDisabledOrInvalidMetaData(request.metadata));
           onStreamingResponse(event, bidiCall, request._id);
           grpcCalls.set(request._id, bidiCall);
           break;
@@ -538,10 +538,10 @@ const onUnaryResponse = (event: IpcMainEvent, requestId: string) => (err: Servic
   grpcCalls.delete(requestId);
 };
 
-const filterDisabledMetaData = (metadata: GrpcRequestHeader[]): Metadata => {
+const filterDisabledOrInvalidMetaData = (metadata: GrpcRequestHeader[]): Metadata => {
   const grpcMetadata = new Metadata();
   for (const entry of metadata) {
-    if (!entry.disabled) {
+    if (!entry.disabled && entry.name) {
       grpcMetadata.add(entry.name, entry.value);
     }
   }

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -26,7 +26,7 @@ import type { Environment, UserUploadEnvironment } from '../models/environment';
 import type { MockRoute } from '../models/mock-route';
 import type { MockServer } from '../models/mock-server';
 import { isProject, type Project } from '../models/project';
-import { isRequest, type Request, type RequestAuthentication, type RequestHeader, type RequestParameter } from '../models/request';
+import { type BaseRequest, isRequest, type Request, type RequestAuthentication, type RequestHeader, type RequestParameter } from '../models/request';
 import { isRequestGroup, type RequestGroup } from '../models/request-group';
 import type { Settings } from '../models/settings';
 import type { WebSocketRequest } from '../models/websocket-request';
@@ -63,7 +63,7 @@ export const getOrInheritAuthentication = ({ request, requestGroups }: { request
   // if no auth is specified on request or folders, default to none
   return { type: 'none' };
 };
-export function getOrInheritHeaders({ request, requestGroups }: { request: Request; requestGroups: RequestGroup[] }): RequestHeader[] {
+export function getOrInheritHeaders({ request, requestGroups }: { request: Pick<BaseRequest, 'headers'>; requestGroups: RequestGroup[] }): RequestHeader[] {
   // recurse over each parent folder to append headers
   // in case of duplicate, node-libcurl joins on comma
   const headers = requestGroups


### PR DESCRIPTION
resolves: INS-4850

- always show the Headers tab in the gRPC request pane in order to send custom headers with the reflection requests (closes #6865)
- combines the headers from the ancestors into the gRPC metadata (also applies to reflection)
- in addition to filtering out disabled headers from gRPC metadata, removes ones that would throw errors (header keys with an empty name)

Opted to keep the "gathering" code localized to the pane since we're doing a whole lot in there already, but I'd like to move a good portion of the code in here into the loader (if feasible) in the future.

Intentionally did not surface validation errors (empty metadata/header keys) in the editor because (I believe) it'll be apparent enough to users visually that empty headers will not be sent