### PR TITLE
Short-ciruit string rendering if require invocation is detected

### DIFF
--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -291,6 +291,14 @@ export async function render<T>(
     ) {
       // Do nothing to these types
     } else if (typeof x === 'string') {
+      // Ref: SEC-1323
+      if (/require\s*\(/ig.test(x)) {
+        // TODO: Push to Sentry instead of logging so we can approximately quantify real-world impact.
+        console.warn('Short-circuiting `render`; string contains possible "require" invocation:', x);
+
+        return x;
+      }
+
       try {
         // @ts-expect-error -- TSCONVERSION
         x = await templating.render(x, { context, path, ignoreUndefinedEnvVariable });

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/electron/renderer';
 import clone from 'clone';
 import orderedJSON from 'json-order';
 
@@ -291,11 +292,10 @@ export async function render<T>(
     ) {
       // Do nothing to these types
     } else if (typeof x === 'string') {
-      // Ref: SEC-1323
+      // Detect if the string contains a require statement
       if (/require\s*\(/ig.test(x)) {
-        // TODO: Push to Sentry instead of logging so we can approximately quantify real-world impact.
         console.warn('Short-circuiting `render`; string contains possible "require" invocation:', x);
-
+        Sentry.captureException(new Error(`Short-circuiting 'render'; string contains possible "require" invocation: ${x}`));
         return x;
       }
 


### PR DESCRIPTION
This PR adds a temporary means of preventing string rendering if a require invocation is detected. This has been tested locally and verified to be functional (enough) against strings in the URL, body, and headers but should cover all flows which render strings with the exception of ones introduced via plugins.

Closes SEC-1323