### PR TITLE
fix: update cookieJar methods to keep the name and params consistent

### DIFF
--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -21,8 +21,8 @@ export const resolveDbByKey = async (request: Request) => {
   if (url.host === 'oAuth2Token.getByRequestId'.toLowerCase()) {
     result = await models.oAuth2Token.getByParentId(body.parentId);
   }
-  if (url.host === 'cookieJar.getOrCreateForWorkspace'.toLowerCase()) {
-    result = await models.cookieJar.getOrCreateForParentId(body.id);
+  if (url.host === 'cookieJar.getOrCreateForParentId'.toLowerCase()) {
+    result = await models.cookieJar.getOrCreateForParentId(body.parentId);
   }
   if (url.host === 'response.getLatestForRequestId'.toLowerCase()) {
     result = await models.response.getLatestForRequest(body.requestId, body.environmentId);

--- a/packages/insomnia/src/templating/base-extension-worker.ts
+++ b/packages/insomnia/src/templating/base-extension-worker.ts
@@ -1,7 +1,6 @@
 import { getAppPlatform, getAppVersion } from '../common/constants';
 import type { Request } from '../models/request';
 import type { Response } from '../models/response';
-import type { Workspace } from '../models/workspace';
 import type { Plugin } from '../plugins/index';
 import type { BaseRenderContext, PluginTemplateTag, PluginTemplateTagContext } from './types';
 import * as templating from './worker';

--- a/packages/insomnia/src/templating/base-extension-worker.ts
+++ b/packages/insomnia/src/templating/base-extension-worker.ts
@@ -239,10 +239,10 @@ export default class BaseExtension {
             },
           },
           cookieJar: {
-            getOrCreateForWorkspace: async (workspace: Workspace) => {
+            getOrCreateForParentId: async (parentId: string) => {
               const resp = await fetch('insomnia-templating-worker-database://cookieJar.getOrCreateForParentId', {
                 method: 'post',
-                body: JSON.stringify({ parentId: workspace._id }),
+                body: JSON.stringify({ parentId }),
               });
 
               const cookieJar = await resp.json();

--- a/packages/insomnia/src/templating/base-extension.ts
+++ b/packages/insomnia/src/templating/base-extension.ts
@@ -121,8 +121,8 @@ export default class BaseExtension {
             getByRequestId: models.oAuth2Token.getByParentId,
           },
           cookieJar: {
-            getOrCreateForWorkspace: (workspace: Workspace) => {
-              return models.cookieJar.getOrCreateForParentId(workspace._id);
+            getOrCreateForParentId: (parentId: string) => {
+              return models.cookieJar.getOrCreateForParentId(parentId);
             },
           },
           response: {

--- a/packages/insomnia/src/templating/types.ts
+++ b/packages/insomnia/src/templating/types.ts
@@ -199,7 +199,7 @@ export interface PluginTemplateTagContext {
       };
       workspace: { getById: (id: string) => Promise<Workspace | null> };
       oAuth2Token: { getByRequestId: (id: string) => Promise<OAuth2Token | null> };
-      cookieJar: { getOrCreateForWorkspace: (workspace: Workspace) => Promise<CookieJar> };
+      cookieJar: { getOrCreateForParentId: (parentId: string) => Promise<CookieJar> };
       response: {
         getLatestForRequestId: typeof getLatestForRequest;
         getBodyBuffer: typeof getBodyBuffer;

--- a/packages/insomnia/src/ui/components/templating/local-template-tags.ts
+++ b/packages/insomnia/src/ui/components/templating/local-template-tags.ts
@@ -346,7 +346,7 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
           throw new Error(`Workspace not found for ${meta.workspaceId}`);
         }
 
-        const cookieJar = await context.util.models.cookieJar.getOrCreateForWorkspace(workspace);
+        const cookieJar = await context.util.models.cookieJar.getOrCreateForParentId(workspace._id);
 
         return new Promise((resolve, reject) => {
           let jar;
@@ -920,7 +920,7 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
             throw new Error('No cookie specified');
           }
 
-          const cookieJar = await context.util.models.cookieJar.getOrCreateForWorkspace(workspace);
+          const cookieJar = await context.util.models.cookieJar.getOrCreateForParentId(workspace._id);
           for (const p of request.parameters) {
             params.push({
               name: (await context.util.render(p.name)) || '',


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
## Background

When using a template to get the cookie, it throws an error.
```js
{% request 'cookie', 'test', '' %}
```
![iShot_2025-04-28_17 21 16](https://github.com/user-attachments/assets/b1a4abc2-9e70-4a32-bb43-3bee86beecf5)

## Root cause

There are two issues:
- We mostly use `cookieJar.getOrCreateForParentId`, but use `getOrCreateForWorkspace` in `templating-worker-database.ts` to match the message.
- `templating-worker-database.ts` uses `body.id` as the parent id, but the real param name used in `base-extension-worker.ts` is `body.parentId`.

## Changes

- Unify all the `getOrCreateForWorkspace` to `getOrCreateForParentId` to avoid similar issues.
- Change the `getOrCreateForParentId` param from workspace to parentId to match the new name
- Fix the wrong used parameter
