### PR TITLE
Support proxy for Websocket requests [INS-5350]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23912,6 +23912,8 @@
         "hkdf": "^0.0.2",
         "hosted-git-info": "5.2.1",
         "html-entities": "^2.6.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
         "httpsnippet": "^2.0.0",
         "iconv-lite": "^0.6.3",
         "js-yaml": "^4.1.0",
@@ -25112,6 +25114,19 @@
         "@esbuild/win32-arm64": "0.25.2",
         "@esbuild/win32-ia32": "0.25.2",
         "@esbuild/win32-x64": "0.25.2"
+      }
+    },
+    "packages/insomnia/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     }
   }

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -64,6 +64,8 @@
     "hosted-git-info": "5.2.1",
     "html-entities": "^2.6.0",
     "httpsnippet": "^2.0.0",
+    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.5",
     "iconv-lite": "^0.6.3",
     "js-yaml": "^4.1.0",
     "jsdom": "^25.0.1",

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -1,7 +1,7 @@
 import electron, { BrowserWindow } from 'electron';
 import fs from 'fs';
 import { MessageType, parseMessage } from 'graphql-ws';
-import { get, type IncomingMessage } from 'http';
+import { type IncomingMessage } from 'http';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import path from 'path';

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -1,7 +1,9 @@
 import electron, { BrowserWindow } from 'electron';
 import fs from 'fs';
 import { MessageType, parseMessage } from 'graphql-ws';
-import type { IncomingMessage } from 'http';
+import { get, type IncomingMessage } from 'http';
+import { HttpProxyAgent } from 'http-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import path from 'path';
 import tls, { type KeyObject, type PxfObject } from 'tls';
 import { v4 as uuidV4 } from 'uuid';
@@ -10,12 +12,12 @@ import { type CloseEvent, type ErrorEvent, type Event, type MessageEvent, WebSoc
 import { AUTH_API_KEY, AUTH_BASIC, AUTH_BEARER } from '../../common/constants';
 import { jarFromCookies } from '../../common/cookies';
 import { generateId, getSetCookieHeaders } from '../../common/misc';
-import { webSocketRequest } from '../../models';
+import { webSocketRequest} from '../../models';
 import * as models from '../../models';
 import type { CookieJar } from '../../models/cookie-jar';
 import type { Request } from '../../models/request';
 import { type RequestAuthentication, type RequestHeader } from '../../models/request';
-import type { BaseWebSocketRequest } from '../../models/websocket-request';
+import { type BaseWebSocketRequest, isWebSocketRequest } from '../../models/websocket-request';
 import type { WebSocketResponse } from '../../models/websocket-response';
 import { COOKIE, HEADER, QUERY_PARAMS } from '../../network/api-key/constants';
 import { getBasicAuthHeader } from '../../network/basic-auth/get-header';
@@ -25,6 +27,7 @@ import { addSetCookiesToToughCookieJar } from '../../network/set-cookie-util';
 import type { RenderedRequest } from '../../templating/types';
 import { parseGraphQLReqeustBody } from '../../utils/graph-ql';
 import { invariant } from '../../utils/invariant';
+import { setDefaultProtocol } from '../../utils/url/protocol';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from '../../utils/url/querystring';
 import { ipcMainHandle, ipcMainOn } from '../ipc/electron';
 
@@ -134,7 +137,7 @@ const openWebSocketConnection = async (
   const responseEnvironmentId = environment ? environment._id : null;
 
   const caCert = await models.caCertificate.findByParentId(options.workspaceId);
-  const caCertficatePath = caCert?.path;
+  const caCertficatePath = (caCert && !caCert.disabled) ? caCert.path : null;        
   // attempt to read CA Certificate PEM from disk, fallback to root certificates
   const caCertificate =
     (caCertficatePath && (await fs.promises.readFile(caCertficatePath)).toString()) || tls.rootCertificates.join('\n');
@@ -239,6 +242,7 @@ const openWebSocketConnection = async (
         global: settings.followRedirects,
       }[request.settingFollowRedirects] ?? true;
     const protocols = lowerCasedEnabledHeaders['sec-websocket-protocol']?.split(',').map(p => p.trim());
+    const shouldUseProxy = settings.proxyEnabled && isWebSocketRequest(request) && request.settingUseProxy;
     const ws = new WebSocket(url, protocols, {
       headers: lowerCasedEnabledHeaders,
       ca: caCertificate,
@@ -248,6 +252,10 @@ const openWebSocketConnection = async (
       rejectUnauthorized: settings.validateSSL,
       followRedirects,
       maxRedirects: settings.maxRedirects > 0 ? settings.maxRedirects : undefined,
+      // apply proxy settings
+      ...(shouldUseProxy && {
+        agent: getProxyAgent(url, settings.httpProxy, settings.httpsProxy),
+      }),
     });
     WebSocketConnections.set(options.requestId, ws);
 
@@ -571,6 +579,13 @@ const findMany = async (options: { responseId: string }): Promise<WebSocketEvent
       .reverse() || []
   );
 };
+
+const getProxyAgent = (url: string, httpProxy: string, httpsProxy: string) => {
+  const useHttpsProxy = url.startsWith('wss:') || url.startsWith('https:');
+  return useHttpsProxy ?
+    new HttpsProxyAgent(setDefaultProtocol(httpsProxy)) : 
+    new HttpProxyAgent(setDefaultProtocol(httpProxy));
+}
 
 export interface WebSocketBridgeAPI {
   open: (options: OpenWebSocketRequestOptions) => void;

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -25,6 +25,7 @@ export interface BaseWebSocketRequest {
   settingStoreCookies: boolean;
   settingSendCookies: boolean;
   settingFollowRedirects: 'global' | 'on' | 'off';
+  settingUseProxy?: boolean;
 }
 
 export type WebSocketRequest = BaseModel & BaseWebSocketRequest & { type: typeof type };
@@ -32,6 +33,9 @@ export type WebSocketRequest = BaseModel & BaseWebSocketRequest & { type: typeof
 export const isWebSocketRequest = (model: Pick<BaseModel, 'type'>): model is WebSocketRequest => model.type === type;
 
 export const isWebSocketRequestId = (id?: string | null) => id?.startsWith(`${prefix}_`);
+
+// for those keys do not need to add in model init method but can update
+export const optionalKeys = ['settingUseProxy'];
 
 export const init = (): BaseWebSocketRequest => ({
   name: 'New WebSocket Request',

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -129,6 +129,17 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                         />
                       </label>
                     </div>
+                    <div className="form-control form-control--thin">
+                      <label>
+                        Use proxy from preferences settings
+                        <input
+                          type="checkbox"
+                          name="settingUseProxy"
+                          checked={request.settingUseProxy}
+                          onChange={toggleCheckBox}
+                        />
+                      </label>
+                    </div>
                   </div>
                   <div className="form-control form-control--outlined">
                     <label>


### PR DESCRIPTION
**Changes**
- Add a new setting for websocket request to consume proxy from Preference settings
<img width="744" alt="Screenshot 2025-04-17 at 14 34 54" src="https://github.com/user-attachments/assets/777a1bfa-04c1-402e-8e95-013d7063399d" />

- Modify websocket connection logic to use proxy agent when proxy is enabled
- Fix a bug that when customized CA cert is disabled, Websocket connection still uses that cert

Closes https://github.com/Kong/insomnia/issues/5562
