### PR TITLE
Fix the issue that SSE connection can not be disconnected in some cases [INS-5464]

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   ],
   "scripts": {
     "dev": "npm start -w insomnia",
-    "dev:local": "cross-env INSOMNIA_AI_URL=https://ai.dev.insomnia.moe INSOMNIA_MOCK_API_URL=http://localhost:8002 INSOMNIA_APP_WEBSITE_URL=http://localhost:8002 INSOMNIA_API_URL=http://localhost:8000 npm start -w insomnia",
     "lint": "npm run lint --workspaces --if-present",
     "type-check": "npm run type-check --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "scripts": {
     "dev": "npm start -w insomnia",
+    "dev:local": "cross-env INSOMNIA_AI_URL=https://ai.dev.insomnia.moe INSOMNIA_MOCK_API_URL=http://localhost:8002 INSOMNIA_APP_WEBSITE_URL=http://localhost:8002 INSOMNIA_API_URL=http://localhost:8000 npm start -w insomnia",
     "lint": "npm run lint --workspaces --if-present",
     "type-check": "npm run type-check --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",

--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -56,8 +56,6 @@ export async function registerInsomniaProtocols() {
           const url = new URL(`${apiURL}/${originalRequest.url.replace(`${insomniaStreamScheme}://`, '')}`);
           const urlStr = url.toString();
 
-          console.log('sse connecting main', apiURL);
-
           const sessionId = new URLSearchParams(url.search).get('sessionId');
 
           const curl = new Curl();
@@ -99,7 +97,6 @@ export async function registerInsomniaProtocols() {
 
           curl.on('stream', async (stream: Readable, _code: number, [headersWithStatus]: HeaderInfo[]) => {
             const { result, ...headers } = headersWithStatus;
-            console.log('sse headers', headers);
             resolve(
               new Response(Readable.toWeb(stream) as ReadableStream, {
                 status: _code,

--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -2,7 +2,7 @@ import { Readable } from 'node:stream';
 
 import { Curl, CurlAuth, CurlFeature, CurlProxy, CurlSslOpt, type HeaderInfo } from '@getinsomnia/node-libcurl';
 import { app, net, protocol, session } from 'electron';
-import { parse as urlParse } from 'url';
+import { parse as urlParse } from 'node:url';
 
 import { getApiBaseURL } from '../common/constants';
 import { get as getSettings } from '../models/settings';
@@ -91,28 +91,35 @@ export async function registerInsomniaProtocols() {
               let unknownProxy = false;
               let curlOptProxyType = CurlProxy.Http;
               switch (proxyType) {
-                case 'PROXY':
+                case 'PROXY': {
                   curlOptProxyType = CurlProxy.Http;
                   break;
-                case 'HTTP':
+                }
+                case 'HTTP': {
                   curlOptProxyType = CurlProxy.Http;
                   break;
-                case 'SOCKS':
+                }
+                case 'SOCKS': {
                   curlOptProxyType = CurlProxy.Socks4;
                   break;
-                case 'HTTPS':
+                }
+                case 'HTTPS': {
                   curlOptProxyType = CurlProxy.Https;
                   break;
-                case 'SOCKS4':
+                }
+                case 'SOCKS4': {
                   curlOptProxyType = CurlProxy.Socks4;
                   break;
-                case 'SOCKS5':
+                }
+                case 'SOCKS5': {
                   curlOptProxyType = CurlProxy.Socks5;
                   break;
-                default:
+                }
+                default: {
                   // unknown proxy type
                   unknownProxy = true;
                   break;
+                }
               }
               if (unknownProxy) {
                 curl.setOpt(Curl.option.PROXY, '');

--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -1,6 +1,13 @@
+import { Readable } from 'node:stream';
+
+import { Curl, CurlAuth, CurlFeature, CurlSslOpt, type HeaderInfo } from '@getinsomnia/node-libcurl';
 import { app, net, protocol } from 'electron';
+import { parse as urlParse } from 'url';
 
 import { getApiBaseURL } from '../common/constants';
+import { get as getSettings } from '../models/settings';
+import * as _userSession from '../models/user-session';
+import { setDefaultProtocol } from './network/libcurl-promise';
 import { resolveDbByKey } from './templating-worker-database';
 
 export interface RegisterProtocolOptions {
@@ -16,7 +23,12 @@ export async function registerInsomniaProtocols() {
   protocol.registerSchemesAsPrivileged([
     {
       scheme: insomniaStreamScheme,
-      privileges: { secure: true, standard: true, supportFetchAPI: true },
+      privileges: {
+        secure: true,
+        standard: true,
+        supportFetchAPI: true,
+        stream: true,
+      },
     },
     {
       scheme: httpsScheme,
@@ -35,14 +47,76 @@ export async function registerInsomniaProtocols() {
   await app.whenReady();
 
   if (!protocol.isProtocolHandled(insomniaStreamScheme)) {
-    protocol.handle(insomniaStreamScheme, async request => {
-      const apiURL = getApiBaseURL();
-      const url = new URL(`${apiURL}/${request.url.replace(`${insomniaStreamScheme}://`, '')}`);
-      const sessionId = new URLSearchParams(url.search).get('sessionId');
-      request.headers.append('X-Session-Id', sessionId || '');
-      return net.fetch(url.toString(), request);
+    protocol.handle(insomniaStreamScheme, async originalRequest => {
+      const settings = await getSettings();
+      // here we use libcurl to forward the SSE request because the SSE request sent by net.fetch can not be disconnected correctly in some cases
+      return await new Promise((resolve, reject) => {
+        try {
+          const apiURL = getApiBaseURL();
+          const url = new URL(`${apiURL}/${originalRequest.url.replace(`${insomniaStreamScheme}://`, '')}`);
+          const urlStr = url.toString();
+
+          console.log('sse connecting main', apiURL);
+
+          const sessionId = new URLSearchParams(url.search).get('sessionId');
+
+          const curl = new Curl();
+          curl.setOpt(Curl.option.URL, urlStr);
+          curl.setOpt(Curl.option.ACCEPT_ENCODING, '');
+          curl.setOpt(Curl.option.SSL_OPTIONS, CurlSslOpt.NativeCa);
+
+          if (!settings.proxyEnabled) {
+            curl.setOpt(Curl.option.PROXY, '');
+          } else {
+            const { protocol } = urlParse(urlStr);
+            const { httpProxy, httpsProxy, noProxy } = settings;
+            const proxyHost = protocol === 'https:' ? httpsProxy : httpProxy;
+            const proxy = proxyHost ? setDefaultProtocol(proxyHost) : null;
+            if (proxy) {
+              curl.setOpt(Curl.option.PROXY, proxy);
+              curl.setOpt(Curl.option.PROXYAUTH, CurlAuth.Any);
+            }
+            if (noProxy) {
+              curl.setOpt(Curl.option.NOPROXY, noProxy);
+            }
+          }
+
+          curl.setOpt(Curl.option.TIMEOUT_MS, 0);
+          curl.setOpt(Curl.option.FOLLOWLOCATION, true);
+          curl.enable(CurlFeature.StreamResponse);
+          curl.setOpt(Curl.option.HTTPHEADER, [
+            ...Array.from(originalRequest.headers.entries()).map(([key, value]) => `${key}: ${value}`),
+            `X-Session-Id: ${sessionId || ''}`,
+          ]);
+
+          curl.on('error', () => {
+            curl.close();
+          });
+
+          curl.on('end', () => {
+            curl.close();
+          });
+
+          curl.on('stream', async (stream: Readable, _code: number, [headersWithStatus]: HeaderInfo[]) => {
+            const { result, ...headers } = headersWithStatus;
+            console.log('sse headers', headers);
+            resolve(
+              new Response(Readable.toWeb(stream) as ReadableStream, {
+                status: _code,
+                statusText: result?.reason,
+                headers: headers,
+              }),
+            );
+          });
+
+          curl.perform();
+        } catch (err) {
+          reject(err);
+        }
+      });
     });
   }
+
   if (!protocol.isProtocolHandled(httpsScheme)) {
     protocol.handle(httpsScheme, async request => {
       return net.fetch(request, { bypassCustomProtocolHandlers: true });

--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'node:stream';
 
-import { Curl, CurlAuth, CurlFeature, CurlSslOpt, type HeaderInfo } from '@getinsomnia/node-libcurl';
-import { app, net, protocol } from 'electron';
+import { Curl, CurlAuth, CurlFeature, CurlSslOpt, type HeaderInfo, CurlProxy } from '@getinsomnia/node-libcurl';
+import { app, net, protocol, session } from 'electron';
 import { parse as urlParse } from 'url';
 
 import { getApiBaseURL } from '../common/constants';
@@ -48,14 +48,17 @@ export async function registerInsomniaProtocols() {
 
   if (!protocol.isProtocolHandled(insomniaStreamScheme)) {
     protocol.handle(insomniaStreamScheme, async originalRequest => {
+      const apiURL = getApiBaseURL();
+      const url = new URL(`${apiURL}/${originalRequest.url.replace(`${insomniaStreamScheme}://`, '')}`);
+      const urlStr = url.toString();
       const settings = await getSettings();
+      // systemProxy follows the PAC return value format.
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file#return_value_format
+      let systemProxyStr = await session.defaultSession.resolveProxy(urlStr);
+
       // here we use libcurl to forward the SSE request because the SSE request sent by net.fetch can not be disconnected correctly in some cases
       return await new Promise((resolve, reject) => {
         try {
-          const apiURL = getApiBaseURL();
-          const url = new URL(`${apiURL}/${originalRequest.url.replace(`${insomniaStreamScheme}://`, '')}`);
-          const urlStr = url.toString();
-
           const sessionId = new URLSearchParams(url.search).get('sessionId');
 
           const curl = new Curl();
@@ -64,7 +67,59 @@ export async function registerInsomniaProtocols() {
           curl.setOpt(Curl.option.SSL_OPTIONS, CurlSslOpt.NativeCa);
 
           if (!settings.proxyEnabled) {
-            curl.setOpt(Curl.option.PROXY, '');
+            // follow system proxy
+            if (!systemProxyStr) {
+              // if systemProxy is empty, it means no proxy is used
+              systemProxyStr = 'DIRECT';
+            }
+
+            const proxies = systemProxyStr
+              .trim()
+              .split(/\s*;\s*/g)
+              .filter(Boolean);
+
+            // only the first proxy specified will be used
+            const firstProxy = proxies[0];
+            const parts = firstProxy.split(/\s+/);
+
+            const proxyType = parts[0];
+
+            if (proxyType === 'DIRECT') {
+              curl.setOpt(Curl.option.PROXY, '');
+            } else {
+              let unknownProxy = false;
+              let curlOptProxyType = CurlProxy.Http;
+              switch (proxyType) {
+                case 'PROXY':
+                  curlOptProxyType = CurlProxy.Http;
+                  break;
+                case 'HTTP':
+                  curlOptProxyType = CurlProxy.Http;
+                  break;
+                case 'SOCKS':
+                  curlOptProxyType = CurlProxy.Socks4;
+                  break;
+                case 'HTTPS':
+                  curlOptProxyType = CurlProxy.Https;
+                  break;
+                case 'SOCKS4':
+                  curlOptProxyType = CurlProxy.Socks4;
+                  break;
+                case 'SOCKS5':
+                  curlOptProxyType = CurlProxy.Socks5;
+                  break;
+                default:
+                  // unknown proxy type
+                  unknownProxy = true;
+                  break;
+              }
+              if (unknownProxy) {
+                curl.setOpt(Curl.option.PROXY, '');
+              } else {
+                curl.setOpt(Curl.option.PROXYTYPE, curlOptProxyType);
+                curl.setOpt(Curl.option.PROXY, parts[1]);
+              }
+            }
           } else {
             const { protocol } = urlParse(urlStr);
             const { httpProxy, httpsProxy, noProxy } = settings;

--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -1,8 +1,8 @@
 import { Readable } from 'node:stream';
+import { parse as urlParse } from 'node:url';
 
 import { Curl, CurlAuth, CurlFeature, CurlProxy, CurlSslOpt, type HeaderInfo } from '@getinsomnia/node-libcurl';
 import { app, net, protocol, session } from 'electron';
-import { parse as urlParse } from 'node:url';
 
 import { getApiBaseURL } from '../common/constants';
 import { get as getSettings } from '../models/settings';
@@ -126,6 +126,12 @@ export async function registerInsomniaProtocols() {
               } else {
                 curl.setOpt(Curl.option.PROXYTYPE, curlOptProxyType);
                 curl.setOpt(Curl.option.PROXY, parts[1]);
+                console.log(
+                  'Using system proxy to send SSE request to insomnia backend:',
+                  systemProxyStr,
+                  proxyType,
+                  parts[1],
+                );
               }
             }
           } else {

--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'node:stream';
 
-import { Curl, CurlAuth, CurlFeature, CurlSslOpt, type HeaderInfo, CurlProxy } from '@getinsomnia/node-libcurl';
+import { Curl, CurlAuth, CurlFeature, CurlProxy, CurlSslOpt, type HeaderInfo } from '@getinsomnia/node-libcurl';
 import { app, net, protocol, session } from 'electron';
 import { parse as urlParse } from 'url';
 
@@ -57,6 +57,7 @@ export async function registerInsomniaProtocols() {
       let systemProxyStr = await session.defaultSession.resolveProxy(urlStr);
 
       // here we use libcurl to forward the SSE request because the SSE request sent by net.fetch can not be disconnected correctly in some cases
+      // see https://github.com/electron/electron/issues/47097
       return await new Promise((resolve, reject) => {
         try {
           const sessionId = new URLSearchParams(url.search).get('sessionId');

--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -126,12 +126,6 @@ export async function registerInsomniaProtocols() {
               } else {
                 curl.setOpt(Curl.option.PROXYTYPE, curlOptProxyType);
                 curl.setOpt(Curl.option.PROXY, parts[1]);
-                console.log(
-                  'Using system proxy to send SSE request to insomnia backend:',
-                  systemProxyStr,
-                  proxyType,
-                  parts[1],
-                );
               }
             }
           } else {

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -326,6 +326,7 @@ export const createConfiguredCurlInstance = ({
   if (caCert) {
     curl.setOpt(Curl.option.CAINFO_BLOB, caCert);
   }
+  // Use the system's native CA store for SSL certificate verification
   curl.setOpt(Curl.option.SSL_OPTIONS, CurlSslOpt.NativeCa);
   certificates.forEach(validCert => {
     const { passphrase, cert, key, pfx } = validCert;
@@ -385,7 +386,9 @@ export const createConfiguredCurlInstance = ({
   }
   const { validateSSL } = settings;
   if (!validateSSL) {
+    // Disable certificate verification
     curl.setOpt(Curl.option.SSL_VERIFYHOST, 0);
+    // Disable hostname verification
     curl.setOpt(Curl.option.SSL_VERIFYPEER, 0);
   }
   debugTimeline.push({
@@ -575,7 +578,8 @@ export const getHttpVersion = (preferredHttpVersion: string) => {
     }
   }
 };
-const setDefaultProtocol = (url: string, defaultProto?: string) => {
+
+export const setDefaultProtocol = (url: string, defaultProto?: string) => {
   const trimmedUrl = url.trim();
   defaultProto = defaultProto || 'http:';
 


### PR DESCRIPTION
When connecting the Insomnia client to a locally running backend service, switching between multiple organizations causes HTTP requests to remain in a pending state.
![image](https://github.com/user-attachments/assets/de3b1820-87df-4ccf-8d95-485a9c8962d0)

I captured and analyzed the client’s network traffic and found that when switching organizations, the old SSE connections are not being closed. Once the number of SSE connections exceeds 6, all new requests remain in a pending state.
![image](https://github.com/user-attachments/assets/ddd2f819-7e13-464c-b68e-180f2a756cb0)

In the renderer process, the EventSource.close method is explicitly called to close old connections when switching organizations, but it clearly doesn’t take effect.

In the Insomnia app, we are not sending requests directly from the renderer process — instead, they are forwarded from the main process using electron.net.fetch.

net.fetch is indeed built on top of Chromium's native networking library, so it makes sense that it's subject to Chromium's per-domain connection limits.

The root cause of the issue was that under certain network conditions, Electron's net.fetch method fails to properly close SSE (Server-Sent Events) connections.

To work around this problem, I explored alternative solutions. I eventually found that using net.request inside protocol.handle, and manually constructing a Response object, provided a viable workaround. By using a ReadableStream as the Response.body and listening for its cancel event, I was able to accurately detect when the SSE connection was closed from the renderer process.

However, this workaround introduced a new problem. Since we're also forwarding regular HTTP requests through protocol.handle, the SSE requests made with net.request are inadvertently intercepted again by the handler designed for HTTP forwarding. That handler uses net.fetch, which brings us back to the original issue—SSE connections still can't be properly closed.

Electron does not provide a way to make net.request bypass other protocol handlers.

As a result, the only viable solution is to avoid using Electron’s built-in networking APIs for SSE entirely. Instead, I switched to using node-libcurl, which successfully establishes and closes SSE connections as expected.