### PR TITLE
fix(Git Sync): Clone uninitialized repositories when loading them

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -154,7 +154,7 @@ export async function loadGitRepository({
   try {
     const gitRepository = await getGitRepository({ workspaceId, projectId });
 
-    if (GitVCS.isInitializedForRepo(gitRepository._id)) {
+    if (GitVCS.isInitializedForRepo(gitRepository._id) && !gitRepository.needsFullClone) {
       return {
         branch: await GitVCS.getCurrentBranch(),
         branches: await GitVCS.listBranches(),


### PR DESCRIPTION
Solves an issue where re-cloning the same repository would not clone the remote.

- [x] Adds a check when loading a git repository to see if a repository is also initialized correctly