### PR TITLE
Fix: rendering in worker error bug [INS-5482]

### DIFF
--- a/packages/insomnia/src/ui/worker/templating-handler.ts
+++ b/packages/insomnia/src/ui/worker/templating-handler.ts
@@ -43,8 +43,13 @@ export function renderInWorker({
     const messageHandler = (event: MessageEvent) => {
       if (event.data.id === id) {
         worker.removeEventListener('message', messageHandler);
-        if (event.data.err) {
-          const error = new RenderError(event.data.err);
+        const workerError = event.data.err;
+        if (workerError) {
+          const error = new RenderError(workerError);
+          if (error instanceof RenderError) {
+            error.path = workerError.path || '';
+            error.location = workerError.location;
+          }
           error.type = 'render';
           const undefinedEnvironmentVariables = extractUndefinedVariableKey(input, newContext);
           if (undefinedEnvironmentVariables.length > 0) {

--- a/packages/insomnia/src/ui/worker/templating-handler.ts
+++ b/packages/insomnia/src/ui/worker/templating-handler.ts
@@ -45,7 +45,7 @@ export function renderInWorker({
         worker.removeEventListener('message', messageHandler);
         const workerError = event.data.err;
         if (workerError) {
-          const error = new RenderError(workerError);
+          const error = new RenderError(workerError.message);
           if (error instanceof RenderError) {
             error.path = workerError.path || '';
             error.location = workerError.location;


### PR DESCRIPTION
**Problem**
Using a environment variable with a invalid nunjck tag in OAuth:
<img width="551" alt="Screenshot 2025-05-08 at 14 21 46" src="https://github.com/user-attachments/assets/539db982-8efd-4855-aa5b-e1a2912c3c28" />
Expected error message that shoud displayed
<img width="768" alt="Screenshot 2025-05-08 at 14 21 34" src="https://github.com/user-attachments/assets/c66230cd-f426-4422-b026-df5d5b98a105" />
Actually result when click **Fetch Tokens**
<img width="573" alt="Screenshot 2025-05-08 at 14 32 05" src="https://github.com/user-attachments/assets/31e91790-19fd-44ce-a175-032d9bfdca2e" />

**Changes**
The ``templating-handler`` is initialized RenderError with the error object, which should be the string type of error message content.
So components using the ``err.message`` to render will throw unexpected React child error.
Change to initialize RenderError with err.message instead. Also add path and location attribute if exists