### PR TITLE
feat: support to set cookie hostOnly property

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/cookie-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cookie-editor-interactions.test.ts
@@ -58,4 +58,31 @@ test.describe('Cookie editor', () => {
     await page.getByRole('tab', { name: 'Console' }).click();
     await expect.soft(page.getByText('foo2=bar2')).toBeVisible();
   });
+
+  test('support __Host- prefix', async ({ page }) => {
+    // Open cookie editor
+    await page.click('button:has-text("Cookies")');
+
+    // Create a new cookie
+    await page.getByRole('button', { name: 'Add Cookie' }).click();
+
+    // Edit the new cookie
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+    await page.getByText('HostOnly').click();
+    await expect.soft(page.locator('input[name="hostOnly"]')).toBeChecked();
+    await page.getByRole('tab', { name: 'Raw' }).click();
+    await page
+      .locator('text=Raw Cookie String >> input[type="text"]')
+      .fill('__Host-foo=bar; Expires=Tue, 19 Jan 2038 03:14:07 GMT; Secure; Domain=localhost; Path=/');
+    await page.locator('text=Done').nth(1).click();
+    await page.click('text=Done');
+
+    // Send request
+    await page.getByLabel('Request Collection').getByTestId('example http').press('Enter');
+    await page.click('[data-testid="request-pane"] button:has-text("Send")');
+
+    // Check in the timeline that the cookie was sent
+    await page.getByRole('tab', { name: 'Console' }).click();
+    await expect.soft(page.getByText('__Host-foo=bar')).toBeVisible();
+  });
 });

--- a/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
@@ -525,7 +525,19 @@ const CookieModifyModal = ({ cookie, isOpen, setIsOpen, onUpdateCookie }: Cookie
                               defaultChecked={editCookie.httpOnly || false}
                               onChange={event => setEditCookie({ ...editCookie, httpOnly: event.target.checked })}
                             />
-                            httpOnly
+                            HttpOnly
+                          </label>
+                        </div>
+                        <div className="grid w-full grid-cols-2 gap-2">
+                          <label className="flex items-center gap-1">
+                            <input
+                              className="space-left"
+                              type="checkbox"
+                              name="hostOnly"
+                              defaultChecked={editCookie.hostOnly || false}
+                              onChange={event => setEditCookie({ ...editCookie, hostOnly: event.target.checked })}
+                            />
+                            HostOnly
                           </label>
                         </div>
                       </TabPanel>
@@ -540,8 +552,9 @@ const CookieModifyModal = ({ cookie, isOpen, setIsOpen, onUpdateCookie }: Cookie
                                   // NOTE: Perform toJSON so we have a plain JS object instead of Cookie instance
                                   const parsed = ToughCookie.parse(event.target.value, { loose: true })?.toJSON();
                                   if (parsed) {
-                                    // Make sure cookie has an id
+                                    // Make sure cookie has an id and keep its host-only-flag
                                     parsed.id = editCookie.id;
+                                    parsed.hostOnly = editCookie.hostOnly;
                                     setEditCookie(parsed as Cookie);
                                   }
                                 } catch (err) {

--- a/packages/insomnia/src/ui/components/rendered-text.tsx
+++ b/packages/insomnia/src/ui/components/rendered-text.tsx
@@ -22,6 +22,10 @@ class RenderedTextInternal extends PureComponent<Props, State> {
     const { render, children } = this.props;
 
     if (!children) {
+      this.setState({
+        renderedText: '',
+        error: '',
+      });
       return;
     }
 

--- a/packages/insomnia/src/ui/components/rendered-text.tsx
+++ b/packages/insomnia/src/ui/components/rendered-text.tsx
@@ -22,10 +22,6 @@ class RenderedTextInternal extends PureComponent<Props, State> {
     const { render, children } = this.props;
 
     if (!children) {
-      this.setState({
-        renderedText: '',
-        error: '',
-      });
       return;
     }
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
## Background

When a cookie has a `__Host-` prefix, it cannot be sent with the request.

## Root Cause

- A cookie with the `__Host-` prefix is special; it can be sent when Secure is true, path is `/`, and when the cookie is hostOnly.
- When a cookie is set without a domain, its host-only-flag is true
- A cookie should be set to a specific URL, but in Insomnia, we don't have such a URL, so we reuse the domain attribute in the cookie as the identifier. It works for most cases, but with this design, we cannot create a hostOnly cookie since we cannot omit a cookie's domain, otherwise we can't know which request needs this cookie.

## References

- [Cookie Name Prefixes](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis/#name-cookie-name-prefixes)
- [host-only-flag](https://datatracker.ietf.org/doc/html/rfc6265#section-5.3)
- [MDN Cookies hostOnly](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie#hostonly)

## Changes

Add `hostOnly` control to the cookie panel

Closes #8653 