### PR TITLE
feat(Git Sync): Introduce UX for migrating legacy Git workspaces to a Git Project

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -2,7 +2,7 @@ import { createHash, randomBytes } from 'crypto';
 import { shell } from 'electron';
 import { app, net } from 'electron/main';
 import { fromUrl } from 'hosted-git-info';
-import { Errors, type PromiseFsClient } from 'isomorphic-git';
+import { Errors, type HeadStatus, type PromiseFsClient, type StageStatus, type WorkdirStatus } from 'isomorphic-git';
 import path from 'path';
 import { v4 } from 'uuid';
 import YAML, { parse } from 'yaml';
@@ -433,17 +433,18 @@ async function containsLegacyInsomniaDir({ fsClient }: { fsClient: PromiseFsClie
  * and each file is named with the database ID as its name, with the `.yaml` extension.
  */
 async function importLegacyInsomniaFolder({ fsClient, projectId }: { fsClient: PromiseFsClient; projectId: string }) {
+  const changes: { path: string; status: [HeadStatus, WorkdirStatus, StageStatus] }[] = [];
   try {
-    const legacyInsomniaFolderStat = await fsClient.promises.lstat('.insomnia');
+    const legacyInsomniaFolderStat = await fsClient.promises.lstat(GIT_INSOMNIA_DIR_NAME);
 
     if (!legacyInsomniaFolderStat.isDirectory()) {
       return;
     }
 
-    const legacyInsomniaModelFolders = await fsClient.promises.readdir('.insomnia');
+    const legacyInsomniaModelFolders = await fsClient.promises.readdir(GIT_INSOMNIA_DIR_NAME);
 
     for (const folder of legacyInsomniaModelFolders) {
-      const folderPath = path.join('.insomnia', folder);
+      const folderPath = path.join(GIT_INSOMNIA_DIR_NAME, folder);
       const folderStat = await fsClient.promises.lstat(folderPath);
 
       if (!folderStat.isDirectory()) {
@@ -461,7 +462,8 @@ async function importLegacyInsomniaFolder({ fsClient, projectId }: { fsClient: P
         }
 
         const fileContents = await fsClient.promises.readFile(filePath, 'utf8');
-        const id = file.split('.')[1];
+
+        const id = file.split('.')[0];
         const type = folder;
 
         // Skip the file if there is a conflict marker
@@ -488,15 +490,33 @@ async function importLegacyInsomniaFolder({ fsClient, projectId }: { fsClient: P
           // This is because the parentId (or a project) is not synced into git, so it will be cleared whenever git writes the workspace into the db, thereby removing it from the project on the client
           // In order to reproduce this bug, comment out the following line, then clone a repository into a local project, then open the workspace, you'll notice it will have moved into the default project
           doc.parentId = projectId;
+
+          const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(doc._id);
+
+          const gitFilePath = `insomnia.${doc._id}.yaml`;
+          await models.workspaceMeta.update(workspaceMeta, { gitFilePath });
+
+          changes.push({
+            path: gitFilePath,
+            status: [0, 1, 0],
+          });
         }
 
         await database.upsert(doc, true);
+        changes.push({
+          path: filePath,
+          // It existed and was removed from the git repository
+          status: [1, 0, 1],
+        });
       }
     }
 
     // Remove the legacy folder
-    await fsClient.promises.rmdir('.insomnia');
-    return {};
+    await fsClient.promises.rmdir(GIT_INSOMNIA_DIR_NAME, { recursive: true });
+
+    return {
+      changes,
+    };
   } catch (e) {
     return {
       errors: [`Failed to import legacy Insomnia folder: ${e.message}`],
@@ -1214,9 +1234,23 @@ export const migrateLegacyInsomniaFolderToFile = async ({ projectId }: { project
 
   const fsClient = await getGitFSClient({ projectId, gitRepositoryId: gitRepository._id });
 
-  await importLegacyInsomniaFolder({ fsClient, projectId });
+  const result = await importLegacyInsomniaFolder({ fsClient, projectId });
 
-  // @TODO - Stage the changes
+  if (result && 'errors' in result && result.errors) {
+    console.error('Failed to import legacy Insomnia folder', result.errors);
+    return;
+  }
+
+  if (!result || 'errors' in result) {
+    console.error('Failed to import legacy Insomnia folder');
+    return;
+  }
+
+  const { changes } = result;
+
+  await GitVCS.stageChanges(changes);
+
+  await GitVCS.setAuthor();
 
   await commitToGitRepoAction({
     projectId,

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -379,29 +379,32 @@ async function containsLegacyInsomniaDir({ fsClient }: { fsClient: PromiseFsClie
     }
   | undefined
 > {
-  const legacyInsomniaFolderStat = await fsClient.promises.lstat('.insomnia');
+  try {
+    const legacyInsomniaFolderStat = await fsClient.promises.lstat(GIT_INSOMNIA_DIR_NAME);
 
-  if (!legacyInsomniaFolderStat.isDirectory()) {
+    if (!legacyInsomniaFolderStat.isDirectory()) {
+      return;
+    }
+
+    const legacyInsomniaWorkspaceFolderPath = path.join(GIT_INSOMNIA_DIR_NAME, models.workspace.type);
+
+    const [workspaceFile] = await fsClient.promises.readdir(legacyInsomniaWorkspaceFolderPath);
+    const workspaceFilePath = path.join(legacyInsomniaWorkspaceFolderPath, workspaceFile);
+
+    const workspaceFileContents = await fsClient.promises.readFile(workspaceFilePath, 'utf8');
+    const workspaceDocument = YAML.parse(workspaceFileContents);
+
+    const workspaceName = workspaceDocument.name || 'Untitled';
+    const workspaceScope = workspaceDocument.scope;
+
+    return {
+      name: workspaceName,
+      scope: workspaceScope,
+    };
+  } catch (e) {
+    console.warn('Failed to read legacy Insomnia directory', e);
     return;
   }
-
-  const legacyInsomniaWorkspaceFolderPath = await fsClient.promises.readdir(
-    path.join('.insomnia', models.workspace.type),
-  );
-
-  const [workspaceFile] = await fsClient.promises.readdir(legacyInsomniaWorkspaceFolderPath);
-  const workspaceFilePath = path.join(legacyInsomniaWorkspaceFolderPath, workspaceFile);
-
-  const workspaceFileContents = await fsClient.promises.readFile(workspaceFilePath, 'utf8');
-  const workspaceDocument = YAML.parse(workspaceFileContents);
-
-  const workspaceName = workspaceDocument.name || 'Untitled';
-  const workspaceScope = workspaceDocument.scope;
-
-  return {
-    name: workspaceName,
-    scope: workspaceScope,
-  };
 }
 
 /**
@@ -422,68 +425,75 @@ async function containsLegacyInsomniaDir({ fsClient }: { fsClient: PromiseFsClie
  * and each file is named with the database ID as its name, with the `.yaml` extension.
  */
 async function importLegacyInsomniaFolder({ fsClient, projectId }: { fsClient: PromiseFsClient; projectId: string }) {
-  const legacyInsomniaFolderStat = await fsClient.promises.lstat('.insomnia');
+  try {
+    const legacyInsomniaFolderStat = await fsClient.promises.lstat('.insomnia');
 
-  if (!legacyInsomniaFolderStat.isDirectory()) {
-    return;
-  }
-
-  const legacyInsomniaModelFolders = await fsClient.promises.readdir('.insomnia');
-
-  for (const folder of legacyInsomniaModelFolders) {
-    const folderPath = path.join('.insomnia', folder);
-    const folderStat = await fsClient.promises.lstat(folderPath);
-
-    if (!folderStat.isDirectory()) {
-      continue;
+    if (!legacyInsomniaFolderStat.isDirectory()) {
+      return;
     }
 
-    const folderFiles = await fsClient.promises.readdir(folderPath);
+    const legacyInsomniaModelFolders = await fsClient.promises.readdir('.insomnia');
 
-    for (const file of folderFiles) {
-      const filePath = path.join(folderPath, file);
-      const fileStat = await fsClient.promises.lstat(filePath);
+    for (const folder of legacyInsomniaModelFolders) {
+      const folderPath = path.join('.insomnia', folder);
+      const folderStat = await fsClient.promises.lstat(folderPath);
 
-      if (!fileStat.isFile()) {
+      if (!folderStat.isDirectory()) {
         continue;
       }
 
-      const fileContents = await fsClient.promises.readFile(filePath, 'utf8');
-      const id = file.split('.')[1];
-      const type = folder;
+      const folderFiles = await fsClient.promises.readdir(folderPath);
 
-      // Skip the file if there is a conflict marker
-      if (fileContents.split('\n').includes('=======')) {
-        return;
+      for (const file of folderFiles) {
+        const filePath = path.join(folderPath, file);
+        const fileStat = await fsClient.promises.lstat(filePath);
+
+        if (!fileStat.isFile()) {
+          continue;
+        }
+
+        const fileContents = await fsClient.promises.readFile(filePath, 'utf8');
+        const id = file.split('.')[1];
+        const type = folder;
+
+        // Skip the file if there is a conflict marker
+        if (fileContents.split('\n').includes('=======')) {
+          return;
+        }
+
+        const doc: models.BaseModel = YAML.parse(fileContents);
+
+        if (id !== doc._id) {
+          throw new Error(`Doc _id does not match file path [${doc._id} != ${id || 'null'}]`);
+        }
+
+        if (type !== doc.type) {
+          throw new Error(`Doc type does not match file path [${doc.type} != ${type || 'null'}]`);
+        }
+
+        if (isWorkspace(doc)) {
+          console.log('[git] setting workspace parent to be that of the active project', {
+            original: doc.parentId,
+            new: projectId,
+          });
+          // Whenever we write a workspace into nedb we should set the parentId to be that of the current project
+          // This is because the parentId (or a project) is not synced into git, so it will be cleared whenever git writes the workspace into the db, thereby removing it from the project on the client
+          // In order to reproduce this bug, comment out the following line, then clone a repository into a local project, then open the workspace, you'll notice it will have moved into the default project
+          doc.parentId = projectId;
+        }
+
+        await database.upsert(doc, true);
       }
-
-      const doc: models.BaseModel = YAML.parse(fileContents);
-
-      if (id !== doc._id) {
-        throw new Error(`Doc _id does not match file path [${doc._id} != ${id || 'null'}]`);
-      }
-
-      if (type !== doc.type) {
-        throw new Error(`Doc type does not match file path [${doc.type} != ${type || 'null'}]`);
-      }
-
-      if (isWorkspace(doc)) {
-        console.log('[git] setting workspace parent to be that of the active project', {
-          original: doc.parentId,
-          new: projectId,
-        });
-        // Whenever we write a workspace into nedb we should set the parentId to be that of the current project
-        // This is because the parentId (or a project) is not synced into git, so it will be cleared whenever git writes the workspace into the db, thereby removing it from the project on the client
-        // In order to reproduce this bug, comment out the following line, then clone a repository into a local project, then open the workspace, you'll notice it will have moved into the default project
-        doc.parentId = projectId;
-      }
-
-      await database.upsert(doc, true);
     }
-  }
 
-  // Remove the legacy folder
-  await fsClient.promises.rmdir('.insomnia');
+    // Remove the legacy folder
+    await fsClient.promises.rmdir('.insomnia');
+    return {};
+  } catch (e) {
+    return {
+      errors: [`Failed to import legacy Insomnia folder: ${e.message}`],
+    };
+  }
 }
 
 async function isInsomniaFile(fullPath: string, fsClient: PromiseFsClient) {
@@ -617,6 +627,8 @@ export const initGitRepoCloneAction = async ({
   );
 
   const legacyInsomniaFile = await containsLegacyInsomniaDir({ fsClient: inMemoryFsClient });
+
+  console.log({ legacyInsomniaFile });
 
   if (legacyInsomniaFile) {
     // Add the legacy Insomnia file on the top of the list

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -209,7 +209,7 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
     await GitVCS.setAuthor();
     await GitVCS.addRemote(uri);
 
-    let legacyInsomniaWorkspace = null;
+    let legacyInsomniaWorkspace;
     if (!workspaceId) {
       legacyInsomniaWorkspace = await containsLegacyInsomniaDir({ fsClient });
     }

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -618,7 +618,12 @@ export const initGitRepoCloneAction = async ({
 
   const legacyInsomniaFile = await containsLegacyInsomniaDir({ fsClient: inMemoryFsClient });
 
-  return { files, legacyInsomniaFile };
+  if (legacyInsomniaFile) {
+    // Add the legacy Insomnia file on the top of the list
+    files.unshift({ ...legacyInsomniaFile, path: '.insomnia' });
+  }
+
+  return { files };
 };
 
 export const cloneGitRepoAction = async ({

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -409,8 +409,7 @@ async function containsLegacyInsomniaDir({ fsClient }: { fsClient: PromiseFsClie
       scope: workspaceScope,
       path: GIT_INSOMNIA_DIR_NAME,
     };
-  } catch (e) {
-    console.warn('Failed to read legacy Insomnia directory', e);
+  } catch {
     return;
   }
 }

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -22,7 +22,7 @@ import { insomniaFileSchema } from '../common/import-v5-parser';
 import { insomniaSchemaTypeToScope } from '../common/insomnia-v5';
 import * as models from '../models';
 import type { GitRepository } from '../models/git-repository';
-import { type WorkspaceScope, WorkspaceScopeKeys } from '../models/workspace';
+import { isWorkspace, type WorkspaceScope, WorkspaceScopeKeys } from '../models/workspace';
 import { fsClient } from '../sync/git/fs-client';
 import GitVCS, {
   GIT_CLONE_DIR,
@@ -365,6 +365,85 @@ export const canPushLoader = async ({
     return { canPush: false };
   }
 };
+
+async function containsInsomniaDir(fsClient: PromiseFsClient): Promise<boolean> {
+  const legacyInsomniaFolderStat = await fsClient.promises.lstat('.insomnia');
+
+  return legacyInsomniaFolderStat.isDirectory();
+}
+
+/**
+ * The legacy git sync functionality stores one `.insomnia` directory in the root of the repository.
+ * The structure looks like this:
+ *
+ * ROOT_REPOSITORY_DIR/
+ * └── .insomnia/
+ *     ├── Workspace/
+ *     │   └── wrk-{{UUID}}.yaml
+ *     ├── Request/
+ *     │   ├── req-{{UUID}}.yaml
+ *     │   └── req-{{UUID}}.yaml
+ *     └── OtherModel/
+ *         └── other-{{UUID}}.yaml
+ *
+ * All entities are stored inside a subdirectory named after the model it represents (e.g., `Request`),
+ * and each file is named with the database ID as its name, with the `.yaml` extension.
+ */
+async function importLegacyInsomniaFolder({ fsClient, projectId }: { fsClient: PromiseFsClient; projectId: string }) {
+  const legacyInsomniaFolderStat = await fsClient.promises.lstat('.insomnia');
+
+  if (legacyInsomniaFolderStat.isDirectory()) {
+    const legacyInsomniaModelFolders = await fsClient.promises.readdir('.insomnia');
+
+    for (const folder of legacyInsomniaModelFolders) {
+      const folderPath = path.join('.insomnia', folder);
+      const folderStat = await fsClient.promises.lstat(folderPath);
+
+      if (folderStat.isDirectory()) {
+        const folderFiles = await fsClient.promises.readdir(folderPath);
+
+        for (const file of folderFiles) {
+          const filePath = path.join(folderPath, file);
+          const fileStat = await fsClient.promises.lstat(filePath);
+
+          if (fileStat.isFile()) {
+            const fileContents = await fsClient.promises.readFile(filePath, 'utf8');
+            const id = file.split('.')[1];
+            const type = folder;
+
+            // Skip the file if there is a conflict marker
+            if (fileContents.split('\n').includes('=======')) {
+              return;
+            }
+
+            const doc: models.BaseModel = YAML.parse(fileContents);
+
+            if (id !== doc._id) {
+              throw new Error(`Doc _id does not match file path [${doc._id} != ${id || 'null'}]`);
+            }
+
+            if (type !== doc.type) {
+              throw new Error(`Doc type does not match file path [${doc.type} != ${type || 'null'}]`);
+            }
+
+            if (isWorkspace(doc)) {
+              console.log('[git] setting workspace parent to be that of the active project', {
+                original: doc.parentId,
+                new: projectId,
+              });
+              // Whenever we write a workspace into nedb we should set the parentId to be that of the current project
+              // This is because the parentId (or a project) is not synced into git, so it will be cleared whenever git writes the workspace into the db, thereby removing it from the project on the client
+              // In order to reproduce this bug, comment out the following line, then clone a repository into a local project, then open the workspace, you'll notice it will have moved into the default project
+              doc.parentId = projectId;
+            }
+
+            await database.upsert(doc, true);
+          }
+        }
+      }
+    }
+  }
+}
 
 async function isInsomniaFile(fullPath: string, fsClient: PromiseFsClient) {
   if (!fullPath.endsWith('.yaml')) {

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -2,7 +2,7 @@ import { createHash, randomBytes } from 'crypto';
 import { shell } from 'electron';
 import { app, net } from 'electron/main';
 import { fromUrl } from 'hosted-git-info';
-import { Errors, type FsClient, type PromiseFsClient } from 'isomorphic-git';
+import { Errors, type PromiseFsClient } from 'isomorphic-git';
 import path from 'path';
 import { v4 } from 'uuid';
 import YAML, { parse } from 'yaml';
@@ -168,15 +168,21 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
   try {
     const gitRepository = await getGitRepository({ workspaceId, projectId });
 
+    const fsClient = await getGitFSClient({ gitRepositoryId: gitRepository._id, projectId, workspaceId });
+
     if (GitVCS.isInitializedForRepo(gitRepository._id) && !gitRepository.needsFullClone) {
+      let legacyInsomniaWorkspace;
+      if (!workspaceId) {
+        legacyInsomniaWorkspace = await containsLegacyInsomniaDir({ fsClient });
+      }
+
       return {
         branch: await GitVCS.getCurrentBranch(),
         branches: await GitVCS.listBranches(),
         gitRepository: gitRepository,
+        legacyInsomniaWorkspace,
       };
     }
-
-    const fsClient = await getGitFSClient({ gitRepositoryId: gitRepository._id, projectId, workspaceId });
 
     // Init VCS
     const { credentials, uri } = gitRepository;
@@ -376,6 +382,7 @@ async function containsLegacyInsomniaDir({ fsClient }: { fsClient: PromiseFsClie
   | {
       scope: WorkspaceScope;
       name: string;
+      path: string;
     }
   | undefined
 > {
@@ -400,6 +407,7 @@ async function containsLegacyInsomniaDir({ fsClient }: { fsClient: PromiseFsClie
     return {
       name: workspaceName,
       scope: workspaceScope,
+      path: GIT_INSOMNIA_DIR_NAME,
     };
   } catch (e) {
     console.warn('Failed to read legacy Insomnia directory', e);
@@ -628,11 +636,9 @@ export const initGitRepoCloneAction = async ({
 
   const legacyInsomniaFile = await containsLegacyInsomniaDir({ fsClient: inMemoryFsClient });
 
-  console.log({ legacyInsomniaFile });
-
   if (legacyInsomniaFile) {
     // Add the legacy Insomnia file on the top of the list
-    files.unshift({ ...legacyInsomniaFile, path: '.insomnia' });
+    files.unshift(legacyInsomniaFile);
   }
 
   return { files };

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -438,7 +438,7 @@ async function importLegacyInsomniaFolder({ fsClient, projectId }: { fsClient: P
     const legacyInsomniaFolderStat = await fsClient.promises.lstat(GIT_INSOMNIA_DIR_NAME);
 
     if (!legacyInsomniaFolderStat.isDirectory()) {
-      return;
+      return {};
     }
 
     const legacyInsomniaModelFolders = await fsClient.promises.readdir(GIT_INSOMNIA_DIR_NAME);
@@ -468,7 +468,9 @@ async function importLegacyInsomniaFolder({ fsClient, projectId }: { fsClient: P
 
         // Skip the file if there is a conflict marker
         if (fileContents.split('\n').includes('=======')) {
-          return;
+          return {
+            errors: [`File ${filePath} contains a merge conflict`],
+          };
         }
 
         const doc: models.BaseModel = YAML.parse(fileContents);
@@ -814,6 +816,11 @@ export const cloneGitRepoAction = async ({
 
       await GitVCS.setAuthor();
       await GitVCS.addRemote(uri);
+
+      const hasLegacyInsomniaDir = await containsLegacyInsomniaDir({ fsClient: inMemoryFsClient });
+      if (hasLegacyInsomniaDir) {
+        await migrateLegacyInsomniaFolderToFile({ projectId: project._id });
+      }
 
       await database.flushChanges(bufferId);
       trackSegmentEvent(SegmentEvent.vcsSyncComplete, {
@@ -1236,26 +1243,19 @@ export const migrateLegacyInsomniaFolderToFile = async ({ projectId }: { project
 
   const result = await importLegacyInsomniaFolder({ fsClient, projectId });
 
-  if (result && 'errors' in result && result.errors) {
+  if (result.errors) {
     console.error('Failed to import legacy Insomnia folder', result.errors);
     return;
   }
 
-  if (!result || 'errors' in result) {
-    console.error('Failed to import legacy Insomnia folder');
-    return;
+  if (result.changes) {
+    await GitVCS.setAuthor();
+    await GitVCS.stageChanges(result.changes);
+    await commitToGitRepoAction({
+      projectId,
+      message: 'Migrated legacy .insomnia folder to file',
+    });
   }
-
-  const { changes } = result;
-
-  await GitVCS.stageChanges(changes);
-
-  await GitVCS.setAuthor();
-
-  await commitToGitRepoAction({
-    projectId,
-    message: 'Migrated legacy .insomnia folder to file',
-  });
 };
 
 export const commitAndPushToGitRepoAction = async ({

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -442,74 +442,78 @@ async function importLegacyInsomniaFolder({ fsClient, projectId }: { fsClient: P
 
     const legacyInsomniaModelFolders = await fsClient.promises.readdir(GIT_INSOMNIA_DIR_NAME);
 
+    const legacyInsomniaFiles: { filePath: string; type: string }[] = [];
+
     for (const folder of legacyInsomniaModelFolders) {
       const folderPath = path.join(GIT_INSOMNIA_DIR_NAME, folder);
       const folderStat = await fsClient.promises.lstat(folderPath);
 
-      if (!folderStat.isDirectory()) {
-        continue;
+      if (folderStat.isDirectory()) {
+        const folderFiles = await fsClient.promises.readdir(folderPath);
+
+        for (const file of folderFiles) {
+          const filePath = path.join(folderPath, file);
+          const fileStat = await fsClient.promises.lstat(filePath);
+
+          if (fileStat.isFile()) legacyInsomniaFiles.push({ filePath, type: folder });
+        }
+      }
+    }
+
+    if (legacyInsomniaFiles.length === 0) {
+      return {};
+    }
+
+    for (const legacyInsomniaFile of legacyInsomniaFiles) {
+      const fileContents = await fsClient.promises.readFile(legacyInsomniaFile.filePath, 'utf8');
+
+      const id = legacyInsomniaFile.filePath.split('.')[0];
+      const type = legacyInsomniaFile.type;
+
+      // Skip the file if there is a conflict marker
+      if (fileContents.split('\n').includes('=======')) {
+        return {
+          errors: [`File ${legacyInsomniaFile.filePath} contains a merge conflict`],
+        };
       }
 
-      const folderFiles = await fsClient.promises.readdir(folderPath);
+      const doc: models.BaseModel = YAML.parse(fileContents);
 
-      for (const file of folderFiles) {
-        const filePath = path.join(folderPath, file);
-        const fileStat = await fsClient.promises.lstat(filePath);
+      if (id !== doc._id) {
+        throw new Error(`Doc _id does not match file path [${doc._id} != ${id || 'null'}]`);
+      }
 
-        if (!fileStat.isFile()) {
-          continue;
-        }
+      if (type !== doc.type) {
+        throw new Error(`Doc type does not match file path [${doc.type} != ${type || 'null'}]`);
+      }
 
-        const fileContents = await fsClient.promises.readFile(filePath, 'utf8');
+      if (isWorkspace(doc)) {
+        console.log('[git] setting workspace parent to be that of the active project', {
+          original: doc.parentId,
+          new: projectId,
+        });
+        // Whenever we write a workspace into nedb we should set the parentId to be that of the current project
+        // This is because the parentId (or a project) is not synced into git, so it will be cleared whenever git writes the workspace into the db, thereby removing it from the project on the client
+        // In order to reproduce this bug, comment out the following line, then clone a repository into a local project, then open the workspace, you'll notice it will have moved into the default project
+        doc.parentId = projectId;
 
-        const id = file.split('.')[0];
-        const type = folder;
+        const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(doc._id);
 
-        // Skip the file if there is a conflict marker
-        if (fileContents.split('\n').includes('=======')) {
-          return {
-            errors: [`File ${filePath} contains a merge conflict`],
-          };
-        }
+        const gitFilePath = `insomnia.${doc._id}.yaml`;
+        await models.workspaceMeta.update(workspaceMeta, { gitFilePath });
 
-        const doc: models.BaseModel = YAML.parse(fileContents);
-
-        if (id !== doc._id) {
-          throw new Error(`Doc _id does not match file path [${doc._id} != ${id || 'null'}]`);
-        }
-
-        if (type !== doc.type) {
-          throw new Error(`Doc type does not match file path [${doc.type} != ${type || 'null'}]`);
-        }
-
-        if (isWorkspace(doc)) {
-          console.log('[git] setting workspace parent to be that of the active project', {
-            original: doc.parentId,
-            new: projectId,
-          });
-          // Whenever we write a workspace into nedb we should set the parentId to be that of the current project
-          // This is because the parentId (or a project) is not synced into git, so it will be cleared whenever git writes the workspace into the db, thereby removing it from the project on the client
-          // In order to reproduce this bug, comment out the following line, then clone a repository into a local project, then open the workspace, you'll notice it will have moved into the default project
-          doc.parentId = projectId;
-
-          const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(doc._id);
-
-          const gitFilePath = `insomnia.${doc._id}.yaml`;
-          await models.workspaceMeta.update(workspaceMeta, { gitFilePath });
-
-          changes.push({
-            path: gitFilePath,
-            status: [0, 1, 0],
-          });
-        }
-
-        await database.upsert(doc, true);
         changes.push({
-          path: filePath,
-          // It existed and was removed from the git repository
-          status: [1, 0, 1],
+          path: gitFilePath,
+          status: [0, 1, 0],
         });
       }
+
+      await database.upsert(doc, true);
+      changes.push({
+        path: legacyInsomniaFile.filePath,
+        // It existed and was removed from the git repository
+        status: [1, 0, 1],
+      });
     }
 
     // Remove the legacy folder

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -2,7 +2,7 @@ import { createHash, randomBytes } from 'crypto';
 import { shell } from 'electron';
 import { app, net } from 'electron/main';
 import { fromUrl } from 'hosted-git-info';
-import { Errors, type PromiseFsClient } from 'isomorphic-git';
+import { Errors, type FsClient, type PromiseFsClient } from 'isomorphic-git';
 import path from 'path';
 import { v4 } from 'uuid';
 import YAML, { parse } from 'yaml';
@@ -209,10 +209,16 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
     await GitVCS.setAuthor();
     await GitVCS.addRemote(uri);
 
+    let legacyInsomniaWorkspace = null;
+    if (!workspaceId) {
+      legacyInsomniaWorkspace = await containsLegacyInsomniaDir({ fsClient });
+    }
+
     return {
       branch: await GitVCS.getCurrentBranch(),
       branches: await GitVCS.listBranches(),
       gitRepository,
+      legacyInsomniaWorkspace,
     };
   } catch (e) {
     const errorMessage = e instanceof Error ? e.message : 'Error while fetching git repository.';
@@ -328,7 +334,7 @@ export const gitChangesLoader = async ({
       branch,
       changes,
     };
-  } catch (e) {
+  } catch {
     return {
       branch: '',
       changes: {
@@ -361,15 +367,41 @@ export const canPushLoader = async ({
     });
 
     return { canPush: hasUnpushedChanges };
-  } catch (err) {
+  } catch {
     return { canPush: false };
   }
 };
 
-async function containsInsomniaDir(fsClient: PromiseFsClient): Promise<boolean> {
+async function containsLegacyInsomniaDir({ fsClient }: { fsClient: PromiseFsClient }): Promise<
+  | {
+      scope: WorkspaceScope;
+      name: string;
+    }
+  | undefined
+> {
   const legacyInsomniaFolderStat = await fsClient.promises.lstat('.insomnia');
 
-  return legacyInsomniaFolderStat.isDirectory();
+  if (!legacyInsomniaFolderStat.isDirectory()) {
+    return;
+  }
+
+  const legacyInsomniaWorkspaceFolderPath = await fsClient.promises.readdir(
+    path.join('.insomnia', models.workspace.type),
+  );
+
+  const [workspaceFile] = await fsClient.promises.readdir(legacyInsomniaWorkspaceFolderPath);
+  const workspaceFilePath = path.join(legacyInsomniaWorkspaceFolderPath, workspaceFile);
+
+  const workspaceFileContents = await fsClient.promises.readFile(workspaceFilePath, 'utf8');
+  const workspaceDocument = YAML.parse(workspaceFileContents);
+
+  const workspaceName = workspaceDocument.name || 'Untitled';
+  const workspaceScope = workspaceDocument.scope;
+
+  return {
+    name: workspaceName,
+    scope: workspaceScope,
+  };
 }
 
 /**
@@ -392,57 +424,66 @@ async function containsInsomniaDir(fsClient: PromiseFsClient): Promise<boolean> 
 async function importLegacyInsomniaFolder({ fsClient, projectId }: { fsClient: PromiseFsClient; projectId: string }) {
   const legacyInsomniaFolderStat = await fsClient.promises.lstat('.insomnia');
 
-  if (legacyInsomniaFolderStat.isDirectory()) {
-    const legacyInsomniaModelFolders = await fsClient.promises.readdir('.insomnia');
+  if (!legacyInsomniaFolderStat.isDirectory()) {
+    return;
+  }
 
-    for (const folder of legacyInsomniaModelFolders) {
-      const folderPath = path.join('.insomnia', folder);
-      const folderStat = await fsClient.promises.lstat(folderPath);
+  const legacyInsomniaModelFolders = await fsClient.promises.readdir('.insomnia');
 
-      if (folderStat.isDirectory()) {
-        const folderFiles = await fsClient.promises.readdir(folderPath);
+  for (const folder of legacyInsomniaModelFolders) {
+    const folderPath = path.join('.insomnia', folder);
+    const folderStat = await fsClient.promises.lstat(folderPath);
 
-        for (const file of folderFiles) {
-          const filePath = path.join(folderPath, file);
-          const fileStat = await fsClient.promises.lstat(filePath);
+    if (!folderStat.isDirectory()) {
+      continue;
+    }
 
-          if (fileStat.isFile()) {
-            const fileContents = await fsClient.promises.readFile(filePath, 'utf8');
-            const id = file.split('.')[1];
-            const type = folder;
+    const folderFiles = await fsClient.promises.readdir(folderPath);
 
-            // Skip the file if there is a conflict marker
-            if (fileContents.split('\n').includes('=======')) {
-              return;
-            }
+    for (const file of folderFiles) {
+      const filePath = path.join(folderPath, file);
+      const fileStat = await fsClient.promises.lstat(filePath);
 
-            const doc: models.BaseModel = YAML.parse(fileContents);
-
-            if (id !== doc._id) {
-              throw new Error(`Doc _id does not match file path [${doc._id} != ${id || 'null'}]`);
-            }
-
-            if (type !== doc.type) {
-              throw new Error(`Doc type does not match file path [${doc.type} != ${type || 'null'}]`);
-            }
-
-            if (isWorkspace(doc)) {
-              console.log('[git] setting workspace parent to be that of the active project', {
-                original: doc.parentId,
-                new: projectId,
-              });
-              // Whenever we write a workspace into nedb we should set the parentId to be that of the current project
-              // This is because the parentId (or a project) is not synced into git, so it will be cleared whenever git writes the workspace into the db, thereby removing it from the project on the client
-              // In order to reproduce this bug, comment out the following line, then clone a repository into a local project, then open the workspace, you'll notice it will have moved into the default project
-              doc.parentId = projectId;
-            }
-
-            await database.upsert(doc, true);
-          }
-        }
+      if (!fileStat.isFile()) {
+        continue;
       }
+
+      const fileContents = await fsClient.promises.readFile(filePath, 'utf8');
+      const id = file.split('.')[1];
+      const type = folder;
+
+      // Skip the file if there is a conflict marker
+      if (fileContents.split('\n').includes('=======')) {
+        return;
+      }
+
+      const doc: models.BaseModel = YAML.parse(fileContents);
+
+      if (id !== doc._id) {
+        throw new Error(`Doc _id does not match file path [${doc._id} != ${id || 'null'}]`);
+      }
+
+      if (type !== doc.type) {
+        throw new Error(`Doc type does not match file path [${doc.type} != ${type || 'null'}]`);
+      }
+
+      if (isWorkspace(doc)) {
+        console.log('[git] setting workspace parent to be that of the active project', {
+          original: doc.parentId,
+          new: projectId,
+        });
+        // Whenever we write a workspace into nedb we should set the parentId to be that of the current project
+        // This is because the parentId (or a project) is not synced into git, so it will be cleared whenever git writes the workspace into the db, thereby removing it from the project on the client
+        // In order to reproduce this bug, comment out the following line, then clone a repository into a local project, then open the workspace, you'll notice it will have moved into the default project
+        doc.parentId = projectId;
+      }
+
+      await database.upsert(doc, true);
     }
   }
+
+  // Remove the legacy folder
+  await fsClient.promises.rmdir('.insomnia');
 }
 
 async function isInsomniaFile(fullPath: string, fsClient: PromiseFsClient) {
@@ -501,6 +542,10 @@ export const initGitRepoCloneAction = async ({
         name: string;
         path: string;
       }[];
+      legacyInsomniaFile?: {
+        scope: WorkspaceScope;
+        name: string;
+      };
     }
   | {
       errors: string[];
@@ -571,7 +616,9 @@ export const initGitRepoCloneAction = async ({
     }),
   );
 
-  return { files };
+  const legacyInsomniaFile = await containsLegacyInsomniaDir({ fsClient: inMemoryFsClient });
+
+  return { files, legacyInsomniaFile };
 };
 
 export const cloneGitRepoAction = async ({
@@ -1137,6 +1184,21 @@ export const commitToGitRepoAction = async ({
   return {
     errors: [],
   };
+};
+
+export const migrateLegacyInsomniaFolderToFile = async ({ projectId }: { projectId: string }) => {
+  const gitRepository = await getGitRepository({ projectId });
+
+  const fsClient = await getGitFSClient({ projectId, gitRepositoryId: gitRepository._id });
+
+  await importLegacyInsomniaFolder({ fsClient, projectId });
+
+  // @TODO - Stage the changes
+
+  await commitToGitRepoAction({
+    projectId,
+    message: 'Migrated legacy .insomnia folder to file',
+  });
 };
 
 export const commitAndPushToGitRepoAction = async ({
@@ -1720,7 +1782,7 @@ function getPreviewItemName(previewDiffItem: { before: string; after: string }) 
     if ((prev && 'fileName' in prev) || 'name' in prev) {
       prevName = prev.fileName || prev.name;
     }
-  } catch (e) {
+  } catch {
     // Nothing to do
   }
 
@@ -1729,7 +1791,7 @@ function getPreviewItemName(previewDiffItem: { before: string; after: string }) 
     if ((next && 'fileName' in next) || 'name' in next) {
       nextName = next.fileName || next.name;
     }
-  } catch (e) {
+  } catch {
     // Nothing to do
   }
 
@@ -2253,6 +2315,7 @@ export interface GitServiceAPI {
   unstageChanges: typeof unstageChangesAction;
   diffFileLoader: typeof diffFileLoader;
   getRepositoryDirectoryTree: typeof getRepositoryDirectoryTree;
+  migrateLegacyInsomniaFolderToFile: typeof migrateLegacyInsomniaFolderToFile;
 
   initSignInToGitHub: typeof initSignInToGitHub;
   completeSignInToGitHub: typeof completeSignInToGitHub;
@@ -2324,6 +2387,10 @@ export const registerGitServiceAPI = () => {
   ipcMainHandle('git.diffFileLoader', (_, options: Parameters<typeof diffFileLoader>[0]) => diffFileLoader(options));
   ipcMainHandle('git.getRepositoryDirectoryTree', (_, options: Parameters<typeof getRepositoryDirectoryTree>[0]) =>
     getRepositoryDirectoryTree(options),
+  );
+  ipcMainHandle(
+    'git.migrateLegacyInsomniaFolderToFile',
+    (_, options: Parameters<typeof migrateLegacyInsomniaFolderToFile>[0]) => migrateLegacyInsomniaFolderToFile(options),
   );
 
   ipcMainHandle('git.initSignInToGitHub', () => initSignInToGitHub());

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -67,6 +67,7 @@ export type HandleChannels =
   | 'git.unstageChanges'
   | 'git.diffFileLoader'
   | 'git.getRepositoryDirectoryTree'
+  | 'git.migrateLegacyInsomniaFolderToFile'
   | 'git.initSignInToGitHub'
   | 'git.completeSignInToGitHub'
   | 'git.signOutOfGitHub'

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -77,6 +77,7 @@ const git: GitServiceAPI = {
   unstageChanges: options => ipcRenderer.invoke('git.unstageChanges', options),
   diffFileLoader: options => ipcRenderer.invoke('git.diffFileLoader', options),
   getRepositoryDirectoryTree: options => ipcRenderer.invoke('git.getRepositoryDirectoryTree', options),
+  migrateLegacyInsomniaFolderToFile: options => ipcRenderer.invoke('git.migrateLegacyInsomniaFolderToFile', options),
 
   initSignInToGitHub: () => ipcRenderer.invoke('git.initSignInToGitHub'),
   completeSignInToGitHub: options => ipcRenderer.invoke('git.completeSignInToGitHub', options),

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -72,6 +72,15 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
     }
   }, [gitRepoDataFetcher, gitRepository?.uri, gitRepository?._id, organizationId, projectId]);
 
+  const legacyInsomniaWorkspace =
+    gitRepoDataFetcher.data &&
+    'legacyInsomniaWorkspace' in gitRepoDataFetcher.data &&
+    gitRepoDataFetcher.data.legacyInsomniaWorkspace
+      ? gitRepoDataFetcher.data.legacyInsomniaWorkspace
+      : null;
+
+  console.log({ isMigrationModalOpen, gitRepository, legacyInsomniaWorkspace });
+
   // Only fetch the repo status if we have a repo uri and we don't have the status already
   const shouldFetchGitRepoStatus = Boolean(
     gitRepository?.uri &&
@@ -493,15 +502,9 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
       {isGitStagingModalOpen && gitRepository && (
         <GitProjectStagingModal onClose={() => setIsGitStagingModalOpen(false)} />
       )}
-      {isMigrationModalOpen && gitRepository && (
+      {isMigrationModalOpen && gitRepository && legacyInsomniaWorkspace && (
         <GitProjectMigrationModal
-          legacyFile={
-            gitRepoDataFetcher.data &&
-            'legacyInsomniaWorkspace' in gitRepoDataFetcher.data &&
-            gitRepoDataFetcher.data.legacyInsomniaWorkspace
-              ? gitRepoDataFetcher.data.legacyInsomniaWorkspace
-              : { name: '', scope: '' }
-          }
+          legacyFile={legacyInsomniaWorkspace}
           onClose={() => {
             setIsMigrationModalOpen(false);
           }}

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -32,6 +32,7 @@ import { Icon } from '../icon';
 import { showAlert, showModal } from '../modals';
 import { GitProjectBranchesModal } from '../modals/git-project-branches-modal';
 import { GitProjectLogModal } from '../modals/git-project-log-modal';
+import { GitProjectMigrationModal } from '../modals/git-project-migration-modal';
 import { GitProjectStagingModal } from '../modals/git-project-staging-modal';
 import { GitProjectRepositorySettingsModal } from '../modals/git-repository-settings-modal';
 import { SyncMergeModal } from '../modals/sync-merge-modal';
@@ -50,6 +51,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
   const [isGitBranchesModalOpen, setIsGitBranchesModalOpen] = useState(false);
   const [isGitLogModalOpen, setIsGitLogModalOpen] = useState(false);
   const [isGitStagingModalOpen, setIsGitStagingModalOpen] = useState(false);
+  const [isMigrationModalOpen, setIsMigrationModalOpen] = useState(false);
 
   const gitPushFetcher = useFetcher<PushToGitRemoteResult>();
   const gitCheckoutFetcher = useFetcher();
@@ -78,6 +80,16 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
       !gitStatusFetcher.data &&
       gitRepoDataFetcher.data,
   );
+
+  useEffect(() => {
+    if (
+      gitRepoDataFetcher.data &&
+      !('errors' in gitRepoDataFetcher.data) &&
+      gitRepoDataFetcher.data.legacyInsomniaWorkspace
+    ) {
+      setIsMigrationModalOpen(true);
+    }
+  }, [gitRepoDataFetcher.data]);
 
   useEffect(() => {
     if (shouldFetchGitRepoStatus) {
@@ -480,6 +492,20 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
       {isGitLogModalOpen && gitRepository && <GitProjectLogModal onClose={() => setIsGitLogModalOpen(false)} />}
       {isGitStagingModalOpen && gitRepository && (
         <GitProjectStagingModal onClose={() => setIsGitStagingModalOpen(false)} />
+      )}
+      {isMigrationModalOpen && gitRepository && (
+        <GitProjectMigrationModal
+          legacyFile={
+            gitRepoDataFetcher.data &&
+            'legacyInsomniaWorkspace' in gitRepoDataFetcher.data &&
+            gitRepoDataFetcher.data.legacyInsomniaWorkspace
+              ? gitRepoDataFetcher.data.legacyInsomniaWorkspace
+              : { name: '', scope: '' }
+          }
+          onClose={() => {
+            setIsMigrationModalOpen(false);
+          }}
+        />
       )}
     </>
   );

--- a/packages/insomnia/src/ui/components/modals/git-project-migration-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-migration-modal.tsx
@@ -12,7 +12,7 @@ import {
   TableBody,
   TableHeader,
 } from 'react-aria-components';
-import { useFetcher, useParams } from 'react-router-dom';
+import { useFetcher, useParams } from 'react-router';
 
 import type { WorkspaceScope } from '../../../models/workspace';
 import { scopeToBgColorMap, scopeToIconMap, scopeToLabelMap, scopeToTextColorMap } from '../../routes/project';

--- a/packages/insomnia/src/ui/components/modals/git-project-migration-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-migration-modal.tsx
@@ -1,13 +1,27 @@
 import React, { type FC } from 'react';
-import { Button, Dialog, Heading, Modal, ModalOverlay } from 'react-aria-components';
+import {
+  Button,
+  Cell,
+  Column,
+  Dialog,
+  Heading,
+  Modal,
+  ModalOverlay,
+  Row,
+  Table,
+  TableBody,
+  TableHeader,
+} from 'react-aria-components';
 import { useFetcher, useParams } from 'react-router-dom';
 
+import type { WorkspaceScope } from '../../../models/workspace';
+import { scopeToBgColorMap, scopeToIconMap, scopeToLabelMap, scopeToTextColorMap } from '../../routes/project';
 import { Icon } from '../icon';
 
-export const GitProjectMigrationModal: FC<{ onClose: () => void; legacyFile: { name: string; scope: string } }> = ({
-  onClose,
-  legacyFile,
-}) => {
+export const GitProjectMigrationModal: FC<{
+  onClose: () => void;
+  legacyFile: { name: string; scope: WorkspaceScope; path: string };
+}> = ({ onClose, legacyFile }) => {
   const { organizationId, projectId } = useParams() as {
     organizationId: string;
     projectId: string;
@@ -40,20 +54,18 @@ export const GitProjectMigrationModal: FC<{ onClose: () => void; legacyFile: { n
         onOpenChange={isOpen => {
           !isOpen && onClose();
         }}
-        className="flex h-[calc(100%-var(--padding-xl))] w-[calc(100%-var(--padding-xl))] flex-col rounded-md border border-solid border-[--hl-sm] bg-[--color-bg] p-[--padding-lg] text-[--color-font]"
+        className="flex max-h-[90dvh] min-h-[420px] w-full max-w-3xl flex-col overflow-hidden rounded-md border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font]"
       >
         <Dialog
           data-loading={migrateLegacyWorkspaceFetcher.state === 'loading' ? 'true' : undefined}
-          className="flex h-full flex-1 flex-col overflow-hidden outline-none data-[loading]:animate-pulse"
+          className="flex h-full flex-1 flex-col overflow-hidden px-10 pt-10 outline-none data-[loading]:animate-pulse"
         >
           {({ close }) => (
             <div className="flex flex-1 flex-col gap-4 overflow-hidden">
               <div className="flex flex-shrink-0 items-center justify-between gap-2">
-                <Heading slot="title" className="text-2xl">
-                  Commit changes{' '}
-                  {migrateLegacyWorkspaceFetcher.state === 'loading' && (
-                    <Icon icon="spinner" className="animate-spin" />
-                  )}
+                <Heading slot="title" className="flex items-center gap-2 text-2xl">
+                  <Icon icon="triangle-exclamation" className="text-[--color-font-warning]" />
+                  We found legacy Insomnia files in your repository
                 </Heading>
                 <Button
                   className="flex aspect-square h-6 flex-shrink-0 items-center justify-center rounded-sm text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
@@ -62,11 +74,85 @@ export const GitProjectMigrationModal: FC<{ onClose: () => void; legacyFile: { n
                   <Icon icon="x" />
                 </Button>
               </div>
-              <div>
-                <p className="text-sm text-[--color-font-secondary]">
-                  {legacyFile.name} - {legacyFile.scope}
-                  You have a legacy Insomnia folder in your project. Would you like to migrate it to a file?
-                </p>
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="max-h-96 w-full select-none overflow-y-auto overflow-x-hidden rounded border border-solid border-[--hl-sm]">
+                  <Table
+                    selectionMode="none"
+                    aria-label="Insomnia files"
+                    className="w-full table-fixed border-separate border-spacing-0"
+                  >
+                    <TableHeader>
+                      <Column
+                        isRowHeader
+                        className="sticky top-0 z-10 border-b border-[--hl-sm] bg-[--hl-xs] px-2 py-2 text-left text-xs font-semibold backdrop-blur backdrop-filter focus:outline-none"
+                      >
+                        Name
+                      </Column>
+                      <Column className="sticky top-0 z-10 border-b border-[--hl-sm] bg-[--hl-xs] px-2 py-2 text-left text-xs font-semibold backdrop-blur backdrop-filter focus:outline-none">
+                        Type
+                      </Column>
+                      <Column className="sticky top-0 z-10 border-b border-[--hl-sm] bg-[--hl-xs] px-2 py-2 text-left text-xs font-semibold backdrop-blur backdrop-filter focus:outline-none">
+                        File path
+                      </Column>
+                    </TableHeader>
+                    <TableBody
+                      className="divide divide-solid divide-[--hl-sm]"
+                      items={[{ id: legacyFile.path, ...legacyFile }]}
+                    >
+                      {file => (
+                        <Row className="group transition-colors focus-within:bg-[--hl-xxs] focus:outline-none">
+                          <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] text-sm font-medium focus:outline-none group-last-of-type:border-none">
+                            <div className="flex items-center gap-2 px-2 py-2">
+                              <span
+                                className={`${scopeToBgColorMap[file.scope]} ${scopeToTextColorMap[file.scope]} flex aspect-square h-6 items-center justify-center rounded`}
+                              >
+                                <Icon icon={scopeToIconMap[file.scope]} className="w-4" />
+                              </span>
+                              <span className="truncate">{file.name}</span>
+                              {legacyFile.path === '.insomnia' && (
+                                <span className="flex items-center gap-2 text-[--color-warning]">
+                                  <Icon icon="triangle-exclamation" />
+                                </span>
+                              )}
+                            </div>
+                          </Cell>
+                          <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] text-sm font-medium focus:outline-none group-last-of-type:border-none">
+                            <span className="flex items-center gap-1 px-2 text-[--hl]">
+                              {scopeToLabelMap[legacyFile.scope]}
+                            </span>
+                          </Cell>
+                          <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] text-sm font-medium focus:outline-none group-last-of-type:border-none">
+                            <span className="flex items-center gap-1 italic text-[--hl]">
+                              <Icon
+                                icon={legacyFile.path === '.insomnia' ? 'folder' : 'file'}
+                                className="text-[--hl]"
+                              />
+                              <span className="truncate px-2 text-[--hl]">{legacyFile.path}</span>
+                            </span>
+                          </Cell>
+                        </Row>
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
+                <div className="rounded-sm bg-[rgba(var(--color-warning-rgb),var(--tw-bg-opacity))] bg-opacity-50 p-[--padding-sm] text-[--color-font-warning]">
+                  <p className="pt-2">
+                    This Git repository contains legacy Insomnia git files. These will be imported and migrated to the
+                    new format supported in Insomnia 11+.
+                  </p>
+                  <p className="pt-2">
+                    By migrating these <strong>a new commit will be created</strong> which once synced will result in
+                    any users on older versions of Insomnia no longer being able to access these collections.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center justify-end gap-2 pb-10">
+                <Button
+                  onPress={migrateLegacyWorkspace}
+                  className="flex h-full w-[10ch] items-center justify-center gap-2 rounded-md border border-solid border-[--hl-md] bg-[rgba(var(--color-surprise-rgb),var(--tw-bg-opacity))] bg-opacity-100 px-4 py-2 text-sm font-semibold text-[--color-font-surprise] ring-1 ring-transparent transition-all hover:bg-opacity-80 focus:ring-inset focus:ring-[--hl-md] aria-pressed:opacity-80"
+                >
+                  Migrate
+                </Button>
               </div>
             </div>
           )}

--- a/packages/insomnia/src/ui/components/modals/git-project-migration-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-migration-modal.tsx
@@ -1,0 +1,77 @@
+import React, { type FC } from 'react';
+import { Button, Dialog, Heading, Modal, ModalOverlay } from 'react-aria-components';
+import { useFetcher, useParams } from 'react-router-dom';
+
+import { Icon } from '../icon';
+
+export const GitProjectMigrationModal: FC<{ onClose: () => void; legacyFile: { name: string; scope: string } }> = ({
+  onClose,
+  legacyFile,
+}) => {
+  const { organizationId, projectId } = useParams() as {
+    organizationId: string;
+    projectId: string;
+    workspaceId: string;
+  };
+
+  const migrateLegacyWorkspaceFetcher = useFetcher();
+
+  const migrateLegacyWorkspace = () => {
+    migrateLegacyWorkspaceFetcher.submit(
+      {},
+      {
+        method: 'POST',
+        action: `/organization/${organizationId}/project/${projectId}/git/migrate-legacy-insomnia-folder-to-file`,
+        encType: 'application/json',
+      },
+    );
+  };
+
+  return (
+    <ModalOverlay
+      isOpen
+      onOpenChange={isOpen => {
+        !isOpen && onClose();
+      }}
+      isDismissable
+      className="fixed left-0 top-0 z-10 flex h-[--visual-viewport-height] w-full items-center justify-center bg-black/30"
+    >
+      <Modal
+        onOpenChange={isOpen => {
+          !isOpen && onClose();
+        }}
+        className="flex h-[calc(100%-var(--padding-xl))] w-[calc(100%-var(--padding-xl))] flex-col rounded-md border border-solid border-[--hl-sm] bg-[--color-bg] p-[--padding-lg] text-[--color-font]"
+      >
+        <Dialog
+          data-loading={migrateLegacyWorkspaceFetcher.state === 'loading' ? 'true' : undefined}
+          className="flex h-full flex-1 flex-col overflow-hidden outline-none data-[loading]:animate-pulse"
+        >
+          {({ close }) => (
+            <div className="flex flex-1 flex-col gap-4 overflow-hidden">
+              <div className="flex flex-shrink-0 items-center justify-between gap-2">
+                <Heading slot="title" className="text-2xl">
+                  Commit changes{' '}
+                  {migrateLegacyWorkspaceFetcher.state === 'loading' && (
+                    <Icon icon="spinner" className="animate-spin" />
+                  )}
+                </Heading>
+                <Button
+                  className="flex aspect-square h-6 flex-shrink-0 items-center justify-center rounded-sm text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+                  onPress={close}
+                >
+                  <Icon icon="x" />
+                </Button>
+              </div>
+              <div>
+                <p className="text-sm text-[--color-font-secondary]">
+                  {legacyFile.name} - {legacyFile.scope}
+                  You have a legacy Insomnia folder in your project. Would you like to migrate it to a file?
+                </p>
+              </div>
+            </div>
+          )}
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+};

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -445,6 +445,12 @@ export const ProjectSettingsForm: FC<Props> = ({
                               <Icon icon={scopeToIconMap[file.scope]} className="w-4" />
                             </span>
                             <span className="truncate">{file.name}</span>
+                            {file.path === '.insomnia' && (
+                              <span className="flex items-center gap-2 text-[--color-warning]">
+                                <Icon icon="triangle-exclamation" />
+                                Legacy Insomnia file
+                              </span>
+                            )}
                           </div>
                         </Cell>
                         <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] text-sm font-medium focus:outline-none group-last-of-type:border-none">
@@ -463,6 +469,16 @@ export const ProjectSettingsForm: FC<Props> = ({
                   </TableBody>
                 </Table>
               </div>
+            </div>
+          )}
+          {insomniaFiles.some(file => file.path === '.insomnia') && (
+            <div className="">
+              <Icon icon="triangle-exclamation" className="text-[--color-warning]" />
+              <p className="">
+                This Git repository contains legacy Insomnia git files. These will be imported and migrated to the new
+                format supported in Insomnia 11+. By migrating these, any users on older versions of Insomnia will no
+                longer be able to access these collections. THIS ACTION CAN NOT BE UNDONE.
+              </p>
             </div>
           )}
           <div className="flex items-center justify-end gap-2 pb-10">

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -448,7 +448,6 @@ export const ProjectSettingsForm: FC<Props> = ({
                             {file.path === '.insomnia' && (
                               <span className="flex items-center gap-2 text-[--color-warning]">
                                 <Icon icon="triangle-exclamation" />
-                                Legacy Insomnia file
                               </span>
                             )}
                           </div>
@@ -460,7 +459,7 @@ export const ProjectSettingsForm: FC<Props> = ({
                         </Cell>
                         <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] text-sm font-medium focus:outline-none group-last-of-type:border-none">
                           <span className="flex items-center gap-1 italic text-[--hl]">
-                            <Icon icon="file" className="text-[--hl]" />
+                            <Icon icon={file.path === '.insomnia' ? 'folder' : 'file'} className="text-[--hl]" />
                             <span className="truncate px-2 text-[--hl]">{file.path}</span>
                           </span>
                         </Cell>
@@ -472,12 +471,18 @@ export const ProjectSettingsForm: FC<Props> = ({
             </div>
           )}
           {insomniaFiles.some(file => file.path === '.insomnia') && (
-            <div className="">
-              <Icon icon="triangle-exclamation" className="text-[--color-warning]" />
-              <p className="">
+            <div className="rounded-sm bg-[rgba(var(--color-warning-rgb),var(--tw-bg-opacity))] bg-opacity-50 p-[--padding-sm] text-[--color-font-warning]">
+              <Heading className="flex items-center gap-2 text-lg font-bold">
+                <Icon icon="triangle-exclamation" className="text-[--color-font-warning]" />
+                We found legacy Insomnia files in your repository
+              </Heading>
+              <p className="pt-2">
                 This Git repository contains legacy Insomnia git files. These will be imported and migrated to the new
-                format supported in Insomnia 11+. By migrating these, any users on older versions of Insomnia will no
-                longer be able to access these collections. THIS ACTION CAN NOT BE UNDONE.
+                format supported in Insomnia 11+.
+              </p>
+              <p className="pt-2">
+                By migrating these <strong>a new commit will be created</strong> which once synced will result in any
+                users on older versions of Insomnia no longer being able to access these collections.
               </p>
             </div>
           )}

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -452,6 +452,13 @@ async function renderApp() {
                                   (await import('./routes/git-project-actions')).getRepositoryDirectoryTree(...args),
                               },
                               {
+                                path: 'migrate-legacy-insomnia-folder-to-file',
+                                action: async (...args) =>
+                                  (await import('./routes/git-project-actions')).migrateLegacyInsomniaFolderToFile(
+                                    ...args,
+                                  ),
+                              },
+                              {
                                 path: 'branch',
                                 children: [
                                   {

--- a/packages/insomnia/src/ui/routes/git-project-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-project-actions.tsx
@@ -453,3 +453,10 @@ export const getRepositoryDirectoryTree: ActionFunction = async ({ params }) => 
 
   return window.main.git.getRepositoryDirectoryTree({ projectId });
 };
+
+export const migrateLegacyInsomniaFolderToFile: ActionFunction = async ({ params }) => {
+  const { projectId } = params;
+  invariant(projectId, 'Project ID is required');
+
+  return window.main.git.migrateLegacyInsomniaFolderToFile({ projectId });
+};

--- a/packages/insomnia/src/ui/routes/git-project-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-project-actions.tsx
@@ -13,6 +13,10 @@ export type GitRepoLoaderData =
       branch: string;
       branches: string[];
       gitRepository: GitRepository | null;
+      legacyInsomniaWorkspace?: {
+        scope: WorkspaceScope;
+        name: string;
+      };
     }
   | {
       errors: string[];

--- a/packages/insomnia/src/ui/routes/git-project-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-project-actions.tsx
@@ -16,6 +16,7 @@ export type GitRepoLoaderData =
       legacyInsomniaWorkspace?: {
         scope: WorkspaceScope;
         name: string;
+        path: string;
       };
     }
   | {


### PR DESCRIPTION
Highlights:

- [x] Cloning a repository will now detect any legacy workspaces stored in `.insomnia` folder and migrate it to the new format.
- [x] When pulling changes or switching to branches - inside a Git Project - with a legacy workspace will prompt the user to migrate to the new format.