### PR TITLE
Solve the bug related to importing multiple workspaces in one file [INS-5077]

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "install-libcurl-electron": "node_modules/.bin/node-pre-gyp install --directory node_modules/@getinsomnia/node-libcurl --update-binary --runtime=electron --target=$target",
     "inso-start": "npm start -w insomnia-inso",
     "inso-package": "npm run build -w insomnia-inso && npm run package -w insomnia-inso",
-    "watch:app": "PLAYWRIGHT=1 npm run build:main.min.js -w insomnia && npm run start:dev-server -w insomnia",
+    "watch:app": "cross-env PLAYWRIGHT=1 npm run build:main.min.js -w insomnia && npm run start:dev-server -w insomnia",
     "app-build": "npm run build -w insomnia",
     "app-package": "npm run package -w insomnia",
     "test:smoke:dev": "npm run test:dev -w insomnia-smoke-test -- --project=Smoke",

--- a/packages/insomnia-smoke-test/fixtures/multiple-workspaces.yaml
+++ b/packages/insomnia-smoke-test/fixtures/multiple-workspaces.yaml
@@ -1,22 +1,25 @@
 _type: export
 __export_format: 4
-__export_date: 2022-10-26T13:22:24.234Z
-__export_source: insomnia.desktop.app:v2022.7.0-beta.3
+__export_date: 2025-03-07T13:29:00.616Z
+__export_source: insomnia.desktop.app:v11.0.0-beta.3
 resources:
-  - _id: req_301ee7822f044678b853f8738d43b671
-    parentId: wrk_21ad31a525d4405dbda1f95d0c5c7b96
-    modified: 1666782885586
-    created: 1666782885586
-    url: ""
-    name: New Request
+  - _id: req_52db8f1ca11c4701904f05f141b9f065
+    parentId: wrk_0b93d1e3ca8e43bb8899703d115f19cf
+    modified: 1741144839224
+    created: 1741144782256
+    url: https://www.baidu.com/
+    name: Request in collection 1
     description: ""
     method: GET
     body: {}
     parameters: []
-    headers: []
+    headers:
+      - name: User-Agent
+        value: insomnia/11.0.0-beta.3
     authentication: {}
-    metaSortKey: -1666782885586
+    metaSortKey: -1741144782256
     isPrivate: false
+    pathParameters: []
     settingStoreCookies: true
     settingSendCookies: true
     settingDisableRenderRequestBody: false
@@ -24,115 +27,31 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
-  - _id: wrk_21ad31a525d4405dbda1f95d0c5c7b96
+  - _id: wrk_0b93d1e3ca8e43bb8899703d115f19cf
     parentId: null
-    modified: 1666781834107
-    created: 1666781834107
-    name: design doc 1
-    description: ""
-    scope: design
-    _type: workspace
-  - _id: req_2ca883f772b944c6bd15e9224e1165cb
-    parentId: wrk_bdf332f870c64853b4e923a655f949fa
-    modified: 1666782891204
-    created: 1666782891204
-    url: ""
-    name: New Request
-    description: ""
-    method: GET
-    body: {}
-    parameters: []
-    headers: []
-    authentication: {}
-    metaSortKey: -1666782891204
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: wrk_bdf332f870c64853b4e923a655f949fa
-    parentId: null
-    modified: 1666781842050
-    created: 1666781842050
-    name: design doc 2
-    description: ""
-    scope: design
-    _type: workspace
-  - _id: req_a32577ff4e9747a08743278c9c3d5843
-    parentId: wrk_a788e78ffada4586b78da74ab6a58ba5
-    modified: 1666782881532
-    created: 1666782881532
-    url: ""
-    name: New Request
-    description: ""
-    method: GET
-    body: {}
-    parameters: []
-    headers: []
-    authentication: {}
-    metaSortKey: -1666782881532
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: wrk_a788e78ffada4586b78da74ab6a58ba5
-    parentId: null
-    modified: 1666781850374
-    created: 1666781850374
-    name: design doc 3
-    description: ""
-    scope: design
-    _type: workspace
-  - _id: req_950d0605d54545199115cb08ffca34b8
-    parentId: wrk_e6ba2aa3127b45f29ea5c47800fd03bb
-    modified: 1666782877009
-    created: 1666782877009
-    url: ""
-    name: New Request
-    description: ""
-    method: GET
-    body: {}
-    parameters: []
-    headers: []
-    authentication: {}
-    metaSortKey: -1666782877009
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: wrk_e6ba2aa3127b45f29ea5c47800fd03bb
-    parentId: null
-    modified: 1666781857328
-    created: 1666781857328
-    name: collection 1
+    modified: 1741144769222
+    created: 1741144769222
+    name: Collection 1
     description: ""
     scope: collection
     _type: workspace
-  - _id: req_5046827caea449638f44a7393178dc57
-    parentId: wrk_a893044e98964298aba252e05a1d116b
-    modified: 1666782874031
-    created: 1666782874031
-    url: ""
-    name: New Request
+  - _id: req_32ecd6d1ab014ef3b1c0d4ca2800dcab
+    parentId: wrk_5ab5ffb21d9f4ae2aef2ef2c83a48c66
+    modified: 1741144878822
+    created: 1741144865045
+    url: https://www.baidu.com/2
+    name: Request in collection 2
     description: ""
     method: GET
     body: {}
     parameters: []
-    headers: []
+    headers:
+      - name: User-Agent
+        value: insomnia/11.0.0-beta.3
     authentication: {}
-    metaSortKey: -1666782874031
+    metaSortKey: -1741144865045
     isPrivate: false
+    pathParameters: []
     settingStoreCookies: true
     settingSendCookies: true
     settingDisableRenderRequestBody: false
@@ -140,824 +59,101 @@ resources:
     settingRebuildPath: true
     settingFollowRedirects: global
     _type: request
-  - _id: wrk_a893044e98964298aba252e05a1d116b
+  - _id: wrk_5ab5ffb21d9f4ae2aef2ef2c83a48c66
     parentId: null
-    modified: 1666781865359
-    created: 1666781865359
-    name: collection 2
+    modified: 1741144855762
+    created: 1741144855762
+    name: Collection 2
     description: ""
     scope: collection
     _type: workspace
-  - _id: req_b1a0b68e0687433a902c13ecc6ec3734
-    parentId: wrk_7a78b6f321ed469a99e9049ff247289d
-    modified: 1666782848082
-    created: 1666782848082
-    url: ""
-    name: New Request
-    description: ""
-    method: GET
-    body: {}
-    parameters: []
-    headers: []
-    authentication: {}
-    metaSortKey: -1666782848082
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: wrk_7a78b6f321ed469a99e9049ff247289d
-    parentId: null
-    modified: 1666781878049
-    created: 1666781878049
-    name: collection 3
-    description: ""
-    scope: collection
-    _type: workspace
-  - _id: req_9a0cca5290b544cba7ac259132c0b719
-    parentId: wrk_4008e14dea714ce3844dd6a790a9817c
-    modified: 1666782863226
-    created: 1666782863226
-    url: ""
-    name: New Request
-    description: ""
-    method: GET
-    body: {}
-    parameters: []
-    headers: []
-    authentication: {}
-    metaSortKey: -1666782863226
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: wrk_4008e14dea714ce3844dd6a790a9817c
-    parentId: null
-    modified: 1666781891933
-    created: 1666781891933
-    name: design doc 4
-    description: ""
-    scope: design
-    _type: workspace
-  - _id: req_e6fcb2c927d744a8aab037e0c5799606
-    parentId: wrk_885166d854fa412da796b86bee922779
-    modified: 1666782842797
-    created: 1666782842797
-    url: ""
-    name: New Request
-    description: ""
-    method: GET
-    body: {}
-    parameters: []
-    headers: []
-    authentication: {}
-    metaSortKey: -1666782842798
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: wrk_885166d854fa412da796b86bee922779
-    parentId: null
-    modified: 1666781900708
-    created: 1666781900708
-    name: collection 4
-    description: ""
-    scope: collection
-    _type: workspace
-  - _id: req_wrk_ca77d560bfe247afa3f287885bba750e3b13e39c
-    parentId: wrk_ca77d560bfe247afa3f287885bba750e
-    modified: 1666781942179
-    created: 1666781942179
-    url: "{{ base_url }}/pets/{{ petId }}"
-    name: Info for a specific pet
-    description: ""
-    method: GET
-    body: {}
-    parameters: []
-    headers: []
-    authentication: {}
-    metaSortKey: -1666781942179
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: wrk_ca77d560bfe247afa3f287885bba750e
-    parentId: null
-    modified: 1666781942713
-    created: 1666781942713
-    name: Swagger Petstore V3 JSON 1.0.0
-    description: ""
-    scope: design
-    _type: workspace
-  - _id: req_wrk_ca77d560bfe247afa3f287885bba750e09e1157b
-    parentId: wrk_ca77d560bfe247afa3f287885bba750e
-    modified: 1666781942196
-    created: 1666781942196
-    url: "{{ base_url }}/pets"
-    name: Create a pet
-    description: ""
-    method: POST
-    body: {}
-    parameters: []
-    headers: []
-    authentication: {}
-    metaSortKey: -1666781942196
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: req_wrk_ca77d560bfe247afa3f287885bba750e26e3ae98
-    parentId: wrk_ca77d560bfe247afa3f287885bba750e
-    modified: 1666781942198
-    created: 1666781942198
-    url: "{{ base_url }}/pets"
-    name: List all pets
-    description: ""
-    method: GET
-    body: {}
-    parameters:
-      - name: limit
-        disabled: true
-        value: "0"
-    headers: []
-    authentication: {}
-    metaSortKey: -1666781942198
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: req_wrk_4beaf4c152e54b60810577fb0300775d3b13e39c
-    parentId: wrk_4beaf4c152e54b60810577fb0300775d
-    modified: 1666781948569
-    created: 1666781948569
-    url: "{{ base_url }}/pets/{{ petId }}"
-    name: Info for a specific pet
-    description: ""
-    method: GET
-    body: {}
-    parameters: []
-    headers: []
-    authentication: {}
-    metaSortKey: -1666781948569
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: wrk_4beaf4c152e54b60810577fb0300775d
-    parentId: null
-    modified: 1666781949091
-    created: 1666781949091
-    name: Swagger Petstore V3 YAML 1.0.0
-    description: ""
-    scope: design
-    _type: workspace
-  - _id: req_wrk_4beaf4c152e54b60810577fb0300775d09e1157b
-    parentId: wrk_4beaf4c152e54b60810577fb0300775d
-    modified: 1666781948586
-    created: 1666781948586
-    url: "{{ base_url }}/pets"
-    name: Create a pet
-    description: ""
-    method: POST
-    body: {}
-    parameters: []
-    headers: []
-    authentication: {}
-    metaSortKey: -1666781948586
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: req_wrk_4beaf4c152e54b60810577fb0300775d26e3ae98
-    parentId: wrk_4beaf4c152e54b60810577fb0300775d
-    modified: 1666781948588
-    created: 1666781948588
-    url: "{{ base_url }}/pets"
-    name: List all pets
-    description: ""
-    method: GET
-    body: {}
-    parameters:
-      - name: limit
-        disabled: true
-        value: "0"
-    headers: []
-    authentication: {}
-    metaSortKey: -1666781948588
-    isPrivate: false
-    settingStoreCookies: true
-    settingSendCookies: true
-    settingDisableRenderRequestBody: false
-    settingEncodeUrl: true
-    settingRebuildPath: true
-    settingFollowRedirects: global
-    _type: request
-  - _id: env_77543d6b4b54e11d5412c433ccbc64736e47ce34
-    parentId: wrk_21ad31a525d4405dbda1f95d0c5c7b96
-    modified: 1666781834110
-    created: 1666781834110
-    name: Base Environment
-    data: {}
-    dataPropertyOrder: null
-    color: null
-    isPrivate: false
-    metaSortKey: 1666781834110
-    _type: environment
-  - _id: jar_77543d6b4b54e11d5412c433ccbc64736e47ce34
-    parentId: wrk_21ad31a525d4405dbda1f95d0c5c7b96
-    modified: 1666781834112
-    created: 1666781834112
-    name: Default Jar
-    cookies: []
-    _type: cookie_jar
-  - _id: spc_501e0d57cf5d495690197f761047e8cf
-    parentId: wrk_21ad31a525d4405dbda1f95d0c5c7b96
-    modified: 1666781834108
-    created: 1666781834108
-    fileName: design doc 1
-    contents: ""
-    contentType: yaml
-    _type: api_spec
-  - _id: env_48323cf5b2a642fcb7ab1045be9c426b
-    parentId: wrk_bdf332f870c64853b4e923a655f949fa
-    modified: 1666781842051
-    created: 1666781842051
-    name: Base Environment
-    data: {}
-    dataPropertyOrder: null
-    color: null
-    isPrivate: false
-    metaSortKey: 1666781834110
-    _type: environment
-  - _id: jar_534dffd55a37474ebe2658c4968966c3
-    parentId: wrk_bdf332f870c64853b4e923a655f949fa
-    modified: 1666781842055
-    created: 1666781842055
-    name: Default Jar
-    cookies: []
-    _type: cookie_jar
-  - _id: spc_c71920334078418a84b67e41dfbe3d20
-    parentId: wrk_bdf332f870c64853b4e923a655f949fa
-    modified: 1666781842077
-    created: 1666781842060
-    fileName: design doc 2
-    contents: ""
-    contentType: yaml
-    _type: api_spec
-  - _id: env_fa0dec2d3ce9470a9c4e2924a9d115fc
-    parentId: wrk_a788e78ffada4586b78da74ab6a58ba5
-    modified: 1666781850375
-    created: 1666781850375
-    name: Base Environment
-    data: {}
-    dataPropertyOrder: null
-    color: null
-    isPrivate: false
-    metaSortKey: 1666781834110
-    _type: environment
-  - _id: jar_8d436535140b4018bf2e31833ae45758
-    parentId: wrk_a788e78ffada4586b78da74ab6a58ba5
-    modified: 1666781850378
-    created: 1666781850378
-    name: Default Jar
-    cookies: []
-    _type: cookie_jar
-  - _id: spc_cac4166eb3134318adbdeb71ee78dee4
-    parentId: wrk_a788e78ffada4586b78da74ab6a58ba5
-    modified: 1666781850400
-    created: 1666781850382
-    fileName: design doc 3
-    contents: ""
-    contentType: yaml
-    _type: api_spec
-  - _id: env_fc7b13a435ca5ef5d6b1bee00dd75aa8948b4c6b
-    parentId: wrk_e6ba2aa3127b45f29ea5c47800fd03bb
-    modified: 1666781857332
-    created: 1666781857332
-    name: Base Environment
-    data: {}
-    dataPropertyOrder: null
-    color: null
-    isPrivate: false
-    metaSortKey: 1666781857332
-    _type: environment
-  - _id: jar_fc7b13a435ca5ef5d6b1bee00dd75aa8948b4c6b
-    parentId: wrk_e6ba2aa3127b45f29ea5c47800fd03bb
-    modified: 1666781857333
-    created: 1666781857333
-    name: Default Jar
-    cookies: []
-    _type: cookie_jar
-  - _id: spc_acd1329f60514abdba8062612058a35d
-    parentId: wrk_e6ba2aa3127b45f29ea5c47800fd03bb
-    modified: 1666781857329
-    created: 1666781857329
-    fileName: collection 1
-    contents: ""
-    contentType: yaml
-    _type: api_spec
-  - _id: env_23dc257191c2419e9de15a9dab52f2af
-    parentId: wrk_a893044e98964298aba252e05a1d116b
-    modified: 1666781865360
-    created: 1666781865360
-    name: Base Environment
-    data: {}
-    dataPropertyOrder: null
-    color: null
-    isPrivate: false
-    metaSortKey: 1666781857332
-    _type: environment
-  - _id: jar_e00521f2f9054cbbb633546a7fe7549c
-    parentId: wrk_a893044e98964298aba252e05a1d116b
-    modified: 1666781865364
-    created: 1666781865364
-    name: Default Jar
-    cookies: []
-    _type: cookie_jar
-  - _id: spc_990bd664545549d2873f0a46629af8be
-    parentId: wrk_a893044e98964298aba252e05a1d116b
-    modified: 1666781865385
-    created: 1666781865367
-    fileName: collection 2
-    contents: ""
-    contentType: yaml
-    _type: api_spec
-  - _id: env_01595179df3542db8b1c94d0de3dc479
-    parentId: wrk_7a78b6f321ed469a99e9049ff247289d
-    modified: 1666781878051
-    created: 1666781878051
-    name: Base Environment
-    data: {}
-    dataPropertyOrder: null
-    color: null
-    isPrivate: false
-    metaSortKey: 1666781857332
-    _type: environment
-  - _id: jar_aa952677563947f488fd3537964d080f
-    parentId: wrk_7a78b6f321ed469a99e9049ff247289d
-    modified: 1666781878055
-    created: 1666781878055
-    name: Default Jar
-    cookies: []
-    _type: cookie_jar
-  - _id: spc_67026fc5e8e141a0808796da92ae66bb
-    parentId: wrk_7a78b6f321ed469a99e9049ff247289d
-    modified: 1666781878076
-    created: 1666781878058
-    fileName: collection 3
-    contents: ""
-    contentType: yaml
-    _type: api_spec
-  - _id: env_64ffa48323084208af89597eb42a250e
-    parentId: wrk_4008e14dea714ce3844dd6a790a9817c
-    modified: 1666781891934
-    created: 1666781891934
-    name: Base Environment
-    data: {}
-    dataPropertyOrder: null
-    color: null
-    isPrivate: false
-    metaSortKey: 1666781834110
-    _type: environment
-  - _id: jar_f3066cc09b674e3ca8e582f4ceb4209f
-    parentId: wrk_4008e14dea714ce3844dd6a790a9817c
-    modified: 1666781891937
-    created: 1666781891937
-    name: Default Jar
-    cookies: []
-    _type: cookie_jar
-  - _id: spc_cc1a6aabe9af486c91b211266c8df600
-    parentId: wrk_4008e14dea714ce3844dd6a790a9817c
-    modified: 1666782861505
-    created: 1666781891941
-    fileName: design doc 4
-    contents: ""
-    contentType: yaml
-    _type: api_spec
-  - _id: env_3d482f7a53cf4f09a5f95115a9155b3e
-    parentId: wrk_885166d854fa412da796b86bee922779
-    modified: 1666781900709
-    created: 1666781900709
-    name: Base Environment
-    data: {}
-    dataPropertyOrder: null
-    color: null
-    isPrivate: false
-    metaSortKey: 1666781857332
-    _type: environment
-  - _id: jar_531fe7fa574b478294c76760afac4fd1
-    parentId: wrk_885166d854fa412da796b86bee922779
-    modified: 1666781900712
-    created: 1666781900712
-    name: Default Jar
-    cookies: []
-    _type: cookie_jar
-  - _id: spc_11a073e0e29b4f10ae4ad17fd0c0fc76
-    parentId: wrk_885166d854fa412da796b86bee922779
-    modified: 1666781900734
-    created: 1666781900716
-    fileName: collection 4
-    contents: ""
-    contentType: yaml
-    _type: api_spec
-  - _id: env_9ec288935d0fd65502fed237175088a5f24e55bf
-    parentId: wrk_ca77d560bfe247afa3f287885bba750e
-    modified: 1666781942204
-    created: 1666781942200
-    name: Base environment
+  - _id: env_173a33b29d93cd45b653ad229c63d5ca6cd2cb7c
+    parentId: wrk_0b93d1e3ca8e43bb8899703d115f19cf
+    modified: 1741353589066
+    created: 1741144769227
+    name: Base Environment 1
     data:
-      base_url: "{{ scheme }}://{{ host }}{{ base_path }}"
+      base1: "1"
     dataPropertyOrder: null
     color: null
     isPrivate: false
-    metaSortKey: 1666781942200
+    metaSortKey: 1741144769227
+    environmentType: kv
+    kvPairData:
+      - id: envPair_6f0ec15c26264d8abd8548b31076d7cc
+        name: base1
+        value: "1"
+        type: str
+        enabled: true
     _type: environment
-  - _id: jar_9ec288935d0fd65502fed237175088a5f24e55bf
-    parentId: wrk_ca77d560bfe247afa3f287885bba750e
-    modified: 1666782834696
-    created: 1666782834696
+  - _id: jar_173a33b29d93cd45b653ad229c63d5ca6cd2cb7c
+    parentId: wrk_0b93d1e3ca8e43bb8899703d115f19cf
+    modified: 1741144830546
+    created: 1741144769237
     name: Default Jar
     cookies: []
     _type: cookie_jar
-  - _id: spc_6524f9363e9f49dbaaa173d8bc7c36d8
-    parentId: wrk_ca77d560bfe247afa3f287885bba750e
-    modified: 1666790517105
-    created: 1666781942714
-    fileName: Swagger Petstore V3 JSON 1.0.0
-    contents: >
-      {
-        "openapi": "3.0.0",
-        "info": {
-          "version": "1.0.0",
-          "title": "Swagger Petstore V3 JSON",
-          "license": {
-            "name": "MIT"
-          }
-        },
-        "servers": [
-          {
-            "url": "http://petstore.swagger.io/v1"
-          }
-        ],
-        "paths": {
-          "/pets": {
-            "get": {
-              "summary": "List all pets",
-              "operationId": "listPets",
-              "tags": [
-                "pets"
-              ],
-              "parameters": [
-                {
-                  "name": "limit",
-                  "in": "query",
-                  "description": "How many items to return at one time (max 100)",
-                  "required": false,
-                  "schema": {
-                    "type": "integer",
-                    "format": "int32"
-                  }
-                }
-              ],
-              "responses": {
-                "200": {
-                  "description": "A paged array of pets",
-                  "headers": {
-                    "x-next": {
-                      "description": "A link to the next page of responses",
-                      "schema": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "$ref": "#/components/schemas/Pets"
-                      }
-                    }
-                  }
-                },
-                "default": {
-                  "description": "unexpected error",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "$ref": "#/components/schemas/Error"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "post": {
-              "summary": "Create a pet",
-              "operationId": "createPets",
-              "tags": [
-                "pets"
-              ],
-              "responses": {
-                "201": {
-                  "description": "Null response"
-                },
-                "default": {
-                  "description": "unexpected error",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "$ref": "#/components/schemas/Error"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "/pets/{petId}": {
-            "get": {
-              "summary": "Info for a specific pet",
-              "operationId": "showPetById",
-              "tags": [
-                "pets"
-              ],
-              "parameters": [
-                {
-                  "name": "petId",
-                  "in": "path",
-                  "required": true,
-                  "description": "The id of the pet to retrieve",
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              ],
-              "responses": {
-                "200": {
-                  "description": "Expected response to a valid request",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "$ref": "#/components/schemas/Pet"
-                      }
-                    }
-                  }
-                },
-                "default": {
-                  "description": "unexpected error",
-                  "content": {
-                    "application/json": {
-                      "schema": {
-                        "$ref": "#/components/schemas/Error"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "components": {
-          "schemas": {
-            "Pet": {
-              "type": "object",
-              "required": [
-                "id",
-                "name"
-              ],
-              "properties": {
-                "id": {
-                  "type": "integer",
-                  "format": "int64"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "tag": {
-                  "type": "string"
-                }
-              }
-            },
-            "Pets": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Pet"
-              }
-            },
-            "Error": {
-              "type": "object",
-              "required": [
-                "code",
-                "message"
-              ],
-              "properties": {
-                "code": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "message": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    contentType: yaml
-    _type: api_spec
-  - _id: env_env_9ec288935d0fd65502fed237175088a5f24e55bf_sub
-    parentId: env_9ec288935d0fd65502fed237175088a5f24e55bf
-    modified: 1666781942202
-    created: 1666781942202
-    name: OpenAPI env
+  - _id: env_f80f54bda1804acca46fb0297c95e71b
+    parentId: env_173a33b29d93cd45b653ad229c63d5ca6cd2cb7c
+    modified: 1741353559820
+    created: 1741353535145
+    name: Sub Environment 1
     data:
-      scheme: http
-      base_path: /v1
-      host: petstore.swagger.io
+      sub1: "1"
     dataPropertyOrder: null
     color: null
     isPrivate: false
-    metaSortKey: 1666781942202
+    metaSortKey: 1741353535145
+    environmentType: kv
+    kvPairData:
+      - id: envPair_fc16421974214993979092b48f7017e3
+        name: sub1
+        value: "1"
+        type: str
+        enabled: true
     _type: environment
-  - _id: env_975cbfbf5feac5d42973525f87e8feacdf1531c3
-    parentId: wrk_4beaf4c152e54b60810577fb0300775d
-    modified: 1666781948594
-    created: 1666781948590
-    name: Base environment
+  - _id: env_19b834dede8b1b4378461f5aae3cc48d37660429
+    parentId: wrk_5ab5ffb21d9f4ae2aef2ef2c83a48c66
+    modified: 1741353619783
+    created: 1741144855765
+    name: Base Environment 2
     data:
-      base_url: "{{ scheme }}://{{ host }}{{ base_path }}"
+      base2: "2"
     dataPropertyOrder: null
     color: null
     isPrivate: false
-    metaSortKey: 1666781948590
+    metaSortKey: 1741144855765
+    environmentType: kv
+    kvPairData:
+      - id: envPair_a7e289c61baa41a69fe920dcd5c43cd2
+        name: base2
+        value: "2"
+        type: str
+        enabled: true
     _type: environment
-  - _id: jar_975cbfbf5feac5d42973525f87e8feacdf1531c3
-    parentId: wrk_4beaf4c152e54b60810577fb0300775d
-    modified: 1666782832684
-    created: 1666782832684
+  - _id: jar_19b834dede8b1b4378461f5aae3cc48d37660429
+    parentId: wrk_5ab5ffb21d9f4ae2aef2ef2c83a48c66
+    modified: 1741144855769
+    created: 1741144855769
     name: Default Jar
     cookies: []
     _type: cookie_jar
-  - _id: spc_4164e989580a44229dde1282223ed069
-    parentId: wrk_4beaf4c152e54b60810577fb0300775d
-    modified: 1666790521098
-    created: 1666781949095
-    fileName: Swagger Petstore V3 YAML 1.0.0
-    contents: |
-      openapi: "3.0.0"
-      info:
-        version: 1.0.0
-        title: Swagger Petstore V3 YAML
-        license:
-          name: MIT
-      servers:
-        - url: http://petstore.swagger.io/v1
-      paths:
-        /pets:
-          get:
-            summary: List all pets
-            operationId: listPets
-            tags:
-              - pets
-            parameters:
-              - name: limit
-                in: query
-                description: How many items to return at one time (max 100)
-                required: false
-                schema:
-                  type: integer
-                  format: int32
-            responses:
-              '200':
-                description: A paged array of pets
-                headers:
-                  x-next:
-                    description: A link to the next page of responses
-                    schema:
-                      type: string
-                content:
-                  application/json:    
-                    schema:
-                      $ref: "#/components/schemas/Pets"
-              default:
-                description: unexpected error
-                content:
-                  application/json:
-                    schema:
-                      $ref: "#/components/schemas/Error"
-          post:
-            summary: Create a pet
-            operationId: createPets
-            tags:
-              - pets
-            responses:
-              '201':
-                description: Null response
-              default:
-                description: unexpected error
-                content:
-                  application/json:
-                    schema:
-                      $ref: "#/components/schemas/Error"
-        /pets/{petId}:
-          get:
-            summary: Info for a specific pet
-            operationId: showPetById
-            tags:
-              - pets
-            parameters:
-              - name: petId
-                in: path
-                required: true
-                description: The id of the pet to retrieve
-                schema:
-                  type: string
-            responses:
-              '200':
-                description: Expected response to a valid request
-                content:
-                  application/json:
-                    schema:
-                      $ref: "#/components/schemas/Pet"
-              default:
-                description: unexpected error
-                content:
-                  application/json:
-                    schema:
-                      $ref: "#/components/schemas/Error"
-      components:
-        schemas:
-          Pet:
-            type: object
-            required:
-              - id
-              - name
-            properties:
-              id:
-                type: integer
-                format: int64
-              name:
-                type: string
-              tag:
-                type: string
-          Pets:
-            type: array
-            items:
-              $ref: "#/components/schemas/Pet"
-          Error:
-            type: object
-            required:
-              - code
-              - message
-            properties:
-              code:
-                type: integer
-                format: int32
-              message:
-                type: string
-    contentType: yaml
-    _type: api_spec
-  - _id: env_env_975cbfbf5feac5d42973525f87e8feacdf1531c3_sub
-    parentId: env_975cbfbf5feac5d42973525f87e8feacdf1531c3
-    modified: 1666781948592
-    created: 1666781948592
-    name: OpenAPI env
+  - _id: env_00c60759733b413ebf8c00a7750d2adc
+    parentId: env_19b834dede8b1b4378461f5aae3cc48d37660429
+    modified: 1741353634174
+    created: 1741353623015
+    name: Sub Environment 2
     data:
-      scheme: http
-      base_path: /v1
-      host: petstore.swagger.io
+      sub2: "2"
     dataPropertyOrder: null
     color: null
     isPrivate: false
-    metaSortKey: 1666781948592
+    metaSortKey: 1741353623015
+    environmentType: kv
+    kvPairData:
+      - id: envPair_8d15427c838a467bb74e477f633743ee
+        name: sub2
+        value: "2"
+        type: str
+        enabled: true
     _type: environment

--- a/packages/insomnia-smoke-test/tests/smoke/dashboard-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/dashboard-interactions.test.ts
@@ -48,43 +48,6 @@ test.describe('Dashboard', async () => {
     });
   });
   test.describe('Interactions', async () => { // Not sure about the name here
-    // TODO(INS-2504) - we don't support importing multiple collections at this time
-    test.skip('Can filter through multiple collections', async ({ app, page }) => {
-      await page.getByLabel('All Files (0)').click();
-      await expect(page.locator('.app')).not.toContainText('Git Sync');
-      await expect(page.locator('.app')).not.toContainText('Setup Git Sync');
-
-      const text = await loadFixture('multiple-workspaces.yaml');
-      await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
-      await page.getByLabel('Import').click();
-      await page.locator('[data-test-id="import-from-clipboard"]').click();
-      await page.getByRole('button', { name: 'Scan' }).click();
-      await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-      await page.getByLabel('Smoke tests').click();
-      // Check that 10 new workspaces are imported besides the default one
-      const workspaceCards = page.getByLabel('Workspaces').getByRole('gridcell');
-      await expect(workspaceCards).toHaveCount(11);
-      await expect(page.locator('.app')).toContainText('New Document');
-      await expect(page.locator('.app')).toContainText('collection 1');
-      await expect(page.locator('.app')).toContainText('design doc 1');
-      await expect(page.locator('.app')).toContainText('Swagger Petstore V3 JSON 1.0.0');
-      await expect(page.locator('.app')).toContainText('Swagger Petstore V3 YAML 1.0.0');
-
-      // Filter by collection
-      const filter = page.locator('[placeholder="Filter\\.\\.\\."]');
-
-      // Filter by word with results expected
-      await filter.fill('design');
-      await expect(page.locator('.card-badge')).toHaveCount(4);
-
-      // Filter by number
-      await filter.fill('3');
-      await expect(page.locator('.card-badge')).toHaveCount(2);
-
-      // Filter by word with no results expected
-      await filter.fill('invalid');
-      await expect(page.locator('.card-badge')).toHaveCount(0);
-    });
 
     test('Can create, rename and delete a document', async ({ page }) => {
       await page.getByLabel('All Files (0)').click();

--- a/packages/insomnia-smoke-test/tests/smoke/import.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/import.test.ts
@@ -1,14 +1,16 @@
-import path from 'node:path';
-
 import { expect } from '@playwright/test';
 
+import { loadFixture } from '../../playwright/paths';
 import { test } from '../../playwright/test';
 
-test('can import multiple workspaces from single file', async ({ page }) => {
+test('can import multiple workspaces from single file', async ({ app, page }) => {
+  const text = await loadFixture('multiple-workspaces.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
   await page.getByLabel('Import').click();
-  await page.locator('[data-test-id="import-file-input"]').setInputFiles(path.join(__dirname, '../..', 'fixtures', 'multiple-workspaces.yaml'));
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  // Have two collections in current project
   await expect(page.getByLabel('Collection 1')).toBeAttached();
   await expect(page.getByLabel('Collection 2')).toBeAttached();
 });

--- a/packages/insomnia-smoke-test/tests/smoke/import.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/import.test.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+
+import { expect } from '@playwright/test';
+
+import { test } from '../../playwright/test';
+
+test('can import multiple workspaces from single file', async ({ page }) => {
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-file-input"]').setInputFiles(path.join(__dirname, '../..', 'fixtures', 'multiple-workspaces.yaml'));
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await expect(page.getByLabel('Collection 1')).toBeAttached();
+  await expect(page.getByLabel('Collection 2')).toBeAttached();
+});

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -239,7 +239,7 @@ export async function importResourcesToProject({ projectId }: { projectId: strin
       continue;
     }
 
-    const workspaceResources = resources.filter(isWorkspace);;
+    const workspaceResources = resources.filter(isWorkspace);
 
     // No workspace, so create one
     if (workspaceResources.length === 0) {
@@ -287,17 +287,17 @@ function filterResourcesInWorkspace(
     }
   });
   // find the workspace id that the resource belongs to
-  function findRootId(id: string, track: Set<string>) {
+  function findRootId(id: string, existingResourceIds: Set<string>) {
     // avoid infinite loop
-    if (track.has(id)) {
+    if (existingResourceIds.has(id)) {
       return id;
     }
-    track.add(id);
+    existingResourceIds.add(id);
     const parentId = idToParentIdMap.get(id);
     if (!parentId) {
       return id;
     }
-    return findRootId(parentId, track);
+    return findRootId(parentId, existingResourceIds);
   }
   return resources.filter(resource => findRootId(resource._id, new Set()) === workspaceId);
 }

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -239,19 +239,69 @@ export async function importResourcesToProject({ projectId }: { projectId: strin
       continue;
     }
 
+    const workspaceResources = resources.filter(isWorkspace);;
+
     // No workspace, so create one
-    if (!resources.find(isWorkspace)) {
+    if (workspaceResources.length === 0) {
       await importResourcesToNewWorkspace(projectId, resourceCacheItem);
       continue;
     }
 
-    // One or more workspaces, add all resources to all workspaces, this could import repeatedly
-    await Promise.all(resources.filter(isWorkspace)
-      .map(resource => importResourcesToNewWorkspace(projectId, resourceCacheItem, resource)));
+    // One or more workspaces in one resourceCacheItem(A resourceCacheItem corresponds to an import file), filter in the resources that belong to each workspace and then import to new workspaces respectively
+    await Promise.all(workspaceResources
+      .map(workspace => {
+        if (workspaceResources.filter(({ _id }) => _id === '__WORKSPACE_ID__').length > 1) {
+          console.warn(`There are more than one workspace with id __WORKSPACE_ID__ in the resources, the importer is ${resourceCacheItem.importer.name}`);
+        }
+        // Here if there is only one workspace in the resources, we import all resources to it
+        let resourcesInCurrentWorkspace = resources;
+        // If there are more than one workspace in the resources, we filter in the resources that belong to the current workspace
+        if (workspaceResources.length > 1) {
+          resourcesInCurrentWorkspace = filterResourcesInWorkspace(resources, workspace);
+        }
+        return importResourcesToNewWorkspace(
+          projectId,
+          {
+            ...resourceCacheItem,
+            resources: resourcesInCurrentWorkspace,
+          },
+          workspace
+        );
+      }));
 
     await db.flushChanges(bufferId);
   }
 }
+
+// Filter resources that belong to the workspace, including the workspace itself
+function filterResourcesInWorkspace(
+  resources: BaseModel[],
+  workspace: Workspace,
+) {
+  const workspaceId = workspace._id;
+  const idToParentIdMap = new Map<string, string>();
+  resources.forEach(resource => {
+    // _id is not supposed to be the same as parentId, but who knows, just check it in case
+    if (resource.parentId && resource._id !== resource.parentId) {
+      idToParentIdMap.set(resource._id, resource.parentId);
+    }
+  });
+  // find the workspace id that the resource belongs to
+  function findRootId(id: string, track: Set<string>) {
+    // avoid infinite loop
+    if (track.has(id)) {
+      return id;
+    }
+    track.add(id);
+    const parentId = idToParentIdMap.get(id);
+    if (!parentId) {
+      return id;
+    }
+    return findRootId(parentId, track);
+  }
+  return resources.filter(resource => findRootId(resource._id, new Set()) === workspaceId);
+}
+
 const isTeamOrAbove = async () => {
   const { accountId } = await userSession.getOrCreate();
   const currentPlan = JSON.parse(localStorage.getItem(`${accountId}:currentPlan`) || '{}') as CurrentPlan || {};
@@ -428,7 +478,6 @@ const importResourcesToNewWorkspace = async (
       contentType: apiSpec.contentType,
       fileName: workspaceToImport?.name,
     });
-
   }
 
   // If we're importing into a new workspace
@@ -450,19 +499,24 @@ const importResourcesToNewWorkspace = async (
     const model = getModel(resource.type);
 
     if (model) {
+      const newParentId = ResourceIdMap.get(resource.parentId);
+      if (!newParentId) {
+        console.warn(`Could not find new parent id for ${resource.name} ${resource._id}`);
+        continue;
+      }
       if (isGrpcRequest(resource)) {
         await models.grpcRequest.create({
           ...resource,
           _id: ResourceIdMap.get(resource._id),
           protoFileId: ResourceIdMap.get(resource.protoFileId),
-          parentId: ResourceIdMap.get(resource.parentId),
+          parentId: newParentId,
         });
       } else if (isUnitTest(resource)) {
         await models.unitTest.create({
           ...resource,
           _id: ResourceIdMap.get(resource._id),
           requestId: ResourceIdMap.get(resource.requestId),
-          parentId: ResourceIdMap.get(resource.parentId),
+          parentId: newParentId,
         });
       } else if (isRequest(resource)) {
         await models.request.create(importRequestWithNewIds(resource, ResourceIdMap, canTransform));

--- a/packages/insomnia/src/ui/components/modals/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal.tsx
@@ -112,6 +112,7 @@ const FileField: FC = () => {
     <div>
       <input
         className="hidden"
+        data-test-id="import-file-input"
         onChange={e => {
           const files = e.target.files;
           if (files) {


### PR DESCRIPTION
Close #8424 
If the user imports a file containing more than one workspace, we create a new workspace for each workspace in the file. Then, all resources in the file are added to all newly created workspaces, regardless of whether they belong to the workspace.
That is why the 'Error: New Requests missing parentId' showed up.

Now we check whether a resource belongs to a workspace before it's added to the workspace.