### PR TITLE
fix: update action bar value after users click import from url

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/import-from-url.yaml
+++ b/packages/insomnia-smoke-test/fixtures/import-from-url.yaml
@@ -1,0 +1,81 @@
+type: collection.insomnia.rest/5.0
+name: simple
+meta:
+  id: wrk_dc393cdd96524c44a632fdc3b09aa5c5
+  created: 1736279931529
+  modified: 1736279931529
+collection:
+  - url: http://localhost:4010/echo?foo=bar&baz=qux
+    name: example http
+    meta:
+      id: req_49f06ac9024446728a9765162d56b95a
+      created: 1666867365377
+      modified: 1666867670885
+      isPrivate: false
+    method: GET
+    scripts:
+      preRequest: console.log('executing pre-request script');
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: ws://localhost:4010?foo=bar&baz=qux
+    name: example websocket
+    meta:
+      id: ws-req_9030f28cd1a64b44971cee35bbc09987
+      created: 1666867628351
+      modified: 1666867647526
+    settings:
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_5ac9997401a64a9ea81374670872319a
+    created: 1666867357074
+    modified: 1666868115288
+  cookies:
+    - id: bc6e6a71-1290-4334-8662-a49c1c58b037
+      key: foo
+      value: bar
+      domain: localhost
+      expires: 2038-01-19T03:14:07.000Z
+      path: /
+      secure: false
+      httpOnly: false
+environments:
+  name: Base Environment
+  meta:
+    id: env_e86a031c9817439bb89991d31a46e50c
+    created: 1666867357072
+    modified: 1666867924188
+    isPrivate: false
+  data:
+    foo: bar
+    current-env: base
+  subEnvironments:
+    - name: production
+      meta:
+        id: env_f5742e2375e24f25b65c2ae97fbbda30
+        created: 1666867721814
+        modified: 1666867928920
+        isPrivate: false
+      data:
+        foo: bar
+        current-env: production
+    - name: staging
+      meta:
+        id: env_fdc1a90ec92c42899f599a4e8ab40a5f
+        created: 1666867735110
+        modified: 1666867933395
+        isPrivate: false
+      data:
+        foo: bar
+        current-env: staging

--- a/packages/insomnia-smoke-test/tests/smoke/import-from-url.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/import-from-url.test.ts
@@ -14,7 +14,7 @@ test.describe('Import from URL', () => {
     await page.getByLabel('simple').click();
   });
 
-  test('Should work as expect in HTTP request', async ({ page }) => {
+  test('Should work as expected in HTTP request', async ({ page }) => {
     const requestUrl = 'http://localhost:4010/echo?foo=bar&baz=qux';
     const codeMirror = page.getByTestId('OneLineEditor').first().locator('.CodeMirror');
 
@@ -40,7 +40,7 @@ test.describe('Import from URL', () => {
     await expect.soft(responsePane).toContainText(requestUrl);
   });
 
-  test('Should work as expect in Websocket request', async ({ page }) => {
+  test('Should work as expected in Websocket request', async ({ page }) => {
     const requestUrl = 'ws://localhost:4010?foo=bar&baz=qux';
     const codeMirror = page.getByTestId('OneLineEditor').first().locator('.CodeMirror');
 

--- a/packages/insomnia-smoke-test/tests/smoke/import-from-url.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/import-from-url.test.ts
@@ -1,0 +1,68 @@
+import { expect } from '@playwright/test';
+
+import { loadFixture } from '../../playwright/paths';
+import { test } from '../../playwright/test';
+
+test.describe('Import from URL', () => {
+  test.beforeEach(async ({ app, page }) => {
+    const text = await loadFixture('import-from-url.yaml');
+    await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+    await page.getByLabel('Import').click();
+    await page.locator('[data-test-id="import-from-clipboard"]').click();
+    await page.getByRole('button', { name: 'Scan' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+    await page.getByLabel('simple').click();
+  });
+
+  test('Should work as expect in HTTP request', async ({ page }) => {
+    const requestUrl = 'http://localhost:4010/echo?foo=bar&baz=qux';
+    const codeMirror = page.getByTestId('OneLineEditor').first().locator('.CodeMirror');
+
+    await page.getByText('example http').click();
+
+    const importFromUrlButton = page.getByRole('button', { name: 'Import from URL' });
+    await importFromUrlButton.click();
+
+    await expect
+      .soft(codeMirror.locator('.CodeMirror-line').getByRole('presentation'))
+      .toHaveText('http://localhost:4010/echo');
+
+    // send
+    await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+
+    // verify response
+    const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+    await expect.soft(statusTag).toContainText('200 OK');
+
+    const responsePane = page.getByTestId('response-pane');
+    await page.getByRole('tab', { name: 'Console' }).click();
+
+    await expect.soft(responsePane).toContainText(requestUrl);
+  });
+
+  test('Should work as expect in Websocket request', async ({ page }) => {
+    const requestUrl = 'ws://localhost:4010?foo=bar&baz=qux';
+    const codeMirror = page.getByTestId('OneLineEditor').first().locator('.CodeMirror');
+
+    await page.getByText('example websocket').click();
+
+    const importFromUrlButton = page.getByRole('button', { name: 'Import from URL' });
+    await importFromUrlButton.click();
+
+    await expect
+      .soft(codeMirror.locator('.CodeMirror-line').getByRole('presentation'))
+      .toHaveText('ws://localhost:4010');
+
+    // connect
+    await page.getByTestId('request-pane').getByRole('button', { name: 'Connect' }).click();
+
+    // verify response
+    const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+    await expect.soft(statusTag).toContainText('101 Switching Protocols');
+
+    const responsePane = page.getByTestId('response-pane');
+    await page.getByRole('tab', { name: 'Console' }).click();
+
+    await expect.soft(responsePane).toContainText(requestUrl);
+  });
+});

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -857,7 +857,7 @@ async function _fixMultipleCookieJars(workspace: Workspace) {
   console.log(`[fix] Merged ${cookieJars.length} cookie jars under ${workspace.name}`);
 }
 
-// Append .git to old git URIs to mimic previous isomorphic-git behaviour
+// Append .git to old git URIs to mimic previous isomorphic-git behavior
 async function _fixOldGitURIs(doc: GitRepository) {
   if (!doc.uriNeedsMigration) {
     return;

--- a/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/codemirror/one-line-editor.tsx
@@ -41,6 +41,7 @@ export interface EditorEventListener<T extends keyof EditorEventMap> {
 export interface OneLineEditorHandle {
   selectAll: () => void;
   focusEnd: () => void;
+  setValue: (value: string) => void;
 }
 export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>(
   (
@@ -351,6 +352,13 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
             codeMirror.current.focus();
           }
           codeMirror.current?.getDoc()?.setCursor(codeMirror.current.getDoc().lineCount(), 0);
+        },
+        setValue: (value: string) => {
+          if (codeMirror.current) {
+            const cursor = codeMirror.current.getCursor();
+            codeMirror.current.setValue(value);
+            codeMirror.current.setCursor(cursor);
+          }
         },
       }),
       [],

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -67,7 +67,7 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
        * Currently the OneLineEditor is a uncontrolled component, and the value is asynchronously, if we change the component to controlled, users need to wait for the value to be updated when inputting, that's not a good experience.
        * So as a workaround, we need to manually update the url bar value.
        */
-      requestUrlBarRef.current?.updateUrl(url);
+      requestUrlBarRef.current?.setUrl(url);
     }
   };
   const gitVersion = useGitVCSVersion();

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, Fragment, useState } from 'react';
+import React, { type FC, Fragment, useRef, useState } from 'react';
 import { Button, Heading, Tab, TabList, TabPanel, Tabs, ToggleButton } from 'react-aria-components';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useParams, useRouteLoaderData } from 'react-router-dom';
@@ -26,7 +26,7 @@ import { Icon } from '../icon';
 import { MarkdownEditor } from '../markdown-editor';
 import { RequestSettingsModal } from '../modals/request-settings-modal';
 import { RenderedQueryString } from '../rendered-query-string';
-import { RequestUrlBar } from '../request-url-bar';
+import { RequestUrlBar, type RequestUrlBarHandle } from '../request-url-bar';
 import { Pane, PaneHeader } from './pane';
 import { PlaceholderRequestPane } from './placeholder-request-pane';
 
@@ -44,6 +44,7 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
   const [isRequestSettingsModalOpen, setIsRequestSettingsModalOpen] = useState(false);
   const patchRequest = useRequestPatcher();
 
+  const requestUrlBarRef = useRef<RequestUrlBarHandle>(null);
   const [dismissPathParameterTip, setDismissPathParameterTip] = useLocalStorage('dismissPathParameterTip', '');
   const handleImportQueryFromUrl = () => {
     let query;
@@ -62,6 +63,11 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
     // Only update if url changed
     if (url !== activeRequest.url) {
       patchRequest(requestId, { url, parameters });
+      /**
+       * Currently the OneLineEditor is a uncontrolled component, and the value is asynchronously, if we change the component to controlled, users need to wait for the value to be updated when inputting, that's not a good experience.
+       * So as a workaround, we need to manually update the url bar value.
+       */
+      requestUrlBarRef.current?.updateUrl(url);
     }
   };
   const gitVersion = useGitVCSVersion();
@@ -98,6 +104,7 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
             handleAutocompleteUrls={() => queryAllWorkspaceUrls(workspaceId, models.request.type, requestId)}
             nunjucksPowerUserMode={settings.nunjucksPowerUserMode}
             onPaste={onPaste}
+            ref={requestUrlBarRef}
           />
         </ErrorBoundary>
       </PaneHeader>

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -39,6 +39,7 @@ interface Props {
 
 export interface RequestUrlBarHandle {
   focusInput: () => void;
+  updateUrl: (url: string) => void;
 }
 
 export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
@@ -94,7 +95,16 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
       }
     }, [inputRef]);
 
-    useImperativeHandle(ref, () => ({ focusInput }), [focusInput]);
+    const updateUrl = useCallback(
+      (url: string) => {
+        if (inputRef.current) {
+          inputRef.current.setValue(url);
+        }
+      },
+      [inputRef],
+    );
+
+    useImperativeHandle(ref, () => ({ focusInput, updateUrl }), [focusInput, updateUrl]);
 
     const [currentInterval, setCurrentInterval] = useState<number | null>(null);
     const [currentTimeout, setCurrentTimeout] = useState<number | undefined>(undefined);

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -39,7 +39,7 @@ interface Props {
 
 export interface RequestUrlBarHandle {
   focusInput: () => void;
-  updateUrl: (url: string) => void;
+  setUrl: (url: string) => void;
 }
 
 export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
@@ -95,7 +95,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
       }
     }, [inputRef]);
 
-    const updateUrl = useCallback(
+    const setUrl = useCallback(
       (url: string) => {
         if (inputRef.current) {
           inputRef.current.setValue(url);
@@ -104,7 +104,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
       [inputRef],
     );
 
-    useImperativeHandle(ref, () => ({ focusInput, updateUrl }), [focusInput, updateUrl]);
+    useImperativeHandle(ref, () => ({ focusInput, setUrl }), [focusInput, setUrl]);
 
     const [currentInterval, setCurrentInterval] = useState<number | null>(null);
     const [currentTimeout, setCurrentTimeout] = useState<number | undefined>(undefined);

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef } from 'react';
 import { useFetcher, useParams } from 'react-router-dom';
 
 import * as models from '../../../models';
@@ -19,139 +19,150 @@ interface ActionBarProps {
   onChange: (value: string) => void;
 }
 
-export const WebSocketActionBar: FC<ActionBarProps> = ({
-  request,
-  environmentId,
-  defaultValue,
-  onChange,
-  readyState,
-}) => {
-  const isOpen = readyState;
-  const oneLineEditorRef = useRef<OneLineEditorHandle>(null);
-  useLayoutEffect(() => {
-    oneLineEditorRef.current?.focusEnd();
-  }, []);
+export interface WebSocketActionBarHandle {
+  updateUrl: (url: string) => void;
+}
 
-  const fetcher = useFetcher();
-  const { organizationId, projectId, workspaceId, requestId } = useParams() as {
-    organizationId: string;
-    projectId: string;
-    workspaceId: string;
-    requestId: string;
-  };
+export const WebSocketActionBar = forwardRef<WebSocketActionBarHandle, ActionBarProps>(
+  ({ request, environmentId, defaultValue, onChange, readyState }, ref) => {
+    const isOpen = readyState;
+    const oneLineEditorRef = useRef<OneLineEditorHandle>(null);
+    useLayoutEffect(() => {
+      oneLineEditorRef.current?.focusEnd();
+    }, []);
 
-  const { updateTabById } = useInsomniaTabContext();
-
-  const connect = useCallback(
-    (connectParams: ConnectActionParams) => {
-      fetcher.submit(JSON.stringify(connectParams), {
-        action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${requestId}/connect`,
-        method: 'post',
-        encType: 'application/json',
-      });
-    },
-    [fetcher, organizationId, projectId, requestId, workspaceId],
-  );
-
-  const handleSubmit = useCallback(async () => {
-    updateTabById?.(request._id, { temporary: false });
-    if (isOpen) {
-      window.main.webSocket.close({ requestId: request._id });
-      return;
-    }
-    // Render any nunjucks tags in the url/headers/authentication settings/cookies
-
-    const workspaceCookieJar = await models.cookieJar.getOrCreateForParentId(workspaceId);
-    // Render any nunjucks tags in the url/headers/authentication settings/cookies
-    const rendered = await tryToInterpolateRequestOrShowRenderErrorModal({
-      request,
-      environmentId,
-      payload: {
-        url: request.url,
-        headers: request.headers,
-        authentication: request.authentication,
-        parameters: request.parameters.filter(p => !p.disabled),
-        workspaceCookieJar,
-      },
-    });
-    rendered &&
-      connect({
-        url: joinUrlAndQueryString(rendered.url, buildQueryStringFromParams(rendered.parameters)),
-        headers: rendered.headers,
-        authentication: rendered.authentication,
-        cookieJar: rendered.workspaceCookieJar,
-        suppressUserAgent: rendered.suppressUserAgent,
-      });
-  }, [connect, environmentId, isOpen, request, updateTabById, workspaceId]);
-
-  useEffect(() => {
-    const sendOnMetaEnter = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === 'Enter') {
-        handleSubmit();
-      }
+    const fetcher = useFetcher();
+    const { organizationId, projectId, workspaceId, requestId } = useParams() as {
+      organizationId: string;
+      projectId: string;
+      workspaceId: string;
+      requestId: string;
     };
-    document
-      .getElementById('sidebar-request-gridlist')
-      ?.addEventListener('keydown', sendOnMetaEnter, { capture: true });
-    return () => {
+
+    const { updateTabById } = useInsomniaTabContext();
+
+    const connect = useCallback(
+      (connectParams: ConnectActionParams) => {
+        fetcher.submit(JSON.stringify(connectParams), {
+          action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${requestId}/connect`,
+          method: 'post',
+          encType: 'application/json',
+        });
+      },
+      [fetcher, organizationId, projectId, requestId, workspaceId],
+    );
+
+    const handleSubmit = useCallback(async () => {
+      updateTabById?.(request._id, { temporary: false });
+      if (isOpen) {
+        window.main.webSocket.close({ requestId: request._id });
+        return;
+      }
+      // Render any nunjucks tags in the url/headers/authentication settings/cookies
+
+      const workspaceCookieJar = await models.cookieJar.getOrCreateForParentId(workspaceId);
+      // Render any nunjucks tags in the url/headers/authentication settings/cookies
+      const rendered = await tryToInterpolateRequestOrShowRenderErrorModal({
+        request,
+        environmentId,
+        payload: {
+          url: request.url,
+          headers: request.headers,
+          authentication: request.authentication,
+          parameters: request.parameters.filter(p => !p.disabled),
+          workspaceCookieJar,
+        },
+      });
+      rendered &&
+        connect({
+          url: joinUrlAndQueryString(rendered.url, buildQueryStringFromParams(rendered.parameters)),
+          headers: rendered.headers,
+          authentication: rendered.authentication,
+          cookieJar: rendered.workspaceCookieJar,
+          suppressUserAgent: rendered.suppressUserAgent,
+        });
+    }, [connect, environmentId, isOpen, request, updateTabById, workspaceId]);
+
+    const updateUrl = useCallback(
+      (url: string) => {
+        if (oneLineEditorRef.current) {
+          oneLineEditorRef.current.setValue(url);
+        }
+      },
+      [oneLineEditorRef],
+    );
+
+    useImperativeHandle(ref, () => ({ updateUrl }), [updateUrl]);
+
+    useEffect(() => {
+      const sendOnMetaEnter = (event: KeyboardEvent) => {
+        if (event.metaKey && event.key === 'Enter') {
+          handleSubmit();
+        }
+      };
       document
         .getElementById('sidebar-request-gridlist')
-        ?.removeEventListener('keydown', sendOnMetaEnter, { capture: true });
-    };
-  }, [handleSubmit]);
+        ?.addEventListener('keydown', sendOnMetaEnter, { capture: true });
+      return () => {
+        document
+          .getElementById('sidebar-request-gridlist')
+          ?.removeEventListener('keydown', sendOnMetaEnter, { capture: true });
+      };
+    }, [handleSubmit]);
 
-  useDocBodyKeyboardShortcuts({
-    request_send: () => handleSubmit(),
-    request_focusUrl: () => {
-      oneLineEditorRef.current?.selectAll();
-    },
-  });
+    useDocBodyKeyboardShortcuts({
+      request_send: () => handleSubmit(),
+      request_focusUrl: () => {
+        oneLineEditorRef.current?.selectAll();
+      },
+    });
 
-  const isConnectingOrClosed = !readyState;
-  return (
-    <>
-      {!isOpen && <span className="flex items-center pl-[--padding-md] text-[--color-notice]">WS</span>}
-      {isOpen && (
-        <span className="text-success flex items-center pl-[--padding-md]">
-          <span className="mr-[--padding-sm] h-2.5 w-2.5 rounded-[50%] bg-[--color-success]" />
-          CONNECTED
-        </span>
-      )}
-      <form
-        className="flex flex-1"
-        aria-disabled={isOpen}
-        onSubmit={event => {
-          event.preventDefault();
-          handleSubmit();
-        }}
-      >
-        <div className="box-border h-full w-full px-[--padding-md]">
-          <OneLineEditor
-            id="websocket-url-bar"
-            ref={oneLineEditorRef}
-            onKeyDown={createKeybindingsHandler({
-              Enter: () => handleSubmit(),
-            })}
-            readOnly={readyState}
-            placeholder="wss://example.com/chat"
-            defaultValue={defaultValue}
-            onChange={onChange}
-            type="text"
-          />
-        </div>
-        <div className="flex p-1">
-          {isConnectingOrClosed ? (
-            <button
-              className="rounded-sm bg-[--color-surprise] px-[--padding-md] text-center text-[--color-font-surprise] hover:brightness-75"
-              type="submit"
-            >
-              Connect
-            </button>
-          ) : (
-            <DisconnectButton requestId={request._id} />
-          )}
-        </div>
-      </form>
-    </>
-  );
-};
+    const isConnectingOrClosed = !readyState;
+    return (
+      <>
+        {!isOpen && <span className="flex items-center pl-[--padding-md] text-[--color-notice]">WS</span>}
+        {isOpen && (
+          <span className="text-success flex items-center pl-[--padding-md]">
+            <span className="mr-[--padding-sm] h-2.5 w-2.5 rounded-[50%] bg-[--color-success]" />
+            CONNECTED
+          </span>
+        )}
+        <form
+          className="flex flex-1"
+          aria-disabled={isOpen}
+          onSubmit={event => {
+            event.preventDefault();
+            handleSubmit();
+          }}
+        >
+          <div className="box-border h-full w-full px-[--padding-md]">
+            <OneLineEditor
+              id="websocket-url-bar"
+              ref={oneLineEditorRef}
+              onKeyDown={createKeybindingsHandler({
+                Enter: () => handleSubmit(),
+              })}
+              readOnly={readyState}
+              placeholder="wss://example.com/chat"
+              defaultValue={defaultValue}
+              onChange={onChange}
+              type="text"
+            />
+          </div>
+          <div className="flex p-1">
+            {isConnectingOrClosed ? (
+              <button
+                className="rounded-sm bg-[--color-surprise] px-[--padding-md] text-center text-[--color-font-surprise] hover:brightness-75"
+                type="submit"
+              >
+                Connect
+              </button>
+            ) : (
+              <DisconnectButton requestId={request._id} />
+            )}
+          </div>
+        </form>
+      </>
+    );
+  },
+);

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -20,7 +20,7 @@ interface ActionBarProps {
 }
 
 export interface WebSocketActionBarHandle {
-  updateUrl: (url: string) => void;
+  setUrl: (url: string) => void;
 }
 
 export const WebSocketActionBar = forwardRef<WebSocketActionBarHandle, ActionBarProps>(
@@ -83,7 +83,7 @@ export const WebSocketActionBar = forwardRef<WebSocketActionBarHandle, ActionBar
         });
     }, [connect, environmentId, isOpen, request, updateTabById, workspaceId]);
 
-    const updateUrl = useCallback(
+    const setUrl = useCallback(
       (url: string) => {
         if (oneLineEditorRef.current) {
           oneLineEditorRef.current.setValue(url);
@@ -92,7 +92,7 @@ export const WebSocketActionBar = forwardRef<WebSocketActionBarHandle, ActionBar
       [oneLineEditorRef],
     );
 
-    useImperativeHandle(ref, () => ({ updateUrl }), [updateUrl]);
+    useImperativeHandle(ref, () => ({ setUrl }), [setUrl]);
 
     useEffect(() => {
       const sendOnMetaEnter = (event: KeyboardEvent) => {

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -37,8 +37,7 @@ import { RequestRenderErrorModal } from '../modals/request-render-error-modal';
 import { RequestSettingsModal } from '../modals/request-settings-modal';
 import { Pane } from '../panes/pane';
 import { RenderedQueryString } from '../rendered-query-string';
-import type { RequestUrlBarHandle } from '../request-url-bar';
-import { WebSocketActionBar } from './action-bar';
+import { WebSocketActionBar, type WebSocketActionBarHandle } from './action-bar';
 
 const supportedAuthTypes: AuthTypes[] = ['apikey', 'basic', 'bearer'];
 
@@ -194,7 +193,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
 
   const [previewMode, setPreviewMode] = useState(CONTENT_TYPE_JSON);
 
-  const requestUrlBarRef = useRef<RequestUrlBarHandle>(null);
+  const webSocketActionBarRef = useRef<WebSocketActionBarHandle>(null);
   const [dismissPathParameterTip, setDismissPathParameterTip] = useLocalStorage('dismissPathParameterTip', '');
 
   useEffect(() => {
@@ -259,7 +258,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
     if (url !== activeRequest.url) {
       patchRequest(requestId, { url, parameters });
       // Please refer to the comment in the request-pane
-      requestUrlBarRef.current?.updateUrl(url);
+      webSocketActionBarRef.current?.setUrl(url);
     }
   };
 
@@ -282,7 +281,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
           defaultValue={activeRequest.url}
           readyState={readyState}
           onChange={url => patchRequest(requestId, { url })}
-          ref={requestUrlBarRef}
+          ref={webSocketActionBarRef}
         />
       </header>
       <Tabs aria-label="Websocket request pane tabs" className="flex h-full w-full flex-1 flex-col">

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -37,6 +37,7 @@ import { RequestRenderErrorModal } from '../modals/request-render-error-modal';
 import { RequestSettingsModal } from '../modals/request-settings-modal';
 import { Pane } from '../panes/pane';
 import { RenderedQueryString } from '../rendered-query-string';
+import type { RequestUrlBarHandle } from '../request-url-bar';
 import { WebSocketActionBar } from './action-bar';
 
 const supportedAuthTypes: AuthTypes[] = ['apikey', 'basic', 'bearer'];
@@ -193,6 +194,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
 
   const [previewMode, setPreviewMode] = useState(CONTENT_TYPE_JSON);
 
+  const requestUrlBarRef = useRef<RequestUrlBarHandle>(null);
   const [dismissPathParameterTip, setDismissPathParameterTip] = useLocalStorage('dismissPathParameterTip', '');
 
   useEffect(() => {
@@ -256,6 +258,8 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
     // Only update if url changed
     if (url !== activeRequest.url) {
       patchRequest(requestId, { url, parameters });
+      // Please refer to the comment in the request-pane
+      requestUrlBarRef.current?.updateUrl(url);
     }
   };
 
@@ -278,6 +282,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
           defaultValue={activeRequest.url}
           readyState={readyState}
           onChange={url => patchRequest(requestId, { url })}
+          ref={requestUrlBarRef}
         />
       </header>
       <Tabs aria-label="Websocket request pane tabs" className="flex h-full w-full flex-1 flex-col">


### PR DESCRIPTION


<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

## Background

After verifying #2937, query params could update immediately, but the value in the URL bar does not reflect the change.

## Root Cause

One line editor is an uncontrolled component. As a result, when the URL is updated, it can't automatically update its value.

## Changes

- Add `setValue` to the one line editor
- Add `setUrl` to the request pane and websocket-request-pane
- Add smoke tests for `Import from URL`

### Before

https://github.com/user-attachments/assets/ba8cb0fd-0680-465f-b9bb-c2e60f5e5268

### After

https://github.com/user-attachments/assets/662ec6af-b46e-452e-b30b-2ee00b8fdf1b
