### PR TITLE
fix: Execute docker/login action only on linux runners

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -211,6 +211,7 @@ jobs:
         run: npm run artifacts -w insomnia-inso
 
       - name: Login to Docker Hub
+        if: runner.os == 'Linux' && runner.arch == 'X64'
         uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb # v2.1.0
         with:
           username: ${{ secrets.DOCKER_REGISTRY_USER }}


### PR DESCRIPTION
* Limit docker/login-action execution to linux runners