### PR TITLE
refactor(sdk): only display error message without stacktrace for minor errors

### DIFF
--- a/packages/insomnia-scripting-environment/src/objects/environments.ts
+++ b/packages/insomnia-scripting-environment/src/objects/environments.ts
@@ -1,5 +1,4 @@
 import { getExistingConsole } from './console';
-import { toMinorScriptError } from './interfaces';
 import { getInterpolator } from './interpolator';
 
 export class Environment {
@@ -156,13 +155,13 @@ export class Vault extends Environment {
       // throw error on get or set method call if enableVaultInScripts is false
       get: (target, prop, receiver) => {
         if (!enableVaultInScripts) {
-          throw toMinorScriptError(new Error('Vault is disabled in script'));
+          throw 'Vault is disabled in script';
         }
         return Reflect.get(target, prop, receiver);
       },
       set: (target, prop, value, receiver) => {
         if (!enableVaultInScripts) {
-          throw toMinorScriptError(new Error('Vault is disabled in script'));
+          throw 'Vault is disabled in script';
         }
         return Reflect.set(target, prop, value, receiver);
       },
@@ -170,14 +169,14 @@ export class Vault extends Environment {
   }
 
   unset = () => {
-    throw toMinorScriptError(new Error('Vault can not be unset in script'));
+    throw 'Vault can not be unset in script';
   };
 
   clear = () => {
-    throw toMinorScriptError(new Error('Vault can not be cleared in script'));
+    throw 'Vault can not be cleared in script';
   };
 
   set = () => {
-    throw toMinorScriptError(new Error('Vault can not be set in script'));
+    throw 'Vault can not be set in script';
   };
 }

--- a/packages/insomnia-scripting-environment/src/objects/environments.ts
+++ b/packages/insomnia-scripting-environment/src/objects/environments.ts
@@ -1,4 +1,5 @@
 import { getExistingConsole } from './console';
+import { toMinorScriptError } from './interfaces';
 import { getInterpolator } from './interpolator';
 
 export class Environment {
@@ -155,13 +156,13 @@ export class Vault extends Environment {
       // throw error on get or set method call if enableVaultInScripts is false
       get: (target, prop, receiver) => {
         if (!enableVaultInScripts) {
-          throw new Error('Vault is disabled in script');
+          throw toMinorScriptError(new Error('Vault is disabled in script'));
         }
         return Reflect.get(target, prop, receiver);
       },
       set: (target, prop, value, receiver) => {
         if (!enableVaultInScripts) {
-          throw new Error('Vault is disabled in script');
+          throw toMinorScriptError(new Error('Vault is disabled in script'));
         }
         return Reflect.set(target, prop, value, receiver);
       },
@@ -169,14 +170,14 @@ export class Vault extends Environment {
   }
 
   unset = () => {
-    throw new Error('Vault can not be unset in script');
+    throw toMinorScriptError(new Error('Vault can not be unset in script'));
   };
 
   clear = () => {
-    throw new Error('Vault can not be cleared in script');
+    throw toMinorScriptError(new Error('Vault can not be cleared in script'));
   };
 
   set = () => {
-    throw new Error('Vault can not be set in script');
+    throw toMinorScriptError(new Error('Vault can not be set in script'));
   };
 }

--- a/packages/insomnia-scripting-environment/src/objects/interfaces.ts
+++ b/packages/insomnia-scripting-environment/src/objects/interfaces.ts
@@ -35,22 +35,3 @@ export interface RequestContext {
   transientVariables?: Omit<IEnvironment, 'id'>;
   parentFolders: { id: string; name: string; environment: Record<string, any> }[];
 }
-
-export interface BaseScriptError {
-  name: string;
-  message: string;
-  stack?: string;
-}
-
-// MinorScriptError is an error that only displays a message on UI, without stacktrace
-export interface MinorScriptError extends BaseScriptError {
-  name: 'MinorScriptError';
-}
-
-// toMinorScriptError wraps an normal error as a MinorScriptError
-export function toMinorScriptError(originalError: Error): MinorScriptError {
-  return {
-    name: 'MinorScriptError',
-    message: `${originalError.message}`,
-  };
-}

--- a/packages/insomnia-scripting-environment/src/objects/interfaces.ts
+++ b/packages/insomnia-scripting-environment/src/objects/interfaces.ts
@@ -47,7 +47,7 @@ export interface MinorScriptError extends BaseScriptError {
   name: 'MinorScriptError';
 }
 
-// toMinorScriptError wraps an exception as an error
+// toMinorScriptError wraps an normal error as a MinorScriptError
 export function toMinorScriptError(originalError: Error): MinorScriptError {
   return {
     name: 'MinorScriptError',

--- a/packages/insomnia-scripting-environment/src/objects/interfaces.ts
+++ b/packages/insomnia-scripting-environment/src/objects/interfaces.ts
@@ -35,3 +35,22 @@ export interface RequestContext {
   transientVariables?: Omit<IEnvironment, 'id'>;
   parentFolders: { id: string; name: string; environment: Record<string, any> }[];
 }
+
+export interface BaseScriptError {
+  name: string;
+  message: string;
+  stack?: string;
+}
+
+// MinorScriptError is an error that only displays a message on UI, without stacktrace
+export interface MinorScriptError extends BaseScriptError {
+  name: 'MinorScriptError';
+}
+
+// toMinorScriptError wraps an exception as an error
+export function toMinorScriptError(originalError: Error): MinorScriptError {
+  return {
+    name: 'MinorScriptError',
+    message: `${originalError.message}`,
+  };
+}

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -37,13 +37,15 @@ window.bridge.onmessage(async (data, callback) => {
     const result = await window.bridge.Promise.race([timeoutPromise, runScript(data)]);
     callback(result);
   } catch (err) {
-    const errMessage = err.message ? `message: ${err.message}; stack: ${err.stack}` : err;
+    const errMessage = err.message ? `Error: ${err.message};` : err;
+    const errStack = err.stack ? `Stack: ${err.stack};` : '';
+    const fullErrMessage = `${errMessage}\n${errStack}`
     Sentry.captureException(errMessage, {
       tags: {
         source: 'hidden-window',
       },
     });
-    callback({ error: errMessage });
+    callback({ error: fullErrMessage });
   } finally {
     window.bridge.setBusy(false);
   }

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -554,7 +554,8 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
     );
 
     const requestId = request._id;
-    const errMessage = err.stack ? `message: ${err.messsage}; stack: ${err.stack}` : err.message;
+    // stack trace is ignored as it is always from preload
+    const errMessage = err.message ? err.message : err;
     const responsePatch = {
       _id: responseId,
       parentId: requestId,


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Change
- [x] Throw a string message instead an error -- Originally I introduced a custom error to do this, but after discussed within team, we plan to avoid introducing error abstraction too early.
- [x] Reformat outputs into message and stack.

Without stack:
![image](https://github.com/user-attachments/assets/99fdd6cd-68b0-4c9c-987c-60b75bd43e42)

With stack:
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/5131769d-6746-48c8-a8d3-aa2827e01b1a" />
