### PR TITLE
Mock browser environment in unit test [INS-5121]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/chai": "^4.3.14",
         "@types/eslint": "^8.56.7",
         "@types/har-format": "^1.2.15",
+        "@types/jsdom": "^21.1.7",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.12.4",
         "@typescript-eslint/eslint-plugin": "^7.5.0",
@@ -6352,6 +6353,18 @@
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
     },
     "node_modules/@types/jshint": {
       "version": "2.12.4",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/chai": "^4.3.14",
     "@types/eslint": "^8.56.7",
     "@types/har-format": "^1.2.15",
+    "@types/jsdom": "^21.1.7",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.12.4",
     "@typescript-eslint/eslint-plugin": "^7.5.0",

--- a/packages/insomnia/setup-vitest.ts
+++ b/packages/insomnia/setup-vitest.ts
@@ -1,3 +1,4 @@
+import { JSDOM } from 'jsdom';
 import { vi } from 'vitest';
 
 import { nodeLibcurlMock } from './src/__mocks__/@getinsomnia/node-libcurl';
@@ -5,6 +6,7 @@ import { electronMock } from './src/__mocks__/electron';
 import { database as db } from './src/common/database';
 import * as models from './src/models';
 import { v4Mock } from './src/models/__mocks__/uuid';
+
 await db.init(models.types(), { inMemoryOnly: true }, true, () => { },);
 vi.mock('electron', () => ({ default: electronMock }));
 
@@ -20,4 +22,24 @@ vi.mock('isomorphic-git', async importOriginal => {
     push: vi.fn(),
     clone: vi.fn(),
   };
+});
+
+const {
+  window,
+} = new JSDOM('<!DOCTYPE html><p>Hello world</p>', {
+  url: 'https://example.org/',
+  referrer: 'https://example.com/',
+  contentType: 'text/html',
+  includeNodeLocations: true,
+  storageQuota: 10000000,
+});
+
+vi.stubGlobal('window', window);
+[
+  'document',
+  'navigator',
+  'FileReader',
+  'Blob',
+].forEach((propName: string) => {
+  vi.stubGlobal(propName, window[propName]);
 });

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -17,7 +17,7 @@ import {
   type WebSocketRequest,
 } from '../models/websocket-request';
 import { isWorkspace, type Workspace } from '../models/workspace';
-import type { CurrentPlan } from '../ui/routes/organization';
+import { type CurrentPlan } from '../ui/routes/organization';
 import { convert, type InsomniaImporter } from '../utils/importers/convert';
 import { id as postmanEnvImporterId } from '../utils/importers/importers/postman-env';
 import { invariant } from '../utils/invariant';


### PR DESCRIPTION

<img width="1337" alt="image" src="https://github.com/user-attachments/assets/4dcde685-c31d-4668-a54e-8b693f377589" />

Some unit tests failed after we introduced Monaco editor because it relies on the browser environment when importing it and we used Node vitest environment to run unit tests before.
But we can not just change the vitest environment to browser because we didn't enable context isolation for Electron and we rely on Node.js in the renderer process.
So I mocked some of the global variables in the browser that the Monaco editor needs.