### PR TITLE
feat: add hotKey to close tab - [INS-5155]

### DIFF
--- a/packages/insomnia/src/common/hotkeys.ts
+++ b/packages/insomnia/src/common/hotkeys.ts
@@ -35,6 +35,7 @@ export const keyboardShortcutDescriptions: Record<KeyboardShortcut, string> = {
   'environment_showVariableSourceAndValue': 'Show variable source and value',
   'beautifyRequestBody': 'Beautify Active Code Editors',
   'graphql_explorer_focus_filter': 'Focus GraphQL Explorer Filter',
+  'close_tab': 'Close Tab',
 };
 
 /**
@@ -162,6 +163,10 @@ const defaultRegistry: HotKeyRegistry = {
   graphql_explorer_focus_filter: {
     macKeys: [{ shift: true, meta: true, keyCode: keyboardKeys.i.keyCode }],
     winLinuxKeys: [{ ctrl: true, shift: true, keyCode: keyboardKeys.i.keyCode }],
+  },
+  close_tab: {
+    macKeys: [{ meta: true, keyCode: keyboardKeys.w.keyCode }],
+    winLinuxKeys: [{ ctrl: true, keyCode: keyboardKeys.w.keyCode }],
   },
 };
 

--- a/packages/insomnia/src/common/settings.ts
+++ b/packages/insomnia/src/common/settings.ts
@@ -55,7 +55,8 @@ export type KeyboardShortcut =
   | 'request_togglePin'
   | 'environment_showVariableSourceAndValue'
   | 'beautifyRequestBody'
-  | 'graphql_explorer_focus_filter';
+  | 'graphql_explorer_focus_filter'
+  | 'close_tab';
 
 /**
  * The collection of defined hotkeys.

--- a/packages/insomnia/src/ui/hooks/use-insomnia-tab.ts
+++ b/packages/insomnia/src/ui/hooks/use-insomnia-tab.ts
@@ -9,6 +9,7 @@ import type { RequestGroup } from '../../models/request-group';
 import type { UnitTestSuite } from '../../models/unit-test-suite';
 import type { WebSocketRequest } from '../../models/websocket-request';
 import type { Workspace } from '../../models/workspace';
+import { useDocBodyKeyboardShortcuts } from '../components/keydown-binder';
 import { type BaseTab, type TabType } from '../components/tabs/tab';
 import { TAB_ROUTER_PATH } from '../components/tabs/tab-list';
 import { formatMethodName, getRequestMethodShortHand } from '../components/tags/method-tag';
@@ -38,7 +39,7 @@ export const useInsomniaTab = ({
   unitTestSuite,
 }: InsomniaTabProps) => {
 
-  const { appTabsRef, addTab, changeActiveTab } = useInsomniaTabContext();
+  const { appTabsRef, addTab, changeActiveTab, closeTabById } = useInsomniaTabContext();
   const location = useLocation();
   const [searchParams] = useSearchParams();
 
@@ -288,4 +289,14 @@ export const useInsomniaTab = ({
       }
     }
   }, [addTab, appTabsRef, changeActiveTab, getCurrentTab, location.pathname, organizationId, packTabInfo]);
+
+  useDocBodyKeyboardShortcuts({
+    close_tab: event => {
+      event.preventDefault();
+      const currentActiveTabId = appTabsRef?.current?.[organizationId]?.activeTabId;
+      if (currentActiveTabId) {
+        closeTabById(currentActiveTabId);
+      }
+    },
+  });
 };


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
close #8487

Changes:

- add a new KeyboardShortcut `close_tab`, and default is cwd+w(macos)/ctrl+w(win).
- user can customize the key shortcut in preference
![image](https://github.com/user-attachments/assets/e2d2246a-7b38-4a6c-b073-58f906d0e0d4)
