### PR TITLE
feat(sdk): enable folder env interfaces for manipulation in script

### DIFF
--- a/packages/insomnia-sdk/src/objects/folders.ts
+++ b/packages/insomnia-sdk/src/objects/folders.ts
@@ -1,0 +1,48 @@
+import { Environment } from './environments';
+
+// Folder reprensents a request folder in Insomnia.
+export class Folder {
+    id: string;
+    name: string;
+    environment: Environment;
+
+    constructor(id: string, name: string, environmentObject: object | undefined) {
+        this.id = id;
+        this.name = name;
+        this.environment = new Environment(`${id}.environment`, environmentObject);
+    }
+
+    toObject = () => {
+        return {
+            id: this.id,
+            name: this.name,
+            environment: this.environment.toObject(),
+        };
+    };
+}
+
+// ParentFolders reprensents ancestor folders of the active request
+export class ParentFolders {
+    constructor(private folders: Folder[]) { }
+
+    get = (idOrName: string) => {
+        return this.folders.find(folder => folder.name === idOrName || folder.id === idOrName);
+    };
+
+    getById = (id: string) => {
+        return this.folders.find(folder => folder.id === id);
+    };
+
+    getByName = (folderName: string) => {
+        return this.folders.find(folder => folder.name === folderName);
+    };
+
+    findValue = (valueKey: string) => {
+        const targetEnv = [...this.folders].reverse().find(folder => folder.environment.has(valueKey));
+        return targetEnv !== undefined ? targetEnv.environment.get(valueKey) : undefined;
+    };
+
+    toObject = () => {
+        return this.folders.map(folder => folder.toObject());
+    };
+}

--- a/packages/insomnia-sdk/src/objects/folders.ts
+++ b/packages/insomnia-sdk/src/objects/folders.ts
@@ -26,15 +26,27 @@ export class ParentFolders {
     constructor(private folders: Folder[]) { }
 
     get = (idOrName: string) => {
-        return this.folders.find(folder => folder.name === idOrName || folder.id === idOrName);
+        const folder = this.folders.find(folder => folder.name === idOrName || folder.id === idOrName);
+        if (!folder) {
+            throw Error(`Folder "${idOrName}" not found`);
+        }
+        return folder;
     };
 
     getById = (id: string) => {
-        return this.folders.find(folder => folder.id === id);
+        const folder = this.folders.find(folder => folder.id === id);
+        if (!folder) {
+            throw Error(`Folder "${id}" not found`);
+        }
+        return folder;
     };
 
     getByName = (folderName: string) => {
-        return this.folders.find(folder => folder.name === folderName);
+        const folder = this.folders.find(folder => folder.name === folderName);
+        if (!folder) {
+            throw Error(`Folder "${folderName}" not found`);
+        }
+        return folder;
     };
 
     findValue = (valueKey: string) => {

--- a/packages/insomnia-sdk/src/objects/insomnia.ts
+++ b/packages/insomnia-sdk/src/objects/insomnia.ts
@@ -9,6 +9,7 @@ import { getExistingConsole } from './console';
 import { CookieObject } from './cookies';
 import { Environment, Variables } from './environments';
 import { Execution } from './execution';
+import { Folder, ParentFolders } from './folders';
 import type { RequestContext } from './interfaces';
 import { transformToSdkProxyOptions } from './proxy-configs';
 import { Request as ScriptRequest, type RequestOptions, toScriptRequestBody } from './request';
@@ -42,6 +43,8 @@ export class InsomniaObject {
 
     private requestTestResults: RequestTestResult[];
 
+    private parentFolders: ParentFolders;
+
     constructor(
         rawObj: {
             globals: Environment;
@@ -56,6 +59,7 @@ export class InsomniaObject {
             requestInfo: RequestInfo;
             execution: Execution;
             response?: ScriptResponse;
+            parentFolders: ParentFolders;
         },
     ) {
         this.globals = rawObj.globals;
@@ -74,6 +78,7 @@ export class InsomniaObject {
         this.clientCertificates = rawObj.clientCertificates;
 
         this.requestTestResults = new Array<RequestTestResult>();
+        this.parentFolders = rawObj.parentFolders;
     }
 
     sendRequest(
@@ -102,7 +107,6 @@ export class InsomniaObject {
         return this._expect(exp);
     }
 
-    // TODO: remove this after enabled iterationData
     get settings() {
         return undefined;
     }
@@ -122,6 +126,7 @@ export class InsomniaObject {
             response: this.response ? this.response.toObject() : undefined,
             requestTestResults: this.requestTestResults,
             execution: this.execution.toObject(),
+            parentFolders: this.parentFolders.toObject(),
         };
     };
 }
@@ -237,6 +242,14 @@ export async function initInsomniaObject(
     const responseBody = await readBodyFromPath(rawObj.response);
     const response = rawObj.response ? toScriptResponse(request, rawObj.response, responseBody) : undefined;
 
+    const parentFolders = new ParentFolders(rawObj.parentFolders.map(folderObj =>
+        new Folder(
+            folderObj.id,
+            folderObj.name,
+            folderObj.environment,
+        )
+    ));
+
     return new InsomniaObject({
         globals,
         environment,
@@ -250,5 +263,6 @@ export async function initInsomniaObject(
         requestInfo,
         response,
         execution,
+        parentFolders,
     });
 };

--- a/packages/insomnia-sdk/src/objects/interfaces.ts
+++ b/packages/insomnia-sdk/src/objects/interfaces.ts
@@ -32,4 +32,5 @@ export interface RequestContext {
     execution: ExecutionOption;
     logs: string[];
     transientVariables?: Omit<IEnvironment, 'id'>;
+    parentFolders: { id: string; name: string; environment: Record<string, any> }[];
 }

--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -1382,3 +1382,73 @@ resources:
           "onlySetByFolderPreScript": {{ onlySetByFolderPreScript }}
         }
     _type: request
+  - _id: fld_01de564274824ecaad272330339ea6b3
+    parentId: wrk_6b9b8455fd784462ae19cd51d7156f86
+    modified: 1668533312225
+    created: 1668533312225
+    name: folder1
+    description: ""
+    environment:
+      val: "1"
+    environmentPropertyOrder: null
+    metaSortKey: -1668533312225
+    _type: request_group
+    preRequestScript: ""
+    afterResponseScript: ""
+  - _id: fld_01de564274824ecaad272330339ea6b4
+    parentId: fld_01de564274824ecaad272330339ea6b3
+    modified: 1668533312225
+    created: 1668533312225
+    name: folder2
+    description: ""
+    environment:
+      val: "2"
+    environmentPropertyOrder: null
+    metaSortKey: -1668533312225
+    _type: request_group
+    preRequestScript: ""
+    afterResponseScript: ""
+  - _id: req_89dade2ee9ee42fbb22d588783a9df21
+    parentId: fld_01de564274824ecaad272330339ea6b4
+    modified: 1636707449231
+    created: 1636141014552
+    url: http://127.0.0.1:4010/echo
+    name: manipulate folder envs
+    description: ""
+    method: POST
+    parameters: []
+    headers:
+      - name: 'Content-Type'
+        value: 'application/json'
+    authentication: {}
+    metaSortKey: -1636141014553
+    isPrivate: false
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    preRequestScript: |-
+      const valFromFolder1 = insomnia.parentFolders.get('folder1').environment.get('val');
+      const valFromFolder1ByName = insomnia.parentFolders.getByName('folder1').environment.get('val');
+      const valFromFolder2 = insomnia.parentFolders.get('folder2').environment.get('val');
+      const valFromFolder2ByName = insomnia.parentFolders.getByName('folder2').environment.get('val');
+      const valFound = insomnia.parentFolders.findValue('val');
+
+      insomnia.environment.set('valFromFolder1', valFromFolder1);
+      insomnia.environment.set('valFromFolder1ByName', valFromFolder1ByName);
+      insomnia.environment.set('valFromFolder2', valFromFolder2);
+      insomnia.environment.set('valFromFolder2ByName', valFromFolder2ByName);
+      insomnia.environment.set('valFound', valFound);
+    body:
+      mimeType: "application/json"
+      text: |-
+        {
+          "valFromFolder1": {{ valFromFolder1 }},
+          "valFromFolder1ByName": {{ valFromFolder1ByName }},
+          "valFromFolder2": {{ valFromFolder2 }},
+          "valFromFolder2ByName": {{ valFromFolder2ByName }},
+          "valFound": {{ valFound }}
+        }
+    _type: request

--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -1393,8 +1393,19 @@ resources:
     environmentPropertyOrder: null
     metaSortKey: -1668533312225
     _type: request_group
-    preRequestScript: ""
     afterResponseScript: ""
+    preRequestScript: |-
+      const folder1ValByFolder1 = insomnia.parentFolders.get('folder1').environment.get('val');
+      const folder1ValByFolder1ByName = insomnia.parentFolders.getByName('folder1').environment.get('val');
+      const folder2ValByFolder1 = insomnia.parentFolders.get('folder2').environment.get('val');
+      const folder2ValByFolder1ByName = insomnia.parentFolders.getByName('folder2').environment.get('val');
+      const valFoundByFolder1 = insomnia.parentFolders.findValue('val');
+
+      insomnia.environment.set('folder1ValByFolder1', folder1ValByFolder1);
+      insomnia.environment.set('folder1ValByFolder1ByName', folder1ValByFolder1ByName);
+      insomnia.environment.set('folder2ValByFolder1', folder2ValByFolder1);
+      insomnia.environment.set('folder2ValByFolder1ByName', folder2ValByFolder1ByName);
+      insomnia.environment.set('valFoundByFolder1', valFoundByFolder1);
   - _id: fld_01de564274824ecaad272330339ea6b4
     parentId: fld_01de564274824ecaad272330339ea6b3
     modified: 1668533312225
@@ -1406,8 +1417,19 @@ resources:
     environmentPropertyOrder: null
     metaSortKey: -1668533312225
     _type: request_group
-    preRequestScript: ""
     afterResponseScript: ""
+    preRequestScript: |-
+      const folder1ValByFolder2 = insomnia.parentFolders.get('folder1').environment.get('val');
+      const folder1ValByFolder2ByName = insomnia.parentFolders.getByName('folder1').environment.get('val');
+      const folder2ValByFolder2 = insomnia.parentFolders.get('folder2').environment.get('val');
+      const folder2ValByFolder2ByName = insomnia.parentFolders.getByName('folder2').environment.get('val');
+      const valFoundByFolder2 = insomnia.parentFolders.findValue('val');
+
+      insomnia.environment.set('folder1ValByFolder2', folder1ValByFolder2);
+      insomnia.environment.set('folder1ValByFolder2ByName', folder1ValByFolder2ByName);
+      insomnia.environment.set('folder2ValByFolder2', folder2ValByFolder2);
+      insomnia.environment.set('folder2ValByFolder2ByName', folder2ValByFolder2ByName);
+      insomnia.environment.set('valFoundByFolder2', valFoundByFolder2);
   - _id: req_89dade2ee9ee42fbb22d588783a9df21
     parentId: fld_01de564274824ecaad272330339ea6b4
     modified: 1636707449231
@@ -1430,25 +1452,37 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     preRequestScript: |-
-      const valFromFolder1 = insomnia.parentFolders.get('folder1').environment.get('val');
-      const valFromFolder1ByName = insomnia.parentFolders.getByName('folder1').environment.get('val');
-      const valFromFolder2 = insomnia.parentFolders.get('folder2').environment.get('val');
-      const valFromFolder2ByName = insomnia.parentFolders.getByName('folder2').environment.get('val');
+      const folder1ValByReq = insomnia.parentFolders.get('folder1').environment.get('val');
+      const folder1ValByReqByName = insomnia.parentFolders.getByName('folder1').environment.get('val');
+      const folder2ValByReq = insomnia.parentFolders.get('folder2').environment.get('val');
+      const folder2ValByReqByName = insomnia.parentFolders.getByName('folder2').environment.get('val');
       const valFound = insomnia.parentFolders.findValue('val');
 
-      insomnia.environment.set('valFromFolder1', valFromFolder1);
-      insomnia.environment.set('valFromFolder1ByName', valFromFolder1ByName);
-      insomnia.environment.set('valFromFolder2', valFromFolder2);
-      insomnia.environment.set('valFromFolder2ByName', valFromFolder2ByName);
+      insomnia.environment.set('folder1ValByReq', folder1ValByReq);
+      insomnia.environment.set('folder1ValByReqByName', folder1ValByReqByName);
+      insomnia.environment.set('folder2ValByReq', folder2ValByReq);
+      insomnia.environment.set('folder2ValByReqByName', folder2ValByReqByName);
       insomnia.environment.set('valFound', valFound);
     body:
       mimeType: "application/json"
       text: |-
         {
-          "valFromFolder1": {{ valFromFolder1 }},
-          "valFromFolder1ByName": {{ valFromFolder1ByName }},
-          "valFromFolder2": {{ valFromFolder2 }},
-          "valFromFolder2ByName": {{ valFromFolder2ByName }},
-          "valFound": {{ valFound }}
+          "folder1ValByReq": {{ folder1ValByReq }},
+          "folder1ValByReqByName": {{ folder1ValByReqByName }},
+          "folder2ValByReq": {{ folder2ValByReq }},
+          "folder2ValByReqByName": {{ folder2ValByReqByName }},
+          "valFound": {{ valFound }},
+
+          "folder1ValByFolder1": {{ folder1ValByFolder1 }},
+          "folder1ValByFolder1ByName": {{ folder1ValByFolder1ByName }},
+          "folder2ValByFolder1": {{ folder2ValByFolder1 }},
+          "folder2ValByFolder1ByName": {{ folder2ValByFolder1ByName }},
+          "valFoundByFolder1": {{ valFoundByFolder1 }},
+
+          "folder1ValByFolder2": {{ folder1ValByFolder2 }},
+          "folder1ValByFolder2ByName": {{ folder1ValByFolder2ByName }},
+          "folder2ValByFolder2": {{ folder2ValByFolder2 }},
+          "folder2ValByFolder2ByName": {{ folder2ValByFolder2ByName }},
+          "valFoundByFolder2": {{ valFoundByFolder2 }}
         }
     _type: request

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -179,6 +179,16 @@ test.describe('pre-request features tests', async () => {
                 'onlySetByFolderPreScript': 888,
             },
         },
+        {
+            name: 'manipulate folder envs',
+            expectedBody: {
+                'valFromFolder1': 1,
+                'valFromFolder1ByName': 1,
+                'valFromFolder2': 2,
+                'valFromFolder2ByName': 2,
+                'valFound': 2,
+            },
+        },
     ];
 
     for (let i = 0; i < testCases.length; i++) {

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -182,11 +182,23 @@ test.describe('pre-request features tests', async () => {
         {
             name: 'manipulate folder envs',
             expectedBody: {
-                'valFromFolder1': 1,
-                'valFromFolder1ByName': 1,
-                'valFromFolder2': 2,
-                'valFromFolder2ByName': 2,
+                'folder1ValByReq': 1,
+                'folder1ValByReqByName': 1,
+                'folder2ValByReq': 2,
+                'folder2ValByReqByName': 2,
                 'valFound': 2,
+
+                'folder1ValByFolder1': 1,
+                'folder1ValByFolder1ByName': 1,
+                'folder2ValByFolder1': 2,
+                'folder2ValByFolder1ByName': 2,
+                'valFoundByFolder1': 2,
+
+                'folder1ValByFolder2': 1,
+                'folder1ValByFolder2ByName': 1,
+                'folder2ValByFolder2': 2,
+                'folder2ValByFolder2ByName': 2,
+                'valFoundByFolder2': 2,
             },
         },
     ];

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -120,6 +120,7 @@ const runScript = async (
     globals: mutatedContextObject.globals,
     requestTestResults: mutatedContextObject.requestTestResults,
     logs: scriptConsole.dumpLogsAsArray(),
+    parentFolders: mutatedContextObject.parentFolders,
   };
 };
 

--- a/packages/insomnia/src/network/concurrency.ts
+++ b/packages/insomnia/src/network/concurrency.ts
@@ -39,6 +39,7 @@ export interface TransformedExecuteScriptContext {
     cookieJar: CookieJar;
     requestTestResults?: RequestTestResult[];
     userUploadEnvironment?: UserUploadEnvironment;
+    parentFolders: { id: string; name: string; environment: Record<string, any> }[];
 }
 
 interface Task {

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -337,7 +337,13 @@ export async function savePatchesMadeByScript(
   mutatedContext.parentFolders.forEach(mutatedFolder => {
     const originalFolder = originalRequestGroups.find(originalFolder => originalFolder._id === mutatedFolder.id);
     if (originalFolder) {
-      models.requestGroup.update(originalFolder, { environment: mutatedFolder.environment });
+      models.requestGroup.update(originalFolder, {
+        environment: mutatedFolder.environment,
+        // also update kvPairData when folder environment type is table view(kv pair)
+        ...(originalFolder.environmentType === EnvironmentType.KVPAIR && {
+          kvPairData: getKVPairFromData(mutatedFolder.environment, originalFolder.environmentPropertyOrder),
+        }),
+      });
     }
   });
 }

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -197,7 +197,6 @@ export const tryToExecutePreRequestScript = async (
   iterationCount?: number,
   runtime?: SendActionRuntime,
 ) => {
-
   const requestGroups = ancestors.filter(doc => isRequest(doc) || isRequestGroup(doc)) as RequestGroup[];
   const folderScripts = requestGroups.reverse()
     .filter(group => group?.preRequestScript)
@@ -206,6 +205,11 @@ export const tryToExecutePreRequestScript = async (
       }
       await fn${i}();
   `);
+  const originalRequestGroups = requestGroups
+    .filter(group => isRequestGroup(group));
+  const parentFolders = originalRequestGroups
+    .map(group => ({ id: group._id, name: group.name, environment: group.environment }));
+
   if (folderScripts.length === 0) {
     return {
       request,
@@ -219,6 +223,7 @@ export const tryToExecutePreRequestScript = async (
       requestTestResults: new Array<RequestTestResult>(),
       transientVariables,
       logs: '',
+      parentFolders,
     };
   }
   const joinedScript = [...folderScripts].join('\n');
@@ -241,6 +246,7 @@ export const tryToExecutePreRequestScript = async (
     settings,
     transientVariables,
     runtime,
+    parentFolders,
   });
   if (!mutatedContext || 'error' in mutatedContext) {
     return {
@@ -253,9 +259,10 @@ export const tryToExecutePreRequestScript = async (
       cookieJar,
       globals: activeGlobalEnvironment,
       requestTestResults: new Array<RequestTestResult>(),
+      parentFolders,
     };
   }
-  await savePatchesMadeByScript(mutatedContext, environment, baseEnvironment, activeGlobalEnvironment);
+  await savePatchesMadeByScript(mutatedContext, environment, baseEnvironment, activeGlobalEnvironment, originalRequestGroups);
 
   return {
     request: mutatedContext.request,
@@ -269,6 +276,7 @@ export const tryToExecutePreRequestScript = async (
     userUploadEnvironment: mutatedContext.userUploadEnvironment,
     execution: mutatedContext.execution,
     transientVariables: mutatedContext.transientVariables,
+    parentFolders: mutatedContext.parentFolders,
   };
 };
 
@@ -281,6 +289,7 @@ export async function savePatchesMadeByScript(
   environment: Environment,
   baseEnvironment: Environment,
   activeGlobalEnvironment: Environment | undefined,
+  originalRequestGroups: RequestGroup[],
   responseCookies?: Cookie[],
 ) {
   if (!mutatedContext) {
@@ -324,10 +333,18 @@ export async function savePatchesMadeByScript(
     invariant(mutatedContext.globals, 'globals must be defined when there is selected one');
     await updateEnvironment(activeGlobalEnvironment, mutatedContext.globals);
   }
+
+  mutatedContext.parentFolders.forEach(mutatedFolder => {
+    const originalFolder = originalRequestGroups.find(originalFolder => originalFolder._id === mutatedFolder.id);
+    if (originalFolder) {
+      models.requestGroup.update(originalFolder, { environment: mutatedFolder.environment });
+    }
+  });
 }
 
 export const tryToExecuteScript = async (context: RequestAndContextAndOptionalResponse) => {
-  const { script,
+  const {
+    script,
     request,
     environment,
     timelinePath,
@@ -345,6 +362,7 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
     execution,
     transientVariables,
     runtime,
+    parentFolders,
   } = context;
   invariant(script, 'script must be provided');
 
@@ -395,6 +413,7 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
         },
         transientVariables,
         logs: [],
+        parentFolders,
       },
     });
     if ('error' in originalOutput) {
@@ -437,6 +456,7 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
       userUploadEnvironment.data = output?.iterationData?.data || [];
       userUploadEnvironment.dataPropertyOrder = userUploadEnvPropertyOrder.map;
     }
+
     if (runtime) {
       await runtime.appendTimeline(timelinePath, output.logs);
     }
@@ -463,6 +483,7 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
       requestTestResults: output.requestTestResults,
       execution: output.execution,
       transientVariables,
+      parentFolders: output.parentFolders,
     };
   } catch (err) {
     await fs.promises.appendFile(
@@ -500,6 +521,7 @@ interface RequestContextForScript {
   settings: Settings;
   execution?: ExecutionOption;
   transientVariables: Environment;
+  parentFolders: { id: string; name: string; environment: Record<string, any> }[];
 }
 
 type RequestAndContextAndResponse = RequestContextForScript & {
@@ -517,6 +539,7 @@ type RequestAndContextAndOptionalResponse = RequestContextForScript & {
   iterationCount?: number;
   eventName?: RequestContext['requestInfo']['eventName'];
   runtime?: SendActionRuntime;
+  parentFolders: { id: string; name: string; environment: Record<string, any> }[];
 };
 
 export async function tryToExecuteAfterResponseScript(context: RequestAndContextAndResponse) {
@@ -528,6 +551,9 @@ export async function tryToExecuteAfterResponseScript(context: RequestAndContext
       }
       await fn${i}();
   `);
+  const originalRequestGroups = requestGroups
+    .filter(group => isRequestGroup(group));
+
   if (folderScripts.length === 0) {
     return {
       ...context,
@@ -547,9 +573,9 @@ export async function tryToExecuteAfterResponseScript(context: RequestAndContext
   const respondedWithoutError = context.response && !('error' in context.response);
   if (respondedWithoutError) {
     const resp = context.response as sendCurlAndWriteTimelineResponse;
-    await savePatchesMadeByScript(postMutatedContext, context.environment, context.baseEnvironment, context.globals, resp.cookies);
+    await savePatchesMadeByScript(postMutatedContext, context.environment, context.baseEnvironment, context.globals, originalRequestGroups, resp.cookies);
   } else {
-    await savePatchesMadeByScript(postMutatedContext, context.environment, context.baseEnvironment, context.globals);
+    await savePatchesMadeByScript(postMutatedContext, context.environment, context.baseEnvironment, context.globals, originalRequestGroups);
   }
 
   return postMutatedContext;

--- a/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
@@ -29,14 +29,15 @@ const unsetEnvVar = 'insomnia.environment.unset("variable_name");';
 const unsetGlbVar = 'insomnia.globals.unset("variable_name");';
 const unsetCollectionVar = 'insomnia.collectionVariables.unset("variable_name");';
 const sendReq =
-  `const resp = await new Promise((resolve, reject) => {
-  insomnia.sendRequest(
-    'https://httpbin.org/anything',
-    (err, resp) => {
-      err != null ? reject(err) : resolve(resp);
-    }
-  );
-});`;
+  `const resp = await insomnia.sendRequest(
+	'https://insomnia.rest/',
+	(err, resp) => {
+		if (err != null) {
+			throw err;
+		}
+	}
+);`;
+
 const logValue = 'console.log("log", variableName);';
 const addHeader = "insomnia.request.addHeader({key: 'X-Header-Name', value: 'header_value' });";
 const removeHeader = "insomnia.request.removeHeader('X-Header-Name');";
@@ -96,6 +97,19 @@ const expectToNotHaveAnyKeys = "insomnia.expect({a: 1, b: 2}).to.not.have.any.ke
 const expectToHaveProperty = "insomnia.expect({a: 1}).to.have.property('a');";
 const expectToBeAnObjectThatHasAllKeys =
   "insomnia.expect({a: 1, b: 2}).to.be.an('object').that.has.all.keys('a', 'b');";
+
+const findFolderEnvValue = `const myEnv = insomnia.parentFolders.findValue('envKey');
+console.log(myEnv);`;
+const getFolderEnvValue = `const myFolder = insomnia.parentFolders.get('folderName');
+if (myFolder === undefined) {
+	throw Error('myFolder not found');
+}
+console.log(myFolder.environment.get('val'));`;
+const setFolderEnvValue = `const myFolder = insomnia.parentFolders.get('myFolder');
+if (myFolder === undefined) {
+	throw Error('myFolder not found');
+}
+myFolder.environment.set('newEnvKey', 'newEnvValue');`;
 
 const lintOptions = {
   globals: {
@@ -212,6 +226,16 @@ const variableSnippetsMenu: SnippetMenuItem = {
           'name': 'Get a collection variable',
           'snippet': getCollectionVar,
         },
+        {
+          'id': 'get-folder-var',
+          'name': 'Get a folder-level variable',
+          'snippet': getFolderEnvValue,
+        },
+        {
+          'id': 'find-folder-var',
+          'name': 'Find a folder-level variable',
+          'snippet': findFolderEnvValue,
+        },
       ],
     },
     {
@@ -237,6 +261,11 @@ const variableSnippetsMenu: SnippetMenuItem = {
           'id': 'set-collection-var',
           'name': 'Set a collection variable',
           'snippet': setCollectionVar,
+        },
+        {
+          'id': 'set-folder-var',
+          'name': 'Set a folder-level variable',
+          'snippet': setFolderEnvValue,
         },
       ],
     },

--- a/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
@@ -1,5 +1,6 @@
 import type { Snippet } from 'codemirror';
 import { CookieObject, Environment, Execution, InsomniaObject, Request as ScriptRequest, RequestInfo, Url, Variables } from 'insomnia-sdk';
+import { ParentFolders } from 'insomnia-sdk/src/objects/folders';
 import React, { type FC, useRef } from 'react';
 import { Button, Collection, Header, Menu, MenuItem, MenuTrigger, Popover, Section, Toolbar } from 'react-aria-components';
 
@@ -541,7 +542,7 @@ export const RequestScriptEditor: FC<Props> = ({
       execution: new Execution({
         location: ['path'],
       }),
-      parentFolders: [],
+      parentFolders: new ParentFolders([]),
     }),
     'insomnia',
   );

--- a/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
@@ -541,6 +541,7 @@ export const RequestScriptEditor: FC<Props> = ({
       execution: new Execution({
         location: ['path'],
       }),
+      parentFolders: [],
     }),
     'insomnia',
   );


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes
- [x] Supported manipulation of folder-level environment from scripts
- [x] Added snippet menu items for folder-level envs
- [x] Added smoke tests

INS-4969
INS-4977
#7736 