### PR TITLE
fix: specify bash as shell to ensure INSO_VERSION can be read on Windows

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -68,6 +68,7 @@ jobs:
         run: npm ci
 
       - name: Setup Inso CLI version env var
+        shell: bash
         run: |
           echo "INSO_VERSION=$(jq .version ./packages/${{ env.INSO_PACKAGE_NAME }}/package.json -rj)" >> $GITHUB_ENV
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

## Background

When users use the inso CLI on Windows, it returns `dev` as its version.

## Root Cause

From the log, the version cannot be read on Windows when building.

![iShot_2025-05-12_17 17 51](https://github.com/user-attachments/assets/2e5ebb6b-52b8-4792-b108-fe11a2fadafc)

Windows uses PowerShell as the default shell, it needs a different expression to set the env, so specify it to use bash to avoid the inconsistency.

## Changes

Specify bash as the shell when `Setup Inso CLI version env var`.

Closes #8397