### PR TITLE
fix(Git Sync): discard changes should delete requests and other entities if they don't exist in the previous version

### DIFF
--- a/packages/insomnia/src/sync/git/project-ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/project-ne-db-client.ts
@@ -89,6 +89,12 @@ export class GitProjectNeDBClient {
 
     const bufferId = await db.bufferChanges();
 
+    const workspace = dataToImport.find(isWorkspace) as Workspace | undefined;
+
+    const isExistingWorkspace = workspace && await models.workspace.getById(workspace._id);
+    // Remove the workspace if it already exists to clean up any descendants that might have been removed.
+    isExistingWorkspace && await models.workspace.remove(workspace);
+
     for (const doc of dataToImport) {
       if (isWorkspace(doc)) {
         console.log('[git] setting workspace parent to be that of the active project', { original: doc.parentId, new: this._projectId });


### PR DESCRIPTION
### The issue:

Inside a Git Project, when a user creates a request in a file and then discards the changes that have been made in that file, any entities e.g. new request that were created are not properly removed from the db.
This means that a user will chose to discard changes but those changes will persist.

Highlights:

- [x] When git updates a file we clean the previous workspace and it's descendants and use the resources provided by that version of the file.

Closes INS-5245