### PR TITLE
Fix search bar disappear when no match collection found in project view

### DIFF
--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -1207,7 +1207,8 @@ const ProjectRoute: FC = () => {
                     </div>
                   </div>
                 )}
-                {filesWithPresence.length > 0 && (
+                {/* Show filter UI if there are files with presence or if the user has entered any filter input(even no match) */}
+                {(filesWithPresence.length > 0 || workspaceListFilter) && (
                   <div className="flex w-full max-w-xl justify-between gap-2 p-[--padding-md]">
                     <SearchField
                       aria-label="Files filter"


### PR DESCRIPTION
**Change**
Fix to show search bar UI when the filter did not match any collections in current project.

Before:
<img width="534" alt="Screenshot 2025-05-07 at 14 24 56" src="https://github.com/user-attachments/assets/ff573391-50ca-413d-af07-e4e8dcd08871" />
After:
<img width="567" alt="Screenshot 2025-05-07 at 14 24 41" src="https://github.com/user-attachments/assets/9b7c447d-cfa9-4cd5-abbc-a182ef6b7e3b" />


Closes https://github.com/Kong/insomnia/issues/8682