### PR TITLE
Render no-standard content-encoding response [INS-4910]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
   },
   "files.insertFinalNewline": true,
   "editor.formatOnSave": true,
-  "editor.formatOnSaveMode": "modifications",
+  "editor.formatOnSaveMode": "file",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always",
     "source.fixAll.ts": "always"

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -29,6 +29,8 @@ export interface CurlRequestOptions {
   caCertficatePath: string | null;
   socketPath?: string;
   authHeader?: { name: string; value: string };
+  // make libcurl not decompress the response content
+  noDecompress?: boolean;
 }
 interface RequestUsedHere {
   headers: any;
@@ -102,7 +104,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
     await fs.promises.mkdir(responsesDir, { recursive: true });
     const responseBodyPath = path.join(responsesDir, uuidv4() + '.response');
 
-    const { requestId, req, finalUrl, settings, certificates, caCertficatePath, socketPath, authHeader } = options;
+    const { requestId, req, finalUrl, settings, certificates, caCertficatePath, socketPath, authHeader, noDecompress = false } = options;
     const caCert = (caCertficatePath && (await fs.promises.readFile(caCertficatePath)).toString());
 
     const { curl, debugTimeline } = createConfiguredCurlInstance({
@@ -112,6 +114,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
       caCert,
       certificates,
       socketPath,
+      noDecompress,
     });
     const { method, body } = req;
     // Only set CURLOPT_CUSTOMREQUEST if not HEAD or GET.
@@ -225,6 +228,12 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
       curl.isOpen && curl.close();
       await waitForStreamToFinish(responseBodyWriteStream);
 
+      // If libcurl can't decompress the response, retry without decompression
+      if (code === CurlCode.CURLE_BAD_CONTENT_ENCODING) {
+        resolve(curlRequest({ ...options, noDecompress: true }));
+        return;
+      }
+
       let error = err + '';
       let statusMessage = 'Error';
 
@@ -260,6 +269,7 @@ export const createConfiguredCurlInstance = ({
   caCert,
   certificates,
   socketPath,
+  noDecompress = false,
 }: {
   req: RequestUsedHere;
   finalUrl: string;
@@ -267,15 +277,21 @@ export const createConfiguredCurlInstance = ({
   certificates: ClientCertificate[];
   caCert: string | null;
   socketPath?: string;
+    noDecompress?: boolean;
 }) => {
   const debugTimeline: ResponseTimelineEntry[] = [];
   const curl = new Curl();
   curl.setOpt(Curl.option.URL, finalUrl);
   socketPath && curl.setOpt(Curl.option.UNIX_SOCKET_PATH, socketPath);
 
-  curl.setOpt(Curl.option.VERBOSE, true); // Set all the basic options
-  curl.setOpt(Curl.option.NOPROGRESS, true); // True so debug function works
-  curl.setOpt(Curl.option.ACCEPT_ENCODING, ''); // True so curl doesn't print progress
+  // Set all the basic options
+
+  // True so debug function works
+  curl.setOpt(Curl.option.VERBOSE, true);
+  // True so curl doesn't print progress
+  curl.setOpt(Curl.option.NOPROGRESS, true);
+  // whether to decompress response content
+  curl.setOpt(Curl.option.ACCEPT_ENCODING, noDecompress ? null : '');
   // fallback to root certificates or leave unset to use keychain on macOS
   if (caCert) {
     curl.setOpt(Curl.option.CAINFO_BLOB, caCert);

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -229,7 +229,7 @@ export const curlRequest = (options: CurlRequestOptions) => new Promise<CurlRequ
       await waitForStreamToFinish(responseBodyWriteStream);
 
       // If libcurl can't decompress the response, retry without decompression
-      if (code === CurlCode.CURLE_BAD_CONTENT_ENCODING) {
+      if (code === CurlCode.CURLE_BAD_CONTENT_ENCODING && !noDecompress) {
         resolve(curlRequest({ ...options, noDecompress: true }));
         return;
       }
@@ -277,7 +277,7 @@ export const createConfiguredCurlInstance = ({
   certificates: ClientCertificate[];
   caCert: string | null;
   socketPath?: string;
-    noDecompress?: boolean;
+  noDecompress?: boolean;
 }) => {
   const debugTimeline: ResponseTimelineEntry[] = [];
   const curl = new Curl();


### PR DESCRIPTION
[https://linear.app/insomnia/issue/INS-4910/support-custom-content-encoding](url)
One of our customers reported that we couldn't render the response, the issue stems from the http response using the non-standard Content-Encoding header 'base64'. Currently, the libcurl library we use supports decompressing the response body with deflate, gzip, and br algorithms.

When the Content-Encoding response header uses a value other than deflate, gzip, or br, libcurl throws an error: "Unrecognized or bad HTTP Content or Transfer-Encoding", with error code 61.

At present, when libcurl throws the "Unrecognized or bad HTTP Content or Transfer-Encoding" error, we cannot retrieve the response body content.

To achieve the same behavior as Postman, we would first send a request. Upon encountering the "Unrecognized or bad HTTP Content or Transfer-Encoding" error, we would set ACCEPT_ENCODING in libcurl to null and resend the request. This way, libcurl will no longer throw the "Unrecognized or bad HTTP Content or Transfer-Encoding" error, and we can retrieve the compressed response body and Try to render it.