### PR TITLE
fix(Import v5): Import multiline body parameter

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/simple.yaml
+++ b/packages/insomnia-smoke-test/fixtures/simple.yaml
@@ -103,6 +103,49 @@ collection:
       cookies:
         send: true
         store: true
+  - name: New Request
+    meta:
+      id: req_845c9ad3b2934f2098cb77a5dce8b0f5
+      created: 1745481338217
+      modified: 1745481802746
+      isPrivate: false
+      sortKey: -1745481338217
+    method: GET
+    body:
+      mimeType: multipart/form-data
+      params:
+        - name: test
+          value: |-
+            {
+            	"a": 1
+            }
+          disabled: false
+          multiline: true
+          id: pair_473715d5390a427fa70284c0222bcffc
+          type: text
+    parameters:
+      - id: pair_eee575c573bd4c7da4fa6c7a2cf131d4
+        name: test
+        value: |-
+          {
+          	"A": 1
+          }
+        disabled: false
+        type: text
+        multiline: application/json
+    headers:
+      - name: Content-Type
+        value: multipart/form-data
+      - name: User-Agent
+        value: insomnia/11.1.0-beta.1
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
 cookieJar:
   name: Default Jar
   meta:

--- a/packages/insomnia/src/common/import-v5-parser.ts
+++ b/packages/insomnia/src/common/import-v5-parser.ts
@@ -362,11 +362,11 @@ export const RequestSchema = z.object({
       params: z
         .array(
           z.object({
-            name: z.string(),
+            name: z.string().default(''),
             value: z.string().optional().default(''),
             description: z.string().optional(),
             disabled: z.boolean().optional(),
-            multiline: z.string().optional(),
+            multiline: z.boolean().optional(),
             id: z.string().optional(),
             fileName: z.string().optional(),
             type: z.string().optional(),

--- a/packages/insomnia/src/models/request.ts
+++ b/packages/insomnia/src/models/request.ts
@@ -190,7 +190,7 @@ export interface RequestBodyParameter {
   value: string;
   description?: string;
   disabled?: boolean;
-  multiline?: string;
+  multiline?: boolean;
   id?: string;
   fileName?: string;
   type?: string;


### PR DESCRIPTION
## Overview:

Importing requests with a multipart/form-data mimeType where one of the parameters is multiline will fail since our schema expects a string (this was the type on our Request model) where we actually store it as a boolean.

## Highlights:

- [x] Updates the type of multiline request body parameters to be boolean instead of string
- [x] Adds a request with multiline options to our e2e test