### PR TITLE
fix inso script not reading config

### DIFF
--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -822,7 +822,7 @@ Test results:`);
       const scriptTask = __configFile?.scripts?.[scriptName];
 
       if (!scriptTask) {
-        logger.fatal(`Could not find inso script "${scriptName}" in the config file.`, Object.keys(__configFile.scripts || {}));
+        logger.fatal(`Could not find inso script "${scriptName}" in the config file.`, Object.keys(__configFile?.scripts || {}));
         return process.exit(1);
       }
 

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -23,7 +23,7 @@ import { v4 as uuidv4 } from 'uuid';
 import packageJson from '../package.json';
 import { exportSpecification, writeFileWithCliOptions } from './commands/export-specification';
 import { getRuleSetFileFromFolderByFilename, lintSpecification } from './commands/lint-specification';
-import type { Database} from './db';
+import type { Database } from './db';
 import { isFile, loadDb } from './db';
 import { insomniaExportAdapter } from './db/adapters/insomnia-adapter';
 import { loadApiSpec, promptApiSpec } from './db/models/api-spec';
@@ -819,10 +819,10 @@ Test results:`);
       options.ci && logger.setReporters([new BasicReporter()]);
       options.printOptions && logger.log('Loaded options', options, '\n');
 
-      const scriptTask = options.__configFile?.scripts?.[scriptName];
+      const scriptTask = __configFile?.scripts?.[scriptName];
 
       if (!scriptTask) {
-        logger.fatal(`Could not find inso script "${scriptName}" in the config file.`);
+        logger.fatal(`Could not find inso script "${scriptName}" in the config file.`, Object.keys(__configFile.scripts || {}));
         return process.exit(1);
       }
 


### PR DESCRIPTION
Fixing a mistake that occurred while refactoring the cli to improve developer experience and add request scripting features.

inso script was reading the `.insorc` into an object
but searching in the wrong object for the values

Also added debug logging

<img width="486" alt="image" src="https://github.com/user-attachments/assets/2a616df5-7945-44ac-92f5-8a47303ed3fe" />


fixes: INS-5290
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
