### PR TITLE
fix(Git Projects): Updating custom credentials

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -978,6 +978,20 @@ export const updateGitRepoAction = async ({
         gitRepositoryId: gitRepository._id,
       });
     }
+
+    await GitVCS.init({
+      repoId: gitRepository._id,
+      uri,
+      directory: GIT_CLONE_DIR,
+      fs: await getGitFSClient({ projectId, workspaceId, gitRepositoryId: gitRepository._id }),
+      gitDirectory: GIT_INTERNAL_DIR,
+      gitCredentials: gitRepository.credentials,
+      legacyDiff: Boolean(workspaceId),
+    });
+
+    await GitVCS.setAuthor();
+    await GitVCS.addRemote(uri);
+
     const { hasUncommittedChanges } = await getGitChanges(GitVCS);
     const hasUnpushedChanges = await GitVCS.canPush(gitRepository.credentials);
 
@@ -985,8 +999,6 @@ export const updateGitRepoAction = async ({
       hasUncommittedChanges,
       hasUnpushedChanges,
     });
-
-    await GitVCS.setAuthor();
 
     return null;
   } catch (e) {

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-project-repository-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-project-repository-settings-modal.tsx
@@ -5,6 +5,7 @@ import { useFetcher, useParams } from 'react-router-dom';
 
 import { docsGitSync } from '../../../../common/documentation';
 import type { GitRepository, OauthProviderName } from '../../../../models/git-repository';
+import type { GitCredentials } from '../../../../sync/git/git-vcs';
 import { Link } from '../../base/link';
 import { Modal, type ModalHandle, type ModalProps } from '../../base/modal';
 import { ModalBody } from '../../base/modal-body';
@@ -17,6 +18,18 @@ import { CustomRepositorySettingsFormGroup } from './custom-repository-settings-
 import { GitHubRepositorySetupFormGroup } from './github-repository-settings-form-group';
 import { GitLabRepositorySetupFormGroup } from './gitlab-repository-settings-form-group';
 
+function getDefaultOAuthProvider(credentials?: GitCredentials | null): OauthProviderName {
+  if (!credentials) {
+    return 'github';
+  }
+
+  if ('oauth2format' in credentials && credentials.oauth2format) {
+    return credentials.oauth2format;
+  }
+
+  return 'custom';
+}
+
 export const GitProjectRepositorySettingsModal = (props: ModalProps & {
   gitRepository?: GitRepository;
 }) => {
@@ -27,7 +40,7 @@ export const GitProjectRepositorySettingsModal = (props: ModalProps & {
   const updateGitRepositoryFetcher = useFetcher();
   const deleteGitRepositoryFetcher = useFetcher();
 
-  const [selectedTab, setTab] = useState<OauthProviderName>('github');
+  const [selectedTab, setTab] = useState<OauthProviderName>(getDefaultOAuthProvider(gitRepository?.credentials));
 
   useEffect(() => {
     modalRef.current?.show();

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
@@ -5,6 +5,7 @@ import { useFetcher, useParams } from 'react-router-dom';
 
 import { docsGitSync } from '../../../../common/documentation';
 import type { GitRepository, OauthProviderName } from '../../../../models/git-repository';
+import type { GitCredentials } from '../../../../sync/git/git-vcs';
 import { Link } from '../../base/link';
 import { Modal, type ModalHandle, type ModalProps } from '../../base/modal';
 import { ModalBody } from '../../base/modal-body';
@@ -17,6 +18,18 @@ import { CustomRepositorySettingsFormGroup } from './custom-repository-settings-
 import { GitHubRepositorySetupFormGroup } from './github-repository-settings-form-group';
 import { GitLabRepositorySetupFormGroup } from './gitlab-repository-settings-form-group';
 
+function getDefaultOAuthProvider(credentials?: GitCredentials | null): OauthProviderName {
+  if (!credentials) {
+    return 'github';
+  }
+
+  if ('oauth2format' in credentials && credentials.oauth2format) {
+    return credentials.oauth2format;
+  }
+
+  return 'custom';
+}
+
 export const GitRepositorySettingsModal = (props: ModalProps & {
   gitRepository?: GitRepository;
 }) => {
@@ -26,7 +39,7 @@ export const GitRepositorySettingsModal = (props: ModalProps & {
   const updateGitRepositoryFetcher = useFetcher();
   const deleteGitRepositoryFetcher = useFetcher();
 
-  const [selectedTab, setTab] = useState<OauthProviderName>('github');
+  const [selectedTab, setTab] = useState<OauthProviderName>(getDefaultOAuthProvider(gitRepository?.credentials));
 
   useEffect(() => {
     modalRef.current?.show();

--- a/packages/insomnia/src/ui/components/modals/project-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/project-modal.tsx
@@ -57,7 +57,7 @@ export const ProjectModal = ({
     username?: string;
     password?: string;
     token?: string;
-    oauth2format: OauthProviderName;
+    oauth2format?: OauthProviderName;
   }>({
     name: project?.name || 'My Project',
     storageType: getDefaultProjectStorageType(storageRule, project),
@@ -67,7 +67,7 @@ export const ProjectModal = ({
     username: gitRepository?.credentials?.username || '',
     password: gitRepository?.credentials && 'password' in gitRepository.credentials ? gitRepository?.credentials?.password : '',
     token: gitRepository?.credentials && 'token' in gitRepository.credentials ? gitRepository?.credentials?.token : '',
-    oauth2format: gitRepository?.credentials && 'oauth2format' in gitRepository.credentials ? gitRepository?.credentials?.oauth2format ?? 'github' : 'github',
+    oauth2format: gitRepository?.credentials && 'oauth2format' in gitRepository.credentials ? gitRepository?.credentials?.oauth2format ?? 'github' : undefined,
   });
 
   const [activeView, setActiveView] = useState<'project' | 'git-clone' | 'git-results' | 'switch-storage-type'>('project');


### PR DESCRIPTION
Highlights:

- [x] Removes an error that was displayed when updating a git repo credentials while the operation worked as expected
- [x] Cleaned up logic for showing the default provider on the repo settings modal
- [x] Fixes an issue where selecting custom credentials when creating a new repo will default to github as the oauth provider