### PR TITLE
Fix: Export globals paramter in Run via CLI if user has selected any global environment

### DIFF
--- a/packages/insomnia/src/ui/components/modals/cli-preview-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cli-preview-modal.tsx
@@ -19,13 +19,14 @@ function generateCommandArgumentsForRequests(workspaceId: string, targetFolderId
 
 export const CLIPreviewModal = ({ onClose, requestIds, targetFolderId, keepManualOrder, iterationCount, delay, filePath, bail }: { onClose: () => void; requestIds: string[]; targetFolderId: string | null; keepManualOrder: boolean; iterationCount: number; delay: number; filePath: string; bail: boolean }) => {
   const { workspaceId } = useParams() as { workspaceId: string };
-  const { activeEnvironment } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
+  const { activeEnvironment, activeGlobalEnvironment } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
   const workspaceIdAndRequestIds = generateCommandArgumentsForRequests(workspaceId, targetFolderId, requestIds, keepManualOrder);
   const iterationCountArgument = iterationCount > 1 ? ` -n ${iterationCount}` : '';
   const delayArgument = delay > 0 ? ` --delay-request ${delay}` : '';
   const iterationFilePath = filePath ? ` -d "${filePath}"` : '';
   const bailArgument = bail ? ' --bail' : '';
-  const cliCommand = `inso run collection ${workspaceIdAndRequestIds} -e ${activeEnvironment._id.slice(0, 10)}${iterationCountArgument}${delayArgument}${iterationFilePath}${bailArgument}`;
+  const globalEnvironmentArgument = activeGlobalEnvironment ? ` --globals ${activeGlobalEnvironment._id.slice(0, 10)}` : '';
+  const cliCommand = `inso run collection ${workspaceIdAndRequestIds} -e ${activeEnvironment._id.slice(0, 10)}${globalEnvironmentArgument}${iterationCountArgument}${delayArgument}${iterationFilePath}${bailArgument}`;
 
   return (
     <ModalOverlay


### PR DESCRIPTION
**Changes**
Fix the issue that when user activates any global environment, **Run Via CLI** has not exported the **globals** Inso parameter.
![Screenshot 2025-03-31 at 17 37 27](https://github.com/user-attachments/assets/569f7475-3f65-4599-9144-d7bce19969c9)

Currently, if user has selected any global environment and click **Run Via CLI**, the selected global environment will not be exposed in CLI preview.
As a result, Inso will use the active global environment in the workspace. But if user has selected other global environment in the current workspace later, the active global environment will be changed. This will make the environment context different from what user is expecting.
Fix this issue by expose active global environment parameter together.
 