### PR TITLE
async getBodyBuffer

### DIFF
--- a/packages/insomnia/src/common/har.ts
+++ b/packages/insomnia/src/common/har.ts
@@ -18,8 +18,7 @@ import { getAppVersion } from './constants';
 import { jarFromCookies } from './cookies';
 import { database } from './database';
 import { filterHeaders, getSetCookieHeaders, hasAuthHeader } from './misc';
-import type { RenderedRequest } from './render';
-import { getRenderedRequestAndContext } from './render';
+import { getRenderedRequestAndContext, type RenderedRequest } from './render';
 
 export interface ExportRequest {
   requestId: string;
@@ -144,7 +143,7 @@ export async function exportHarResponse(response: Response | null) {
     httpVersion: 'HTTP/1.1',
     cookies: getResponseCookies(response),
     headers: getResponseHeaders(response),
-    content: getResponseContent(response),
+    content: await getResponseContent(response),
     redirectURL: '',
     headersSize: -1,
     bodySize: -1,
@@ -343,8 +342,8 @@ function mapCookie(cookie: ToughCookie) {
   return harCookie;
 }
 
-function getResponseContent(response: Response) {
-  let body = models.response.getBodyBuffer(response);
+async function getResponseContent(response: Response) {
+  let body = await models.response.getBodyBuffer(response);
 
   if (body === null) {
     body = Buffer.alloc(0);

--- a/packages/insomnia/src/models/__tests__/response.test.ts
+++ b/packages/insomnia/src/models/__tests__/response.test.ts
@@ -14,7 +14,7 @@ describe('migrate()', () => {
     const response = await models.initModel(models.response.type, {
       bodyPath,
     });
-    const body = await models.response.getBodyBuffer(response).toString();
+    const body = (await models.response.getBodyBuffer(response)).toString();
     expect(response.bodyCompression).toBe('zip');
     expect(body).toBe('Hello World!');
   });

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -40,6 +40,8 @@ export interface BaseResponse {
   elapsedTime: number;
   headers: ResponseHeader[];
   bodyPath: string;
+  // if body is less than 5MB, it's stored in memory
+  bodyBuffer?: Buffer;
   // Actual bodies are stored on the filesystem
   timelinePath: string;
   // Actual timelines are stored on the filesystem
@@ -249,7 +251,7 @@ export const readCurlResponse = async (options: { bodyPath?: string; bodyCompres
 export const getBodyBuffer = async (
   response?: { bodyPath?: string; bodyCompression?: Compression },
   readFailureValue?: string,
-): Promise<Buffer | string | null> => {
+): Promise<Buffer | string> => {
   if (!response?.bodyPath) {
     // No body, so return empty Buffer
     return Buffer.alloc(0);
@@ -263,7 +265,7 @@ export const getBodyBuffer = async (
     return rawBuffer;
   } catch (err) {
     console.warn('Failed to read response body', err.message);
-    return readFailureValue === undefined ? null : readFailureValue;
+    return readFailureValue === undefined ? Buffer.alloc(0) : readFailureValue;
   }
 };
 

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -232,7 +232,7 @@ export const getBodyStream = (
 };
 export const readCurlResponse = async (options: { bodyPath?: string; bodyCompression?: Compression }) => {
   const readFailureMsg = '[main/curlBridgeAPI] failed to read response body message';
-  const bodyBufferOrErrMsg = getBodyBuffer(options, readFailureMsg);
+  const bodyBufferOrErrMsg = await getBodyBuffer(options, readFailureMsg);
   // TODO(jackkav): simplify the fail msg and reuse in other getBodyBuffer renderer calls
 
   if (!bodyBufferOrErrMsg) {
@@ -246,21 +246,21 @@ export const readCurlResponse = async (options: { bodyPath?: string; bodyCompres
 
   return { body: bodyBufferOrErrMsg.toString('utf8'), error: '' };
 };
-export const getBodyBuffer = (
+export const getBodyBuffer = async (
   response?: { bodyPath?: string; bodyCompression?: Compression },
   readFailureValue?: string,
-): Buffer | string | null => {
+): Promise<Buffer | string | null> => {
   if (!response?.bodyPath) {
     // No body, so return empty Buffer
     return Buffer.alloc(0);
   }
   try {
-    const rawBuffer = fs.readFileSync(response?.bodyPath);
+    const rawBuffer = await fs.promises.readFile(response?.bodyPath);
     if (response?.bodyCompression === 'zip') {
-      return zlib.gunzipSync(rawBuffer);
-    } else {
-      return rawBuffer;
+      return new Promise((resolve, reject) => zlib.gunzip(rawBuffer, (err, buffer) => err ? reject(err) : resolve(buffer)));
     }
+
+    return rawBuffer;
   } catch (err) {
     console.warn('Failed to read response body', err.message);
     return readFailureValue === undefined ? null : readFailureValue;

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -103,7 +103,7 @@ describe('sendCurlAndWriteTimeline()', () => {
       '/tmp/res_id',
       'res_id'
     );
-    const bodyBuffer = models.response.getBodyBuffer(response);
+    const bodyBuffer = await models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
@@ -182,7 +182,7 @@ describe('sendCurlAndWriteTimeline()', () => {
       '/tmp/res_id',
       'res_id'
     );
-    const bodyBuffer = models.response.getBodyBuffer(response);
+    const bodyBuffer = await models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
@@ -210,7 +210,7 @@ describe('sendCurlAndWriteTimeline()', () => {
         USERAGENT: '',
         VERBOSE: true,
         SSL_OPTIONS: 'NativeCa',
-     },
+      },
     });
   });
 
@@ -286,7 +286,7 @@ describe('sendCurlAndWriteTimeline()', () => {
       '/tmp/res_id',
       'res_id'
     );
-    const bodyBuffer = models.response.getBodyBuffer(response);
+    const bodyBuffer = await models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
@@ -350,7 +350,7 @@ describe('sendCurlAndWriteTimeline()', () => {
       '/tmp/res_id',
       'res_id'
     );
-    const bodyBuffer = models.response.getBodyBuffer(response);
+    const bodyBuffer = await models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
@@ -434,7 +434,7 @@ describe('sendCurlAndWriteTimeline()', () => {
       '/tmp/res_id',
       'res_id'
     );
-    const bodyBuffer = models.response.getBodyBuffer(response);
+    const bodyBuffer = await models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
@@ -499,7 +499,7 @@ describe('sendCurlAndWriteTimeline()', () => {
       '/tmp/res_id',
       'res_id'
     );
-    const bodyBuffer = models.response.getBodyBuffer(response);
+    const bodyBuffer = await models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
@@ -543,7 +543,7 @@ describe('sendCurlAndWriteTimeline()', () => {
       '/tmp/res_id',
       'res_id'
     );
-    const bodyBuffer = models.response.getBodyBuffer(response);
+    const bodyBuffer = await models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
@@ -586,7 +586,7 @@ describe('sendCurlAndWriteTimeline()', () => {
       '/tmp/res_id',
       'res_id'
     );
-    const bodyBuffer = models.response.getBodyBuffer(response);
+    const bodyBuffer = await models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
@@ -630,7 +630,7 @@ describe('sendCurlAndWriteTimeline()', () => {
       '/tmp/res_id',
       'res_id'
     );
-    const bodyBuffer = models.response.getBodyBuffer(response);
+    const bodyBuffer = await models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
@@ -735,7 +735,7 @@ describe('sendCurlAndWriteTimeline()', () => {
       '/tmp/res_id',
       'res_id'
     );
-    const bodyBuffer = models.response.getBodyBuffer(response);
+    const bodyBuffer = await models.response.getBodyBuffer(response);
     const body = JSON.parse(String(bodyBuffer));
     expect(body).toEqual({
       meta: {},
@@ -790,7 +790,7 @@ describe('sendCurlAndWriteTimeline()', () => {
       '/tmp/res_id',
       'res_id'
     );
-    expect(JSON.parse(String(models.response.getBodyBuffer(responseV1))).options.HTTP_VERSION).toBe('V1_0');
+    expect(JSON.parse(String(await models.response.getBodyBuffer(responseV1))).options.HTTP_VERSION).toBe('V1_0');
     expect(getHttpVersion(HttpVersions.V1_0).curlHttpVersion).toBe(CurlHttpVersion.V1_0);
     expect(getHttpVersion(HttpVersions.V1_1).curlHttpVersion).toBe(CurlHttpVersion.V1_1);
     expect(getHttpVersion(HttpVersions.V2PriorKnowledge).curlHttpVersion).toBe(CurlHttpVersion.V2PriorKnowledge);

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -167,7 +167,7 @@ export const getOAuth2Token = async (
   const response = await sendAccessTokenRequest(requestId, authentication, params, headers);
   const old = await models.oAuth2Token.getOrCreateByParentId(requestId);
   return models.oAuth2Token.update(old, transformNewAccessTokenToOauthModel(
-    oauthResponseToAccessToken(authentication.accessTokenUrl, response)
+    await oauthResponseToAccessToken(authentication.accessTokenUrl, response)
   ));
 };
 // 1. get token from db and return if valid
@@ -210,7 +210,7 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   const response = await sendAccessTokenRequest(requestId, authentication, params, []);
 
   const statusCode = response.statusCode || 0;
-  const bodyBuffer = models.response.getBodyBuffer(response);
+  const bodyBuffer = await models.response.getBodyBuffer(response);
 
   if (statusCode === 401) {
     // If the refresh token was rejected due an unauthorized request, we will
@@ -250,8 +250,8 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   }));
 }
 
-export const oauthResponseToAccessToken = (accessTokenUrl: string, response: Response) => {
-  const bodyBuffer = models.response.getBodyBuffer(response);
+export const oauthResponseToAccessToken = async (accessTokenUrl: string, response: Response) => {
+  const bodyBuffer = await models.response.getBodyBuffer(response);
   if (!bodyBuffer) {
     return {
       xResponseId: response._id,

--- a/packages/insomnia/src/plugins/context/__tests__/response.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/response.test.ts
@@ -49,7 +49,7 @@ describe('response.*', () => {
     expect(result.response.getStatusCode()).toBe(200);
     expect(result.response.getBytesRead()).toBe(123);
     expect(result.response.getTime()).toBe(321);
-    expect(result.response.getBody().toString()).toBe('Hello World!');
+    expect((await result.response.getBody())?.toString()).toBe('Hello World!');
   });
 
   it('works for basic and empty response', async () => {
@@ -58,7 +58,7 @@ describe('response.*', () => {
     expect(result.response.getStatusCode()).toBe(0);
     expect(result.response.getBytesRead()).toBe(0);
     expect(result.response.getTime()).toBe(0);
-    expect(result.response.getBody().length).toBe(0);
+    expect((await result.response.getBody())?.length).toBe(0);
   });
 
   it('works for getting headers', () => {

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -89,7 +89,7 @@ const fetchGraphQLSchemaForRequest = async ({
   requestId: string;
   environmentId: string;
   url: string;
-    inputValueDeprecation: boolean;
+  inputValueDeprecation: boolean;
 }) => {
   if (!url) {
     return;
@@ -158,7 +158,7 @@ const fetchGraphQLSchemaForRequest = async ({
         },
       };
     }
-    const bodyBuffer = models.response.getBodyBuffer(response);
+    const bodyBuffer = await models.response.getBodyBuffer(response);
     if (bodyBuffer) {
       const { data, errors } = JSON.parse(bodyBuffer.toString());
       if (errors?.length) {

--- a/packages/insomnia/src/ui/components/mocks/mock-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/mocks/mock-response-pane.tsx
@@ -135,6 +135,7 @@ export const MockResponsePane = () => {
             error={activeResponse.error}
             filter={''}
             filterHistory={[]}
+            bodyBuffer={activeResponse.bodyBuffer}
             getBody={() => models.response.getBodyBuffer(activeResponse)}
             previewMode={previewMode}
             responseId={activeResponse._id}

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -240,6 +240,7 @@ export const ResponsePane: FC<Props> = ({
             error={activeResponse.error}
             filter={filter}
             filterHistory={filterHistory}
+            bodyBuffer={activeResponse.bodyBuffer}
             getBody={() => models.response.getBodyBuffer(activeResponse)}
             previewMode={activeResponse.error ? PREVIEW_MODE_SOURCE : previewMode}
             responseId={activeResponse._id}

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -63,18 +63,6 @@ export const ResponsePane: FC<Props> = ({
     responseFilterHistory.unshift(responseFilter);
     patchRequestMeta(requestId, { responseFilterHistory });
   };
-  const handleGetResponseBody = useCallback(() => {
-    if (!activeResponse) {
-      return null;
-    }
-    return models.response.getBodyBuffer(activeResponse);
-  }, [activeResponse]);
-  const handleCopyResponseToClipboard = useCallback(async () => {
-    const bodyBuffer = handleGetResponseBody();
-    if (bodyBuffer) {
-      window.clipboard.writeText(bodyBuffer.toString('utf8'));
-    }
-  }, [handleGetResponseBody]);
 
   const { isExecuting, steps } = useExecutionState({ requestId: activeRequest._id });
 
@@ -233,7 +221,12 @@ export const ResponsePane: FC<Props> = ({
           <Toolbar className="w-full flex-shrink-0 h-[--line-height-sm] border-b border-solid border-[--hl-md] flex items-center px-2">
             <PreviewModeDropdown
               download={handleDownloadResponseBody}
-              copyToClipboard={handleCopyResponseToClipboard}
+              copyToClipboard={async () => {
+                const bodyBuffer = activeResponse ? await models.response.getBodyBuffer(activeResponse) : null;
+                if (bodyBuffer) {
+                  window.clipboard.writeText(bodyBuffer.toString('utf8'));
+                }
+              }}
             />
           </Toolbar>
           <ResponseViewer
@@ -247,7 +240,7 @@ export const ResponsePane: FC<Props> = ({
             error={activeResponse.error}
             filter={filter}
             filterHistory={filterHistory}
-            getBody={handleGetResponseBody}
+            getBody={() => models.response.getBodyBuffer(activeResponse)}
             previewMode={activeResponse.error ? PREVIEW_MODE_SOURCE : previewMode}
             responseId={activeResponse._id}
             updateFilter={activeResponse.error ? undefined : handleSetFilter}

--- a/packages/insomnia/src/ui/components/viewers/response-multipart-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-multipart-viewer.tsx
@@ -220,7 +220,7 @@ export const ResponseMultipartViewer: FC<Props> = ({
           error={null}
           filter={filter}
           filterHistory={filterHistory}
-          getBody={() => new Promise(resolve => resolve(selectedPart?.value))}
+          bodyBuffer={Buffer.from(selectedPart?.value || '')}
           key={`${responseId}::${selectedPart?.id}`}
           previewMode={PREVIEW_MODE_FRIENDLY}
           responseId={`${responseId}[${selectedPart?.id}]`}

--- a/packages/insomnia/src/ui/components/viewers/response-multipart-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-multipart-viewer.tsx
@@ -71,12 +71,6 @@ export const ResponseMultipartViewer: FC<Props> = ({
     init();
   }, [bodyBuffer, contentType]);
 
-  const selectPart = useCallback((part: Part) => {
-    setSelectedPart(part);
-  }, []);
-
-  const partBuffer = useCallback(() => selectedPart?.value, [selectedPart]);
-
   const viewHeaders = useCallback(() => {
     if (!selectedPart) {
       return;
@@ -185,7 +179,7 @@ export const ResponseMultipartViewer: FC<Props> = ({
                 <ItemContent
                   icon={selectedPart?.id === part.id ? 'check' : 'empty'}
                   label={part.title}
-                  onClick={() => selectPart(part)}
+                  onClick={() => setSelectedPart(part)}
                 />
               </DropdownItem>
             ))}
@@ -226,7 +220,7 @@ export const ResponseMultipartViewer: FC<Props> = ({
           error={null}
           filter={filter}
           filterHistory={filterHistory}
-          getBody={partBuffer}
+          getBody={() => new Promise(resolve => resolve(selectedPart?.value))}
           key={`${responseId}::${selectedPart?.id}`}
           previewMode={PREVIEW_MODE_FRIENDLY}
           responseId={`${responseId}[${selectedPart?.id}]`}

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -2,6 +2,7 @@ import iconv from 'iconv-lite';
 import React, {
   Fragment,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from 'react';
@@ -46,7 +47,7 @@ export interface ResponseViewerProps {
   editorFontSize: number;
   filter: string;
   filterHistory: string[];
-  getBody: (...args: any[]) => any;
+  getBody: (...args: any[]) => Promise<Buffer | string | null>;
   previewMode: string;
   responseId: string;
   url: string;
@@ -75,26 +76,36 @@ export const ResponseViewer = ({
   const [blockingBecauseTooLarge, setBlockingBecauseTooLarge] = useState(!alwaysShowLargeResponses && largeResponse);
   const [parseError, setParseError] = useState('');
 
-  const [bodyBuffer, setBodyBuffer] = useState<Buffer | null>(() => {
-    let initialBody = null;
-    try {
-      if (!blockingBecauseTooLarge) {
-        initialBody = getBody();
+  const [bodyBuffer, setBodyBuffer] = useState<Buffer | null>(null);
+  useEffect(() => {
+    const fn = async () => {
+      try {
+        const bodyBuffer = await getBody();
+        if (typeof bodyBuffer === 'string') {
+          return setParseError(bodyBuffer);
+        }
+        if (bodyBuffer !== null) {
+          return setBodyBuffer(bodyBuffer);
+        }
+      } catch (err) {
+        setParseError(`Failed reading response from filesystem: ${err.stack}`);
       }
-    } catch (err) {
-      setParseError(`Failed reading response from filesystem: ${err.stack}`);
-    }
-    return initialBody;
-  });
-
+    };
+    fn();
+  }, [getBody]);
   const editorRef = useRef<CodeEditorHandle>(null);
 
-  const _handleDismissBlocker = useCallback(() => {
+  const _handleDismissBlocker = useCallback(async () => {
     setBlockingBecauseTooLarge(false);
 
     try {
-      const bodyBuffer = getBody();
-      setBodyBuffer(bodyBuffer);
+      const bodyBuffer = await getBody();
+      if (typeof bodyBuffer === 'string') {
+        return setParseError(bodyBuffer);
+      }
+      if (bodyBuffer !== null) {
+        return setBodyBuffer(bodyBuffer);
+      }
       setBlockingBecauseTooLarge(false);
     } catch (err) {
       setParseError(`Failed reading response from filesystem: ${err.stack}`);
@@ -403,5 +414,3 @@ export const ResponseViewer = ({
     />
   );
 };
-
-ResponseViewer.displayName = 'ResponseViewer';

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -76,7 +76,7 @@ export const ResponseViewer = ({
   const [blockingBecauseTooLarge, setBlockingBecauseTooLarge] = useState(!alwaysShowLargeResponses && largeResponse);
   const [parseError, setParseError] = useState('');
 
-  const [bodyBuffer, setBodyBuffer] = useState<Buffer | null>(null);
+  const [bodyBuffer, setBodyBuffer] = useState<Buffer | null>(Buffer.from('Loading...'));
   useEffect(() => {
     const fn = async () => {
       try {
@@ -92,7 +92,9 @@ export const ResponseViewer = ({
       }
     };
     fn();
-  }, [getBody]);
+    // TODO: remove this when response has its own route loader
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [responseId]);
   const editorRef = useRef<CodeEditorHandle>(null);
 
   const _handleDismissBlocker = useCallback(async () => {

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -2,7 +2,6 @@ import iconv from 'iconv-lite';
 import React, {
   Fragment,
   useCallback,
-  useEffect,
   useRef,
   useState,
 } from 'react';
@@ -47,7 +46,8 @@ export interface ResponseViewerProps {
   editorFontSize: number;
   filter: string;
   filterHistory: string[];
-  getBody: (...args: any[]) => Promise<Buffer | string | null>;
+  bodyBuffer?: Buffer;
+  getBody?: (...args: any[]) => Promise<Buffer | string | null>;
   previewMode: string;
   responseId: string;
   url: string;
@@ -57,6 +57,7 @@ export interface ResponseViewerProps {
 
 export const ResponseViewer = ({
   bytes,
+  bodyBuffer,
   getBody,
   contentType: originalContentType,
   disableHtmlPreviewJs,
@@ -76,39 +77,18 @@ export const ResponseViewer = ({
   const [blockingBecauseTooLarge, setBlockingBecauseTooLarge] = useState(!alwaysShowLargeResponses && largeResponse);
   const [parseError, setParseError] = useState('');
 
-  const [bodyBuffer, setBodyBuffer] = useState<Buffer | null>(Buffer.from('Loading...'));
-  useEffect(() => {
-    const fn = async () => {
-      try {
-        const bodyBuffer = await getBody();
-        if (typeof bodyBuffer === 'string') {
-          return setParseError(bodyBuffer);
-        }
-        if (bodyBuffer !== null) {
-          return setBodyBuffer(bodyBuffer);
-        }
-      } catch (err) {
-        setParseError(`Failed reading response from filesystem: ${err.stack}`);
-      }
-    };
-    fn();
-    // TODO: remove this when response has its own route loader
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [responseId]);
+  const [overSizedBody, setOversizedBody] = useState<Buffer | null>(bodyBuffer || null);
+
   const editorRef = useRef<CodeEditorHandle>(null);
 
   const _handleDismissBlocker = useCallback(async () => {
     setBlockingBecauseTooLarge(false);
 
     try {
-      const bodyBuffer = await getBody();
-      if (typeof bodyBuffer === 'string') {
-        return setParseError(bodyBuffer);
-      }
-      if (bodyBuffer !== null) {
-        return setBodyBuffer(bodyBuffer);
-      }
-      setBlockingBecauseTooLarge(false);
+      const buffer = await getBody?.();
+      const bufferOrError = typeof buffer === 'string' ? Buffer.from(buffer) : buffer;
+
+      return setOversizedBody(bufferOrError || null);
     } catch (err) {
       setParseError(`Failed reading response from filesystem: ${err.stack}`);
     }
@@ -137,14 +117,14 @@ export const ResponseViewer = ({
 
   const _getContentType = useCallback(() => {
     const lowercasedOriginalContentType = originalContentType.toLowerCase();
-    if (!bodyBuffer || bodyBuffer.length === 0) {
+    if (!overSizedBody || overSizedBody.length === 0) {
       return lowercasedOriginalContentType;
     }
     // Try to detect JSON in all cases (even if a different header is set).
     // Apparently users often send JSON with weird content-types like text/plain.
     try {
-      if (bodyBuffer && bodyBuffer.length > 0) {
-        JSON.parse(bodyBuffer.toString('utf8'));
+      if (overSizedBody && overSizedBody.length > 0) {
+        JSON.parse(overSizedBody.toString('utf8'));
         return 'application/json';
       }
     } catch (error) { }
@@ -152,7 +132,7 @@ export const ResponseViewer = ({
     // It is fairly common for webservers to send errors in HTML by default.
     // NOTE: This will probably never throw but I'm not 100% so wrap anyway
     try {
-      const isProbablyHTML = bodyBuffer
+      const isProbablyHTML = overSizedBody
         .slice(0, 100)
         .toString()
         .trim()
@@ -167,10 +147,10 @@ export const ResponseViewer = ({
     } catch (error) { }
 
     return lowercasedOriginalContentType;
-  }, [originalContentType, bodyBuffer]);
+  }, [originalContentType, overSizedBody]);
 
   const getBodyAsString = useCallback(() => {
-    if (!bodyBuffer) {
+    if (!overSizedBody) {
       return '';
     }
     // Show everything else as "source"
@@ -178,12 +158,12 @@ export const ResponseViewer = ({
     const charset = match && match.length >= 2 ? match[1] : 'utf-8';
     // Sometimes iconv conversion fails so fallback to regular buffer
     try {
-      return iconv.decode(bodyBuffer, charset);
+      return iconv.decode(overSizedBody, charset);
     } catch (err) {
       console.warn('[response] Failed to decode body', err);
-      return bodyBuffer.toString();
+      return overSizedBody.toString();
     }
-  }, [bodyBuffer, _getContentType]);
+  }, [overSizedBody, _getContentType]);
 
   if (responseError || parseError) {
     return (
@@ -239,7 +219,7 @@ export const ResponseViewer = ({
     );
   }
 
-  if (!bodyBuffer) {
+  if (!overSizedBody) {
     return (
       <div className="pad faint">
         Failed to read response body from filesystem
@@ -247,7 +227,7 @@ export const ResponseViewer = ({
     );
   }
 
-  if (bodyBuffer.length === 0) {
+  if (overSizedBody.length === 0) {
     return <div className="pad faint">No body returned for response</div>;
   }
 
@@ -291,7 +271,7 @@ export const ResponseViewer = ({
     contentType.indexOf('image/') === 0
   ) {
     const justContentType = contentType.split(';')[0];
-    const base64Body = bodyBuffer.toString('base64');
+    const base64Body = overSizedBody.toString('base64');
     return (
       <div className="scrollable-container tall wide">
         <div className="scrollable">
@@ -326,7 +306,7 @@ export const ResponseViewer = ({
   ) {
     return (
       <div className="tall wide scrollable">
-        <ResponsePDFViewer body={bodyBuffer} key={responseId} />
+        <ResponsePDFViewer body={overSizedBody} key={responseId} />
       </div>
     );
   }
@@ -337,7 +317,7 @@ export const ResponseViewer = ({
   ) {
     return (
       <div className="tall wide scrollable">
-        <ResponseCSVViewer body={bodyBuffer} key={responseId} />
+        <ResponseCSVViewer body={overSizedBody} key={responseId} />
       </div>
     );
   }
@@ -348,7 +328,7 @@ export const ResponseViewer = ({
   ) {
     return (
       <ResponseMultipartViewer
-        bodyBuffer={bodyBuffer}
+        bodyBuffer={overSizedBody}
         contentType={contentType}
         disableHtmlPreviewJs={disableHtmlPreviewJs}
         disablePreviewLinks={disablePreviewLinks}
@@ -368,7 +348,7 @@ export const ResponseViewer = ({
     contentType.indexOf('audio/') === 0
   ) {
     const justContentType = contentType.split(';')[0];
-    const base64Body = bodyBuffer.toString('base64');
+    const base64Body = overSizedBody.toString('base64');
     return (
       <div className="vertically-center" key={responseId}>
         <audio controls>

--- a/packages/insomnia/src/ui/routes/mock-route.tsx
+++ b/packages/insomnia/src/ui/routes/mock-route.tsx
@@ -47,6 +47,17 @@ export const loader: LoaderFunction = async ({ params }): Promise<MockRouteLoade
   const reqIds = (await models.request.findByParentId(mockRouteId)).map(r => r._id);
 
   const responses = await db.findMostRecentlyModified<Response>(models.response.type, { parentId: { $in: reqIds } });
+  const activeResponse = responses?.[0];
+  if (activeResponse && 'bodyPath' in activeResponse) {
+    // read the body if its smaller than the limit add it to the activeResponse
+    const length = Math.max(activeResponse.bytesContent, activeResponse.bytesRead);
+    const isOversizedResponse = length > 5 * 1024 * 1024; // 5MB
+    // Oversized repsonses are handled in the response-viewer.tsx for now
+    if (!isOversizedResponse) {
+      const buffer = await models.response.getBodyBuffer(activeResponse);
+      activeResponse.bodyBuffer = typeof buffer === 'string' ? Buffer.from(buffer) : buffer;
+    }
+  }
   return {
     mockServer,
     mockRoute,

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -107,6 +107,17 @@ export const loader: LoaderFunction = async ({ params }): Promise<RequestLoaderD
   const responses = (filterResponsesByEnv ? filteredResponses : allResponses)
     .sort((a: BaseModel, b: BaseModel) => (a.created > b.created ? -1 : 1));
 
+  if (activeResponse && 'bodyPath' in activeResponse) {
+    // read the body if its smaller than the limit add it to the activeResponse
+    const length = Math.max(activeResponse.bytesContent, activeResponse.bytesRead);
+    const isOversizedResponse = length > 5 * 1024 * 1024; // 5MB
+    // Oversized repsonses are handled in the response-viewer.tsx for now
+    if (!isOversizedResponse) {
+      const buffer = await models.response.getBodyBuffer(activeResponse);
+      activeResponse.bodyBuffer = typeof buffer === 'string' ? Buffer.from(buffer) : buffer;
+    }
+  }
+
   // Q(gatzjames): load mock servers here or somewhere else?
   const mockServers = await models.mockServer.findByProjectId(projectId);
   const mockRoutes = await database.find<MockRoute>(models.mockRoute.type, { parentId: { $in: mockServers.map(s => s._id) } });
@@ -486,15 +497,15 @@ export interface RunnerContextForRequest {
 }
 
 export const sendActionImplementation = async (options: {
-    requestId: string;
-    shouldPromptForPathAfterResponse: boolean | undefined;
-    ignoreUndefinedEnvVariable: boolean | undefined;
-    testResultCollector?: RunnerContextForRequest;
-    iteration?: number;
-    iterationCount?: number;
-    userUploadEnvironment?: UserUploadEnvironment;
-    transientVariables?: Environment;
-    runtime?: SendActionRuntime;
+  requestId: string;
+  shouldPromptForPathAfterResponse: boolean | undefined;
+  ignoreUndefinedEnvVariable: boolean | undefined;
+  testResultCollector?: RunnerContextForRequest;
+  iteration?: number;
+  iterationCount?: number;
+  userUploadEnvironment?: UserUploadEnvironment;
+  transientVariables?: Environment;
+  runtime?: SendActionRuntime;
 }) => {
   const {
     requestId,


### PR DESCRIPTION
in order to build a serialisable bridge for web worker its necessary to make all the api consistent promises
getBodyBuffer was the exception as it was synchronous

this aims to correct that and any consequences

adds responses under 5mb to loader

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
