### PR TITLE
fix render error bug

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/global-environments.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/global-environments.test.ts
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 import { loadFixture } from '../../playwright/paths';
 import { test } from '../../playwright/test';
 
@@ -20,6 +22,12 @@ test.describe('Global Environments', async () => {
 
         await page.getByRole('link', { name: 'collection-for-global-' }).click();
         await page.getByTestId('New Request').getByLabel('GET New Request', { exact: true }).click();
+        // check if it appears red with error message in tag editor
+        await page.getByText('Body', { exact: true }).click();
+        await page.getByText('_[\'global-base\']').click();
+        await expect(page.getByLabel('Live Preview')).toContainText('Failed to render environment variables: _[\'global-base\']');
+        await page.getByRole('button', { name: 'Done' }).click();
+        // check if it appears as a custom message when sending the request
         await page.getByRole('button', { name: 'Send' }).click();
         await page.getByRole('heading', { name: '2 environment variables are' }).click();
         await page.getByRole('button', { name: 'Cancel' }).click();

--- a/packages/insomnia/src/ui/worker/templating-handler.ts
+++ b/packages/insomnia/src/ui/worker/templating-handler.ts
@@ -36,10 +36,13 @@ export function renderInWorker({ input, context, path, ignoreUndefinedEnvVariabl
         if (event.data.err) {
           const error = new RenderError(event.data.err);
           error.type = 'render';
-          error.extraInfo = {
-            subType: 'environmentVariable',
-            undefinedEnvironmentVariables: extractUndefinedVariableKey(input, newContext),
-          };
+          const undefinedEnvironmentVariables = extractUndefinedVariableKey(input, newContext);
+          if (undefinedEnvironmentVariables.length > 0) {
+            error.extraInfo = {
+              subType: 'environmentVariable',
+              undefinedEnvironmentVariables,
+            };
+          }
           return reject(error);
         }
         return resolve(event.data.result);


### PR DESCRIPTION
when a tag would fail it wouldn't show the error because the extraInfo object contained an empty array
this change conditionally adds the extra info if the array has elements

TODO
- [x] add a test to ensure that tags can have error and show error messages in the tooltip
- [ ] consider the merits of using a custom error object (RenderError) with three optional fields, explore alternative, stricter code paths.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
