### PR TITLE
fix(cli): proxy options do not work and stop loading settings and cookies from exports - INS-5429

### DIFF
--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -152,12 +152,12 @@ describe('inso dev bundle', () => {
     // Disabled this test
     // currently settings loading is disabled, as it could include values like proxies from UI, which might not make sense for the cli.
     // it can be re-enabled if necessary
-    xit('send request with settings enabled (by testing followRedirects)', async () => {
-      const input =
-        '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/db/fixtures/nedb --requestNamePattern "withSettings" --verbose "Insomnia Designer" wrk_0b96eff';
-      const result = await runCliFromRoot(input);
-      expect(result.stdout).not.toContain("Issue another request to this URL: 'https://insomnia.rest/'");
-    });
+    // it('send request with settings enabled (by testing followRedirects)', async () => {
+    //   const input =
+    //     '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/db/fixtures/nedb --requestNamePattern "withSettings" --verbose "Insomnia Designer" wrk_0b96eff';
+    //   const result = await runCliFromRoot(input);
+    //   expect(result.stdout).not.toContain("Issue another request to this URL: 'https://insomnia.rest/'");
+    // });
 
     it('run collection: run requests in specified order', async () => {
       const input =

--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -149,7 +149,10 @@ describe('inso dev bundle', () => {
       expect(result.stdout).toContain('Adding SSL KEY certificate');
     });
 
-    it('send request with settings enabled (by testing followRedirects)', async () => {
+    // Disabled this test
+    // currently settings loading is disabled, as it could include values like proxies from UI, which might not make sense for the cli.
+    // it can be re-enabled if necessary
+    xit('send request with settings enabled (by testing followRedirects)', async () => {
       const input =
         '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/db/fixtures/nedb --requestNamePattern "withSettings" --verbose "Insomnia Designer" wrk_0b96eff';
       const result = await runCliFromRoot(input);

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -333,11 +333,11 @@ export const go = (args?: string[]) => {
     noProxy: '',
   };
 
-  if (process.env.HTTP_PROXY || process.env.HTTPS_PROXY) {
+  if (process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy) {
     proxySettings.proxyEnabled = true;
-    proxySettings.httpProxy = process.env.HTTP_PROXY || '';
-    proxySettings.httpsProxy = process.env.HTTPS_PROXY || '';
-    proxySettings.noProxy = process.env.NO_PROXY || '';
+    proxySettings.httpProxy = process.env.HTTP_PROXY || process.env.http_proxy || '';
+    proxySettings.httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy || '';
+    proxySettings.noProxy = process.env.NO_PROXY || process.env.no_proxy || '';
   }
 
   // export and lint logic

--- a/packages/insomnia-inso/src/db/index.ts
+++ b/packages/insomnia-inso/src/db/index.ts
@@ -1,8 +1,6 @@
 import { stat } from 'fs/promises';
 import type { CaCertificate } from 'insomnia/src/models/ca-certificate';
 import type { ClientCertificate } from 'insomnia/src/models/client-certificate';
-import type { CookieJar } from 'insomnia/src/models/cookie-jar';
-import type { Settings } from 'insomnia/src/models/settings';
 
 import { logger } from '../cli';
 import gitAdapter from './adapters/git-adapter';
@@ -29,8 +27,6 @@ export interface Database {
   UnitTest: UnitTest[];
   ClientCertificate: ClientCertificate[];
   CaCertificate: CaCertificate[];
-  CookieJar: CookieJar[];
-  Settings: Settings[];
 }
 
 export const emptyDb = (): Database => ({
@@ -44,8 +40,6 @@ export const emptyDb = (): Database => ({
   UnitTestSuite: [],
   ClientCertificate: [],
   CaCertificate: [],
-  CookieJar: [],
-  Settings: [],
 });
 
 export type DbAdapter = (dir: string, filterTypes?: (keyof Database)[]) => Promise<Database | null>;

--- a/packages/insomnia-inso/src/db/index.ts
+++ b/packages/insomnia-inso/src/db/index.ts
@@ -1,6 +1,7 @@
 import { stat } from 'fs/promises';
 import type { CaCertificate } from 'insomnia/src/models/ca-certificate';
 import type { ClientCertificate } from 'insomnia/src/models/client-certificate';
+import type { CookieJar } from 'insomnia/src/models/cookie-jar';
 
 import { logger } from '../cli';
 import gitAdapter from './adapters/git-adapter';
@@ -27,6 +28,7 @@ export interface Database {
   UnitTest: UnitTest[];
   ClientCertificate: ClientCertificate[];
   CaCertificate: CaCertificate[];
+  CookieJar: CookieJar[];
 }
 
 export const emptyDb = (): Database => ({
@@ -40,6 +42,7 @@ export const emptyDb = (): Database => ({
   UnitTestSuite: [],
   ClientCertificate: [],
   CaCertificate: [],
+  CookieJar: [],
 });
 
 export type DbAdapter = (dir: string, filterTypes?: (keyof Database)[]) => Promise<Database | null>;

--- a/packages/insomnia-smoke-test/fixtures/simple.yaml
+++ b/packages/insomnia-smoke-test/fixtures/simple.yaml
@@ -48,6 +48,23 @@ collection:
         send: true
         store: true
       rebuildPath: true
+  - url: http://localhost:4010/pets/1
+    name: proxyEnabled
+    meta:
+      id: req_49f06ac9024446728a9765162d56b95b
+      created: 1666867365377
+      modified: 1666867670885
+      isPrivate: false
+    method: GET
+    scripts: {}
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
   - url: http://localhost:4010/graphql
     name: example graphql
     meta:

--- a/packages/insomnia-smoke-test/tests/smoke/preferences-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/preferences-interactions.test.ts
@@ -44,7 +44,6 @@ test('Check filter responses by environment preference', async ({ app, page }) =
 test('Enable http and https proxies', async ({ app, page }) => {
   const responsePane = page.getByTestId('response-pane');
 
-  // Set filter responses by environment
   await page.getByTestId('settings-button').click();
   await page.locator('text=Insomnia Preferences').first().click();
   await page.locator('[name="timeout"]').fill('1000');
@@ -55,7 +54,6 @@ test('Enable http and https proxies', async ({ app, page }) => {
   await page.locator('[name="httpsProxy"]').fill('127.0.0.1:2222');
   await page.locator('[name="noProxy"]').fill('');
   await page.locator('.app').press('Escape');
-  // await page.waitForTimeout(1000);
 
   const text = await loadFixture('simple.yaml');
   await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);

--- a/packages/insomnia-smoke-test/tests/smoke/preferences-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/preferences-interactions.test.ts
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 import { loadFixture } from '../../playwright/paths';
 import { test } from '../../playwright/test';
 
@@ -37,4 +39,35 @@ test('Check filter responses by environment preference', async ({ app, page }) =
   await page.locator('[data-testid="request-pane"] button:has-text("Send")').click();
   await page.click('text=Console');
   await page.locator('text=HTTP/1.1 200 OK').click();
+});
+
+test('Enable http and https proxies', async ({ app, page }) => {
+  const responsePane = page.getByTestId('response-pane');
+
+  // Set filter responses by environment
+  await page.getByTestId('settings-button').click();
+  await page.locator('text=Insomnia Preferences').first().click();
+  await page.locator('[name="timeout"]').fill('1000');
+
+  await page.getByRole('tab', { name: 'Proxy' }).click();
+  await page.locator('text=Enable proxy').click();
+  await page.locator('[name="httpProxy"]').fill('127.0.0.1:1111');
+  await page.locator('[name="httpsProxy"]').fill('127.0.0.1:2222');
+  await page.locator('[name="noProxy"]').fill('');
+  await page.locator('.app').press('Escape');
+  // await page.waitForTimeout(1000);
+
+  const text = await loadFixture('simple.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await page.getByLabel('simple').click();
+
+  // send the request and check timeline
+  await page.getByLabel('Request Collection').getByTestId('proxyEnabled').press('Enter');
+  await page.locator('[data-testid="request-pane"] button:has-text("Send")').click();
+  await page.click('text=Console');
+  await expect.soft(responsePane).toContainText('Trying 127.0.0.1:1111'); // updated proxy
 });

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -414,10 +414,10 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
     transientVariables,
     runtime,
     parentFolders,
+    settings,
   } = context;
   invariant(script, 'script must be provided');
 
-  const settings = await models.settings.get();
   // location is the complete path of a request, including project, collection and folder(if have).
   const requestLocation = ancestors
     .filter(doc => isRequest(doc) || isRequestGroup(doc) || isWorkspace(doc) || isProject(doc))


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Background
Potentially related to #8540
- CLI proxy options (#8257) are not working, as options are overridden in the deeper call stack.
- No longer load settings and cookies from exports(#8111), as they seems not necessary in CLI execution.

### Changes
- [x] Remove db loading to make CLI setting overriding work
- [x] Stop loading settings and cookies from exports
- [x] Disabled a test for loading settings
- [x] Added a test for proxying
- [x] Also accept proxy options in lowercase.