### PR TITLE
feat: temporary tabs - [INS-5088]

### DIFF
--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
@@ -19,6 +19,7 @@ import { RenderError } from '../../../templating/render-error';
 import { getGrpcConnectionErrorDetails } from '../../../utils/grpc';
 import { tryToInterpolateRequestOrShowRenderErrorModal } from '../../../utils/try-interpolate';
 import { setDefaultProtocol } from '../../../utils/url/protocol';
+import { useInsomniaTabContext } from '../../context/app/insomnia-tab-context';
 import { useRequestPatcher } from '../../hooks/use-request';
 import { useActiveRequestSyncVCSVersion, useGitVCSVersion } from '../../hooks/use-vcs-version';
 import type { GrpcRequestState } from '../../routes/debug';
@@ -109,6 +110,9 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
   const activeRequestSyncVersion = useActiveRequestSyncVCSVersion();
   const { workspaceId, requestId } = useParams() as { workspaceId: string; requestId: string };
   const patchRequest = useRequestPatcher();
+
+  const { updateTabById } = useInsomniaTabContext();
+
   // Reset the response pane state when we switch requests, the environment gets modified, or the (Git|Sync)VCS version changes
   const uniquenessKey = `${activeEnvironment.modified}::${requestId}::${gitVersion}::${activeRequestSyncVersion}`;
   const method = methods.find(c => c.fullPath === activeRequest.protoMethodName);
@@ -128,6 +132,9 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
         const clientCertificate = workspaceClientCertificates.find(c => !c.disabled && urlMatchesCertHost(setDefaultProtocol(c.host, 'grpc:'), request.url, false));
         const caCertificate = (await models.caCertificate.findByParentId(workspaceId));
         const caCertificatePath = caCertificate && !caCertificate.disabled ? caCertificate.path : undefined;
+
+        updateTabById?.(requestId, { temporary: true });
+
         window.main.grpc.start({
           request,
           rejectUnauthorized: settings.validateSSL,
@@ -136,7 +143,7 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
             clientKey: clientCertificate?.key ? await readFile(clientCertificate?.key || '', 'utf8') : undefined,
             caCertificate: caCertificatePath ? await readFile(caCertificatePath, 'utf8') : undefined,
           } : {}),
-       });
+        });
         setGrpcState({
           ...grpcState,
           requestMessages: [],
@@ -248,9 +255,9 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                       ...rendered,
                       rejectUnauthorized: settings.validateSSL,
                       ...(activeRequest.url.toLowerCase().startsWith('grpcs:') ? {
-                      clientCert,
-                      clientKey,
-                      caCertificate: caCertificatePath ? await readFile(caCertificatePath, 'utf8') : undefined,
+                        clientCert,
+                        clientKey,
+                        caCertificate: caCertificatePath ? await readFile(caCertificatePath, 'utf8') : undefined,
                       } : {}),
                     };
                     const methods = await window.main.grpc.loadMethodsFromReflection(rendered);
@@ -286,8 +293,8 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
           </div>
         </PaneHeader>
         <PaneBody>
-            <Tabs aria-label='Grpc request pane tabs' className="flex-1 w-full h-full flex flex-col">
-              <TabList className='w-full flex-shrink-0  overflow-x-auto border-solid scro border-b border-b-[--hl-md] bg-[--color-bg] flex items-center h-[--line-height-sm]' aria-label='Request pane tabs'>
+          <Tabs aria-label='Grpc request pane tabs' className="flex-1 w-full h-full flex flex-col">
+            <TabList className='w-full flex-shrink-0  overflow-x-auto border-solid scro border-b border-b-[--hl-md] bg-[--color-bg] flex items-center h-[--line-height-sm]' aria-label='Request pane tabs'>
               {methodType && (
                 <Tab
                   className='flex-shrink-0 h-full flex items-center justify-between cursor-pointer gap-2 outline-none select-none px-3 py-1 text-[--hl] aria-selected:text-[--color-font]  hover:bg-[--hl-sm] hover:text-[--color-font] aria-selected:bg-[--hl-xs] aria-selected:focus:bg-[--hl-sm] aria-selected:hover:bg-[--hl-sm] focus:bg-[--hl-sm] transition-colors duration-300'
@@ -296,10 +303,10 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                   {GrpcMethodTypeName[methodType]}
                 </Tab>
               )}
-                <Tab className='flex-shrink-0 h-full flex items-center justify-between cursor-pointer gap-2 outline-none select-none px-3 py-1 text-[--hl] aria-selected:text-[--color-font]  hover:bg-[--hl-sm] hover:text-[--color-font] aria-selected:bg-[--hl-xs] aria-selected:focus:bg-[--hl-sm] aria-selected:hover:bg-[--hl-sm] focus:bg-[--hl-sm] transition-colors duration-300' id='headers'>
-                  Headers
-                </Tab>
-              </TabList>
+              <Tab className='flex-shrink-0 h-full flex items-center justify-between cursor-pointer gap-2 outline-none select-none px-3 py-1 text-[--hl] aria-selected:text-[--color-font]  hover:bg-[--hl-sm] hover:text-[--color-font] aria-selected:bg-[--hl-xs] aria-selected:focus:bg-[--hl-sm] aria-selected:hover:bg-[--hl-sm] focus:bg-[--hl-sm] transition-colors duration-300' id='headers'>
+                Headers
+              </Tab>
+            </TabList>
             {methodType && (
               <TabPanel className={'w-full h-full overflow-y-auto'} id='method-type'>
                 <>
@@ -375,20 +382,20 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
                 </>
               </TabPanel>
             )}
-              <TabPanel className={'w-full h-full overflow-y-auto'} id='headers'>
-                <ErrorBoundary key={uniquenessKey} errorClassName="font-error pad text-center">
-                  <KeyValueEditor
-                    namePlaceholder="header"
-                    valuePlaceholder="value"
-                    descriptionPlaceholder="description"
-                    pairs={activeRequest.metadata}
-                    isDisabled={running}
-                    handleGetAutocompleteNameConstants={getCommonHeaderNames}
-                    handleGetAutocompleteValueConstants={getCommonHeaderValues}
-                    onChange={(metadata: GrpcRequestHeader[]) => patchRequest(requestId, { metadata })}
-                  />
-                </ErrorBoundary>
-              </TabPanel>
+            <TabPanel className={'w-full h-full overflow-y-auto'} id='headers'>
+              <ErrorBoundary key={uniquenessKey} errorClassName="font-error pad text-center">
+                <KeyValueEditor
+                  namePlaceholder="header"
+                  valuePlaceholder="value"
+                  descriptionPlaceholder="description"
+                  pairs={activeRequest.metadata}
+                  isDisabled={running}
+                  handleGetAutocompleteNameConstants={getCommonHeaderNames}
+                  handleGetAutocompleteValueConstants={getCommonHeaderValues}
+                  onChange={(metadata: GrpcRequestHeader[]) => patchRequest(requestId, { metadata })}
+                />
+              </ErrorBoundary>
+            </TabPanel>
           </Tabs>
         </PaneBody>
       </Pane>

--- a/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/grpc-request-pane.tsx
@@ -133,7 +133,7 @@ export const GrpcRequestPane: FunctionComponent<Props> = ({
         const caCertificate = (await models.caCertificate.findByParentId(workspaceId));
         const caCertificatePath = caCertificate && !caCertificate.disabled ? caCertificate.path : undefined;
 
-        updateTabById?.(requestId, { temporary: true });
+        updateTabById?.(requestId, { temporary: false });
 
         window.main.grpc.start({
           request,

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -13,6 +13,7 @@ import { getOrInheritAuthentication, getOrInheritHeaders } from '../../network/n
 import { tryToInterpolateRequestOrShowRenderErrorModal } from '../../utils/try-interpolate';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from '../../utils/url/querystring';
 import { SegmentEvent } from '../analytics';
+import { useInsomniaTabContext } from '../context/app/insomnia-tab-context';
 import { useReadyState } from '../hooks/use-ready-state';
 import { useRequestPatcher } from '../hooks/use-request';
 import { useRequestMetaPatcher } from '../hooks/use-request';
@@ -101,6 +102,8 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
   const [currentTimeout, setCurrentTimeout] = useState<number | undefined>(undefined);
   const fetcher = useFetcher();
 
+  const { updateTabById } = useInsomniaTabContext();
+
   const { organizationId, projectId, workspaceId, requestId } = useParams() as { organizationId: string; projectId: string; workspaceId: string; requestId: string };
   const connect = useCallback((connectParams: ConnectActionParams) => {
     fetcher.submit(JSON.stringify(connectParams),
@@ -121,6 +124,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
   }, [fetcher, organizationId, projectId, requestId, workspaceId]);
 
   const sendOrConnect = useCallback(async (shouldPromptForPathAfterResponse?: boolean, ignoreUndefinedEnvVariable?: boolean) => {
+    updateTabById?.(requestId, { temporary: false });
     models.stats.incrementExecutedRequests();
     window.main.trackSegmentEvent({
       event: SegmentEvent.requestExecute,
@@ -186,7 +190,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({
         ),
       });
     }
-  }, [activeEnvironment._id, activeRequest, activeWorkspace._id, connect, requestId, send, settings.preferredHttpVersion]);
+  }, [activeEnvironment._id, activeRequest, activeWorkspace._id, connect, requestId, send, settings.preferredHttpVersion, updateTabById]);
 
   useEffect(() => {
     const sendOnMetaEnter = (event: KeyboardEvent) => {

--- a/packages/insomnia/src/ui/components/tabs/tab.tsx
+++ b/packages/insomnia/src/ui/components/tabs/tab.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, { useCallback } from 'react';
 import { Button, GridListItem } from 'react-aria-components';
 
@@ -22,6 +23,7 @@ export interface BaseTab {
   // method is used to display the tag color
   tag?: string;
   method?: string;
+  temporary?: boolean;
 };
 
 const REQUEST_METHOD_STYLE_MAP: Record<string, string> = {
@@ -128,6 +130,14 @@ export const InsomniaTab = ({ tab }: { tab: BaseTab }) => {
     }
   }, [currentOrgTabs.activeTabId, tab.id]);
 
+  const { updateTabById } = useInsomniaTabContext();
+
+  const handleDoubleClick = () => {
+    if (tab.temporary) {
+      updateTabById?.(tab.id, { temporary: false });
+    }
+  };
+
   return (
     <GridListItem
       textValue={`tab-${tab.name}`}
@@ -137,13 +147,17 @@ export const InsomniaTab = ({ tab }: { tab: BaseTab }) => {
     >
       {({ isSelected, isHovered }) => (
         <Tooltip delay={1000} message={`${tab.projectName} / ${tab.workspaceName}`} className='h-full'>
-          <div
+          <div onDoubleClick={handleDoubleClick}
             onAuxClick={e => handleAuxClick(e, tab.id)}
             onContextMenu={handleContextMenu}
             className={`relative flex items-center h-full px-[10px] flex-nowrap border-solid border-r border-[--hl-sm] hover:text-[--color-font] outline-none max-w-[200px] cursor-pointer ${(!isSelected && !isHovered) && 'opacity-[0.7]'}`}
           >
             {renderTabIcon(tab.type)}
-            <span className='mx-[8px] text-nowrap overflow-hidden text-ellipsis'>{tab.name}</span>
+            <span
+              className={classNames('mx-[8px] text-nowrap overflow-hidden text-ellipsis', {
+                'italic': tab.temporary,
+              })}
+            >{tab.name}</span>
             <Button
               className='hover:bg-[--hl-md] h-[15px] w-[15px] flex justify-center items-center'
               onPress={() => handleClose(tab.id)}

--- a/packages/insomnia/src/ui/components/tabs/tab.tsx
+++ b/packages/insomnia/src/ui/components/tabs/tab.tsx
@@ -147,7 +147,8 @@ export const InsomniaTab = ({ tab }: { tab: BaseTab }) => {
     >
       {({ isSelected, isHovered }) => (
         <Tooltip delay={1000} message={`${tab.projectName} / ${tab.workspaceName}`} className='h-full'>
-          <div onDoubleClick={handleDoubleClick}
+          <div
+            onDoubleClick={handleDoubleClick}
             onAuxClick={e => handleAuxClick(e, tab.id)}
             onContextMenu={handleContextMenu}
             className={`relative flex items-center h-full px-[10px] flex-nowrap border-solid border-r border-[--hl-sm] hover:text-[--color-font] outline-none max-w-[200px] cursor-pointer ${(!isSelected && !isHovered) && 'opacity-[0.7]'}`}

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -5,6 +5,7 @@ import * as models from '../../../models';
 import type { WebSocketRequest } from '../../../models/websocket-request';
 import { tryToInterpolateRequestOrShowRenderErrorModal } from '../../../utils/try-interpolate';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from '../../../utils/url/querystring';
+import { useInsomniaTabContext } from '../../context/app/insomnia-tab-context';
 import type { ConnectActionParams } from '../../routes/request';
 import { OneLineEditor, type OneLineEditorHandle } from '../codemirror/one-line-editor';
 import { createKeybindingsHandler, useDocBodyKeyboardShortcuts } from '../keydown-binder';
@@ -28,6 +29,8 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, environmentId,
   const fetcher = useFetcher();
   const { organizationId, projectId, workspaceId, requestId } = useParams() as { organizationId: string; projectId: string; workspaceId: string; requestId: string };
 
+  const { updateTabById } = useInsomniaTabContext();
+
   const connect = useCallback((connectParams: ConnectActionParams) => {
     fetcher.submit(JSON.stringify(connectParams), {
       action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${requestId}/connect`,
@@ -37,6 +40,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, environmentId,
   }, [fetcher, organizationId, projectId, requestId, workspaceId]);
 
   const handleSubmit = useCallback(async () => {
+    updateTabById?.(request._id, { temporary: false });
     if (isOpen) {
       window.main.webSocket.close({ requestId: request._id });
       return;
@@ -63,7 +67,7 @@ export const WebSocketActionBar: FC<ActionBarProps> = ({ request, environmentId,
       cookieJar: rendered.workspaceCookieJar,
       suppressUserAgent: rendered.suppressUserAgent,
     });
-  }, [connect, environmentId, isOpen, request, workspaceId]);
+  }, [connect, environmentId, isOpen, request, updateTabById, workspaceId]);
 
   useEffect(() => {
     const sendOnMetaEnter = (event: KeyboardEvent) => {

--- a/packages/insomnia/src/ui/context/app/insomnia-tab-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-tab-context.tsx
@@ -18,7 +18,7 @@ interface ContextProps {
   appTabsRef?: React.MutableRefObject<InsomniaTabs | undefined>;
   closeTabById: (id: string) => void;
   addTab: (tab: BaseTab) => void;
-  changeActiveTab: (id: string) => void;
+  changeActiveTab: (id: string, options?: { navigate: boolean }) => void;
   closeAllTabsUnderWorkspace?: (workspaceId: string) => void;
   closeAllTabsUnderProject?: (projectId: string) => void;
   batchCloseTabs?: (ids: string[]) => void;
@@ -79,6 +79,20 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
   const addTab = useCallback((tab: BaseTab) => {
     const currentTabs = appTabsRef?.current?.[organizationId] || { tabList: [], activeTabId: '' };
 
+    if (tab.temporary) {
+      // If the tab is temporary, replace the existing temporary tab
+      const temporaryIndex = currentTabs.tabList.findIndex(t => t.temporary);
+      if (temporaryIndex !== -1) {
+        const newTabList = [...currentTabs.tabList];
+        newTabList.splice(temporaryIndex, 1, tab);
+        updateInsomniaTabs({
+          organizationId,
+          tabList: newTabList,
+          activeTabId: tab.id,
+        });
+        return;
+      }
+    }
     updateInsomniaTabs({
       organizationId,
       tabList: [...currentTabs.tabList, tab],
@@ -244,14 +258,16 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
     });
   }, [organizationId, updateInsomniaTabs]);
 
-  const changeActiveTab = useCallback((id: string) => {
+  const changeActiveTab = useCallback((id: string, options = { navigate: true }) => {
     const currentTabs = appTabsRef?.current?.[organizationId] || { tabList: [], activeTabId: '' };
     if (!currentTabs) {
       return;
     }
     const tab = currentTabs?.tabList.find(tab => tab.id === id);
-    // keep the search params when navigate to another tab
-    tab?.url && navigate(tab.url);
+    if (options?.navigate && tab?.url) {
+      navigate(tab.url);
+    }
+
     updateInsomniaTabs({
       organizationId,
       tabList: currentTabs.tabList,

--- a/packages/insomnia/src/ui/hooks/use-insomnia-tab.ts
+++ b/packages/insomnia/src/ui/hooks/use-insomnia-tab.ts
@@ -41,7 +41,7 @@ export const useInsomniaTab = ({
 
   const { appTabsRef, addTab, changeActiveTab, closeTabById } = useInsomniaTabContext();
   const location = useLocation();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const generateTabUrl = useCallback((type: TabType) => {
     if (type === 'request') {
@@ -276,7 +276,22 @@ export const useInsomniaTab = ({
     if (!currentTab && type) {
       const tabInfo = packTabInfo(type);
       if (tabInfo) {
-        addTab(tabInfo);
+        let temporary = false;
+        // current temporary tabs scope only for request collection
+        if ((type === 'request' || type === 'folder' || type === 'collection') && !searchParams.get('created')) {
+          temporary = true;
+        }
+
+        if (searchParams.get('created')) {
+          const newSearchParams = new URLSearchParams(searchParams);
+          newSearchParams.delete('created');
+          setSearchParams(newSearchParams);
+        }
+
+        addTab({
+          ...tabInfo,
+          temporary,
+        });
         return;
       }
     }
@@ -285,10 +300,10 @@ export const useInsomniaTab = ({
     if (currentTab) {
       const currentActiveTabId = appTabsRef?.current?.[organizationId]?.activeTabId;
       if (currentActiveTabId !== currentTab.id) {
-        changeActiveTab(currentTab.id);
+        changeActiveTab(currentTab.id, { navigate: false });
       }
     }
-  }, [addTab, appTabsRef, changeActiveTab, getCurrentTab, location.pathname, organizationId, packTabInfo]);
+  }, [addTab, appTabsRef, changeActiveTab, getCurrentTab, location.pathname, organizationId, packTabInfo, searchParams, setSearchParams]);
 
   useDocBodyKeyboardShortcuts({
     close_tab: event => {

--- a/packages/insomnia/src/ui/hooks/use-request.ts
+++ b/packages/insomnia/src/ui/hooks/use-request.ts
@@ -10,11 +10,14 @@ import type { RequestMeta } from '../../models/request-meta';
 import type { Settings } from '../../models/settings';
 import type { WebSocketRequest } from '../../models/websocket-request';
 import type { WorkspaceMeta } from '../../models/workspace-meta';
+import { useInsomniaTabContext } from '../context/app/insomnia-tab-context';
 
 export const useRequestPatcher = () => {
   const { organizationId, projectId, workspaceId } = useParams<{ organizationId: string; projectId: string; workspaceId: string }>();
+  const { updateTabById } = useInsomniaTabContext();
   const fetcher = useFetcher();
   return (requestId: string, patch: Partial<GrpcRequest> | Partial<Request> | Partial<WebSocketRequest>) => {
+    updateTabById?.(requestId, { temporary: false });
     fetcher.submit(JSON.stringify(patch), {
       action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${requestId}/update`,
       method: 'post',
@@ -25,8 +28,10 @@ export const useRequestPatcher = () => {
 
 export const useRequestMetaPatcher = () => {
   const { organizationId, projectId, workspaceId } = useParams<{ organizationId: string; projectId: string; workspaceId: string }>();
+  const { updateTabById } = useInsomniaTabContext();
   const fetcher = useFetcher();
   return (requestId: string, patch: Partial<GrpcRequestMeta> | Partial<RequestMeta>) => {
+    updateTabById?.(requestId, { temporary: false });
     fetcher.submit(patch, {
       action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${requestId}/update-meta`,
       method: 'post',
@@ -37,8 +42,10 @@ export const useRequestMetaPatcher = () => {
 
 export const useRequestGroupPatcher = () => {
   const { organizationId, projectId, workspaceId } = useParams<{ organizationId: string; projectId: string; workspaceId: string }>();
+  const { updateTabById } = useInsomniaTabContext();
   const fetcher = useFetcher();
   return (requestGroupId: string, patch: Partial<RequestGroup>) => {
+    updateTabById?.(requestGroupId, { temporary: false });
     fetcher.submit(JSON.stringify(patch), {
       action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request-group/${requestGroupId}/update`,
       method: 'post',
@@ -49,8 +56,10 @@ export const useRequestGroupPatcher = () => {
 
 export const useRequestGroupMetaPatcher = () => {
   const { organizationId, projectId, workspaceId } = useParams<{ organizationId: string; projectId: string; workspaceId: string }>();
+  const { updateTabById } = useInsomniaTabContext();
   const fetcher = useFetcher();
   return (requestGroupId: string, patch: Partial<RequestGroupMeta>) => {
+    updateTabById?.(requestGroupId, { temporary: false });
     fetcher.submit(patch, {
       action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request-group/${requestGroupId}/update-meta`,
       method: 'post',

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -227,7 +227,8 @@ export const createRequestAction: ActionFunction = async ({ request, params }) =
   models.stats.incrementCreatedRequests();
   window.main.trackSegmentEvent({ event: SegmentEvent.requestCreate, properties: { requestType } });
 
-  return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${activeRequestId}`);
+  // add a created query param to the URL to indicate that the request was just created, this is for distinguishing if we will create a temporary or permanent tab
+  return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${activeRequestId}?created=true`);
 };
 export const updateRequestAction: ActionFunction = async ({ request, params }) => {
   const { requestId } = params;


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

**Background**

> Add an option not to open a new tab when clicking on a folders (i have to many folders and need to close tabs... boring)
(https://github.com/Kong/insomnia/discussions/6108#discussioncomment-12263700)

support temporary tabs to avoid creating too many useless tabs.

**Scope**
only for Request Collection

**Highlights**

- Click on request/folder in the sidebar, create a temporary tab with a different style(italic font style).
- only one temporary tab exists, click another request will replace the existing temporary tab.
- double click & edit request & send request will convert the temporary tab to a permanent one.
- create new request will create a permanent tab


https://github.com/user-attachments/assets/743900af-6444-4a4b-a1c8-a19c89a29f84

