### PR TITLE
fix: Set native menus per-window

### DIFF
--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -699,7 +699,7 @@ export function createWindow({ firstLaunch }: { firstLaunch?: boolean } = {}): E
     template.push(developerMenu);
   }
 
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+  mainBrowserWindow.setMenu(Menu.buildFromTemplate(template));
   return mainBrowserWindow;
 }
 


### PR DESCRIPTION
Resolves #8399.

Previously when a new window was created `Menu.setApplicationMenu()` was called, which would change all windows' native menu to the newly created one - causing every window menu to reference the newly created `BrowserWindow`. This causes weird behaviour with old windows (see `Before` video).

Now each window is set their own `Menu` instance which will have their own `BrowserWindow`.

> [!NOTE]
>  This mostly impacts Windows and Linux, may need some testing on Mac to make sure behaviour is still as expected.

### Before
https://github.com/user-attachments/assets/2a7878e1-d706-4c3f-8ff3-73a40577c372

### After
https://github.com/user-attachments/assets/b7048a37-9120-4589-bc84-af1eb749671f