### PR TITLE
Chore: Fix vault case failure and add one more test for vault key

### DIFF
--- a/packages/insomnia-smoke-test/playwright.config.ts
+++ b/packages/insomnia-smoke-test/playwright.config.ts
@@ -33,6 +33,7 @@ const config: PlaywrightTestConfig = {
       screenshots: true,
       snapshots: true,
     },
+    permissions: ['clipboard-read'],
   },
   reporter: process.env.CI ? 'github' : 'list',
   timeout: process.env.CI ? 60 * 1000 : 20 * 1000,

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -5,6 +5,20 @@ import { test } from '../../playwright/test';
 
 test.describe('Test Insomnia Vault', async () => {
 
+  test('check vault key display and can copy', async ({ page, app }) => {
+    await page.locator('[data-testid="settings-button"]').click();
+    await page.locator('text=Insomnia Preferences').first().click();
+    // get text under div with data-testid="vault-key"
+    const expectedVaultKeyValue = 'eyJhbGciOiJBMjU2R0NNIiwiZXh0Ijp0cnVlLCJrIjoia';
+    const vaultKeyValue = await page.getByTestId('VaultKeyDisplayPanel').innerText();
+    await expect(vaultKeyValue).toContain(expectedVaultKeyValue);
+    await page.getByTitle('Copy Vault Key').click();
+    // get clipboard content
+    const handle = await app.evaluateHandle(() => navigator.clipboard.readText());
+    const clipboardContent = await handle.jsonValue();
+    await expect(clipboardContent).toContain(expectedVaultKeyValue);
+  });
+
   test('create global private sub environment to store vaults', async ({ page, app }) => {
     await page.getByLabel('Create in project').click();
     await page.getByLabel('Create', { exact: true }).getByText('Environment').click();

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -5,7 +5,7 @@ import { test } from '../../playwright/test';
 
 test.describe('Test Insomnia Vault', async () => {
 
-  test('check vault key display and can copy', async ({ page, app }) => {
+  test('check vault key display and can copy', async ({ page }) => {
     await page.locator('[data-testid="settings-button"]').click();
     await page.locator('text=Insomnia Preferences').first().click();
     // get text under div with data-testid="vault-key"
@@ -14,7 +14,7 @@ test.describe('Test Insomnia Vault', async () => {
     await expect(vaultKeyValue).toContain(expectedVaultKeyValue);
     await page.getByTitle('Copy Vault Key').click();
     // get clipboard content
-    const handle = await app.evaluateHandle(() => navigator.clipboard.readText());
+    const handle = await page.evaluateHandle(() => navigator.clipboard.readText());
     const clipboardContent = await handle.jsonValue();
     await expect(clipboardContent).toContain(expectedVaultKeyValue);
   });

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -61,6 +61,7 @@ test.describe('Test Insomnia Vault', async () => {
     // activate request
     await page.getByTestId('normal').getByLabel('GET normal', { exact: true }).click();
     await page.getByRole('button', { name: 'Send' }).click();
+    await page.waitForTimeout(1000);
     await page.getByRole('tab', { name: 'Console' }).click();
     await page.getByText('bar').click();
     await page.getByText('world').click();
@@ -101,6 +102,7 @@ test.describe('Test Insomnia Vault', async () => {
     // activate request
     await page.getByTestId('legacy-array-vault').getByLabel('GET legacy-array-vault', { exact: true }).click();
     await page.getByRole('button', { name: 'Send' }).click();
+    await page.waitForTimeout(1000);
     await page.getByRole('tab', { name: 'Console' }).click();
     await page.getByText('password').click();
     await page.getByText('bar').click();

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -268,16 +268,16 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
 
   useEffect(() => {
     const unsubscribe = window.main.on('nunjucks-context-menu-command', (_, { key, tag, nunjucksTag, needsEnterprisePlan, displayName }) => {
-      if (needsEnterprisePlan && !isEnterprisePlan) {
-        // show modal if current user is not an enteprise user and the command is an enterprise feature
-        showModal(UpgradeModal, {
-          newPlan: 'enterprise',
-          featureName: displayName,
-          isOwner,
-        });
-        return;
-      }
       if (id === key) {
+        if (needsEnterprisePlan && !isEnterprisePlan) {
+          // show modal if current user is not an enteprise user and the command is an enterprise feature
+          showModal(UpgradeModal, {
+            newPlan: 'enterprise',
+            featureName: displayName,
+            isOwner,
+          });
+          return;
+        };
         if (nunjucksTag) {
           const { type, template, range } = nunjucksTag as nunjucksTagContextMenuOptions;
           switch (type) {

--- a/packages/insomnia/src/ui/components/settings/vault-key-panel.tsx
+++ b/packages/insomnia/src/ui/components/settings/vault-key-panel.tsx
@@ -42,6 +42,7 @@ export const VaultKeyDisplayInput = ({ vaultKey }: { vaultKey: string }) => {
     <div className="flex items-center gap-3 bg-[--hl-xs] px-2 py-1 border border-solid border-[--hl-sm] w-full">
       <div
         className="w-[calc(100%-50px)] truncate"
+        data-testid="VaultKeyDisplayPanel"
         onDoubleClick={(event: React.MouseEvent) => {
           event.preventDefault();
           event.stopPropagation();


### PR DESCRIPTION
**Changes:** 
- Fix the flaky case of the newly added vault related smoke add
- Add one more test case for vault key check
- Move check enterprise logic for one-line-editor only when subscription key matches the editor id