### PR TITLE
Expose a new event listener to handle the web worker ipcRenderer requ…

### DIFF
--- a/packages/insomnia/src/templating/base-extension-worker.ts
+++ b/packages/insomnia/src/templating/base-extension-worker.ts
@@ -21,6 +21,36 @@ export interface HelperContext {
   renderPurpose: any;
   util: any;
 }
+
+export async function workerIpcRendererInvoke(channel: string, ...args: any[]) {
+  return new Promise((resolve, reject) => {
+    const id = `worker-ipcRenderer-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+    // Set up a one-time message handler for the response
+    const messageHandler = (event: MessageEvent) => {
+      const data = JSON.parse(event.data || '{}');
+      if (data.type === 'worker-ipcRenderer-response' && data.id === id) {
+        self.removeEventListener('message', messageHandler);
+
+        if (data.error) {
+          reject(new Error(data.error));
+        } else {
+          resolve(data?.result);
+        }
+      }
+    };
+
+    self.addEventListener('message', messageHandler);
+
+    // Send the IPC request to the renderer process
+    self.postMessage({
+      type: 'worker-ipcRenderer-request',
+      id,
+      channel,
+      args,
+    });
+  });
+}
 export default class BaseExtension {
   _ext: PluginTemplateTag | null = null;
   _plugin: Plugin | null = null;
@@ -117,6 +147,7 @@ export default class BaseExtension {
       meta: renderMeta,
       renderPurpose,
       util: {
+        workerIpcRendererInvoke,
         render: (str: string) =>
           templating.render(str, {
             context: renderContext,

--- a/packages/insomnia/src/ui/worker/templating-handler.ts
+++ b/packages/insomnia/src/ui/worker/templating-handler.ts
@@ -1,9 +1,14 @@
 
+import { ipcRenderer } from 'electron';
+
+import type { HandleChannels, MainOnChannels } from '../../main/ipc/electron';
 import { extractUndefinedVariableKey, RenderError } from '../../templating/render-error';
 
+type IpcRendererChannel = HandleChannels | MainOnChannels;
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- see below
 // @ts-ignore -- inso transpiles to commonjs so doesn't play nice with this
 const worker = new Worker(new URL('./templating-worker.ts', import.meta.url), { type: 'module' });
+const ipcRendererChannelWhitelist: IpcRendererChannel[] = [];
 
 // Triggered by a mistake in the work initialization code above
 worker.addEventListener('error', event => {
@@ -30,20 +35,53 @@ export function renderInWorker({ input, context, path, ignoreUndefinedEnvVariabl
   const payloadWithHash = JSON.stringify({ id, input, context: newContext, path, ignoreUndefinedEnvVariable });
   worker.postMessage(payloadWithHash);
   return new Promise((resolve, reject) => {
-    const messageHandler = (event: MessageEvent) => {
+    const messageHandler = async (event: MessageEvent) => {
       if (event.data.id === id) {
         worker.removeEventListener('message', messageHandler);
         if (event.data.err) {
           const error = new RenderError(event.data.err);
           error.type = 'render';
-          error.extraInfo = {
-            subType: 'environmentVariable',
-            undefinedEnvironmentVariables: extractUndefinedVariableKey(input, newContext),
-          };
+          const missingVariables = extractUndefinedVariableKey(input, newContext);
+          if (missingVariables.length > 0) {
+            error.extraInfo = {
+              subType: 'environmentVariable',
+              undefinedEnvironmentVariables: extractUndefinedVariableKey(input, newContext),
+            };
+          }
           return reject(error);
         }
         return resolve(event.data.result);
-      }
+      } else {
+        // Process ipcRenderer messages from worker
+        if (event.data?.type === 'worker-ipcRenderer-request') {
+          const { id, channel, args } = event.data;
+          const responseType = 'worker-ipcRenderer-response';
+          if (channel && ipcRendererChannelWhitelist.includes(channel)) {
+            // only allowed channel will be forwarded to main process
+            try {
+              // Forward the request to the main process
+              const result = await ipcRenderer.invoke(channel, ...args);
+              worker.postMessage(JSON.stringify({
+                type: responseType,
+                id,
+                result,
+              }));
+            } catch (error) {
+              worker.postMessage(JSON.stringify({
+                type: responseType,
+                id,
+                error: error.message,
+              }));
+            }
+          } else {
+            worker.postMessage(JSON.stringify({
+              type: responseType,
+              id,
+              error: `Channel ${channel} is not allowed`,
+            }));
+          }
+        }
+      };
     };
     worker.addEventListener('message', messageHandler);
   });

--- a/packages/insomnia/src/ui/worker/templating-handler.ts
+++ b/packages/insomnia/src/ui/worker/templating-handler.ts
@@ -36,52 +36,55 @@ export function renderInWorker({ input, context, path, ignoreUndefinedEnvVariabl
   worker.postMessage(payloadWithHash);
   return new Promise((resolve, reject) => {
     const messageHandler = async (event: MessageEvent) => {
-      if (event.data.id === id) {
+      const isTheResponseWeAreWaitingFor = event.data.id === id;
+      if (isTheResponseWeAreWaitingFor) {
         worker.removeEventListener('message', messageHandler);
         if (event.data.err) {
           const error = new RenderError(event.data.err);
           error.type = 'render';
-          const missingVariables = extractUndefinedVariableKey(input, newContext);
-          if (missingVariables.length > 0) {
+          const undefinedEnvironmentVariables = extractUndefinedVariableKey(input, newContext);
+          if (undefinedEnvironmentVariables.length > 0) {
             error.extraInfo = {
               subType: 'environmentVariable',
-              undefinedEnvironmentVariables: extractUndefinedVariableKey(input, newContext),
+              undefinedEnvironmentVariables,
             };
           }
           return reject(error);
         }
         return resolve(event.data.result);
-      } else {
-        // Process ipcRenderer messages from worker
-        if (event.data?.type === 'worker-ipcRenderer-request') {
-          const { id, channel, args } = event.data;
-          const responseType = 'worker-ipcRenderer-response';
-          if (channel && ipcRendererChannelWhitelist.includes(channel)) {
-            // only allowed channel will be forwarded to main process
-            try {
-              // Forward the request to the main process
-              const result = await ipcRenderer.invoke(channel, ...args);
-              worker.postMessage(JSON.stringify({
-                type: responseType,
-                id,
-                result,
-              }));
-            } catch (error) {
-              worker.postMessage(JSON.stringify({
-                type: responseType,
-                id,
-                error: error.message,
-              }));
-            }
-          } else {
-            worker.postMessage(JSON.stringify({
-              type: responseType,
-              id,
-              error: `Channel ${channel} is not allowed`,
-            }));
-          }
+      }
+      // In the scope of a render, we are also interested in listening for requests to the main process
+      // Question: is it necessary to add another communication mechanism for this or can it be a new plugin function?
+      // Process ipcRenderer messages from worker
+      if (event.data?.type === 'worker-ipcRenderer-request') {
+        const { id, channel, args } = event.data;
+        const responseType = 'worker-ipcRenderer-response';
+        const isAllowedChannel = ipcRendererChannelWhitelist.includes(channel);
+        if (!isAllowedChannel) {
+          // (@kent) Can this be a reject error instead?
+          return worker.postMessage(JSON.stringify({
+            type: responseType,
+            id,
+            error: `Channel ${channel} is not allowed`,
+          }));
         }
-      };
+        // only allowed channel will be forwarded to main process
+        try {
+          // Forward the request to the main process
+          const result = await ipcRenderer.invoke(channel, ...args);
+          worker.postMessage(JSON.stringify({
+            type: responseType,
+            id,
+            result,
+          }));
+        } catch (error) {
+          worker.postMessage(JSON.stringify({
+            type: responseType,
+            id,
+            error: error.message,
+          }));
+        }
+      }
     };
     worker.addEventListener('message', messageHandler);
   });


### PR DESCRIPTION
**Changes**
- Expose a new event listener to handle the web worker ipcRenderer request to make process. Use a whitelist so that only limited of channels are exposed to web worker ipcRenderer request.
-  Fix Nunjuck tag preview modal do not show error message
