### PR TITLE
fix(Key-Value Editor): the key value editor should scroll if there is an overflow

### DIFF
--- a/packages/insomnia/src/ui/components/editors/environment-key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/environment-key-value-editor/key-value-editor.tsx
@@ -191,7 +191,7 @@ export const EnvironmentKVEditor = ({ data, onChange, vaultKey = '', isPrivate =
     try {
       JSON.parse(input);
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   };

--- a/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/key-value-editor.tsx
@@ -357,7 +357,7 @@ export const KeyValueEditor: FC<Props> = ({
           }}
         </ListBox>
       )}
-      <div onKeyDownCapture={onKeyDownOuter} className="relative w-full">
+      <div onKeyDownCapture={onKeyDownOuter} className="relative w-full overflow-hidden flex flex-col">
         <ListBox
           aria-label="Key-value pairs"
           selectionMode="none"


### PR DESCRIPTION
Highlights:

- [x] Fixes an issue where the key-value editor won't scroll when it overflows

Closes #8681