### PR TITLE
fix: mask client secret input in OAuth 2.0 authentication [INS-4974]

### DIFF
--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -92,7 +92,7 @@ const credentialsInBodyOptions = [
 
 const getFields = (authentication: Extract<RequestAuthentication, { type: typeof AUTH_OAUTH_2 }>) => {
   const clientId = <AuthInputRow label='Client ID' property='clientId' key='clientId' />;
-  const clientSecret = <AuthInputRow label='Client Secret' property='clientSecret' key='clientSecret' />;
+  const clientSecret = <AuthInputRow label='Client Secret' property='clientSecret' key='clientSecret' mask />;
   const usePkce = <AuthToggleRow label='Use PKCE' property='usePkce' key='usePkce' onTitle='Disable PKCE' offTitle='Enable PKCE' />;
   const pkceMethod = <AuthSelectRow
     label='Code Challenge Method'


### PR DESCRIPTION
<img width="1216" alt="image" src="https://github.com/user-attachments/assets/b9e01829-6fdb-4ba1-a640-3d9180a57be8" />

<img width="1212" alt="image" src="https://github.com/user-attachments/assets/8e7116ba-153e-4284-8fa3-b56d9347a6cc" />

Closes: INS-4974, [2274](https://github.com/Kong/insomnia/issues/2274)