### PR TITLE
Selectively short-circuit rendering instead of always doing so when requires are detected [SEC-1323] [INS-4963]

### DIFF
--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -293,11 +293,24 @@ export async function render<T>(
     ) {
       // Do nothing to these types
     } else if (typeof x === 'string') {
-      // Detect if the string contains a require statement
-      if (/require\s*\(/ig.test(x)) {
-        console.warn('Short-circuiting `render`; string contains possible "require" invocation:', x);
-        Sentry.captureException(new Error(`Short-circuiting 'render'; string contains possible "require" invocation: ${x}`));
-        return x;
+      // Allowed modules could have valid use cases within templates, and we know for a fact that these modules cannot be
+      // used as part of an exploit.
+      const allowedModules = ['crypto', 'path'];
+      const matches = [...x.matchAll(/require\s*\(\s*["'`]([^'"`]*)['"`]/gi)].map(match => match[1]);
+
+      if (matches.length) {
+        // Only allow the string to be rendered if required modules are *all* in the allowed modules list. If any modules
+        // outside of the allowed list is detected, we short-circuit rendering and return the raw string.
+        for (const match of matches) {
+          if (allowedModules.includes(match)) {
+            continue;
+          } else {
+            console.warn('Short-circuiting `render`; string contains at least one disallowed "require" invocation:', x);
+            Sentry.captureException(new Error(`Short-circuiting 'render'; string contains at least one disallowed "require" invocation: ${x}`));
+
+            return x;
+          }
+        }
       }
 
       try {


### PR DESCRIPTION
This PR builds on top of #8358 to allow certain inbuilt modules to be `require`d. We probably only need to merge this if we discover there are folks using specific modules and we're unable to provide an acceptable workaround once `require`s are restricted. A few other things to consider:

- Is it possible for the input string to be complex enough to cause a ReDoS?
- We should have test cases to specifically cover scenarios where strings contain no requires, multiple requires, or a mix of allowed and disallowed requires.