### PR TITLE
feat(Inso CLI): Allow using the workspace name to match a spec file

### DIFF
--- a/packages/insomnia-inso/src/db/models/api-spec.ts
+++ b/packages/insomnia-inso/src/db/models/api-spec.ts
@@ -9,7 +9,9 @@ const entity = 'api specification';
 
 export const loadApiSpec = (db: Database, identifier: string): ApiSpec | null | undefined => {
   logger.trace('Load %s with identifier `%s` from data store', entity, identifier);
-  const items = db.ApiSpec.filter(spec => matchIdIsh(spec, identifier) || spec.fileName === identifier);
+  const items = db.ApiSpec.filter(
+    spec => matchIdIsh(spec, identifier) || spec.fileName === identifier || spec.name === identifier,
+  );
   logger.trace('Found %d.', items.length);
   return ensureSingleOrNone(items, entity);
 };


### PR DESCRIPTION
Highlights:

- [x] Extends the matching logic for finding API specs by identifier in Inso. We now also check for the Spec name which default to the Workspace name.