### PR TITLE
chore: Try to improve smoke test tracing to figure failure/flaky case causes [INS-5056]

### DIFF
--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -135,7 +135,7 @@ export const test = baseTest.extend<{
       if (traceMode === 'on' || (traceMode === 'retain-on-failure' && testFailed) || (traceMode === 'on-first-retry' && testInfo.retry === 1)) {
         // Set tracing file name with the test status
         await appContext.tracing.stop({
-          path: path.join(testInfo.outputDir, `trace-${testInfo.status}.zip`),
+          path: path.join(testInfo.outputDir, `trace-${testInfo.title}-${testInfo.status}.zip`),
         });
       } else {
         // Discard the trace if not needed

--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -133,7 +133,8 @@ export const test = baseTest.extend<{
       // set testFailed to true if the test timed out or failed
       testFailed = testFailed || testInfo.status === 'timedOut' || testInfo.status === 'failed';
       if (traceMode === 'on' || (traceMode === 'retain-on-failure' && testFailed) || (traceMode === 'on-first-retry' && testInfo.retry === 1)) {
-        // Set tracing file name with the test status
+        // Use a different name rather than the default trace.zip to avoid overwriting the trace.
+        // Refer: https://github.com/microsoft/playwright/issues/35005
         await appContext.tracing.stop({
           path: path.join(testInfo.outputDir, `trace-${testInfo.title}-${testInfo.status}.zip`),
         });

--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -123,12 +123,24 @@ export const test = baseTest.extend<{
       await appContext.tracing.start(traceOptions);
     }
 
-    await use(electronApp);
-
-    if (captureTrace) {
-      await appContext.tracing.stop({
-        path: path.join(testInfo.outputDir, 'trace.zip'),
-      });
+    let testFailed = false;
+    try {
+      await use(electronApp);
+    } catch (error) {
+      testFailed = true;
+      throw error;
+    } finally {
+      // set testFailed to true if the test timed out or failed
+      testFailed = testFailed || testInfo.status === 'timedOut' || testInfo.status === 'failed';
+      if (traceMode === 'on' || (traceMode === 'retain-on-failure' && testFailed) || (traceMode === 'on-first-retry' && testInfo.retry === 1)) {
+        // Set tracing file name with the test status
+        await appContext.tracing.stop({
+          path: path.join(testInfo.outputDir, `trace-${testInfo.status}.zip`),
+        });
+      } else {
+        // Discard the trace if not needed
+        await appContext.tracing.stop();
+      }
     }
 
     await electronApp.close();

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -162,6 +162,8 @@ test.describe('Check vault used in environment', async () => {
     await page.getByRole('option', { name: 'New Environment' }).click();
     await page.getByText('Base Environment1').click();
     await page.getByTestId('underlay').click();
+    // ensure environment is activated
+    await page.waitForTimeout(1000);
     // activate request
     await page.getByTestId('normal').getByLabel('GET normal', { exact: true }).click();
     await page.getByRole('button', { name: 'Send' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -162,8 +162,6 @@ test.describe('Check vault used in environment', async () => {
     await page.getByRole('option', { name: 'New Environment' }).click();
     await page.getByText('Base Environment1').click();
     await page.getByTestId('underlay').click();
-    // ensure environment is activated
-    await page.waitForTimeout(1000);
     // activate request
     await page.getByTestId('normal').getByLabel('GET normal', { exact: true }).click();
     await page.getByRole('button', { name: 'Send' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -445,8 +445,8 @@ test.describe('pre-request features tests', async () => {
         await page.getByRole('tab', { name: 'Tests' }).click();
 
         const responsePane = page.getByTestId('response-pane');
-        expect(responsePane).toContainText('FAILunhappy tests | error: AssertionError: expected 199 to deeply equal 200 | ACTUAL: 199 | EXPECTED: 200Pre-request Test');
-        expect(responsePane).toContainText('PASShappy tests');
+        await expect(responsePane).toContainText('FAILunhappy tests | error: AssertionError: expected 199 to deeply equal 200 | ACTUAL: 199 | EXPECTED: 200Pre-request Test');
+        await expect(responsePane).toContainText('PASShappy tests');
     });
 
     test('environment and baseEnvironment can be persisted', async ({ page }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -291,9 +291,9 @@ test.describe('runner features tests', async () => {
 
             const consoleTabContent = page.locator('.pane-two');
             if (expectToHaveLog) {
-                expect(consoleTabContent).toContainText("it won't print");
+                await expect(consoleTabContent).toContainText("it won't print");
             } else {
-                expect(consoleTabContent).not.toContainText("it won't print");
+                await expect(consoleTabContent).not.toContainText("it won't print");
             }
         }
     });


### PR DESCRIPTION
Current smoke test tracing logic has the following issues:
- Although we set trace mode to 'retain-on-failure', it actually captures traces for every test case, no matter sucess or failure. As a result, the trace file is too huge to navigator to failed cases easily.
- The tracing file for common flaky cases with 'timeout' problems does not contain screenshots. This made it difficult to triage root causes of the flaky cases.

Fix these issues with conditional tracing logic and fix two failed cases cause by the tracing change