### PR TITLE
fix(Import): Allow importing cookies with empty value and other properties

### DIFF
--- a/packages/insomnia/src/common/import-v5-parser.ts
+++ b/packages/insomnia/src/common/import-v5-parser.ts
@@ -28,12 +28,12 @@ const CACertificateSchema = z.object({
 });
 
 const CookieSchema = z.object({
-  id: z.string(),
-  key: z.string(),
-  value: z.string(),
+  id: z.string().optional().default(() => crypto.randomUUID()),
+  key: z.string().optional().default(''),
+  value: z.string().optional().default(''),
   expires: z.coerce.date().nullable().default(null),
-  domain: z.string(),
-  path: z.string(),
+  domain: z.string().optional().default(''),
+  path: z.string().optional().default('/'),
   secure: z.boolean().optional().default(false),
   httpOnly: z.boolean().optional().default(false),
   extensions: z.array(jsonSchema).optional(),


### PR DESCRIPTION
Fixes an issue where importing cookies with undefined values would fail to import an Insomnia v5 file.
 - [x] Makes cookie value, id, key, domain and path optional and defaults to empty string if needed