### PR TITLE
chore: bump sentry sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3066,16 +3066,16 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.0.tgz",
-      "integrity": "sha512-Q57JGpH6T4dkYHo9tKXONgLtxzsh1ZEW5M9A/OwKrZFyEpLqWgjhcZ3hIuVvDlhb426iDF1f9FPToV/mi5rpeA==",
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.1.tgz",
+      "integrity": "sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@types/connect": "3.4.36"
+        "@types/connect": "3.4.38"
       },
       "engines": {
         "node": ">=14"
@@ -3085,13 +3085,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.0.tgz",
-      "integrity": "sha512-88+qCHZC02up8PwKHk0UQKLLqGGURzS3hFQBZC7PnGwReuoKjHXS1o29H58S+QkXJpkTr2GACbx8j6mUoGjNPA==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.1.tgz",
+      "integrity": "sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0"
+        "@opentelemetry/instrumentation": "^0.57.1"
       },
       "engines": {
         "node": ">=14"
@@ -3101,14 +3101,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.0.tgz",
-      "integrity": "sha512-XFWVx6k0XlU8lu6cBlCa29ONtVt6ADEjmxtyAyeF2+rifk8uBJbk1La0yIVfI0DoKURGbaEDTNelaXG9l/lNNQ==",
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.1.tgz",
+      "integrity": "sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "engines": {
@@ -3119,14 +3119,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.44.1.tgz",
-      "integrity": "sha512-RoVeMGKcNttNfXMSl6W4fsYoCAYP1vi6ZAWIGhBY+o7R9Y0afA7f9JJL0j8LHbyb0P0QhSYk+6O56OwI2k4iRQ==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.44.2.tgz",
+      "integrity": "sha512-arSp97Y4D2NWogoXRb8CzFK3W2ooVdvqRRtQDljFt9uC3zI6OuShgey6CVFC0JxT1iGjkAr1r4PDz23mWrFULQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "engines": {
@@ -3137,14 +3137,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fs": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.0.tgz",
-      "integrity": "sha512-JGwmHhBkRT2G/BYNV1aGI+bBjJu4fJUD/5/Jat0EWZa2ftrLV3YE8z84Fiij/wK32oMZ88eS8DI4ecLGZhpqsQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.1.tgz",
+      "integrity": "sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.0"
+        "@opentelemetry/instrumentation": "^0.57.1"
       },
       "engines": {
         "node": ">=14"
@@ -3154,13 +3154,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.0.tgz",
-      "integrity": "sha512-at8GceTtNxD1NfFKGAuwtqM41ot/TpcLh+YsGe4dhf7gvv1HW/ZWdq6nfRtS6UjIvZJOokViqLPJ3GVtZItAnQ==",
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.1.tgz",
+      "integrity": "sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0"
+        "@opentelemetry/instrumentation": "^0.57.1"
       },
       "engines": {
         "node": ">=14"
@@ -3170,13 +3170,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.0.tgz",
-      "integrity": "sha512-Cc8SMf+nLqp0fi8oAnooNEfwZWFnzMiBHCGmDFYqmgjPylyLmi83b+NiTns/rKGwlErpW0AGPt0sMpkbNlzn8w==",
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.1.tgz",
+      "integrity": "sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0"
+        "@opentelemetry/instrumentation": "^0.57.1"
       },
       "engines": {
         "node": ">=14"
@@ -3186,14 +3186,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.1.tgz",
-      "integrity": "sha512-VH6mU3YqAKTePPfUPwfq4/xr049774qWtfTuJqVHoVspCLiT3bW+fCQ1toZxt6cxRPYASoYaBsMA3CWo8B8rcw==",
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.2.tgz",
+      "integrity": "sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "engines": {
@@ -3204,51 +3204,17 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.1.tgz",
-      "integrity": "sha512-ThLmzAQDs7b/tdKI3BV2+yawuF09jF111OFsovqT1Qj3D8vjwKBwhi/rDE5xethwn4tSXtZcJ9hBsVAlWFQZ7g==",
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.2.tgz",
+      "integrity": "sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/instrumentation": "0.57.1",
+        "@opentelemetry/instrumentation": "0.57.2",
         "@opentelemetry/semantic-conventions": "1.28.0",
         "forwarded-parse": "2.1.2",
         "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/api-logs": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.1.tgz",
-      "integrity": "sha512-I4PHczeujhQAQv6ZBzqHYEUiggZL4IdSMixtVD3EYqbdrjujE7kRfI5QohjlPoJm8BvenoW5YaTMWRrbpot6tg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.1.tgz",
-      "integrity": "sha512-SgHEKXoVxOjc20ZYusPG3Fh+RLIZTSa4x8QtD3NfgAUDyqdFFS9W1F2ZVbZkqDCdyMcQG02Ok4duUGLHJXHgbA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.57.1",
-        "@types/shimmer": "^1.2.0",
-        "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -3268,13 +3234,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.0.tgz",
-      "integrity": "sha512-4HqP9IBC8e7pW9p90P3q4ox0XlbLGme65YTrA3UTLvqvo4Z6b0puqZQP203YFu8m9rE/luLfaG7/xrwwqMUpJw==",
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.1.tgz",
+      "integrity": "sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -3286,13 +3252,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-kafkajs": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.0.tgz",
-      "integrity": "sha512-LB+3xiNzc034zHfCtgs4ITWhq6Xvdo8bsq7amR058jZlf2aXXDrN9SV4si4z2ya9QX4tz6r4eZJwDkXOp14/AQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.1.tgz",
+      "integrity": "sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "engines": {
@@ -3303,13 +3269,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.0.tgz",
-      "integrity": "sha512-SlT0+bLA0Lg3VthGje+bSZatlGHw/vwgQywx0R/5u9QC59FddTQSPJeWNw29M6f8ScORMeUOOTwihlQAn4GkJQ==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.1.tgz",
+      "integrity": "sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "engines": {
@@ -3320,14 +3286,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.0.tgz",
-      "integrity": "sha512-HFdvqf2+w8sWOuwtEXayGzdZ2vWpCKEQv5F7+2DSA74Te/Cv4rvb2E5So5/lh+ok4/RAIPuvCbCb/SHQFzMmbw==",
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.1.tgz",
+      "integrity": "sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "engines": {
@@ -3338,13 +3304,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.0.tgz",
-      "integrity": "sha512-Tn7emHAlvYDFik3vGU0mdwvWJDwtITtkJ+5eT2cUquct6nIs+H8M47sqMJkCpyPe5QIBJoTOHxmc6mj9lz6zDw==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.1.tgz",
+      "integrity": "sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0"
+        "@opentelemetry/instrumentation": "^0.57.1"
       },
       "engines": {
         "node": ">=14"
@@ -3354,13 +3320,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.51.0.tgz",
-      "integrity": "sha512-cMKASxCX4aFxesoj3WK8uoQ0YUrRvnfxaO72QWI2xLu5ZtgX/QvdGBlU3Ehdond5eb74c2s1cqRQUIptBnKz1g==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.52.0.tgz",
+      "integrity": "sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "engines": {
@@ -3371,14 +3337,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.0.tgz",
-      "integrity": "sha512-mtVv6UeaaSaWTeZtLo4cx4P5/ING2obSqfWGItIFSunQBrYROfhuVe7wdIrFUs2RH1tn2YYpAJyMaRe/bnTTIQ==",
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.1.tgz",
+      "integrity": "sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "engines": {
@@ -3389,13 +3355,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.0.tgz",
-      "integrity": "sha512-tWWyymgwYcTwZ4t8/rLDfPYbOTF3oYB8SxnYMtIQ1zEf5uDm90Ku3i6U/vhaMyfHNlIHvDhvJh+qx5Nc4Z3Acg==",
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.1.tgz",
+      "integrity": "sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mysql": "2.15.26"
       },
@@ -3407,13 +3373,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.0.tgz",
-      "integrity": "sha512-qLslv/EPuLj0IXFvcE3b0EqhWI8LKmrgRPIa4gUd8DllbBpqJAvLNJSv3cC6vWwovpbSI3bagNO/3Q2SuXv2xA==",
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.2.tgz",
+      "integrity": "sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1"
       },
@@ -3424,33 +3390,16 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.44.0.tgz",
-      "integrity": "sha512-t16pQ7A4WYu1yyQJZhRKIfUNvl5PAaF2pEteLvgJb/BWdd1oNuU1rOYt4S825kMy+0q4ngiX281Ss9qiwHfxFQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.50.0.tgz",
-      "integrity": "sha512-TtLxDdYZmBhFswm8UIsrDjh/HFBeDXd4BLmE8h2MxirNHewLJ0VS9UUddKKEverb5Sm2qFVjqRjcU+8Iw4FJ3w==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.1.tgz",
+      "integrity": "sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.57.0",
-        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.6"
@@ -3462,24 +3411,14 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.0.tgz",
-      "integrity": "sha512-aTUWbzbFMFeRODn3720TZO0tsh/49T8H3h8vVnVKJ+yE36AeW38Uj/8zykQ/9nO8Vrtjr5yKuX3uMiG/W8FKNw==",
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.1.tgz",
+      "integrity": "sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -3491,13 +3430,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.0.tgz",
-      "integrity": "sha512-9zhjDpUDOtD+coeADnYEJQ0IeLVCj7w/hqzIutdp5NqS1VqTAanaEfsEcSypyvYv5DX3YOsTUoF+nr2wDXPETA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.1.tgz",
+      "integrity": "sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/tedious": "^4.0.14"
       },
@@ -3509,14 +3448,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-undici": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.0.tgz",
-      "integrity": "sha512-vm+V255NGw9gaSsPD6CP0oGo8L55BffBc8KnxqsMuc6XiAD1L8SFNzsW0RHhxJFqy9CJaJh+YiJ5EHXuZ5rZBw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.1.tgz",
+      "integrity": "sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.0"
+        "@opentelemetry/instrumentation": "^0.57.1"
       },
       "engines": {
         "node": ">=14"
@@ -3643,49 +3582,16 @@
       }
     },
     "node_modules/@prisma/instrumentation": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.22.0.tgz",
-      "integrity": "sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.5.0.tgz",
+      "integrity": "sha512-morJDtFRoAp5d/KENEm+K6Y3PQcn5bCvpJ5a9y3V3DNMrNy/ZSn2zulPGj+ld+Xj2UYVoaMJ8DpBX/o6iF6OiA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api": "^1.8",
-        "@opentelemetry/instrumentation": "^0.49 || ^0.50 || ^0.51 || ^0.52.0 || ^0.53.0",
-        "@opentelemetry/sdk-trace-base": "^1.22"
-      }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
-      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.53.0",
-        "@types/shimmer": "^1.2.0",
-        "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
+        "@opentelemetry/api": "^1.8"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -6080,157 +5986,156 @@
       "license": "0BSD"
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.55.0.tgz",
-      "integrity": "sha512-ROgqtQfpH/82AQIpESPqPQe0UyWywKJsmVIqi3c5Fh+zkds5LUxnssTj3yNd1x+kxaPDVB023jAP+3ibNgeNDw==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.11.0.tgz",
+      "integrity": "sha512-XS71kRf7lw5St/Jc9G2Viy1cKgqGoPHqUAykXEtFt38JVXdf1TY/dSbKv/PAgNqMvC1xvdTsN0HF/81o7DNUEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.55.0"
+        "@sentry/core": "9.11.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.55.0.tgz",
-      "integrity": "sha512-cP3BD/Q6pquVQ+YL+rwCnorKuTXiS9KXW8HNKu4nmmBAyf7urjs+F6Hr1k9MXP5yQ8W3yK7jRWd09Yu6DHWOiw==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.11.0.tgz",
+      "integrity": "sha512-50KiRmrF1Ldr+KoRawqcCYVk7TAVP8K/I81Jk9YWwlp1+Pu1ArpYDmTNCLXTgoyiyO38aHefKGZJX6AKFuSsUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.55.0"
+        "@sentry/core": "9.11.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.55.0.tgz",
-      "integrity": "sha512-roCDEGkORwolxBn8xAKedybY+Jlefq3xYmgN2fr3BTnsXjSYOPC7D1/mYqINBat99nDtvgFvNfRcZPiwwZ1hSw==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.11.0.tgz",
+      "integrity": "sha512-0k24h58O/2VQw1dwT/zQiWvUzLNQxpxbrVN/MYPT7czSEhI+1bX8fxMHXZORl2JqhetImMXzxH3XkuHQPEqQMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "8.55.0",
-        "@sentry/core": "8.55.0"
+        "@sentry-internal/browser-utils": "9.11.0",
+        "@sentry/core": "9.11.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.55.0.tgz",
-      "integrity": "sha512-nIkfgRWk1091zHdu4NbocQsxZF1rv1f7bbp3tTIlZYbrH62XVZosx5iHAuZG0Zc48AETLE7K4AX9VGjvQj8i9w==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.11.0.tgz",
+      "integrity": "sha512-ZcRg8TWfF0ucjK2i+4TY/blRNJ7YKrgMpx19pFj6eCOJ1K8geSkAFPIfDHcQEwIU1ZTN+HiCwx0JvTI9YZxjfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "8.55.0",
-        "@sentry/core": "8.55.0"
+        "@sentry-internal/replay": "9.11.0",
+        "@sentry/core": "9.11.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.55.0.tgz",
-      "integrity": "sha512-1A31mCEWCjaMxJt6qGUK+aDnLDcK6AwLAZnqpSchNysGni1pSn1RWSmk9TBF8qyTds5FH8B31H480uxMPUJ7Cw==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.11.0.tgz",
+      "integrity": "sha512-DSDj8wQJoiLqqOcntl+7phjd8l8KN9A0vaV7mZNHWbrHU3MVwXqTyLyERRLC6wi0t7F5kqczqa3xLmKjK/fMZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "8.55.0",
-        "@sentry-internal/feedback": "8.55.0",
-        "@sentry-internal/replay": "8.55.0",
-        "@sentry-internal/replay-canvas": "8.55.0",
-        "@sentry/core": "8.55.0"
+        "@sentry-internal/browser-utils": "9.11.0",
+        "@sentry-internal/feedback": "9.11.0",
+        "@sentry-internal/replay": "9.11.0",
+        "@sentry-internal/replay-canvas": "9.11.0",
+        "@sentry/core": "9.11.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.0.tgz",
-      "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.11.0.tgz",
+      "integrity": "sha512-qfb4ahGZubbrNh1MnbEqyHFp87rIwQIZapyQLCaYpudXrP1biEpLOV3mMDvDJWCdX460hoOwQ3SkwipV3We/7w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/electron": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-5.12.0.tgz",
-      "integrity": "sha512-bJdj/AD+Jp2kX/J5cx8qMuieHcl6akhxRVjcGV9pdttLzJHz/Ve7PavKA9W0T3F647+4KVHguFoUnnOzM6hPQg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-6.5.0.tgz",
+      "integrity": "sha512-VFwIr8ovbJGWW3rdnWGEVkRHTVLFj9IiTjguzcCKGGDS3Q1oBqhbxPjX6EKaIubVSKjE1G2gtt+Q9CfM/tMDdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "8.55.0",
-        "@sentry/core": "8.55.0",
-        "@sentry/node": "8.55.0",
+        "@sentry/browser": "9.11.0",
+        "@sentry/core": "9.11.0",
+        "@sentry/node": "9.11.0",
         "deepmerge": "4.3.1"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.55.0.tgz",
-      "integrity": "sha512-h10LJLDTRAzYgay60Oy7moMookqqSZSviCWkkmHZyaDn+4WURnPp5SKhhfrzPRQcXKrweiOwDSHBgn1tweDssg==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.11.0.tgz",
+      "integrity": "sha512-luDsNDHsHkoXbL2Rf1cEKijh6hBfjzGQe09iP6kdZr+HB0bO+qoLe+nZLzSIQTWgWSt2XYNQyiLAsaMlbJZhJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^1.30.1",
         "@opentelemetry/core": "^1.30.1",
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/instrumentation-amqplib": "^0.46.0",
-        "@opentelemetry/instrumentation-connect": "0.43.0",
-        "@opentelemetry/instrumentation-dataloader": "0.16.0",
-        "@opentelemetry/instrumentation-express": "0.47.0",
-        "@opentelemetry/instrumentation-fastify": "0.44.1",
-        "@opentelemetry/instrumentation-fs": "0.19.0",
-        "@opentelemetry/instrumentation-generic-pool": "0.43.0",
-        "@opentelemetry/instrumentation-graphql": "0.47.0",
-        "@opentelemetry/instrumentation-hapi": "0.45.1",
-        "@opentelemetry/instrumentation-http": "0.57.1",
-        "@opentelemetry/instrumentation-ioredis": "0.47.0",
-        "@opentelemetry/instrumentation-kafkajs": "0.7.0",
-        "@opentelemetry/instrumentation-knex": "0.44.0",
-        "@opentelemetry/instrumentation-koa": "0.47.0",
-        "@opentelemetry/instrumentation-lru-memoizer": "0.44.0",
-        "@opentelemetry/instrumentation-mongodb": "0.51.0",
-        "@opentelemetry/instrumentation-mongoose": "0.46.0",
-        "@opentelemetry/instrumentation-mysql": "0.45.0",
-        "@opentelemetry/instrumentation-mysql2": "0.45.0",
-        "@opentelemetry/instrumentation-nestjs-core": "0.44.0",
-        "@opentelemetry/instrumentation-pg": "0.50.0",
-        "@opentelemetry/instrumentation-redis-4": "0.46.0",
-        "@opentelemetry/instrumentation-tedious": "0.18.0",
-        "@opentelemetry/instrumentation-undici": "0.10.0",
+        "@opentelemetry/instrumentation": "^0.57.2",
+        "@opentelemetry/instrumentation-amqplib": "^0.46.1",
+        "@opentelemetry/instrumentation-connect": "0.43.1",
+        "@opentelemetry/instrumentation-dataloader": "0.16.1",
+        "@opentelemetry/instrumentation-express": "0.47.1",
+        "@opentelemetry/instrumentation-fastify": "0.44.2",
+        "@opentelemetry/instrumentation-fs": "0.19.1",
+        "@opentelemetry/instrumentation-generic-pool": "0.43.1",
+        "@opentelemetry/instrumentation-graphql": "0.47.1",
+        "@opentelemetry/instrumentation-hapi": "0.45.2",
+        "@opentelemetry/instrumentation-http": "0.57.2",
+        "@opentelemetry/instrumentation-ioredis": "0.47.1",
+        "@opentelemetry/instrumentation-kafkajs": "0.7.1",
+        "@opentelemetry/instrumentation-knex": "0.44.1",
+        "@opentelemetry/instrumentation-koa": "0.47.1",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.44.1",
+        "@opentelemetry/instrumentation-mongodb": "0.52.0",
+        "@opentelemetry/instrumentation-mongoose": "0.46.1",
+        "@opentelemetry/instrumentation-mysql": "0.45.1",
+        "@opentelemetry/instrumentation-mysql2": "0.45.2",
+        "@opentelemetry/instrumentation-pg": "0.51.1",
+        "@opentelemetry/instrumentation-redis-4": "0.46.1",
+        "@opentelemetry/instrumentation-tedious": "0.18.1",
+        "@opentelemetry/instrumentation-undici": "0.10.1",
         "@opentelemetry/resources": "^1.30.1",
         "@opentelemetry/sdk-trace-base": "^1.30.1",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
-        "@prisma/instrumentation": "5.22.0",
-        "@sentry/core": "8.55.0",
-        "@sentry/opentelemetry": "8.55.0",
-        "import-in-the-middle": "^1.11.2"
+        "@opentelemetry/semantic-conventions": "^1.30.0",
+        "@prisma/instrumentation": "6.5.0",
+        "@sentry/core": "9.11.0",
+        "@sentry/opentelemetry": "9.11.0",
+        "import-in-the-middle": "^1.13.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.55.0.tgz",
-      "integrity": "sha512-UvatdmSr3Xf+4PLBzJNLZ2JjG1yAPWGe/VrJlJAqyTJ2gKeTzgXJJw8rp4pbvNZO8NaTGEYhhO+scLUj0UtLAQ==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.11.0.tgz",
+      "integrity": "sha512-B6RumUFGb1+Q4MymY7IZbdl1Ayz2srqf46itFr1ohE/IpwY7OWKMntop8fxyccUW3ptmPp9cPkBJOaa9UdJhSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.55.0"
+        "@sentry/core": "9.11.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -7064,9 +6969,9 @@
       "license": "MIT"
     },
     "node_modules/@types/connect": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
-      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18709,9 +18614,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.8.0.tgz",
-      "integrity": "sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.9.5.tgz",
+      "integrity": "sha512-DYTWtWpfd5FOro3UnAfwvhD8jh59r2ig8bPtc9H8Ds7MscE/9NYruUQWFAOuraRl29jwcT2kyMFQ3MxeaVjUhg==",
       "dev": true,
       "license": "MIT"
     },
@@ -24041,7 +23946,7 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@getinsomnia/api-client": "0.0.10",
         "@getinsomnia/srp-js": "1.0.0-alpha.1",
-        "@sentry/electron": "^5.12.0",
+        "@sentry/electron": "^6.5.0",
         "@stoplight/spectral-core": "^1.19.5",
         "@stoplight/spectral-formats": "^1.8.2",
         "@stoplight/spectral-ruleset-bundler": "1.6.2",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -94,7 +94,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@getinsomnia/api-client": "0.0.10",
     "@getinsomnia/srp-js": "1.0.0-alpha.1",
-    "@sentry/electron": "^5.12.0",
+    "@sentry/electron": "^6.5.0",
     "@stoplight/spectral-core": "^1.19.5",
     "@stoplight/spectral-formats": "^1.8.2",
     "@stoplight/spectral-ruleset-bundler": "1.6.2",

--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -195,7 +195,7 @@ const _launchApp = async () => {
         console.log('[main] Open Deep Link URL sent from second instance', lastArg);
         window.webContents.send('shell:open', lastArg);
       });
-      window = windowUtils.createWindowsAndReturnMain({ firstLaunch: true });
+      window = windowUtils.createWindowsAndReturnMain();
       const openDeepLinkUrl = (url: string) => {
         console.log('[main] Open Deep Link URL', url);
         window = windowUtils.createWindowsAndReturnMain();

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -139,7 +139,7 @@ export const ipcMainOn = (
   channel: MainOnChannels,
   listener: (event: IpcMainEvent, ...args: any[]) => Promise<void> | any,
 ) => ipcMain.on(channel, listener);
-export type OnceChannels = 'halfSecondAfterAppStart' | 'landingPageRendered';
+export type OnceChannels = 'halfSecondAfterAppStart';
 export const ipcMainOnce = (
   channel: OnceChannels,
   listener: (event: IpcMainEvent, ...args: any[]) => Promise<void> | any,

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -1,12 +1,9 @@
-import * as Sentry from '@sentry/electron/main';
 import chardet from 'chardet';
 import type { MarkerRange } from 'codemirror';
 import { app, BrowserWindow, type IpcRendererEvent, type MenuItemConstructorOptions, shell } from 'electron';
 import fs from 'fs';
 import iconv from 'iconv-lite';
 
-import type { LandingPage } from '../../common/sentry';
-import { APP_START_TIME, SentryMetrics } from '../../common/sentry';
 import type { HiddenBrowserWindowBridgeAPI } from '../../hidden-window';
 import * as models from '../../models';
 import type { SegmentEvent } from '../analytics';
@@ -26,7 +23,7 @@ import {
   updateLatestStepName,
 } from '../network/request-timing';
 import type { WebSocketBridgeAPI } from '../network/websocket';
-import { ipcMainHandle, ipcMainOn, ipcMainOnce, type RendererOnChannels } from './electron';
+import { ipcMainHandle, ipcMainOn, type RendererOnChannels } from './electron';
 import extractPostmanDataDumpHandler from './extractPostmanDataDump';
 import type { gRPCBridgeAPI } from './grpc';
 import type { secretStorageBridgeAPI } from './secret-storage';
@@ -72,7 +69,6 @@ export interface RendererToMainBridgeAPI {
   startExecution: (options: { requestId: string }) => void;
   completeExecutionStep: (options: { requestId: string }) => void;
   updateLatestStepName: (options: { requestId: string; stepName: string }) => void;
-  landingPageRendered: (landingPage: LandingPage, tags?: Record<string, string>) => void;
   extractJsonFileFromPostmanDataDumpArchive: (archivePath: string) => Promise<any>;
 }
 export function registerMainHandlers() {
@@ -176,20 +172,6 @@ export function registerMainHandlers() {
       shell.openExternal(href);
     }
   });
-
-  ipcMainOnce(
-    'landingPageRendered',
-    (_, { landingPage, tags = {} }: { landingPage: LandingPage; tags?: Record<string, string> }) => {
-      const duration = performance.now() - APP_START_TIME;
-      Sentry.metrics.distribution(SentryMetrics.APP_START_DURATION, duration, {
-        tags: {
-          landingPage,
-          ...tags,
-        },
-        unit: 'millisecond',
-      });
-    },
-  );
 
   ipcMainHandle('extractJsonFileFromPostmanDataDumpArchive', extractPostmanDataDumpHandler);
 }

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/electron/main';
 import {
   app,
   BrowserWindow,
@@ -28,7 +27,6 @@ import {
 } from '../common/constants';
 import { docsBase } from '../common/documentation';
 import * as log from '../common/log';
-import { APP_START_TIME, SentryMetrics } from '../common/sentry';
 import { invariant } from '../utils/invariant';
 import ElectronStorage from './electron-storage';
 import { ipcMainOn } from './ipc/electron';
@@ -168,7 +166,7 @@ export function stopHiddenBrowserWindow() {
   hiddenWindowIsBusy = false;
 }
 
-export function createWindow({ firstLaunch }: { firstLaunch?: boolean } = {}): ElectronBrowserWindow {
+export function createWindow(): ElectronBrowserWindow {
   const { bounds, fullscreen, maximize } = getBounds();
   const { x, y, width, height } = bounds;
 
@@ -256,12 +254,7 @@ export function createWindow({ firstLaunch }: { firstLaunch?: boolean } = {}): E
   const appUrl = process.env.APP_RENDER_URL || pathToFileURL(appPath).href;
 
   console.log(`[main] Loading ${appUrl}`);
-  if (firstLaunch) {
-    const duration = performance.now() - APP_START_TIME;
-    Sentry.metrics.distribution(SentryMetrics.MAIN_PROCESS_START_DURATION, duration, {
-      unit: 'millisecond',
-    });
-  }
+
   mainBrowserWindow.loadURL(appUrl);
   // Emitted when the window is closed.
   mainBrowserWindow.on('closed', () => {
@@ -808,8 +801,8 @@ export function initElectronStorage() {
   return electronStorage;
 }
 
-export function createWindowsAndReturnMain({ firstLaunch }: { firstLaunch?: boolean } = {}) {
-  const mainWindow = browserWindows.get('Insomnia') ?? createWindow({ firstLaunch });
+export function createWindowsAndReturnMain() {
+  const mainWindow = browserWindows.get('Insomnia') ?? createWindow();
   if (!browserWindows.get('HiddenBrowserWindow')) {
     createHiddenBrowserWindow();
   }

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -148,11 +148,6 @@ const main: Window['main'] = {
         port.postMessage({ ...options, type: 'runPreRequestScript' });
       }),
   },
-  landingPageRendered: (landingPage, tags) =>
-    ipcRenderer.send('landingPageRendered', {
-      landingPage,
-      tags,
-    }),
   extractJsonFileFromPostmanDataDumpArchive: archivePath =>
     ipcRenderer.invoke('extractJsonFileFromPostmanDataDumpArchive', archivePath),
 };

--- a/packages/insomnia/src/ui/routes/auth.login.tsx
+++ b/packages/insomnia/src/ui/routes/auth.login.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { Button } from 'react-aria-components';
 import { type ActionFunction, redirect, useFetcher, useNavigate } from 'react-router-dom';
 
-import { LandingPage } from '../../common/sentry';
 import { SegmentEvent } from '../analytics';
 import { getLoginUrl } from '../auth-session-provider';
 import { Icon } from '../components/icon';
@@ -60,10 +59,6 @@ const Login = () => {
       },
     );
   };
-
-  useEffect(() => {
-    window.main.landingPageRendered(LandingPage.Login);
-  }, []);
 
   const logoutMessage = window.localStorage.getItem('logoutMessage');
   useEffect(() => {

--- a/packages/insomnia/src/ui/routes/debug.tsx
+++ b/packages/insomnia/src/ui/routes/debug.tsx
@@ -51,7 +51,6 @@ import {
 } from '../../common/constants';
 import { type ChangeBufferEvent, database as db } from '../../common/database';
 import { generateId, isNotNullOrUndefined } from '../../common/misc';
-import { LandingPage } from '../../common/sentry';
 import type { PlatformKeyCombinations } from '../../common/settings';
 import type { GrpcMethodInfo } from '../../main/ipc/grpc';
 import * as models from '../../models';
@@ -70,7 +69,7 @@ import { isRequestGroup, isRequestGroupId, type RequestGroup } from '../../model
 import type { RequestGroupMeta } from '../../models/request-group-meta';
 import { getByParentId as getRequestMetaByParentId } from '../../models/request-meta';
 import { isWebSocketRequest, isWebSocketRequestId, type WebSocketRequest } from '../../models/websocket-request';
-import { isDesign, isScratchpad } from '../../models/workspace';
+import { isDesign } from '../../models/workspace';
 import { scrollElementIntoView } from '../../utils';
 import { getGrpcConnectionErrorDetails, isGrpcConnectionError } from '../../utils/grpc';
 import { invariant } from '../../utils/invariant';
@@ -751,13 +750,6 @@ export const Debug: FC = () => {
       mediaQuery.removeEventListener('change', handleChange);
     };
   }, [settings.forceVerticalLayout, direction]);
-
-  useEffect(() => {
-    if (isScratchpad(activeWorkspace)) {
-      window.main.landingPageRendered(LandingPage.Scratchpad);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useInsomniaTab({
     organizationId,

--- a/packages/insomnia/src/ui/routes/onboarding.tsx
+++ b/packages/insomnia/src/ui/routes/onboarding.tsx
@@ -1,8 +1,7 @@
 import type { IconName } from '@fortawesome/fontawesome-svg-core';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Link, Route, Routes, useLocation } from 'react-router-dom';
 
-import { LandingPage } from '../../common/sentry';
 import { InsomniaLogo } from '../components/insomnia-icon';
 import { TrailLinesContainer } from '../components/trail-lines-container';
 import git_projects from '../images/onboarding/git_projects.png';
@@ -126,10 +125,6 @@ const FeatureWizardView = () => {
 
 const Onboarding = () => {
   const location = useLocation();
-
-  useEffect(() => {
-    window.main.landingPageRendered(LandingPage.Onboarding);
-  }, []);
 
   return (
     <div className="relative flex h-full w-full bg-[--color-bg] text-left">

--- a/packages/insomnia/src/ui/routes/organization.tsx
+++ b/packages/insomnia/src/ui/routes/organization.tsx
@@ -1,5 +1,4 @@
-import * as Sentry from '@sentry/electron/renderer';
-import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react';
+import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import {
   Button,
   Link,
@@ -30,7 +29,6 @@ import { useLocalStorage } from 'react-use';
 import * as session from '../../account/session';
 import { getAppWebsiteBaseURL } from '../../common/constants';
 import { database } from '../../common/database';
-import { SentryMetrics } from '../../common/sentry';
 import { userSession } from '../../models';
 import { updateLocalProjectToRemote } from '../../models/helpers/project';
 import {
@@ -659,24 +657,6 @@ const OrganizationRoute = () => {
 
   const { generating: loadingAI, progress: loadingAIProgress } = useAIContext();
 
-  const nextOrganizationId = useRef<string>();
-  const startSwitchOrganizationTime = useRef<number>();
-
-  useEffect(() => {
-    if (
-      nextOrganizationId.current &&
-      startSwitchOrganizationTime.current &&
-      nextOrganizationId.current === organizationId
-    ) {
-      const duration = performance.now() - startSwitchOrganizationTime.current;
-      Sentry.metrics.distribution(SentryMetrics.ORGANIZATION_SWITCH_DURATION, duration, {
-        unit: 'millisecond',
-      });
-      nextOrganizationId.current = undefined;
-      startSwitchOrganizationTime.current = undefined;
-    }
-  }, [organizationId]);
-
   return (
     <InsomniaEventStreamProvider>
       <InsomniaTabProvider>
@@ -761,8 +741,6 @@ const OrganizationRoute = () => {
                                 : 'outline-transparent hover:outline-[--hl-md] focus:outline-[--hl-md]'
                             }`}
                             onClick={async () => {
-                              nextOrganizationId.current = organization.id;
-                              startSwitchOrganizationTime.current = performance.now();
                               const routeForOrganization = await getInitialRouteForOrganization({
                                 organizationId: organization.id,
                               });

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1,6 +1,5 @@
 import type { IconName } from '@fortawesome/fontawesome-svg-core';
-import * as Sentry from '@sentry/electron/renderer';
-import React, { type FC, Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import React, { type FC, Fragment, useEffect, useMemo, useState } from 'react';
 import {
   Button,
   GridList,
@@ -46,7 +45,6 @@ import {
 } from '../../common/constants';
 import { database } from '../../common/database';
 import { fuzzyMatchAll, isNotNullOrUndefined } from '../../common/misc';
-import { LandingPage, SentryMetrics } from '../../common/sentry';
 import { descendingNumberSort, sortMethodMap } from '../../common/sorting';
 import * as models from '../../models';
 import { userSession } from '../../models';
@@ -929,24 +927,6 @@ const ProjectRoute: FC = () => {
   const isProjectInconsistent =
     isRemoteProjectInconsistent || isLocalProjectInconsistent || isGitSyncProjectInconsistent;
 
-  useEffect(() => {
-    window.main.landingPageRendered(LandingPage.ProjectDashboard);
-  }, []);
-
-  const nextProjectId = useRef<string>();
-  const startSwitchProjectTime = useRef<number>();
-
-  useEffect(() => {
-    if (nextProjectId.current && startSwitchProjectTime.current && nextProjectId.current === projectId) {
-      const duration = performance.now() - startSwitchProjectTime.current;
-      Sentry.metrics.distribution(SentryMetrics.PROJECT_SWITCH_DURATION, duration, {
-        unit: 'millisecond',
-      });
-      nextProjectId.current = undefined;
-      startSwitchProjectTime.current = undefined;
-    }
-  }, [projectId]);
-
   return (
     <ErrorBoundary>
       <Fragment>
@@ -1047,8 +1027,6 @@ const ProjectRoute: FC = () => {
                   onSelectionChange={keys => {
                     if (keys !== 'all') {
                       const [value] = keys.values();
-                      nextProjectId.current = value.toString();
-                      startSwitchProjectTime.current = performance.now();
 
                       navigate({
                         pathname: `/organization/${organizationId}/project/${value}`,

--- a/packages/insomnia/src/ui/routes/remote-collections.tsx
+++ b/packages/insomnia/src/ui/routes/remote-collections.tsx
@@ -1,9 +1,7 @@
-import * as Sentry from '@sentry/electron/renderer';
 import { type ActionFunction, type LoaderFunction, redirect } from 'react-router-dom';
 
 import { database, type Operation } from '../../common/database';
 import { isNotNullOrUndefined } from '../../common/misc';
-import { SentryMetrics } from '../../common/sentry';
 import * as models from '../../models';
 import { canSync } from '../../models';
 import type { ApiSpec } from '../../models/api-spec';
@@ -443,7 +441,6 @@ export const deleteBranchAction: ActionFunction = async ({ params, request }) =>
 };
 
 export const pullFromRemoteAction: ActionFunction = async ({ params }) => {
-  const startPullActionTime = performance.now();
   const { organizationId, projectId, workspaceId } = params;
   invariant(typeof projectId === 'string', 'Project Id is required');
   invariant(typeof workspaceId === 'string', 'Workspace Id is required');
@@ -462,12 +459,6 @@ export const pullFromRemoteAction: ActionFunction = async ({ params }) => {
 
     await database.batchModifyDocs(delta);
     delete remoteCompareCache[workspaceId];
-
-    const duration = performance.now() - startPullActionTime;
-    Sentry.metrics.distribution(SentryMetrics.CLOUD_SYNC_DURATION, duration, {
-      unit: 'millisecond',
-      tags: { action: 'pull' },
-    });
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Unknown error while pulling from remote.';
     return {
@@ -514,7 +505,6 @@ export const fetchRemoteBranchAction: ActionFunction = async ({ request, params 
 };
 
 export const pushToRemoteAction: ActionFunction = async ({ params }) => {
-  const startPushActionTime = performance.now();
   const { projectId, workspaceId } = params;
   invariant(typeof projectId === 'string', 'Project Id is required');
   invariant(typeof workspaceId === 'string', 'Workspace Id is required');
@@ -530,12 +520,6 @@ export const pushToRemoteAction: ActionFunction = async ({ params }) => {
       teamProjectId: project.remoteId,
     });
     delete remoteCompareCache[workspaceId];
-
-    const duration = performance.now() - startPushActionTime;
-    Sentry.metrics.distribution(SentryMetrics.CLOUD_SYNC_DURATION, duration, {
-      unit: 'millisecond',
-      tags: { action: 'push' },
-    });
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Unknown error while pushing to remote.';
     return {

--- a/packages/insomnia/src/ui/routes/workspace.tsx
+++ b/packages/insomnia/src/ui/routes/workspace.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect } from 'react';
-import { type LoaderFunction, Outlet, useLoaderData } from 'react-router-dom';
+import React from 'react';
+import { type LoaderFunction, Outlet } from 'react-router-dom';
 
 import type { SortOrder } from '../../common/constants';
 import { database } from '../../common/database';
 import { fuzzyMatchAll } from '../../common/misc';
-import { LandingPage } from '../../common/sentry';
 import { sortMethodMap } from '../../common/sorting';
 import * as models from '../../models';
 import type { ApiSpec } from '../../models/api-spec';
@@ -338,13 +337,6 @@ export const revalidateWorkspaceActiveRequestByFolder = async (requestGroup: Req
 };
 
 const WorkspaceRoute = () => {
-  const { activeWorkspace } = useLoaderData() as WorkspaceLoaderData;
-
-  useEffect(() => {
-    const { scope } = activeWorkspace;
-    window.main.landingPageRendered(LandingPage.Workspace, { scope });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
   return <Outlet />;
 };
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
https://docs.sentry.io/platforms/javascript/migration/v8-to-v9/#package-removals
There are some breaking changes:

- The metrics API has been removed from the SDK.
- Use @sentry/core instead @sentry/type


closes: INS-5326
close #8463 

future todo: 

- [ ] use [span-metrics](https://docs.sentry.io/concepts/key-terms/tracing/span-metrics/) to do performance calculation
