### PR TITLE
fix: Escape key closes environment editor modal in vim mode [INS-4975]

### DIFF
--- a/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/code-editor.tsx
@@ -413,15 +413,17 @@ export const CodeEditor = memo(forwardRef<CodeEditorHandle, CodeEditorProps>(({
       });
       // Stop the editor from handling global keyboard shortcuts except for the autocomplete binding
       const isShortcutButNotAutocomplete = isUserDefinedKeyboardShortcut && !isAutoCompleteBinding;
+
       // Should not capture escape in order to exit modals
       const isEscapeKey = event.code === 'Escape';
+
       if (isShortcutButNotAutocomplete) {
         // @ts-expect-error -- unsound property assignment
-        event.codemirrorIgnore = true;
+        event.codemirrorIgnore = settings.editorKeyMap !== 'vim';
         // Stop the editor from handling the escape key
       } else if (isEscapeKey) {
         // @ts-expect-error -- unsound property assignment
-        event.codemirrorIgnore = true;
+        event.codemirrorIgnore = settings.editorKeyMap !== 'vim';
       } else {
         event.stopPropagation();
 


### PR DESCRIPTION
Prevent CodeMirror from capturing escape key and shortcuts based on keymap settings

Closes INS-4975, [4877](https://github.com/Kong/insomnia/issues/4877) 