### PR TITLE
Unescape forward slash in json string when previewing response [INS-5465]

### DIFF
--- a/packages/insomnia/src/common/misc.ts
+++ b/packages/insomnia/src/common/misc.ts
@@ -242,3 +242,18 @@ export function isNotNullOrUndefined<ValueType>(value: ValueType | null | undefi
 }
 
 export const toKebabCase = (value: string) => value.replace(/ /g, '-');
+
+// unescape forward slashes in a string if needed
+export function unescapeForwardSlash(str: string): string {
+  // Use a regular expression to find runs of one or more backslashes (bs) followed by a slash
+  return str.replace(/(\\+)\//g, (match, bs) => {
+    // Determine if the number of backslashes is odd or even
+    // Odd count: the last backslash escapes the slash; we remove that one
+    if (bs.length % 2 === 1) {
+      // Keep all but the last backslash, then append the unescaped forward slash
+      return bs.slice(0, bs.length - 1) + '/';
+    }
+    // Even count: all backslashes are literal escapes; leave the sequence unchanged
+    return match;
+  });
+}

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -7,6 +7,7 @@ import {
   PREVIEW_MODE_FRIENDLY,
   PREVIEW_MODE_RAW,
 } from '../../../common/constants';
+import { unescapeForwardSlash } from '../../../common/misc';
 import { CodeEditor, type CodeEditorHandle } from '../codemirror/code-editor';
 import { useDocBodyKeyboardShortcuts } from '../keydown-binder';
 import { ResponseCSVViewer } from './response-csv-viewer';
@@ -217,10 +218,11 @@ export const ResponseViewer = ({
     // Although there is a prettifier for json inside the CodeEditor, but it is to prettify json strings that is being edited which may have syntax errors.
     // There are some cases that the prettifier inside the CodeEditor can not handle.
     // See https://github.com/Kong/insomnia/issues/1556
+    // The user wants the forward slash in the json string to be unescaped when previewing JSON response.
     // Here the CodeEditor is readonly and the bodyStr is supposed to be a valid json string.
-    // So we try to use the native JSON.stringify to prettify the json string better. The native way can handle the issue.
+    // So we try to unescape the forward slashes before passing it to the CodeEditor.
     try {
-      bodyStr = JSON.stringify(JSON.parse(bodyStr));
+      bodyStr = unescapeForwardSlash(bodyStr);
     } catch (err) {}
     return (
       <CodeEditor

--- a/packages/insomnia/src/ui/components/viewers/viewers.test.ts
+++ b/packages/insomnia/src/ui/components/viewers/viewers.test.ts
@@ -1,0 +1,15 @@
+import { expect, it } from 'vitest';
+
+import { unescapeForwardSlash } from '../../../common/misc';
+
+it('unescape forward slash correctly', () => {
+  const tests = [
+    { input: '{"path":"some\\/dir\\/file"}', expected: '{"path":"some/dir/file"}' },
+    { input: '{"pattern":"\\\\/abc"}', expected: '{"pattern":"\\\\/abc"}' },
+    { input: '{"weird":"\\\\\\/test"}', expected: '{"weird":"\\\\/test"}' },
+  ];
+  tests.forEach(({ input, expected }) => {
+    const result = unescapeForwardSlash(input);
+    expect(result).toBe(expected);
+  });
+});


### PR DESCRIPTION
Close https://github.com/Kong/insomnia/issues/8517
This issue originates from https://github.com/Kong/insomnia/issues/1556
I used JSON.stringify(JSON.parse(resStr)) in https://github.com/Kong/insomnia/pull/8354 to prettify JSON.
But that leads to the problem of floating-point precision loss https://github.com/Kong/insomnia/issues/8517

So I wrote a dedicated function unescapeForwardSlash, to do it.