### PR TITLE
fix: template render error [INS-4962]

### DIFF
--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -170,7 +170,11 @@ export async function initInsomniaObject(
 
     // replace all variables in the raw URL before parsing it
     const sanitizedRawUrl = `${rawObj.request.url}`.replace(/{{\s*\_\./g, '{{');
-    const renderedRawUrl = variables.replaceIn(sanitizedRawUrl);
+    let renderedRawUrl = sanitizedRawUrl;
+
+    // FIXME: hack to solve INS-4962, remove underscores, single quotes & square brackets
+    const tmpSanitizedRawUrl = sanitizedRawUrl.replace(/[_'[\]]/g, '');
+    renderedRawUrl = variables.replaceIn(tmpSanitizedRawUrl);
 
     // parse the URL to get the host + protocol
     const renderedUrl = toUrlObject(renderedRawUrl);

--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -168,8 +168,13 @@ export async function initInsomniaObject(
         localVars: localVariables,
     });
 
-    // replace all variables in the raw URL before parsing it; remove underscores, single quotes & square brackets
-    const sanitizedRawUrl = `${rawObj.request.url}`.replace(/{{\s*\_\./g, '{{').replace(/[_'[\]]/g, '');
+    // sanitize URL, see _updateElementText in nunjuncks-tags.ts
+    const sanitizedRawUrl = rawObj.request.url.replace(/\\/g, '')
+        .replace(/^{%/, '')
+        .replace(/%}$/, '')
+        .replace(/^{{/, '')
+        .replace(/}}$/, '')
+        .trim();
     const renderedRawUrl = variables.replaceIn(sanitizedRawUrl);
     const renderedUrl = toUrlObject(renderedRawUrl);
 

--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -168,15 +168,9 @@ export async function initInsomniaObject(
         localVars: localVariables,
     });
 
-    // replace all variables in the raw URL before parsing it
-    const sanitizedRawUrl = `${rawObj.request.url}`.replace(/{{\s*\_\./g, '{{');
-    let renderedRawUrl = sanitizedRawUrl;
-
-    // FIXME: hack to solve INS-4962, remove underscores, single quotes & square brackets
-    const tmpSanitizedRawUrl = sanitizedRawUrl.replace(/[_'[\]]/g, '');
-    renderedRawUrl = variables.replaceIn(tmpSanitizedRawUrl);
-
-    // parse the URL to get the host + protocol
+    // replace all variables in the raw URL before parsing it; remove underscores, single quotes & square brackets
+    const sanitizedRawUrl = `${rawObj.request.url}`.replace(/{{\s*\_\./g, '{{').replace(/[_'[\]]/g, '');
+    const renderedRawUrl = variables.replaceIn(sanitizedRawUrl);
     const renderedUrl = toUrlObject(renderedRawUrl);
 
     // filter client certificates by the rendered base URL

--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -35,7 +35,7 @@ resources:
     modified: 1738847468596
     created: 1738847375384
     url: "{{ _['examplehost']}}"
-    name: INS-4962 Environment custom tag
+    name: Special template tag format
     description: ""
     method: GET
     body: {}

--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -30,6 +30,31 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
+  - _id: req_500ec0e5dd254eb7aa7eea758c9da3a4
+    parentId: wrk_6b9b8455fd784462ae19cd51d7156f86
+    modified: 1738847468596
+    created: 1738847375384
+    url: "{{ _['examplehost']}}"
+    name: INS-4962 Environment custom tag
+    description: ""
+    method: GET
+    body: {}
+    parameters: []
+    headers:
+      - name: User-Agent
+        value: insomnia/10.3.1-beta.3
+    authentication: {}
+    preRequestScript: console.log('test')
+    metaSortKey: -1738847375384
+    isPrivate: false
+    pathParameters: []
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
   - _id: wrk_6b9b8455fd784462ae19cd51d7156f86
     parentId: null
     modified: 1707808692801
@@ -218,7 +243,8 @@ resources:
     modified: 1707808692805
     created: 1707808692805
     name: Base Environment
-    data: {}
+    data:
+      examplehost: "https://mock.insomnia.rest"
     dataPropertyOrder: null
     color: null
     isPrivate: false

--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -55,6 +55,31 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
+  - _id: req_8737ee72c809428d9a187cf1feb0bc05
+    parentId: wrk_6b9b8455fd784462ae19cd51d7156f86
+    modified: 1738856398102
+    created: 1738856350541
+    url: "{{_['a']['b']['c']['url']}}"
+    name: Multiple template tags format
+    description: ""
+    method: GET
+    body: {}
+    parameters: []
+    headers:
+      - name: User-Agent
+        value: insomnia/10.3.1-beta.3
+    authentication: {}
+    preRequestScript: console.log('test')
+    metaSortKey: -1738810244689.5
+    isPrivate: false
+    pathParameters: []
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
   - _id: wrk_6b9b8455fd784462ae19cd51d7156f86
     parentId: null
     modified: 1707808692801
@@ -245,6 +270,10 @@ resources:
     name: Base Environment
     data:
       examplehost: "https://mock.insomnia.rest"
+      a:
+        b:
+          c:
+            url: "https://mock.insomnia.rest"
     dataPropertyOrder: null
     color: null
     isPrivate: false

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -414,7 +414,7 @@ test.describe('pre-request features tests', async () => {
         expect(responsePane).toContainText('PASShappy tests');
     });
 
-    test('environment and baseEnvironment can be persisted', async ({ page }) => {
+    test.only('environment and baseEnvironment can be persisted', async ({ page }) => {
         const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
         await page.getByLabel('Request Collection').getByTestId('persist environment').press('Enter');
 
@@ -438,6 +438,13 @@ test.describe('pre-request features tests', async () => {
             '__fromScript2': 'collection',
             '__fromScript': 'environment',
             'examplehost': 'https://mock.insomnia.rest',
+            'a': {
+                'b': {
+                    'c': {
+                        'url': 'https://mock.insomnia.rest',
+                    },
+                },
+            },
         });
     });
 });

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -437,6 +437,7 @@ test.describe('pre-request features tests', async () => {
             '__fromScript1': 'baseEnvironment',
             '__fromScript2': 'collection',
             '__fromScript': 'environment',
+            'examplehost': 'https://mock.insomnia.rest',
         });
     });
 });

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -414,7 +414,7 @@ test.describe('pre-request features tests', async () => {
         expect(responsePane).toContainText('PASShappy tests');
     });
 
-    test.only('environment and baseEnvironment can be persisted', async ({ page }) => {
+    test('environment and baseEnvironment can be persisted', async ({ page }) => {
         const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
         await page.getByLabel('Request Collection').getByTestId('persist environment').press('Enter');
 

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
@@ -34,6 +34,10 @@ test.describe('test hidden window handling', async () => {
     await page.getByText('Special template tag format').click();
     await page.getByRole('button', { name: 'Send' }).click();
     await page.getByText('200 OK').click();
+
+    await page.getByText('Multiple template tags format').click();
+    await page.getByRole('button', { name: 'Send' }).click();
+    await page.getByText('200 OK').click();
   });
 
   test('handle hidden browser window getting closed', async ({ app, page }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
@@ -30,6 +30,11 @@ test.describe('test hidden window handling', async () => {
 
     // check the response pane message
     await page.click('text=Request was cancelled');
+
+    // check special environment variable case INS-4962
+    await page.getByText('INS-4962 Environment custom').click();
+    await page.getByRole('button', { name: 'Send' }).click();
+    await page.getByText('200 OK').click();
   });
 
   test('handle hidden browser window getting closed', async ({ app, page }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
@@ -31,8 +31,7 @@ test.describe('test hidden window handling', async () => {
     // check the response pane message
     await page.click('text=Request was cancelled');
 
-    // check special environment variable case INS-4962
-    await page.getByText('INS-4962 Environment custom').click();
+    await page.getByText('Special template tag format').click();
     await page.getByRole('button', { name: 'Send' }).click();
     await page.getByText('200 OK').click();
   });


### PR DESCRIPTION
This PR closes INS-4962. Changes:

- A "dirty" fix to the issue - follows same approach as https://github.com/Kong/insomnia/blob/b7e959758bc012e102730266931fa2ceeb031970/packages/insomnia/src/ui/components/codemirror/extensions/nunjucks-tags.ts#L283-L288
- Reproduction of the bug added to `pre-request-script-window` smoke test to help test a better a fix in the future.

## context

The bug was introduced after `10.3.0` due to the sanitization code we added in order to solve another bug (see https://github.com/Kong/insomnia/commit/90bd25c55f1b8fa9e9505cd4f0fd44e8e685da4b#diff-28ee43a50d28cabb98317967663a3abd59d3e11c9fafa39bca88eed9d290c0b6R173). 

Something about the `variables.replaceIn(sanitizedRawUrl)` call that happens on the insomnia sdk does not work well with this particular format of template tags `{{ _['host_environment'] }}`.


## notes

One important thing to note, is that the code-path to render template tags in `insomnia-sdk` is a different one than the one we use on the app (for example for rendering the templates in the preview of the URL )

- The app we use this render function: https://github.com/Kong/insomnia/blob/b7e959758bc012e102730266931fa2ceeb031970/packages/insomnia/src/common/render.ts#L262
- But in the SDK we use this one: https://github.com/Kong/insomnia/blob/b7e959758bc012e102730266931fa2ceeb031970/packages/insomnia-sdk/src/objects/interpolator.ts#L11


We might want to consider merging both to make use of old edge case fixes we already have done before the sdk.


Another side-note is that to debug this issue is a bit tricky as it requires:
1. start hidden browser window
2. send a request
3. show hidden browser window
4. going to dev tools of hidden browser window

<img width="338" alt="image" src="https://github.com/user-attachments/assets/ce801a43-21ea-4958-b0be-6dea90e7e21d" />



