### PR TITLE
fix: Pin all external github actions to their corresponding commit SHAs

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@266845213695c3047d210b2e8fbc42ecdaf45802 # master
         with:
           test-bot: false
 
@@ -36,7 +36,7 @@ jobs:
         run: brew tap homebrew/homebrew-cask --force
 
       - name: Configure Git user
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@266845213695c3047d210b2e8fbc42ecdaf45802 # master
         with:
           username: 'insomnia-infra'
 
@@ -46,17 +46,17 @@ jobs:
       # Update Homebrew's Inso(mnia) formulae
       # https://github.com/Homebrew/actions/tree/master/bump-formulae
       - name: Bump Inso (Beta) Formula
-        uses: Homebrew/actions/bump-packages@master
+        uses: Homebrew/actions/bump-packages@266845213695c3047d210b2e8fbc42ecdaf45802 # master
         with:
           token: ${{ secrets.HOMEBREW_PR_GH_TOKEN }}
           casks: inso@beta
       - name: Bump Inso Formula
-        uses: Homebrew/actions/bump-packages@master
+        uses: Homebrew/actions/bump-packages@266845213695c3047d210b2e8fbc42ecdaf45802 # master
         with:
           token: ${{ secrets.HOMEBREW_PR_GH_TOKEN }}
           casks: inso
       - name: Bump Insomnia Formula
-        uses: Homebrew/actions/bump-packages@master
+        uses: Homebrew/actions/bump-packages@266845213695c3047d210b2e8fbc42ecdaf45802 # master
         with:
           token: ${{ secrets.HOMEBREW_PR_GH_TOKEN }}
           # Bump only these formulae if outdated

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -116,7 +116,7 @@ jobs:
       # signs unpacked electron-builder contents, in this case only the .exe
       - name: Code-sign unpacked .exe (Windows only)
         if: runner.os == 'Windows'
-        uses: sslcom/esigner-codesign@develop
+        uses: sslcom/esigner-codesign@3b2dc3b6075c05ef889d88b761a1fd0183b28c6a # develop
         with:
           command: batch_sign
           username: ${{secrets.ES_USERNAME}}
@@ -174,7 +174,7 @@ jobs:
 
       - name: Notarize Inso CLI installer (macOS only)
         if:  runner.os == 'macOS'
-        uses: lando/notarize-action@v2
+        uses: lando/notarize-action@b5c3ef16cf2fbcf2af26dc58c90255ec242abeed # v2
         with:
           product-path: ./packages/${{ env.INSO_PACKAGE_NAME }}/artifacts/inso-${{ matrix.os }}-${{ env.INSO_VERSION }}.pkg
           primary-bundle-id: com.insomnia.inso
@@ -185,13 +185,13 @@ jobs:
 
       - name: Staple Inso CLI installer (macOS only)
         if: runner.os == 'macOS'
-        uses: BoundfoxStudios/action-xcode-staple@v1
+        uses: BoundfoxStudios/action-xcode-staple@1e2200b448c6ed4dd44b963ff17d3e340fc6b064 # v1
         with:
           product-path: ./packages/${{ env.INSO_PACKAGE_NAME }}/artifacts/inso-${{ matrix.os }}-${{ env.INSO_VERSION }}.pkg
 
       - name: Notarize Inso CLI binary (macOS only)
         if: runner.os == 'macOS'
-        uses: lando/notarize-action@v2
+        uses: lando/notarize-action@b5c3ef16cf2fbcf2af26dc58c90255ec242abeed # v2
         with:
           product-path: ./packages/${{ env.INSO_PACKAGE_NAME }}/binaries/inso
           primary-bundle-id: com.insomnia.inso-binary
@@ -262,7 +262,7 @@ jobs:
           BRANCH: ${{ github.ref_name }}
 
       - name: update-pull-request
-        uses: kt3k/update-pr-description@v2.0.0
+        uses: kt3k/update-pr-description@fef8b17c6648e0daa550d2ed6b5cf140d282574e # v2.0.0
         with:
           pr_body: |
             # WARNING: <ins>Do not merge</ins> this PR. Use the "Publish" workflow.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -51,7 +51,7 @@ jobs:
         run: npm ci
 
       - name: Download release artifacts from insomnia-ee
-        uses: robinraju/release-downloader@v1
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1
         with:
           repository: ${{ env.ARTIFACTS_REPOSITORY }}
           tag: core@${{ env.RELEASE_VERSION }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Docker meta for Inso CLI Docker Image
         id: inso_docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
         with:
           images: ${{ env.INSO_DOCKER_IMAGE }}
           tags: |
@@ -73,7 +73,7 @@ jobs:
 
       # Setup regctl to parse platform specific image digest from image manifest
       - name: Install regctl
-        uses: regclient/actions/regctl-installer@main
+        uses: regclient/actions/regctl-installer@ce5fd131e371ffcdd7508b478cb223b3511a9183 # main
 
       # The image manifest digest/sha is generated only after the image is published to registry
       - name: Parse architecture specific digest from image manifest
@@ -123,7 +123,7 @@ jobs:
           ${{env.ARTIFACTS_DOWNLOAD_PATH}}/Insomnia.Core-${{env.RELEASE_VERSION}}.{snap,tar.gz,zip,rpm,dmg,deb,AppImage,exe}
 
       - name: Create Tag and Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1
         id: core_tag_and_release
         with:
           tag: ${{ env.RELEASE_CORE_TAG }}
@@ -136,7 +136,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts to release
-        uses: xresloader/upload-to-github-release@v1
+        uses: xresloader/upload-to-github-release@d29300fdff9f0fcd7c3eb960c490b2a6640fbf50 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -195,7 +195,7 @@ jobs:
 
       - name: Upload x64 Linux snap to snapcraft (beta and stable only)
         if: ${{ !contains(github.event.inputs.version, 'alpha') }}
-        uses: canonical/action-publish@v1
+        uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN_FILE_NEW }}
         with:
@@ -229,7 +229,7 @@ jobs:
             ${{ env.IS_PRERELEASE == 'true' && '--internal' || '--publish' }}
 
       - name: Configure Git user
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@266845213695c3047d210b2e8fbc42ecdaf45802 # master
         with:
           username: ${{ (github.event_name == 'workflow_dispatch' && github.actor) || 'insomnia-infra' }}
 

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -67,7 +67,7 @@ jobs:
           echo "RELEASE_BRANCH=release/$(node -e "console.log(require('./packages/insomnia/package.json').version)")" >> $GITHUB_ENV
 
       - name: Create Branch # Create a branch if it doesn't exist
-        uses: peterjgrainger/action-create-branch@v2.2.0
+        uses: peterjgrainger/action-create-branch@c2800a3a9edbba2218da6861fa46496cf8f3195a # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -81,7 +81,7 @@ jobs:
 
       - name: Configure Git user
         id: configure_git_user
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@266845213695c3047d210b2e8fbc42ecdaf45802 # master
         with:
           username: ${{ (github.event_name == 'workflow_dispatch' && github.actor) || 'insomnia-infra' }}
 
@@ -117,7 +117,7 @@ jobs:
           RELEASE_GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
 
       - name: Run the Action
-        uses: devops-infra/action-pull-request@v0.4.2
+        uses: devops-infra/action-pull-request@3f1cdfa7c7976f6302e820e2b391e846d933693c # v0.4.2
         with:
           github_token: ${{ secrets.RELEASE_GH_TOKEN }}
           source_branch: ${{ env.RELEASE_BRANCH}}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -23,13 +23,13 @@ jobs:
           ref: ${{ github.event.release.target_commitish }}
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1
         with:
           latest-version: ${{ github.event.release.tag_name }}
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5
         with:
           branch: ${{ github.event.release.target_commitish }}
           commit_message: Update CHANGELOG


### PR DESCRIPTION
Replace branch reference with commit SHA for external github actions