### PR TITLE
fix: domain in cookie list not update when be set to empty

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/cookie-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cookie-editor-interactions.test.ts
@@ -58,4 +58,31 @@ test.describe('Cookie editor', () => {
     await page.getByRole('tab', { name: 'Console' }).click();
     await expect.soft(page.getByText('foo2=bar2')).toBeVisible();
   });
+
+  test('cookie list should update when cookie is updated', async ({ page }) => {
+    // Open cookie editor
+    await page.click('button:has-text("Cookies")');
+
+    // Set domain to empty
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+    await page.getByRole('tab', { name: 'Raw' }).click();
+    await page
+      .locator('text=Raw Cookie String >> input[type="text"]')
+      .fill('foo2=bar2; Expires=Tue, 19 Jan 2038 03:14:07 GMT; Path=/');
+    await page.locator('text=Done').nth(1).click();
+
+    await expect.soft(page.getByTestId('cookie-test-iteration-0').getByTestId('cookie-domain')).toBeEmpty();
+
+    // Set domain to example.com
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+    await page.getByRole('tab', { name: 'Raw' }).click();
+    await page
+      .locator('text=Raw Cookie String >> input[type="text"]')
+      .fill('foo2=bar2; Expires=Tue, 19 Jan 2038 03:14:07 GMT; Path=/; Domain=example.com');
+    await page.locator('text=Done').nth(1).click();
+
+    await expect
+      .soft(page.getByTestId('cookie-test-iteration-0').getByTestId('cookie-domain'))
+      .toHaveText('example.com');
+  });
 });

--- a/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
@@ -284,7 +284,7 @@ const CookieList = ({ cookies, onCookieDelete, onUpdateCookie }: CookieListProps
               textValue={cookie.domain}
               className="flex min-h-[40px] justify-between gap-2 rounded-sm px-2 py-1 leading-[36px] outline-none odd:bg-[--hl-xs]"
             >
-              <span className="flex min-w-[20%] items-center break-all leading-relaxed">
+              <span className="flex min-w-[20%] items-center break-all leading-relaxed" data-testid="cookie-domain">
                 <RenderedText>{cookie.domain || ''}</RenderedText>
               </span>
               <span className="flex w-[70%] items-center break-all leading-relaxed">

--- a/packages/insomnia/src/ui/components/rendered-text.tsx
+++ b/packages/insomnia/src/ui/components/rendered-text.tsx
@@ -22,6 +22,10 @@ class RenderedTextInternal extends PureComponent<Props, State> {
     const { render, children } = this.props;
 
     if (!children) {
+      this.setState({
+        renderedText: '',
+        error: '',
+      });
       return;
     }
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
## Issue
INS-5474

The Domain in the cookie list is not updated when it's set to empty

https://github.com/user-attachments/assets/bf0d2c0a-8390-4020-ae08-fc60bc1616c8

## Changes

- Set `renderedText` state to empty in RenderedTextInternal when children is a false value
- Add tests

