### PR TITLE
fix: .deb and .snap upload on publish [no-ticket]

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -227,15 +227,6 @@ jobs:
           snap: artifacts/Linux-X64-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}-amd64.snap
           release: ${{ contains(github.event.inputs.version, 'beta') && 'beta' || 'stable' }}
 
-      - name: Upload arm64 Linux to snapcraft (beta and stable only)
-        if: ${{ !contains(github.event.inputs.version, 'alpha') }}
-        uses: canonical/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN_FILE_NEW }}
-        with:
-          snap: artifacts/Linux-ARM64-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}-arm64.snap
-          release: ${{ contains(github.event.inputs.version, 'beta') && 'beta' || 'stable' }}
-
       # TODO: also release for aarch64 Linux?
       - name: Upload .deb to pulp and/or cloudsmith (stable only)
         if: ${{ !contains(github.event.inputs.version, 'alpha') && !contains(github.event.inputs.version, 'beta') }}
@@ -264,7 +255,7 @@ jobs:
         uses: Homebrew/actions/git-user-config@master
         with:
           username: ${{ (github.event_name == 'workflow_dispatch' && github.actor) || 'insomnia-infra' }}
-          
+
       - name: Merge git branch into develop
         run: |
           remote_repo="https://${GITHUB_ACTOR}:${RELEASE_GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -224,7 +224,7 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN_FILE_NEW }}
         with:
-          snap: artifacts/Linux-X64-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}-x64.snap
+          snap: artifacts/Linux-X64-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}-amd64.snap
           release: ${{ contains(github.event.inputs.version, 'beta') && 'beta' || 'stable' }}
 
       - name: Upload arm64 Linux to snapcraft (beta and stable only)
@@ -254,7 +254,7 @@ jobs:
           entrypoint: /entrypoint.sh
           args: >
             release
-            --file artifacts/Linux-X64-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}-x64.deb
+            --file artifacts/Linux-X64-artifacts/insomnia/dist/Insomnia.Core-${{ env.RELEASE_VERSION }}-amd64.deb
             --dist-name ubuntu
             --dist-version focal
             --package-type insomnia


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ba7581bf-4eb3-499f-9fb9-88b1e8a2ff64)

The architecture on electron-builder config adopts slightly different flavour for the file descriptors:
- `x64`
- `x86_64`
- `amd64`

This caused the `release-publish` to fail because it was trying to grab a file that does not exist.

This also removes the step where we try to upload arm64.snap - which we are not producing on release-build at the moment, hence the job would fail.

Note: the previous .deb (which is downloadable via API) needs to account for the new `_amd64`  - we will need to work on creating different download links (and buttons on insomnia-website)