### PR TITLE
Fix the bug that the default menu can not be replaced on mac

### DIFF
--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -699,7 +699,13 @@ export function createWindow({ firstLaunch }: { firstLaunch?: boolean } = {}): E
     template.push(developerMenu);
   }
 
-  mainBrowserWindow.setMenu(Menu.buildFromTemplate(template));
+  if (isMac()) {
+    Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+  } else {
+    // setMenu only works for Windows and Linux
+    mainBrowserWindow.setMenu(Menu.buildFromTemplate(template));
+  }
+
   return mainBrowserWindow;
 }
 


### PR DESCRIPTION
browserWindow.setMenu is exclusive for win and linux, use Menu.setApplicationMenu for mac.