### PR TITLE
fix: unknow type in sync

### DIFF
--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -171,6 +171,11 @@ export const database = {
       return _send<T[]>('find', ...arguments);
     }
     return new Promise<T[]>((resolve, reject) => {
+      if (!db[type]) {
+        console.warn(`[db] No collection for type "${type}"`);
+        resolve([]);
+        return;
+      }
       (db[type] as NeDB<T>)
         .find(query)
         .sort(sort)

--- a/packages/insomnia/src/common/import-v5-parser.ts
+++ b/packages/insomnia/src/common/import-v5-parser.ts
@@ -435,6 +435,7 @@ export const WebsocketRequestSchema = z.object({
     },
   }),
   meta: MetaSchema.extend({
+    id: z.string().startsWith('ws-req'),
     sortKey: z.number().optional(),
   }).optional(),
 });

--- a/packages/insomnia/src/sync/vcs/pull-backend-project.ts
+++ b/packages/insomnia/src/sync/vcs/pull-backend-project.ts
@@ -57,7 +57,10 @@ export const pullBackendProject = async ({ vcs, backendProject, remoteProject }:
       doc.parentId = remoteProject._id;
       workspaceId = doc._id;
     }
-    await database.upsert(doc);
+    const allModelType = models.types();
+    if (allModelType.includes(doc.type)) {
+      await database.upsert(doc);
+    }
   }
 
   await database.flushChanges(flushId);


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
**Background**

This is a fix for sync between different versions(The new version includes new DB model types to sync).
When testing the new Socket.io feature, if we push the new commit that includes the socket.io request. Then we use an older version and pull, there are some unexpected behaviors

- git sync
    - Will recognize socket.io as websocket and can not select it.
- cloud sync
    - Can not pull an unsynced workspace or new commit (Unknown database type causes js error)


_This pr can fix the 2 issues above, but when we check the diff in the older version, the new type request was deleted.
Consider whether this can be fixed or the user can be better prompted_
<img width="1321" alt="image" src="https://github.com/user-attachments/assets/45b8e824-856e-4b37-a370-6a88a73154a8" />
