### PR TITLE
fix: Table view environment variables are not updated when changed in pre-request/after-response scripts [INS-4875]

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -263,6 +263,35 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
+  - _id: req_66ec1468f5ba410baac7dee5a71b9d82
+    parentId: fld_01de564274824ecaad272330339ea6b2
+    modified: 1739257792104
+    created: 1739257376971
+    url: http://127.0.0.1:4010/echo
+    name: update kv pair environment
+    description: ""
+    method: POST
+    body:
+      mimeType: application/json
+      text: "{}"
+    parameters: []
+    headers:
+      - name: Content-Type
+        value: application/json
+    authentication: {}
+    preRequestScript: |-
+      insomnia.environment.set('__environment_type', '__environment_value_kv');
+      insomnia.environment.set('examplehost', 'http://url-from-script');
+    metaSortKey: -1636141014503
+    isPrivate: false
+    pathParameters: []
+    settingStoreCookies: true
+    settingSendCookies: true
+    settingDisableRenderRequestBody: false
+    settingEncodeUrl: true
+    settingRebuildPath: true
+    settingFollowRedirects: global
+    _type: request
   - _id: env_f9ef1d097c5e00986051fcb4f7a921eea1a86916
     parentId: wrk_6b9b8455fd784462ae19cd51d7156f86
     modified: 1707808692805

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -447,6 +447,32 @@ test.describe('pre-request features tests', async () => {
             },
         });
     });
+
+    test('kv pair environment can be updated', async ({ page }) => {
+        const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+        await page.getByLabel('Request Collection').getByTestId('update kv pair environment').press('Enter');
+        // switch to table view environment
+        await page.getByLabel('Manage Environments').click();
+        await page.getByRole('button', { name: 'Manage collection environments' }).click();
+        await page.getByLabel('Table Edit').click();
+        await page.getByRole('button', { name: 'Close' }).click();
+        await page.getByTestId('underlay').click();
+
+        // send request
+        await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+
+        // verify response
+        await page.waitForSelector('[data-testid="response-status-tag"]:visible');
+        await expect(statusTag).toContainText('200 OK');
+
+        // verify persisted environment
+        await page.getByRole('button', { name: 'Manage Environments' }).click();
+        await page.getByRole('button', { name: 'Manage collection environments' }).click();
+        // check new environment value
+        await page.getByText('__environment_type').click();
+        await page.getByText('__environment_value_kv').click();
+        await page.getByText('http://url-from-script').click();
+    });
 });
 
 test.describe('unhappy paths', async () => {

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -465,10 +465,9 @@ test.describe('pre-request features tests', async () => {
         await page.waitForSelector('[data-testid="response-status-tag"]:visible');
         await expect(statusTag).toContainText('200 OK');
 
-        // verify persisted environment
+        // verify table environments have been updated
         await page.getByRole('button', { name: 'Manage Environments' }).click();
         await page.getByRole('button', { name: 'Manage collection environments' }).click();
-        // check new environment value
         await page.getByText('__environment_type').click();
         await page.getByText('__environment_value_kv').click();
         await page.getByText('http://url-from-script').click();


### PR DESCRIPTION
**Changes:** 
- [x] Modify ``savePatchesMadeByScript `` logic to update kv pair data for table view environments if necessary
- [x] Add smoke test to cover update environment in scripts and check table environments have been updated
