### PR TITLE
refactor: default hide the swagger preview

### DIFF
--- a/packages/insomnia/src/ui/routes/design.tsx
+++ b/packages/insomnia/src/ui/routes/design.tsx
@@ -197,7 +197,7 @@ const Design: FC = () => {
   const updateApiSpecFetcher = useFetcher();
   const generateRequestCollectionFetcher = useFetcher();
   const [isLintPaneOpen, setIsLintPaneOpen] = useState(false);
-  const [isSpecPaneOpen, setIsSpecPaneOpen] = useState(true);
+  const [isSpecPaneOpen, setIsSpecPaneOpen] = useState(false);
 
   const { components, info, servers, paths } = parsedSpec || {};
   const { requestBodies, responses, parameters, headers, schemas, securitySchemes } = components || {};

--- a/packages/insomnia/src/ui/routes/design.tsx
+++ b/packages/insomnia/src/ui/routes/design.tsx
@@ -197,7 +197,7 @@ const Design: FC = () => {
   const updateApiSpecFetcher = useFetcher();
   const generateRequestCollectionFetcher = useFetcher();
   const [isLintPaneOpen, setIsLintPaneOpen] = useState(false);
-  const [isSpecPaneOpen, setIsSpecPaneOpen] = useState(false);
+  const [isSpecPaneOpen, setIsSpecPaneOpen] = useState(Boolean(parsedSpec));
 
   const { components, info, servers, paths } = parsedSpec || {};
   const { requestBodies, responses, parameters, headers, schemas, securitySchemes } = components || {};


### PR DESCRIPTION
- we want to hide the swagger panel by default until enabled
