### PR TITLE
Only collapse folder when icon is clicked

### DIFF
--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -1041,7 +1041,7 @@ export const Debug: FC = () => {
                   if (isRequestGroupId(id)) {
                     const item = collection.find(i => i.doc._id === id);
                     if (item) {
-                      groupMetaPatcher(item.doc._id, { collapsed: !item.collapsed });
+                      groupMetaPatcher(item.doc._id, { collapsed: false });
                       navigate(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request-group/${id}?${searchParams.toString()}`);
                       return;
                     }
@@ -1211,6 +1211,7 @@ const CollectionGridListItem = ({
   activeProject,
   item,
   organizationId,
+  groupMetaPatcher,
   patchGroup,
   patchRequest,
   projectId,
@@ -1295,12 +1296,16 @@ const CollectionGridListItem = ({
           </span>
         )}
         {isRequestGroup(item.doc) && (
-          <span>
+          <Button
+            aria-label='Collapse folder'
+            onPress={() => groupMetaPatcher(item.doc._id, { collapsed: !item.collapsed })}
+            className="flex items-center justify-center h-8 aspect-square rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all text-sm"
+          >
             <Icon
               className="w-6 flex-shrink-0"
               icon={item.collapsed ? 'folder' : 'folder-open'}
             />
-          </span>
+          </Button>
         )}
         <EditableInput
           editable={isEditable}


### PR DESCRIPTION
Implements a version of [this feature request](https://github.com/Kong/insomnia/discussions/7908#discussion-7133107) https://github.com/Kong/insomnia/discussions/7908#discussion-7133107 which attempts to simplify workflows which modify folder properties between requests.

Behavior implemented expands a folder when clicked anywhere within the menu item, but only collapses it when the folder icon is clicked.