### PR TITLE
fix(sdk): change insomnia.test mechanism to improve the nested test cases

### DIFF
--- a/packages/insomnia-sdk/src/objects/test.ts
+++ b/packages/insomnia-sdk/src/objects/test.ts
@@ -28,7 +28,9 @@ export async function test(
         }
     };
 
-    startTestObserver(wrapFn());
+    const testPromise = wrapFn();
+    startTestObserver(testPromise);
+    return testPromise;
 }
 
 let testPromises = new Array<Promise<void>>();

--- a/packages/insomnia-sdk/src/objects/test.ts
+++ b/packages/insomnia-sdk/src/objects/test.ts
@@ -3,27 +3,41 @@ export async function test(
     fn: () => Promise<void>,
     log: (testResult: RequestTestResult) => void,
 ) {
-    const started = performance.now();
+    const wrapFn = async () => {
+        const started = performance.now();
 
-    try {
-        await fn();
-        const executionTime = performance.now() - started;
-        log({
-            testCase: msg,
-            status: 'passed',
-            executionTime,
-            category: 'unknown',
-        });
-    } catch (e) {
-        const executionTime = performance.now() - started;
-        log({
-            testCase: msg,
-            status: 'failed',
-            executionTime,
-            errorMessage: `error: ${e} | ACTUAL: ${e.actual} | EXPECTED: ${e.expected}`,
-            category: 'unknown',
-        });
-    }
+        try {
+            await fn();
+
+            const executionTime = performance.now() - started;
+            log({
+                testCase: msg,
+                status: 'passed',
+                executionTime,
+                category: 'unknown',
+            });
+        } catch (e) {
+            const executionTime = performance.now() - started;
+            log({
+                testCase: msg,
+                status: 'failed',
+                executionTime,
+                errorMessage: `error: ${e} | ACTUAL: ${e.actual} | EXPECTED: ${e.expected}`,
+                category: 'unknown',
+            });
+        }
+    };
+
+    startTestObserver(wrapFn());
+}
+
+let testPromises = new Array<Promise<void>>();
+export async function waitForAllTestsDone() {
+    await Promise.allSettled(testPromises);
+    testPromises = [];
+}
+function startTestObserver(promise: Promise<void>) {
+    testPromises.push(promise);
 }
 
 export async function skip(

--- a/packages/insomnia-smoke-test/fixtures/after-response-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/after-response-collection.yaml
@@ -41,6 +41,31 @@ collection:
           insomnia.expect(199).to.eql(200);
           insomnia.expect(199).to.be.oneOf([201,202]);
         });
+
+        function happyTestInFunc() {
+          insomnia.test('happyTestInFunc', () => {
+            insomnia.expect(200).to.eql(200);
+          });
+        }
+        function sadTestInFunc() {
+          insomnia.test('sadTestInFunc', () => {
+            insomnia.expect(199).to.eql(200);
+          });
+        }
+        function asyncHappyTestInFunc() {
+          insomnia.test('asyncHappyTestInFunc', async () => {
+            insomnia.expect(200).to.eql(200);
+          });
+        }
+        function asyncSadTestInFunc() {
+          insomnia.test('asyncSadTestInFunc', async () => {
+            insomnia.expect(199).to.eql(200);
+          });
+        }
+        happyTestInFunc();
+        sadTestInFunc();
+        asyncHappyTestInFunc();
+        asyncSadTestInFunc();
     settings:
       renderRequestBody: true
       encodeUrl: true

--- a/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
@@ -47,7 +47,8 @@ collection:
             insomnia.test('req1-post-check', () => {
                 insomnia.expect(insomnia.response.code).to.eql(200);
             });
-            insomnia.test('req1-post-check-failed', () => {
+            insomnia.test('req1-post-check-failed', async () => {
+                await new Promise(resolve => setTimeout(resolve, 50));
                 insomnia.expect(insomnia.response.code).to.eql(201);
             });
         settings:
@@ -231,11 +232,11 @@ collection:
     scripts:
       preRequest: |-
         insomnia.test('req2-pre-check', () => {
-        insomnia.expect(200).to.eql(200);
+          insomnia.expect(200).to.eql(200);
         });
       afterResponse: |-
         insomnia.test('req2-post-check', () => {
-            insomnia.expect(insomnia.response.code).to.eql(200);
+          insomnia.expect(insomnia.response.code).to.eql(200);
         });
     settings:
       renderRequestBody: true

--- a/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
@@ -96,6 +96,40 @@ collection:
         store: true
       rebuildPath: true
   - url: http://127.0.0.1:4010/echo
+    name: await-test
+    meta:
+      id: req_823443a369a74ac48cb9baa27ed8245c
+      created: 1636141014550
+      modified: 1636707449230
+      isPrivate: false
+      sortKey: -1636141014552
+    method: POST
+    scripts:
+      afterResponse: |-
+        await insomnia.test('t1', async () => {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          insomnia.expect(201).to.eql(200);
+        });
+
+        async function myTest() {
+          await insomnia.test('t2', () => {
+            insomnia.expect(201).to.eql(200);
+          });
+        }
+        await myTest();
+
+        insomnia.test('t3', () => {
+          insomnia.expect(201).to.eql(200);
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: http://127.0.0.1:4010/echo
     name: req01
     meta:
       id: req_dc69d06415b7405699aabf0048bc8190

--- a/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
@@ -30,6 +30,10 @@ test.describe('after-response script features tests', async () => {
         const responsePane = page.getByTestId('response-pane');
         await expect(responsePane).toContainText('PASS');
         await expect(responsePane).toContainText('FAILunhappy tests | error: AssertionError: expected 199 to deeply equal 200 | ACTUAL: 199 | EXPECTED: 200');
+        await expect(responsePane).toContainText('PASShappyTestInFunc');
+        await expect(responsePane).toContainText('FAILsadTestInFunc | error: AssertionError: expected 199 to deeply equal 200 | ACTUAL: 199 | EXPECTED: 200');
+        await expect(responsePane).toContainText('PASSasyncHappyTestInFunc');
+        await expect(responsePane).toContainText('FAILasyncSadTestInFunc | error: AssertionError: expected 199 to deeply equal 200 | ACTUAL: 199 | EXPECTED: 200');
     });
 
     test('environment and baseEnvironment can be persisted', async ({ page }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -88,8 +88,8 @@ test.describe('runner features tests', async () => {
 
         const expectedTestOrder = [
             'folder-pre-check',
-            'req1-pre-check',
             'req1-pre-check-skipped',
+            'req1-pre-check',
             'folder-post-check',
             'req1-post-check',
             'expected 200 to deeply equal 201',
@@ -133,10 +133,11 @@ test.describe('runner features tests', async () => {
             // req2 should be skipped from pre-request script
             expect(iterationTestResultElement).not.toContainText('req2');
         }
+
         await verifyResultRows(page, 4, 1, 6, [
             'folder-pre-check',
-            'req1-pre-check',
             'req1-pre-check-skipped',
+            'req1-pre-check',
             'folder-post-check',
             'req1-post-check',
             'expected 200 to deeply equal 201',
@@ -239,10 +240,10 @@ test.describe('runner features tests', async () => {
         await page.getByText('0 / 4').first().click();
 
         const expectedTestOrder = [
-            'async_pre_test',
             'sync_pre_test',
-            'async_post_test',
+            'async_pre_test',
             'sync_post_test',
+            'async_post_test',
         ];
 
         await verifyResultRows(page, 0, 0, 4, expectedTestOrder, 1);

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -165,6 +165,26 @@ test.describe('runner features tests', async () => {
         await verifyResultRows(page, 3, 0, 3, expectedTestOrder, 1);
     });
 
+    test('await test works', async ({ page }) => {
+        await page.getByTestId('run-collection-btn-quick').click();
+
+        await page.locator('.runner-request-list-await-test').click();
+
+        // send
+        await page.getByRole('button', { name: 'Run', exact: true }).click();
+
+        // check result
+        await page.getByText('0 / 3').first().click();
+
+        const expectedTestOrder = [
+            't1',
+            't2',
+            't3',
+        ];
+
+        await verifyResultRows(page, 0, 0, 3, expectedTestOrder, 1);
+    });
+
     test('run req5 3 times with setNextRequest in the after-response script', async ({ page }) => {
         await page.getByTestId('run-collection-btn-quick').click();
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes
- [x] Change the mechanism of `insomnia.test` to improve the nested test cases
- [x] Support `await insomnia.test`
- [x] Enable autocomplete for `insomnia.test` and `insomnia.expect`
- [x] Added smoke tests

Add sync or async cases in script to test it:

```javascript
          insomnia.test('asyncHappyTestInFunc', () => {
            insomnia.expect(200).to.eql(200);
          });

          insomnia.test('asyncHappyTestInFunc', async () => {
            insomnia.expect(200).to.eql(200);
          });
```
INS-5005