### PR TITLE
refactor: rename the copy for example

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/openapi.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/openapi.test.ts
@@ -5,7 +5,7 @@ import { test } from '../../playwright/test';
 test('can render Spectral OpenAPI lint errors', async ({ page }) => {
   await page.getByRole('button', { name: 'Create document' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click();
-  await page.click('text=start from an example');
+  await page.click('text=start from boilerplate');
 
   const codeEditor = page.locator('.pane-one');
   await expect.soft(codeEditor).toContainText('openapi: 3.0.0');

--- a/packages/insomnia/src/ui/components/design-empty-state.tsx
+++ b/packages/insomnia/src/ui/components/design-empty-state.tsx
@@ -80,7 +80,7 @@ export const DesignEmptyState: FC<Props> = ({ onImport }) => {
                   onImport(spec.exampleOpenApiSpec);
                 }}
               >
-                start from an example
+                start from boilerplate
               </Button>
             </span>
           </p>


### PR DESCRIPTION
- change the copy for API designer empty state to "start from boilerplate"