### PR TITLE
fix(Import): When body params have a file we shouldn't require a value

### DIFF
--- a/packages/insomnia/src/common/import-v5-parser.ts
+++ b/packages/insomnia/src/common/import-v5-parser.ts
@@ -305,7 +305,7 @@ export const RequestSchema = z.object({
     fileName: z.string().optional(),
     params: z.array(z.object({
       name: z.string(),
-      value: z.string(),
+      value: z.string().optional(),
       description: z.string().optional(),
       disabled: z.boolean().optional(),
       multiline: z.string().optional(),

--- a/packages/insomnia/src/common/import-v5-parser.ts
+++ b/packages/insomnia/src/common/import-v5-parser.ts
@@ -305,7 +305,7 @@ export const RequestSchema = z.object({
     fileName: z.string().optional(),
     params: z.array(z.object({
       name: z.string(),
-      value: z.string().optional(),
+      value: z.string().optional().default(''),
       description: z.string().optional(),
       disabled: z.boolean().optional(),
       multiline: z.string().optional(),


### PR DESCRIPTION
When parsing a body param that is of type file we shouldn't require a value since it's optional

Closes #8529 #8581