### PR TITLE
Adjust alignment & copy in Organization empty state

### DIFF
--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1481,16 +1481,16 @@ const ProjectRoute: FC = () => {
                 </div>
               </div>
             ) : (
-                <div className="w-full flex flex-col gap-2 items-center justify-center overflow-hidden">
-                <p className='text-lg'>
-                  This is an empty Organization. To get started create your first project.
+              <div className="w-full h-full flex flex-col gap-2 items-center justify-center overflow-hidden">
+                <p className='text-lg px-8 mb-4 text-center'>
+                  This is an empty organization. Create a project to get started.
                 </p>
                 <Button
-                  aria-label="Create new Project"
+                  aria-label="Create Project"
                   onPress={() => setIsNewProjectModalOpen(true)}
                   className="flex items-center justify-center px-4 gap-2 py-2 bg-[--hl-xxs] aria-pressed:bg-[--hl-sm] rounded-sm text-[--color-font] hover:bg-[--hl-xs] focus:ring-inset ring-1 ring-transparent focus:ring-[--hl-md] transition-all"
                 >
-                  <Icon icon="plus-circle" /> Create a new Project
+                  <Icon icon="plus-circle" /> Create Project
                 </Button>
               </div>
             )}


### PR DESCRIPTION
This PR fixes a layout issue in the Organization empty state, and updates the copy to use an active rather than passive voice.

Before:
<img width="1682" alt="SCR-20250307-jdfl" src="https://github.com/user-attachments/assets/9092f836-17a2-4020-b4eb-0f085de3dcd7" />

After:

| Desktop | Minimum width |
|--|--|
| <img width="1682" alt="SCR-20250307-jett" src="https://github.com/user-attachments/assets/833f2951-f551-4693-8ce3-f43082507cd5" /> | <img width="502" alt="SCR-20250307-jcow" src="https://github.com/user-attachments/assets/55f3f0ea-f236-44c6-acb4-afad58ca99f5" /> |
